### PR TITLE
Explore Tab Refactor

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -401,7 +401,7 @@ function enableDefaultActions() {
         window.location.hash = anchor;
         // use HTML5 history API to update the url without reloading the DOM
         history.pushState('', document.title, window.location.href);
-        window.scrollTo(0,currentScroll);
+        window.scrollTo(0, currentScroll);
     });
 
   // Remove styling set in scpPlotsDidRender

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -397,21 +397,11 @@ function enableDefaultActions() {
     // when clicking the main study view page tabs, update the current URL so that when you refresh the tab stays open
     $('#study-tabs').on('shown.bs.tab', function(event) {
         var anchor = $(event.target).attr('href');
-        var currentUrl = window.location.href;
-        var urlParts = currentUrl.split('#');
-        var newUrl = '';
-        if (urlParts.length === 1) {
-            newUrl = currentUrl + anchor;
-        } else if (urlParts[1] === '') {
-            newUrl = currentUrl.replace(/#/, '') + anchor;
-        } else {
-            var currentTab = urlParts[1];
-            // we need to replace the current tab with the new one in the anchor/parameter string
-            replaceRegex = new RegExp('#' + currentTab);
-            newUrl = currentUrl.replace(replaceRegex, anchor);
-        }
+        var currentScroll = $(window).scrollTop();
+        window.location.hash = anchor;
         // use HTML5 history API to update the url without reloading the DOM
-        history.pushState('', document.title, newUrl);
+        history.pushState('', document.title, window.location.href);
+        window.scrollTo(0,currentScroll);
     });
 
   // Remove styling set in scpPlotsDidRender

--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -40,14 +40,21 @@ $(document).on('click', '.bam-browse-genome', function(e) {
 });
 
 $(document).on('click', '#genome-tab-nav', function (e) {
+  var currentScroll = $(window).scrollTop();
   window.location.hash = '#genome-tab';
-
+  window.scrollTo(0, currentScroll);
   // Go to Google sign-in page, redirect to this view after authenticating.
   if (accessToken === null) {
     ga('send', 'event', 'genome', 'sign_in_start');
     localStorage.setItem('signed-in-via-genome-tab', true);
     window.location = '/single_cell/users/auth/google_oauth2';
   }
+});
+
+$(document).on('click', '#plots-tab-nav', function (e) {
+    var currentScroll = $(window).scrollTop();
+    window.location.hash = '#study-visualize';
+    window.scrollTo(0, currentScroll);
 });
 
 /**

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -557,10 +557,10 @@ module Api
         assembly_name = param_list[:assembly]
         matching_taxon = Taxon.find_by(common_name: /#{species_name}/i)
         matching_assembly = GenomeAssembly.find_by(name: /#{assembly_name}/i)
-        if matching_taxon.present?
+        if matching_taxon.present? && !species_name.blank?
           @study_file.taxon_id = matching_taxon.id
         end
-        if matching_assembly.present?
+        if matching_assembly.present? && !assembly_name.blank?
           @study_file.genome_assembly_id = matching_assembly.id
         end
       end

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -135,6 +135,12 @@ module Api
             end
           end
           parameter do
+            key :name, 'study_file[name]'
+            key :in, :formData
+            key :required, true
+            key :type, :string
+          end
+          parameter do
             key :name, 'study_file[species]'
             key :description, '(optional) Common name of a species registered in the portal to set taxon_id association manually'
             key :type, :string

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -395,7 +395,7 @@ class StudiesController < ApplicationController
       # delete firecloud workspace so it can be reused (unless specified by user), and raise error if unsuccessful
       # if successful, we're clear to queue the study for deletion
       if params[:workspace] == 'persist'
-        @study.update(firecloud_workspace: nil)
+        @study.update(firecloud_workspace: SecureRandom.uuid)
       else
         begin
           Study.firecloud_client.delete_workspace(@study.firecloud_project, @study.firecloud_workspace)

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1053,7 +1053,8 @@ class Study
   # return all study files for a given analysis & visualization component
   def get_analysis_outputs(analysis_name, visualization_name=nil, cluster_name=nil, annotation_name=nil)
     criteria = {
-        'options.analysis_name' => analysis_name
+        'options.analysis_name' => analysis_name,
+        :queued_for_deletion => false
     }
     if visualization_name.present?
       criteria.merge!('options.visualization_name' => visualization_name)

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -717,6 +717,41 @@ class Study
 
   ###
   #
+  # DATA VISUALIZATION GETTERS
+  #
+  # used to govern rendering behavior on /app/views/site/_study_visualize.html
+  ##
+
+  def has_expression_data?
+    self.genes.any?
+  end
+
+  def has_cluster_data?
+    self.cluster_groups.any?
+  end
+
+  def has_cell_metadata?
+    self.cell_metadata.any?
+  end
+
+  def has_gene_lists?
+    self.precomputed_scores.any?
+  end
+
+  def can_visualize_clusters?
+    self.has_cluster_data? && self.has_cell_metadata?
+  end
+
+  def can_visualize_genome_data?
+    self.has_bam_files? || self.has_analysis_outputs?('infercnv', 'ideogram.js')
+  end
+
+  def can_visualize?
+    self.can_visualize_clusters? || self.can_visualize_genome_data?
+  end
+
+  ###
+  #
   # DATA PATHS & URLS
   #
   ###

--- a/app/views/site/_search_options.html.erb
+++ b/app/views/site/_search_options.html.erb
@@ -1,234 +1,243 @@
 <%= form_for(:search, url: search_genes_path(accession: @study.accession, study_name: @study.url_safe_name), html: {class: 'form', id: 'search-genes-form', data: {remote: true}}) do |f| %>
-  <%= f.hidden_field :cluster, value: set_cluster_value(@study, params) %>
-  <%= f.hidden_field :boxpoints, value: params[:boxpoints].nil? ? 'all' : params[:boxpoints] %>
-  <%= f.hidden_field :annotation, value: set_annotation_value(@study, params) %>
-  <%= f.hidden_field :subsample, value: set_subsample_value(params) %>
-  <%= f.hidden_field :plot_type, value: set_distribution_plot_type_value(params) %>
-  <%= f.hidden_field :heatmap_row_centering, value: set_heatmap_row_centering_value(params) %>
-  <%= f.hidden_field :heatmap_size, value: set_heatmap_size_value(params) %>
-  <%= f.hidden_field :colorscale, value: set_colorscale_value(@study, params) %>
-  <%= hidden_field_tag :scpbr, params[:scpbr] %>
-
-<div id="search-omnibar">
-  <div id="search-omnibar-menu">
-    <i id="search-omnibar-menu-icon" class="fas fa-bars" aria-hidden="true"></i>
-  </div>
-  <div class="input-group">
-    <%= f.autocomplete_field :genes, autocomplete_gene_name_gene_index_path(study_id: @study._id), {multiple: true, class: 'form-control search-genes-input', placeholder: 'Search genes', value: set_search_value, data: {delimiter: ' '} } %>
-    <span class="input-group-btn">
-      <button class="btn btn-default" id="perform-gene-search" type="button">
-        <span class="fas fa-search"></span>
-      </button>
-    </span>
-  </div>
-</div>
-
-<div id="search-parent" class="panel-group" style="display: none;">
-  <div class="panel panel-info" id="search-options-panel">
-    <div class="panel-heading">
-      <div class="panel-title">
-        <h4><a href="#panel-genes-search" data-toggle="collapse" data-parent="#search-parent" id="search-genes-link"><span class='fas fa-search'></span> Advanced Gene Search</a></h4>
-      </div>
+  <% if @study.has_expression_data? %>
+    <%= f.hidden_field :cluster, value: set_cluster_value(@study, params) %>
+    <%= f.hidden_field :boxpoints, value: params[:boxpoints].nil? ? 'all' : params[:boxpoints] %>
+    <%= f.hidden_field :annotation, value: set_annotation_value(@study, params) %>
+    <%= f.hidden_field :subsample, value: set_subsample_value(params) %>
+    <%= f.hidden_field :plot_type, value: set_distribution_plot_type_value(params) %>
+    <%= f.hidden_field :heatmap_row_centering, value: set_heatmap_row_centering_value(params) %>
+    <%= f.hidden_field :heatmap_size, value: set_heatmap_size_value(params) %>
+    <%= f.hidden_field :colorscale, value: set_colorscale_value(@study, params) %>
+    <%= hidden_field_tag :scpbr, params[:scpbr] %>
+  <% end %>
+  <div id="search-omnibar">
+    <div id="search-omnibar-menu">
+      <i id="search-omnibar-menu-icon" class="fas fa-bars" aria-hidden="true"></i>
     </div>
-    <div class="panel-body collapse in" id="panel-genes-search">
-      <div class="row">
-        <div class="col-sm-12">
-              <div class="form-group">
-                <%= f.label :upload, "Upload gene list" %><br/>
-                <%= f.file_field :upload, class: 'form-control', accept: '.txt,text/plain' %>
-              </div>
-              <div class="form-group">
-                <%= f.label :consensus, "Collapse genes by <i class='fas fa-question-circle'></i>".html_safe, title: "Multiple genes only: Collapse expression scores of multiple genes for each cell using this metric.  Selecting 'None' will view genes individually as a heatmap.", data: {toggle: 'tooltip', placement: 'right'} %><br/>
-                <%= f.select :consensus, options_for_select([['Mean', 'mean'],['Median', 'median']], params[:consensus]), {include_blank: 'None'}, {class: 'form-control'} %>
-              </div>
-              <%= link_to "<span class='fas fa-chevron-left'></span> Back".html_safe, "javascript:", class: "btn pull-right #{action_name == 'study' ? 'btn-default disabled' : 'btn-warning'}", id: 'clear-gene-search', title: 'Clear gene search and return to cluster scatter plots', data: {toggle: 'tooltip'} %>
-              <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-                  $('#clear-gene-search').click(function(){
-                      clearForm('search_genes');
-                      $(this).tooltip('hide');
-                      var urlParams = getRenderUrlParams();
-                      var url = "<%= view_study_path(accession: @study.accession, study_name: @study.url_safe_name )%>?" + urlParams;
-                      launchModalSpinner('#spinner_target', '#loading-modal', function() {
-                          $.ajax({
-                              url: url,
-                              type: 'GET',
-                              dataType: 'script'
-                          });
-                      });
-                  });
-                  $('#perform-gene-search').click(function(){
-                      var fileInput = $('#search_upload')[0];
-                      if (fileInput.files.length) {
-                          var reader = new FileReader();
-                          var upload = fileInput.files[0];
-                          reader.readAsText(upload);
-                          $(reader).on('load', function(e) {
-                              var file = e.target.result,
-                                  results;
-                              if (file && file.length) {
-                                  lines = file.split(/[,\n]/);
-                                  sanitizedContent = [];
-                                  $(lines).each(function(i, line) {
-                                      // scrub quotes if present
-                                      line = line.replace(/(\'|\")/g, '');
-                                      if (!line.match(UNSAFE_CHARACTERS)) {
-                                          sanitizedContent.push(line);
-                                      }
-                                  });
-                                  searchString = sanitizedContent.join(' ');
-                                  $('#search_genes').val(searchString);
-                                  $(fileInput).val("").change(submitGeneSearch());
-                              }
-                          });
-                      } else {
-                          submitGeneSearch();
-                      }
-                  });
-                  function submitGeneSearch() {
-                      if ( $('#search_genes').val() == '' && $('#search_upload').val() == '' ) {
-                          alert('You must specify at least one gene or upload a list of genes to search');
-                          setErrorOnBlank($('.search-genes-input'));
-                      } else {
-                          $(window).off('resizeEnd');
-                          launchModalSpinner('#spinner_target', '#loading-modal', function() {
-                              var form = $('#search-genes-form');
-                              $.ajax({
-                                  type: 'POST',
-                                  url: form.attr('action'),
-                                  data: form.serialize(),
-                                  dataType: 'script'
-                              });
-                          });
-                      }
-                  };
-              </script>
-          <% end %>
-        </div>
-      </div>
+    <div class="input-group">
+      <% if @study.has_expression_data? %>
+        <%= f.autocomplete_field :genes, autocomplete_gene_name_gene_index_path(study_id: @study._id), {multiple: true, class: 'form-control search-genes-input', placeholder: 'Search genes', value: set_search_value, data: {delimiter: ' '} } %>
+      <% else %>
+        <input class="form-control" type="text" disabled="disabled" data-toggle="tooltip" title="This study has no gene expression data available" />
+      <% end %>
+      <span class="input-group-btn">
+        <button class="btn btn-default" id="perform-gene-search" type="button">
+          <span class="fas fa-search"></span>
+        </button>
+      </span>
     </div>
   </div>
-  <div class="panel panel-info" id="gene-lists-panel">
-    <div class="panel-heading">
-      <div class="panel-title">
-        <h4><a href="#panel-gene-lists" data-toggle="collapse" data-parent="#search-parent" id="gene-lists-link"><span class='fas fa-file-alt'></span> View Gene Lists</a></h4>
-      </div>
-    </div>
-    <div class="panel-body collapse" id="panel-gene-lists">
-      <div class="row">
-        <div class="col-sm-12">
-          <%= form_tag(view_gene_set_expression_path(accession: params[:accession], study_name: params[:study_name]), id: 'gene-sets', method: :get, data: {remote: true}) do %>
-              <%= label_tag :gene_set, 'Mean expression' %>
-              <%= select_tag :gene_set, options_for_select(@precomputed, params[:gene_set]), {include_blank: 'Select gene list', class: 'form-control'} %>
-              <%= hidden_field_tag :gene_set_cluster %>
-              <%= hidden_field_tag :gene_set_annotation %>
-              <%= hidden_field_tag :gene_set_subsample %>
-              <%= hidden_field_tag :scpbr, params[:scpbr] %>
 
-            <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-                // set default values on render
-                $('#gene_set_cluster').val($('#search_cluster').val());
-                $('#gene_set_annotation').val($('#search_annotation').val());
-                $('#gene_set_subsample').val($('#search_subsample').val());
-                $('#gene_set').change(function() {
-                  if ($(this).val() != '') {
-                    launchModalSpinner('#spinner_target', '#loading-modal', function() {
-                      $('#gene-sets').submit();
-                    });
-
-                  }
-                });
-              </script>
-          <% end %>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-sm-12">
-          <%= form_tag(search_precomputed_results_path(accession: params[:accession], study_name: params[:study_name]), id: 'precomputed-expression', data: {remote: true}) do %>
-              <%= label_tag :expression, 'Heatmaps' %><br />
-              <%= select_tag :expression, options_for_select(@precomputed, params[:precomputed]), {include_blank: 'Select gene list', class: "form-control"} %>
-              <%= hidden_field_tag :scpbr, params[:scpbr] %>
-              <% if action_name !~ /precomputed/ %>
-                  <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-                    $('#expression').change(function() {
-                      if ($(this).val() != '') {
-                        launchModalSpinner('#spinner_target', '#loading-modal', function() {
-                          $('#precomputed-expression').submit();
-                        });
-                      }
-                    });
-                  </script>
-              <% end %>
-          <% end %>
-        </div>
-      </div>
-    </div>
-  </div>
-  <% if action_name !~ /heatmap/ %>
-    <div class="panel panel-<%= user_signed_in? ? 'info' : 'default' %>" id="annotations-panel">
+  <div id="search-parent" class="panel-group" style="display: none;">
+    <% if @study.has_expression_data? %>
+      <div class="panel panel-info" id="search-options-panel">
       <div class="panel-heading">
         <div class="panel-title">
-          <h4><a href="#panel-selection" data-toggle="<%= user_signed_in? ? 'collapse' : 'tooltip'%>" data-parent="#search-parent" id="create_annotations_panel" title="<%= user_signed_in? ? '' : 'Sign in to create custom annotations.'%>"><span class='fas fa-tags'></span> Create Annotations</a></h4>
+          <h4><a href="#panel-genes-search" data-toggle="collapse" data-parent="#search-parent" id="search-genes-link"><span class='fas fa-search'></span> Advanced Gene Search</a></h4>
         </div>
       </div>
-      <div class="panel-body collapse" id="panel-selection">
-        <div class="row form-group">
+      <div class="panel-body collapse in" id="panel-genes-search">
+        <div class="row">
           <div class="col-sm-12">
-            <div id="scattergl_div" class="text-center">
-              <% if user_signed_in? %>
-                <%= link_to "Select Cells <i class='fas fa-toggle-off'></i>".html_safe, '#/', class: 'btn btn-default btn-sm', id: 'toggle-scatter', data: {toggle: 'tooltip', placement: 'right', trigger: 'hover'}, title: 'Enable cell selection for creating custom annotations (may hurt performance on large clusters).  Only available on 2d data.' %>
-                <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-                    $('#toggle-scatter').click(function() {
-                        if (CLUSTER_TYPE === '2d') {
-                            $('#toggle-scatter').children().toggleClass('fa-toggle-on fa-toggle-off');
-                            $('#selection_div').toggleClass('collapse');
-                            var loadedCluster = $('#cluster').val();
-                            var loadedAnnotation = $('#annotation').val();
-                            var loadedSubsample = $('#subsample').val();
+            <div class="form-group">
+              <%= f.label :upload, "Upload gene list" %><br/>
+              <%= f.file_field :upload, class: 'form-control', accept: '.txt,text/plain' %>
+            </div>
+            <div class="form-group">
+              <%= f.label :consensus, "Collapse genes by <i class='fas fa-question-circle'></i>".html_safe, title: "Multiple genes only: Collapse expression scores of multiple genes for each cell using this metric.  Selecting 'None' will view genes individually as a heatmap.", data: {toggle: 'tooltip', placement: 'right'} %><br/>
+              <%= f.select :consensus, options_for_select([['Mean', 'mean'],['Median', 'median']], params[:consensus]), {include_blank: 'None'}, {class: 'form-control'} %>
+            </div>
+            <%= link_to "<span class='fas fa-chevron-left'></span> Back".html_safe, "javascript:", class: "btn pull-right #{action_name == 'study' ? 'btn-default disabled' : 'btn-warning'}", id: 'clear-gene-search', title: 'Clear gene search and return to cluster scatter plots', data: {toggle: 'tooltip'} %>
+            <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+                $('#clear-gene-search').click(function(){
+                    clearForm('search_genes');
+                    $(this).tooltip('hide');
+                    var urlParams = getRenderUrlParams();
+                    var url = "<%= view_study_path(accession: @study.accession, study_name: @study.url_safe_name )%>?" + urlParams;
+                    launchModalSpinner('#spinner_target', '#loading-modal', function() {
+                        $.ajax({
+                            url: url,
+                            type: 'GET',
+                            dataType: 'script'
+                        });
+                    });
+                });
+                $('#perform-gene-search').click(function(){
+                    var fileInput = $('#search_upload')[0];
+                    if (fileInput.files.length) {
+                        var reader = new FileReader();
+                        var upload = fileInput.files[0];
+                        reader.readAsText(upload);
+                        $(reader).on('load', function(e) {
+                            var file = e.target.result,
+                                results;
+                            if (file && file.length) {
+                                lines = file.split(/[,\n]/);
+                                sanitizedContent = [];
+                                $(lines).each(function(i, line) {
+                                    // scrub quotes if present
+                                    line = line.replace(/(\'|\")/g, '');
+                                    if (!line.match(UNSAFE_CHARACTERS)) {
+                                        sanitizedContent.push(line);
+                                    }
+                                });
+                                searchString = sanitizedContent.join(' ');
+                                $('#search_genes').val(searchString);
+                                $(fileInput).val("").change(submitGeneSearch());
+                            }
+                        });
+                    } else {
+                        submitGeneSearch();
+                    }
+                });
+                function submitGeneSearch() {
+                    if ( $('#search_genes').val() == '' && $('#search_upload').val() == '' ) {
+                        alert('You must specify at least one gene or upload a list of genes to search');
+                        setErrorOnBlank($('.search-genes-input'));
+                    } else {
+                        $(window).off('resizeEnd');
+                        launchModalSpinner('#spinner_target', '#loading-modal', function() {
+                            var form = $('#search-genes-form');
                             $.ajax({
-                                url: '<%= show_user_annotations_form_path(accession: @study.accession, study_name: @study.url_safe_name) %>?cluster=' + loadedCluster + '&annotation=' + loadedAnnotation + '&subsample=' + loadedSubsample,
+                                type: 'POST',
+                                url: form.attr('action'),
+                                data: form.serialize(),
                                 dataType: 'script'
                             });
-                        } else {
-                            alert('You may not create annotations on 3d data.  Please select a different cluster before continuing.');
-                            return false;
-                        }
-                    });
-                </script>
+                        });
+                    }
+                };
+            </script>
+          </div>
+        </div>
+      </div>
+    </div>
+    <% end %>
+    <% if @study.has_gene_lists? %>
+      <div class="panel panel-info" id="gene-lists-panel">
+      <div class="panel-heading">
+        <div class="panel-title">
+          <h4><a href="#panel-gene-lists" data-toggle="collapse" data-parent="#search-parent" id="gene-lists-link"><span class='fas fa-file-alt'></span> View Gene Lists</a></h4>
+        </div>
+      </div>
+      <div class="panel-body collapse" id="panel-gene-lists">
+        <div class="row">
+          <div class="col-sm-12">
+            <%= form_tag(view_gene_set_expression_path(accession: params[:accession], study_name: params[:study_name]), id: 'gene-sets', method: :get, data: {remote: true}) do %>
+                <%= label_tag :gene_set, 'Mean expression' %>
+                <%= select_tag :gene_set, options_for_select(@precomputed, params[:gene_set]), {include_blank: 'Select gene list', class: 'form-control'} %>
+                <%= hidden_field_tag :gene_set_cluster %>
+                <%= hidden_field_tag :gene_set_annotation %>
+                <%= hidden_field_tag :gene_set_subsample %>
+                <%= hidden_field_tag :scpbr, params[:scpbr] %>
 
-              <% else %>
-                <%= link_to "Select Cells <i class='fas fa-toggle-off '></i>".html_safe, '#/', class: 'btn btn-default btn-disabled btn-sm', id: 'disabled', data: {toggle: 'tooltip', placement: 'right', trigger: 'hover'}, title: 'Log in to enable cell selection.' %>
-              <% end %>
-            </div>
+              <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+                  // set default values on render
+                  $('#gene_set_cluster').val($('#search_cluster').val());
+                  $('#gene_set_annotation').val($('#search_annotation').val());
+                  $('#gene_set_subsample').val($('#search_subsample').val());
+                  $('#gene_set').change(function() {
+                    if ($(this).val() != '') {
+                      launchModalSpinner('#spinner_target', '#loading-modal', function() {
+                        $('#gene-sets').submit();
+                      });
+
+                    }
+                  });
+                </script>
+            <% end %>
           </div>
         </div>
         <div class="row">
           <div class="col-sm-12">
-            <div id="selection_div" class="collapse"></div>
+            <%= form_tag(search_precomputed_results_path(accession: params[:accession], study_name: params[:study_name]), id: 'precomputed-expression', data: {remote: true}) do %>
+                <%= label_tag :expression, 'Heatmaps' %><br />
+                <%= select_tag :expression, options_for_select(@precomputed, params[:precomputed]), {include_blank: 'Select gene list', class: "form-control"} %>
+                <%= hidden_field_tag :scpbr, params[:scpbr] %>
+                <% if action_name !~ /precomputed/ %>
+                    <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+                      $('#expression').change(function() {
+                        if ($(this).val() != '') {
+                          launchModalSpinner('#spinner_target', '#loading-modal', function() {
+                            $('#precomputed-expression').submit();
+                          });
+                        }
+                      });
+                    </script>
+                <% end %>
+            <% end %>
           </div>
         </div>
       </div>
     </div>
-    <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-      <% if user_signed_in? %>
+    <% end %>
+    <% if action_name !~ /heatmap/ && @study.can_visualize_clusters? %>
+      <div class="panel panel-<%= user_signed_in? ? 'info' : 'default' %>" id="annotations-panel">
+        <div class="panel-heading">
+          <div class="panel-title">
+            <h4><a href="#panel-selection" data-toggle="<%= user_signed_in? ? 'collapse' : 'tooltip'%>" data-parent="#search-parent" id="create_annotations_panel" title="<%= user_signed_in? ? '' : 'Sign in to create custom annotations.'%>"><span class='fas fa-tags'></span> Create Annotations</a></h4>
+          </div>
+        </div>
+        <div class="panel-body collapse" id="panel-selection">
+          <div class="row form-group">
+            <div class="col-sm-12">
+              <div id="scattergl_div" class="text-center">
+                <% if user_signed_in? %>
+                  <%= link_to "Select Cells <i class='fas fa-toggle-off'></i>".html_safe, '#/', class: 'btn btn-default btn-sm', id: 'toggle-scatter', data: {toggle: 'tooltip', placement: 'right', trigger: 'hover'}, title: 'Enable cell selection for creating custom annotations (may hurt performance on large clusters).  Only available on 2d data.' %>
+                  <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+                      $('#toggle-scatter').click(function() {
+                          if (CLUSTER_TYPE === '2d') {
+                              $('#toggle-scatter').children().toggleClass('fa-toggle-on fa-toggle-off');
+                              $('#selection_div').toggleClass('collapse');
+                              var loadedCluster = $('#cluster').val();
+                              var loadedAnnotation = $('#annotation').val();
+                              var loadedSubsample = $('#subsample').val();
+                              $.ajax({
+                                  url: '<%= show_user_annotations_form_path(accession: @study.accession, study_name: @study.url_safe_name) %>?cluster=' + loadedCluster + '&annotation=' + loadedAnnotation + '&subsample=' + loadedSubsample,
+                                  dataType: 'script'
+                              });
+                          } else {
+                              alert('You may not create annotations on 3d data.  Please select a different cluster before continuing.');
+                              return false;
+                          }
+                      });
+                  </script>
 
-        var targetPlotString = '<%= params[:gene_set].nil? && params[:gene].nil? ? 'cluster-plot' : 'scatter-plot' %>';
+                <% else %>
+                  <%= link_to "Select Cells <i class='fas fa-toggle-off '></i>".html_safe, '#/', class: 'btn btn-default btn-disabled btn-sm', id: 'disabled', data: {toggle: 'tooltip', placement: 'right', trigger: 'hover'}, title: 'Log in to enable cell selection.' %>
+                <% end %>
+              </div>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-sm-12">
+              <div id="selection_div" class="collapse"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+        <% if user_signed_in? %>
 
-        // Stick the search for selection facilitation in expression pages if selecting annotation
-        $('#panel-selection').on('show.bs.collapse', function () {
-            $(document).off('scroll', '#search-parent');
-            $('#search-parent').stickyPanel(stickyOptions);
-            window.scrollTo(0,$(('#' + targetPlotString)).offset().top -175);
-            var boxSelectBtn = $("a[data-title='Box Select]");
-            boxSelectBtn.click();
-        });
+          var targetPlotString = '<%= params[:gene_set].nil? && params[:gene].nil? ? 'cluster-plot' : 'scatter-plot' %>';
 
-        $('#panel-genes-search').on('show.bs.collapse', function () {
-            var searchParent = $('#search-parent');
-            if (typeof searchParent.data("stickyPanel.state") !== 'undefined') {
-                searchParent.stickyPanel('unstick');
-            }
-        });
-      <% end %>
-    </script>
-  <% end %>
-</div>
+          // Stick the search for selection facilitation in expression pages if selecting annotation
+          $('#panel-selection').on('show.bs.collapse', function () {
+              $(document).off('scroll', '#search-parent');
+              $('#search-parent').stickyPanel(stickyOptions);
+              window.scrollTo(0,$(('#' + targetPlotString)).offset().top -175);
+              var boxSelectBtn = $("a[data-title='Box Select]");
+              boxSelectBtn.click();
+          });
+
+          $('#panel-genes-search').on('show.bs.collapse', function () {
+              var searchParent = $('#search-parent');
+              if (typeof searchParent.data("stickyPanel.state") !== 'undefined') {
+                  searchParent.stickyPanel('unstick');
+              }
+          });
+        <% end %>
+      </script>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/site/_search_options.html.erb
+++ b/app/views/site/_search_options.html.erb
@@ -1,5 +1,5 @@
 <%= form_for(:search, url: search_genes_path(accession: @study.accession, study_name: @study.url_safe_name), html: {class: 'form', id: 'search-genes-form', data: {remote: true}}) do |f| %>
-  <% if @study.has_expression_data? %>
+  <% if @study.has_expression_data? && @study.can_visualize_clusters? %>
     <%= f.hidden_field :cluster, value: set_cluster_value(@study, params) %>
     <%= f.hidden_field :boxpoints, value: params[:boxpoints].nil? ? 'all' : params[:boxpoints] %>
     <%= f.hidden_field :annotation, value: set_annotation_value(@study, params) %>
@@ -15,10 +15,10 @@
       <i id="search-omnibar-menu-icon" class="fas fa-bars" aria-hidden="true"></i>
     </div>
     <div class="input-group">
-      <% if @study.has_expression_data? %>
+      <% if @study.has_expression_data? && @study.can_visualize_clusters? %>
         <%= f.autocomplete_field :genes, autocomplete_gene_name_gene_index_path(study_id: @study._id), {multiple: true, class: 'form-control search-genes-input', placeholder: 'Search genes', value: set_search_value, data: {delimiter: ' '} } %>
       <% else %>
-        <input class="form-control" type="text" disabled="disabled" data-toggle="tooltip" title="This study has no gene expression data available" />
+        <input class="form-control" type="text" disabled="disabled" data-toggle="tooltip" title="This study has no gene expression and clustering data available" />
       <% end %>
       <span class="input-group-btn">
         <button class="btn btn-default" id="perform-gene-search" type="button">
@@ -29,7 +29,7 @@
   </div>
 
   <div id="search-parent" class="panel-group" style="display: none;">
-    <% if @study.has_expression_data? %>
+    <% if @study.has_expression_data? && @study.can_visualize_clusters? %>
       <div class="panel panel-info" id="search-options-panel">
       <div class="panel-heading">
         <div class="panel-title">
@@ -112,6 +112,7 @@
         </div>
       </div>
     </div>
+    <% end %>
     <% end %>
     <% if @study.has_gene_lists? %>
       <div class="panel panel-info" id="gene-lists-panel">
@@ -240,4 +241,3 @@
       </script>
     <% end %>
   </div>
-<% end %>

--- a/app/views/site/_study_visualize.html.erb
+++ b/app/views/site/_study_visualize.html.erb
@@ -17,37 +17,42 @@
       </ul>
       <%= render partial: 'view_options' %>
       <div class="tab-content">
-        <div class="tab-pane active" id="plots-tab" role="tabpanel">
-          <div class="panel panel-default no-top-border">
-            <div id="plots" class="panel-collapse collapse in">
-              <div class="panel-body">
-                <div class="col-md-12">
-                  <div class="row">
-                    <div class="col-xs-12">
-                      <div id="colorscale-target"></div>
-                      <div id="toggle-plots"></div>
+        <% if @study.can_visualize_clusters? %>
+          <div class="tab-pane active" id="plots-tab" role="tabpanel">
+            <div class="panel panel-default no-top-border">
+              <div id="plots" class="panel-collapse collapse in">
+                <div class="panel-body">
+                  <div class="col-md-12">
+                    <div class="row">
+                      <div class="col-xs-12">
+                        <div id="colorscale-target"></div>
+                        <div id="toggle-plots"></div>
+                      </div>
+                    </div>
+                    <div class="row">
+                      <div id="cluster-plot"></div>
+                      <div id="cluster-figure-legend"></div>
                     </div>
                   </div>
-                  <div class="row">
-                    <div id="cluster-plot"></div>
-                    <div id="cluster-figure-legend"></div>
-                  </div>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </div>
-      <% if @study.can_visualize_genome_data? %>
-        <div class="tab-pane" id="genome-tab" role="tabpanel" >
-          <div class="panel panel-default no-top-border">
-            <div id="genome-container" class="panel-collapse collapse in"></div>
-            <%= render partial: '/site/genome/genome' %>
+        <% end %>
+        <% if @study.can_visualize_genome_data? %>
+          <div class="tab-pane<%= !@study.can_visualize_clusters? ? ' active' : nil%>" id="genome-tab" role="tabpanel" >
+            <div class="panel panel-default no-top-border">
+              <div id="genome-container" class="panel-collapse collapse in">
+                <div style="padding: 15px 30px;">
+                  <%= render partial: '/site/genome/genome' %>
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
     </div>
   </div>
-</div>
 </div>
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
   <% if @study.can_visualize_clusters? %>
@@ -140,5 +145,33 @@
             }
         });
     });
+  <% end %>
+    $('#ideogram_annotation').on('change', function() {
+        var ideogramFiles = <%= raw @ideogram_files.to_json %>;
+        var fileId = $(this).val();
+        if (fileId !== '') {
+            var ideogramAnnot = ideogramFiles[fileId];
+            window.ideogramInferCnvSettings = ideogramAnnot.ideogram_settings;
+            initializeIdeogram(ideogramAnnot.ideogram_settings.annotationsPath);
+        } else {
+            $('#tracks-to-display, #_ideogramOuterWrap').html('');
+            $('#ideogramTitle').remove();
+        }
+
+    });
+  <% if !@study.can_visualize_clusters? && @ideogram_files.present? %>
+    // user has no clusters, but does have ideogram annotations
+    $(document).ready(function () {
+        if (<%= !user_signed_in? %>) {
+          $('#study-tabs a[href="#study-visualize"]').on('shown.bs.tab', function() {
+              $('#genome-tab-nav').click(); // force user to sign in
+          });
+        } else {
+            var ideogramSelect = $('#ideogram_annotation');
+            var firstIdeogram = $('#ideogram_annotation option')[1].value;
+            ideogramSelect.val(firstIdeogram).trigger('change'); // manually trigger change to cause ideogram to render
+        }
+    });
+
   <% end %>
 </script>

--- a/app/views/site/_study_visualize.html.erb
+++ b/app/views/site/_study_visualize.html.erb
@@ -6,9 +6,11 @@
     <div class="row-offcanvas row-offcanvas-right">
       <div id="view-options-nav"><a href="#view-options" id="view-option-link" data-toggle="offcanvas"><i class="fas fa-cog" aria-hidden="true"></i> View Options </a></div>
       <ul class="nav nav-tabs" role="tablist" id="view-tabs">
-        <li role="presentation" class="study-nav active" id="plots-tab-nav"><a href="#plots-tab" data-toggle="tab">Clusters </a></li>
-        <% if @study.has_analysis_outputs?('infercnv', 'ideogram.js') or @study.has_bam_files? %>
-          <li role="presentation" class="study-nav" id="genome-tab-nav">
+        <% if @study.can_visualize_clusters? %>
+          <li role="presentation" class="study-nav active" id="plots-tab-nav"><a href="#plots-tab" data-toggle="tab">Clusters </a></li>
+        <% end %>
+        <% if @study.can_visualize_genome_data? %>
+          <li role="presentation" class="study-nav<%= !@study.can_visualize_clusters? ? ' active' : nil %>" id="genome-tab-nav">
             <a href="#genome-tab" data-toggle="tab">Genome </a>
           </li>
         <% end %>
@@ -35,7 +37,7 @@
           </div>
         </div>
       </div>
-      <% if @study.has_analysis_outputs?('infercnv', 'ideogram.js') or @study.has_bam_files? %>
+      <% if @study.can_visualize_genome_data? %>
         <div class="tab-pane" id="genome-tab" role="tabpanel" >
           <div class="panel panel-default no-top-border">
             <div id="genome-container" class="panel-collapse collapse in"></div>
@@ -48,7 +50,7 @@
 </div>
 </div>
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-
+  <% if @study.can_visualize_clusters? %>
     $('#cluster-plot').data('rendered', false);
 
     var baseCamera = {
@@ -138,5 +140,5 @@
             }
         });
     });
-
+  <% end %>
 </script>

--- a/app/views/site/_view_options.html.erb
+++ b/app/views/site/_view_options.html.erb
@@ -26,21 +26,32 @@
           </div>
         </div>
       </div>
-    <% elsif !@study.can_visualize_clusters? && @study.has_analysis_outputs?('infercnv', 'ideogram.js') %>
-      <div id="ideogram-panel" class="no-top-border">
-        <div class="panel-body">
-          <div id="ideogram-options" class="panel-collapse collapse in">
-            <div class="form-group col-sm-4">
-              <%= label_tag :ideogram_annotation, 'Select Ideogram Annotation' %><br />
-              <%= select_tag :ideogram_annotation, options_for_select(@ideogram_files), class: 'form-control' %>
-            </div>
-          </div>
-        </div>
-      </div>
     <% end %>
       <div id="view-options-accordion" class="panel-group">
+        <% if !@study.can_visualize_clusters? && @study.has_analysis_outputs?('infercnv', 'ideogram.js') && action_name == 'study' %>
+          <div id="genome-options-panel" class="panel panel-info %>">
+            <div class="panel-heading">
+              <div class="panel-title">
+                <a data-toggle="collapse" id="genome-panel-link" data-parent="#view-options-accordion" href="#genome-plot-controls"><span class="fas fa-chevron-down toggle-glyph"></span> Genome</a>
+              </div>
+            </div>
+            <div id="genome-plot-controls" class="panel-collapse collapse in">
+
+              <div id="ideogram-panel" class="no-top-border">
+                <div class="panel-body">
+                  <div id="ideogram-options" class="panel-collapse collapse in">
+                    <div class="form-group col-sm-4">
+                      <%= label_tag :ideogram_annotation, 'Select Ideogram File' %><br />
+                      <%= select_tag :ideogram_annotation, options_for_select(@ideogram_files.map {|id, opts| [opts[:display], id]}), include_blank: true, class: 'form-control' %>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
         <% if @study.has_expression_data? %>
-        <div id="expression-options-panel" class="panel <%= /view_gene_(set_)?expression$/.match(action_name) ? "panel-info" : "panel-default" %>">
+          <div id="expression-options-panel" class="panel <%= /view_gene_(set_)?expression$/.match(action_name) ? "panel-info" : "panel-default" %>">
             <div class="panel-heading">
               <div class="panel-title">
                 <a data-toggle="collapse" id="distribution-panel-link" data-parent="#view-options-accordion" href="#distribution-plot-controls"><span class="fas fa-chevron-<%= action_name == 'view_gene_expression' ? 'down' : 'right' %> toggle-glyph"></span> Distribution</a>
@@ -64,78 +75,81 @@
                 </div>
               </div>
             </div>
-        </div>
-        <div id="original-view-panel" class="panel <%= /view_gene_(set_)?expression$/.match(action_name) ? "panel-info" : "panel-default" %>">
-          <div class="panel-heading">
-            <div class="panel-title">
-              <a data-toggle="collapse" id="scatter-panel-link" data-parent="#view-options-accordion" href="#original-view-controls"><span class="fas fa-chevron-right toggle-glyph"></span> Scatter</a>
-            </div>
           </div>
-          <div id="original-view-controls" class="panel-collapse collapse">
-            <div class="panel-body">
-              <div class="row">
-                <div class="col-xs-12">
-                  <%= render partial: 'colorscale_picker' %>
-                </div>
+        <% end %>
+        <% if @study.can_visualize_clusters? %>
+          <div id="original-view-panel" class="panel <%= action_name !~ /heatmap/ ? "panel-info" : "panel-default" %>">
+            <div class="panel-heading">
+              <div class="panel-title">
+                <a data-toggle="collapse" id="scatter-panel-link" data-parent="#view-options-accordion" href="#original-view-controls"><span class="fas fa-chevron-right toggle-glyph"></span> Scatter</a>
               </div>
             </div>
-          </div>
-        </div>
-
-        <div id="heatmap-panel" class="panel <%= action_name =~ /heatmap/ ? 'panel-info' : 'panel-default' %>">
-          <div class="panel-heading">
-            <div class="panel-title">
-              <a data-toggle="collapse" id="heatmap-panel-link" data-parent="#view-options-accordion" href="#heatmap-controls"><span class="fas fa-chevron-<%= action_name =~ /heatmap/ ? 'down' : 'right' %> toggle-glyph"></span> Heatmap</a>
-            </div>
-          </div>
-          <div id="heatmap-controls" class="panel-collapse collapse <% if action_name =~ /heatmap/ %>in<% end %>">
-            <div class="panel-body">
-              <div class="form-group row">
-                <div class="col-sm-4">
-                  <%= label_tag :heatmap_row_centering, 'Row centering' %> <span class="fas fa-question-circle" data-toggle="tooltip" title="Row-center expression data using the selected metric.  Selecting a value other than none will enforce global color values."></span><br />
-                  <%= select_tag :heatmap_row_centering, options_for_select([['Z-score [(v - mean) / stdev]','z-score'],['Robust z-score [(v - median) / MAD]', 'robust-z-score']], params[:heatmap_row_centering]), {include_blank: 'None', class: 'form-control'} %>
-                </div>
-
-              </div>
-            <!-- if action_name =~ /heatmap/ -->
-              <div class="row">
-                <div class="col-sm-4">
-                  <div class="row">
-                    <div class="col-xs-12">
-                      <%= label_tag :heatmap_size, 'Heatmap size (in pixels)', class: 'control-label' %><i class="fas fa-fw fa-question-circle" title="Redraw heatmap plot to specified size in pixels.  Leaving this blank will show all rows at 100% zoom." data-toggle="tooltip"></i>
-                    </div>
+            <div id="original-view-controls" class="panel-collapse collapse">
+              <div class="panel-body">
+                <div class="row">
+                  <div class="col-xs-12">
+                    <%= render partial: 'colorscale_picker' %>
                   </div>
-                  <div class="row">
-                    <div class="col-xs-12">
-                      <div class="input-group">
-                        <%= number_field_tag :heatmap_size, params[:heatmap_size], class: 'form-control' %>
-                        <div class="input-group-btn">
-                          <button type="submit" id="resize-heatmap" class="btn btn-success"><i class="fas fa-fw fa-sync-alt"></i></button>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+        <% if @study.has_expression_data? %>
+          <div id="heatmap-panel" class="panel <%= action_name =~ /heatmap/ ? 'panel-info' : 'panel-default' %>">
+            <div class="panel-heading">
+              <div class="panel-title">
+                <a data-toggle="collapse" id="heatmap-panel-link" data-parent="#view-options-accordion" href="#heatmap-controls"><span class="fas fa-chevron-<%= action_name =~ /heatmap/ ? 'down' : 'right' %> toggle-glyph"></span> Heatmap</a>
+              </div>
+            </div>
+            <div id="heatmap-controls" class="panel-collapse collapse <% if action_name =~ /heatmap/ %>in<% end %>">
+              <div class="panel-body">
+                <div class="form-group row">
+                  <div class="col-sm-4">
+                    <%= label_tag :heatmap_row_centering, 'Row centering' %> <span class="fas fa-question-circle" data-toggle="tooltip" title="Row-center expression data using the selected metric.  Selecting a value other than none will enforce global color values."></span><br />
+                    <%= select_tag :heatmap_row_centering, options_for_select([['Z-score [(v - mean) / stdev]','z-score'],['Robust z-score [(v - median) / MAD]', 'robust-z-score']], params[:heatmap_row_centering]), {include_blank: 'None', class: 'form-control'} %>
+                  </div>
+
+                </div>
+              <!-- if action_name =~ /heatmap/ -->
+                <div class="row">
+                  <div class="col-sm-4">
+                    <div class="row">
+                      <div class="col-xs-12">
+                        <%= label_tag :heatmap_size, 'Heatmap size (in pixels)', class: 'control-label' %><i class="fas fa-fw fa-question-circle" title="Redraw heatmap plot to specified size in pixels.  Leaving this blank will show all rows at 100% zoom." data-toggle="tooltip"></i>
+                      </div>
+                    </div>
+                    <div class="row">
+                      <div class="col-xs-12">
+                        <div class="input-group">
+                          <%= number_field_tag :heatmap_size, params[:heatmap_size], class: 'form-control' %>
+                          <div class="input-group-btn">
+                            <button type="submit" id="resize-heatmap" class="btn btn-success"><i class="fas fa-fw fa-sync-alt"></i></button>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
-                </div>
-                <div class="form-group col-sm-8">
-                  <div class="row">
-                    <div class="col-xs-12">
-                      <%= label_tag :fit_options, 'Fit Options', class: 'control-label' %><i class="fas fa-fw fa-question-circle" title="Use these buttons to rescale the contents of the heatmap plot.  Each option is can be toggled and combined with other options." data-toggle="tooltip"></i>
+                  <div class="form-group col-sm-8">
+                    <div class="row">
+                      <div class="col-xs-12">
+                        <%= label_tag :fit_options, 'Fit Options', class: 'control-label' %><i class="fas fa-fw fa-question-circle" title="Use these buttons to rescale the contents of the heatmap plot.  Each option is can be toggled and combined with other options." data-toggle="tooltip"></i>
+                      </div>
+                    </div>
+                    <div class="row">
+                      <div class="col-xs-12">
+                        <%= link_to "<i class='fas fa-fw fa-arrows-alt-v'></i> Fit Rows".html_safe, '#/', id: 'fit-rows', class: 'btn btn-default fit-btn', title: 'Rescale heatmap to fit all rows in plot area', data: {fit: 'rows', active: 'off', toggle: 'tooltip' } %>
+                        <%= link_to "<i class='fas fa-fw fa-arrows-alt-h'></i> Fit Columns".html_safe, '#/', id: 'fit-cols', class: 'btn btn-default fit-btn', title: 'Rescale heatmap to fit all columns in plot area', data: {fit: 'cols', active: 'off', toggle: 'tooltip' } %>
+                        <%= link_to "<i class='fas fa-fw fa-arrows-alt'></i> Toggle Fullscreen".html_safe, '#/', id: 'view-fullscreen', class: 'btn btn-default', title: 'Close all options panels and redraw heatmap at full zoom to use available area', data: {active: 'off', toggle: 'tooltip' } %>
+                      </div>
                     </div>
                   </div>
-                  <div class="row">
-                    <div class="col-xs-12">
-                      <%= link_to "<i class='fas fa-fw fa-arrows-alt-v'></i> Fit Rows".html_safe, '#/', id: 'fit-rows', class: 'btn btn-default fit-btn', title: 'Rescale heatmap to fit all rows in plot area', data: {fit: 'rows', active: 'off', toggle: 'tooltip' } %>
-                      <%= link_to "<i class='fas fa-fw fa-arrows-alt-h'></i> Fit Columns".html_safe, '#/', id: 'fit-cols', class: 'btn btn-default fit-btn', title: 'Rescale heatmap to fit all columns in plot area', data: {fit: 'cols', active: 'off', toggle: 'tooltip' } %>
-                      <%= link_to "<i class='fas fa-fw fa-arrows-alt'></i> Toggle Fullscreen".html_safe, '#/', id: 'view-fullscreen', class: 'btn btn-default', title: 'Close all options panels and redraw heatmap at full zoom to use available area', data: {active: 'off', toggle: 'tooltip' } %>
-                    </div>
-                  </div>
                 </div>
+              <!-- end -->
               </div>
-            <!-- end -->
+            </div>
           </div>
-        </div>
-      </div>
-    <% end %>
+        <% end %>
     </div>
   </div>
 </div>

--- a/app/views/site/_view_options.html.erb
+++ b/app/views/site/_view_options.html.erb
@@ -1,5 +1,6 @@
 <div id="view-options-panel" class="panel sidebar-offcanvas">
 	<div id="view-options" class="panel-default no-top-border">
+    <% if @study.can_visualize_clusters? %>
       <div id="precomputed-panel" class="no-top-border">
         <div class="panel-body">
           <div id="precomputed" class="panel-collapse collapse <% if action_name != /precomputed/ %>in<% end %>">
@@ -25,7 +26,20 @@
           </div>
         </div>
       </div>
+    <% elsif !@study.can_visualize_clusters? && @study.has_analysis_outputs?('infercnv', 'ideogram.js') %>
+      <div id="ideogram-panel" class="no-top-border">
+        <div class="panel-body">
+          <div id="ideogram-options" class="panel-collapse collapse in">
+            <div class="form-group col-sm-4">
+              <%= label_tag :ideogram_annotation, 'Select Ideogram Annotation' %><br />
+              <%= select_tag :ideogram_annotation, options_for_select(@ideogram_files), class: 'form-control' %>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
       <div id="view-options-accordion" class="panel-group">
+        <% if @study.has_expression_data? %>
         <div id="expression-options-panel" class="panel <%= /view_gene_(set_)?expression$/.match(action_name) ? "panel-info" : "panel-default" %>">
             <div class="panel-heading">
               <div class="panel-title">
@@ -121,6 +135,7 @@
           </div>
         </div>
       </div>
+    <% end %>
     </div>
   </div>
 </div>

--- a/app/views/site/analysis/_submit_workflow.html.erb
+++ b/app/views/site/analysis/_submit_workflow.html.erb
@@ -109,7 +109,6 @@
           tabClass: 'nav-tabs',
           onTabShow: function(tab, navigation, index, clickedIndex, clickedTab) {
               var step = $(tab[0]).attr('id');
-              console.log('id: ' + step);
               if (step === 'select-inputs-nav') {
                   wizard.find('.pager .next').hide();
               } else {

--- a/app/views/site/study.html.erb
+++ b/app/views/site/study.html.erb
@@ -4,7 +4,7 @@
 <div id="tab-root">
   <ul class="nav nav-tabs" role="tablist" id="study-tabs">
     <li role="presentation" class="study-nav active" id="study-summary-nav"><a href="#study-summary" data-toggle="tab">Summary <i class="far fa-fw fa-file-alt"></i></a></li>
-    <% if @study.initialized? %>
+    <% if @study.can_visualize? %>
       <li role="presentation" class="study-nav" id="study-visualize-nav"><a href="#study-visualize" data-toggle="tab">Explore <i class="fas fa-fw fa-eye"></i></a></li>
     <% else %>
       <li role="presentation" class="study-nav disabled" id="study-visualize-nav"><a href="#study-visualize" data-toggle="tooltip" title="This study has no data to view">Explore <i class="fas fa-fw fa-eye"></i></a></li>
@@ -34,7 +34,7 @@
       <%= render partial: 'study_description_view' %>
     </div>
     <div class="tab-pane" id="study-visualize" role="tabpanel">
-      <% if @study.initialized? %>
+      <% if @study.can_visualize? %>
         <%= render partial: 'study_visualize' %>
       <% end %>
     </div>

--- a/app/views/studies/_study_file_form.html.erb
+++ b/app/views/studies/_study_file_form.html.erb
@@ -33,7 +33,7 @@
       <%= render partial: 'expression_file_fields', locals: {f: f.dup} %>
     <% elsif study_file.file_type == '10X Genes File' || study_file.file_type == '10X Barcodes File' %>
       <%= render partial: 'mm_coordinate_association_fields', locals: {f: f.dup} %>
-    <% elsif study_file.file_type == 'BAM' %>
+    <% elsif study_file.file_type == 'BAM Index' %>
       <%= render partial: 'bam_association_fields', locals: {f: f.dup} %>
     <% end %>
   </div>

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -188,7 +188,7 @@ class UiTestSuite < Test::Unit::TestCase
     opts = species_dropdown.find_elements(:tag_name, 'option')
     available_species = opts.delete_if {|opt| opt['value'] == ''}
     if available_species.any?
-      species_dropdown.send_key(available_species.sample.text)
+      species_dropdown.send_keys(available_species.sample.text)
     end
     # upload expression matrix
     upload_expression = @driver.find_element(:id, 'upload-expression')
@@ -209,7 +209,7 @@ class UiTestSuite < Test::Unit::TestCase
     opts = species_dropdown.find_elements(:tag_name, 'option')
     available_species = opts.delete_if {|opt| opt['value'] == ''}
     if available_species.any?
-      species_dropdown.send_key(available_species.sample.text)
+      species_dropdown.send_keys(available_species.sample.text)
     end
     upload_expression_2 = exp_2_form.find_element(:id, 'upload-expression')
     upload_expression_2.send_keys(@test_data_path + 'expression_matrix_example_2.txt')
@@ -240,15 +240,15 @@ class UiTestSuite < Test::Unit::TestCase
     upload_cluster.send_keys(@test_data_path + 'cluster_example_2.txt')
     wait_for_render(:id, 'start-file-upload')
     # add labels and axis ranges
-    cluster_form_1.find_element(:id, :study_file_x_axis_min).send_key(-100)
-    cluster_form_1.find_element(:id, :study_file_x_axis_max).send_key(100)
-    cluster_form_1.find_element(:id, :study_file_y_axis_min).send_key(-75)
-    cluster_form_1.find_element(:id, :study_file_y_axis_max).send_key(75)
-    cluster_form_1.find_element(:id, :study_file_z_axis_min).send_key(-125)
-    cluster_form_1.find_element(:id, :study_file_z_axis_max).send_key(125)
-    cluster_form_1.find_element(:id, :study_file_x_axis_label).send_key('X Axis')
-    cluster_form_1.find_element(:id, :study_file_y_axis_label).send_key('Y Axis')
-    cluster_form_1.find_element(:id, :study_file_z_axis_label).send_key('Z Axis')
+    cluster_form_1.find_element(:id, :study_file_x_axis_min).send_keys(-100)
+    cluster_form_1.find_element(:id, :study_file_x_axis_max).send_keys(100)
+    cluster_form_1.find_element(:id, :study_file_y_axis_min).send_keys(-75)
+    cluster_form_1.find_element(:id, :study_file_y_axis_max).send_keys(75)
+    cluster_form_1.find_element(:id, :study_file_z_axis_min).send_keys(-125)
+    cluster_form_1.find_element(:id, :study_file_z_axis_max).send_keys(125)
+    cluster_form_1.find_element(:id, :study_file_x_axis_label).send_keys('X Axis')
+    cluster_form_1.find_element(:id, :study_file_y_axis_label).send_keys('Y Axis')
+    cluster_form_1.find_element(:id, :study_file_z_axis_label).send_keys('Z Axis')
     # perform upload
     upload_btn = cluster_form_1.find_element(:id, 'start-file-upload')
     upload_btn.click
@@ -297,7 +297,7 @@ class UiTestSuite < Test::Unit::TestCase
     opts = species_dropdown.find_elements(:tag_name, 'option')
     available_species = opts.delete_if {|opt| opt['value'] == '' || opt.text.downcase == 'human' }
     if available_species.any?
-      species_dropdown.send_key(available_species.sample.text)
+      species_dropdown.send_keys(available_species.sample.text)
     end
     upload_fastq = fastq_form.find_element(:class, 'upload-fastq')
     upload_fastq.send_keys(@test_data_path + 'cell_1_R1_001.fastq.gz')
@@ -316,7 +316,7 @@ class UiTestSuite < Test::Unit::TestCase
     opts = species_dropdown.find_elements(:tag_name, 'option')
     available_species = opts.delete_if {|opt| opt['value'] == '' || opt.text.downcase == 'human' }
     if available_species.any?
-      species_dropdown.send_key(available_species.sample.text)
+      species_dropdown.send_keys(available_species.sample.text)
     end
     new_upload_fastq = new_fastq_form.find_element(:class, 'upload-fastq')
     new_upload_fastq.send_keys(@test_data_path + 'cell_1_I1_001.fastq.gz')
@@ -428,7 +428,7 @@ class UiTestSuite < Test::Unit::TestCase
     opts = species_dropdown.find_elements(:tag_name, 'option')
     available_species = opts.delete_if {|opt| opt['value'] == ''}
     if available_species.any?
-      species_dropdown.send_key(available_species.sample.text)
+      species_dropdown.send_keys(available_species.sample.text)
     end
     upload_expression = exp_form.find_element(:id, 'upload-expression')
     upload_expression.send_keys(@test_data_path + 'expression_matrix_example.txt')
@@ -515,7 +515,7 @@ class UiTestSuite < Test::Unit::TestCase
     opts = species_dropdown.find_elements(:tag_name, 'option')
     available_species = opts.delete_if {|opt| opt['value'] == ''}
     if available_species.any?
-      species_dropdown.send_key(available_species.sample.text)
+      species_dropdown.send_keys(available_species.sample.text)
     end
     upload_expression = exp_form.find_element(:id, 'upload-expression')
     upload_expression.send_keys(@test_data_path + 'expression_matrix_example.txt')
@@ -606,7 +606,7 @@ class UiTestSuite < Test::Unit::TestCase
     opts = species_dropdown.find_elements(:tag_name, 'option')
     available_species = opts.delete_if {|opt| opt['value'] == ''}
     if available_species.any?
-      species_dropdown.send_key(available_species.sample.text)
+      species_dropdown.send_keys(available_species.sample.text)
     end
     upload_expression = exp_form.find_element(:id, 'upload-expression')
     upload_expression.send_keys(@test_data_path + 'expression_matrix_example_gzipped.txt.gz')
@@ -651,7 +651,7 @@ class UiTestSuite < Test::Unit::TestCase
     opts = species_dropdown.find_elements(:tag_name, 'option')
     available_species = opts.delete_if {|opt| opt['value'] == ''}
     if available_species.any?
-      species_dropdown.send_key(available_species.sample.text)
+      species_dropdown.send_keys(available_species.sample.text)
     end
     upload_expression = matrix_form.find_element(:id, 'upload-expression')
     upload_expression.send_keys(@test_data_path + 'GRCh38/test_matrix.mtx')
@@ -732,7 +732,7 @@ class UiTestSuite < Test::Unit::TestCase
     opts = species_dropdown.find_elements(:tag_name, 'option')
     available_species = opts.delete_if {|opt| opt['value'] == ''}
     if available_species.any?
-      species_dropdown.send_key(available_species.sample.text)
+      species_dropdown.send_keys(available_species.sample.text)
     end
     upload_expression = exp_form.find_element(:id, 'upload-expression')
     upload_expression.send_keys(@test_data_path + 'expression_matrix_example.txt')
@@ -854,7 +854,7 @@ class UiTestSuite < Test::Unit::TestCase
     opts = species_dropdown.find_elements(:tag_name, 'option')
     available_species = opts.delete_if {|opt| opt['value'] == ''}
     if available_species.any?
-      species_dropdown.send_key(available_species.sample.text)
+      species_dropdown.send_keys(available_species.sample.text)
     end
     upload_expression = exp_form.find_element(:id, 'upload-expression')
     upload_expression.send_keys(@test_data_path + 'expression_matrix_example_bad.txt')
@@ -874,7 +874,7 @@ class UiTestSuite < Test::Unit::TestCase
     opts = species_dropdown.find_elements(:tag_name, 'option')
     available_species = opts.delete_if {|opt| opt['value'] == ''}
     if available_species.any?
-      species_dropdown.send_key(available_species.sample.text)
+      species_dropdown.send_keys(available_species.sample.text)
     end
     upload_expression = exp_2_form.find_element(:id, 'upload-expression')
     upload_expression.send_keys(@test_data_path + 'R_format_text.txt')
@@ -1253,7 +1253,7 @@ class UiTestSuite < Test::Unit::TestCase
           opts = species_dropdown.find_elements(:tag_name, 'option')
           available_species = opts.delete_if {|opt| opt['value'] == ''}
           if available_species.any?
-            species_dropdown.send_key(available_species.sample.text)
+            species_dropdown.send_keys(available_species.sample.text)
           end
         when 'metadata_example.txt'
           file_type.send_keys('Metadata')
@@ -1276,7 +1276,7 @@ class UiTestSuite < Test::Unit::TestCase
         available_species = opts.delete_if {|opt| opt['value'] == ''}
         if available_species.any?
           taxon = available_species.sample.text
-          species_dropdown.send_key(taxon)
+          species_dropdown.send_keys(taxon)
         end
       end
 
@@ -1398,7 +1398,7 @@ class UiTestSuite < Test::Unit::TestCase
     # search for a gene
     gene = @genes.sample
     search_box = @driver.find_element(:id, 'search_genes')
-    search_box.send_key(gene)
+    search_box.send_keys(gene)
     search_genes = @driver.find_element(:id, 'perform-gene-search')
     search_genes.click
 
@@ -1648,7 +1648,7 @@ class UiTestSuite < Test::Unit::TestCase
     # search for a gene to make sure styles persist
     gene = @genes.sample
     search_box = @driver.find_element(:id, 'search_genes')
-    search_box.send_key(gene)
+    search_box.send_keys(gene)
     search_genes = @driver.find_element(:id, 'perform-gene-search')
     search_genes.click
     @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
@@ -1979,7 +1979,7 @@ class UiTestSuite < Test::Unit::TestCase
       quota_edit = @driver.find_element(:class, 'daily-user-download-quota-edit')
       quota_edit.click
       multiplier = @driver.find_element(:id, 'admin_configuration_multiplier')
-      multiplier.send_key('byte')
+      multiplier.send_keys('byte')
       save = @driver.find_element(:id, 'save-configuration')
       save.click
       wait_until_page_loads(path)
@@ -1988,9 +1988,9 @@ class UiTestSuite < Test::Unit::TestCase
       create = @driver.find_element(id: 'create-new-configuration')
       create.click
       value = @driver.find_element(:id, 'admin_configuration_value')
-      value.send_key(2)
+      value.send_keys(2)
       multiplier = @driver.find_element(:id, 'admin_configuration_multiplier')
-      multiplier.send_key('byte')
+      multiplier.send_keys('byte')
       save = @driver.find_element(:id, 'save-configuration')
       save.click
       wait_until_page_loads(path)
@@ -2021,7 +2021,7 @@ class UiTestSuite < Test::Unit::TestCase
     quota_edit = @driver.find_element(:class, 'daily-user-download-quota-edit')
     quota_edit.click
     multiplier = @driver.find_element(:id, 'admin_configuration_multiplier')
-    multiplier.send_key('terabyte')
+    multiplier.send_keys('terabyte')
     save = @driver.find_element(:id, 'save-configuration')
     save.click
     wait_until_page_loads(path)
@@ -2616,7 +2616,7 @@ class UiTestSuite < Test::Unit::TestCase
     # perform negative search first to test redirect
     bad_gene = 'foo'
     search_box = @driver.find_element(:id, 'search_genes')
-    search_box.send_key(bad_gene)
+    search_box.send_keys(bad_gene)
     search_genes = @driver.find_element(:id, 'perform-gene-search')
     search_genes.click
     wait_for_modal_open('message_modal')
@@ -2627,7 +2627,7 @@ class UiTestSuite < Test::Unit::TestCase
     # load random gene to search
     gene = @genes.sample
     search_box = @driver.find_element(:id, 'search_genes')
-    search_box.send_key(gene)
+    search_box.send_keys(gene)
     search_genes = @driver.find_element(:id, 'perform-gene-search')
     search_genes.click
     assert element_present?(:id, 'box-controls'), 'could not find expression violin plot'
@@ -2657,7 +2657,7 @@ class UiTestSuite < Test::Unit::TestCase
         is_box_plot = plot_ops.select {|opt| opt.selected?}.sample.text == 'Box Plot'
         if is_box_plot
           new_plot = plot_ops.select {|opt| !opt.selected?}.sample.text
-          plot_dropdown.send_key(new_plot)
+          plot_dropdown.send_keys(new_plot)
         end
         # wait until violin plot renders, at this point all 3 should be done
 
@@ -2673,7 +2673,7 @@ class UiTestSuite < Test::Unit::TestCase
         plot_dropdown = @driver.find_element(:id, 'plot_type')
         plot_ops = plot_dropdown.find_elements(:tag_name, 'option')
         new_plot = plot_ops.select {|opt| !opt.selected?}.sample.text
-        plot_dropdown.send_key(new_plot)
+        plot_dropdown.send_keys(new_plot)
 
         # wait until box plot renders, at this point all 3 should be done
         @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
@@ -2706,7 +2706,7 @@ class UiTestSuite < Test::Unit::TestCase
 
     new_gene = @genes.sample
     search_box = @driver.find_element(:id, 'search_genes')
-    search_box.send_key(new_gene)
+    search_box.send_keys(new_gene)
     search_genes = @driver.find_element(:id, 'perform-gene-search')
     search_genes.click
     assert element_present?(:id, 'box-controls'), 'could not find expression boxplot'
@@ -2734,7 +2734,7 @@ class UiTestSuite < Test::Unit::TestCase
     private_plot_dropdown = @driver.find_element(:id, 'plot_type')
     private_plot_ops = private_plot_dropdown.find_elements(:tag_name, 'option')
     private_new_plot = private_plot_ops.select {|opt| !opt.selected?}.sample.text
-    private_plot_dropdown.send_key(private_new_plot)
+    private_plot_dropdown.send_keys(private_new_plot)
 
     # wait until box plot renders, at this point all 3 should be done
     @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
@@ -2812,7 +2812,7 @@ class UiTestSuite < Test::Unit::TestCase
         is_box_plot = plot_ops.select {|opt| opt.selected?}.sample.text == 'Box Plot'
         if is_box_plot
           new_plot = plot_ops.select {|opt| !opt.selected?}.sample.text
-          plot_dropdown.send_key(new_plot)
+          plot_dropdown.send_keys(new_plot)
         end
         # wait until violin plot renders, at this point all 3 should be done
 
@@ -2828,7 +2828,7 @@ class UiTestSuite < Test::Unit::TestCase
         plot_dropdown = @driver.find_element(:id, 'plot_type')
         plot_ops = plot_dropdown.find_elements(:tag_name, 'option')
         new_plot = plot_ops.select {|opt| !opt.selected?}.sample.text
-        plot_dropdown.send_key(new_plot)
+        plot_dropdown.send_keys(new_plot)
 
         # wait until box plot renders, at this point all 3 should be done
         @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
@@ -2906,7 +2906,7 @@ class UiTestSuite < Test::Unit::TestCase
     private_plot_dropdown = @driver.find_element(:id, 'plot_type')
     private_plot_ops = private_plot_dropdown.find_elements(:tag_name, 'option')
     private_new_plot = private_plot_ops.select {|opt| !opt.selected?}.sample.text
-    private_plot_dropdown.send_key(private_new_plot)
+    private_plot_dropdown.send_keys(private_new_plot)
 
     # wait until box plot renders, at this point all 3 should be done
     @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
@@ -2963,7 +2963,7 @@ class UiTestSuite < Test::Unit::TestCase
     # resize heatmap
     scroll_to(:bottom)
     heatmap_size = @driver.find_element(:id, 'heatmap_size')
-    heatmap_size.send_key(1000)
+    heatmap_size.send_keys(1000)
     @wait.until {wait_for_morpheus_render('#heatmap-plot', 'morpheus')}
 
     resize_heatmap_drawn = @driver.execute_script("return $('#heatmap-plot').data('morpheus').heatmap !== undefined;")
@@ -3086,7 +3086,7 @@ class UiTestSuite < Test::Unit::TestCase
     end
     # load numeric annotation to test 2d scatter feature
     annotation_select = panel_div.find_element(:class, 'annotation-select')
-    annotation_select.send_key('Average Intensity')
+    annotation_select.send_keys('Average Intensity')
     # wait half second for event to fire
     @wait.until {wait_for_plotly_render('#' + plot_id, 'rendered')}
     updated_data = @driver.execute_script("return document.getElementById('#{plot_id}').data")
@@ -3117,7 +3117,7 @@ class UiTestSuite < Test::Unit::TestCase
     end
     # load numeric annotation to test 2d scatter feature
     private_annotation_select = private_panel_div.find_element(:class, 'annotation-select')
-    private_annotation_select.send_key('Average Intensity')
+    private_annotation_select.send_keys('Average Intensity')
     # wait half second for event to fire
     sleep(0.5)
     @wait.until {wait_for_plotly_render('#' + private_plot_id, 'rendered')}
@@ -3249,7 +3249,7 @@ class UiTestSuite < Test::Unit::TestCase
         is_box_plot = plot_ops.select {|opt| opt.selected?}.sample.text == 'Box Plot'
         if is_box_plot
           new_plot = plot_ops.select {|opt| !opt.selected?}.sample.text
-          plot_dropdown.send_key(new_plot)
+          plot_dropdown.send_keys(new_plot)
         end
         # wait until violin plot renders, at this point all 3 should be done
 
@@ -3265,7 +3265,7 @@ class UiTestSuite < Test::Unit::TestCase
         plot_dropdown = @driver.find_element(:id, 'plot_type')
         plot_ops = plot_dropdown.find_elements(:tag_name, 'option')
         new_plot = plot_ops.select {|opt| !opt.selected?}.sample.text
-        plot_dropdown.send_key(new_plot)
+        plot_dropdown.send_keys(new_plot)
 
         # wait until box plot renders, at this point all 3 should be done
         @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
@@ -3332,7 +3332,7 @@ class UiTestSuite < Test::Unit::TestCase
     private_plot_dropdown = @driver.find_element(:id, 'plot_type')
     private_plot_ops = private_plot_dropdown.find_elements(:tag_name, 'option')
     private_new_plot = private_plot_ops.select {|opt| !opt.selected?}.sample.text
-    private_plot_dropdown.send_key(private_new_plot)
+    private_plot_dropdown.send_keys(private_new_plot)
 
     # wait until box plot renders, at this point all 3 should be done
     @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
@@ -3390,7 +3390,7 @@ class UiTestSuite < Test::Unit::TestCase
     # now search for a gene and make sure values are preserved
     gene = @genes.sample
     search_box = @driver.find_element(:id, 'search_genes')
-    search_box.send_key(gene)
+    search_box.send_keys(gene)
     search_genes = @driver.find_element(:id, 'perform-gene-search')
     search_genes.click
 
@@ -3492,7 +3492,7 @@ class UiTestSuite < Test::Unit::TestCase
     cluster_dropdown = options_form.find_element(:id, 'study_default_options_cluster')
     cluster_opts = cluster_dropdown.find_elements(:tag_name, 'option')
     new_cluster = cluster_opts.select {|opt| !opt.selected?}.sample.text
-    cluster_dropdown.send_key(new_cluster)
+    cluster_dropdown.send_keys(new_cluster)
 
     # wait one second while annotation options update
     sleep(1)
@@ -3502,7 +3502,7 @@ class UiTestSuite < Test::Unit::TestCase
     annotation_opts = annotation_dropdown.find_elements(:tag_name, 'option')
     # get value, not text, of dropdown
     new_annot = annotation_opts.select {|opt| !opt.selected?}.sample['value']
-    annotation_dropdown.send_key(new_annot)
+    annotation_dropdown.send_keys(new_annot)
 
     # if annotation option is now numeric, pick a color val
     new_color = ''
@@ -3510,7 +3510,7 @@ class UiTestSuite < Test::Unit::TestCase
     if color_dropdown['disabled'] != 'true'
       color_opts = color_dropdown.find_elements(:tag_name, 'option')
       new_color = color_opts.select {|opt| !opt.selected?}.sample.text
-      color_dropdown.send_key(new_color)
+      color_dropdown.send_keys(new_color)
     end
 
     # change expression axis label
@@ -3557,7 +3557,7 @@ class UiTestSuite < Test::Unit::TestCase
     # now check gene expression pages
     gene = @genes.sample
     search_box = @driver.find_element(:id, 'search_genes')
-    search_box.send_key(gene)
+    search_box.send_keys(gene)
     search_genes = @driver.find_element(:id, 'perform-gene-search')
     search_genes.click
     @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
@@ -3659,7 +3659,7 @@ class UiTestSuite < Test::Unit::TestCase
     cluster_dropdown = options_form.find_element(:id, 'study_default_options_cluster')
     cluster_opts = cluster_dropdown.find_elements(:tag_name, 'option')
     new_cluster = cluster_opts.select {|opt| !opt.selected?}.sample.text
-    cluster_dropdown.send_key(new_cluster)
+    cluster_dropdown.send_keys(new_cluster)
     # change cluster point size, turn on borders, and reset alpha
     cluster_point_size = options_form.find_element(:id, 'study_default_options_cluster_point_size')
     cluster_point_size.clear
@@ -3678,7 +3678,7 @@ class UiTestSuite < Test::Unit::TestCase
     annotation_opts = annotation_dropdown.find_elements(:tag_name, 'option')
     # get value, not text, of dropdown
     new_annot = annotation_opts.select {|opt| !opt.selected?}.sample['value']
-    annotation_dropdown.send_key(new_annot)
+    annotation_dropdown.send_keys(new_annot)
 
     # if annotation option is now numeric, pick a color val
     new_color = ''
@@ -3686,14 +3686,14 @@ class UiTestSuite < Test::Unit::TestCase
     if color_dropdown['disabled'] != 'true'
       color_opts = color_dropdown.find_elements(:tag_name, 'option')
       new_color = color_opts.select {|opt| !opt.selected?}.sample.text
-      color_dropdown.send_key(new_color)
+      color_dropdown.send_keys(new_color)
     end
 
     # set cell count
     new_cells = rand(100) + 1
     cell_count = @driver.find_element(:id, 'study_cell_count')
     cell_count.clear
-    cell_count.send_key(new_cells)
+    cell_count.send_keys(new_cells)
 
     # manually set rendered to false to avoid a race condition when checking for updates
     @driver.execute_script("$('#cluster-plot').data('rendered', false);")
@@ -3853,7 +3853,7 @@ class UiTestSuite < Test::Unit::TestCase
     scroll_to(:top)
     gene = @genes.sample
     search_box = @driver.find_element(:id, 'search_genes')
-    search_box.send_key(gene)
+    search_box.send_keys(gene)
     search_genes = @driver.find_element(:id, 'perform-gene-search')
     search_genes.click
 
@@ -3878,7 +3878,7 @@ class UiTestSuite < Test::Unit::TestCase
     plot_dropdown = @driver.find_element(:id, 'plot_type')
     plot_ops = plot_dropdown.find_elements(:tag_name, 'option')
     new_plot = plot_ops.select {|opt| !opt.selected?}.sample.text
-    plot_dropdown.send_key(new_plot)
+    plot_dropdown.send_keys(new_plot)
 
     # wait until box plot renders, at this point all 3 should be done
     @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
@@ -3981,7 +3981,7 @@ class UiTestSuite < Test::Unit::TestCase
     # load random gene to search
     gene = @genes.sample
     search_box = @driver.find_element(:id, 'search_genes')
-    search_box.send_key(gene)
+    search_box.send_keys(gene)
     wait_for_render(:id, 'perform-gene-search')
     search_genes = @driver.find_element(:id, 'perform-gene-search')
     search_genes.click
@@ -4007,7 +4007,7 @@ class UiTestSuite < Test::Unit::TestCase
     plot_dropdown = @driver.find_element(:id, 'plot_type')
     plot_ops = plot_dropdown.find_elements(:tag_name, 'option')
     new_plot = plot_ops.select {|opt| !opt.selected?}.sample.text
-    plot_dropdown.send_key(new_plot)
+    plot_dropdown.send_keys(new_plot)
 
     # wait until box plot renders, at this point all 3 should be done
     @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
@@ -4060,7 +4060,7 @@ class UiTestSuite < Test::Unit::TestCase
 
     # add 'new' to the name of annotation
     name = @driver.find_element(:id, 'user_annotation_name')
-    name.send_key("new")
+    name.send_keys("new")
 
     # add 'new' to the labels
     annotation_labels = @driver.find_elements(:id, 'user-annotation_values')
@@ -4107,7 +4107,7 @@ class UiTestSuite < Test::Unit::TestCase
     # revert name
     name = @driver.find_element(:id, 'user_annotation_name')
     name.clear
-    name.send_key("user-#{$random_seed}")
+    name.send_keys("user-#{$random_seed}")
 
     # revert labels
     annotation_labels = @driver.find_elements(:id, 'user-annotation_values')
@@ -4201,7 +4201,7 @@ class UiTestSuite < Test::Unit::TestCase
     # load random gene to search
     gene = @genes.sample
     search_box = @driver.find_element(:id, 'search_genes')
-    search_box.send_key(gene)
+    search_box.send_keys(gene)
     wait_for_render(:id, 'perform-gene-search')
     search_genes = @driver.find_element(:id, 'perform-gene-search')
     search_genes.click
@@ -4231,7 +4231,7 @@ class UiTestSuite < Test::Unit::TestCase
     plot_dropdown = @driver.find_element(:id, 'plot_type')
     plot_ops = plot_dropdown.find_elements(:tag_name, 'option')
     new_plot = plot_ops.select {|opt| !opt.selected?}.sample.text
-    plot_dropdown.send_key(new_plot)
+    plot_dropdown.send_keys(new_plot)
 
     # wait until box plot renders, at this point all 3 should be done
     @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
@@ -4274,7 +4274,7 @@ class UiTestSuite < Test::Unit::TestCase
     # change name
     name = @driver.find_element(:id, 'user_annotation_name')
     name.clear
-    name.send_key("user-#{$random_seed}-exp-Share")
+    name.send_keys("user-#{$random_seed}-exp-Share")
 
     # update annotation
     submit = @driver.find_element(:id, 'submit-button')
@@ -4327,7 +4327,7 @@ class UiTestSuite < Test::Unit::TestCase
     # change name
     name = @driver.find_element(:id, 'user_annotation_name')
     name.clear
-    name.send_key("user-#{$random_seed}-exp")
+    name.send_keys("user-#{$random_seed}-exp")
 
     # update the annotation
     submit = @driver.find_element(:id, 'submit-button')
@@ -4449,7 +4449,7 @@ class UiTestSuite < Test::Unit::TestCase
     # load random gene to search
     gene = @genes.sample
     search_box = @driver.find_element(:id, 'search_genes')
-    search_box.send_key(gene)
+    search_box.send_keys(gene)
     search_genes = @driver.find_element(:id, 'perform-gene-search')
     search_genes.click
 
@@ -4474,7 +4474,7 @@ class UiTestSuite < Test::Unit::TestCase
     plot_dropdown = @driver.find_element(:id, 'plot_type')
     plot_ops = plot_dropdown.find_elements(:tag_name, 'option')
     new_plot = plot_ops.select {|opt| !opt.selected?}.sample.text
-    plot_dropdown.send_key(new_plot)
+    plot_dropdown.send_keys(new_plot)
 
     # wait until box plot renders, at this point all 3 should be done
     @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
@@ -4819,12 +4819,9 @@ class UiTestSuite < Test::Unit::TestCase
     puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
 
-  # Test loading data directly into web browser from Google Cloud Storage (GCS).
-  # This test depends on a workspace already existing in FireCloud called development-infercnv-q418-ui-test
-  # if this study has been deleted, this test will fail until the workspace is re-created with at least
-  # 3 default files for expression, metadata, one cluster, and a file for Ideogram.js annotations
-  # Also requires an administrator to register a taxon of 'human' with at least one genome assembly
-  test 'front-end: workflows: load from gcs' do
+  # Test loading data from GCS into Ideogram; also tests the ability to view a study w/o clusters, metadata, or
+  # gene expression.  Relies on a FireCloud workspace called development-ideogram-only
+  test 'front-end: ideogram only' do
     puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     # log in first
@@ -4832,13 +4829,11 @@ class UiTestSuite < Test::Unit::TestCase
     login($test_email, $test_email_password)
     @driver.get @base_url + '/studies/new'
 
-    # create a new study using an existing workspace, also generate a random name to validate that workspace name
-    # and study name can be different
-    random_name = "Load from GCS #{$random_seed}"
+    random_name = "Ideogram Only #{$random_seed}"
     study_form = @driver.find_element(:id, 'new_study')
     study_form.find_element(:id, 'study_name').send_keys(random_name)
     study_form.find_element(:id, 'study_use_existing_workspace').send_keys('Yes')
-    study_form.find_element(:id, 'study_firecloud_workspace').send_keys("development-infercnv-q418-ui-test")
+    study_form.find_element(:id, 'study_firecloud_workspace').send_keys("development-ideogram-only")
     share = @driver.find_element(:id, 'add-study-share')
     @wait.until {share.displayed?}
     share.click
@@ -4849,135 +4844,31 @@ class UiTestSuite < Test::Unit::TestCase
     save_study.click
     @wait.until {element_present?(:id, 'unsynced-study-files')}
     close_modal('message_modal')
-    puts 'Created Load from GCS... study'
 
-    # sync each file
     study_file_forms = @driver.find_elements(:class, 'unsynced-study-file')
     study_file_forms.each do |form|
-      filename = form.find_element(:id, 'study_file_name')['value']
-      if filename == 'cluster_example.txt' or filename == 'expression_matrix_example_human.txt' or filename == 'metadata_example.txt'
-        file_type = form.find_element(:id, 'study_file_file_type')
-        case filename
-          when 'cluster_example.txt'
-            file_type.send_keys('Cluster')
-            cluster_file_name = form.find_element(:id, 'study_file_name')
-            cluster_file_name.clear
-            cluster_file_name.send_keys('cluster')
-          when 'expression_matrix_example_human.txt'
-            file_type.send_keys('Expression Matrix')
-            species_dropdown = form.find_element(:id, 'study_file_taxon_id')
-            @wait.until {file_type.displayed?}
-            opts = species_dropdown.find_elements(:tag_name, 'option')
-            available_species = opts.keep_if {|opt| opt.text.downcase == 'human'} # need human data
-            if available_species.any?
-              species_dropdown.send_key(available_species.sample.text)
-            end
-          when 'metadata_example.txt'
-            file_type.send_keys('Metadata')
-        end
-        sync_button = form.find_element(:class, 'save-study-file')
-        sync_button.click
-        close_modal('sync-notice-modal')
-      end
+      file_type = form.find_element(:id, 'study_file_file_type')
+      file_type.send_keys('Ideogram Annotations')
+      species_dropdown = form.find_element(:id, 'study_file_taxon_id')
+      @wait.until {file_type.displayed?}
+      species_dropdown.send_keys('human') # from lib/assets/default_species_assemblies.txt
+      sleep(2) # this is required as the assemblies dropdown is about to get re-rendered, so we don't want a stale reference
+      assemblies_dropdown = form.find_element(:id, 'study_file_genome_assembly_id')
+      assemblies_dropdown.send_keys('GRCh37') # from lib/assets/default_species_assemblies.txt
+      sync_button = form.find_element(:class, 'save-study-file')
+      sync_button.click
+      close_modal('sync-notice-modal')
     end
-
-    # now assert that forms were re-rendered in synced data panel
-    sync_panel = @driver.find_element(:id, 'synced-data-panel-toggle')
-    sync_panel.click
-
-    sleep(10) # Give time for expression matrix to parse
-
-    # lastly, check info page to make sure everything did in fact parse and complete
-    studies_path = @base_url + '/studies'
-    @driver.get studies_path
-    wait_until_page_loads(studies_path)
-
-    show_button = @driver.find_element(:class, "load-from-gcs-#{$random_seed}-show")
-    show_button.click
-    @wait.until {element_present?(:id, 'info-panel')}
 
     # make sure parsing succeeded
-    sync_study_path = @base_url + "/study/load-from-gcs-#{$random_seed}"
+    sync_study_path = @base_url + "/study/ideogram-only-#{$random_seed}"
     @driver.get(sync_study_path)
     study_accession = extract_accession_from_url(@driver.current_url)
-    loaded_sync_study_path = @base_url + "/study/#{study_accession}/load-from-gcs-#{$random_seed}"
+    loaded_sync_study_path = @base_url + "/study/#{study_accession}/ideogram-only-#{$random_seed}"
     wait_until_page_loads(loaded_sync_study_path)
-    open_ui_tab('study-analysis')
-    wait_for_render(:id, 'submissions-table')
-
-    # Go to Sync Submission Outputs page
-    submissions_table = @driver.find_element(:id, 'submissions-table')
-    submissions = submissions_table.find_element(:tag_name, 'tbody').find_elements(:tag_name, 'tr')
-    completed_submission = submissions.find {|sub|
-      sub.find_element(:class, "submission-state").text == 'Done' &&
-          sub.find_element(:class, "submission-status").text == 'Succeeded'
-    }
-    sync_btn = completed_submission.find_element(:class, 'sync-submission-outputs')
-    sync_btn.click
-    puts "Went to Sync Submission Outputs page"
-
-    # Sync annotation data for Ideogram.js
-    wait_for_render(:class, 'unsynced-study-file')
-    study_file_forms = @driver.find_elements(:class, 'unsynced-study-file')
-    ideogram_annots_form = nil
-    study_file_forms.each do |form|
-      filename = form.find_element(:id, 'study_file_name')
-      if filename['value'].end_with?('ideogram_exp_means.tar.gz')
-        # for the purpose of the test, we only need one such file
-        ideogram_annots_form = form
-      end
-    end
-    dropdown = ideogram_annots_form.find_element(:id, 'study_file_file_type')
-    opts = dropdown.find_elements(:tag_name, 'option')
-    opt = opts.detect {|opt| opt.text == 'Analysis Output'}
-    opt.click
-    @wait.until {element_present?(:id, 'study_file_taxon_id')}
-    species_dropdown = ideogram_annots_form.find_element(:id, 'study_file_taxon_id')
-    @wait.until {species_dropdown.displayed?}
-    opts = species_dropdown.find_elements(:tag_name, 'option')
-    available_species = opts.keep_if {|opt| opt.text.downcase == 'human'} # need human data
-    if available_species.any?
-      species_dropdown.send_key(available_species.sample.text)
-    end
-    sleep(2) # this is required as the assemblies dropdown is about to get re-rendered, so we don't want a stale reference
-    assemblies_dropdown = ideogram_annots_form.find_element(:id, 'study_file_genome_assembly_id')
-    assembly_opts = assemblies_dropdown.find_elements(:tag_name, 'option')
-    available_assemblies = assembly_opts.delete_if {|opt| opt['value'] == ''}
-    if available_assemblies.any?
-      assemblies_dropdown.send_key(available_assemblies.sample.text)
-    end
-    sync_button = ideogram_annots_form.find_element(:class, 'save-study-file')
-    sync_button.click
-    close_modal('sync-notice-modal')
-    puts "Synced annotation data for Ideogram.js"
-
-    sleep(10) # Give time for ideogram_exp_means.tar.gz to parse
-
-    # Ensure we can load Ideogram and render its annotations
-    @driver.get(loaded_sync_study_path)
-    wait_until_page_loads(loaded_sync_study_path)
-
-    # If "Explore" tab is disabled, wait 20 seconds and try again
-    vis_tab = @driver.find_element(:css, '#study-visualize-nav a')
-    if vis_tab.attribute('data-original-title') == 'This study has no data to view'
-      sleep(20)
-      @driver.get(loaded_sync_study_path)
-      wait_until_page_loads(loaded_sync_study_path)
-    end
-
-    open_ui_tab('study-visualize')
-    wait_for_render(:id, 'plots-tab')
-    @wait.until {wait_for_plotly_render('#cluster-plot', 'rendered')}
-
-    # Select a cluster that is indeed group-based
-    view_options_panel = @driver.find_element(:id, 'view-option-link')
-    view_options_panel.click
-    wait_for_render(:id, 'view-options')
-    annotations = @driver.find_element(:id, 'annotation').find_elements(:tag_name, 'option')
-    annotations.select {|opt| opt.text == 'Sub-Cluster'}.first.click
 
     # open the 'genome' tab
-    open_ui_tab('genome-tab')
+    open_ui_tab('study-visualize')
     wait_for_render(:css, '#tracks-to-display #filter_1')
     wait_for_render(:id, 'ideogram-container')
     user_ideogram = @driver.execute_script("return $('#_ideogramOuterWrap canvas').length > 0")
@@ -4988,21 +4879,17 @@ class UiTestSuite < Test::Unit::TestCase
     logout_from_portal
     puts "Logged out"
     @driver.get(loaded_sync_study_path)
-    wait_until_page_loads(loaded_sync_study_path)
-    open_ui_tab('study-visualize')
-    wait_for_render(:id, 'plots-tab')
-
-    # Click 'Genome' tab and verify that anonymous user is brought to sign-in page
-    tab = @driver.find_element(:id, "genome-tab-nav")
-    tab.click
+    # we can't use open_ui_tab as this has an explicit wait that will not return in this case as we prompt to sign in
+    explore_tab = @driver.find_element(:id, 'study-visualize-nav')
+    explore_tab.click
     @wait.until { @driver.current_url.include?('https://accounts.google.com/signin') }
     puts "Verified no public access to genome visualization"
 
     # clean up
     login_as_other($test_email, $test_email_password)
-    @driver.get studies_path
-    wait_until_page_loads(studies_path)
-    delete = @driver.find_element(:class, "load-from-gcs-#{$random_seed}-delete-local")
+    @driver.get @base_url + '/studies'
+    wait_until_page_loads(@base_url + '/studies')
+    delete = @driver.find_element(:class, "ideogram-only-#{$random_seed}-delete-local")
     delete.click
     accept_alert
     close_modal('message_modal')
@@ -5054,19 +4941,18 @@ class UiTestSuite < Test::Unit::TestCase
           opts = species_dropdown.find_elements(:tag_name, 'option')
           available_species = opts.delete_if {|opt| opt['value'] == ''}
           if available_species.any?
-            species_dropdown.send_key(available_species.sample.text)
+            species_dropdown.send_keys(available_species.sample.text)
           end
         when 'metadata_example.txt'
           file_type.send_keys('Metadata')
         when bam_file
           file_type.send_keys('BAM')
           species_dropdown = form.find_element(:id, 'study_file_taxon_id')
-          opts = species_dropdown.find_elements(:tag_name, 'option')
-          available_species = opts.delete_if {|opt| opt['value'] == '' || opt.text.downcase == 'human'}
-          if available_species.any?
-            species_dropdown.send_key(available_species.sample.text)
-          end
-        when bam_file + '.bai'
+          species_dropdown.send_keys('mouse') # from lib/assets/default_species_assemblies.txt
+          sleep(2) # wait for first assembly to load
+          assemblies_dropdown = form.find_element(:id, 'study_file_genome_assembly_id')
+          assemblies_dropdown.send_keys('GRCm38') # from lib/assets/default_species_assemblies.txt
+        when "#{bam_file + '.bai'}"
           file_type.send_keys('BAM Index')
           bam_target_menu = form.find_element(:id, 'study_file_options_bam_id')
           bam_target_menu.send_keys(bam_file)
@@ -5084,17 +4970,22 @@ class UiTestSuite < Test::Unit::TestCase
     # lastly, check info page to make sure everything did in fact parse and complete
     studies_path = @base_url + '/studies'
     @driver.get studies_path
-    wait_until_page_loads(studies_path)
 
     show_button = @driver.find_element(:class, "igv-js-ui-test-#{$random_seed}-show")
     show_button.click
     @wait.until {element_present?(:id, 'info-panel')}
+    study_url = @driver.current_url
+    gene_count = @driver.find_element(:id, 'gene-count').text.to_i
+    while gene_count == 0
+      @driver.get study_url
+      gene_count = @driver.find_element(:id, 'gene-count').text.to_i
+    end
 
     # Go to study, click 'Browse genome' in Downloads tab
     study_path = @base_url + "/study/igv-js-ui-test-#{$random_seed}"
     @driver.get(study_path)
     study_accession = extract_accession_from_url(@driver.current_url)
-    loaded_path = @base_url + "/study/#{study_accession}/test-study-#{$random_seed}"
+    loaded_path = @base_url + "/study/#{study_accession}/igv-js-ui-test-#{$random_seed}"
     wait_until_page_loads(loaded_path)
     open_ui_tab('study-download')
     browse_genome_button = @driver.find_element(:class, "bam-browse-genome")
@@ -5108,17 +4999,19 @@ class UiTestSuite < Test::Unit::TestCase
     # Search for a gene
     gene = @genes.sample
     search_box = @driver.find_element(:id, 'search_genes')
-    search_box.send_key(gene)
+    search_box.send_keys(gene)
     search_box.click
+    search_genes = @driver.find_element(:id, 'perform-gene-search')
+    search_genes.click
 
     # Verify igv.js displays tracks in Explore tab's single-gene view
+    @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
+    open_ui_tab('genome-tab')
     wait_for_render(:class, 'igv-track-div')
     igv_displayed = @driver.execute_script("return $('.igv-track-div').length === 4")
     assert igv_displayed, "igv.js did not display 4 tracks in Explore tab's single-gene view"
 
     # clean up
-    logout_from_portal
-    login_as_other($test_email, $test_email_password)
     @driver.get studies_path
     wait_until_page_loads(studies_path)
     delete = @driver.find_element(:class, "igv-js-ui-test-#{$random_seed}-delete-local")


### PR DESCRIPTION
* Enabling the ability to visualize genomic data without adding clusters/metadata/gene expression files
* Search & View options tab components now render dynamically based on presence of data types
* Bugfix: Using delete-local option for studies immediately releases FireCloud workspace to be used in other studies
* Bugfix: correctly honoring species/assembly information when creating study files via REST API