### PR TITLE
Categorizing all 'engaged' actions into one group

### DIFF
--- a/app/models/analysis_configuration.rb
+++ b/app/models/analysis_configuration.rb
@@ -258,7 +258,7 @@ class AnalysisConfiguration
       method = Study.firecloud_client.get_method(self.namespace, self.name, self.snapshot)
       self.synopsis = method['synopsis']
     rescue => e
-      error_context = ErrorTracker.format_extra_context(self, last_config)
+      error_context = ErrorTracker.format_extra_context(self)
       ErrorTracker.report_exception(e, self.user, error_context)
       Rails.logger.error "Error retrieving analysis WDL synopsis for #{self.identifier}: #{e.message}"
       e

--- a/app/views/site/_selection_submit.html.erb
+++ b/app/views/site/_selection_submit.html.erb
@@ -21,7 +21,7 @@
             setErrorOnBlank(needText);
         } else {
             $('#generic-modal-title').html("Saving... Please Wait");
-            ga('send', 'event', 'custom_cell_annotation', 'create_annotation');
+            ga('send', 'event', 'engaged_user_action', 'create_custom_cell_annotation');
             launchModalSpinner('#generic-modal-spinner', '#generic-modal', function() {
                 var form = $('#selection-well > form');
                 form.submit();

--- a/app/views/site/create_workspace_submission.js.erb
+++ b/app/views/site/create_workspace_submission.js.erb
@@ -8,6 +8,6 @@ closeModalSpinner('#generic-modal-spinner', '#generic-modal', function () {
         dataType: 'script'
     });
     var requestUrl = '<%= javascript_safe_url(request.fullpath) %>';
-    ga('send', 'event', 'terra_pipeline', 'workspace_submission_created');
+    ga('send', 'event', 'engaged_user_action', 'terra_pipeline_submission');
     gaTrack(requestUrl, 'Single Cell Portal');
 });

--- a/app/views/site/search/_search_genes.html.erb
+++ b/app/views/site/search/_search_genes.html.erb
@@ -49,7 +49,7 @@
             var numGenes = genes.length;
             requestUrl += '?genes=' + genes.join('+') + '&num_genes=' + numGenes;
             gaTrack(requestUrl, 'Single Cell Portal | Global Gene Search');
-            ga('send', 'event', 'global_gene_search', 'submit_search');
+            ga('send', 'event', 'engaged_user_action', 'global_gene_search');
             return true;
         }
     });

--- a/app/views/site/view_gene_expression.js.erb
+++ b/app/views/site/view_gene_expression.js.erb
@@ -5,6 +5,6 @@ closeModalSpinner('#spinner_target', '#loading-modal', function () {
     $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices') %>");
     enableDefaultActions();
     var requestUrl = "<%= javascript_safe_url(request.fullpath) %>";
-    ga('send', 'event', 'study_gene_search', 'view_single_gene');
+    ga('send', 'event', 'engaged_user_action', 'study_gene_search_single');
     gaTrack(requestUrl, 'Single Cell Portal');
 });

--- a/app/views/site/view_gene_expression_heatmap.js.erb
+++ b/app/views/site/view_gene_expression_heatmap.js.erb
@@ -7,6 +7,6 @@ closeModalSpinner('#spinner_target', '#loading-modal', function () {
     $(window).off('resizeEnd');
     enableDefaultActions();
     var requestUrl = "<%= javascript_safe_url(request.fullpath) %>";
-    ga('send', 'event', 'study_gene_search', 'view_multiple_genes')
+    ga('send', 'event', 'engaged_user_action', 'study_gene_search_multiple')
     gaTrack(requestUrl, 'Single Cell Portal');
 });


### PR DESCRIPTION
* Allows for correct summing when rolling up action counts (users not double counted)
* Still preserving individual actions as labels instead of categories