### PR TITLE
Enable deployment notification banner dismissal

### DIFF
--- a/app/views/layouts/_deployment_notification_banner.erb
+++ b/app/views/layouts/_deployment_notification_banner.erb
@@ -1,0 +1,21 @@
+<div class="notification-banner">
+  <button type="button" class="close" id='close-notification-banner' aria-label="Close" style="padding-right: 15px; color: #ffffff">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <div class="col-sm-3">
+    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+    <span>Service Alert: Starting on</span></br>
+    <span><%= @deployment_notification.deployment_time.strftime("%a %b %d, %Y %I:%M %p") %> ET</span>
+  </div>
+  <div >
+    <span class="align-middle"><%= @deployment_notification.message %></span>
+  </div>
+</div>
+<script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+
+    // listener to set the unique cookie for deleting banner as well as delete banner
+    $('#close-notification-banner').click(function() {
+        Cookies.set('hide_deployment_notification', '<%= @deployment_notification.id %>')
+        $(".notification-banner").remove();
+    });
+</script>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -64,35 +64,11 @@
 			<% end %>
 		</ul>
 	</div>
-  <% if @deployment_notification.present?%>
-    <% if Time.zone.now >= @deployment_notification.display_time%>
-    <div class="notification-banner">
-      <button type="button" class="close" id='close-notification-banner' aria-label="Close" style="padding-right: 10px;">
-        <span aria-hidden="true">&times;</span>
-      </button>
-      <div class="col-sm-3">
-        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-        <span>Service Alert: Starting on</span></br>
-        <span><%= @deployment_notification.deployment_time.strftime("%a %b %d, %Y %I:%M %p") %> ET</span>
-      </div>
-      <div >
-        <span class="align-middle"><%= @deployment_notification.message %></span>
-      </div>
-
-    </div>
-    <%end %>
-    <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-        $('#close-notification-banner').click(function() {
-            $(".notification-banner").hide();
-            if ( typeof Cookies.get('hide_deployment_notification') === 'undefined' ) {
-                Cookies.set('hide_deployment_notification', 'true')
-            }
-        });
-        $(document).ready(function() {
-            if ( typeof Cookies.get('hide_deployment_notification') !== 'undefined' ) {
-                $(".notification-banner").hide();
-            }
-        });
-    </script>
-  <%end %>
+  <% if @deployment_notification.present? %>
+    <% if Time.zone.now >= @deployment_notification.display_time %>
+      <% if cookies[:hide_deployment_notification].nil? || cookies[:hide_deployment_notification] !=  @deployment_notification.id.to_s  %>
+        <%= render partial: '/layouts/deployment_notification_banner', locals: {deployment_notification: @deployment_notification} %>
+      <% end %>
+    <% end %>
+  <% end %>
 </nav>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -65,16 +65,34 @@
 		</ul>
 	</div>
   <% if @deployment_notification.present?%>
-    <% if Time.zone.now >= @deployment_notification.display_time %>
+    <% if Time.zone.now >= @deployment_notification.display_time%>
     <div class="notification-banner">
-      <div class="col-sm-3"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+      <button type="button" class="close" id='close-notification-banner' aria-label="Close" style="padding-right: 10px;">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <div class="col-sm-3">
+        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
         <span>Service Alert: Starting on</span></br>
-        <span><%= @deployment_notification.deployment_time.strftime("%a %b %d, %Y %I:%M%p") %> ET</span>
+        <span><%= @deployment_notification.deployment_time.strftime("%a %b %d, %Y %I:%M %p") %> ET</span>
       </div>
-      <div>
-        <div class="align-middle"><%= @deployment_notification.message %></div>
+      <div >
+        <span class="align-middle"><%= @deployment_notification.message %></span>
       </div>
+
     </div>
     <%end %>
+    <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+        $('#close-notification-banner').click(function() {
+            $(".notification-banner").hide();
+            if ( typeof Cookies.get('hide_deployment_notification') === 'undefined' ) {
+                Cookies.set('hide_deployment_notification', 'true')
+            }
+        });
+        $(document).ready(function() {
+            if ( typeof Cookies.get('hide_deployment_notification') !== 'undefined' ) {
+                $(".notification-banner").hide();
+            }
+        });
+    </script>
   <%end %>
 </nav>


### PR DESCRIPTION
This PR deals with [SCP-1725](https://broadworkbench.atlassian.net/browse/SCP-1725). This will enable users to close banner deployment notifications. 

A close 'X' button was added to the deployment notification banner. When clicked, the banner is removed from the site for that user. This is done by setting a cookie when the banner is closed. 