### PR TITLE
Hide expression thresholds

### DIFF
--- a/app/assets/javascripts/scp-ideogram.js
+++ b/app/assets/javascripts/scp-ideogram.js
@@ -84,51 +84,15 @@
 //     $('#ideogram-container').append(table);
 //   }
 
+
+// Monkey patch "drawHeatmaps" method in Ideogram to fix SCP-1573
+// TODO: Fix upstream in more refined manner, pull update, remove this patch.
 function monkeyPatchIdeogram() {
-  console.log('in monkeyPatchIdeogram')
-  // Monkey patch "drawHeatmaps" method in Ideogram to fix SCP-1573
-  // TODO: Fix upstream in more refined manner, pull update, remove this patch.
-  
   originalAfterRawAnnots = ideogram.afterRawAnnots;
   ideogram.afterRawAnnots = function() {
     var penultimateThreshold = ideogram.rawAnnots.metadata.heatmapThresholds.slice(-2)[0];
-    // ideogram.rawAnnots.metadata.heatmapThresholds.push(lastThreshold);
-    // ideogram.rawAnnots.metadata.heatmapThresholds.push(lastThreshold);
-
     ideogram.rawAnnots.metadata.heatmapThresholds.splice(-1, 1, penultimateThreshold + 1/10000);
-    console.log('ideogram.rawAnnots.metadata.heatmapThresholds after splice')
-    console.log(ideogram.rawAnnots.metadata.heatmapThresholds)
-
     originalAfterRawAnnots.apply(this);
-
-    console.log('ideogram.rawAnnots.metadata.heatmapThresholds after apply')
-    console.log(ideogram.rawAnnots.metadata.heatmapThresholds)
-
-
-    // var i, j, heatmaps, thresholds, threshold, newThresholds,
-    //   newHeatmaps = [];
-
-    // originalAfterRawAnnots.apply(this);
-    
-    // heatmaps = ideogram.config.heatmaps;
-    // for (i = 0; i < heatmaps.length; i++) {
-    //   newHeatmaps.push(heatmaps[i]);
-    //   thresholds = heatmaps[i].thresholds;
-    //   newThresholds = [];
-    //   for (j = 0; j < thresholds.length; j++) {
-    //     threshold = thresholds[j];
-    //     if (threshold[1] === '#undefined') { 
-    //       // Omit nonsensical "#undefined" threshold
-    //       continue;
-    //     }
-    //     newThresholds.push(threshold);
-    //   }
-    //   newHeatmaps[i].thresholds = newThresholds;
-    // }
-    // ideogram.config.heatmaps = newHeatmaps;
-    // console.log('ideogram.config.heatmaps');
-    // console.log(ideogram.config.heatmaps);
-    
   }
 }
 
@@ -168,7 +132,7 @@ function updateMargin(event) {
 function addMarginControl() {
   chrMargin = (typeof chrMargin === 'undefined' ? 10 : chrMargin)
     marginSlider =
-      `<label id="chrMarginContainer" style="float:left; position: relative; top: 50px; left: -130px;">
+      `<label id="chrMarginContainer">
         Chromosome margin
       <input type="range" id="chrMargin" list="chrMarginList" value="` + chrMargin + `">
       </label>
@@ -245,7 +209,7 @@ function ideoRangeChangeEventHandler(event) {
 }
 
 function addIdeoRangeControls() {
-  addThresholdControl();
+  // addThresholdControl();
   addMarginControl();
 
   document.removeEventListener('change', ideoRangeChangeEventHandler);

--- a/app/assets/javascripts/scp-ideogram.js
+++ b/app/assets/javascripts/scp-ideogram.js
@@ -85,12 +85,13 @@
 //   }
 
 
-// Monkey patch "drawHeatmaps" method in Ideogram to fix SCP-1573
+// Monkey patch "afterRawAnnots" method in Ideogram to fix SCP-1573
 // TODO: Fix upstream in more refined manner, pull update, remove this patch.
 function monkeyPatchIdeogram() {
   originalAfterRawAnnots = ideogram.afterRawAnnots;
   ideogram.afterRawAnnots = function() {
     var penultimateThreshold = ideogram.rawAnnots.metadata.heatmapThresholds.slice(-2)[0];
+    // Ensures default heatmap does not show black unexpectedly
     ideogram.rawAnnots.metadata.heatmapThresholds.splice(-1, 1, penultimateThreshold + 1/10000);
     originalAfterRawAnnots.apply(this);
   }


### PR DESCRIPTION
This temporarily hides the new "Expression thresholds" UI for genomic heatmaps until it is more robust.  

These changes pass local automated UI tests for genome visualizations.