### PR TITLE
Allow users to specify whether to use a metadata convention in UI [SCP-1913, SCP-2001]

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -624,9 +624,9 @@ module Api
       def study_file_params
         params.require(:study_file).permit(:_id, :study_id, :taxon_id, :genome_assembly_id, :study_file_bundle_id, :name,
                                            :upload, :upload_file_name, :upload_content_type, :upload_file_size, :remote_location,
-                                           :description, :file_type, :status, :human_fastq_url, :human_data, :cluster_type,
-                                           :generation, :x_axis_label, :y_axis_label, :z_axis_label, :x_axis_min, :x_axis_max,
-                                           :y_axis_min, :y_axis_max, :z_axis_min, :z_axis_max, :species, :assembly,
+                                           :description, :file_type, :status, :human_fastq_url, :human_data, :use_metadata_convention,
+                                           :cluster_type, :generation, :x_axis_label, :y_axis_label, :z_axis_label, :x_axis_min,
+                                           :x_axis_max, :y_axis_min, :y_axis_max, :z_axis_min, :z_axis_max, :species, :assembly,
                                            options: [:cluster_group_id, :font_family, :font_size, :font_color, :matrix_id,
                                                      :submission_id, :bam_id, :analysis_name, :visualization_name, :cluster_name,
                                                      :annotation_name])

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1327,9 +1327,9 @@ class StudiesController < ApplicationController
   # study file params whitelist
   def study_file_params
     params.require(:study_file).permit(:_id, :study_id, :name, :upload, :upload_file_name, :upload_content_type, :upload_file_size,
-                                       :remote_location, :description, :file_type, :status, :human_fastq_url, :human_data, :cluster_type,
-                                       :generation, :x_axis_label, :y_axis_label, :z_axis_label, :x_axis_min, :x_axis_max, :y_axis_min,
-                                       :y_axis_max, :z_axis_min, :z_axis_max, :taxon_id, :genome_assembly_id, :study_file_bundle_id,
+                                       :remote_location, :description, :file_type, :status, :human_fastq_url, :human_data, :use_metadata_convention,
+                                       :cluster_type, :generation, :x_axis_label, :y_axis_label, :z_axis_label, :x_axis_min, :x_axis_max,
+                                       :y_axis_min, :y_axis_max, :z_axis_min, :z_axis_max, :taxon_id, :genome_assembly_id, :study_file_bundle_id,
                                        options: [:cluster_group_id, :font_family, :font_size, :font_color, :matrix_id, :submission_id,
                                                  :bam_id, :analysis_name, :visualization_name, :cluster_name, :annotation_name])
   end

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -230,7 +230,11 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
                       " --gene-file #{genes_file.gs_url} --barcode-file #{barcodes_file.gs_url}"
       end
     when 'ingest_cell_metadata'
-      command_line += " --cell-metadata-file #{study_file.gs_url} --ingest-cell-metadata --validate-convention"
+      if study_file.use_metadata_convention:
+        validate_convention = "--validate-convention"
+      else:
+        validate_convention = ""
+      command_line += " --cell-metadata-file #{study_file.gs_url} --ingest-cell-metadata #{validate_convention}"
     when 'ingest_cluster'
       command_line += " --cluster-file #{study_file.gs_url} --ingest-cluster"
     when 'ingest_subsample'

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -230,11 +230,10 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
                       " --gene-file #{genes_file.gs_url} --barcode-file #{barcodes_file.gs_url}"
       end
     when 'ingest_cell_metadata'
-      if study_file.use_metadata_convention:
-        validate_convention = "--validate-convention"
-      else:
-        validate_convention = ""
-      command_line += " --cell-metadata-file #{study_file.gs_url} --ingest-cell-metadata #{validate_convention}"
+      command_line += " --cell-metadata-file #{study_file.gs_url} --ingest-cell-metadata"
+      if study_file.use_metadata_convention
+        command_line += " --validate-convention"
+      end
     when 'ingest_cluster'
       command_line += " --cluster-file #{study_file.gs_url} --ingest-cluster"
     when 'ingest_subsample'

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -62,6 +62,7 @@ class StudyFile
   field :data_dir, type: String
   field :human_fastq_url, type: String
   field :human_data, type: Boolean, default: false
+  field :use_metadata_convention, type: Boolean, default: false
   field :generation, type: String
   field :x_axis_label, type: String, default: ''
   field :y_axis_label, type: String, default: ''
@@ -183,6 +184,11 @@ class StudyFile
       key :default, false
       key :description, 'Boolean indication whether StudyFile represents human data'
     end
+    property :use_metadata_convention do
+      key :type, :boolean
+      key :default, false
+      key :description, 'Boolean indication whether StudyFile uses the metadata convention'
+    end
     property :generation do
       key :type, :string
       key :description, 'GCS generation tag of File in bucket'
@@ -300,6 +306,11 @@ class StudyFile
           key :default, false
           key :description, 'Boolean indication whether StudyFile represents human data'
         end
+        property :use_metadata_convention do
+          key :type, :boolean
+          key :default, false
+          key :description, 'Boolean indication whether StudyFile uses the metadata convention'
+        end
         property :generation do
           key :type, :string
           key :description, 'GCS generation tag of File in bucket'
@@ -389,6 +400,11 @@ class StudyFile
           key :type, :boolean
           key :default, false
           key :description, 'Boolean indication whether StudyFile represents human data'
+        end
+        property :use_metadata_convention do
+          key :type, :boolean
+          key :default, false
+          key :description, 'Boolean indication whether StudyFile uses the metadata convention'
         end
         property :generation do
           key :type, :string

--- a/app/views/studies/_initialize_metadata_form.html.erb
+++ b/app/views/studies/_initialize_metadata_form.html.erb
@@ -23,8 +23,8 @@
       <% if !study_file.upload_file_name.nil? %>
         <p><label>Link to file </label><br /><%= render partial: '/layouts/download_link', locals: {study: @study, study_file: study_file} %></p>
       <% else %>
-        <div class="col-sm-4">
-        <%= f.label :use_metadata_convention, "Use Metadata Convention?" %><br />
+        <div class="col-sm-5">
+        <%= f.label :use_metadata_convention, "Use Metadata Convention?" %> <%= render partial: 'metadata_convention_help_popover', locals: {id: f.object.id.to_s} %><br />
         <%= f.select :use_metadata_convention, options_for_select([['Yes', true],['No', false]], study_file.use_metadata_convention), {}, class: 'form-control use-metadata-convention' %>
       </div>
         <%= f.label :upload, 'Upload Data File' %><br />

--- a/app/views/studies/_initialize_metadata_form.html.erb
+++ b/app/views/studies/_initialize_metadata_form.html.erb
@@ -23,6 +23,10 @@
       <% if !study_file.upload_file_name.nil? %>
         <p><label>Link to file </label><br /><%= render partial: '/layouts/download_link', locals: {study: @study, study_file: study_file} %></p>
       <% else %>
+        <div class="col-sm-4">
+        <%= f.label :use_metadata_convention, "Use Metadata Convention?" %><br />
+        <%= f.select :use_metadata_convention, options_for_select([['Yes', true],['No', false]], study_file.use_metadata_convention), {}, class: 'form-control use-metadata-convention' %>
+      </div>
         <%= f.label :upload, 'Upload Data File' %><br />
         <%= f.file_field :upload, class: 'btn btn-info fileinput-button', id: 'upload-metadata' %>
         <%= f.hidden_field :status, value: study_file.new_record? ? 'uploading' : 'uploaded' %>

--- a/app/views/studies/_metadata_convention_help_popover.html.erb
+++ b/app/views/studies/_metadata_convention_help_popover.html.erb
@@ -1,0 +1,11 @@
+<a href="#/" title="Why use the metadata convention?" class="label label-default pull-right" id="metadata-convention-popover-<%= id %>"
+   data-content="Using the metadata convention will enable your data to be discovered through an upcoming faceted search interface.  Using the convention means extra validation will be applied to ensure your metadata conforms to standard vocabularies.  <!-- Uncomment, amend if needed per SCP-1986 <a href='https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-Convention'>Learn more</a>. -->"
+   data-toggle="popover">
+  Why?
+</a>
+
+<script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+
+    enableHoverPopovers('#metadata-convention-popover-<%= id %>');
+
+</script>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -244,7 +244,8 @@ Devise.setup do |config|
   config.omniauth :google_oauth2, ENV['OAUTH_CLIENT_ID'], ENV['OAUTH_CLIENT_SECRET'],
                   prompt: 'consent', access_type: 'offline',
                   scope: FireCloudClient::GOOGLE_SCOPES.join(' '),
-                  :client_options => {:ssl => {:ca_file => '/etc/pki/tls/certs/ca-bundle.crt'} }
+                  :client_options => {:ssl => {:ca_file => '/etc/pki/tls/certs/ca-bundle.crt'} },
+                  skip_jwt: Rails.env.development? ? true : false
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
This implements a checkbox on the metadata upload form to indicate whether the convention will be used, and a tooltip describing what it means to use a metadata convention.

I have locally verified that I can upload a metadata file with or without a metadata convention, and that this now passes the `--validate-convention` flag to `ingest_pipeline.py` in PAPI as appropriate.  Related integration is being developed in parallel.

Also, this fixes randomly-occurring `JWT::InvalidIatError` OAuth2 errors that have recently plagued my development environment.

This satisifies SCP-2001 and the UI part of SCP-1913.