### PR TITLE
Adding user identifier to FireCloud API calls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,17 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :invalid_csrf
 
+  # set current_user for use outside of controllers
+  # from https://stackoverflow.com/questions/2513383/access-current-user-in-model
+  around_action :set_current_user
+  def set_current_user
+    Current.user = current_user
+    yield
+  ensure
+    # to address the thread variable leak issues in Puma/Thin webserver
+    Current.user = nil
+  end
+
   # auth action for portal admins
   def authenticate_admin
     unless current_user.admin?

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -354,9 +354,6 @@ class SiteController < ApplicationController
           @submissions.delete_if {|submission| deleted_submissions.include?(submission['submissionId'])}
         end
 
-        # load samples from workspace
-        set_workspace_samples
-
         # load list of available workflows
         @workflows_list = load_available_workflows
       end

--- a/lib/current.rb
+++ b/lib/current.rb
@@ -1,0 +1,4 @@
+# module to access Devise current_user object outside of ActionControllers
+module Current
+  thread_mattr_accessor :user
+end


### PR DESCRIPTION
Adding the Current module to extract the current_user from any requests made by users and passing that along to all FireCloud API calls.  Database identifier in lieu of email.