### PR TITLE
updating tcell version, removing duplicate script calls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,7 +395,7 @@ GEM
     swagger_ui_engine (1.1.2)
       rails (>= 4.2)
       sass-rails
-    tcell_agent (1.1.4)
+    tcell_agent (1.1.9)
       ffi (>= 1.3.0)
       json (>= 1.8)
     terrapin (0.6.0)
@@ -501,7 +501,7 @@ DEPENDENCIES
   will_paginate_mongoid
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.5.5p157
 
 BUNDLED WITH
    1.17.3

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,9 +27,6 @@
     <script src="https://us.jsagent.tcell.insight.rapid7.com/tcellagent.min.js" nonce="<%= content_security_policy_script_nonce %>"
             tcellappid="<%= ENV['TCELL_AGENT_APP_ID'] %>" tcellapikey="<%= ENV['TCELL_AGENT_API_KEY'] %>"
             tcellbaseurl="https://us.agent.tcell.insight.rapid7.com/api/v1"></script>
-
-    <script src="https://jsagent.tcell.io/tcellagent.min.js" nonce="<%= content_security_policy_script_nonce %>"
-            tcellappid="<%= ENV['TCELL_AGENT_APP_ID'] %>" tcellapikey="<%= ENV['TCELL_AGENT_API_KEY'] %>"></script>
   <% end %>
 
   <% if @selected_branding_group.present? %>


### PR DESCRIPTION
Updating to the latest version of TCell (1.1.9) to address CPU spikes under heavy load.