### PR TITLE
Handling for 'detached' studies

### DIFF
--- a/app/controllers/api/v1/api_base_controller.rb
+++ b/app/controllers/api/v1/api_base_controller.rb
@@ -13,6 +13,16 @@ module Api
       rescue_from NoMethodError, Faraday::ConnectionFailed do |exception|
         render json: {error: exception.message}, status: 500
       end
+
+      ##
+      # Generic message formatters to use in Swagger responses
+      # TODO: Extend to 401/403/404
+      ##
+
+      # handle a 410 response message (both in UI and API) - this only happens when a Study workspace has been deleted
+      def self.resource_gone
+        'Study workspace is not found, cannot complete action'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -970,7 +970,7 @@ module Api
       end
 
       def check_study_detached
-        if @study.detached
+        if @study.detached?
           head 410 and return
         end
       end

--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -7,6 +7,9 @@ module Api
       before_action :set_current_api_user!
       before_action :set_study, except: [:studies, :analyses, :get_analysis]
       before_action :set_analysis_configuration, only: [:get_analysis, :get_study_analysis_config]
+      before_action :check_study_detached, only: [:download_data, :stream_data, :get_study_analysis_config,
+                                                  :submit_study_analysis, :get_study_submissions,
+                                                  :get_study_submission, :sync_submission_outputs]
       before_action :check_study_view_permission, except: [:studies, :analyses, :get_analysis]
       before_action :check_study_compute_permission,
                     only: [:get_study_analysis_config, :submit_study_analysis, :get_study_submissions,
@@ -127,6 +130,9 @@ module Api
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
+          end
         end
       end
 
@@ -208,6 +214,9 @@ module Api
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
+          end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
           end
         end
       end
@@ -957,6 +966,12 @@ module Api
           head 401
         else
           head 403 unless @study.can_compute?(current_api_user)
+        end
+      end
+
+      def check_study_detached
+        if @study.detached
+          head 410 and return
         end
       end
 

--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -131,7 +131,7 @@ module Api
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
         end
       end
@@ -216,7 +216,7 @@ module Api
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
         end
       end

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -548,7 +548,7 @@ module Api
         @study = Study.find_by(id: params[:id])
         if @study.nil? || @study.queued_for_deletion?
           head 404 and return
-        elsif @study.detached
+        elsif @study.detached?
           head 410 and return
         end
       end

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -76,6 +76,9 @@ module Api
           response 404 do
             key :description, 'Study is not found'
           end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
+          end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
@@ -118,6 +121,9 @@ module Api
           end
           response 404 do
             key :description, 'Study is not found'
+          end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
@@ -178,6 +184,9 @@ module Api
           response 404 do
             key :description, 'Study is not found'
           end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
+          end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
@@ -234,6 +243,9 @@ module Api
           end
           response 404 do
             key :description, 'Study is not found'
+          end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
@@ -362,6 +374,9 @@ module Api
           end
           response 404 do
             key :description, 'Study is not found'
+          end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
@@ -533,6 +548,8 @@ module Api
         @study = Study.find_by(id: params[:id])
         if @study.nil? || @study.queued_for_deletion?
           head 404 and return
+        elsif @study.detached
+          head 410 and return
         end
       end
 

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -77,7 +77,7 @@ module Api
             key :description, 'Study is not found'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
@@ -123,7 +123,7 @@ module Api
             key :description, 'Study is not found'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
@@ -185,7 +185,7 @@ module Api
             key :description, 'Study is not found'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
@@ -245,7 +245,7 @@ module Api
             key :description, 'Study is not found'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
@@ -376,7 +376,7 @@ module Api
             key :description, 'Study is not found'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'

--- a/app/controllers/api/v1/study_file_bundles_controller.rb
+++ b/app/controllers/api/v1/study_file_bundles_controller.rb
@@ -46,6 +46,9 @@ module Api
           response 404 do
             key :description, 'Study is not found'
           end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
+          end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
@@ -94,6 +97,9 @@ module Api
           end
           response 404 do
             key :description, 'Study or StudyFileBundle is not found'
+          end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
@@ -145,6 +151,9 @@ module Api
           end
           response 404 do
             key :description, 'Study is not found'
+          end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
@@ -201,6 +210,9 @@ module Api
           response 404 do
             key :description, 'Study or StudyFileBundle is not found'
           end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
+          end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
@@ -225,6 +237,8 @@ module Api
         @study = Study.find_by(id: params[:study_id])
         if @study.nil? || @study.queued_for_deletion?
           head 404 and return
+        elsif @study.detached
+          head 410 and return
         end
       end
 

--- a/app/controllers/api/v1/study_file_bundles_controller.rb
+++ b/app/controllers/api/v1/study_file_bundles_controller.rb
@@ -237,7 +237,7 @@ module Api
         @study = Study.find_by(id: params[:study_id])
         if @study.nil? || @study.queued_for_deletion?
           head 404 and return
-        elsif @study.detached
+        elsif @study.detached?
           head 410 and return
         end
       end

--- a/app/controllers/api/v1/study_file_bundles_controller.rb
+++ b/app/controllers/api/v1/study_file_bundles_controller.rb
@@ -47,7 +47,7 @@ module Api
             key :description, 'Study is not found'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
@@ -99,7 +99,7 @@ module Api
             key :description, 'Study or StudyFileBundle is not found'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
@@ -153,7 +153,7 @@ module Api
             key :description, 'Study is not found'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
@@ -211,7 +211,7 @@ module Api
             key :description, 'Study or StudyFileBundle is not found'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -51,6 +51,9 @@ module Api
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
+          end
         end
       end
 
@@ -99,6 +102,9 @@ module Api
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
+          end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
           end
         end
       end
@@ -175,6 +181,9 @@ module Api
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
+          end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
           end
           response 422 do
             key :description, 'StudyFile validation failed'
@@ -254,6 +263,9 @@ module Api
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
+          end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
           end
           response 422 do
             key :description, 'StudyFile validation failed'
@@ -352,6 +364,9 @@ module Api
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
+          end
         end
       end
 
@@ -419,6 +434,9 @@ module Api
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
+          end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
           end
           response 412 do
             key :description, 'StudyFile can only be parsed when bundled in a StudyFileBundle along with other required files, such as MM Coordinate Matrices and 10X Genes/Barcodes files'
@@ -534,6 +552,9 @@ module Api
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
+          end
           response 412 do
             key :description, 'StudyFile can only be parsed when bundled in a StudyFileBundle along with other required files, such as MM Coordinate Matrices and 10X Genes/Barcodes files'
           end
@@ -582,6 +603,8 @@ module Api
         @study = Study.find_by(id: params[:study_id])
         if @study.nil? || @study.queued_for_deletion?
           head 404 and return
+        elsif @study.detached
+          head 410 and return
         end
       end
 

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -603,7 +603,7 @@ module Api
         @study = Study.find_by(id: params[:study_id])
         if @study.nil? || @study.queued_for_deletion?
           head 404 and return
-        elsif @study.detached
+        elsif @study.detached?
           head 410 and return
         end
       end

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -52,7 +52,7 @@ module Api
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
         end
       end
@@ -104,7 +104,7 @@ module Api
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
         end
       end
@@ -183,7 +183,7 @@ module Api
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 422 do
             key :description, 'StudyFile validation failed'
@@ -265,7 +265,7 @@ module Api
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 422 do
             key :description, 'StudyFile validation failed'
@@ -365,7 +365,7 @@ module Api
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
         end
       end
@@ -436,7 +436,7 @@ module Api
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 412 do
             key :description, 'StudyFile can only be parsed when bundled in a StudyFileBundle along with other required files, such as MM Coordinate Matrices and 10X Genes/Barcodes files'
@@ -553,7 +553,7 @@ module Api
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 412 do
             key :description, 'StudyFile can only be parsed when bundled in a StudyFileBundle along with other required files, such as MM Coordinate Matrices and 10X Genes/Barcodes files'

--- a/app/controllers/api/v1/study_shares_controller.rb
+++ b/app/controllers/api/v1/study_shares_controller.rb
@@ -51,6 +51,9 @@ module Api
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
+          end
         end
       end
 
@@ -99,6 +102,9 @@ module Api
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
+          end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
           end
         end
       end
@@ -150,6 +156,9 @@ module Api
           end
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
+          end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
           end
           response 422 do
             key :description, 'StudyShare validation failed'
@@ -218,6 +227,9 @@ module Api
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
+          end
           response 422 do
             key :description, 'StudyShare validation failed'
           end
@@ -270,6 +282,9 @@ module Api
           response 406 do
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
+          response 410 do
+            key :description, 'Study workspace is not found, cannot complete action'
+          end
         end
       end
 
@@ -291,6 +306,8 @@ module Api
         @study = Study.find_by(id: params[:study_id])
         if @study.nil? || @study.queued_for_deletion?
           head 404 and return
+        elsif @study.detached
+          head 410 and return
         end
       end
 

--- a/app/controllers/api/v1/study_shares_controller.rb
+++ b/app/controllers/api/v1/study_shares_controller.rb
@@ -306,7 +306,7 @@ module Api
         @study = Study.find_by(id: params[:study_id])
         if @study.nil? || @study.queued_for_deletion?
           head 404 and return
-        elsif @study.detached
+        elsif @study.detached?
           head 410 and return
         end
       end

--- a/app/controllers/api/v1/study_shares_controller.rb
+++ b/app/controllers/api/v1/study_shares_controller.rb
@@ -52,7 +52,7 @@ module Api
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
         end
       end
@@ -104,7 +104,7 @@ module Api
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
         end
       end
@@ -158,7 +158,7 @@ module Api
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 422 do
             key :description, 'StudyShare validation failed'
@@ -228,7 +228,7 @@ module Api
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
           response 422 do
             key :description, 'StudyShare validation failed'
@@ -283,7 +283,7 @@ module Api
             key :description, 'Accept or Content-Type headers missing or misconfigured'
           end
           response 410 do
-            key :description, 'Study workspace is not found, cannot complete action'
+            key :description, ApiBaseController.resource_gone
           end
         end
       end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -35,7 +35,7 @@ class SiteController < ApplicationController
                                                    :delete_workspace_samples, :get_workspace_submissions, :create_workspace_submission,
                                                    :get_submission_workflow, :abort_submission_workflow, :get_submission_errors,
                                                    :get_submission_outputs, :delete_submission_files, :get_submission_metadata]
-  before_action :check_study_detached, only: [:download_file, :update_study_settings, :create_totat, :download_bulk_files,
+  before_action :check_study_detached, only: [:download_file, :update_study_settings, :download_bulk_files,
                                               :get_fastq_files, :get_workspace_samples, :update_workspace_samples,
                                               :delete_workspace_samples, :get_workspace_submissions, :create_workspace_submission,
                                               :get_submission_workflow, :abort_submission_workflow, :get_submission_errors,

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -311,7 +311,7 @@ class SiteController < ApplicationController
     # double check on download availability: first, check if administrator has disabled downloads
     # then check individual statuses to see what to enable/disable
     # if the study is 'detached', then everything is set to false by default
-    set_firecloud_permissions(@study.detached)
+    set_firecloud_permissions(@study.detached?)
     set_study_default_options
     # load options and annotations
     if @study.can_visualize_clusters?
@@ -322,7 +322,7 @@ class SiteController < ApplicationController
     end
 
     # only populate if study has ideogram results & is not 'detached'
-    if @study.has_analysis_outputs?('infercnv', 'ideogram.js') && !@study.detached
+    if @study.has_analysis_outputs?('infercnv', 'ideogram.js') && !@study.detached?
       @ideogram_files = {}
       @study.get_analysis_outputs('infercnv', 'ideogram.js').each do |file|
         opts = file.options.with_indifferent_access # allow lookup by string or symbol
@@ -411,7 +411,7 @@ class SiteController < ApplicationController
     @y_axis_title = load_expression_axis_title
     if request.format == 'text/html'
       # only set this check on full page loads (happens if user was not signed in but then clicked the 'genome' tab)
-      set_firecloud_permissions(@study.detached)
+      set_firecloud_permissions(@study.detached?)
       @user_can_edit = @study.can_edit?(current_user)
       @user_can_compute = @study.can_compute?(current_user)
       @user_can_download = @study.can_download?(current_user)
@@ -1501,7 +1501,7 @@ class SiteController < ApplicationController
 
   # check if a study is 'detached' from a workspace
   def check_study_detached
-    if @study.detached
+    if @study.detached?
       @alert = 'We were unable to complete your request as the study is question is detached from the workspace (maybe the workspace was deleted?)'
       respond_to do |format|
         format.js {render js: "alert('#{@alert}');"}

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -15,14 +15,18 @@ class StudiesController < ApplicationController
   respond_to :html, :js, :json
 
   before_action :set_study, except: [:index, :new, :create, :download_private_file]
-  before_action :set_file_types, only: [:sync_study, :sync_submission_outputs, :sync_study_file, :sync_orphaned_study_file, :update_study_file_from_sync]
+  before_action :set_file_types, only: [:sync_study, :sync_submission_outputs, :sync_study_file, :sync_orphaned_study_file,
+                                        :update_study_file_from_sync]
   before_action :check_edit_permissions, except: [:index, :new, :create, :download_private_file]
   before_action do
     authenticate_user!
     check_access_settings
   end
   # special before_action to make sure FireCloud is available and pre-empt any calls when down
-  before_action :check_firecloud_status, except: [:index, :do_upload, :resume_upload, :update_status, :retrieve_wizard_upload, :parse ]
+  before_action :check_firecloud_status, except: [:index, :do_upload, :resume_upload, :update_status,
+                                                  :retrieve_wizard_upload, :parse]
+  before_action :check_study_detached, only: [:edit, :update, :initialize_study, :sync_study, :sync_submission_outputs,
+                                              :download_private_file]
 
   ###
   #
@@ -43,7 +47,7 @@ class StudiesController < ApplicationController
     @directories = @study.directory_listings.are_synced
     @primary_data = @study.directory_listings.primary_data
     @other_data = @study.directory_listings.non_primary_data
-    @allow_downloads = Study.firecloud_client.services_available?('GoogleBuckets')
+    @allow_downloads = Study.firecloud_client.services_available?('GoogleBuckets') && !@study.detached
     @analysis_metadata = @study.analysis_metadata.to_a
     # load study default options
     set_study_default_options
@@ -393,7 +397,8 @@ class StudiesController < ApplicationController
 
       # delete firecloud workspace so it can be reused (unless specified by user), and raise error if unsuccessful
       # if successful, we're clear to queue the study for deletion
-      if params[:workspace] == 'persist'
+      # if a study is detached, then force the 'persist' option as it will fail otherwise
+      if params[:workspace] == 'persist' || @study.detached
         @study.update(firecloud_workspace: SecureRandom.uuid)
       else
         begin
@@ -1403,6 +1408,15 @@ class StudiesController < ApplicationController
                                  alert: alert and return}
         format.json {head 503}
       end
+    end
+  end
+
+  # check if a study is 'detached' and handle accordingly
+  def check_study_detached
+    if @study.detached
+      redirect_to merge_default_redirect_params(request.referrer, scpbr: params[:scpbr]),
+                  alert: "We were unable to complete your request as the study is question is detached from the workspace (maybe the workspace was deleted?)" and return
+
     end
   end
 

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -25,8 +25,7 @@ class StudiesController < ApplicationController
   # special before_action to make sure FireCloud is available and pre-empt any calls when down
   before_action :check_firecloud_status, except: [:index, :do_upload, :resume_upload, :update_status,
                                                   :retrieve_wizard_upload, :parse]
-  before_action :check_study_detached, only: [:edit, :update, :initialize_study, :sync_study, :sync_submission_outputs,
-                                              :download_private_file]
+  before_action :check_study_detached, only: [:edit, :update, :initialize_study, :sync_study, :sync_submission_outputs]
 
   ###
   #
@@ -648,6 +647,9 @@ class StudiesController < ApplicationController
     if !user_signed_in? || !@study.can_view?(current_user)
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
                   alert: 'You do not have permission to perform that action.' and return
+    elsif @study.detached?
+      redirect_to merge_default_redirect_params(request.referrer, scpbr: params[:scpbr]),
+                  alert: "We were unable to complete your request as the study is question is detached from the workspace (maybe the workspace was deleted?)" and return
     elsif @study.embargoed?(current_user)
       redirect_to merge_default_redirect_params(view_study_path(accession: @study.accession, study_name: @study.url_safe_name), scpbr: params[:scpbr]),
                   alert: "You may not download any data from this study until #{@study.embargo.to_s(:long)}." and return

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -308,6 +308,11 @@ class Study
       key :default, false
       key :description, 'Boolean indication of whether Study has at least one of all required StudyFile types parsed to enable visualizations (Expression Matrix, Metadata, Cluster)'
     end
+    property :detached do
+      key :type, :boolean
+      key :default, false
+      key :description, 'Boolean indication of whether Study has been \'detached\' from its FireCloud workspace, usually when the workspace is deleted directly in FireCloud'
+    end
     property :view_count do
       key :type, :number
       key :format, :integer
@@ -454,6 +459,11 @@ class Study
       key :default, true
       key :description, 'Boolean indication of whether Study is publicly readable'
     end
+    property :detached do
+      key :type, :boolean
+      key :default, false
+      key :description, 'Boolean indication of whether Study has been \'detached\' from its FireCloud workspace, usually when the workspace is deleted directly in FireCloud'
+    end
     property :cell_count do
       key :type, :number
       key :format, :integer
@@ -485,6 +495,11 @@ class Study
       key :type, :boolean
       key :default, true
       key :description, 'Boolean indication of whether Study is publicly readable'
+    end
+    property :detached do
+      key :type, :boolean
+      key :default, false
+      key :description, 'Boolean indication of whether Study has been \'detached\' from its FireCloud workspace, usually when the workspace is deleted directly in FireCloud'
     end
     property :cell_count do
       key :type, :number

--- a/app/views/api/v1/site/_study.json.jbuilder
+++ b/app/views/api/v1/site/_study.json.jbuilder
@@ -2,6 +2,11 @@ json.set! :accession, study.accession
 json.set! :name, study.name
 json.set! :description, study.description
 json.set! :public, study.public
+json.set! :detached, study.detached
 json.set! :cell_count, study.cell_count
 json.set! :gene_count, study.gene_count
-json.study_files study.study_files, partial: 'api/v1/site/study_file', as: :study_file, locals: {study: study}
+if study.detached
+  json.set! :study_files, 'Unavailable (cannot load study workspace or bucket)'
+else
+  json.study_files study.study_files, partial: 'api/v1/site/study_file', as: :study_file, locals: {study: study}
+end

--- a/app/views/api/v1/site/_study_in_list.json.jbuilder
+++ b/app/views/api/v1/site/_study_in_list.json.jbuilder
@@ -2,5 +2,6 @@ json.set! :accession, study.accession
 json.set! :name, study.name
 json.set! :description, study.description
 json.set! :public, study.public
+json.set! :detached, study.detached
 json.set! :cell_count, study.cell_count
 json.set! :gene_count, study.gene_count

--- a/app/views/site/_study_tabs_nav.html.erb
+++ b/app/views/site/_study_tabs_nav.html.erb
@@ -1,0 +1,34 @@
+<ul class="nav nav-tabs" role="tablist" id="study-tabs">
+  <li role="presentation" class="study-nav active" id="study-summary-nav"><a href="#study-summary" data-toggle="tab">Summary <i class="far fa-fw fa-file-alt"></i></a></li>
+  <% if @study.can_visualize? %>
+    <li role="presentation" class="study-nav" id="study-visualize-nav"><a href="#study-visualize" data-toggle="tab">Explore <i class="fas fa-fw fa-eye"></i></a></li>
+  <% else %>
+    <li role="presentation" class="study-nav disabled" id="study-visualize-nav"><a href="#study-visualize" data-toggle="tooltip" title="This study has no data to view">Explore <i class="fas fa-fw fa-eye"></i></a></li>
+  <% end %>
+  <% if @study.detached %>
+    <li role="presentation" class="study-nav disabled" id="study-download-nav"><a href="#study-download" data-toggle="tooltip" title="Downloads are disabled for this study - cannot load workspace">Download <i class="fas fa-fw fa-download"></i></a></li>
+    <% if @user_can_edit %>
+     <li role="presentation" class="study-nav disabled" id="study-settings-nav"><a href="#study-settings" data-toggle="tooltip" title="Edits are been disabled for this study - cannot load workspace">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
+    <% end %>
+  <% else %>
+    <% if @user_can_download %>
+      <li role="presentation" class="study-nav" id="study-download-nav"><a href="#study-download" data-toggle="tab">Download <i class="fas fa-fw fa-download"></i></a></li>
+    <% else %>
+      <li role="presentation" class="study-nav disabled" id="study-download-nav"><a href="#study-download" data-toggle="tooltip" title="Please sign in to download data">Download <i class="fas fa-fw fa-download"></i></a></li>
+    <% end %>
+    <% if @allow_firecloud_access && @user_can_compute %>
+      <% if @allow_computes %>
+        <li role="presentation" class="study-nav" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tab">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
+      <% else %>
+        <li role="presentation" class="study-nav disabled" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tooltip" title="Study workspaces are currently unavailable - please try again later.">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
+      <% end %>
+    <% end %>
+    <% if @allow_firecloud_access && @user_can_edit %>
+      <% if @allow_edits %>
+        <li role="presentation" class="study-nav" id="study-settings-nav"><a href="#study-settings" data-toggle="tab">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
+      <% else %>
+        <li role="presentation" class="study-nav disabled" id="study-settings-nav"><a href="#study-settings" data-toggle="tooltip" title="Study workspaces are currently unavailable - please try again later.">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
+      <% end %>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/site/study.html.erb
+++ b/app/views/site/study.html.erb
@@ -2,37 +2,7 @@
   <%= render partial: 'study_title_bar' %>
 </div>
 <div id="tab-root">
-  <ul class="nav nav-tabs" role="tablist" id="study-tabs">
-    <li role="presentation" class="study-nav active" id="study-summary-nav"><a href="#study-summary" data-toggle="tab">Summary <i class="far fa-fw fa-file-alt"></i></a></li>
-    <% if @study.can_visualize? %>
-      <li role="presentation" class="study-nav" id="study-visualize-nav"><a href="#study-visualize" data-toggle="tab">Explore <i class="fas fa-fw fa-eye"></i></a></li>
-    <% else %>
-      <li role="presentation" class="study-nav disabled" id="study-visualize-nav"><a href="#study-visualize" data-toggle="tooltip" title="This study has no data to view">Explore <i class="fas fa-fw fa-eye"></i></a></li>
-    <% end %>
-    <% if @user_can_download %>
-      <% if !@study.detached %>
-        <li role="presentation" class="study-nav" id="study-download-nav"><a href="#study-download" data-toggle="tab">Download <i class="fas fa-fw fa-download"></i></a></li>
-      <% else %>
-        <li role="presentation" class="study-nav disabled" id="study-download-nav"><a href="#study-download" data-toggle="tooltip" title="Downloads have been disabled for this study">Download <i class="fas fa-fw fa-download"></i></a></li>
-      <% end %>
-    <% else %>
-      <li role="presentation" class="study-nav disabled" id="study-download-nav"><a href="#study-download" data-toggle="tooltip" title="Please sign in to download data">Download <i class="fas fa-fw fa-download"></i></a></li>
-    <% end %>
-    <% if @allow_firecloud_access && @user_can_compute %>
-      <% if @allow_computes %>
-        <li role="presentation" class="study-nav" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tab">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
-      <% else %>
-        <li role="presentation" class="study-nav disabled" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tooltip" title="Study workspaces are currently unavailable - please try again later.">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
-      <% end %>
-    <% end %>
-    <% if @allow_firecloud_access && @user_can_edit %>
-      <% if @allow_edits %>
-        <li role="presentation" class="study-nav" id="study-settings-nav"><a href="#study-settings" data-toggle="tab">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
-      <% else %>
-        <li role="presentation" class="study-nav disabled" id="study-settings-nav"><a href="#study-settings" data-toggle="tooltip" title="Study workspaces are currently unavailable - please try again later.">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
-      <% end %>
-    <% end %>
-  </ul>
+  <%= render :partial => 'study_tabs_nav' %>
   <div class="tab-content top-pad">
     <div class="tab-pane active in" id="study-summary" role="tabpanel">
       <%= render partial: 'study_description_view' %>

--- a/app/views/site/study.html.erb
+++ b/app/views/site/study.html.erb
@@ -10,7 +10,11 @@
       <li role="presentation" class="study-nav disabled" id="study-visualize-nav"><a href="#study-visualize" data-toggle="tooltip" title="This study has no data to view">Explore <i class="fas fa-fw fa-eye"></i></a></li>
     <% end %>
     <% if @user_can_download %>
-      <li role="presentation" class="study-nav" id="study-download-nav"><a href="#study-download" data-toggle="tab">Download <i class="fas fa-fw fa-download"></i></a></li>
+      <% if !@study.detached %>
+        <li role="presentation" class="study-nav" id="study-download-nav"><a href="#study-download" data-toggle="tab">Download <i class="fas fa-fw fa-download"></i></a></li>
+      <% else %>
+        <li role="presentation" class="study-nav disabled" id="study-download-nav"><a href="#study-download" data-toggle="tooltip" title="Downloads have been disabled for this study">Download <i class="fas fa-fw fa-download"></i></a></li>
+      <% end %>
     <% else %>
       <li role="presentation" class="study-nav disabled" id="study-download-nav"><a href="#study-download" data-toggle="tooltip" title="Please sign in to download data">Download <i class="fas fa-fw fa-download"></i></a></li>
     <% end %>
@@ -38,7 +42,7 @@
         <%= render partial: 'study_visualize' %>
       <% end %>
     </div>
-    <% if @user_can_download %>
+    <% if @user_can_download && !@study.detached %>
       <div class="tab-pane" id="study-download" role="tabpanel">
         <%= render partial: 'study_download_data' %>
       </div>

--- a/test/api/site_controller_test.rb
+++ b/test/api/site_controller_test.rb
@@ -59,4 +59,21 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
            "Required inputs do not match; expected '#{@analysis_configuration.required_inputs(true)}' but found #{json['required_inputs']}"
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
+
+  test 'should respond 410 on detached study' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # manually set detached to validate 410 status
+    @study = Study.find_by(name: 'API Test Study')
+    @study.update(detached: true)
+    file = @study.study_files.first
+
+    execute_http_request(:get, api_v1_site_study_download_data_path(accession: @study.accession, filename: file.upload_file_name))
+    assert_response 410,
+                    "Did not provide correct response code when downloading file from detached study, expected 401 but found #{response.code}"
+
+    # reset status so downstream tests don't break
+    @study.update(detached: false)
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
 end

--- a/test/integration/study_validation_test.rb
+++ b/test/integration/study_validation_test.rb
@@ -306,5 +306,21 @@ class StudyAdminTest < ActionDispatch::IntegrationTest
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
+
+  test 'should redirect for detached studies' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+    @study = Study.find_by(name: 'Testing Study')
+    # manually set 'detached' to true to validate file download requests fail
+    @study.update(detached: true)
+
+    # try to download a file
+    file = @study.study_files.first
+    get download_file_path(accession: @study.accession, study_name: @study.url_safe_name, filename: file.upload_file_name)
+    assert_response 302, "Did not attempt to redirect on a download from a detached study, expected 302 but found #{response.code}"
+
+    # reset 'detached' so downstream tests don't fail
+    @study.update(detached: false)
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
 end
 

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -585,7 +585,7 @@ class UiTestSuite < Test::Unit::TestCase
 
   # text gzip parsing of expression matrices
   test 'admin: create-study: gzip expression matrix' do
-    puts "Test method: #{self.method_name}"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     # log in first
     @driver.get @base_url
@@ -622,13 +622,13 @@ class UiTestSuite < Test::Unit::TestCase
     wait_until_page_loads(studies_path)
     study_file_count = @driver.find_element(:id, "gzip-parse-#{$random_seed}-study-file-count")
     assert study_file_count.text == '1', "found incorrect number of study files; expected 1 and found #{study_file_count.text}"
-    puts "Test method: #{self.method_name} successful!"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful"
   end
 
   # test bundling process for file uploads
   # also tests ParseUtils.cell_ranger_expression_parse on small 100x25 gene-barcode matrix
   test 'admin: create-study: file bundles' do
-    puts "Test method: #{self.method_name}"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     # log in first
     @driver.get @base_url
@@ -703,7 +703,7 @@ class UiTestSuite < Test::Unit::TestCase
     delete.click
     accept_alert
     close_modal('message_modal')
-    puts "Test method: #{self.method_name} successful!"
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful"
   end
 
   # test embargo functionality
@@ -1226,7 +1226,7 @@ class UiTestSuite < Test::Unit::TestCase
     study_form = @driver.find_element(:id, 'new_study')
     study_form.find_element(:id, 'study_name').send_keys(random_name)
     study_form.find_element(:id, 'study_use_existing_workspace').send_keys('Yes')
-    study_form.find_element(:id, 'study_firecloud_workspace').send_keys("development-sync-test-study")
+    study_form.find_element(:id, 'study_firecloud_workspace').send_keys("sync-test-study")
     share = @driver.find_element(:id, 'add-study-share')
     @wait.until {share.displayed?}
     share.click
@@ -1376,7 +1376,7 @@ class UiTestSuite < Test::Unit::TestCase
     share_row = @driver.find_element(:id, share_email_id)
     shared_email = share_row.find_element(:class, 'share-email').text
     assert shared_email == $share_email, "did not find correct email for share, expected #{$share_email} but found #{shared_email}"
-    shared_permission = share_row.find_element(:class, 'share-permission').text
+    shared_permission = share_row.find_element(:class, 'share-permission').text.split.first
     assert shared_permission == 'View', "did not find correct share permissions, expected View but found #{shared_permission}"
 
     # make sure parsing succeeded
@@ -1442,7 +1442,7 @@ class UiTestSuite < Test::Unit::TestCase
     @driver.get studies_path
     wait_until_page_loads(studies_path)
     study_file_count = @driver.find_element(:id, "sync-test-#{$random_seed}-study-file-count").text.to_i
-    assert study_file_count == 4, "did not remove files, expected 4 but found #{study_file_count}"
+    assert study_file_count == 2, "did not remove files, expected 2 but found #{study_file_count}"
 
     # remove share and resync
     edit_button = @driver.find_element(:class, "sync-test-#{$random_seed}-edit")
@@ -1469,7 +1469,7 @@ class UiTestSuite < Test::Unit::TestCase
 
     # now login as share user and check workspace
     login_as_other($share_email, $share_email_password)
-    firecloud_workspace = "https://portal.firecloud.org/#workspaces/single-cell-portal/sync-test-#{$random_seed}"
+    firecloud_workspace = "https://portal.firecloud.org/#workspaces/single-cell-portal-development/sync-test-#{$random_seed}"
     @driver.get firecloud_workspace
     accept_firecloud_tos
     assert !element_present?(:class, 'fa-check-circle'), 'did not revoke access - study workspace still loads'
@@ -1493,7 +1493,7 @@ class UiTestSuite < Test::Unit::TestCase
     study_form = @driver.find_element(:id, 'new_study')
     study_form.find_element(:id, 'study_name').send_keys(random_name)
     study_form.find_element(:id, 'study_use_existing_workspace').send_keys('Yes')
-    study_form.find_element(:id, 'study_firecloud_workspace').send_keys("development-authorization-domain-test-study")
+    study_form.find_element(:id, 'study_firecloud_workspace').send_keys("authorization-domain-test-study")
 
     save_study = @driver.find_element(:id, 'save-study')
     save_study.click


### PR DESCRIPTION
Adding 'detached' attribute for studies (indicates the underlying workspace/bucket has been deleted)
* Will disable all edits/downloads but allow visualization to continue
* Cannot be set directly, only gets set as part of the Study.storage_sanity_check cron
* Updates to portal & API controllers to support this 