### PR TITLE
Fix legend overlapping scatter plot

### DIFF
--- a/app/views/site/render_cluster.js.erb
+++ b/app/views/site/render_cluster.js.erb
@@ -27,6 +27,15 @@ $(window).on('resizeEnd', function() {
     }
 });
 
+// Ensure cluster plot is sized properly upon clicking Explore tab (SCP-1106)
+$('body').on('click', '#study-visualize-nav > a', function() {
+  window.exploreResizeTO = setTimeout(function () {
+    $(window).trigger('resizeEnd');
+    delete window.exploreResizeTO;
+    $('#study-visualize-nav > a').off('click');
+  }, 50);
+})
+
 // attach click event for toggle switch
 $('#toggle-traces').click(function() {
     togglePlotlyTraces('cluster-plot');


### PR DESCRIPTION
This ensures that the plot depicted clusters is sized properly upon clicking Explore tab.  

Previously, upon e.g. going from the home page to a study page then clicking "Explore", the plot was sometimes very narrow and its legend was mashed on top of it.  Now the appropriate width is calculated immediately after clicking the Explore tab, fixing the layout bug.