### PR TITLE
adding daily cron to update status on running analyses

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -172,10 +172,12 @@ class ReportsController < ApplicationController
       @submission_stats = []
       AnalysisSubmission.order(:submitted_on => :asc).each do |analysis|
         @submission_stats << {submitter: analysis.submitter, analysis: analysis.analysis_name, status: analysis.status,
-                              submitted_on: analysis.submitted_on, completed_on: analysis.completed_on}
+                              submitted_on: analysis.submitted_on, completed_on: analysis.completed_on,
+                              firecloud_workspace: "#{analysis.firecloud_project}/#{analysis.firecloud_workspace}",
+                              study_info_url: study_url(id: analysis.study_id)}
       end
       filename = "analysis_submissions_#{Date.today.strftime('%F')}.txt"
-      report_headers = %w(email analysis status submission_date completion_date).join("\t")
+      report_headers = %w(email analysis status submission_date completion_date firecloud_workspace study_info_url).join("\t")
       report_data = @submission_stats.map {|sub| sub.values.join("\t")}.join("\n")
       send_data [report_headers, report_data].join("\n"), filename: filename
     else

--- a/rails_startup.bash
+++ b/rails_startup.bash
@@ -108,6 +108,7 @@ echo "*** COMPLETED ***"
 
 echo "*** ADDING REPORTING CRONS ***"
 (crontab -u app -l ; echo "5 0 * * Sun . /home/app/.cron_env ; cd /home/app/webapp/; /home/app/webapp/bin/rails runner -e $PASSENGER_APP_ENV \"ReportTimePoint.weekly_returning_users\" >> /home/app/webapp/log/cron_out.log 2>&1") | crontab -u app -
+(crontab -u app -l ; echo "@daily . /home/app/.cron_env ; cd /home/app/webapp/; /home/app/webapp/bin/rails runner -e $PASSENGER_APP_ENV \"AnalysisSubmission.update_running_submissions\" >> /home/app/webapp/log/cron_out.log 2>&1") | crontab -u app -
 echo "*** COMPLETED ***"
 
 echo "*** SENDING RESTART NOTIFICATION ***"

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -2253,7 +2253,7 @@ class UiTestSuite < Test::Unit::TestCase
       end
       submission_report = File.open(download_path)
       headers = submission_report.readline.split("\t").map(&:strip)
-      expected_headers = %w(email analysis status submission_date completion_date)
+      expected_headers = %w(email analysis status submission_date completion_date firecloud_workspace study_info_url)
       assert headers == expected_headers,
              "Did not find correctly formatted report, expected headers of '#{expected_headers.join(', ')}' but found '#{headers.join(', ')}'"
 


### PR DESCRIPTION
* Daily cron job to check for updates to analysis submissions that haven't completed yet
* Error handling for workspaces that have been deleted before submissions can update status