### PR TITLE
100k cell subsample, bugfixes

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -897,7 +897,7 @@ class SiteController < ApplicationController
       @user_annotation = UserAnnotation.new(user_id: user_annotation_params[:user_id], study_id: user_annotation_params[:study_id],
                                             cluster_group_id: user_annotation_params[:cluster_group_id],
                                             values: @data_names, name: user_annotation_params[:name],
-                                            source_resolution: params[:subsample_threshold.present? ? params[:subsample_threshold].to_i : nil])
+                                            source_resolution: user_annotation_params[:subsample_threshold].present? ? user_annotation_params[:subsample_threshold].to_i : nil)
 
       # override cluster setter to use the current selected cluster, needed for reloading
       @cluster = @user_annotation.cluster_group

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -894,7 +894,10 @@ class SiteController < ApplicationController
       end
 
       # Create the annotation
-      @user_annotation = UserAnnotation.new(user_id: user_annotation_params[:user_id], study_id: user_annotation_params[:study_id], cluster_group_id: user_annotation_params[:cluster_group_id], values: @data_names, name: user_annotation_params[:name])
+      @user_annotation = UserAnnotation.new(user_id: user_annotation_params[:user_id], study_id: user_annotation_params[:study_id],
+                                            cluster_group_id: user_annotation_params[:cluster_group_id],
+                                            values: @data_names, name: user_annotation_params[:name],
+                                            source_resolution: params[:subsample_threshold.present? ? params[:subsample_threshold].to_i : nil])
 
       # override cluster setter to use the current selected cluster, needed for reloading
       @cluster = @user_annotation.cluster_group

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -38,7 +38,7 @@ class ClusterGroup
   index({ study_id: 1, study_file_id: 1}, { unique: false, background: true })
 
   # fixed values to subsample at
-  SUBSAMPLE_THRESHOLDS = [1000, 10000, 20000].freeze
+  SUBSAMPLE_THRESHOLDS = [1000, 10000, 20000, 100000].freeze
 
   MAX_THRESHOLD = 100000
 

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -632,9 +632,9 @@ class Study
     end
   end
 
-  # check if a user has permission do download data from this study (either is public and user is signed in or user has a direct share)
+  # check if a user has permission do download data from this study (either is public and user is signed in, user is an admin, or user has a direct share)
   def can_download?(user)
-    (self.public? && user.present?) || self.has_bucket_access?(user)
+    (self.public? && user.present?) || (user.present? && user.admin?) || self.has_bucket_access?(user)
   end
 
   # check if user can delete a study - only owners can

--- a/app/views/user_annotations/index.html.erb
+++ b/app/views/user_annotations/index.html.erb
@@ -22,7 +22,7 @@
                 <td><%= user_annotation.values.map{|x| "<span class='label label-#{ x == 'Undefined' ? 'warning' : 'default'} #{user_annotation.name_as_id}'>#{x}</span>"}.join(' ').html_safe %></td>
                 <td class="annotation-study <%= user_annotation.name_as_id %>_study"><%= link_to user_annotation.study.name,  view_study_path(accession: user_annotation.study.accession, study_name: user_annotation.study.url_safe_name) %></td>
                 <td class="annotation-cluster <%= user_annotation.name_as_id %>_cluster"><%= user_annotation.cluster_group.name %></td>
-                <td><%= user_annotation.subsampled_at %></td>
+                <td><%= user_annotation.source_resolution_label %></td>
                 <td><%= user_annotation.user.email %></td>
                 <td>
                   <%= scp_link_to "<span class='fas fa-chart-bar'></span> Plot Annotation".html_safe, view_study_path(accession: user_annotation.study.accession, study_name: user_annotation.study.url_safe_name, cluster: user_annotation.cluster_group.name, annotation: user_annotation.formatted_annotation_identifier) + '#study-visualize', class: "btn btn-xs btn-info #{user_annotation.name_as_id}-show"  %>

--- a/bin/boot_mongo
+++ b/bin/boot_mongo
@@ -14,6 +14,7 @@ $0 [OPTION]
 -d VALUE	set the data directory to mount inside the MySQL Docker container (defaults to $HOME/Documents/Data/docker-mongo)
 -m VALUE	set the max memory cache size (in GB) for wiredTiger (defaults to 10GB)
 -r VALUE	set the max memory allocation size (in GB) for container (defaults to 12GB)
+-s VALUE  set the internalQueryExecMaxBlockingSortBytes parameter (defaults to 128GB)
 -u VALUE	set the MONGO_USERNAME variable (no default value)
 -p VALUE	set the MONGO_PASSWORD variable (no default value)
 -H COMMAND	print this text
@@ -25,8 +26,9 @@ CONTAINER_NAME="mongodb"
 DATA_DIR="$HOME/Documents/Data/docker-mongo"
 MAX_RAM=12G
 MAX_RAM_CACHE_GB=4
+SORT_BUFFER=134217728
 
-while getopts "n:d:m:r:p:H" OPTION; do
+while getopts "n:d:m:r:p:s:H" OPTION; do
 case $OPTION in
 	n)
 		CONTAINER_NAME="$OPTARG"
@@ -46,6 +48,9 @@ case $OPTION in
 	p)
 		MONGO_PASSWORD="$OPTARG"
 		;;
+	s)
+	  SORT_BUFFER="$OPTARG"
+	  ;;
 	H)
 		echo "$usage"
 		exit 0
@@ -57,4 +62,4 @@ case $OPTION in
 	esac
 done
 
-docker run --name $CONTAINER_NAME -p 27017:27017 -v $DATA_DIR:/data/db:rw -v $DATA_DIR/log:/var/log/mongodb:rw -d -m $MAX_RAM mongo --logpath /var/log/mongodb/mongodb.log --wiredTigerCacheSizeGB $MAX_RAM_CACHE_GB
+docker run --name $CONTAINER_NAME -p 27017:27017 -v $DATA_DIR:/data/db:rw -v $DATA_DIR/log:/var/log/mongodb:rw -d -m $MAX_RAM mongo --logpath /var/log/mongodb/mongodb.log --wiredTigerCacheSizeGB $MAX_RAM_CACHE_GB --setParameter internalQueryExecMaxBlockingSortBytes=$SORT_BUFFER

--- a/bin/boot_mongo
+++ b/bin/boot_mongo
@@ -14,7 +14,7 @@ $0 [OPTION]
 -d VALUE	set the data directory to mount inside the MySQL Docker container (defaults to $HOME/Documents/Data/docker-mongo)
 -m VALUE	set the max memory cache size (in GB) for wiredTiger (defaults to 10GB)
 -r VALUE	set the max memory allocation size (in GB) for container (defaults to 12GB)
--s VALUE  set the internalQueryExecMaxBlockingSortBytes parameter (defaults to 128GB)
+-s VALUE	set the internalQueryExecMaxBlockingSortBytes parameter (defaults to 128GB)
 -u VALUE	set the MONGO_USERNAME variable (no default value)
 -p VALUE	set the MONGO_PASSWORD variable (no default value)
 -H COMMAND	print this text

--- a/db/migrate/20190517171441_generate100_k_subsamples.rb
+++ b/db/migrate/20190517171441_generate100_k_subsamples.rb
@@ -1,0 +1,30 @@
+class Generate100KSubsamples < Mongoid::Migration
+  def self.up
+    ClusterGroup.all.each do |cluster|
+      if cluster.points > 100000
+        cell_metadata = CellMetadatum.where(study_id: cluster.study.id)
+        # create cluster-based annotation subsamples first
+        if cluster.cell_annotations.any?
+          cluster.cell_annotations.each do |cell_annot|
+            cluster.delay.generate_subsample_arrays(100000, cell_annot[:name], cell_annot[:type], 'cluster')
+          end
+        end
+        # create study-based annotation subsamples
+        cell_metadata.each do |metadata|
+          cluster.delay.generate_subsample_arrays(100000, metadata.name, metadata.annotation_type, 'study')
+        end
+        CacheRemovalJob.new(cluster.study.accession).delay.perform
+      end
+    end
+  end
+
+  def self.down
+    ClusterGroup.all.each do |cluster|
+      if cluster.points > 100000
+        DataArray.where(study_id: cluster.study.id, study_file_id: cluster.study_file.id, linear_data_id: cluster.id,
+                        linear_data_type: 'ClusterGroup', subsample_threshold: 100000).delete_all
+        CacheRemovalJob.new(cluster.study.accession).delay.perform
+      end
+    end
+  end
+end

--- a/db/migrate/20190522190416_set_source_resolution_for_user_annotations.rb
+++ b/db/migrate/20190522190416_set_source_resolution_for_user_annotations.rb
@@ -1,0 +1,16 @@
+class SetSourceResolutionForUserAnnotations < Mongoid::Migration
+  def self.up
+    UserAnnotation.each do |annot|
+      resolution = annot.subsampled_at
+      if resolution == 'All Cells'
+        annot.update(source_resolution: nil)
+      else
+        annot.update(source_resolution: resolution.to_i)
+      end
+    end
+  end
+
+  def self.down
+    UserAnnotation.all.each {|annot| annot.unset(:source_resolution)}
+  end
+end

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^11.0.1",
     "@rails/webpacker": "3.5",
+    "fstream": "1.0.12",
     "ideogram": "1.8.0",
     "igv": "2.1.0",
     "jquery": "3.4.0",

--- a/test/models/cluster_group_test.rb
+++ b/test/models/cluster_group_test.rb
@@ -20,8 +20,6 @@ class ClusterGroupTest < ActiveSupport::TestCase
 
     # generate subsampled arrays at 1K
     @cluster_group.generate_subsample_arrays(1000, 'Category', 'group', 'cluster')
-    @cluster_group.generate_subsample_arrays(10000, 'Category', 'group', 'cluster')
-    @cluster_group.generate_subsample_arrays(20000, 'Category', 'group', 'cluster')
 
     # load subsampled arrays
     subsample_x = @cluster_group.concatenate_data_arrays('x', 'coordinates', 1000, 'Category--group--cluster')
@@ -128,8 +126,6 @@ class ClusterGroupTest < ActiveSupport::TestCase
 
     # generate subsampled arrays at 1K
     @cluster_group.generate_subsample_arrays(1000, 'Label', 'group', 'study')
-    @cluster_group.generate_subsample_arrays(10000, 'Label', 'group', 'study')
-    @cluster_group.generate_subsample_arrays(20000, 'Label', 'group', 'study')
 
     # load subsampled arrays (study based)
     subsample_x = @cluster_group.concatenate_data_arrays('x', 'coordinates', 1000, 'Label--group--study')

--- a/test/models/cluster_group_test.rb
+++ b/test/models/cluster_group_test.rb
@@ -18,8 +18,10 @@ class ClusterGroupTest < ActiveSupport::TestCase
     category_array = @cluster_group.concatenate_data_arrays('Category', 'annotations')
     original_category_values = @cluster_group.cell_annotations.find {|c| c[:name] == 'Category'}['values'].sort
 
-    # generate subsampled arrays at 1K
+    # generate subsampled arrays at 1K, 10K, 20K (needed for user annotation tests later)
     @cluster_group.generate_subsample_arrays(1000, 'Category', 'group', 'cluster')
+    @cluster_group.generate_subsample_arrays(10000, 'Category', 'group', 'cluster')
+    @cluster_group.generate_subsample_arrays(20000, 'Category', 'group', 'cluster')
 
     # load subsampled arrays
     subsample_x = @cluster_group.concatenate_data_arrays('x', 'coordinates', 1000, 'Category--group--cluster')
@@ -124,8 +126,11 @@ class ClusterGroupTest < ActiveSupport::TestCase
     z_array = @cluster_group.concatenate_data_arrays('z', 'coordinates')
     cell_array = @cluster_group.concatenate_data_arrays('text', 'cells')
 
-    # generate subsampled arrays at 1K
+    # generate subsampled arrays at 1K, 10K, and 20K (needed for user annotation tests later)
     @cluster_group.generate_subsample_arrays(1000, 'Label', 'group', 'study')
+    @cluster_group.generate_subsample_arrays(10000, 'Label', 'group', 'study')
+    @cluster_group.generate_subsample_arrays(20000, 'Label', 'group', 'study')
+
 
     # load subsampled arrays (study based)
     subsample_x = @cluster_group.concatenate_data_arrays('x', 'coordinates', 1000, 'Label--group--study')

--- a/test/models/user_annotation_test.rb
+++ b/test/models/user_annotation_test.rb
@@ -22,7 +22,7 @@ class UserAnnotationTest < ActiveSupport::TestCase
     potential_labels = %w[Label--group--study Category--group--cluster]
     loaded_annotation = potential_labels.sample
     puts "loaded_annotation: #{loaded_annotation}"
-    @user_annotation = UserAnnotation.create(user_id: @user.id, study_id: @study.id, cluster_group_id: @cluster.id, values: keys, name: 'fulldata')
+    @user_annotation = UserAnnotation.create(user_id: @user.id, study_id: @study.id, cluster_group_id: @cluster.id, values: keys, name: 'fulldata', source_resolution: nil)
 
     #build user_data_array_attributes
     user_data_arrays_attributes = {}
@@ -61,8 +61,8 @@ class UserAnnotationTest < ActiveSupport::TestCase
     end
 
     #Check that created at method works correctly
-    created_at = @user_annotation.subsampled_at
-    assert created_at == 'Created at Full Data', "Incorrect created at, '#{created_at} should be 'Created at Full Data"
+    created_at = @user_annotation.source_resolution_label
+    assert created_at == 'All Cells', "Incorrect created at, '#{created_at} should be 'Created at Full Data"
 
     #Check that 16 data arrays were created
     num_data_arrays = @user_annotation.user_data_arrays.all.to_a.count
@@ -86,7 +86,8 @@ class UserAnnotationTest < ActiveSupport::TestCase
     potential_labels = %w[Label--group--study Category--group--cluster]
     loaded_annotation = potential_labels.sample
     puts "loaded_annotation: #{loaded_annotation}"
-    @user_annotation = UserAnnotation.create(user_id: @user.id, study_id: @study.id, cluster_group_id: @cluster.id, values: keys, name: 'twenty')
+    @user_annotation = UserAnnotation.create(user_id: @user.id, study_id: @study.id, cluster_group_id: @cluster.id,
+                                             values: keys, name: 'twenty', source_resolution: 20000)
 
     #build user_data_array_attributes
     user_data_arrays_attributes = {}
@@ -129,8 +130,8 @@ class UserAnnotationTest < ActiveSupport::TestCase
     end
 
     #Check that created at method works correctly
-    created_at = @user_annotation.subsampled_at
-    assert created_at == 'Created at a subsample of 20,000 Cells', "Incorrect created at, '#{created_at} should be 'Created at a subsample of 20,000 Cells"
+    created_at = @user_annotation.source_resolution_label
+    assert created_at == '20000 Cells', "Incorrect created at, '#{created_at} should be 'Created at a subsample of 20,000 Cells"
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
@@ -150,7 +151,8 @@ class UserAnnotationTest < ActiveSupport::TestCase
     potential_labels = %w[Label--group--study Category--group--cluster]
     loaded_annotation = potential_labels.sample
 
-    @user_annotation = UserAnnotation.create(user_id: @user.id, study_id: @study.id, cluster_group_id: @cluster.id, values: keys, name: 'ten')
+    @user_annotation = UserAnnotation.create(user_id: @user.id, study_id: @study.id, cluster_group_id: @cluster.id,
+                                             values: keys, name: 'ten', source_resolution: 10000)
 
     #build user_data_array_attributes
     user_data_arrays_attributes = {}
@@ -193,8 +195,8 @@ class UserAnnotationTest < ActiveSupport::TestCase
     end
 
     #Check that created at method works correctly
-    created_at = @user_annotation.subsampled_at
-    assert created_at == 'Created at a subsample of 10,000 Cells', "Incorrect created at, '#{created_at} should be 'Created at a subsample of 10,000 Cells"
+    created_at = @user_annotation.source_resolution_label
+    assert created_at == '10000 Cells', "Incorrect created at, '#{created_at} should be 'Created at a subsample of 10,000 Cells"
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
@@ -214,7 +216,8 @@ class UserAnnotationTest < ActiveSupport::TestCase
     potential_labels = %w[Label--group--study Category--group--cluster]
     loaded_annotation = potential_labels.sample
     puts "loaded_annotation: #{loaded_annotation}"
-    @user_annotation = UserAnnotation.create(user_id: @user.id, study_id: @study.id, cluster_group_id: @cluster.id, values: keys, name: 'one')
+    @user_annotation = UserAnnotation.create(user_id: @user.id, study_id: @study.id, cluster_group_id: @cluster.id,
+                                             values: keys, name: 'one', source_resolution: 1000)
 
     #build user_data_array_attributes
     user_data_arrays_attributes = {}
@@ -257,8 +260,8 @@ class UserAnnotationTest < ActiveSupport::TestCase
     end
 
     #Check that created at method works correctly
-    created_at = @user_annotation.subsampled_at
-    assert created_at == 'Created at a subsample of 1,000 Cells', "Incorrect created at, '#{created_at} should be 'Created at a subsample of 1,000 Cells"
+    created_at = @user_annotation.source_resolution_label
+    assert created_at == '1000 Cells', "Incorrect created at, '#{created_at} should be 'Created at a subsample of 1,000 Cells"
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2710,10 +2710,10 @@ fsevents@^1.2.2:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
-fstream@^1.0.0, fstream@^1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
-  integrity sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=
+fstream@1.0.12, fstream@^1.0.0, fstream@^1.0.2:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
   dependencies:
     graceful-fs "^4.1.2"
     inherits "~2.0.0"


### PR DESCRIPTION
100K Subsampling Threshold
* Adding 100K as top-level subsampling option
* Migration to backfill data where needed
* Increasing MongoDB in-memory sort buffer size for local deployments to allow 100K subsamples
Bugfixes:
* Restoring permission for admins to download data from studies w/o direct share
* Updating js package fstream re: security issue