### PR TITLE
Adding subsampling calls to ingest_job

### DIFF
--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -235,7 +235,7 @@ class IngestJob
       self.study.set_gene_count
     when 'Cluster'
       self.set_study_default_options
-      # self.launch_subsample_jobs
+      self.launch_subsample_jobs
     end
     self.set_study_initialized
   end
@@ -290,7 +290,7 @@ class IngestJob
                                                                     action: :ingest_subsample)
         Rails.logger.info "Subsampling run initiated: #{submission.name}, queueing Ingest poller"
         IngestJob.new(pipeline_name: submission.name, study: self.study, study_file: self.study_file,
-                      user: self.user).poll_for_completion
+                      user: self.user, action: self.action).poll_for_completion
       end
     when 'Metadata'
       # subsample all cluster files that have already finished parsing.  any in-process cluster parses, or new submissions

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -19,7 +19,7 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   # GCP Compute project to run pipelines in
   COMPUTE_PROJECT = ENV['GOOGLE_CLOUD_PROJECT'].blank? ? '' : ENV['GOOGLE_CLOUD_PROJECT']
   # Docker image in GCP project to pull for running ingest jobs
-  INGEST_DOCKER_IMAGE = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:0.8.2'
+  INGEST_DOCKER_IMAGE = 'gcr.io/broad-singlecellportal-staging/ingest-pipeline:0.8.4_631e4dd'
   # Network and sub-network names, if needed
   GCP_NETWORK_NAME = ENV['GCP_NETWORK_NAME']
   GCP_SUB_NETWORK_NAME = ENV['GCP_SUB_NETWORK_NAME']

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -259,7 +259,7 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
                       " --gene-file #{genes_file.gs_url} --barcode-file #{barcodes_file.gs_url}"
       end
     when 'ingest_cell_metadata'
-      command_line += " --cell-metadata-file #{study_file.gs_url} --ingest-cell-metadata"
+      command_line += " --cell-metadata-file #{study_file.gs_url} --study-accession #{study.accession} --ingest-cell-metadata"
       if study_file.use_metadata_convention
         command_line += " --validate-convention"
       end

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -19,7 +19,7 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   # GCP Compute project to run pipelines in
   COMPUTE_PROJECT = ENV['GOOGLE_CLOUD_PROJECT'].blank? ? '' : ENV['GOOGLE_CLOUD_PROJECT']
   # Docker image in GCP project to pull for running ingest jobs
-  INGEST_DOCKER_IMAGE = 'gcr.io/broad-singlecellportal-staging/ingest-pipeline:0.8.4_631e4dd'
+  INGEST_DOCKER_IMAGE = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:0.9.0'
   # Network and sub-network names, if needed
   GCP_NETWORK_NAME = ENV['GCP_NETWORK_NAME']
   GCP_SUB_NETWORK_NAME = ENV['GCP_SUB_NETWORK_NAME']

--- a/bin/run_unit_tests.sh
+++ b/bin/run_unit_tests.sh
@@ -58,7 +58,6 @@ else
                     test/api/study_file_bundles_controller_test.rb
                     test/api/study_shares_controller_test.rb
                     test/api/directory_listings_controller_test.rb
-                    test/models/cluster_group_test.rb
                     test/models/user_annotation_test.rb
                     test/models/parse_utils_test.rb
                     test/models/analysis_configuration_test.rb

--- a/test/models/cluster_group_test.rb
+++ b/test/models/cluster_group_test.rb
@@ -1,5 +1,8 @@
 require "test_helper"
 
+# DEPRECATED
+# This test case is deprecated in favor of subsampling in scp-ingest-pipeline
+
 class ClusterGroupTest < ActiveSupport::TestCase
   def setup
     @cluster_group = ClusterGroup.first


### PR DESCRIPTION
Adding subsampling calls (where appropriate) to successful cluster/metadata file ingest runs to generate subsampled clustering data at the required thresholds.

This satisfies [SCP-1998](https://broadworkbench.atlassian.net/browse/SCP-1998)