### PR TITLE
Granular Firecloud error handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,7 +41,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # check whether downloads/study editing has been revoked and prevent user access
+  # check whether the portal has been put in 'safe-mode'
   def check_access_settings
     redirect = request.referrer.nil? ? site_path : request.referrer
     access = AdminConfiguration.firecloud_access_enabled?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,8 +44,8 @@ class ApplicationController < ActionController::Base
   # check whether downloads/study editing has been revoked and prevent user access
   def check_access_settings
     redirect = request.referrer.nil? ? site_path : request.referrer
-    downloads_enabled = AdminConfiguration.firecloud_access_enabled?
-    if !downloads_enabled
+    access = AdminConfiguration.firecloud_access_enabled?
+    if !access
       redirect_to merge_default_redirect_params(redirect, scpbr: params[:scpbr]), alert: "Study access has been temporarily disabled by the site adminsitrator.  Please contact #{view_context.mail_to('single_cell_portal@broadinstitute.org')} if you require assistance." and return
     end
   end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -259,7 +259,7 @@ class SiteController < ApplicationController
 
           # double check on download availability: first, check if administrator has disabled downloads
           # then check if FireCloud is available and disable download links if either is true
-          @allow_downloads = AdminConfiguration.firecloud_access_enabled? && Study.firecloud_client.api_available?
+          @allow_downloads = Study.firecloud_client.services_available?('GoogleBuckets')
         else
           set_study_default_options
         end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -291,7 +291,9 @@ class SiteController < ApplicationController
     # double check on download availability: first, check if administrator has disabled downloads
     # then check if FireCloud is available and disable download links if either is true
     @allow_firecloud_access = AdminConfiguration.firecloud_access_enabled?
-    @allow_downloads = @allow_firecloud_access && Study.firecloud_client.api_available?
+    @allow_downloads = Study.firecloud_client.services_available?('GoogleBuckets')
+    @allow_computes = Study.firecloud_client.services_available?('Agora', 'Rawls')
+    @allow_edits = Study.firecloud_client.services_available?('Sam', 'Rawls')
     set_study_default_options
     # load options and annotations
     if @study.initialized?
@@ -310,7 +312,8 @@ class SiteController < ApplicationController
 
     # if user has permission to run workflows, load available workflows and current submissions
 
-    if @allow_firecloud_access
+
+    if @allow_firecloud_access && @allow_computes
       if user_signed_in? && @study.can_compute?(current_user)
         # load list of previous submissions
         workspace = Study.firecloud_client.get_workspace(@study.firecloud_project, @study.firecloud_workspace)
@@ -690,7 +693,7 @@ class SiteController < ApplicationController
     # next check if downloads have been disabled by administrator, this will abort the download
     # download links shouldn't be rendered in any case, this just catches someone doing a straight GET on a file
     # also check if FireCloud is unavailable and abort if so as well
-    if !AdminConfiguration.firecloud_access_enabled? || !Study.firecloud_client.api_available?
+    if !AdminConfiguration.firecloud_access_enabled? || !Study.firecloud_client.services_available?('GoogleBuckets')
       head 503 and return
     end
 
@@ -1413,12 +1416,21 @@ class SiteController < ApplicationController
 
   # check compute permissions for study
   def check_compute_permissions
-    if !user_signed_in? || !@study.can_compute?(current_user)
-      @alert ='You do not have permission to perform that action.'
+    if Study.firecloud_client.services_available?('Rawls')
+      if !user_signed_in? || !@study.can_compute?(current_user)
+        @alert ='You do not have permission to perform that action.'
+        respond_to do |format|
+          format.js {render action: :notice}
+          format.html {redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: @alert and return}
+          format.json {head 403}
+        end
+      end
+    else
+      @alert ='Compute services are currently unavailable - please check back later.'
       respond_to do |format|
         format.js {render action: :notice}
         format.html {redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: @alert and return}
-        format.json {head 403}
+        format.json {head 503}
       end
     end
   end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -289,7 +289,7 @@ class SiteController < ApplicationController
     @other_data = @study.directory_listings.non_primary_data
 
     # double check on download availability: first, check if administrator has disabled downloads
-    # then check if FireCloud is available and disable download links if either is true
+    # then check individual statuses to see what to enable/disable
     @allow_firecloud_access = AdminConfiguration.firecloud_access_enabled?
     @allow_downloads = Study.firecloud_client.services_available?('GoogleBuckets')
     @allow_computes = Study.firecloud_client.services_available?('Agora', 'Rawls')
@@ -692,7 +692,7 @@ class SiteController < ApplicationController
 
     # next check if downloads have been disabled by administrator, this will abort the download
     # download links shouldn't be rendered in any case, this just catches someone doing a straight GET on a file
-    # also check if FireCloud is unavailable and abort if so as well
+    # also check if workspace google buckets are available
     if !AdminConfiguration.firecloud_access_enabled? || !Study.firecloud_client.services_available?('GoogleBuckets')
       head 503 and return
     end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -43,7 +43,7 @@ class StudiesController < ApplicationController
     @directories = @study.directory_listings.are_synced
     @primary_data = @study.directory_listings.primary_data
     @other_data = @study.directory_listings.non_primary_data
-    @allow_downloads = AdminConfiguration.firecloud_access_enabled? && Study.firecloud_client.api_available?
+    @allow_downloads = Study.firecloud_client.services_available?('GoogleBuckets')
     @analysis_metadata = @study.analysis_metadata.to_a
     # load study default options
     set_study_default_options
@@ -705,7 +705,7 @@ class StudiesController < ApplicationController
     # next check if downloads have been disabled by administrator, this will abort the download
     # download links shouldn't be rendered in any case, this just catches someone doing a straight GET on a file
     # also check if FireCloud is unavailable and abort if so as well
-    if !AdminConfiguration.firecloud_access_enabled? || !Study.firecloud_client.api_available?
+    if !AdminConfiguration.firecloud_access_enabled? || !Study.firecloud_client.services_available?('GoogleBuckets')
       head 503 and return
     end
     begin

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -704,7 +704,7 @@ class StudiesController < ApplicationController
 
     # next check if downloads have been disabled by administrator, this will abort the download
     # download links shouldn't be rendered in any case, this just catches someone doing a straight GET on a file
-    # also check if FireCloud is unavailable and abort if so as well
+    # also check if workspace google buckets are available
     if !AdminConfiguration.firecloud_access_enabled? || !Study.firecloud_client.services_available?('GoogleBuckets')
       head 503 and return
     end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1349,7 +1349,7 @@ class StudiesController < ApplicationController
 
   # check on FireCloud API status and respond accordingly
   def check_firecloud_status
-    unless Study.firecloud_client.api_available?
+    unless Study.firecloud_client.services_available?('Sam', 'Rawls')
       alert = 'Study workspaces are temporarily unavailable, so we cannot complete your request.  Please try again later.'
       respond_to do |format|
         format.js {render js: "$('.modal').modal('hide'); alert('#{alert}')" and return}

--- a/app/mailers/single_cell_mailer.rb
+++ b/app/mailers/single_cell_mailer.rb
@@ -195,7 +195,21 @@ class SingleCellMailer < ApplicationMailer
       @admins = User.where(admin: true).map(&:email)
 
       unless @admins.empty?
-        mail(to: @admins, reply_to: @requester, subject: "[Single Cell Portal Admin Notification#{Rails.env != 'production' ? " (#{Rails.env})" : nil}]: #{@subject}") do |format|
+        mail(to: @admins, reply_to: @requester, subject: "[Single Cell Portal Admin Notification #{Rails.env != 'production' ? " (#{Rails.env})" : nil}]: #{@subject}") do |format|
+          format.html
+        end
+      end
+    end
+  end
+
+  # notifier of FireCloud API service interruptions
+  def firecloud_api_notification(current_status, requester)
+    unless Rails.application.config.disable_admin_notifications == true
+      @admins = User.where(admin: true).map(&:email)
+      @requester = requester.nil? ? 'no-reply@broadinstitute.org' : requester
+      @current_status = current_status
+      unless @admins.empty?
+        mail(to: @admins, reply_to: @requester, subject: "[Single Cell Portal Admin Notification #{Rails.env != 'production' ? " (#{Rails.env})" : nil}]: ALERT: FIRECLOUD API SERVICE INTERRUPTION") do |format|
           format.html
         end
       end
@@ -217,7 +231,7 @@ class SingleCellMailer < ApplicationMailer
     @missing_files = missing_files
     @admins = User.where(admin: true).map(&:email)
 
-    mail(to: @admins, subject: "[Single Cell Portal Admin Notification#{Rails.env != 'production' ? " (#{Rails.env})" : nil}]: Sanity check results: #{@missing_files.size} files missing") do |format|
+    mail(to: @admins, subject: "[Single Cell Portal Admin Notification #{Rails.env != 'production' ? " (#{Rails.env})" : nil}]: Sanity check results: #{@missing_files.size} files missing") do |format|
       format.html
     end
   end

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -195,46 +195,16 @@ class AdminConfiguration
     job_count
   end
 
-  # method to be called from cron to check the health status of the FireCloud API and set access if an outage is detected
+  # method to be called from cron to check the health status of the FireCloud API
+  # This method no longer disables access as we now do realtime checks on routes that depend on certain services being up
+  # 'local-off' mode can now be used to manually put the portal in read-only mode
   def self.check_api_health
-    notifier_config = AdminConfiguration.find_or_create_by(config_type: AdminConfiguration::API_NOTIFIER_NAME, value_type: 'Boolean')
-    firecloud_access = AdminConfiguration.find_or_create_by(config_type: AdminConfiguration::FIRECLOUD_ACCESS_NAME, value_type: 'String')
-    api_available = Study.firecloud_client.api_available?
+    api_ok = Study.firecloud_client.api_available?
 
-    # gotcha for very first time this is ever called
-    if firecloud_access.value.nil?
-      firecloud_access.update(value: 'on')
-    end
-
-    if notifier_config.value.nil?
-      notifier_config.update(value: 1)
-    end
-
-    # if api is down...
-    if !api_available
-      # if access is still enabled, set to local-off and send notification to admins (if enabled)
-      if firecloud_access.value == 'on'
-        Rails.logger.error "#{Time.now}: ALERT: FIRECLOUD API UNAVAILABLE -- setting FireCloud access to 'local-off'"
-        firecloud_access.update(value: 'local-off')
-        if notifier_config.value == '1'
-          current_time = Time.now.strftime('%D %r')
-          SingleCellMailer.admin_notification('ALERT: FIRECLOUD API UNAVAILABLE', nil, "<p>The FireCloud API was found to be unavailable at #{current_time}.  Access has been disabled locally until API access is manually turned back on or the next automatic check returns positive.").deliver_now
-          notifier_config.update(value: '0')
-        end
-      end
-    # if api is up...
-    else
-      if firecloud_access.value == 'local-off'
-        # local-off is currently used exclusively for API outages, so if the API is up and the portal is set to local-off,
-        # then we can assume that the portal was put in this mode by AdminConfiguration.check_api_health and should
-        # automatically recover.  This will not affect disabling compute or all access settings.
-        firecloud_access.update(value: 'on')
-        if notifier_config.value == '0'
-          current_time = Time.now.strftime('%D %r')
-          SingleCellMailer.admin_notification('ALERT: FireCloud API recovery', nil, "<p>The FireCloud API has recovered as of #{current_time}.  Access has been automatically restored.").deliver_now
-          notifier_config.update(value: '1')
-        end
-      end
+    if !api_ok
+      current_status = Study.firecloud_client.api_status
+      Rails.logger.error "#{Time.now}: ALERT: FIRECLOUD API SERVICE INTERRUPTION -- current status: #{current_status}"
+      SingleCellMailer.firecloud_api_notification(current_status).deliver_now
     end
   end
 

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -292,7 +292,7 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   # determine if FireCloud api is currently up/available
   #
   # * *return*
-  #   - +Boolean+ indication of FireCloud current status
+  #   - +Boolean+ indication of FireCloud current root status
   def api_available?
     begin
       response = self.api_status
@@ -326,6 +326,31 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
     rescue RestClient::ExceptionWithResponse => e
       Rails.logger.error "#{Time.now}: FireCloud status error: #{e.message}"
       e.response
+    end
+  end
+
+  # get health check on individual FireCloud services by name from FireCloudClient#api_status
+  # Should not be used to assess overall API health, but rather a quick thumbs up/down on a specific service
+  #
+  # * *params*
+  #   #   - +services+ (Array) => array of service names (from api_status['systems']), passed with splat operator, so should not be an actual array
+  # * *return*
+  #   - +Boolean+ indication of availability of requested FireCloud service
+  def services_available?(*services)
+    api_status = self.api_status
+    if api_status.is_a?(Hash)
+      api_ok = true
+      services.each do |service|
+        if api_status['systems'].present? && api_status['systems'][service].present? && api_status['systems'][service]['ok']
+          next
+        else
+          api_ok = false
+          break
+        end
+      end
+      api_ok
+    else
+      false
     end
   end
 

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -314,9 +314,8 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   def api_status
     path = self.api_root + '/status'
     # make sure access token is still valid
-    self.access_token_expired? ? self.refresh_access_token : nil
     headers = {
-        'Authorization' => "Bearer #{self.access_token['access_token']}",
+        'Authorization' => "Bearer #{self.valid_access_token['access_token']}",
         'Content-Type' => 'application/json',
         'Accept' => 'application/json'
     }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
   <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
   <%= stylesheet_link_tag    'application', media: 'all' %>
-  <%= nonced_javascript_include_tag "https://cdn.plot.ly/plotly-1.39.2.min.js" %>
+  <%= nonced_javascript_include_tag "https://cdn.plot.ly/plotly-1.39.3.min.js" %>
   <%= nonced_javascript_include_tag 'application' %>
   <%= nonced_javascript_include_tag "https://cdn.datatables.net/plug-ins/1.10.15/sorting/natural.js" %>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -3,7 +3,11 @@
 <div id="profile-tab-root">
   <ul class="nav nav-tabs" role="tablist" id="profile-tabs">
     <li role="presentation" class="profile-nav active" id="profile-emails-nav"><a href="#profile-emails" data-toggle="tab">Email Delivery</a></li>
-    <li role="presentation" class="profile-nav" id="profile-firecloud-nav"><a href="#profile-firecloud" data-toggle="tab">FireCloud Profile</a></li>
+    <% if @profiles_available %>
+      <li role="presentation" class="profile-nav" id="profile-firecloud-nav"><a href="#profile-firecloud" data-toggle="tab">FireCloud Profile</a></li>
+    <% else %>
+      <li role="presentation" class="profile-nav disabled" id="profile-firecloud-nav"><a href="#profile-firecloud" data-toggle="tooltip" title="FireCloud profiles are currently unavailable, please check back later.">FireCloud Profile</a></li>
+    <% end %>
   </ul>
 
   <div class="tab-content top-pad">
@@ -68,9 +72,11 @@
         </tbody>
       </table>
     </div>
-    <div class="tab-pane" id="profile-firecloud" role="tabpanel">
-      <%= render partial: 'user_firecloud_profile' %>
-    </div>
+    <% if @profiles_available %>
+      <div class="tab-pane" id="profile-firecloud" role="tabpanel">
+        <%= render partial: 'user_firecloud_profile' %>
+      </div>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/single_cell_mailer/firecloud_api_notification.html.erb
+++ b/app/views/single_cell_mailer/firecloud_api_notification.html.erb
@@ -1,0 +1,26 @@
+<p>A service outage of the FireCloud API was detected at <%= Time.now.to_s(:long) %>.  Affected services will be disabled on a per-request basis.</p>
+<h3>Current Status</h3>
+<table border="1">
+  <thead>
+    <tr>
+      <th>Service Name</th>
+      <th>Status</th>
+      <th>Errors</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @current_status['systems'].each do |system, statuses| %>
+      <tr>
+        <td><%= system %></td>
+        <td><%= statuses['ok'] ? 'OK' : 'Error' %></td>
+        <td>
+          <% if statuses['messages'].present? %>
+            <% statuses['messages'].each do |message| %>
+              <p><%= message %></p>
+            <% end %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -171,7 +171,7 @@
           <% end %>
         </td>
         <td>
-          <% if @allow_downloads %>
+          <% if @allow_downloads && @allow_firecloud_access %>
             <%= render partial: '/layouts/download_link', locals: {study: @study, study_file: study_file} %>
           <% else %>
             <%= link_to 'Currently Unavailable', 'javascript:;', class: 'btn btn-danger disabled-download', disabled: true %>

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -1,6 +1,7 @@
 <div class="row">
   <div class="col-xs-12">
-    <h2>Study Files <span class="badge"><%= @study_files.count %></span>  <%= link_to "<i class='fas fa-question-circle'></i> Bulk Download".html_safe, 'javascript:;', class: 'btn btn-default pull-right', id: 'download-help' %></h2>
+    <h2>Study Files <span class="badge"><%= @study_files.count %></span>  <%= link_to "<i class='fas fa-question-circle'></i> Bulk Download".html_safe, 'javascript:;', class: "btn btn-default pull-right #{!@allow_downloads ? 'disabled' : nil}", id: 'download-help' %></h2>
+    <% if @allow_downloads %>
     <div class="modal fade" id="download-help-modal" role="dialog" aria-labelledby="download-help-modal" aria-hidden="true">
       <div class="modal-dialog modal-lg">
         <div class="modal-content">
@@ -146,6 +147,7 @@
           writeDownloadCommand(downloadObject);
         });
     </script>
+    <% end %>
   </div>
 </div>
 <div class="table-responsive">

--- a/app/views/site/edit_study_description.js.erb
+++ b/app/views/site/edit_study_description.js.erb
@@ -1,4 +1,4 @@
-$('#study-summary').html("<%= escape_javascript(render partial: 'study_description_edit') %>");
+$('#study-description-content').html("<%= escape_javascript(render partial: 'study_description_edit') %>");
 
 ClassicEditor
     .create( document.querySelector( '#study_description' ),

--- a/app/views/site/study.html.erb
+++ b/app/views/site/study.html.erb
@@ -15,10 +15,18 @@
       <li role="presentation" class="study-nav disabled" id="study-download-nav"><a href="#study-download" data-toggle="tooltip" title="Only authenticated users with download privileges can download data">Download <i class="fas fa-fw fa-download"></i></a></li>
     <% end %>
     <% if @allow_firecloud_access && @study.can_compute?(current_user) %>
-      <li role="presentation" class="study-nav" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tab">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
+      <% if @allow_computes %>
+        <li role="presentation" class="study-nav" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tab">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
+      <% else %>
+        <li role="presentation" class="study-nav disabled" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tooltip" title="Study workspaces are currently unavailable - please try again later.">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
+  <% end %>
     <% end %>
     <% if @allow_firecloud_access && @study.can_edit?(current_user) %>
-      <li role="presentation" class="study-nav" id="study-settings-nav"><a href="#study-settings" data-toggle="tab">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
+      <% if @allow_edits %>
+        <li role="presentation" class="study-nav" id="study-settings-nav"><a href="#study-settings" data-toggle="tab">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
+      <% else %>
+        <li role="presentation" class="study-nav disabled" id="study-settings-nav"><a href="#study-settings" data-toggle="tooltip" title="Study workspaces are currently unavailable - please try again later.">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
+      <% end %>
     <% end %>
   </ul>
   <div class="tab-content top-pad">
@@ -35,12 +43,12 @@
         <%= render partial: 'study_download_data' %>
       </div>
     <% end %>
-    <% if @allow_firecloud_access && @study.can_compute?(current_user) %>
+    <% if @allow_firecloud_access && @allow_computes && @study.can_compute?(current_user) %>
       <div class="tab-pane" id="study-analysis" role="tabpanel">
         <%= render partial: 'study_analysis' %>
       </div>
     <% end %>
-    <% if @allow_firecloud_access && @study.can_edit?(current_user) %>
+    <% if @allow_firecloud_access && @allow_edits && @study.can_edit?(current_user) %>
       <div class="tab-pane" id="study-settings" role="tabpanel">
         <div class="row">
           <div class="col-xs-12" id="study-settings-form-target">

--- a/bin/boot_docker
+++ b/bin/boot_docker
@@ -104,6 +104,9 @@ case $OPTION in
 	esac
 done
 
+# rebuild the docker image if necessary
+docker build -t single_cell_docker:$DOCKER_IMAGE_VERSION -f Dockerfile .
+
 if [[ $PASSENGER_APP_ENV = "production" ]]
 then
 	# generate random secret key for secure cookies

--- a/test/integration/fire_cloud_client_test.rb
+++ b/test/integration/fire_cloud_client_test.rb
@@ -50,14 +50,13 @@ class FireCloudClientTest < ActiveSupport::TestCase
     puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
 
-  # assert FireCloud is responding
+  # assert status health check is returning true/false
   def test_firecloud_api_available
     puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     # check that API is up
-    assert @fire_cloud_client.api_available?, 'FireCloud API is not available'
-    firecloud_status = @fire_cloud_client.api_status
-    assert firecloud_status['ok'], 'Detailed FireCloud API status is not available'
+    api_available = @fire_cloud_client.api_available?
+    assert [true, false].include?(api_available), 'Did not receive corret boolean response'
 
     puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end

--- a/test/integration/fire_cloud_client_test.rb
+++ b/test/integration/fire_cloud_client_test.rb
@@ -51,13 +51,31 @@ class FireCloudClientTest < ActiveSupport::TestCase
   end
 
   # assert FireCloud is responding
-  def test_firecloud_status
+  def test_firecloud_api_available
     puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     # check that API is up
     assert @fire_cloud_client.api_available?, 'FireCloud API is not available'
     firecloud_status = @fire_cloud_client.api_status
     assert firecloud_status['ok'], 'Detailed FireCloud API status is not available'
+
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
+  end
+
+  # get the current FireCloud API status
+  def test_firecloud_api_status
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
+
+    status = @fire_cloud_client.api_status
+    assert status.is_a?(Hash), "Did not get expected status Hash object; found #{status.class.name}"
+    assert status['ok'].present?, 'Did not find root status message'
+    assert status['systems'].present?, 'Did not find system statuses'
+    # look for presence of systems that SCP depends on
+    services = %w(Rawls Agora Sam Thurloe)
+    services.each do |service|
+      assert status['systems'][service].present?, "Did not find required service: #{service}"
+      assert [true, false].include?(status['systems'][serivce]['ok']), "Did not find expected 'ok' message of true/false; found: #{status['systems'][serivce]['ok']}"
+    end
 
     puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end

--- a/test/integration/fire_cloud_client_test.rb
+++ b/test/integration/fire_cloud_client_test.rb
@@ -587,8 +587,6 @@ class FireCloudClientTest < ActiveSupport::TestCase
     puts 'getting API URL for file...'
     api_url = @fire_cloud_client.generate_api_url(@fire_cloud_client.project, workspace_name, participant_filename)
     assert api_url.start_with?("https://www.googleapis.com/storage"), "Did not receive correctly formatted api_url, expected to start with 'https://www.googleapis.com/storage' but found #{api_url}"
-    participant_contents = participant_upload.read
-    assert participant_contents == api_url_response.body, "Response body contents are incorrect, expected '#{participant_contents}' but found '#{api_url_response.body}'"
 
     # close upload files
     participant_upload.close

--- a/test/integration/fire_cloud_client_test.rb
+++ b/test/integration/fire_cloud_client_test.rb
@@ -73,7 +73,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
     services = %w(Rawls Agora Sam Thurloe)
     services.each do |service|
       assert status['systems'][service].present?, "Did not find required service: #{service}"
-      assert [true, false].include?(status['systems'][serivce]['ok']), "Did not find expected 'ok' message of true/false; found: #{status['systems'][serivce]['ok']}"
+      assert [true, false].include?(status['systems'][service]['ok']), "Did not find expected 'ok' message of true/false; found: #{status['systems'][service]['ok']}"
     end
 
     puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
@@ -586,8 +586,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
     # generate a media URL for a file
     puts 'getting API URL for file...'
     api_url = @fire_cloud_client.generate_api_url(@fire_cloud_client.project, workspace_name, participant_filename)
-    api_url_response = RestClient.get api_url
-    assert api_url_response.code == 200, "Did not receive correct response code on api_url, expected 200 but found #{api_url_response.code}"
+    assert api_url.start_with?("https://www.googleapis.com/storage"), "Did not receive correctly formatted api_url, expected to start with 'https://www.googleapis.com/storage' but found #{api_url}"
     participant_contents = participant_upload.read
     assert participant_contents == api_url_response.body, "Response body contents are incorrect, expected '#{participant_contents}' but found '#{api_url_response.body}'"
 

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -2245,7 +2245,7 @@ class UiTestSuite < Test::Unit::TestCase
     wait_for_modal_open('message_modal')
     assert element_visible?(:id, 'message_modal'), 'confirmation modal did not show.'
     notice_content = @driver.find_element(:id, 'notice-content')
-    confirmation_message = 'Your message has been successfully delivered.'
+    confirmation_message = 'Your request has been submitted.'
     assert notice_content.text == confirmation_message, "did not find confirmation message, expected #{confirmation_message} but found #{notice_content.text}"
 
     puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -1599,7 +1599,7 @@ class UiTestSuite < Test::Unit::TestCase
 
     open_ui_tab('profile-firecloud')
 
-    job_title_field = @driver.find_element(:id, 'firecloud_profile_title')
+    job_title_field = @driver.find_element(:id, 'fire_cloud_profile_title')
     job_title_field.clear
     new_title = "Random Title #{$random_seed}"
     job_title_field.send_keys(new_title)
@@ -1612,7 +1612,7 @@ class UiTestSuite < Test::Unit::TestCase
     wait_for_render(:id, 'profile-header')
     open_ui_tab('profile-firecloud')
 
-    job_title = @driver.find_element(:id, 'firecloud_profile_title')['value']
+    job_title = @driver.find_element(:id, 'fire_cloud_profile_title')['value']
     assert job_title == new_title, "Did not update job title correctly, expected '#{new_title}' but found '#{job_title}'"
 
     puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"


### PR DESCRIPTION
* FireCloud service availability is now checked on a per-service, per-request basis and disabled as necessary
* Portal no longer auto-enables 'safe-mode' when service outages are detected
* Admin notification email includes current service status