### PR TITLE
API retry backoffs, StudyFileBundle bugfixes, Docker updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM broadinstitute/kdux-rails-baseimage:1.5
+FROM broadinstitute/kdux-rails-baseimage:1.6
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-2.5.1'

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,5 @@ COPY webapp.conf /etc/nginx/sites-enabled/webapp.conf
 COPY nginx.conf /etc/nginx/nginx.conf
 RUN rm -f /etc/service/nginx/down
 
-# Compile native support for passenger for Ruby 2.3
+# Compile native support for passenger for Ruby 2.5
 RUN passenger-config build-native-support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
     gibberish (2.1.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    google-api-client (0.24.2)
+    google-api-client (0.25.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)
       httpclient (>= 2.8.1, < 3.0)
@@ -163,15 +163,15 @@ GEM
       google-cloud-env (~> 1.0)
     google-cloud-env (1.0.5)
       faraday (~> 0.11)
-    google-cloud-storage (1.14.2)
+    google-cloud-storage (1.15.0)
       digest-crc (~> 0.4)
       google-api-client (~> 0.23)
       google-cloud-core (~> 1.2)
       googleauth (~> 0.6.2)
-    googleauth (0.6.6)
+    googleauth (0.6.7)
       faraday (~> 0.12)
       jwt (>= 1.4, < 3.0)
-      memoist (~> 0.12)
+      memoist (~> 0.16)
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.7)
@@ -350,7 +350,7 @@ GEM
     selenium-webdriver (3.14.1)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
-    signet (0.10.0)
+    signet (0.11.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
@@ -454,4 +454,4 @@ DEPENDENCIES
   will_paginate_mongoid
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,7 +276,7 @@ GEM
     parallel (1.12.1)
     power_assert (1.1.3)
     public_suffix (3.0.3)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-proxy (0.6.4)
       rack
     rack-test (1.1.0)

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -432,7 +432,7 @@ module Api
         begin
           # create a map of file extension to use for creating directory_listings of groups of 10+ files of the same type
           @file_extension_map = {}
-          workspace_files = Study.firecloud_client.execute_gcloud_method(:get_workspace_files, @study.firecloud_project, @study.firecloud_workspace)
+          workspace_files = Study.firecloud_client.execute_gcloud_method(:get_workspace_files, 0, @study.firecloud_project, @study.firecloud_workspace)
           # see process_workspace_bucket_files in private methods for more details on syncing
           process_workspace_bucket_files(workspace_files)
           while workspace_files.next?
@@ -466,24 +466,37 @@ module Api
         # now remove files that we found that were supposed to be in directory_listings
         @unsynced_files.delete_if {|file| files_to_remove.include?(file.generation)}
 
-        # now check against latest list of files by directory vs. what was just found to see if we are missing anything and add directory to unsynced list
+        # now check against latest list of files by directory vs. what was just found to see if we are missing anything and
+        # add directory to unsynced list. also check if an existing directory is now 'orphaned' because it was moved and
+        # store that reference for removal after the check is complete
+        orphaned_directories = []
         @directories.each do |directory|
           synced = true
-          directory.files.each do |file|
-            if @files_by_dir[directory.name].detect {|f| f['generation'].to_s == file['generation'].to_s}.nil?
-              synced = false
-              directory.files.delete(file)
-            else
-              next
+          if @files_by_dir[directory.name].present?
+            directory.files.each do |file|
+              if @files_by_dir[directory.name].detect {|f| f['generation'].to_s == file['generation'].to_s}.nil?
+                synced = false
+                directory.files.delete(file)
+              else
+                next
+              end
             end
+            # if no longer synced, check if already in the list and remove as files list has changed
+            if !synced
+              @unsynced_directories.delete_if {|dir| dir.name == directory.name}
+              @unsynced_directories << directory
+            elsif directory.sync_status
+              @synced_directories << directory
+            end
+          else
+            # directory did not exist in @files_by_dir, so this directory_listing is orphaned and should be removed
+            orphaned_directories << directory
           end
-          # if no longer synced, check if already in the list and remove as files list has changed
-          if !synced
-            @unsynced_directories.delete_if {|dir| dir.name == directory.name}
-            @unsynced_directories << directory
-          elsif directory.sync_status
-            @synced_directories << directory
-          end
+        end
+
+        # remove orphaned directories
+        orphaned_directories.each do |orphan|
+          orphan.destroy
         end
 
         # provisionally save unsynced directories so we don't have to pass huge arrays of filenames/sizes in the form
@@ -492,6 +505,9 @@ module Api
           directory.save
         end
 
+        # reload unsynced directories to remove any that were orphaned
+        @unsynced_directories = @study.directory_listings.unsynced
+
         # split directories into primary data types and 'others'
         @unsynced_primary_data_dirs = @unsynced_directories.select {|dir| dir.file_type == 'fastq'}
         @unsynced_other_dirs = @unsynced_directories.select {|dir| dir.file_type != 'fastq'}
@@ -499,6 +515,10 @@ module Api
         # now determine if we have study_files that have been 'orphaned' (cannot find a corresponding bucket file)
         @orphaned_study_files = @study_files - @synced_study_files
         @available_files = @unsynced_files.map {|f| {name: f.name, generation: f.generation, size: f.upload_file_size}}
+
+        # now remove any 'bundled' files from @synced_study_files so we can render them inside their parent file's form
+        bundled_file_ids = @study.study_file_bundles.map {|bundle| bundle.bundled_files.to_a.map(&:id)}.flatten
+        @synced_study_files.delete_if {|file| bundled_file_ids.include?(file.id)}
       end
 
       private

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -349,10 +349,10 @@ module Api
         begin
           # make sure file is in FireCloud first
           unless human_data || @study_file.generation.blank?
-            present = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, @study.firecloud_project,
+            present = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, @study.firecloud_project,
                                                                    @study.firecloud_workspace, @study_file.upload_file_name)
             if present
-              Study.firecloud_client.execute_gcloud_method(:delete_workspace_file, @study.firecloud_project,
+              Study.firecloud_client.execute_gcloud_method(:delete_workspace_file, 0, @study.firecloud_project,
                                                            @study.firecloud_workspace, @study_file.upload_file_name)
             end
           end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -703,13 +703,13 @@ class SiteController < ApplicationController
 
     begin
       # get filesize and make sure the user is under their quota
-      requested_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, @study.firecloud_project, @study.firecloud_workspace, params[:filename])
+      requested_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, @study.firecloud_project, @study.firecloud_workspace, params[:filename])
       if requested_file.present?
         filesize = requested_file.size
         user_quota = current_user.daily_download_quota + filesize
         # check against download quota that is loaded in ApplicationController.get_download_quota
         if user_quota <= @download_quota
-          @signed_url = Study.firecloud_client.execute_gcloud_method(:generate_signed_url, @study.firecloud_project, @study.firecloud_workspace, params[:filename], expires: 15)
+          @signed_url = Study.firecloud_client.execute_gcloud_method(:generate_signed_url, 0, @study.firecloud_project, @study.firecloud_workspace, params[:filename], expires: 15)
           current_user.update(daily_download_quota: user_quota)
         else
           redirect_to merge_default_redirect_params(view_study_path(@study.url_safe_name), scpbr: params[:scpbr]), alert: 'You have exceeded your current daily download quota.  You must wait until tomorrow to download this file.' and return
@@ -1268,7 +1268,7 @@ class SiteController < ApplicationController
       logger.info "#{Time.now}: deleting analysis metadata for #{params[:submission_id]} in #{@study.url_safe_name}"
       AnalysisMetadatum.where(submission_id: params[:submission_id]).delete
       logger.info "#{Time.now}: queueing submission #{params[:submission]} deletion in #{@study.firecloud_workspace}"
-      submission_files = Study.firecloud_client.execute_gcloud_method(:get_workspace_files, @study.firecloud_project, @study.firecloud_workspace, prefix: params[:submission_id])
+      submission_files = Study.firecloud_client.execute_gcloud_method(:get_workspace_files, 0, @study.firecloud_project, @study.firecloud_workspace, prefix: params[:submission_id])
       DeleteQueueJob.new(submission_files).perform
     rescue => e
       logger.error "#{Time.now}: unable to remove submission #{params[:submission_id]} files from #{@study.firecloud_workspace} due to: #{e.message}"
@@ -2224,11 +2224,11 @@ class SiteController < ApplicationController
     filename = (is_study_file ? file.upload_file_name : file[:name])
 
     begin
-      signed_url = fc_client.execute_gcloud_method(:generate_signed_url,
-                                                              @study.firecloud_project,
-                                                              @study.firecloud_workspace,
-                                                              filename,
-                                                              expires: 1.day.to_i) # 1 day in seconds, 86400
+      signed_url = fc_client.execute_gcloud_method(:generate_signed_url, 0,
+                                                   @study.firecloud_project,
+                                                   @study.firecloud_workspace,
+                                                   filename,
+                                                   expires: 1.day.to_i) # 1 day in seconds, 86400
       curl_config = [
           'url="' + signed_url + '"',
           'output="' + filename + '"'

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -155,7 +155,7 @@ class StudiesController < ApplicationController
     begin
       # create a map of file extension to use for creating directory_listings of groups of 10+ files of the same type
       @file_extension_map = {}
-      workspace_files = Study.firecloud_client.execute_gcloud_method(:get_workspace_files, @study.firecloud_project, @study.firecloud_workspace)
+      workspace_files = Study.firecloud_client.execute_gcloud_method(:get_workspace_files, 0, @study.firecloud_project, @study.firecloud_workspace)
       # see process_workspace_bucket_files in private methods for more details on syncing
       process_workspace_bucket_files(workspace_files)
       while workspace_files.next?
@@ -281,7 +281,7 @@ class StudiesController < ApplicationController
         workflow['outputs'].each do |output, file_url|
           file_location = file_url.gsub(/gs\:\/\/#{@study.bucket_id}\//, '')
           # get google instance of file
-          file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, @study.firecloud_project,
+          file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, @study.firecloud_project,
                                                               @study.firecloud_workspace, file_location)
           if file.present?
             # depending on the requested 'depth' of the new file (i.e. how many directories to include in the new name),
@@ -298,7 +298,7 @@ class StudiesController < ApplicationController
             end
             # check if file has already been synced first
             # we can only do this by md5 hash as the filename and generation will be different
-            existing_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, @study.firecloud_project,
+            existing_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, @study.firecloud_project,
                                                                          @study.firecloud_workspace, new_location)
             if existing_file.present? && existing_file.md5 == file.md5 && StudyFile.where(study_id: @study.id, upload_file_name: new_location).exists?
               next
@@ -782,14 +782,14 @@ class StudiesController < ApplicationController
     end
     begin
       # get filesize and make sure the user is under their quota
-      requested_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, @study.firecloud_project,
+      requested_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, @study.firecloud_project,
                                                                     @study.firecloud_workspace, params[:filename])
       if requested_file.present?
         filesize = requested_file.size
         user_quota = current_user.daily_download_quota + filesize
         # check against download quota that is loaded in ApplicationController.get_download_quota
         if user_quota <= @download_quota
-          @signed_url = Study.firecloud_client.execute_gcloud_method(:generate_signed_url, @study.firecloud_project,
+          @signed_url = Study.firecloud_client.execute_gcloud_method(:generate_signed_url, 0, @study.firecloud_project,
                                                                      @study.firecloud_workspace, params[:filename], expires: 15)
           current_user.update(daily_download_quota: user_quota)
         else
@@ -1011,10 +1011,10 @@ class StudiesController < ApplicationController
         begin
           # make sure file is in FireCloud first as user may be aborting the upload
           unless human_data
-            present = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, @study.firecloud_project,
+            present = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, @study.firecloud_project,
                                                                    @study.firecloud_workspace, @study_file.upload_file_name)
             if present
-              Study.firecloud_client.execute_gcloud_method(:delete_workspace_file, @study.firecloud_project,
+              Study.firecloud_client.execute_gcloud_method(:delete_workspace_file, 0, @study.firecloud_project,
                                                            @study.firecloud_workspace, @study_file.upload_file_name)
             end
           end

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -228,14 +228,15 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   #   - +path+ (String) => FireCloud REST API path
   #   - +payload+ (Hash) => HTTP POST/PATCH/PUT body for creates/updates, defaults to nil
   #		- +opts+ (Hash) => Hash of extra options (defaults are file_upload=false, max_attemps=MAX_RETRY_COUNT)
+  #   - +retry_count+ (Integer) => current count of number of retries.  defaults to 0 and self-increments
   #
   # * *return*
   #   - +Hash+, +Boolean+ depending on response body
   # * *raises*
   #   - +RuntimeError+
-  def process_firecloud_request(http_method, path, payload=nil, opts={})
+  def process_firecloud_request(http_method, path, payload=nil, opts={}, retry_count=0)
     # set up default options
-    request_opts = {file_upload: false, max_attempts: MAX_RETRY_COUNT}.merge(opts)
+    request_opts = {file_upload: false}.merge(opts)
 
     # check for token expiry first before executing
     if self.access_token_expired?
@@ -251,24 +252,18 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
       headers.merge!({'Content-Type' => 'application/json'})
     end
 
-    # initialize counter to prevent endless feedback loop
-    @retry_count ||= 0
-
     # process request
-    if @retry_count < request_opts[:max_attempts]
+    if retry_count < MAX_RETRY_COUNT
       begin
-        @retry_count += 1
         @obj = RestClient::Request.execute(method: http_method, url: path, payload: payload, headers: headers)
         # handle response codes as necessary
         if ok?(@obj.code) && !@obj.body.blank?
-          @retry_count = 0
           begin
             return JSON.parse(@obj.body)
           rescue JSON::ParserError => e
             return @obj.body
           end
         elsif ok?(@obj.code) && @obj.body.blank?
-          @retry_count = 0
           return true
         else
           Rails.logger.info "#{Time.now}: Unexpected response #{@obj.code}, not sure what to do here..."
@@ -283,10 +278,9 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
           retry_time = (@retry_count - 1) * RETRY_INTERVAL
           sleep(retry_time)
         end
-        process_firecloud_request(http_method, path, payload, opts)
+        process_firecloud_request(http_method, path, payload, opts, retry_count + 1)
       end
     else
-      @retry_count = 0
       error_message = parse_error_message(@error)
       Rails.logger.error "#{Time.now}: Retry count exceeded - #{error_message}"
       raise RuntimeError.new(error_message)
@@ -1249,29 +1243,27 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   #
   # * *params*
   #   - +method_name+ (String, Symbol) => name of FireCloudClient GCS method to execute
+  #   - +retry_count+ (Integer) => current count of number of retries.  defaults to 0 and self-increments
   #   - +params+ (Array) => array of method parameters (passed with splat operator, so does not need to be an actual array)
   #
   # * *return*
   #   - Object depends on method, can be one of the following: +Google::Cloud::Storage::Bucket+, +Google::Cloud::Storage::File+,
   #     +Google::Cloud::Storage::FileList+, +Boolean+, +File+, or +String+
 
-  def execute_gcloud_method(method_name, *params)
-    @retries ||= 0
-    if @retries < MAX_RETRY_COUNT
+  def execute_gcloud_method(method_name, retry_count=0, *params)
+    if retry_count < MAX_RETRY_COUNT
       begin
         self.send(method_name, *params)
       rescue => e
         @error = e.message
         Rails.logger.info "#{Time.now}: error calling #{method_name} with #{params.join(', ')}; #{e.message} -- retry ##{@retries}"
-        @retries += 1
         unless RETRY_IGNORE_LIST.include?(method_name)
           retry_time = (@retries - 1) * RETRY_INTERVAL
           sleep(retry_time)
         end
-        execute_gcloud_method(method_name, *params)
+        execute_gcloud_method(method_name, retry_count + 1, *params)
       end
     else
-      @retries = 0
       Rails.logger.info "#{Time.now}: Retry count exceeded: #{@error}"
       raise RuntimeError.new "#{@error}"
     end

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -20,8 +20,8 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   GOOGLE_SCOPES = %w(https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/cloud-billing.readonly https://www.googleapis.com/auth/devstorage.read_only)
   # constant used for retry loops in process_firecloud_request and execute_gcloud_method
   MAX_RETRY_COUNT = 5
-  # constant used for incremental backoffs on retries (in seconds)
-  RETRY_INTERVAL = 15
+  # constant used for incremental backoffs on retries (in seconds); ignored when running unit/integration test suite
+  RETRY_INTERVAL = Rails.env == 'test' ? 0 : 15
   # default namespace used for all FireCloud workspaces owned by the 'portal'
   PORTAL_NAMESPACE = 'single-cell-portal'
   # location of Google service account JSON (must be absolute path to file)

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -22,6 +22,7 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   MAX_RETRY_COUNT = 5
   # constant used for incremental backoffs on retries (in seconds); ignored when running unit/integration test suite
   RETRY_INTERVAL = Rails.env == 'test' ? 0 : 15
+  # List of URLs/Method names to ignore incremental backoffs on (in cases of UI blocking)
   RETRY_IGNORE_LIST = ["#{BASE_URL}/register", :generate_signed_url, :generate_api_url]
   # default namespace used for all FireCloud workspaces owned by the 'portal'
   PORTAL_NAMESPACE = 'single-cell-portal'

--- a/app/models/genome_annotation.rb
+++ b/app/models/genome_annotation.rb
@@ -32,7 +32,7 @@ class GenomeAnnotation
       if config.present?
         begin
           reference_project, reference_workspace = config.value.split('/')
-          Study.firecloud_client.execute_gcloud_method(:generate_api_url, reference_project,
+          Study.firecloud_client.execute_gcloud_method(:generate_api_url, 0, reference_project,
                                                                  reference_workspace, self.link)
         rescue => e
           Rails.logger.error "Cannot generate public genome annotation link for #{self.link}: #{e.message}"
@@ -55,7 +55,7 @@ class GenomeAnnotation
       if config.present?
         begin
           reference_project, reference_workspace = config.value.split('/')
-          Study.firecloud_client.execute_gcloud_method(:generate_api_url, reference_project,
+          Study.firecloud_client.execute_gcloud_method(:generate_api_url, 0, reference_project,
                                                        reference_workspace, self.index_link)
         rescue => e
           Rails.logger.error "Cannot generate public genome annotation index link for #{self.index_link}: #{e.message}"
@@ -78,7 +78,7 @@ class GenomeAnnotation
       if config.present?
         begin
           reference_project, reference_workspace = config.value.split('/')
-          Study.firecloud_client.execute_gcloud_method(:generate_signed_url, reference_project,
+          Study.firecloud_client.execute_gcloud_method(:generate_signed_url, 0, reference_project,
                                                        reference_workspace, self.link, expires: 15)
         rescue => e
           Rails.logger.error "Cannot generate genome annotation download link for #{self.link}: #{e.message}"
@@ -113,8 +113,8 @@ class GenomeAnnotation
       if config.present?
         begin
           reference_project, reference_workspace = config.value.split('/')
-          genome_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, reference_project, reference_workspace,
-                                                                     self.link)
+          genome_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, reference_project,
+                                                                     reference_workspace, self.link)
           if !genome_file.present?
             errors.add(:link, "was not found in the reference workspace of #{config.value}.  Please check the link and try again.")
           end
@@ -145,8 +145,8 @@ def check_genome_annotation_index_link
     if config.present?
       begin
         reference_project, reference_workspace = config.value.split('/')
-        genome_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, reference_project, reference_workspace,
-                                                                   self.index_link)
+        genome_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, reference_project,
+                                                                   reference_workspace, self.index_link)
         if !genome_file.present?
           errors.add(:index_link, "was not found in the reference workspace of #{config.value}.  Please check the index link and try again.")
         end

--- a/app/models/parse_utils.rb
+++ b/app/models/parse_utils.rb
@@ -296,7 +296,7 @@ class ParseUtils
       local_path = File.join(study.data_store_path, study_file.download_location)
     else
       Rails.logger.info "Downloading #{study_file.upload_file_name} from remote"
-      Study.firecloud_client.execute_gcloud_method(:download_workspace_file, study.firecloud_project,
+      Study.firecloud_client.execute_gcloud_method(:download_workspace_file, 0, study.firecloud_project,
                                                    study.firecloud_workspace, study_file.bucket_location,
                                                    study.data_store_path, verify: :none)
       Rails.logger.info "Successful localization of #{study_file.upload_file_name}"

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1209,7 +1209,9 @@ class Study
       if !opts[:local] || !expression_file.is_local?
         # make sure data dir exists first
         self.make_data_dir
-        Study.firecloud_client.execute_gcloud_method(:download_workspace_file, self.firecloud_project, self.firecloud_workspace, expression_file.bucket_location, self.data_store_path, verify: :none)
+        Study.firecloud_client.execute_gcloud_method(:download_workspace_file, 0, self.firecloud_project,
+                                                     self.firecloud_workspace, expression_file.bucket_location,
+                                                     self.data_store_path, verify: :none)
         @file_location = File.join(self.data_store_path, expression_file.bucket_location)
       end
 
@@ -1477,7 +1479,9 @@ class Study
         # make sure data dir exists first
         Rails.logger.info "Localizing file: #{ordinations_file.upload_file_name} in #{self.data_store_path}"
         self.make_data_dir
-        Study.firecloud_client.execute_gcloud_method(:download_workspace_file, self.firecloud_project, self.firecloud_workspace, ordinations_file.bucket_location, self.data_store_path, verify: :none)
+        Study.firecloud_client.execute_gcloud_method(:download_workspace_file, 0, self.firecloud_project,
+                                                     self.firecloud_workspace, ordinations_file.bucket_location,
+                                                     self.data_store_path, verify: :none)
         @file_location = File.join(self.data_store_path, ordinations_file.bucket_location)
       end
 
@@ -1823,7 +1827,9 @@ class Study
       if !opts[:local] || !coordinate_file.is_local?
         # make sure data dir exists first
         self.make_data_dir
-        Study.firecloud_client.execute_gcloud_method(:download_workspace_file, self.firecloud_project, self.firecloud_workspace, coordinate_file.bucket_location, self.data_store_path, verify: :none)
+        Study.firecloud_client.execute_gcloud_method(:download_workspace_file, 0, self.firecloud_project,
+                                                     self.firecloud_workspace, coordinate_file.bucket_location,
+                                                     self.data_store_path, verify: :none)
         @file_location = File.join(self.data_store_path, coordinate_file.bucket_location)
       end
 
@@ -2044,7 +2050,9 @@ class Study
       if !opts[:local] || !metadata_file.is_local?
         # make sure data dir exists first
         self.make_data_dir
-        Study.firecloud_client.execute_gcloud_method(:download_workspace_file, self.firecloud_project, self.firecloud_workspace, metadata_file.bucket_location, self.data_store_path, verify: :none)
+        Study.firecloud_client.execute_gcloud_method(:download_workspace_file, 0, self.firecloud_project,
+                                                     self.firecloud_workspace, metadata_file.bucket_location,
+                                                     self.data_store_path, verify: :none)
         @file_location = File.join(self.data_store_path, metadata_file.bucket_location)
       end
 
@@ -2321,7 +2329,9 @@ class Study
       if !opts[:local] || !marker_file.is_local?
         # make sure data dir exists first
         self.make_data_dir
-        Study.firecloud_client.execute_gcloud_method(:download_workspace_file, self.firecloud_project, self.firecloud_workspace, marker_file.bucket_location, self.data_store_path, verify: :none)
+        Study.firecloud_client.execute_gcloud_method(:download_workspace_file, 0, self.firecloud_project,
+                                                     self.firecloud_workspace, marker_file.bucket_location,
+                                                     self.data_store_path, verify: :none)
         @file_location = File.join(self.data_store_path, marker_file.bucket_location)
       end
 
@@ -2522,7 +2532,9 @@ class Study
         File.rename gzip_filepath, file_location
         opts.merge!(content_encoding: 'gzip')
       end
-      remote_file = Study.firecloud_client.execute_gcloud_method(:create_workspace_file, self.firecloud_project, self.firecloud_workspace, file.upload.path, file.bucket_location, opts)
+      remote_file = Study.firecloud_client.execute_gcloud_method(:create_workspace_file, 0, self.firecloud_project,
+                                                                 self.firecloud_workspace, file.upload.path,
+                                                                 file.bucket_location, opts)
       # store generation tag to know whether a file has been updated in GCP
       Rails.logger.info "#{Time.now}: Updating #{file.bucket_location}:#{file.id} with generation tag: #{remote_file.generation} after successful upload"
       file.update(generation: remote_file.generation)

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -2499,7 +2499,7 @@ class Study
   def send_to_firecloud(file)
     begin
       Rails.logger.info "#{Time.now}: Uploading #{file.bucket_location}:#{file.id} to FireCloud workspace: #{self.firecloud_workspace}"
-      file_location = file.remote_location.blank? ? file.upload.path : File.join(self.data_store_path, file.remote_location)
+      file_location = file.local_location.to_s
       # determine if file needs to be compressed
       first_two_bytes = File.open(file_location).read(2)
       gzip_signature = StudyFile::GZIP_MAGIC_NUMBER # per IETF

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -836,7 +836,9 @@ class StudyFile
           puts msg
           Rails.logger.info msg
           file_location = File.join(study.data_store_path, self.download_location)
-          Study.firecloud_client.execute_gcloud_method(:download_workspace_file, study.firecloud_project, study.firecloud_workspace, self.bucket_location, download_location, verify: :none)
+          Study.firecloud_client.execute_gcloud_method(:download_workspace_file, 0, study.firecloud_project,
+                                                       study.firecloud_workspace, self.bucket_location, download_location,
+                                                       verify: :none)
           content_type = self.determine_content_type
           shift_headers = true
           if content_type == 'application/gzip'

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -530,9 +530,18 @@ class StudyFile
     self.remote_location.blank? ? self.upload_file_name : self.remote_location
   end
 
+  def local_location
+    path = Rails.root.join(self.study.data_store_path, self.download_location)
+    if File.exists?(path)
+      path
+    else
+      path = Rails.root.join(self.study.data_store_path, self.bucket_location)
+      File.exists?(path) ? path : nil
+    end
+  end
+
   def is_local?
-    File.exists?(Rails.root.join(self.study.data_store_path, self.download_location)) ||
-        File.exists?(Rails.root.join(self.study.data_store_path, self.bucket_location))
+    self.local_location.present?
   end
 
   # get any 'bundled' files that correspond to this file

--- a/app/models/upload_cleanup_job.rb
+++ b/app/models/upload_cleanup_job.rb
@@ -15,15 +15,15 @@ class UploadCleanupJob < Struct.new(:study, :study_file, :retry_count)
     elsif study_file.queued_for_deletion || study.queued_for_deletion
       Rails.logger.info "#{Time.now}: aborting UploadCleanupJob for #{study_file.bucket_location}:#{study_file.id} in '#{study.name}', file queued for deletion"
     else
-      file_location = study_file.local_location
-      if !file_location.present?
+      if !study_file.is_local?
         Rails.logger.error "#{Time.now}: error in UploadCleanupJob for #{study.name}:#{study_file.bucket_location}:#{study_file.id}; file no longer present"
-        SingleCellMailer.admin_notification('File missing on cleanup', nil, "<p>The study file #{study_file.upload_file_name} was missing from the local file system at the time of cleanup job execution.  Please check #{study.firecloud_workspace} to ensure the upload occurred.</p>")
+        SingleCellMailer.admin_notification('File missing on cleanup', nil, "<p>The study file #{study_file.upload_file_name} was missing from the local file system at the time of cleanup job execution.  Please check #{study.firecloud_project}/#{study.firecloud_workspace} to ensure the upload occurred.</p>")
       else
         begin
           # check workspace bucket for existence of remote file
           Rails.logger.info "#{Time.now}: performing UploadCleanupJob for #{study_file.bucket_location}:#{study_file.id} in '#{study.name}'"
-          remote_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, study.firecloud_project, study.firecloud_workspace, study_file.bucket_location)
+          remote_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, study.firecloud_project,
+                                                                     study.firecloud_workspace, study_file.bucket_location)
           if remote_file.present?
             # check generation tags to make sure we're in sync
             Rails.logger.info "#{Time.now}: remote file located for #{study_file.bucket_location}:#{study_file.id}, checking generation tag"

--- a/app/models/upload_cleanup_job.rb
+++ b/app/models/upload_cleanup_job.rb
@@ -60,7 +60,7 @@ class UploadCleanupJob < Struct.new(:study, :study_file, :retry_count)
             Delayed::Job.enqueue(UploadCleanupJob.new(study, study_file, retries), run_at: run_at)
           else
             Rails.logger.error "#{Time.now}: error in UploadCleanupJob for #{study.name}:#{study_file.bucket_location}:#{study_file.id}; #{e.message}"
-            SingleCellMailer.admin_notification('UploadCleanupJob failure', nil, "<p>The following failure occurred when attempting to clean up #{study_file.upload.path}: #{e.message}</p>").deliver_now
+            SingleCellMailer.admin_notification('UploadCleanupJob failure', nil, "<p>The following failure occurred when attempting to upload/clean up #{study.firecloud_project}/#{study.firecloud_workspace}:#{study_file.bucket_location}: #{e.message}</p>").deliver_now
           end
         end
       end

--- a/app/views/admin_configurations/index.html.erb
+++ b/app/views/admin_configurations/index.html.erb
@@ -82,18 +82,18 @@
                   <%= f.hidden_field :status, value: @current_firecloud_status %>
                   <div class="form-group row">
                     <div class="col-md-offset-2 col-md-4">
-                      <%= link_to "Disable All Access".html_safe, '#/', class: "btn btn-lg btn-block btn-danger #{@current_firecloud_status == 'off' ? 'disabled' : 'firecloud-status'}", id: 'disable-firecloud-access', method: :post, data: {dismiss: @current_firecloud_status == 'off' ? nil : 'modal', status: 'off'} %>
+                      <%= link_to "Disable All Access".html_safe, '#/', class: "btn btn-lg btn-block btn-danger #{@current_firecloud_status == 'off' ? 'disabled' : 'firecloud-status'}", id: 'disable-firecloud-access', data: {dismiss: @current_firecloud_status == 'off' ? nil : 'modal', status: 'off'} %>
                     </div>
                     <div class="col-md-4">
-                      <%= link_to "Disable Local Access".html_safe, '#/', class: "btn btn-lg btn-block btn-danger #{@current_firecloud_status == 'off' ? 'disabled' : 'firecloud-status'}", id: 'disable-local-access', method: :post, data: {dismiss: @current_firecloud_status == 'off' ? nil : 'modal', status: 'local-off'} %>
+                      <%= link_to "Disable Local Access".html_safe, '#/', class: "btn btn-lg btn-block btn-danger #{@current_firecloud_status == 'off' ? 'disabled' : 'firecloud-status'}", id: 'disable-local-access', data: {dismiss: @current_firecloud_status == 'off' ? nil : 'modal', status: 'local-off'} %>
                     </div>
                   </div>
                   <div class="form-group row">
                     <div class="col-md-offset-2 col-md-4">
-                      <%= link_to "Disable Compute Access".html_safe, '#/', class: "btn btn-lg btn-block btn-warning #{@current_firecloud_status == 'readonly' ? 'disabled' : 'firecloud-status'}", id: 'disable-compute-access', method: :post, data: {dismiss: @current_firecloud_status == 'readonly' ? nil : 'modal', status: 'readonly'} %>
+                      <%= link_to "Disable Compute Access".html_safe, '#/', class: "btn btn-lg btn-block btn-warning #{@current_firecloud_status == 'readonly' ? 'disabled' : 'firecloud-status'}", id: 'disable-compute-access', data: {dismiss: @current_firecloud_status == 'readonly' ? nil : 'modal', status: 'readonly'} %>
                     </div>
                     <div class="col-md-4">
-                      <%= link_to "Enable All Access".html_safe, '#/', class: "btn btn-lg btn-block btn-success #{@current_firecloud_status == 'on' ? 'disabled' : 'firecloud-status'}", id: 'enable-firecloud-access', method: :post, data: {dismiss: @current_firecloud_status == 'on' ? nil : 'modal', status: 'on'} %>
+                      <%= link_to "Enable All Access".html_safe, '#/', class: "btn btn-lg btn-block btn-success #{@current_firecloud_status == 'on' ? 'disabled' : 'firecloud-status'}", id: 'enable-firecloud-access', data: {dismiss: @current_firecloud_status == 'on' ? nil : 'modal', status: 'on'} %>
                     </div>
                   </div>
                 <% end %>

--- a/app/views/single_cell_mailer/sanity_check.html.erb
+++ b/app/views/single_cell_mailer/sanity_check.html.erb
@@ -20,3 +20,4 @@
     <% end %>
   </tbody>
 </table>
+<p>Any files that were not uploaded to their respective buckets have been scheduled to retry.</p>

--- a/app/views/studies/_taxon_fields.html.erb
+++ b/app/views/studies/_taxon_fields.html.erb
@@ -24,7 +24,7 @@
         var selectedTaxon = speciesDropdown.val();
         if (selectedTaxon !== '') {
           // perform check to see if human was selected
-          var fileType = speciesDropdown.find('#study_file_file_type').val();
+          var fileType = speciesDropdown.parentsUntil('form').parent().find('.file-type').val();
           $.getJSON('<%= get_taxon_path %>?taxon=' + selectedTaxon, function (taxon) {
             if ((fileType === 'BAM' || fileType === 'Fastq') && taxon.restricted ) {
               var restrictedData = confirm('Is this ' + fileType + ' file ' + taxon.common_name + ' data?\n\n' +

--- a/test/integration/study_creation_test.rb
+++ b/test/integration/study_creation_test.rb
@@ -379,6 +379,22 @@ class StudyCreationTest < ActionDispatch::IntegrationTest
     assert updated_bundle.study_files.size == 3,
            "Associations did not set correctly on study_file_bundle, expected 3 but found #{updated_bundle.study_files.size}"
     assert updated_bundle.completed?, "Bundle did not successfully initialize, expected completed? to be true but found #{updated_bundle.completed?}"
+
+    # parse data
+    ParseUtils.cell_ranger_expression_parse(@study, @test_user, coordinate_matrix, genes_file, barcodes_file, {skip_upload: true})
+    assert @study.genes.size == 100, "Did not parse correct number of genes, expected 100 but found #{@study.genes.size}"
+
+    # delete a bundled file (must call DeleteQueueJob manually as delayed_job isn't running)
+    DeleteQueueJob.new(genes_file).perform
+    assert @study.genes.size == 0, "Did not delete parsed data when removing bundled file, expected 0 but found #{@study.genes.size}"
+    # reload the bundle and assert it is no longer completed
+    incomplete_bundle = @study.study_file_bundles.first
+    assert !incomplete_bundle.completed?, "Incomplete undle still shows as completed: #{incomplete_bundle.completed?}"
+
+    # delete parent file to confirm complete deletion
+    DeleteQueueJob.new(coordinate_matrix).perform
+    assert @study.study_file_bundles.count == 0, "Study file bundle is still present; expected 0 but found #{@study.study_file_bundles.count}"
+    assert @study.study_files.where(queued_for_deletion: false).size == 0, "Did not remove all files, expected 0 but found #{@study.study_files.where(queued_for_deletion: false).size}"
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 

--- a/test/ui_test_helper.rb
+++ b/test/ui_test_helper.rb
@@ -348,6 +348,7 @@ class Test::Unit::TestCase
   # load file either in browser or download and check for existence
   def download_file(link, basename)
     link.click
+    sleep(3)
     if @driver.current_url.include?('https://storage.googleapis.com/')
       assert @driver.current_url =~ /#{basename}/, "Downloaded file url incorrect, did not find #{basename}"
       @driver.navigate.back

--- a/test/ui_test_helper.rb
+++ b/test/ui_test_helper.rb
@@ -52,9 +52,9 @@ def parse_test_arguments(arguments)
       $env = arg.gsub(/\-E\=/, '')
     elsif arg =~ /\-r\=/
       $random_seed = arg.gsub(/\-r\=/, '')
-    elsif arg =~ /\-v/
+    elsif arg == '-v'
       $verbose = true
-    elsif arg =~ /\-i/
+    elsif arg == '-i'
       $headless = false
     end
   end

--- a/test/ui_test_helper.rb
+++ b/test/ui_test_helper.rb
@@ -368,7 +368,7 @@ class Test::Unit::TestCase
       accept = @driver.find_element(:xpath, "//a[@data-test-id='accept-button']")
       $verbose ? puts('accepting FireCloud Terms of Service') : nil
       accept.click
-    rescue Selenium::WebDriver::Error::NoSuchElementError => e
+    rescue Selenium::WebDriver::Error::NoSuchElementError
       $verbose ? puts('no FireCloud Terms of Service to accept') : nil
     end
   end

--- a/test/ui_test_helper.rb
+++ b/test/ui_test_helper.rb
@@ -363,6 +363,16 @@ class Test::Unit::TestCase
     end
   end
 
+  def accept_firecloud_tos
+    begin
+      accept = @driver.find_element(:xpath, "//a[@data-test-id='accept-button']")
+      $verbose ? puts('accepting FireCloud Terms of Service') : nil
+      accept.click
+    rescue Selenium::WebDriver::Error::NoSuchElementError => e
+      $verbose ? puts('no FireCloud Terms of Service to accept') : nil
+    end
+  end
+
   private
 
   def complete_login_process(email, password)

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -2417,7 +2417,7 @@ class UiTestSuite < Test::Unit::TestCase
 
   # search for a single gene and view plots
   test 'front-end: search-genes: single' do
-    puts "Test method: '#{self.method_name}'"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     path = @base_url + "/study/test-study-#{$random_seed}"
     @driver.get(path)
@@ -2554,12 +2554,12 @@ class UiTestSuite < Test::Unit::TestCase
     reference_rendered = @driver.execute_script("return $('#expression-plots').data('reference-rendered')")
     assert reference_rendered, "private reference plot did not finish rendering, expected true but found #{reference_rendered}"
 
-    puts "Test method: '#{self.method_name}' successful!"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
 
   # search for multiple genes, but collapse using a consensus metric and view plots
   test 'front-end: search-genes: multiple consensus' do
-    puts "Test method: '#{self.method_name}'"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     path = @base_url + "/study/test-study-#{$random_seed}"
     @driver.get(path)
@@ -2722,12 +2722,12 @@ class UiTestSuite < Test::Unit::TestCase
     reference_rendered = @driver.execute_script("return $('#expression-plots').data('reference-rendered')")
     assert reference_rendered, "private reference plot did not finish rendering, expected true but found #{reference_rendered}"
 
-    puts "Test method: '#{self.method_name}' successful!"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
 
   # search for multiple genes and view as a heatmap
   test 'front-end: search-genes: multiple heatmap' do
-    puts "Test method: '#{self.method_name}'"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     path = @base_url + "/study/test-study-#{$random_seed}"
     @driver.get(path)
@@ -2804,12 +2804,12 @@ class UiTestSuite < Test::Unit::TestCase
     new_queried_genes = @driver.find_elements(:class, 'queried-gene').map(&:text)
     assert new_genes.sort == new_queried_genes.sort, "found incorrect genes, expected #{new_genes.sort} but found #{new_queried_genes.sort}"
 
-    puts "Test method: '#{self.method_name}' successful!"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
 
   # search for multiple genes by uploading a text file of gene names
   test 'front-end: search-genes: multiple upload file' do
-    puts "Test method: '#{self.method_name}'"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     path = @base_url + "/study/test-study-#{$random_seed}"
     @driver.get(path)
@@ -2848,12 +2848,12 @@ class UiTestSuite < Test::Unit::TestCase
     private_heatmap_drawn = @driver.execute_script("return $('#heatmap-plot').data('morpheus').heatmap !== undefined;")
     assert private_heatmap_drawn, "heatmap plot encountered error, expected true but found #{private_heatmap_drawn}"
 
-    puts "Test method: '#{self.method_name}' successful!"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
 
   # perform a global gene search for public & private studies
   test 'front-end: search-genes: global' do
-    puts "Test method: '#{self.method_name}'"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     @driver.get @base_url
     wait_until_page_loads(@base_url)
@@ -2922,12 +2922,12 @@ class UiTestSuite < Test::Unit::TestCase
     private_new_plot_type = private_updated_data.first['type']
     assert private_new_plot_type == 'scattergl', "Did not correctly update private plot to 2d scatter, expected 'scattergl' but found '#{private_new_plot_type}'"
 
-    puts "Test method: '#{self.method_name}' successful!"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
 
   # view a list of marker genes as a heatmap
   test 'front-end: marker-gene: heatmap' do
-    puts "Test method: '#{self.method_name}'"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     path = @base_url + "/study/test-study-#{$random_seed}"
     @driver.get(path)
@@ -2985,12 +2985,12 @@ class UiTestSuite < Test::Unit::TestCase
     private_heatmap_drawn = @driver.execute_script("return $('#heatmap-plot').data('morpheus').heatmap !== undefined;")
     assert private_heatmap_drawn, "heatmap plot encountered error, expected true but found #{private_heatmap_drawn}"
 
-    puts "Test method: '#{self.method_name}' successful!"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
 
   # view a list of marker genes as distribution plots
   test 'front-end: marker-gene: box/scatter' do
-    puts "Test method: '#{self.method_name}'"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     path = @base_url + "/study/test-study-#{$random_seed}"
     @driver.get(path)
@@ -3132,7 +3132,7 @@ class UiTestSuite < Test::Unit::TestCase
     reference_rendered = @driver.execute_script("return $('#expression-plots').data('reference-rendered')")
     assert reference_rendered, "private reference plot did not finish rendering, expected true but found #{reference_rendered}"
 
-    puts "Test method: '#{self.method_name}' successful!"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
 
   ##

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -791,6 +791,7 @@ class UiTestSuite < Test::Unit::TestCase
     firecloud_link.click
     @driver.switch_to.window(@driver.window_handles.last)
     sleep(1) # we need a sleep to let the driver catch up, otherwise we can get stuck in an inbetween state
+    accept_firecloud_tos
     completed = @driver.find_elements(:class, 'fa-check-circle')
     assert completed.size >= 1, 'did not provision workspace properly'
     assert @driver.current_url == firecloud_url, 'did not open firecloud workspace'
@@ -1005,6 +1006,7 @@ class UiTestSuite < Test::Unit::TestCase
     # verify that workspace is still there
     firecloud_url = 'https://portal.firecloud.org/#workspaces/single-cell-portal/development-sync-test-study'
     open_new_page(firecloud_url)
+    accept_firecloud_tos
     completed = @driver.find_elements(:class, 'fa-check-circle')
     assert completed.size >= 1, "did not find workspace - may have been deleted; please check #{firecloud_url}"
 
@@ -1445,6 +1447,7 @@ class UiTestSuite < Test::Unit::TestCase
     login_as_other($share_email, $share_email_password)
     firecloud_workspace = "https://portal.firecloud.org/#workspaces/single-cell-portal/sync-test-#{$random_seed}"
     @driver.get firecloud_workspace
+    accept_firecloud_tos
     assert !element_present?(:class, 'fa-check-circle'), 'did not revoke access - study workspace still loads'
 
     puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
@@ -1746,6 +1749,7 @@ class UiTestSuite < Test::Unit::TestCase
     # assert access is revoked
     firecloud_url = "https://portal.firecloud.org/#workspaces/single-cell-portal/#{$env}-test-study-#{$random_seed}"
     @driver.get firecloud_url
+    accept_firecloud_tos
     assert !element_present?(:class, 'fa-check-circle'), 'did not revoke access - study workspace still loads'
 
     # test that study admin access is disabled


### PR DESCRIPTION
* Adding incremental retry backoffs to FireCloud & GCS API errors (5 times, adds 15 sec. per retry)
  * Also includes blacklist of methods/URLs to not increment backoff in cases of UI blocking
* Refactoring UploadCleanupJob to retry pushing files to FireCloud on failure (up to 3 times over 10 minutes)
  * Study.storage_sanity_check will now also push missing files using UploadCleanupJob
* Fixing bug with StudyFileBundles not cleaning up after themselves on deletion of parent file (either during or after upload has completed)
* Updates
  * Updated rack to 2.0.6 re: CVE-2018-16470/1
  * Updated Docker base image version to 1.6
    * Updated yarn to 1.12.3