### PR TITLE
updating to bundler 2.1 to avoid build issues in CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -504,4 +504,4 @@ RUBY VERSION
    ruby 2.5.5p157
 
 BUNDLED WITH
-   1.17.3
+   2.1.0


### PR DESCRIPTION
This resolves build issues in Travis with Rubygems updates and using bundler 1.x