### PR TITLE
FireCloudClient enhancements, download & sync bug fixes

### DIFF
--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -391,7 +391,8 @@ module Api
           firecloud_permissions = Study.firecloud_client.get_workspace_acl(@study.firecloud_project, @study.firecloud_workspace)
           firecloud_permissions['acl'].each do |user, permissions|
             # skip project owner permissions, they aren't relevant in this context
-            if permissions['accessLevel'] =~ /OWNER/i
+            # also skip the readonly service account
+            if permissions['accessLevel'] =~ /OWNER/i || (Study.read_only_firecloud_client.present? && user == Study.read_only_firecloud_client.isser)
               next
             else
               # determine whether permissions are incorrect or missing completely

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -112,7 +112,8 @@ class StudiesController < ApplicationController
       firecloud_permissions = Study.firecloud_client.get_workspace_acl(@study.firecloud_project, @study.firecloud_workspace)
       firecloud_permissions['acl'].each do |user, permissions|
         # skip project owner permissions, they aren't relevant in this context
-        if permissions['accessLevel'] =~ /OWNER/i
+        # also skip the readonly service account
+        if permissions['accessLevel'] =~ /OWNER/i || (Study.read_only_firecloud_client.present? && user == Study.read_only_firecloud_client.isser)
           next
         else
           # determine whether permissions are incorrect or missing completely

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -1277,7 +1277,8 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
       sleep(retry_time) unless RETRY_BACKOFF_BLACKLIST.include?(method_name)
       # only retry if status code indicates a possible temporary error, and we are under the retry limit and
       # not calling a method that is blocked from retries
-      if should_retry?(e.code) && retry_count < MAX_RETRY_COUNT && !ERROR_IGNORE_LIST.include?(method_name)
+      status_code = e.respond_to?(:code) ? e.code : nil
+      if should_retry?(status_code) && retry_count < MAX_RETRY_COUNT && !ERROR_IGNORE_LIST.include?(method_name)
         execute_gcloud_method(method_name, current_retry, *params)
       else
         # we have reached our retry limit or the response code indicates we should not retry

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -24,8 +24,10 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   MAX_RETRY_COUNT = 5
   # constant used for incremental backoffs on retries (in seconds); ignored when running unit/integration test suite
   RETRY_INTERVAL = Rails.env == 'test' ? 0 : 15
+  # List of URLs/Method names to never retry on or report error, regardless of error state
+  ERROR_IGNORE_LIST = ["#{BASE_URL}/register"]
   # List of URLs/Method names to ignore incremental backoffs on (in cases of UI blocking)
-  RETRY_IGNORE_LIST = ["#{BASE_URL}/register", :generate_signed_url, :generate_api_url]
+  RETRY_BACKOFF_BLACKLIST = ["#{BASE_URL}/register", :generate_signed_url, :generate_api_url]
   # default namespace used for all FireCloud workspaces owned by the 'portal'
   PORTAL_NAMESPACE = ENV['PORTAL_NAMESPACE'].present? ? ENV['PORTAL_NAMESPACE'] : 'single-cell-portal'
   # location of Google service account JSON (must be absolute path to file)
@@ -274,41 +276,31 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
     end
 
     # process request
-    if retry_count < MAX_RETRY_COUNT
-      begin
-        @obj = RestClient::Request.execute(method: http_method, url: path, payload: payload, headers: headers)
-        # handle response codes as necessary
-        if ok?(@obj.code) && !@obj.body.blank?
-          begin
-            return JSON.parse(@obj.body)
-          rescue JSON::ParserError => e
-            ErrorTracker.report_exception(e, self.issuer_object, {method: http_method, url: path,
-                                                                  payload: payload, opts: opts, retry_count: retry_count})
-            return @obj.body
-          end
-        elsif ok?(@obj.code) && @obj.body.blank?
-          return true
-        else
-          Rails.logger.info "Unexpected response #{@obj.code}, not sure what to do here..."
-          @obj.message
+    begin
+      response = RestClient::Request.execute(method: http_method, url: path, payload: payload, headers: headers)
+      # handle response using helper
+      handle_response(response)
+    rescue RestClient::Exception => e
+      current_retry = retry_count + 1
+      context = " encountered when requesting '#{path}', attempt ##{current_retry}"
+      log_message = e.message + context
+      Rails.logger.error log_message
+      retry_time = retry_count * RETRY_INTERVAL
+      sleep(retry_time) unless RETRY_BACKOFF_BLACKLIST.include?(path) # only sleep if non-blocking
+      # only retry if status code indicates a possible temporary error, and we are under the retry limit and
+      # not calling a method that is blocked from retries
+      if should_retry?(e.http_code) && retry_count < MAX_RETRY_COUNT && !ERROR_IGNORE_LIST.include?(path)
+        process_firecloud_request(http_method, path, payload, opts, current_retry)
+      else
+        # we have reached our retry limit or the response code indicates we should not retry
+        unless ERROR_IGNORE_LIST.include?(path)
+          ErrorTracker.report_exception(e, self.issuer_object, {method: http_method, url: path, payload: payload,
+                                                                opts: opts, retry_count: retry_count})
         end
-      rescue RestClient::Exception => e
-        ErrorTracker.report_exception(e, self.issuer_object, {method: http_method, url: path, payload: payload,
-                                                              opts: opts, retry_count: retry_count})
-        context = " encountered when requesting '#{path}', attempt ##{retry_count + 1}"
-        log_message = e.message + context
-        Rails.logger.error log_message
-        @error = e
-        unless RETRY_IGNORE_LIST.include?(path)
-          retry_time = retry_count * RETRY_INTERVAL
-          sleep(retry_time)
-        end
-        process_firecloud_request(http_method, path, payload, opts, retry_count + 1)
+        error_message = parse_error_message(e)
+        Rails.logger.error "Retry count exceeded when requesting '#{path}' - #{error_message}"
+        raise RuntimeError.new(error_message)
       end
-    else
-      error_message = parse_error_message(@error)
-      Rails.logger.error "Retry count exceeded when requesting '#{path}' - #{error_message}"
-      raise RuntimeError.new(error_message)
     end
   end
 
@@ -1276,23 +1268,26 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   #     +Google::Cloud::Storage::FileList+, +Boolean+, +File+, or +String+
 
   def execute_gcloud_method(method_name, retry_count=0, *params)
-    if retry_count < MAX_RETRY_COUNT
-      begin
-        self.send(method_name, *params)
-      rescue => e
-        ErrorTracker.report_exception(e, self.issuer_object, {method_name: method_name, retry_count: retry_count,
-                                                              params: params})
-        @error = e.message
-        Rails.logger.info "error calling #{method_name} with #{params.join(', ')}; #{e.message} -- attempt ##{retry_count + 1}"
-        unless RETRY_IGNORE_LIST.include?(method_name)
-          retry_time = retry_count * RETRY_INTERVAL
-          sleep(retry_time)
+    begin
+      self.send(method_name, *params)
+    rescue => e
+      current_retry = retry_count + 1
+      Rails.logger.info "error calling #{method_name} with #{params.join(', ')}; #{e.message} -- attempt ##{current_retry}"
+      retry_time = retry_count * RETRY_INTERVAL
+      sleep(retry_time) unless RETRY_BACKOFF_BLACKLIST.include?(method_name)
+      # only retry if status code indicates a possible temporary error, and we are under the retry limit and
+      # not calling a method that is blocked from retries
+      if should_retry?(e.code) && retry_count < MAX_RETRY_COUNT && !ERROR_IGNORE_LIST.include?(method_name)
+        execute_gcloud_method(method_name, current_retry, *params)
+      else
+        # we have reached our retry limit or the response code indicates we should not retry
+        unless ERROR_IGNORE_LIST.include?(method_name)
+          ErrorTracker.report_exception(e, self.issuer_object, {method_name: method_name,
+                                                                retry_count: current_retry, params: params})
         end
-        execute_gcloud_method(method_name, retry_count + 1, *params)
+        Rails.logger.info "Retry count exceeded calling #{method_name} with #{params.join(', ')}: #{e.message}"
+        raise RuntimeError.new "#{e.message}"
       end
-    else
-      Rails.logger.info "Retry count exceeded calling #{method_name} with #{params.join(', ')}: #{@error}"
-      raise RuntimeError.new "#{@error}"
     end
   end
 
@@ -1536,6 +1531,18 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
     [200, 201, 202, 204, 206].include?(code)
   end
 
+  # determine if request should be retried based on response code
+  #
+  # * *params*
+  #   - +code+ (Integer) => integer HTTP response code
+  #
+  # * *return*
+  #   - +Boolean+ of whether or not response code indicates a retry should be executed
+  def should_retry?(code)
+    # if code is nil, we're not sure so retry anyway
+    code.nil? || [403, 502, 503].include?(code)
+  end
+
   # merge hash of options into single URL query string
   #
   # * *params*
@@ -1546,6 +1553,54 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   def merge_query_options(opts)
     # return nil if opts is empty, else concat
     opts.blank? ? nil : '?' + opts.to_a.map {|k,v| "#{k}=#{v}"}.join("&")
+  end
+
+  # handle a RestClient::Response object
+  #
+  # * *params*
+  #   - +response+ (String) => an RestClient response object
+  #
+  # * *return*
+  #   - +Hash+ if response body is JSON, or +String+ of original body
+  def handle_response(response)
+    begin
+      if ok?(response.code)
+        if response.body.present?
+          parse_response_body(response.body)
+        else
+          true # blank body
+        end
+      else
+        Rails.logger.info "Unexpected response #{response.code}, not sure what to do here..."
+        response.message
+      end
+    rescue => e
+      # don't report, just return
+      response.message
+    end
+  end
+
+  # parse a response body based on the content
+  #
+  # * *params*
+  #   - +response_body+ (String) => an RestClient response body
+  #
+  # * *return*
+  #   - +Hash+ if response body is JSON, or +String+ of original body
+  def parse_response_body(response_body)
+    is_json?(response_body) ? JSON.parse(response_body) : response_body
+  end
+
+  # determine if a response body is parseable as JSON
+  #
+  # * *params*
+  #   - +content+ (String) => an RestClient response body
+  #
+  # * *return*
+  #   - +Boolean+ indication if content is JSON
+  def is_json?(content)
+    chars = [content[0], content[content.size - 1]]
+    chars == %w({ }) || chars == %w([ ])
   end
 
   # return a more user-friendly error message
@@ -1581,7 +1636,7 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
           return error.message
         end
       rescue => e
-        ErrorTracker.report_exception(e, self.issuer_object, {original_error: error})
+        # reporting error doesn't help, so ignore
         Rails.logger.error e.message
         error.message + ': ' + error.http_body
       end

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -1611,7 +1611,7 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   # * *return*
   #   - +String+ representation of complete error message, with http body if present
   def parse_error_message(error)
-    if error.http_body.blank?
+    if error.http_body.blank? || !is_json?(error.http_body)
       error.message
     else
       begin

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -2618,7 +2618,7 @@ class Study
       Delayed::Job.enqueue(UploadCleanupJob.new(file.study, file, 0), run_at: run_at)
       Rails.logger.info "#{Time.now}: cleanup job for #{file.bucket_location}:#{file.id} scheduled for #{run_at}"
     rescue => e
-      error_context = ErrorTracker.format_extra_context(self, study_file)
+      error_context = ErrorTracker.format_extra_context(self, file)
       ErrorTracker.report_exception(e, user, error_context)
       # if upload fails, try again using UploadCleanupJob in 2 minutes
       run_at = 2.minutes.from_now

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -2666,26 +2666,13 @@ class Study
     unless Rails.env == 'test' || self.queued_for_deletion
       if manual_set || self.public_changed? || self.new_record?
         if self.firecloud_workspace.present? && self.firecloud_project.present? && Study.read_only_firecloud_client.present?
-          read_only_email = Study.read_only_firecloud_client.issuer
           access_level = self.public? ? 'READER' : 'NO ACCESS'
           if !grant_access # revoke all access
             access_level = 'NO ACCESS'
           end
           Rails.logger.info "#{Time.now}: setting readonly access on #{self.name} to #{access_level}"
-          case access_level
-          when 'NO ACCESS'
-            read_only_share = self.study_shares.find_by(email: read_only_email)
-            read_only_share.destroy if read_only_share.present?
-          when 'READER'
-            unless self.study_shares.non_reviewers.include?(read_only_email)
-              new_share = self.study_shares.build(email: read_only_email, permission: 'View')
-              new_share.save
-            else
-              Rails.logger.info "#{Time.now}: aborting setting readonly access on #{self.name}; share already exists"
-            end
-          else
-            Rails.logger.info "#{Time.now}: invalid readonly access permission level of #{access_level} on #{self.name}"
-          end
+          readonly_acl = Study.firecloud_client.create_workspace_acl(Study.read_only_firecloud_client.issuer, access_level, false, false)
+          Study.firecloud_client.update_workspace_acl(self.firecloud_project, self.firecloud_workspace, readonly_acl)
         end
       end
     end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -2675,7 +2675,7 @@ class Study
           case access_level
           when 'NO ACCESS'
             read_only_share = self.study_shares.find_by(email: read_only_email)
-            read_only_share.destroy
+            read_only_share.destroy if read_only_share.present?
           when 'READER'
             unless self.study_shares.non_reviewers.include?(read_only_email)
               new_share = self.study_shares.build(email: read_only_email, permission: 'View')

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -453,7 +453,7 @@ class Study
   validates_presence_of   :name, on: :update
   validates_uniqueness_of :url_safe_name, on: :update, message: ": The name you provided tried to create a public URL (%{value}) that is already assigned.  Please rename your study to a different value."
   validate :prevent_firecloud_attribute_changes, on: :update
-
+  validates_presence_of :firecloud_project, :firecloud_workspace
   # callbacks
   before_validation :set_url_safe_name
   before_validation :set_data_dir, :set_firecloud_workspace_name, on: :create

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -9,7 +9,7 @@
             <h2 class="text-center">Bulk Download</h2>
           </div>
           <div class="modal-body">
-            <% if @study.can_direct_download?(current_user) %>
+            <% if @study.has_bucket_access?(current_user) %>
             <p class="lead">To download all files using <code>gsutil</code>, run the following command:</p>
             <pre>gsutil -m cp -r gs://<%= @study.bucket_id %> [target path]</pre>
               <% if @directories.any? %>

--- a/app/views/site/_study_settings_form.html.erb
+++ b/app/views/site/_study_settings_form.html.erb
@@ -115,26 +115,28 @@
   <div class="form-group">
     <h3>Sharing</h3>
     <%= f.fields_for :study_shares do |share| %>
-      <div class="well well-sm">
-        <div class="form-group row">
-          <div class="col-sm-6">
-            <%= share.label :email %>
-            <% if !share.object.new_record? %>
-              <span class="fas fa-exclamation-triangle text-danger" data-toggle="tooltip" data-placement="right" title="Editing share emails is not permitted.  If the email is incorrect, please delete the share and create a new one."></span>
-            <% end %>
-            <br />
-            <%= share.text_field :email, class: 'form-control share-email', readonly: !share.object.new_record?, autocomplete: 'no' %>
-          </div>
-          <div class="col-sm-5">
-            <%= share.label :permission %><br />
-            <%= share.select :permission, options_for_select(StudyShare::PERMISSION_TYPES, share.object.permission), {}, class: 'form-control share-permission' %>
-          </div>
-          <div class="col-sm-1">
-            <%= share.label :delete, "&nbsp;".html_safe %><br />
-            <%= share.link_to_remove "<span class='btn btn-sm btn-danger'><span class='fas fa-times'></span></span>".html_safe, data: {confirm: 'Are you sure?  This cannot be undone unless you reload the page before saving.'} %>
+      <% if share.object.show_share? %>
+        <div class="well well-sm">
+          <div class="form-group row">
+            <div class="col-sm-6">
+              <%= share.label :email %>
+              <% if !share.object.new_record? %>
+                <span class="fas fa-exclamation-triangle text-danger" data-toggle="tooltip" data-placement="right" title="Editing share emails is not permitted.  If the email is incorrect, please delete the share and create a new one."></span>
+              <% end %>
+              <br />
+              <%= share.text_field :email, class: 'form-control share-email', readonly: !share.object.new_record?, autocomplete: 'no' %>
+            </div>
+            <div class="col-sm-5">
+              <%= share.label :permission %><br />
+              <%= share.select :permission, options_for_select(StudyShare::PERMISSION_TYPES, share.object.permission), {}, class: 'form-control share-permission' %>
+            </div>
+            <div class="col-sm-1">
+              <%= share.label :delete, "&nbsp;".html_safe %><br />
+              <%= share.link_to_remove "<span class='btn btn-sm btn-danger'><span class='fas fa-times'></span></span>".html_safe, data: {confirm: 'Are you sure?  This cannot be undone unless you reload the page before saving.'} %>
+            </div>
           </div>
         </div>
-      </div>
+      <% end %>
     <% end %>
     <%= f.link_to_add "<span class='fas fa-plus'></span> Share Study".html_safe, :study_shares, class: 'btn btn-primary', id: 'add-study-share' %>
   </div>

--- a/lib/error_tracker.rb
+++ b/lib/error_tracker.rb
@@ -2,8 +2,8 @@ module ErrorTracker
 
   # capture and report an exception to Sentry via Raven, setting user context & params as needed
   def self.report_exception(exception, user, extra_context={})
-    # only report to Sentry if configured and not in test environment
-    if Rails.env == 'test' || ENV['SENTRY_DSN'].nil?
+    # only report to Sentry if configured and not in dev or test environment
+    if %w(development test).include?(Rails.env) || ENV['SENTRY_DSN'].nil?
       Rails.logger.error "Suppressing error reporting to Sentry: #{exception.class.name}:#{exception.message}"
     else
       Raven.capture_exception(exception, user: {identifer: extract_user_identifier(user)}, extra: extra_context)


### PR DESCRIPTION
* Enhanced retry logic in FireCloudClient class (only retries on what are determined to be possible temporary errors (502/503, and 403 in some circumstances)
* Refined response and error handling, including improved external error reporting
* Bug fix for bulk data download on studies where a user has access through a FireCloud user group share
* StudyShares no longer created for read-only service account when syncing public studies