### PR TITLE
fixing API bugs re: missing tokens

### DIFF
--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -215,8 +215,8 @@ module Api
               elsif @study.has_bucket_access?(current_api_user)
                 token = current_api_user.api_access_token
               else
-                alert = 'You do not have permission to stream the requested file'
-                render json: {error: alert}, status: 403
+                alert = 'You do not have permission to stream the requested file from the bucket'
+                render json: {error: alert}, status: 403 and return
               end
               render json: {filename: params[:filename], url: @media_url, access_token: token}
             else

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -572,7 +572,7 @@ class Study
   end
 
   # return all studies that are viewable by a given user as a Mongoid criterion
-  def self.viewable(user)
+  def self.viewable(user, opts={})
     if user.admin?
       self.where(queued_for_deletion: false)
     else
@@ -581,7 +581,15 @@ class Study
       shares = StudyShare.where(email: user.email).map(&:study).select {|s| !s.queued_for_deletion }.map(&:id)
       group_shares = []
       if user.registered_for_firecloud
-        user_client = FireCloudClient.new(user, FireCloudClient::PORTAL_NAMESPACE)
+        if opts[:api_request] # request is coming via API, so we have a valid OAuth token to use
+          # use the regular constructor, but overwrite the access token
+          # TODO: solve this more holistically by creating a way to instantiate a client with just a token, or
+          # by not clearing refresh tokens on reboot
+          user_client = FireCloudClient.new
+          user_client.access_token[:access_token] = user.api_access_token
+        else
+          user_client = FireCloudClient.new(user, FireCloudClient::PORTAL_NAMESPACE)
+        end
         user_groups = user_client.get_user_groups.map {|g| g['groupEmail']}
         group_shares = StudyShare.where(:email.in => user_groups).map(&:study).select {|s| !s.queued_for_deletion }.map(&:id)
       end


### PR DESCRIPTION
* Bugfixes
  * User's not signed into portal can still view list of available studies when authenticated into API
  * api/v1/site/stream_data now responds with authorization bearer token to use with subsequent request
  * setting proper statuses on JSON responses in api/v1/site
  * study.has_bucket_access? correctly excludes admins w/o direct access