### PR TITLE
Adding analysis configuration description to API responses

### DIFF
--- a/app/views/api/v1/site/_analysis.json.jbuilder
+++ b/app/views/api/v1/site/_analysis.json.jbuilder
@@ -5,5 +5,6 @@ json.set! :configuration_namespace, analysis.configuration_namespace
 json.set! :configuration_name, analysis.configuration_name
 json.set! :configuration_snapshot, analysis.configuration_snapshot
 json.set! :synopsis, analysis.synopsis
+json.set! :description, strip_tags(analysis.description)
 json.set! :entity_type, analysis.entity_type
 json.set! :required_inputs, analysis.required_inputs(true)

--- a/app/views/api/v1/site/_analysis_in_list.json.jbuilder
+++ b/app/views/api/v1/site/_analysis_in_list.json.jbuilder
@@ -5,4 +5,5 @@ json.set! :configuration_namespace, analysis.configuration_namespace
 json.set! :configuration_name, analysis.configuration_name
 json.set! :configuration_snapshot, analysis.configuration_snapshot
 json.set! :synopsis, analysis.synopsis
+json.set! :description, strip_tags(analysis.description)
 json.set! :entity_type, analysis.entity_type

--- a/app/views/api/v1/site/_analysis_info.json.jbuilder
+++ b/app/views/api/v1/site/_analysis_info.json.jbuilder
@@ -1,4 +1,5 @@
 json.set! :namespace, analysis.namespace
 json.set! :name, analysis.name
 json.set! :snapshot, analysis.snapshot
+json.set! :description, strip_tags(analysis.description)
 json.set! :entity_type, analysis.entity_type

--- a/app/views/site/_study_settings_form.html.erb
+++ b/app/views/site/_study_settings_form.html.erb
@@ -129,6 +129,7 @@
             <div class="col-sm-5">
               <%= share.label :permission %><br />
               <%= share.select :permission, options_for_select(StudyShare::PERMISSION_TYPES, share.object.permission), {}, class: 'form-control share-permission' %>
+              <span class="help-block share-description"><%= StudyShare::PERMISSION_DESCRIPTION_MAP[share.object.permission] %></span>
             </div>
             <div class="col-sm-1">
               <%= share.label :delete, "&nbsp;".html_safe %><br />
@@ -159,5 +160,12 @@
             var updateForm = $('#update-study-settings-form');
             updateForm.submit();
         });
+    });
+
+    $("#update-study-settings-form").on('change', '.share-permission', function() {
+        var newPermission = $(this).val();
+        var permissionText = <%= raw StudyShare::PERMISSION_DESCRIPTION_MAP.to_json %>;
+        var descField = $(this).next('.share-description');
+        descField.html(permissionText[newPermission])
     });
 </script>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -116,4 +116,4 @@ User.create!(email:'testing.user.2@gmail.com', password:'someotherpassword',
 # Analysis Configuration seeds
 AnalysisConfiguration.create(namespace: 'single-cell-portal', name: 'split-cluster', snapshot: 1, user_id: user.id,
                              configuration_namespace: 'single-cell-portal', configuration_name: 'split-cluster',
-                             configuration_snapshot: 2, description: 'This is an test description.')
+                             configuration_snapshot: 2, description: 'This is a test description.')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -116,4 +116,4 @@ User.create!(email:'testing.user.2@gmail.com', password:'someotherpassword',
 # Analysis Configuration seeds
 AnalysisConfiguration.create(namespace: 'single-cell-portal', name: 'split-cluster', snapshot: 1, user_id: user.id,
                              configuration_namespace: 'single-cell-portal', configuration_name: 'split-cluster',
-                             configuration_snapshot: 2, description: '<p>This is an test description.</p>')
+                             configuration_snapshot: 2, description: 'This is an test description.')

--- a/test/api/site_controller_test.rb
+++ b/test/api/site_controller_test.rb
@@ -53,6 +53,8 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert json['name'] == @analysis_configuration.name,
            "Did not load correct analysis name, expected '#{@analysis_configuration.name}' but found '#{json['name']}'"
+    assert json['description'] == @analysis_configuration.description,
+           "Description did not match; expected '#{@analysis_configuration.description}' but found '#{json['description']}'"
     assert json['required_inputs'] == @analysis_configuration.required_inputs(true),
            "Required inputs do not match; expected '#{@analysis_configuration.required_inputs(true)}' but found #{json['required_inputs']}"
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"


### PR DESCRIPTION
All API responses for listing/configuring analyses now include the configuration 'description' to allow for API users to have the same contextual information as GUI users.