### PR TITLE
Prevent plotting extremely many points

### DIFF
--- a/app/assets/javascripts/kernel-functions.js
+++ b/app/assets/javascripts/kernel-functions.js
@@ -20,6 +20,27 @@ function nrd0(X){
     return 0.9 * min * Math.pow(X.length, -0.2)
 }
 
+// More memory- and time-efficient analogs of Math.min and Math.max.
+// From https://stackoverflow.com/a/13440842/10564415.
+function arrayMin(arr) {
+  var len = arr.length, min = Infinity;
+  while (len--) {
+    if (arr[len] < min) {
+      min = arr[len];
+    }
+  }
+  return min;
+};
+function arrayMax(arr) {
+  var len = arr.length, max = -Infinity;
+  while (len--) {
+    if (arr[len] > max) {
+      max = arr[len];
+    }
+  }
+  return max;
+};
+
 //This is the master function that creates all the plotly traces.
 //Takes an array of arrays and returns the data array of traces and the layout variable
 function createTracesAndLayout(arr, title, jitter='all'){
@@ -39,7 +60,7 @@ function createTracesAndLayout(arr, title, jitter='all'){
             jitter = false;
         }
         // check if there is a distribution before adding trace
-        if ( Math.max(...dist) !== Math.min(...dist) ) {
+        if ( arrayMax(dist) !== arrayMin(dist) ) {
             // make a violin plot if there is a distribution
             data = data.concat([{
                 type: 'violin',

--- a/app/assets/javascripts/kernel-functions.js
+++ b/app/assets/javascripts/kernel-functions.js
@@ -30,7 +30,7 @@ function arrayMin(arr) {
     }
   }
   return min;
-};
+}
 function arrayMax(arr) {
   var len = arr.length, max = -Infinity;
   while (len--) {
@@ -39,7 +39,7 @@ function arrayMax(arr) {
     }
   }
   return max;
-};
+}
 
 //This is the master function that creates all the plotly traces.
 //Takes an array of arrays and returns the data array of traces and the layout variable

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -40,7 +40,7 @@ class ClusterGroup
   # fixed values to subsample at
   SUBSAMPLE_THRESHOLDS = [1000, 10000, 20000].freeze
 
-  MAX_THRESHOLD = 250000
+  MAX_THRESHOLD = 100000
 
   COLORBREWER_SET = %w(#e41a1c #377eb8 #4daf4a #984ea3 #ff7f00 #a65628 #f781bf #999999
     #66c2a5 #fc8d62 #8da0cb #e78ac3 #a6d854 #ffd92f #e5c494 #b3b3b3 #8dd3c7

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -40,6 +40,8 @@ class ClusterGroup
   # fixed values to subsample at
   SUBSAMPLE_THRESHOLDS = [1000, 10000, 20000].freeze
 
+  MAX_THRESHOLD = 250000
+
   COLORBREWER_SET = %w(#e41a1c #377eb8 #4daf4a #984ea3 #ff7f00 #a65628 #f781bf #999999
     #66c2a5 #fc8d62 #8da0cb #e78ac3 #a6d854 #ffd92f #e5c494 #b3b3b3 #8dd3c7
     #bebada #fb8072 #80b1d3 #fdb462 #b3de69 #fccde5 #d9d9d9 #bc80bd #ccebc5 #ffed6f)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
   <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
   <%= stylesheet_link_tag    'application', media: 'all' %>
-  <%= nonced_javascript_include_tag "https://cdn.plot.ly/plotly-1.39.3.min.js" %>
+  <%= nonced_javascript_include_tag "https://cdn.plot.ly/plotly-1.47.4.min.js" %>
   <%= nonced_javascript_pack_tag 'application' %>
   <%= nonced_javascript_include_tag 'application' %>
   <%= nonced_javascript_include_tag "https://cdn.datatables.net/plug-ins/1.10.15/sorting/natural.js" %>

--- a/app/views/site/_view_options.html.erb
+++ b/app/views/site/_view_options.html.erb
@@ -19,7 +19,7 @@
                 <!-- if action_name !~ /heatmap/ -->
                 <div class="form-group col-sm-4">
                   <%= label_tag :subsample, 'Subsampling threshold' %>&nbsp;<i class='fas fa-question-circle' title="Take a representative subsample of the current cluster.  Choosing all cells may dramatically increase rendering time." data-toggle="tooltip"></i><br />
-                  <%= select_tag :subsample, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), {include_blank: 'All Cells', class: 'form-control'} %>
+                  <%= select_tag :subsample, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), include_blank: @cluster.points < ClusterGroup::MAX_THRESHOLD ? 'All Cells' : false, class: 'form-control' %>
                 </div>
                 <!-- end -->
             </div>

--- a/app/views/site/search/_gene_result_view_options.html.erb
+++ b/app/views/site/search/_gene_result_view_options.html.erb
@@ -10,5 +10,5 @@
 
 <div class="form-group">
   <%= label_tag "#{@target}-subsample".to_sym, 'Subsampling threshold' %>&nbsp;<i class='fas fa-question-circle' title="Take a representative subsample of the current cluster.  Choosing all cells may dramatically increase rendering time." data-toggle="tooltip"></i><br />
-  <%= select_tag "#{@target}-subsample".to_sym, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), {include_blank: 'All Cells', class: 'form-control subsample-select'} %>
+  <%= select_tag "#{@target}-subsample".to_sym, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), {include_blank: @cluster.points < ClusterGroup::MAX_THRESHOLD ? 'All Cells' : false, class: 'form-control subsample-select'} %>
 </div>


### PR DESCRIPTION
This fixes a bug in which searching a gene with "All Cells" in the Subsampling threshold dropdown list breaks the Single Cell Portal UI if the cluster has a very large number of cells.  It does so by omitting the "All Cells" option if the number of points is 250,000 or more.