### PR TITLE
Fix access token for genome visualizations in public studies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 !/log/.keep
 /tmp
 .idea
+.vscode
 /public/single_cell/data/*
 /db/*.json
 /data/*

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -300,25 +300,20 @@ module ApplicationHelper
 	end
 
 	# return an access token for viewing GCS objects client side, depending on study privacy
-	# eweitz 2018-09-17: Disable public access while evaluating success of new Genome tab sign-in UX
-	# def get_read_access_token(study, user)
-	# 	if study.public? && Study.read_only_firecloud_client.present?
-	# 		Study.read_only_firecloud_client.valid_access_token["access_token"]
-	# 	else
-	# 		if user.present?
-	# 			user.valid_access_token[:access_token]
-	# 		else
-	# 			nil
-	# 		end
-	# 	end
-	# end
-
-	# return an access token for viewing GCS objects client side, for signed-in users
-	def get_read_access_token(study, user)
-		if user.present?
-			user.valid_access_token[:access_token]
+  def get_read_access_token(study, user)
+    if user.present? && study.public? && Study.read_only_firecloud_client.present?
+			Study.read_only_firecloud_client.valid_access_token["access_token"]
+		else
+			nil
 		end
 	end
+
+	# # return an access token for viewing GCS objects client side, for signed-in users
+	# def get_read_access_token(study, user)
+	# 	if user.present?
+	# 		user.valid_access_token[:access_token]
+	# 	end
+	# end
 
 	def pluralize_without_count(count, noun, text=nil)
 		count.to_i == 1 ? "#{noun}#{text}" : "#{noun.pluralize}#{text}"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -300,13 +300,13 @@ module ApplicationHelper
 	end
 
 	# return an access token for viewing GCS objects client side, depending on study privacy
-  def get_read_access_token(study, user)
-    if user.present?
-      if study.public? && Study.read_only_firecloud_client.present?
-        Study.read_only_firecloud_client.valid_access_token["access_token"]
-      else
-        user.valid_access_token[:access_token]
-      end
+	def get_read_access_token(study, user)
+		if user.present?
+			if study.public? && Study.read_only_firecloud_client.present?
+				Study.read_only_firecloud_client.valid_access_token["access_token"]
+			else
+				user.valid_access_token[:access_token]
+			end
 		else
 			nil
 		end
@@ -321,5 +321,5 @@ module ApplicationHelper
 
 	def pluralize_without_count(count, noun, text=nil)
 		count.to_i == 1 ? "#{noun}#{text}" : "#{noun.pluralize}#{text}"
-  end
+	end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -299,7 +299,8 @@ module ApplicationHelper
 		email.gsub(/[@\.]/, '-')
 	end
 
-	# return an access token for viewing GCS objects client side, depending on study privacy
+	# Return an access token for viewing GCS objects client side, depending on study privacy
+	# Context: https://github.com/broadinstitute/single_cell_portal_core/pull/239
 	def get_read_access_token(study, user)
 		if user.present?
 			if study.public? && Study.read_only_firecloud_client.present?
@@ -311,13 +312,6 @@ module ApplicationHelper
 			nil
 		end
 	end
-
-	# # return an access token for viewing GCS objects client side, for signed-in users
-	# def get_read_access_token(study, user)
-	# 	if user.present?
-	# 		user.valid_access_token[:access_token]
-	# 	end
-	# end
 
 	def pluralize_without_count(count, noun, text=nil)
 		count.to_i == 1 ? "#{noun}#{text}" : "#{noun.pluralize}#{text}"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -321,5 +321,5 @@ module ApplicationHelper
 
 	def pluralize_without_count(count, noun, text=nil)
 		count.to_i == 1 ? "#{noun}#{text}" : "#{noun.pluralize}#{text}"
-	end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -301,8 +301,12 @@ module ApplicationHelper
 
 	# return an access token for viewing GCS objects client side, depending on study privacy
   def get_read_access_token(study, user)
-    if user.present? && study.public? && Study.read_only_firecloud_client.present?
-			Study.read_only_firecloud_client.valid_access_token["access_token"]
+    if user.present?
+      if study.public? && Study.read_only_firecloud_client.present?
+        Study.read_only_firecloud_client.valid_access_token["access_token"]
+      else
+        user.valid_access_token[:access_token]
+      end
 		else
 			nil
 		end

--- a/test/ui_test_helper.rb
+++ b/test/ui_test_helper.rb
@@ -392,4 +392,14 @@ class Test::Unit::TestCase
     password_next = @driver.find_element(:id, 'passwordNext')
     password_next.click
   end
+
+  # Click an <option> from a <select> dropdown menu.
+  # Addresses race condition in standard send_keys methods.
+  def select_option_from_dropdown(form, dropdown_id, option_text)
+    dropdown = form.find_element(:id, dropdown_id)
+    opts = dropdown.find_elements(:tag_name, 'option')
+    option = opts.detect {|opt| opt['text'] == option_text}
+    option.click
+  end
+
 end

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -4959,7 +4959,9 @@ class UiTestSuite < Test::Unit::TestCase
         when bam_file
           file_type.send_keys('BAM')
           species_dropdown = form.find_element(:id, 'study_file_taxon_id')
-          species_dropdown.send_keys('mouse') # from lib/assets/default_species_assemblies.txt
+          opts = species_dropdown.find_elements(:tag_name, 'option')
+          mouse_option = opts.detect {|opt| opt['text'] == 'mouse'}
+          mouse_option.click
           sleep(2) # wait for first assembly to load
           assemblies_dropdown = form.find_element(:id, 'study_file_genome_assembly_id')
           assemblies_dropdown.send_keys('GRCm38') # from lib/assets/default_species_assemblies.txt

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -4958,7 +4958,7 @@ class UiTestSuite < Test::Unit::TestCase
           file_type.send_keys('Metadata')
         when bam_file
           file_type.send_keys('BAM')
-          # TODO: Determine where else this is needed, apply there.
+          # TODO: Determine where else this is needed, apply there.  See SCP-1572.
           select_option_from_dropdown(form, 'study_file_taxon_id', 'mouse')
           sleep(2) # wait for first assembly to load
           assemblies_dropdown = form.find_element(:id, 'study_file_genome_assembly_id')

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -4958,10 +4958,8 @@ class UiTestSuite < Test::Unit::TestCase
           file_type.send_keys('Metadata')
         when bam_file
           file_type.send_keys('BAM')
-          species_dropdown = form.find_element(:id, 'study_file_taxon_id')
-          opts = species_dropdown.find_elements(:tag_name, 'option')
-          mouse_option = opts.detect {|opt| opt['text'] == 'mouse'}
-          mouse_option.click
+          # TODO: Determine where else this is needed, apply there.
+          select_option_from_dropdown(form, 'study_file_taxon_id', 'mouse')
           sleep(2) # wait for first assembly to load
           assemblies_dropdown = form.find_element(:id, 'study_file_genome_assembly_id')
           assemblies_dropdown.send_keys('GRCm38') # from lib/assets/default_species_assemblies.txt


### PR DESCRIPTION
This enables any signed-in users to see genome visualizations in public studies.  Previously for such public visualizations, signed-in users would need "view" permission explicitly granted to them by the study owner.  That is too restrictive.

An update to a functional test verifies this fix.  I've locally run functional UI tests related to this feature (`ruby test/ui_test_suite.rb -n /front-end.*(ideogram|igv).*/ ...`) and they pass.

This also fixes an edge-case bug in our UI test suite in which a race condition sometimes caused the wrong option to be selected.