### PR TITLE
updates to Taxon.parse_from_file

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -81,7 +81,7 @@ class TaxonsController < ApplicationController
     begin
       species_upload = params[:upload]
       new_records = Taxon.parse_from_file(species_upload, current_user)
-      redirect_to taxons_path, notice: "Upload successful - new species added: #{new_records[:new_species]}, new assemblies added: #{new_records[:new_assemblies]}"
+      redirect_to taxons_path, notice: "Upload successful - new/updated species added: #{new_records[:new_species]}, new/updated assemblies added: #{new_records[:new_assemblies]}, new/updated annotations added: #{new_records[:new_annotations]}"
     rescue => e
       Rails.logger.error "Error parsing uploaded species file: #{e.message}"
       redirect_to taxons_path, alert: "An error occurred while parsing the uploaded file: #{e.message}"

--- a/app/models/genome_annotation.rb
+++ b/app/models/genome_annotation.rb
@@ -9,7 +9,7 @@ class GenomeAnnotation
   field :index_link, type: String
   field :release_date, type: Date
 
-  validates_presence_of :name, :link, :release_date
+  validates_presence_of :name, :link, :index_link, :release_date
   validates_uniqueness_of :name, scope: :genome_assembly_id
 
   validate :check_genome_annotation_link


### PR DESCRIPTION
Admins can now specify genome annotations when uploading a file containing species information.  Also, and entries that already exist in the database will be updated with new information to preserve current associations.