### PR TITLE
Persist gene search in distribution tab after login

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -954,3 +954,20 @@ $(document).ajaxError(function (e, xhr, settings) {
         location.href = url;
     }
 });
+
+// preserve the state of gene search beyond page reload (in case user needs to sign in)
+function preserveGeneSearch() {
+    console.log('preserving search state');
+    // construct a gene expression URL to load after action is completed
+    var searchUrl = window.location.origin + window.location.pathname + '/gene_expression';
+    var urlParams = getRenderUrlParams();
+    var genes = $('#search_genes').val().split(' ');
+    if (genes.length === 1) {
+        searchUrl += '/' + genes[0] + '?'
+    } else {
+        searchUrl += '?search%5Bgenes%5D=' + genes.join('+') + '&';
+    }
+    searchUrl += urlParams + window.location.hash;
+    localStorage.setItem('previous-search-url', searchUrl);
+    console.log('search form saved');
+}

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -971,3 +971,11 @@ function preserveGeneSearch() {
     localStorage.setItem('previous-search-url', searchUrl);
     console.log('search form saved');
 }
+
+// reopen current tab on page refresh
+function reopenUiTab(navTarget) {
+    var tab = window.location.hash;
+    if (tab !== '') {
+        $(navTarget + ' a[href="#' + tab + '"]').tab('show');
+    }
+}

--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -43,11 +43,18 @@ $(document).on('click', '#genome-tab-nav', function (e) {
   var currentScroll = $(window).scrollTop();
   window.location.hash = '#genome-tab';
   window.scrollTo(0, currentScroll);
-  // Go to Google sign-in page, redirect to this view after authenticating.
+
+
+// Go to Google sign-in page, redirect to this view after authenticating.
   if (accessToken === null) {
-    ga('send', 'event', 'genome', 'sign_in_start');
-    localStorage.setItem('signed-in-via-genome-tab', true);
-    window.location = '/single_cell/users/auth/google_oauth2';
+      // preserve all current search form values, but only if gene(s) are present
+      var geneSearch = $('#search_genes').val();
+      if (geneSearch !== '') {
+          preserveGeneSearch();
+      }
+      ga('send', 'event', 'genome', 'sign_in_start');
+      localStorage.setItem('signed-in-via-genome-tab', true);
+      window.location = '/single_cell/users/auth/google_oauth2';
   }
 });
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,13 +23,6 @@
       <%= render '/layouts/ga_script.js' %>
   </script>
 
-
-	<% if Rails.env == 'production' %>
-    <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-        // suppress logging in production
-        var console = { log: function() {} };
-    </script>
-	<% end %>
   <% if ENV['TCELL_AGENT_APP_ID'].present? && ENV['TCELL_AGENT_API_KEY'].present? %>
     <script src="https://jsagent.tcell.io/tcellagent.min.js" nonce="<%= content_security_policy_script_nonce %>"
             tcellappid="<%= ENV['TCELL_AGENT_APP_ID'] %>" tcellapikey="<%= ENV['TCELL_AGENT_API_KEY'] %>"></script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,14 @@
   <%= csrf_meta_tags %>
   <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+      // if we had search forms to preserve, recall and resubmit
+      if ( localStorage.getItem('previous-search-url') ) {
+          var searchUrl = localStorage.getItem('previous-search-url');
+          localStorage.removeItem('previous-search-url');
+          window.location = searchUrl;
+      }
+  </script>
   <%= stylesheet_link_tag    'application', media: 'all' %>
   <%= nonced_javascript_include_tag "https://cdn.plot.ly/plotly-1.39.3.min.js" %>
   <%= nonced_javascript_pack_tag 'application' %>

--- a/app/views/site/_search_options.html.erb
+++ b/app/views/site/_search_options.html.erb
@@ -53,10 +53,11 @@
                     clearForm('search_genes');
                     $(this).tooltip('hide');
                     var urlParams = getRenderUrlParams();
-                    var url = "<%= view_study_path(accession: @study.accession, study_name: @study.url_safe_name )%>?" + urlParams;
+                    var url = "<%= view_study_path(accession: @study.accession, study_name: @study.url_safe_name )%>";
+                    history.pushState('', document.title, url);
                     launchModalSpinner('#spinner_target', '#loading-modal', function() {
                         $.ajax({
-                            url: url,
+                            url: url + '?' + urlParams,
                             type: 'GET',
                             dataType: 'script'
                         });

--- a/app/views/site/study.html.erb
+++ b/app/views/site/study.html.erb
@@ -78,10 +78,5 @@
 
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
     // re-open a tab on reload if necessary
-    var urlParts = window.location.href.split('#');
-    if (urlParts.length > 1) {
-        openedTab = urlParts[1];
-        console.log('opening ' + openedTab + ' tab');
-        $('#study-tabs a[href="#' + openedTab + '"]').tab('show');
-    }
+    reopenUiTab('#study-tabs');
 </script>

--- a/app/views/site/view_gene_expression.html.erb
+++ b/app/views/site/view_gene_expression.html.erb
@@ -81,10 +81,5 @@
 
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
     // re-open a tab on reload if necessary
-    var urlParts = window.location.href.split('#');
-    if (urlParts.length > 1) {
-        openedTab = urlParts[1];
-        console.log('opening ' + openedTab + ' tab');
-        $('#study-tabs a[href="#' + openedTab + '"]').tab('show');
-    }
+    reopenUiTab('#study-tabs');
 </script>

--- a/app/views/site/view_gene_expression.html.erb
+++ b/app/views/site/view_gene_expression.html.erb
@@ -1,0 +1,90 @@
+<script nonce="<%= content_security_policy_script_nonce %>">
+    $('#breadcrumbs').replaceWith("<%= escape_javascript(render partial: '/layouts/breadcrumbs') %>");
+</script>
+<div id="title-bar">
+  <%= render partial: 'view_gene_expression_title_bar' %>
+</div>
+<div id="tab-root">
+  <ul class="nav nav-tabs" role="tablist" id="study-tabs">
+    <li role="presentation" class="study-nav active" id="study-summary-nav"><a href="#study-summary" data-toggle="tab">Summary <i class="far fa-fw fa-file-alt"></i></a></li>
+    <% if @study.can_visualize? %>
+      <li role="presentation" class="study-nav" id="study-visualize-nav"><a href="#study-visualize" data-toggle="tab">Explore <i class="fas fa-fw fa-eye"></i></a></li>
+    <% else %>
+      <li role="presentation" class="study-nav disabled" id="study-visualize-nav"><a href="#study-visualize" data-toggle="tooltip" title="This study has no data to view">Explore <i class="fas fa-fw fa-eye"></i></a></li>
+    <% end %>
+    <% if @user_can_download %>
+      <li role="presentation" class="study-nav" id="study-download-nav"><a href="#study-download" data-toggle="tab">Download <i class="fas fa-fw fa-download"></i></a></li>
+    <% else %>
+      <li role="presentation" class="study-nav disabled" id="study-download-nav"><a href="#study-download" data-toggle="tooltip" title="Only authenticated users with download privileges can download data">Download <i class="fas fa-fw fa-download"></i></a></li>
+    <% end %>
+    <% if @allow_firecloud_access && @user_can_compute %>
+      <% if @allow_computes %>
+        <li role="presentation" class="study-nav" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tab">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
+      <% else %>
+        <li role="presentation" class="study-nav disabled" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tooltip" title="Study workspaces are currently unavailable - please try again later.">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
+  <% end %>
+    <% end %>
+    <% if @allow_firecloud_access && @user_can_edit %>
+      <% if @allow_edits %>
+        <li role="presentation" class="study-nav" id="study-settings-nav"><a href="#study-settings" data-toggle="tab">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
+      <% else %>
+        <li role="presentation" class="study-nav disabled" id="study-settings-nav"><a href="#study-settings" data-toggle="tooltip" title="Study workspaces are currently unavailable - please try again later.">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
+      <% end %>
+    <% end %>
+  </ul>
+  <div class="tab-content top-pad">
+    <div class="tab-pane active in" id="study-summary" role="tabpanel">
+      <%= render partial: 'study_description_view' %>
+    </div>
+    <div class="tab-pane" id="study-visualize" role="tabpanel">
+      <% if @study.can_visualize? %>
+        <%= render partial: 'view_gene_expression' %>
+      <% end %>
+    </div>
+    <% if @user_can_download %>
+      <div class="tab-pane" id="study-download" role="tabpanel">
+        <%= render partial: 'study_download_data' %>
+      </div>
+    <% end %>
+    <% if @allow_firecloud_access && @allow_computes && @user_can_compute %>
+      <div class="tab-pane" id="study-analysis" role="tabpanel">
+        <%= render partial: 'study_analysis' %>
+      </div>
+    <% end %>
+    <% if @allow_firecloud_access && @allow_edits && @user_can_edit %>
+      <div class="tab-pane" id="study-settings" role="tabpanel">
+        <div class="row">
+          <div class="col-xs-12" id="study-settings-form-target">
+            <%= render partial: 'study_settings_form' %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="modal fade" id="update-study-settings-modal" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="text-center">Updating Study... Please wait<br/></h4>
+      </div>
+      <div class="modal-body">
+        <div class="spinner-target" id="update-study-settings-spinner"></div>
+      </div>
+      <div class="modal-footer">
+        <button class="close" data-dismiss="modal">×</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+    // re-open a tab on reload if necessary
+    var urlParts = window.location.href.split('#');
+    if (urlParts.length > 1) {
+        openedTab = urlParts[1];
+        console.log('opening ' + openedTab + ' tab');
+        $('#study-tabs a[href="#' + openedTab + '"]').tab('show');
+    }
+</script>

--- a/app/views/site/view_gene_expression_heatmap.html.erb
+++ b/app/views/site/view_gene_expression_heatmap.html.erb
@@ -81,10 +81,5 @@
 
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
     // re-open a tab on reload if necessary
-    var urlParts = window.location.href.split('#');
-    if (urlParts.length > 1) {
-        openedTab = urlParts[1];
-        console.log('opening ' + openedTab + ' tab');
-        $('#study-tabs a[href="#' + openedTab + '"]').tab('show');
-    }
+    reopenUiTab('#study-tabs');
 </script>

--- a/app/views/site/view_gene_expression_heatmap.html.erb
+++ b/app/views/site/view_gene_expression_heatmap.html.erb
@@ -1,0 +1,90 @@
+<script nonce="<%= content_security_policy_script_nonce %>">
+    $('#breadcrumbs').replaceWith("<%= escape_javascript(render partial: '/layouts/breadcrumbs') %>");
+</script>
+<div id="title-bar">
+  <%= render partial: 'view_gene_expression_heatmap_title_bar' %>
+</div>
+<div id="tab-root">
+  <ul class="nav nav-tabs" role="tablist" id="study-tabs">
+    <li role="presentation" class="study-nav active" id="study-summary-nav"><a href="#study-summary" data-toggle="tab">Summary <i class="far fa-fw fa-file-alt"></i></a></li>
+    <% if @study.can_visualize? %>
+      <li role="presentation" class="study-nav" id="study-visualize-nav"><a href="#study-visualize" data-toggle="tab">Explore <i class="fas fa-fw fa-eye"></i></a></li>
+    <% else %>
+      <li role="presentation" class="study-nav disabled" id="study-visualize-nav"><a href="#study-visualize" data-toggle="tooltip" title="This study has no data to view">Explore <i class="fas fa-fw fa-eye"></i></a></li>
+    <% end %>
+    <% if @user_can_download %>
+      <li role="presentation" class="study-nav" id="study-download-nav"><a href="#study-download" data-toggle="tab">Download <i class="fas fa-fw fa-download"></i></a></li>
+    <% else %>
+      <li role="presentation" class="study-nav disabled" id="study-download-nav"><a href="#study-download" data-toggle="tooltip" title="Only authenticated users with download privileges can download data">Download <i class="fas fa-fw fa-download"></i></a></li>
+    <% end %>
+    <% if @allow_firecloud_access && @user_can_compute %>
+      <% if @allow_computes %>
+        <li role="presentation" class="study-nav" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tab">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
+      <% else %>
+        <li role="presentation" class="study-nav disabled" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tooltip" title="Study workspaces are currently unavailable - please try again later.">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
+  <% end %>
+    <% end %>
+    <% if @allow_firecloud_access && @user_can_edit %>
+      <% if @allow_edits %>
+        <li role="presentation" class="study-nav" id="study-settings-nav"><a href="#study-settings" data-toggle="tab">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
+      <% else %>
+        <li role="presentation" class="study-nav disabled" id="study-settings-nav"><a href="#study-settings" data-toggle="tooltip" title="Study workspaces are currently unavailable - please try again later.">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
+      <% end %>
+    <% end %>
+  </ul>
+  <div class="tab-content top-pad">
+    <div class="tab-pane active in" id="study-summary" role="tabpanel">
+      <%= render partial: 'study_description_view' %>
+    </div>
+    <div class="tab-pane" id="study-visualize" role="tabpanel">
+      <% if @study.can_visualize? %>
+        <%= render partial: 'view_gene_expression_heatmap' %>
+      <% end %>
+    </div>
+    <% if @user_can_download %>
+      <div class="tab-pane" id="study-download" role="tabpanel">
+        <%= render partial: 'study_download_data' %>
+      </div>
+    <% end %>
+    <% if @allow_firecloud_access && @allow_computes && @user_can_compute %>
+      <div class="tab-pane" id="study-analysis" role="tabpanel">
+        <%= render partial: 'study_analysis' %>
+      </div>
+    <% end %>
+    <% if @allow_firecloud_access && @allow_edits && @user_can_edit %>
+      <div class="tab-pane" id="study-settings" role="tabpanel">
+        <div class="row">
+          <div class="col-xs-12" id="study-settings-form-target">
+            <%= render partial: 'study_settings_form' %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="modal fade" id="update-study-settings-modal" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="text-center">Updating Study... Please wait<br/></h4>
+      </div>
+      <div class="modal-body">
+        <div class="spinner-target" id="update-study-settings-spinner"></div>
+      </div>
+      <div class="modal-footer">
+        <button class="close" data-dismiss="modal">×</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+    // re-open a tab on reload if necessary
+    var urlParts = window.location.href.split('#');
+    if (urlParts.length > 1) {
+        openedTab = urlParts[1];
+        console.log('opening ' + openedTab + ' tab');
+        $('#study-tabs a[href="#' + openedTab + '"]').tab('show');
+    }
+</script>

--- a/bin/job_monitor.rb
+++ b/bin/job_monitor.rb
@@ -58,9 +58,6 @@ if @running == false
 	# send email via mailer to handle auth correctly
 	system(". /home/app/.cron_env ; /home/app/webapp/bin/rails runner -e #{@env} \"SingleCellMailer.delayed_job_email('#{@log_message}').deliver_now\"")
 
-  # unlock orphaned jobs
-	system(". /home/app/.cron_env ; /home/app/webapp/bin/rails runner -e #{@env} \"AdminConfiguration.restart_locked_jobs\"")
-
 	# write to log
 	log = File.open('log/delayed_job.log', 'w+')
 	log.write @log_message

--- a/bin/job_monitor.rb
+++ b/bin/job_monitor.rb
@@ -26,7 +26,7 @@ end
 
 # check to make sure all delayed_job daemons are still running
 @running = true
-if pids.size != processes.size || processes.size == 0
+if pids.size != processes.size || processes.size != @num_workers
 	@running = false
 else
 	pids.each do |command, pid|

--- a/test/integration/fire_cloud_client_test.rb
+++ b/test/integration/fire_cloud_client_test.rb
@@ -332,6 +332,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
       assert copied_config['methodConfiguration']['name'] == configuration['name'], "Copied configuration name is incorrect, expected '#{configuration['name']}' but found '#{copied_config['methodConfiguration']['name']}'"
       assert copied_config['methodConfiguration']['namespace'] == workspace['namespace'], "Copied configuration name is incorrect, expected '#{workspace['namespace']}' but found '#{copied_config['methodConfiguration']['namespace']}'"
     rescue => e
+      @fire_cloud_client.delete_workspace(@fire_cloud_client.project, workspace_name)
       skip "Skipping test due to error from methods repo (this is not a regression but a known issue with some methods missing configurations): #{e.message}"
     end
 

--- a/test/integration/fire_cloud_client_test.rb
+++ b/test/integration/fire_cloud_client_test.rb
@@ -14,6 +14,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
   def setup
     @fire_cloud_client = Study.firecloud_client
     @test_email = 'singlecelltest@gmail.com'
+    @random_test_seed = SecureRandom.uuid # use same random seed to differentiate between entire runs
   end
 
   ##
@@ -100,7 +101,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
     puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     # set workspace name
-    workspace_name = "#{self.method_name}-#{SecureRandom.uuid}"
+    workspace_name = "#{self.method_name}-#{@random_test_seed}"
 
     # create workspace
     puts 'creating workspace...'
@@ -127,7 +128,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
     # set workspace attribute
     puts 'setting workspace attribute...'
     new_attribute = {
-        'random_attribute' => SecureRandom.uuid
+        'random_attribute' => @random_test_seed
     }
     updated_ws_attributes = @fire_cloud_client.set_workspace_attributes(@fire_cloud_client.project, workspace_name, new_attribute)
     assert updated_ws_attributes['attributes'] == new_attribute, "Did not properly set new attribute to workspace, expected '#{new_attribute}' but found '#{updated_ws_attributes['attributes']}'"
@@ -147,7 +148,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
     puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     # set workspace name
-    workspace_name = "#{self.method_name}-#{SecureRandom.uuid}"
+    workspace_name = "#{self.method_name}-#{@random_test_seed}"
 
     # create workspace
     puts 'creating workspace...'
@@ -312,7 +313,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
     puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     # set workspace name
-    workspace_name = "#{self.method_name}-#{SecureRandom.uuid}"
+    workspace_name = "#{self.method_name}-#{@random_test_seed}"
 
     # create workspace
     puts 'creating workspace...'
@@ -383,7 +384,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
     puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     # set group name
-    group_name = "test-group-#{SecureRandom.uuid}"
+    group_name = "test-group-#{@random_test_seed}"
     puts 'creating group...'
     group = @fire_cloud_client.create_user_group(group_name)
     assert group.present?, 'Did not create user group'
@@ -496,7 +497,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
     puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     # set workspace name
-    workspace_name = "#{self.method_name}-#{SecureRandom.uuid}"
+    workspace_name = "#{self.method_name}-#{@random_test_seed}"
 
     # create workspace
     puts 'creating workspace...'
@@ -520,7 +521,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
     puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     # set workspace name
-    workspace_name = "#{self.method_name}-#{SecureRandom.uuid}"
+    workspace_name = "#{self.method_name}-#{@random_test_seed}"
 
     # create workspace
     puts 'creating workspace...'

--- a/test/ui_test_helper.rb
+++ b/test/ui_test_helper.rb
@@ -198,6 +198,15 @@ class Test::Unit::TestCase
     $verbose ? puts('login successful') : nil
   end
 
+  # log back into portal with account that has already signed in once
+  def log_back_in(email)
+    $verbose ? puts('logging back in as ' + email) : nil
+    user_email = @driver.find_element(:xpath, "//div[@data-email='#{email}']")
+    user_email.click
+    handle_oauth_redirect(email)
+    $verbose ? puts('login successful') : nil
+  end
+
   # method to log out of google so that we can log in with a different account
   def login_as_other(email, password)
     invalidate_google_session

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -5023,6 +5023,29 @@ class UiTestSuite < Test::Unit::TestCase
     igv_displayed = @driver.execute_script("return $('.igv-track-div').length === 4")
     assert igv_displayed, "igv.js did not display 4 tracks in Explore tab's single-gene view"
 
+    # sign out and prove that gene search state is remembered after new login
+    logout_from_portal
+    @driver.get(loaded_path)
+    wait_until_page_loads(loaded_path)
+    open_ui_tab('study-visualize')
+    @wait.until {wait_for_plotly_render('#cluster-plot', 'rendered')}
+    # Search for a gene
+    gene = @genes.sample
+    search_box = @driver.find_element(:id, 'search_genes')
+    search_box.send_keys(gene)
+    search_box.click
+    search_genes = @driver.find_element(:id, 'perform-gene-search')
+    search_genes.click
+    @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
+
+    # open genome tab and validate gene search is remembered
+    genome_nav = @driver.find_element(:id, 'genome-tab-nav')
+    genome_nav.click
+    log_back_in($test_email)
+    @wait.until {element_visible?(:id, 'genome-tab')}
+    queried_gene = @driver.find_element(:class, 'queried-gene')
+    assert queried_gene.text == gene, "did not load the correct gene, expected #{gene} but found #{queried_gene.text}"
+
     # clean up
     @driver.get studies_path
     wait_until_page_loads(studies_path)


### PR DESCRIPTION
* Persisting gene search after a user logs in when clicking the 'Genome' tab 
* Bugfixes
  * Restoring javascript console in production environment
  * bin/job_monitor.rb correctly notices missing job workers that no longer have a pid file