### PR TITLE
defaulting parameters to not render if optional

### DIFF
--- a/app/models/analysis_parameter.rb
+++ b/app/models/analysis_parameter.rb
@@ -21,8 +21,8 @@ class AnalysisParameter
   field :associated_model_display_method, type: String # model instance method that should be called to set DISPLAY value by (for dropdowns)
   field :association_filter_attribute, type: String # attribute to filter instances of :associated_model by (e.g. file_type)
   field :association_filter_value, type: String # attribute value to use in above filter (e.g. Expresion Matrix)
-  field :output_file_type, type: String
-  field :visible, type: Boolean, default: true # whether or not to render parameter input in submission form
+  field :output_file_type, type: String # StudyFile#file_type of output files
+  field :visible, type: Boolean, default: proc { optional == true ? false : true} # default to true if input is required
   field :apply_to_all, type: Boolean, default: false # whether or not to apply :associated_model_method to all instances (if an array type input)
   field :is_reference_bundle, type: Boolean, default: false # whether or not this input is for a reference genome
 

--- a/app/models/analysis_parameter.rb
+++ b/app/models/analysis_parameter.rb
@@ -22,7 +22,7 @@ class AnalysisParameter
   field :association_filter_attribute, type: String # attribute to filter instances of :associated_model by (e.g. file_type)
   field :association_filter_value, type: String # attribute value to use in above filter (e.g. Expresion Matrix)
   field :output_file_type, type: String # StudyFile#file_type of output files
-  field :visible, type: Boolean, default: proc { optional == true ? false : true} # default to true if input is required
+  field :visible, type: Boolean, default: proc { !optional } # default to true if input is required
   field :apply_to_all, type: Boolean, default: false # whether or not to apply :associated_model_method to all instances (if an array type input)
   field :is_reference_bundle, type: Boolean, default: false # whether or not this input is for a reference genome
 


### PR DESCRIPTION
All optional analysis input parameters (as defined by the configuration) will default to not rendering in the UI unless changed by an administrator.  Required inputs still default to visible = true.