### PR TITLE
adding description field to analysis configurations

### DIFF
--- a/app/controllers/analysis_configurations_controller.rb
+++ b/app/controllers/analysis_configurations_controller.rb
@@ -162,7 +162,7 @@ class AnalysisConfigurationsController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def analysis_configuration_params
       params.require(:analysis_configuration).permit(:namespace, :name, :snapshot, :configuration_namespace,
-                                                     :configuration_name, :configuration_snapshot, :user_id,
+                                                     :configuration_name, :configuration_snapshot, :user_id, :description,
                                                      external_resources_attributes: [:id, :_destroy, :title, :description,
                                                                                      :url, :publication_url])
     end

--- a/app/models/analysis_configuration.rb
+++ b/app/models/analysis_configuration.rb
@@ -38,6 +38,10 @@ class AnalysisConfiguration
       key :type, :string
       key :description, 'Short description of analysis method'
     end
+    property :description do
+      key :type, :string
+      key :description, 'Long-form description of analysis method, or information regarding running analysis'
+    end
     property :entity_type do
       key :type, :string
       key :description, 'FireCloud entity model type supported by analysis method'
@@ -74,6 +78,10 @@ class AnalysisConfiguration
       key :type, :string
       key :description, 'Short description of analysis method'
     end
+    property :description do
+      key :type, :string
+      key :description, 'Long-form description of analysis method, or information regarding running analysis'
+    end
     property :entity_type do
       key :type, :string
       key :description, 'FireCloud entity model type supported by analysis method'
@@ -92,6 +100,7 @@ class AnalysisConfiguration
   field :configuration_snapshot, type: Integer
   field :synopsis, type: String
   field :entity_type, type: String
+  field :description, type: String, default: ''
 
   validate :ensure_wdl_keys
   validates_presence_of :namespace, :name, :snapshot, :configuration_namespace, :configuration_name, :configuration_snapshot

--- a/app/views/analysis_configurations/_submission_preview_form.html.erb
+++ b/app/views/analysis_configurations/_submission_preview_form.html.erb
@@ -1,5 +1,6 @@
 <div class="row">
   <div class="col-sm-offset-3 col-sm-6">
+    <div id="analysis-configuration-description"><%= analysis_configuration.description.html_safe %></div>
     <%= form_for(:submission, url: '#', html: {class: 'form'}) do |f| %>
       <% analysis_configuration.analysis_parameters.inputs.sort_by(&:config_param_name).each do |parameter| %>
         <div class="form-group row <%= !parameter.visible? ? 'preview-hidden-input bg-info' : nil %>">

--- a/app/views/analysis_configurations/show.html.erb
+++ b/app/views/analysis_configurations/show.html.erb
@@ -20,8 +20,12 @@
   <dt>Entity Type</dt>
   <dd><%= @analysis_configuration.entity_type %></dd>
 </dl>
-<h3>Documentation Links</h3>
 <%= nested_form_for(@analysis_configuration, method: :patch, html: {class: 'form'} ) do |f| %>
+  <div class="form-group">
+    <%= f.label :description %>
+    <%= f.text_area :description %>
+  </div>
+  <h3>Documentation Links</h3>
   <%= f.fields_for :external_resources %>
   <p><%= f.link_to_add "<span class='fas fa-plus'></span> Add a Link".html_safe, :external_resources, class: 'btn btn-sm btn-info',
                     id: 'add-external-resource' %></p>
@@ -56,6 +60,20 @@
 </p>
 
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+
+    ClassicEditor
+        .create( document.querySelector( '#analysis_configuration_description' ),
+            {
+                toolbar: ["heading", '|',  "bold", "italic", "link", "bulletedList", "numberedList", "blockQuote", '|', "undo", "redo"]
+            }
+        )
+        .then( function(editor) {
+            editor.ui.view.editable.editableElement.style.maxHeight = '300px';
+        } )
+        .catch( function(error) {
+                console.error( error );
+            }
+        );
 
     // populate dropdown with JSON response values
     function populateDropdown(formInput, options) {

--- a/app/views/site/analysis/_analysis_submission_form.html.erb
+++ b/app/views/site/analysis/_analysis_submission_form.html.erb
@@ -1,5 +1,6 @@
 <div class="row">
   <div class="col-sm-offset-3 col-sm-6">
+    <div id="analysis-configuration-description"><%= @analysis_configuration.description.html_safe %></div>
     <%= render partial: '/layouts/external_resources_view', locals: {instance: @analysis_configuration} %>
     <%= hidden_field_tag :analysis_configuration_id, @analysis_configuration.id.to_s %>
     <% @analysis_configuration.analysis_parameters.inputs.sort_by(&:config_param_name).each do |parameter| %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -116,4 +116,4 @@ User.create!(email:'testing.user.2@gmail.com', password:'someotherpassword',
 # Analysis Configuration seeds
 AnalysisConfiguration.create(namespace: 'single-cell-portal', name: 'split-cluster', snapshot: 1, user_id: user.id,
                              configuration_namespace: 'single-cell-portal', configuration_name: 'split-cluster',
-                             configuration_snapshot: 2)
+                             configuration_snapshot: 2, description: '<p>This is an test description.</p>')

--- a/test/controllers/analysis_configurations_controller_test.rb
+++ b/test/controllers/analysis_configurations_controller_test.rb
@@ -27,6 +27,7 @@ class AnalysisConfigurationsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'form.analysis-parameter-form', 2, 'Did not find correct number of analysis parameter entries'
     assert_select 'form.input-analysis-parameter', 1, 'Did not find correct number of inputs'
     assert_select 'form.output-analysis-parameter', 1, 'Did not find correct number of outputs'
+    assert_select 'textarea#analysis_configuration_description', text: @analysis_configuration.description
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 


### PR DESCRIPTION
Adding a description field to all AnalysisConfiguration objects to allow administrators to add extra context or informational messages that are not parameter-dependent, such as guidelines or limitations for usage.