### PR TITLE
adding csrf protection to omniauth/google_oauth2 sign in routes/links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ end
 
 gem 'devise'
 gem 'omniauth-google-oauth2'
+gem 'omniauth-rails_csrf_protection'
 gem 'googleauth'
 gem 'google-cloud-storage', require: 'google/cloud/storage'
 gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,6 +284,9 @@ GEM
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
     os (1.0.0)
     paperclip (6.0.0)
@@ -472,6 +475,7 @@ DEPENDENCIES
   nested_form!
   non-stupid-digest-assets
   omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   parallel
   rails (= 5.2.2.1)
   rails-jquery-autocomplete!

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -8,6 +8,6 @@
         </div>
       </div>
     </div>
-    <p class="text-center"><%= link_to "Sign in with <span class='fab fa-google'></span>".html_safe, user_google_oauth2_omniauth_authorize_path, class: 'btn btn-lg btn-danger', id: 'google-auth' %></p>
+    <p class="text-center"><%= link_to "Sign in with <span class='fab fa-google'></span>".html_safe, user_google_oauth2_omniauth_authorize_path, method: :post, class: 'btn btn-lg btn-danger', id: 'google-auth' %></p>
   </div>
 </div>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -60,7 +60,7 @@
 				</li>
 			<% else %>
 
-				<li><%= scp_link_to "<span class='fas fa-sign-in-alt fa-fw'></span> Sign In".html_safe, user_google_oauth2_omniauth_authorize_path, class: 'left-border-0-5', id: 'login-nav' %></li>
+				<li><%= scp_link_to "<span class='fas fa-sign-in-alt fa-fw'></span> Sign In".html_safe, user_google_oauth2_omniauth_authorize_path, method: :post, class: 'left-border-0-5', id: 'login-nav' %></li>
 			<% end %>
 		</ul>
 	</div>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -23,11 +23,12 @@ SecureHeaders::Configuration.default do |config|
       # directive values: these values will directly translate into source directives
       default_src: %w('self'),
       block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
-      frame_src: %w('self'), # if child-src isn't supported, the value for frame-src will be set.
+      frame_src: %w('self' https://us.input.tcell.insight.rapid7.com), # if child-src isn't supported, the value for frame-src will be set.
       font_src: %w('self' data:),
       form_action: %w('self' https://accounts.google.com),
       connect_src: %w('self' https://www.google-analytics.com https://unpkg.com https://www.googleapis.com https://s3.amazonaws.com
-                      https://portals.broadinstitute.org https://data.broadinstitute.org https://api.tcell.io https://input.tcell.io),
+                      https://portals.broadinstitute.org https://data.broadinstitute.org https://api.tcell.io https://input.tcell.io
+                      https://us.input.tcell.insight.rapid7.com/),
       img_src: %w('self' data: https://www.google-analytics.com https://online.swagger.io),
       manifest_src: %w('self'),
       object_src: %w('none'),

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -25,7 +25,7 @@ SecureHeaders::Configuration.default do |config|
       block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
       frame_src: %w('self'), # if child-src isn't supported, the value for frame-src will be set.
       font_src: %w('self' data:),
-      form_action: %w('self'),
+      form_action: %w('self' https://accounts.google.com),
       connect_src: %w('self' https://www.google-analytics.com https://unpkg.com https://www.googleapis.com https://s3.amazonaws.com
                       https://portals.broadinstitute.org https://data.broadinstitute.org https://api.tcell.io https://input.tcell.io),
       img_src: %w('self' data: https://www.google-analytics.com https://online.swagger.io),


### PR DESCRIPTION
As per CVE-2015-9284, Omniauth-generated sign in routes are subject to CSRF forgery and can allow secondary accounts to be linked to primary accounts without user interaction.  While the impact of this is very low for SCP (we only use Google OAuth2, and do not have other accounts), the fix removes the vulnerability altogether.  SCP will respond with 404 on GETs to the sign_in path, and 422 to any POSTs that do not have a valid CSRF token.