### PR TITLE
User session timeouts

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -967,6 +967,8 @@ window.clearGeneSearchLoading = function() {
 // force login on ajax 401
 $(document).ajaxError(function (e, xhr, settings) {
     if (xhr.status == 401) {
-        location.reload();
+        alert('You are not signed in or your session has expired - please login to continue.');
+        var url = 'https://' + window.location.hostname + '/single_cell/users/auth/google_oauth2';
+        location.href = url;
     }
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -963,3 +963,10 @@ window.clearGeneSearchLoading = function() {
     $('#wrap').data('spinner').stop();
     $('#gene-search-results-count').html($('.gene-panel').length);
 };
+
+// force login on ajax 401
+$(document).ajaxError(function (e, xhr, settings) {
+    if (xhr.status == 401) {
+        location.reload();
+    }
+});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -966,7 +966,7 @@ window.clearGeneSearchLoading = function() {
 
 // force login on ajax 401
 $(document).ajaxError(function (e, xhr, settings) {
-    if (xhr.status == 401) {
+    if (xhr.status === 401) {
         alert('You are not signed in or your session has expired - please login to continue.');
         var url = 'https://' + window.location.hostname + '/single_cell/users/auth/google_oauth2';
         location.href = url;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,6 @@ class ApplicationController < ActionController::Base
   ###
 
   before_action :set_csrf_headers
-  before_action :check_session_timeout
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,9 +30,9 @@ class User
 
 
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable, :timeoutable
+  # :confirmable, :lockable, :timeoutable and :omniauthable,
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable,
+         :recoverable, :rememberable, :trackable, :validatable, :timeoutable,
          :omniauthable, :omniauth_providers => [:google_oauth2]
 
   validates_format_of :email, :with => Devise.email_regexp, message: 'is not a valid email address.'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -155,7 +155,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 1.minutes
+  config.timeout_in = 30.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -155,7 +155,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 20.minutes
+  config.timeout_in = 1.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
* Adding 30 minute timeout on idle user sessions
* Supports catching 401s on AJAX calls and prompts user to reauthenticate