### PR TITLE
orphaned DirectoryListing refactoring

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,5 +1,5 @@
 Delayed::Worker.destroy_failed_jobs = true
 Delayed::Worker.max_attempts = 1
-Delayed::Worker.max_run_time = 12.hours
+Delayed::Worker.max_run_time = 24.hours
 Delayed::Worker.read_ahead = 10
 Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))


### PR DESCRIPTION
* Correctly clears orphaned DirectoryListing objects when users move files to different locations
* Now clears out file entries after iteration cycle is complete rather than deleting from in-memory array