### PR TITLE
Fix bug in public genome visualizations by removing sign-in requirement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -492,6 +492,7 @@ DEPENDENCIES
   spring
   swagger-blocks
   swagger_ui_engine
+  tcell_agent
   test-unit
   travis
   truncate_html

--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -132,7 +132,7 @@ function initializeIgv() {
   var igvContainer, igvOptions, tracks, genome, genesTrack, bamTracks,
     genesTrackName, genes, locus;
 
-  // Bail if already displayed or not signed in
+  // Bail if already displayed
   if (igvIsDisplayed()) return;
 
   delete igv.browser;

--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -43,19 +43,6 @@ $(document).on('click', '#genome-tab-nav', function (e) {
   var currentScroll = $(window).scrollTop();
   window.location.hash = '#genome-tab';
   window.scrollTo(0, currentScroll);
-
-
-// Go to Google sign-in page, redirect to this view after authenticating.
-  if (accessToken === null) {
-      // preserve all current search form values, but only if gene(s) are present
-      var geneSearch = $('#search_genes').val();
-      if (typeof geneSearch !== 'undefined' && geneSearch !== '') {
-          preserveGeneSearch();
-      }
-      ga('send', 'event', 'genome', 'sign_in_start');
-      localStorage.setItem('signed-in-via-genome-tab', true);
-      window.location = '/single_cell/users/auth/google_oauth2';
-  }
 });
 
 $(document).on('click', '#plots-tab-nav', function (e) {
@@ -146,7 +133,7 @@ function initializeIgv() {
     genesTrackName, genes, locus;
 
   // Bail if already displayed or not signed in
-  if (igvIsDisplayed() || accessToken === null) return;
+  if (igvIsDisplayed()) return;
 
   delete igv.browser;
 
@@ -187,25 +174,8 @@ $(document).ready(function() {
   if (window.location.hash === '#genome-tab') {
     $('#study-visualize-nav > a').click();
 
-    // Reload igv if refreshing, but not upon clicking back button in sign-in
-    if (accessToken !== null) $('#genome-tab-nav > a').click();
-  }
-
-  var signedInViaGenomeTab = localStorage.getItem('signed-in-via-genome-tab');
-  if (signedInViaGenomeTab === 'true') {
-    ga('send', 'event', 'genome', 'sign_in_end_success');
-
-    // Remove usage analysis token
-    localStorage.removeItem('signed-in-via-genome-tab');
-
-    // Load igv
-    $('#study-visualize-nav > a').click();
+    // Reload igv if refreshing
     $('#genome-tab-nav > a').click();
   }
 
-  if (accessToken === null) {
-    $('#genome-tab-nav')
-      .attr('title', 'Click to sign in; only authenticated users can visualize genomes')
-      .attr('data-toogle', 'tooltip');
-  }
 });

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -302,15 +302,11 @@ module ApplicationHelper
 	# Return an access token for viewing GCS objects client side, depending on study privacy
 	# Context: https://github.com/broadinstitute/single_cell_portal_core/pull/239
 	def get_read_access_token(study, user)
-		if user.present?
-			if study.public? && Study.read_only_firecloud_client.present?
-				Study.read_only_firecloud_client.valid_access_token["access_token"]
-			else
-				user.valid_access_token[:access_token]
-			end
-		else
-			nil
-		end
+    if study.public? && Study.read_only_firecloud_client.present?
+      Study.read_only_firecloud_client.valid_access_token["access_token"]
+    elsif user.present?
+      user.valid_access_token[:access_token]
+    end
 	end
 
 	def pluralize_without_count(count, noun, text=nil)

--- a/app/views/site/_study_visualize.html.erb
+++ b/app/views/site/_study_visualize.html.erb
@@ -162,15 +162,9 @@
   <% if !@study.can_visualize_clusters? && @ideogram_files.present? %>
     // user has no clusters, but does have ideogram annotations
     $(document).ready(function () {
-        if (<%= !user_signed_in? %>) {
-          $('#study-tabs a[href="#study-visualize"]').on('shown.bs.tab', function() {
-              $('#genome-tab-nav').click(); // force user to sign in
-          });
-        } else {
-            var ideogramSelect = $('#ideogram_annotation');
-            var firstIdeogram = $('#ideogram_annotation option')[1].value;
-            ideogramSelect.val(firstIdeogram).trigger('change'); // manually trigger change to cause ideogram to render
-        }
+      var ideogramSelect = $('#ideogram_annotation');
+      var firstIdeogram = $('#ideogram_annotation option')[1].value;
+      ideogramSelect.val(firstIdeogram).trigger('change'); // manually trigger change to cause ideogram to render
     });
 
   <% end %>

--- a/app/views/site/genome/_genome.html.erb
+++ b/app/views/site/genome/_genome.html.erb
@@ -3,10 +3,8 @@ Minimal DOM scaffolding and server-side data for genomic visualizations.
 See partials referenced below and scp-igv.js for larger bodies of code.
 -->
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-  var at;
   if (typeof accessToken === 'undefined') {
-    at = '<%= get_read_access_token(@study, current_user) %>';
-    window.accessToken = (at === '' ? null : at);
+    window.accessToken = '<%= get_read_access_token(@study, current_user) %>';
   }
 </script>
 <% if @study.has_analysis_outputs?('infercnv', 'ideogram.js') and action_name == 'study' %>

--- a/app/views/site/genome/_ideogram.html.erb
+++ b/app/views/site/genome/_ideogram.html.erb
@@ -31,8 +31,3 @@
   margin-left: 110px;
 }
 </style>
-<script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-
-
-
-</script>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -31,7 +31,7 @@ SecureHeaders::Configuration.default do |config|
       connect_src: ['\'self\'', "https://#{ENV['HOSTNAME']}", 'https://www.google-analytics.com', 'https://unpkg.com', 'https://igv.org',
                     'https://www.googleapis.com', 'https://s3.amazonaws.com', 'https://data.broadinstitute.org', 'https://portals.broadinstitute.org',
                     'https://us.input.tcell.insight.rapid7.com', 'https://api.tcell.io', 'https://us.browser.tcell.insight.rapid7.com',
-                    'https://us.agent.tcell.insight.rapid7.com', 'https://us.jsagent.tcell.insight.rapid7.com'],
+                    'https://us.agent.tcell.insight.rapid7.com', 'https://us.jsagent.tcell.insight.rapid7.com', 'https://accounts.google.com'],
       img_src: %w('self' data: https://www.google-analytics.com https://online.swagger.io),
       manifest_src: %w('self'),
       object_src: %w('none'),

--- a/test/ui_test_helper.rb
+++ b/test/ui_test_helper.rb
@@ -198,15 +198,6 @@ class Test::Unit::TestCase
     $verbose ? puts('login successful') : nil
   end
 
-  # log back into portal with account that has already signed in once
-  def log_back_in(email)
-    $verbose ? puts('logging back in as ' + email) : nil
-    user_email = @driver.find_element(:xpath, "//div[@data-email='#{email}']")
-    user_email.click
-    handle_oauth_redirect(email)
-    $verbose ? puts('login successful') : nil
-  end
-
   # method to log out of google so that we can log in with a different account
   def login_as_other(email, password)
     invalidate_google_session

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -5045,30 +5045,6 @@ class UiTestSuite < Test::Unit::TestCase
     igv_single_instance = @driver.execute_script("return $('.igv-root-div').length === 1;")
     assert igv_single_instance, "Multiple instances of igv.js are display; only one should be"
 
-
-    # sign out and prove that gene search state is remembered after new login
-    logout_from_portal
-    @driver.get(loaded_path)
-    wait_until_page_loads(loaded_path)
-    open_ui_tab('study-visualize')
-    @wait.until {wait_for_plotly_render('#cluster-plot', 'rendered')}
-    # Search for a gene
-    gene = @genes.sample
-    search_box = @driver.find_element(:id, 'search_genes')
-    search_box.send_keys(gene)
-    search_box.click
-    search_genes = @driver.find_element(:id, 'perform-gene-search')
-    search_genes.click
-    @wait.until {wait_for_plotly_render('#expression-plots', 'box-rendered')}
-
-    # open genome tab and validate gene search is remembered
-    genome_nav = @driver.find_element(:id, 'genome-tab-nav')
-    genome_nav.click
-    log_back_in($test_email)
-    @wait.until {element_visible?(:id, 'genome-tab')}
-    queried_gene = @driver.find_element(:class, 'queried-gene')
-    assert queried_gene.text == gene, "did not load the correct gene, expected #{gene} but found #{queried_gene.text}"
-
     # clean up
     @driver.get studies_path
     wait_until_page_loads(studies_path)


### PR DESCRIPTION
This fixes broken sign-in for visualizations in the "Genome" tab by removing a bespoke user-flow for authentication.  

Genome visualizations in public studies now do not require authentication.  This matches handling for other types of visualizations in public studies.

I've verified these changes locally by running UI tests for IGV and Ideogram.

This satisfies [SCP-1856](https://broadworkbench.atlassian.net/browse/SCP-1856).