### PR TITLE
Restore interactive thresholds for genomic heatmap

### DIFF
--- a/app/assets/javascripts/scp-ideogram.js
+++ b/app/assets/javascripts/scp-ideogram.js
@@ -84,19 +84,6 @@
 //     $('#ideogram-container').append(table);
 //   }
 
-
-// Monkey patch "afterRawAnnots" method in Ideogram to fix SCP-1573
-// TODO: Fix upstream in more refined manner, pull update, remove this patch.
-function monkeyPatchIdeogram() {
-  originalAfterRawAnnots = ideogram.afterRawAnnots;
-  ideogram.afterRawAnnots = function() {
-    var penultimateThreshold = ideogram.rawAnnots.metadata.heatmapThresholds.slice(-2)[0];
-    // Ensures default heatmap does not show black unexpectedly
-    ideogram.rawAnnots.metadata.heatmapThresholds.splice(-1, 1, penultimateThreshold + 1/10000);
-    originalAfterRawAnnots.apply(this);
-  }
-}
-
 var legend = [{
   name: 'Expression level',
   rows: [
@@ -133,7 +120,7 @@ function updateMargin(event) {
 function addMarginControl() {
   chrMargin = (typeof chrMargin === 'undefined' ? 10 : chrMargin)
     marginSlider =
-      `<label id="chrMarginContainer">
+      `<label id="chrMarginContainer" style="float:left; position: relative; top: 50px; left: -130px;">
         Chromosome margin
       <input type="range" id="chrMargin" list="chrMarginList" value="` + chrMargin + `">
       </label>
@@ -184,7 +171,9 @@ function addThresholdControl() {
 
   expressionThresholdSlider =
     `<label id="expressionThresholdContainer" style="float: left">
-        Expression threshold
+      <span class="glossary" title="Denoiser.  Adjusts mapping between inferCNV's output heatmap threshold values and normal vs. loss/gain signal.  Analogous to inferCNV denoise parameters, e.g. --noise_filter." style="cursor: help;">
+      Expression threshold
+      </span>
       <input type="range" id="expressionThreshold" list="expressionThresholdList" value="` + expressionThreshold + `">
       <datalist id="expressionThresholdList">
         <option value="0" label="0.">
@@ -210,7 +199,7 @@ function ideoRangeChangeEventHandler(event) {
 }
 
 function addIdeoRangeControls() {
-  // addThresholdControl();
+  addThresholdControl();
   addMarginControl();
 
   document.removeEventListener('change', ideoRangeChangeEventHandler);
@@ -288,7 +277,6 @@ function initializeIdeogram(url) {
     annotationsLayout: 'heatmap',
     legend: legend,
     onDrawAnnots: createTrackFilters,
-    onLoad: monkeyPatchIdeogram,
     debug: true,
     rotatable: false,
     chrMargin: 10,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^11.0.1",
     "@rails/webpacker": "3.5",
-    "ideogram": "1.7.0",
+    "ideogram": "1.8.0",
     "igv": "2.1.0",
     "jquery": "3.4.0",
     "jquery-ui": "1.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3077,10 +3077,10 @@ icss-utils@^2.1.0:
   dependencies:
     postcss "^6.0.1"
 
-ideogram@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.7.0.tgz#32c9745d92b096449e804b128f009c9c1dd02702"
-  integrity sha512-AeZeqhUdxAUSbzs/HyM8nSkV8R8PE2YVhORvmQDTxGlK1E38SNqpFPNbaHZ0+NyjtVvSieFwLU208oLyAc31Uw==
+ideogram@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.8.0.tgz#4fecca909199d0d38efe04cee94f36b81508536a"
+  integrity sha512-nGehmjKrfWWfcD2h6w7+cW0do/Bzm+h60CVAEly7V5iICW+qfLFPbwH7RRoOhRN2fYAsBoDNGLuBz5zAxJ1PgQ==
   dependencies:
     commander "^2.19.0"
     crossfilter "1.3.12"


### PR DESCRIPTION
This restores interactive heatmap thresholds for the genomic heatmap visualization for inferCNV results (see #243), by including an upstream fix from Ideogram.js.