### PR TITLE
Enable cluster plot for "All Cells", switch to subsampling for gene search

### DIFF
--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -37,10 +37,10 @@ class ClusterGroup
   index({ study_id: 1 }, { unique: false, background: true })
   index({ study_id: 1, study_file_id: 1}, { unique: false, background: true })
 
-  # fixed values to subsample at
-  SUBSAMPLE_THRESHOLDS = [20000, 10000, 1000].freeze
-
   MAX_THRESHOLD = 100000
+
+  # fixed values to subsample at
+  SUBSAMPLE_THRESHOLDS = [100000, 20000, 10000, 1000].freeze
 
   COLORBREWER_SET = %w(#e41a1c #377eb8 #4daf4a #984ea3 #ff7f00 #a65628 #f781bf #999999
     #66c2a5 #fc8d62 #8da0cb #e78ac3 #a6d854 #ffd92f #e5c494 #b3b3b3 #8dd3c7

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -37,13 +37,10 @@ class ClusterGroup
   index({ study_id: 1 }, { unique: false, background: true })
   index({ study_id: 1, study_file_id: 1}, { unique: false, background: true })
 
-  # fixed values to subsample at
-  SUBSAMPLE_THRESHOLDS = [100000, 20000, 10000, 1000].freeze
-
   MAX_THRESHOLD = 100000
 
   # fixed values to subsample at
-  SUBSAMPLE_THRESHOLDS = [100000, 20000, 10000, 1000].freeze
+  SUBSAMPLE_THRESHOLDS = [MAX_THRESHOLD, 20000, 10000, 1000].freeze
 
   COLORBREWER_SET = %w(#e41a1c #377eb8 #4daf4a #984ea3 #ff7f00 #a65628 #f781bf #999999
     #66c2a5 #fc8d62 #8da0cb #e78ac3 #a6d854 #ffd92f #e5c494 #b3b3b3 #8dd3c7

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -38,7 +38,7 @@ class ClusterGroup
   index({ study_id: 1, study_file_id: 1}, { unique: false, background: true })
 
   # fixed values to subsample at
-  SUBSAMPLE_THRESHOLDS = [1000, 10000, 20000].freeze
+  SUBSAMPLE_THRESHOLDS = [20000, 10000, 1000].freeze
 
   MAX_THRESHOLD = 100000
 

--- a/app/views/site/_expression_plots_plotly.html.erb
+++ b/app/views/site/_expression_plots_plotly.html.erb
@@ -160,7 +160,10 @@ var expressionData = [];
     <% @values.sort_by {|k,v| k}.each do |cluster, data| %>
       formatted_array.push(["<%= cluster %>", <%= raw data[:y] %>]);
     <% end %>
-    var title = "<%= params[:cluster]%>";
+    var title = '<%= params[:cluster]%>';
+    <% if @expression[:all][:x].length >= ClusterGroup::MAX_THRESHOLD %>
+    title += ' (subsampled to <%= ClusterGroup::MAX_THRESHOLD %> cells)';
+    <% end %>
     var data = createTracesAndLayout(formatted_array, title, jitter_var);
     expressionData = [].concat.apply([], data[0] );
     expressionLayout = data[1];

--- a/app/views/site/_view_options.html.erb
+++ b/app/views/site/_view_options.html.erb
@@ -24,6 +24,9 @@
                   <% else %>
                   <%= select_tag :subsample, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), include_blank: 'All Cells', class: 'form-control' %>
                   <% end %>
+                  <%if @cluster.points >= ClusterGroup::MAX_THRESHOLD %>
+                  <small>Subsampling will be used for gene search results.</small>
+                  <% end %>
                 </div>
                 <!-- end -->
             </div>

--- a/app/views/site/_view_options.html.erb
+++ b/app/views/site/_view_options.html.erb
@@ -19,7 +19,11 @@
                 <!-- if action_name !~ /heatmap/ -->
                 <div class="form-group col-sm-4">
                   <%= label_tag :subsample, 'Subsampling threshold' %>&nbsp;<i class='fas fa-question-circle' title="Take a representative subsample of the current cluster.  Choosing all cells may dramatically increase rendering time." data-toggle="tooltip"></i><br />
+                  <% if /view_gene_(set_)?expression$/.match(action_name) %>
+                  <%= select_tag :subsample, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), {include_blank: @cluster.points < ClusterGroup::MAX_THRESHOLD ? 'All Cells' : false, class: 'form-control'} %>
+                  <% else %>
                   <%= select_tag :subsample, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), include_blank: 'All Cells', class: 'form-control' %>
+                  <% end %>
                 </div>
                 <!-- end -->
             </div>

--- a/app/views/site/_view_options.html.erb
+++ b/app/views/site/_view_options.html.erb
@@ -18,14 +18,20 @@
 
                 <!-- if action_name !~ /heatmap/ -->
                 <div class="form-group col-sm-4">
-                  <%= label_tag :subsample, 'Subsampling threshold' %>&nbsp;<i class='fas fa-question-circle' title="Take a representative subsample of the current cluster.  Choosing all cells may dramatically increase rendering time." data-toggle="tooltip"></i><br />
+                  <%= label_tag :subsample, 'Subsampling threshold' %>
+                  &nbsp;
+                  <i
+                    class='fas fa-question-circle'
+                    title="Take a representative subsample of the current cluster.
+                      <% if /view_gene_(set_)?expression$/.match(action_name) === false %>Choosing all cells may dramatically increase rendering time.  <% end %>
+                      <% if @cluster.points < ClusterGroup::MAX_THRESHOLD %>
+                      <% else %>Gene search results will be subsampled to <%= ClusterGroup::MAX_THRESHOLD %> cells.<% end %>"
+                    data-toggle="tooltip"></i>
+                  <br />
                   <% if /view_gene_(set_)?expression$/.match(action_name) %>
                   <%= select_tag :subsample, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), {include_blank: @cluster.points < ClusterGroup::MAX_THRESHOLD ? 'All Cells' : false, class: 'form-control'} %>
                   <% else %>
                   <%= select_tag :subsample, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), include_blank: 'All Cells', class: 'form-control' %>
-                  <% end %>
-                  <%if @cluster.points >= ClusterGroup::MAX_THRESHOLD %>
-                  <small>Subsampling will be used for gene search results.</small>
                   <% end %>
                 </div>
                 <!-- end -->

--- a/app/views/site/search/_gene_result_view_options.html.erb
+++ b/app/views/site/search/_gene_result_view_options.html.erb
@@ -10,5 +10,5 @@
 
 <div class="form-group">
   <%= label_tag "#{@target}-subsample".to_sym, 'Subsampling threshold' %>&nbsp;<i class='fas fa-question-circle' title="Take a representative subsample of the current cluster.  Choosing all cells may dramatically increase rendering time." data-toggle="tooltip"></i><br />
-  <%= select_tag "#{@target}-subsample".to_sym, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), {include_blank: 'All Cells', class: 'form-control subsample-select'} %>
+  <%= select_tag "#{@target}-subsample".to_sym, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), {include_blank: @cluster.points < ClusterGroup::MAX_THRESHOLD ? 'All Cells' : false, class: 'form-control subsample-select'} %>
 </div>


### PR DESCRIPTION
This enables the default cluster plot for the "All Cells" subsampling threshold, and automatically switches to subsampling our highest enumerated threshold (i.e. 100,000 cells) for gene search.

By doing so, this PR addresses a drawback in #254.  It allows extremely many cells to be shown in a cluster plot, while providing a way for SCP gene search results to still work for such large studies.