### PR TITLE
Fix CSP issue in igv.js

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -27,7 +27,7 @@ SecureHeaders::Configuration.default do |config|
       font_src: %w('self' data:),
       form_action: %w('self'),
       connect_src: %w('self' https://www.google-analytics.com https://unpkg.com https://www.googleapis.com https://s3.amazonaws.com
-                      https://portals.broadinstitute.org),
+                      https://portals.broadinstitute.org https://data.broadinstitute.org),
       img_src: %w('self' data: https://www.google-analytics.com),
       manifest_src: %w('self'),
       object_src: %w('none'),


### PR DESCRIPTION
This fixes a Content Security Policy error caused by domain-specific igv.js behavior.  IGV will now be able to increment its usage counter.