### PR TITLE
Remove hard-coded species data in genome visualizations

### DIFF
--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -11,6 +11,8 @@ window.hasDisplayedIgv = false;
 window.bamsToViewInIgv = [];
 window.selectedBams = {};
 
+window.genomeAssemblyInView = '';
+
 /**
  * Upon clicking 'Browse in genome', show selected BAM in igv.js in Genome tab.
  */
@@ -77,7 +79,7 @@ function getGenesTrack(genome, genesTrackName) {
   var gtfFile, genesTrack;
 
   // gtfFiles assigned in _genome.html.erb
-  gtfFile = gtfFiles[genome];
+  gtfFile = gtfFiles[genome].genome_annotations;
 
   genesTrack = {
     name: genesTrackName,
@@ -105,6 +107,7 @@ igv.GenomeUtils.getKnownGenomes = function () {
   return originalGetKnownGenomes.apply(this).then(function(reference) {
     var key,
         newRef = {};
+    newRef['GRCm38'] = reference['mm10']; // Fix name
     for (key in reference) {
       delete reference[key].tracks;
       newRef[key] = reference[key];
@@ -129,9 +132,8 @@ function initializeIgv() {
   genes = $('.queried-gene');
   locus = (genes.length === 0) ? ['myc'] : [genes.first().text()];
 
-  // TODO: Remove hard-coding of genome after SCP species integration
   genome = bamsToViewInIgv[0].genomeAssembly;
-  genesTrackName = 'Genes | ' + bamsToViewInIgv[0].genomeAnnotation;
+  genesTrackName = 'Genes | ' + bamsToViewInIgv[0].genomeAnnotation.name;
   genesTrack = getGenesTrack(genome, genesTrackName);
   bamTracks = getBamTracks();
   tracks = [genesTrack].concat(bamTracks);

--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -130,8 +130,8 @@ function initializeIgv() {
   locus = (genes.length === 0) ? ['myc'] : [genes.first().text()];
 
   // TODO: Remove hard-coding of genome after SCP species integration
-  genome = 'mm10';
-  genesTrackName = 'Genes | GENCODE M17';
+  genome = bamsToViewInIgv[0].genomeAssembly;
+  genesTrackName = 'Genes | ' + bamsToViewInIgv[0].genomeAnnotation;
   genesTrack = getGenesTrack(genome, genesTrackName);
   bamTracks = getBamTracks();
   tracks = [genesTrack].concat(bamTracks);

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -280,7 +280,7 @@ class StudiesController < ApplicationController
             # we can only do this by md5 hash as the filename and generation will be different
             existing_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, @study.firecloud_project,
                                                                          @study.firecloud_workspace, new_location)
-            if existing_file.present? && existing_file.md5 == file.md5
+            if existing_file.present? && existing_file.md5 == file.md5 && StudyFile.where(study_id: @study.id, upload_file_name: new_location).exists?
               next
             else
               # now copy the file to a new location for syncing, marking as default type of 'Analysis Output'

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -506,6 +506,9 @@ class StudiesController < ApplicationController
       # set queued_for_deletion manually - gotcha due to race condition on page reloading and how quickly delayed_job can process jobs
       @study.update(queued_for_deletion: true)
 
+      # Remove the analysis.json before enqueuing the delete job
+      AnalysisMetadatum.where(study_id: @study.id).delete_all
+
       # queue jobs to delete study caches & study itself
       CacheRemovalJob.new(@study.url_safe_name).delay.perform
       DeleteQueueJob.new(@study).delay.perform

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -86,7 +86,7 @@ class TaxonsController < ApplicationController
     def taxon_params
       params.require(:taxon).permit(:common_name, :scientific_name, :taxon_identifier, :user_id, :notes, :aliases,
                                     genome_assemblies_attributes: [:id, :name, :alias, :release_date, :_destroy,
-                                    genome_annotations_attributes: [:id, :name, :link, :release_date,
+                                    genome_annotations_attributes: [:id, :name, :link, :index_link, :release_date,
                                     :_destroy]])
     end
 end

--- a/app/models/genome_annotation.rb
+++ b/app/models/genome_annotation.rb
@@ -44,8 +44,8 @@ class GenomeAnnotation
     end
   end
 
-  # generate a URL that can be accessed publicly for this genome annotation
-  def public_annotation_link
+  # generate a URL that can be accessed publicly for this genome annotation's index
+  def public_annotation_index_link
     if self.index_link.starts_with?('http')
       self.index_link
     else
@@ -157,5 +157,4 @@ def check_genome_annotation_index_link
       errors.add(:index_link, '- you have not specified a Reference Data Workspace.  Please add this via the Admin Config panel before registering a taxon.')
     end
   end
-end
 end

--- a/app/models/genome_annotation.rb
+++ b/app/models/genome_annotation.rb
@@ -6,12 +6,14 @@ class GenomeAnnotation
 
   field :name, type: String
   field :link, type: String
+  field :index_link, type: String
   field :release_date, type: Date
 
   validates_presence_of :name, :link, :release_date
   validates_uniqueness_of :name, scope: :genome_assembly_id
 
   validate :check_genome_annotation_link
+  validate :check_genome_annotation_index_link
 
   before_destroy :remove_study_file_associations
 
@@ -34,6 +36,29 @@ class GenomeAnnotation
                                                                  reference_workspace, self.link)
         rescue => e
           Rails.logger.error "Cannot generate public genome annotation link for #{self.link}: #{e.message}"
+          ''
+        end
+      else
+        ''
+      end
+    end
+  end
+
+  # generate a URL that can be accessed publicly for this genome annotation
+  def public_annotation_link
+    if self.index_link.starts_with?('http')
+      self.index_link
+    else
+      # assume the index link is a relative path to a file in a GCS bucket, then use service account to generate api url
+      # will then need to use user or read-only service account access_token to render in client
+      config = AdminConfiguration.find_by(config_type: 'Reference Data Workspace')
+      if config.present?
+        begin
+          reference_project, reference_workspace = config.value.split('/')
+          Study.firecloud_client.execute_gcloud_method(:generate_api_url, reference_project,
+                                                       reference_workspace, self.index_link)
+        rescue => e
+          Rails.logger.error "Cannot generate public genome annotation index link for #{self.index_link}: #{e.message}"
           ''
         end
       else
@@ -101,4 +126,36 @@ class GenomeAnnotation
       end
     end
   end
+end
+
+# validate that the supplied genome annotation link is valid
+def check_genome_annotation_index_link
+  if self.index_link.starts_with?('http')
+    begin
+      response = RestClient.get index_link
+      unless response.code == 200
+        errors.add(:index_link, "was not found at the specified index link: #{index_link}.  The response code was #{response.code} rather than 200.")
+      end
+    rescue => e
+      errors.add(:index_link, "was not found due to an error: #{e.message}.  Please check the index link and try again.")
+    end
+  else
+    # assume the link is a relative path to a file in a GCS bucket
+    config = AdminConfiguration.find_by(config_type: 'Reference Data Workspace')
+    if config.present?
+      begin
+        reference_project, reference_workspace = config.value.split('/')
+        genome_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, reference_project, reference_workspace,
+                                                                   self.index_link)
+        if !genome_file.present?
+          errors.add(:index_link, "was not found in the reference workspace of #{config.value}.  Please check the index link and try again.")
+        end
+      rescue => e
+        errors.add(:index_link, "was not found due to an error: #{e.message}.  Please check the index link and try again.")
+      end
+    else
+      errors.add(:index_link, '- you have not specified a Reference Data Workspace.  Please add this via the Admin Config panel before registering a taxon.')
+    end
+  end
+end
 end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -688,7 +688,7 @@ class Study
     self.study_files.where('options.analysis_name' => analysis_name, 'options.visualization_name' => visualization_name)
   end
 
-  # return all study files for a given analysis & visualization component
+  # Return settings for this study's inferCNV ideogram visualization
   def get_ideogram_infercnv_settings
     exp_file = self.get_analysis_outputs('infercnv', 'ideogram.js').first
     {

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -704,39 +704,33 @@ class Study
           'url' => bam_file.api_url,
           'indexUrl' => bam_file.bundled_files.first.api_url,
           'genomeAssembly' => bam_file.genome_assembly_name,
-          'genomeAnnotation' => bam_file.genome_annotation,
-          'genomeAnnotationLink' => bam_file.genome_annotation_link
+          'genomeAnnotation' => bam_file.genome_annotation
       }
     end
     bams
   end
 
-  # Get gene annotations tracks for igv.js,
-  # as reference-genome keyed list of GCS API URLs for BED and BED index files
-  def get_gene_tracks
-    gene_tracks = {}
-    if self.has_bam_files?
-      reference_workspace = AdminConfiguration.find_by(config_type: 'Reference Data Workspace')
-      opts = reference_workspace.options
-      namespace, name = reference_workspace.value.split('/')
+  def get_genome_annotations_by_assembly
+    genome_annotations = {}
+    bam_files = self.study_files.by_type('BAM')
+    bam_files.each do |bam_file|
+      assembly = bam_file.genome_assembly_name
+      if !genome_annotations.key?(assembly)
+        genome_annotations[assembly] = {}
+      end
+      genome_annotation = bam_file.genome_annotation
+      if !genome_annotations[assembly].key?(genome_annotation)
 
-      # We'll generalize later, e.g. take in (genome assembly) reference_name as a URL parameter
-      # to this 'study' method's endpoint
-      reference_name = 'mm10'
-
-      gene_tracks = {
-          mm10: {}
-      }
-
-      reference_gtf_key = opts.keys.find {|o| o =~ /^#{reference_name}.*_gtf$/}
-      reference_gtf = opts[reference_gtf_key]
-      gene_tracks[:mm10][:url] = Study.firecloud_client.generate_api_url(namespace, name, reference_gtf)
-
-      reference_gtf_index_key = opts.keys.find {|o| o =~ /^#{reference_name}.*_gtf_index$/}
-      reference_gtf_index = opts[reference_gtf_index_key]
-      gene_tracks[:mm10][:indexUrl] = Study.firecloud_client.generate_api_url(namespace, name, reference_gtf_index)
+        # Only handle one annotation per genome assembly for now;
+        # enhance to support multiple annotations when UI supports it
+        genome_annotations[assembly]['genome_annotations'] = {
+          'name': genome_annotation,
+          'url': bam_file.genome_annotation_link,
+          'indexUrl': bam_file.genome_annotation_index_link
+        }
+      end
     end
-    gene_tracks
+    genome_annotations
   end
 
   def taxons

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -688,6 +688,16 @@ class Study
     self.study_files.where('options.analysis_name' => analysis_name, 'options.visualization_name' => visualization_name)
   end
 
+  # return all study files for a given analysis & visualization component
+  def get_ideogram_infercnv_settings
+    exp_file = self.get_analysis_outputs('infercnv', 'ideogram.js').first
+    {
+      'organism': exp_file.species_name,
+      'assembly': exp_file.genome_assembly['name'],
+      'annotationsPath': exp_file.api_url
+    }
+  end
+
   def has_bam_files?
     self.study_files.by_type('BAM').any?
   end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -702,7 +702,10 @@ class Study
     bam_files.each do |bam_file|
       bams << {
           'url' => bam_file.api_url,
-          'indexUrl' => bam_file.bundled_files.first.api_url
+          'indexUrl' => bam_file.bundled_files.first.api_url,
+          'genomeAssembly' => bam_file.genome_assembly_name,
+          'genomeAnnotation' => bam_file.genome_annotation,
+          'genomeAnnotationLink' => bam_file.genome_annotation_link
       }
     end
     bams

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -329,6 +329,15 @@ class StudyFile
     end
   end
 
+  # helper to return public link to genome annotation index, if present
+  def genome_annotation_index_link
+    if self.genome_assembly.present? && self.genome_assembly.current_annotation.present?
+      self.genome_assembly.current_annotation.public_annotation_index_link
+    else
+      nil
+    end
+  end
+
   ###
   #
   # CACHING METHODS

--- a/app/views/site/genome/_genome.html.erb
+++ b/app/views/site/genome/_genome.html.erb
@@ -18,7 +18,7 @@ See partials referenced below and scp-igv.js for larger bodies of code.
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
   if (typeof bamAndBaiFiles === 'undefined') {
     window.bamAndBaiFiles = <%= raw @study.get_bam_files.to_json %>;
-    window.gtfFiles = <%= raw @study.get_gene_tracks.to_json %>;
+    window.gtfFiles = <%= raw @study.get_genome_annotations_by_assembly.to_json %>;
   }
   </script>
   <%= render partial: '/site/genome/igv' %>

--- a/app/views/site/genome/_genome.html.erb
+++ b/app/views/site/genome/_genome.html.erb
@@ -9,9 +9,7 @@ See partials referenced below and scp-igv.js for larger bodies of code.
 </script>
 <% if @study.has_analysis_outputs?('infercnv', 'ideogram.js') and action_name == 'study' %>
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-  window.ideogramOrganism = '<%= raw @study.get_analysis_outputs('infercnv', 'ideogram.js').first.species_name %>';
-  window.ideogramAssembly = '<%= raw @study.get_analysis_outputs('infercnv', 'ideogram.js').first.genome_assembly.name %>';
-  window.ideogramAnnotsPath = '<%= raw @study.get_analysis_outputs('infercnv', 'ideogram.js').first.api_url %>';
+  window.ideogramInferCnvSettings = <%= raw @study.get_ideogram_infercnv_settings.to_json %>;
 </script>
   <%= render partial: '/site/genome/ideogram' %>
 <% end %>

--- a/app/views/site/genome/_genome.html.erb
+++ b/app/views/site/genome/_genome.html.erb
@@ -9,7 +9,9 @@ See partials referenced below and scp-igv.js for larger bodies of code.
 </script>
 <% if @study.has_analysis_outputs?('infercnv', 'ideogram.js') and action_name == 'study' %>
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-  window.annotationsPath = '<%= raw @study.get_analysis_outputs('infercnv', 'ideogram.js').first.api_url %>';
+  window.ideogramOrganism = '<%= raw @study.get_analysis_outputs('infercnv', 'ideogram.js').first.species_name %>';
+  window.ideogramAssembly = '<%= raw @study.get_analysis_outputs('infercnv', 'ideogram.js').first.genome_assembly.name %>';
+  window.ideogramAnnotsPath = '<%= raw @study.get_analysis_outputs('infercnv', 'ideogram.js').first.api_url %>';
 </script>
   <%= render partial: '/site/genome/ideogram' %>
 <% end %>

--- a/app/views/site/genome/_ideogram.html.erb
+++ b/app/views/site/genome/_ideogram.html.erb
@@ -133,11 +133,11 @@
 
   var ideogram = new Ideogram({
     container: '#ideogram-container',
-    organism: 'human',
-    assembly: 'GRCh38',
+    organism: ideogramOrganism.toLowerCase(),
+    assembly: ideogramAssembly,
     chrHeight: 400,
     dataDir: 'https://unpkg.com/ideogram@1.1.1/dist/data/bands/native/',
-    annotationsPath: annotationsPath,
+    annotationsPath: ideogramAnnotsPath,
     annotationTracks: annotationTracks,
     // annotationsLayout: 'heatmap',
     heatmaps: [

--- a/app/views/site/genome/_ideogram.html.erb
+++ b/app/views/site/genome/_ideogram.html.erb
@@ -133,11 +133,11 @@
 
   var ideogram = new Ideogram({
     container: '#ideogram-container',
-    organism: ideogramOrganism.toLowerCase(),
-    assembly: ideogramAssembly,
+    organism: ideogramInferCnvSettings.organism.toLowerCase(),
+    assembly: ideogramInferCnvSettings.assembly,
     chrHeight: 400,
     dataDir: 'https://unpkg.com/ideogram@1.1.1/dist/data/bands/native/',
-    annotationsPath: ideogramAnnotsPath,
+    annotationsPath: ideogramInferCnvSettings.annotationsPath,
     annotationTracks: annotationTracks,
     // annotationsLayout: 'heatmap',
     heatmaps: [

--- a/app/views/studies/_initialize_primary_data_form.html.erb
+++ b/app/views/studies/_initialize_primary_data_form.html.erb
@@ -24,11 +24,12 @@
     </div>
     <div class="col-sm-4">
       <%= f.label :taxon_id, 'Species' %><br />
-      <%= f.select :taxon_id, options_from_collection_for_select(Taxon.sorted, :id, :display_name, study_file.taxon_id), {prompt: 'None selected...'}, {class: 'form-control taxon-select'} %>
+      <%= f.select :taxon_id, options_from_collection_for_select(Taxon.sorted, :id, :display_name, study_file.taxon_id), {include_blank: 'None selected...'}, {class: 'form-control taxon-select'} %>
     </div>
-    <div class="col-sm-4 hidden genome-assembly-association">
-      <%= f.label :genome_assembly_id, 'Genome Assembly' %><br />
-      <%= f.select :genome_assembly_id, options_for_select([]), {prompt: 'Please select species...'}, {class: 'form-control genome-assembly-select'} %>
+    <div class="col-sm-4 <%= study_file.file_type == 'BAM' ? nil : 'hidden' %> genome-assembly-association">
+      <%= f.label :genome_assembly_id, 'Genome Assembly' %><br/>
+      <% assemblies = study_file.genome_assembly.present? ? study_file.genome_assembly.taxon.genome_assemblies.map {|a| [a.name, a.id]} : [] %>
+      <%= f.select :genome_assembly_id, options_for_select(assemblies, study_file.genome_assembly.present? ? study_file.genome_assembly.id : nil), {prompt: 'Please select species...'}, {class: 'form-control genome-assembly-select'} %>
     </div>
   </div>
   <div class="form-group row">

--- a/app/views/studies/_shared_sync_functions.js.erb
+++ b/app/views/studies/_shared_sync_functions.js.erb
@@ -45,7 +45,7 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', function() {
         // disable sync button until user has selected a matrix pair
         console.log('disabling sync button on ' + submitBtn.attr('id'));
         submitBtn.attr('disabled', 'disabled');
-    } else if (fileType === 'BAM') {
+    } else if (fileType === 'BAM' || fileType === 'Analysis Output') {
         extraInfo.empty();
         taxonTarget.html("<%= j(render partial: 'taxon_fields', locals: {f: f}) %>");
         assemblySelect = form.find('.genome-assembly-association');
@@ -73,7 +73,7 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', function() {
                 }));
             });
         }
-        // disable sync button until user has selected a BAM file
+        // disable app/views/studies/_synced_study_file_form.html.erb button until user has selected a BAM file
         submitBtn.attr('disabled', 'disabled');
     } else {
         extraInfo.empty();

--- a/app/views/studies/_shared_sync_functions.js.erb
+++ b/app/views/studies/_shared_sync_functions.js.erb
@@ -9,8 +9,6 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', function() {
     var taxonTarget = form.find('.taxon-select-target');
     var submitBtn = $('#sync-study-file-<%= study_file.id %>');
 
-    console.log("Selected file type: " + fileType);
-
     // render fields & process entries based on file type
     if (fileType === 'Cluster') {
         extraInfo.html("<%= j(render partial: 'cluster_axis_fields', locals: {f: f}) %>");
@@ -49,7 +47,6 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', function() {
         console.log('disabling sync button on ' + submitBtn.attr('id'));
         submitBtn.attr('disabled', 'disabled');
     } else if (fileType === 'BAM' || fileType === 'Analysis Output') {
-        alert('Selected "Analysis Output"!')
         extraInfo.empty();
         taxonTarget.html("<%= j(render partial: 'taxon_fields', locals: {f: f}) %>");
         assemblySelect = form.find('.genome-assembly-association');
@@ -77,7 +74,7 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', function() {
                 }));
             });
         }
-        // disable app/views/studies/_synced_study_file_form.html.erb button until user has selected a BAM file
+        // disable sync button until user has selected a BAM file
         submitBtn.attr('disabled', 'disabled');
     } else {
         extraInfo.empty();

--- a/app/views/studies/_shared_sync_functions.js.erb
+++ b/app/views/studies/_shared_sync_functions.js.erb
@@ -8,6 +8,9 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', function() {
     var extraInfo = $('#study-file-<%= study_file.id %>-extra-info');
     var taxonTarget = form.find('.taxon-select-target');
     var submitBtn = $('#sync-study-file-<%= study_file.id %>');
+
+    console.log("Selected file type: " + fileType);
+
     // render fields & process entries based on file type
     if (fileType === 'Cluster') {
         extraInfo.html("<%= j(render partial: 'cluster_axis_fields', locals: {f: f}) %>");
@@ -46,10 +49,11 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', function() {
         console.log('disabling sync button on ' + submitBtn.attr('id'));
         submitBtn.attr('disabled', 'disabled');
     } else if (fileType === 'BAM' || fileType === 'Analysis Output') {
+        alert('Selected "Analysis Output"!')
         extraInfo.empty();
         taxonTarget.html("<%= j(render partial: 'taxon_fields', locals: {f: f}) %>");
         assemblySelect = form.find('.genome-assembly-association');
-        assemblySelect.removeClass('hidden')
+        assemblySelect.removeClass('hidden');
     } else if (fileType === 'Fastq') {
         extraInfo.empty();
         alert('Fastq files are stored in Sequence Data Directories (see below).  Please select another file type.');
@@ -111,3 +115,27 @@ $("#sync-study-file-<%= study_file.id %>").click(function() {
 $('#study-file-<%= study_file.id %>').on('change', '.filename', function() {
     validateName($(this).val(), $("#study-file-<%= study_file._id %> .filename"));
 });
+
+$(document).ready(function() {
+  var extraInfo, taxonFields;
+
+  extraInfo = $('#study-file-<%= study_file.id %>-extra-info');
+  taxonFields = "<%= j(render partial: 'taxon_fields', locals: {f: f}) %>";
+
+  // Creates "Species" and "Genome assembly" drop-down menu inputs
+  // for "Analysis Output" study files
+  $('.unsynced-study-file #study_file_file_type').each(function(i, el) {
+    var taxonTarget, assemblySelect, form,
+      fileTypeInput = $(el);
+
+    if (fileTypeInput.val() !== 'Analysis Output') return;
+
+    extraInfo.empty();
+    form = fileTypeInput.closest('form');
+    taxonTarget = form.find('.taxon-select-target');
+    taxonTarget.html(taxonFields)
+
+    assemblySelect = form.find('.genome-assembly-association');
+    assemblySelect.removeClass('hidden');
+  });
+})

--- a/app/views/studies/_synced_study_file_form.html.erb
+++ b/app/views/studies/_synced_study_file_form.html.erb
@@ -60,7 +60,7 @@
       <%= render partial: 'layouts/download_link', locals: {study_file: study_file} %>
     </div>
     <div class="col-sm-4 taxon-select-target">
-      <% if study_file.file_type == 'BAM' || study_file.file_type == 'Fastq' %>
+      <% if study_file.file_type == 'BAM' || study_file.file_type == 'Fastq' || study_file.file_type == 'Analysis Output' %>
         <%= render partial: 'taxon_fields', locals: {f: f} %>
       <% end %>
     </div>

--- a/app/views/studies/_taxon_fields.html.erb
+++ b/app/views/studies/_taxon_fields.html.erb
@@ -21,21 +21,21 @@
       window.isTaxonSelectHandlerDefined = true;
 
       $(document).on('change', '.taxon-select', function () {
-        var speciesDropown = $(this);
-        var assemblyDropdown = speciesDropown.find('.genome-assembly-select');
-        var selectedTaxon = speciesDropown.val();
+        var speciesDropdown = $(this);
+        var assemblyDropdown = speciesDropdown.parentsUntil('.taxon-select-target').find('.genome-assembly-select');
+        var selectedTaxon = speciesDropdown.val();
         if (selectedTaxon !== '') {
           // perform check to see if human was selected
-          var fileType = speciesDropown.find('#study_file_file_type').val();
+          var fileType = speciesDropdown.find('#study_file_file_type').val();
           $.getJSON('<%= get_taxon_path %>?taxon=' + selectedTaxon, function (taxon) {
             if ((fileType === 'BAM' || fileType === 'Fastq') && restrictedTaxons.includes(taxon.taxon_identifier)) {
               var restrictedData = confirm('Is this ' + fileType + ' file ' + taxon.common_name + ' data?\n\n' +
                 'The Single Cell Portal does not currently permit storing ' + taxon.common_name + ' sequence data.  ' +
                 'Selecting "OK" will remove this list from your study (source data files will be unaffected).');
               if (restrictedData) {
-                speciesDropown.remove();
+                speciesDropdown.remove();
               } else {
-                speciesDropown.val('');
+                speciesDropdown.val('');
                 assemblyDropdown.empty();
                 assemblyDropdown.append('<option value="">Please select species...</option>');
               }

--- a/app/views/studies/_taxon_fields.html.erb
+++ b/app/views/studies/_taxon_fields.html.erb
@@ -13,43 +13,51 @@
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
 
     var restrictedTaxons = <%= raw Taxon::RESTRICTED_NCBI_TAXON_IDS %>;
-    $('#study-file-<%= f.object.id %>').find('.taxon-select').on('change', function() {
-        var select = $(this);
-        var assemblyDropdown = $('#study-file-<%= f.object.id %>').find('.genome-assembly-select');
-        var selectedTaxon = $(this).val();
+
+    if (typeof isTaxonSelectHandlerDefined === 'undefined') {
+
+      // Ensures event handler is attached only once;
+      // needed for e.g. _share_sync_functions.js.erb
+      window.isTaxonSelectHandlerDefined = true;
+
+      $(document).on('change', '.taxon-select', function () {
+        var speciesDropown = $(this);
+        var assemblyDropdown = speciesDropown.find('.genome-assembly-select');
+        var selectedTaxon = speciesDropown.val();
         if (selectedTaxon !== '') {
-            // perform check to see if human was selected
-            var fileType = $('#study-file-<%= f.object.id %>').find('#study_file_file_type').val();
-            $.getJSON('<%= get_taxon_path %>?taxon=' + selectedTaxon, function(taxon) {
-                if ( (fileType === 'BAM' || fileType === 'Fastq' ) && restrictedTaxons.includes(taxon.taxon_identifier) ) {
-                    var restrictedData = confirm('Is this ' + fileType + ' file ' + taxon.common_name + ' data?\n\n' +
-                        'The Single Cell Portal does not currently permit storing ' + taxon.common_name + ' sequence data.  ' +
-                        'Selecting "OK" will remove this list from your study (source data files will be unaffected).');
-                    if (restrictedData) {
-                        $('#study-file-<%= f.object.id %>').remove();
-                    } else {
-                        select.val('');
-                        assemblyDropdown.empty();
-                        assemblyDropdown.append('<option value="">Please select species...</option>');
-                    }
-                } else {
-                    $.getJSON('<%= get_taxon_assemblies_path %>?taxon=' + selectedTaxon, function (data) {
-                            assemblyDropdown.empty();
-                            $(data).each(function (index, assembly) {
-                                assemblyDropdown.append($('<option />', {
-                                    value: assembly[1],
-                                    text: assembly[0]
-                                }));
-                            });
-                        }
-                    )
+          // perform check to see if human was selected
+          var fileType = speciesDropown.find('#study_file_file_type').val();
+          $.getJSON('<%= get_taxon_path %>?taxon=' + selectedTaxon, function (taxon) {
+            if ((fileType === 'BAM' || fileType === 'Fastq') && restrictedTaxons.includes(taxon.taxon_identifier)) {
+              var restrictedData = confirm('Is this ' + fileType + ' file ' + taxon.common_name + ' data?\n\n' +
+                'The Single Cell Portal does not currently permit storing ' + taxon.common_name + ' sequence data.  ' +
+                'Selecting "OK" will remove this list from your study (source data files will be unaffected).');
+              if (restrictedData) {
+                speciesDropown.remove();
+              } else {
+                speciesDropown.val('');
+                assemblyDropdown.empty();
+                assemblyDropdown.append('<option value="">Please select species...</option>');
+              }
+            } else {
+              $.getJSON('<%= get_taxon_assemblies_path %>?taxon=' + selectedTaxon, function (data) {
+                  assemblyDropdown.empty();
+                  $(data).each(function (index, assembly) {
+                    assemblyDropdown.append($('<option />', {
+                      value: assembly[1],
+                      text: assembly[0]
+                    }));
+                  });
                 }
-            })
+              )
+            }
+          })
 
         } else {
-            assemblyDropdown.empty();
-            assemblyDropdown.append('<option value="">Please select species...</option>');
+          assemblyDropdown.empty();
+          assemblyDropdown.append('<option value="">Please select species...</option>');
         }
-    });
+      });
+    }
 
 </script>

--- a/app/views/studies/_taxon_fields.html.erb
+++ b/app/views/studies/_taxon_fields.html.erb
@@ -1,11 +1,12 @@
 <div class="row">
   <div class="col-xs-6">
     <%= f.label :taxon_id, 'Species' %><br />
-    <%= f.select :taxon_id, options_from_collection_for_select(Taxon.sorted, :id, :display_name, f.object.taxon_id), {prompt: 'None selected...'}, {class: 'form-control taxon-select'} %>
+    <%= f.select :taxon_id, options_from_collection_for_select(Taxon.sorted, :id, :display_name, f.object.taxon_id), {include_blank: 'None selected...'}, {class: 'form-control taxon-select'} %>
   </div>
-  <div class="col-xs-6 genome-assembly-association hidden">
-    <%= f.label :genome_assembly_id, 'Genome Assembly' %><br />
-    <%= f.select :genome_assembly_id, options_for_select([]), {prompt: 'Please select species...'}, {class: 'form-control genome-assembly-select'} %>
+  <div class="col-xs-6 <%= f.object.file_type == 'BAM' || f.object.file_type == 'Analysis Output' ? nil : 'hidden' %> genome-assembly-association">
+    <%= f.label :genome_assembly_id, 'Genome Assembly' %><br/>
+    <% assemblies = f.object.genome_assembly.present? ? f.object.genome_assembly.taxon.genome_assemblies.map {|a| [a.name, a.id]} : [] %>
+    <%= f.select :genome_assembly_id, options_for_select(assemblies, f.object.genome_assembly.present? ? f.object.genome_assembly.id : nil), {prompt: 'Please select species...'}, {class: 'form-control genome-assembly-select'} %>
   </div>
 </div>
 

--- a/app/views/taxons/_genome_annotation_fields.html.erb
+++ b/app/views/taxons/_genome_annotation_fields.html.erb
@@ -12,6 +12,10 @@
       <%= f.label :link %><br />
       <%= f.text_field :link, class: 'form-control' %>
     </div>
+    <div class="col-sm-7">
+      <%= f.label :index_link %><br/>
+      <%= f.text_field :index_link, class: 'form-control' %>
+    </div>
     <div class="col-sm-1">
       <label>&nbsp;</label><br />
       <%= f.link_to_remove "<span class='btn btn-sm btn-danger'><span class='fas fa-times'></span></span>".html_safe, data: {confirm: 'Are you sure?  This cannot be undone unless you reload the page before saving.'} %>


### PR DESCRIPTION
This removes hard-coded species data in SCP's genome visualization components, i.e. igv.js and Ideogram.js.  

Previously, igv.js hard-coded the mouse genome "mm10" and Ideogram.js hard-coded "human" and its "GRCh38" assembly.  Now, that data is pulled in dynamically, ultimately from our new species-related models.

Fixes for upstream issues in setting species data during file sync are also included.

Ultimately, this change will enable our genome visualizations to more easily support additional organisms.