### PR TITLE
reindex at startup always to avoid errors when adding new indices

### DIFF
--- a/rails_startup.bash
+++ b/rails_startup.bash
@@ -66,16 +66,18 @@ echo "*** ADDING CRONTAB TO CHECK DELAYED_JOB ***"
 echo "*/15 * * * * . /home/app/.cron_env ; /home/app/webapp/bin/job_monitor.rb -e=$PASSENGER_APP_ENV >> /home/app/webapp/log/cron_out.log 2>&1" | crontab -u app -
 echo "*** COMPLETED ***"
 
+echo "*** REINDEXING DATABASE ***"
+sudo -E -u app -H bin/bundle exec rake RAILS_ENV=$PASSENGER_APP_ENV db:mongoid:create_indexes
+echo "*** COMPLETED ***"
+
 echo "*** ADDING CRONTAB TO REINDEX DATABASE ***"
 (crontab -u app -l ; echo "@daily . /home/app/.cron_env ; cd /home/app/webapp/; bin/bundle exec rake RAILS_ENV=$PASSENGER_APP_ENV db:mongoid:create_indexes >> /home/app/webapp/log/cron_out.log 2>&1") | crontab -u app -
 echo "*** COMPLETED ***"
-
 
 if [[ $PASSENGER_APP_ENV = "development" ]]
 then
   echo "*** DELETING QUEUED STUDIES & FILES ***"
   # run cleanups at boot, don't run crons to reduce memory usage
-  sudo -E -u app -H bin/bundle exec rake RAILS_ENV=$PASSENGER_APP_ENV db:mongoid:create_indexes
 	sudo -E -u app -H bin/rails runner -e $PASSENGER_APP_ENV "StudyFile.delay.delete_queued_files"
 	sudo -E -u app -H bin/rails runner -e $PASSENGER_APP_ENV "UserAnnotation.delay.delete_queued_annotations"
 	sudo -E -u app -H bin/rails runner -e $PASSENGER_APP_ENV "Study.delay.delete_queued_studies"


### PR DESCRIPTION
This avoids potential errors on deployments to staging/production when changes have been made to any of the MongoDB indices.