### PR TITLE
Docker base image update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM singlecellportal/rails-baseimage:0.2.3
+FROM singlecellportal/rails-baseimage:1.0.0
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-2.5.5'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM broadinstitute/kdux-rails-baseimage:1.9
+FROM singlecellportal/rails-baseimage:0.2.3
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-2.5.5'

--- a/test/ui_test_helper.rb
+++ b/test/ui_test_helper.rb
@@ -195,6 +195,8 @@ class Test::Unit::TestCase
     complete_login_process(email, password)
     # wait for redirect to finish by checking for footer element
     handle_oauth_redirect(email)
+    # accept SCP terms of service if needed
+    accept_scp_tos
     $verbose ? puts('login successful') : nil
   end
 
@@ -214,6 +216,8 @@ class Test::Unit::TestCase
     complete_login_process(email, password)
     # wait for redirect to finish by checking for footer element
     handle_oauth_redirect(email)
+    # accept SCP terms of service if needed
+    accept_scp_tos
     $verbose ? puts('login successful') : nil
   end
 
@@ -402,4 +406,14 @@ class Test::Unit::TestCase
     option.click
   end
 
+  def accept_scp_tos
+    $verbose ? puts('checking SCP terms of service') : nil
+    @wait.until {@driver.current_url =~ /single_cell/}
+    if @driver.current_url =~ /accept_tos/
+      $verbose ? puts('accepting SCP terms of service') : nil
+      accept = @driver.find_element(:id, 'accept-tos')
+      accept.click
+    end
+    $verbose ? puts('SCP terms of service check complete') : nil
+  end
 end


### PR DESCRIPTION
* Updating to using new Docker image singlecellportal/rails-baseimage:0.2.3, which incorporates the marketplace.gcr.io/google/ubuntu1804:latest managed base image.  This image is regularly updated and patched by Google to include all necessary security patches/fixes.

This satisfies [SCP-1999](https://broadworkbench.atlassian.net/browse/SCP-1999)