### PR TITLE
Checking firecloud registration before compute permissions/billing projects check

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -977,6 +977,6 @@ function preserveGeneSearch() {
 function reopenUiTab(navTarget) {
     var tab = window.location.hash;
     if (tab !== '') {
-        $(navTarget + ' a[href="#' + tab + '"]').tab('show');
+        $(navTarget + ' a[href="' + tab + '"]').tab('show');
     }
 }

--- a/app/controllers/billing_projects_controller.rb
+++ b/app/controllers/billing_projects_controller.rb
@@ -17,6 +17,7 @@ class BillingProjectsController < ApplicationController
 
   respond_to :html, :js, :json
   before_action :authenticate_user!
+  before_action :check_firecloud_registration
   before_action :check_firecloud_status
   before_action :create_firecloud_client
   before_action :check_project_permissions, except: [:index, :create]
@@ -216,6 +217,14 @@ class BillingProjectsController < ApplicationController
   # AUTH/PERMISSON CHECKS
   #
   ##
+
+  # make sure a user is registered for firecloud before showing billing information
+  def check_firecloud_registration
+    unless current_user.registered_for_firecloud
+      alert = 'You must complete your FireCloud registration before viewing your available billing projects.'
+      redirect_to view_profile_path(current_user.id) + '#profile-firecloud', alert: alert and return
+    end
+  end
 
   # check to make sure that the current user has access to the current project
   def check_project_permissions

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -644,7 +644,7 @@ class Study
 
   # check if a user can run workflows on the given study
   def can_compute?(user)
-    if user.nil?
+    if user.nil? || !user.registered_for_firecloud?
       false
     else
       begin

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -114,4 +114,8 @@
         $('#update-user-profile').submit();
     });
 
+    $(document).ready(function() {
+        reopenUiTab('#profile-tabs')
+    });
+
 </script>


### PR DESCRIPTION
Skipping checking compute permissions in workspaces for users who have not registered for FireCloud.  Also, redirect to FireCloud profile page when user tries to load billing projects if they haven't registered yet.  Both will throw unnecessary 401s that get reported to Sentry.