### PR TITLE
adding bare domain redirect to home page via 302

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  # bare domain redirect to homepage
+  get '/', to:redirect('/single_cell', status: 302)
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   scope 'single_cell' do
     # API Routes

--- a/test/controllers/site_controller_test.rb
+++ b/test/controllers/site_controller_test.rb
@@ -10,6 +10,16 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
     @study = Study.first
   end
 
+  test 'should redirect to home page from bare domain' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+    get '/'
+    assert_response 302, "Did not receive correct HTTP status code, expected 302 but found #{status}"
+    assert_redirected_to site_path, "Did not provide correct redirect, should have gone to #{site_path} but found #{path}"
+    follow_redirect!
+    assert_equal(site_path, path, "Redirect did not successfully complete, #{site_path} != #{path}")
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
   test 'should redirect to correct study name url' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
 

--- a/webapp.conf
+++ b/webapp.conf
@@ -24,10 +24,10 @@ server {
 			rewrite ^(.*)$ /single_cell/maintenance.html break;
 		}
 
-        location ^~ /single_cell/assets/ {
-            gzip_static on;
-            expires max;
-        }
+		location ^~ /single_cell/assets/ {
+				gzip_static on;
+				expires max;
+		}
 
 		add_header    X-Forwarded-Proto https always;
 		proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Will redirect from bare domain (singlecell.broadinstitute.org) to the correct sub-path of /single_cell.

This satisfies [SCP-1935](https://broadworkbench.atlassian.net/browse/SCP-1935)