### PR TITLE
Updating parse completion/failure email contents

### DIFF
--- a/app/mailers/single_cell_mailer.rb
+++ b/app/mailers/single_cell_mailer.rb
@@ -29,14 +29,22 @@ class SingleCellMailer < ApplicationMailer
     end
   end
 
-  def notify_user_parse_complete(email, title, message)
+  def notify_user_parse_complete(email, title, message, study)
     @message = message
+    @study = study
     mail(to: email, subject: '[Single Cell Portal Notifier] ' + title)
   end
 
-  def notify_user_parse_fail(email, title, error)
+  def notify_user_parse_fail(email, title, error, study)
     @error = error
-    mail(to: email, subject: '[Single Cell Portal Notifier] ' + title)
+    @study = study
+    dev_email_config = AdminConfiguration.find_by(config_type: 'QA Dev Email')
+    if dev_email_config.present?
+      dev_email = dev_email_config.value
+      mail(to: email, bcc: dev_email, subject: '[Single Cell Portal Notifier] ' + title)
+    else
+      mail(to: email, subject: '[Single Cell Portal Notifier] ' + title)
+    end
   end
 
   def daily_disk_status

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -19,7 +19,8 @@ class AdminConfiguration
   FIRECLOUD_ACCESS_NAME = 'FireCloud Access'
   API_NOTIFIER_NAME = 'API Health Check Notifier'
   NUMERIC_VALS = %w(byte kilobyte megabyte terabyte petabyte exabyte)
-  CONFIG_TYPES = ['Daily User Download Quota', 'Workflow Name', 'Portal FireCloud User Group', 'Reference Data Workspace', 'Read-Only Access Control', API_NOTIFIER_NAME]
+  CONFIG_TYPES = ['Daily User Download Quota', 'Workflow Name', 'Portal FireCloud User Group',
+                  'Reference Data Workspace', 'Read-Only Access Control', 'QA Dev Email', API_NOTIFIER_NAME]
   ALL_CONFIG_TYPES = CONFIG_TYPES.dup << FIRECLOUD_ACCESS_NAME
   VALUE_TYPES = %w(Numeric Boolean String)
 
@@ -32,7 +33,8 @@ class AdminConfiguration
   validates_inclusion_of :value_type, in: VALUE_TYPES
   validates_inclusion_of :multiplier, in: NUMERIC_VALS, allow_blank: true
   validates_format_of :value, with: ValidationTools::OBJECT_LABELS,
-                      message: ValidationTools::OBJECT_LABELS_ERROR
+                      message: ValidationTools::OBJECT_LABELS_ERROR,
+                      unless: proc {|attributes| attributes.config_type == 'QA Dev Email'} # allow '@' for this config
 
   validate :manage_readonly_access
 

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -310,6 +310,11 @@ class ClusterGroup
     true
   end
 
+  # determine which subsampling levels are required for this cluster
+  def subsample_thresholds_required
+    ClusterGroup::SUBSAMPLE_THRESHOLDS.select {|sample| sample < self.points}
+  end
+
   ##
   #
   # CLASS INSTANCE METHODS

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -207,7 +207,7 @@ class IngestJob
       self.study_file.reload # refresh cached instance of study_file
       subject = "#{self.study_file.file_type} file: '#{self.study_file.upload_file_name}' has completed parsing"
       message = self.generate_success_email_array
-      SingleCellMailer.notify_user_parse_complete(self.user.email, subject, message).deliver_now
+      SingleCellMailer.notify_user_parse_complete(self.user.email, subject, message, self.study).deliver_now
       self.set_study_state_after_ingest
       self.study_file.invalidate_cache_by_file_type # clear visualization caches for file
     elsif self.done? && self.failed?
@@ -219,7 +219,7 @@ class IngestJob
       Study.firecloud_client.delete_workspace_file(self.study.bucket_id, self.study_file.bucket_location)
       subject = "Error: #{self.study_file.file_type} file: '#{self.study_file.upload_file_name}' parse has failed"
       email_content = self.generate_error_email_body
-      SingleCellMailer.notify_user_parse_fail(self.user.email, subject, email_content).deliver_now
+      SingleCellMailer.notify_user_parse_fail(self.user.email, subject, email_content, self.study).deliver_now
     else
       Rails.logger.info "IngestJob poller: #{self.pipeline_name} is not done; queuing check for #{run_at}"
       self.delay(run_at: run_at).poll_for_completion

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -34,7 +34,7 @@ class IngestJob
   # Can also clear out existing data if necessary (in case of a re-parse)
   #
   # * *params*
-  #   - +reparse+ [Boolean] => Indication of whether or not a file is being re-ingested, will delete existing documents
+  #   - +reparse+ (Boolean) => Indication of whether or not a file is being re-ingested, will delete existing documents
   #
   # * *yields*
   #   - (Google::Apis::GenomicsV2alpha1::Operation) => Will submit an ingest job in PAPI
@@ -203,10 +203,13 @@ class IngestJob
       Rails.logger.info "IngestJob poller: #{self.pipeline_name} is done!"
       Rails.logger.info "IngestJob poller: #{self.pipeline_name} status: #{self.current_status}"
       self.study_file.update(parse_status: 'parsed')
+      self.study.reload # refresh cached instance of study
+      self.study_file.reload # refresh cached instance of study_file
       subject = "#{self.study_file.file_type} file: '#{self.study_file.upload_file_name}' has completed parsing"
-      message = ["Total parse time: #{self.get_total_runtime}"]
+      message = self.generate_success_email_array
       SingleCellMailer.notify_user_parse_complete(self.user.email, subject, message).deliver_now
       self.set_study_state_after_ingest
+      self.study_file.invalidate_cache_by_file_type # clear visualization caches for file
     elsif self.done? && self.failed?
       Rails.logger.error "IngestJob poller: #{self.pipeline_name} has failed."
       # log errors to application log for inspection
@@ -224,15 +227,18 @@ class IngestJob
   end
 
   # Set study state depending on what kind of file was just ingested
+  # Does not return anything, but will set state and launch other jobs as needed
+  #
+  # * *yields
+  # *
+  #   - Study#set_cell_count, :set_study_default_options, Study#set_gene_count, and :set_study_initialized
   def set_study_state_after_ingest
     case self.study_file.file_type
     when 'Metadata'
       self.study.set_cell_count
       self.set_study_default_options
       self.launch_subsample_jobs
-    when 'Expression Matrix'
-      self.study.set_gene_count
-    when 'MM Coordinate Matrix'
+    when /Matrix/
       self.study.set_gene_count
     when 'Cluster'
       self.set_study_default_options
@@ -242,6 +248,9 @@ class IngestJob
   end
 
   # Set the default options for a study after ingesting Clusters/Cell Metadata
+  #
+  # * *yields*
+  #   - Sets study default options for clusters/annotations
   def set_study_default_options
     case self.study_file.file_type
     when 'Metadata'
@@ -270,6 +279,9 @@ class IngestJob
   end
 
   # Set the study "initialized" attribute if all main models are populated
+  #
+  # * *yields*
+  #   - Sets study initialized to True if needed
   def set_study_initialized
     if self.study.cluster_groups.any? && self.study.genes.any? && self.study.cell_metadata.any? && !self.study.initialized?
       self.study.update(initialized: true)
@@ -277,6 +289,9 @@ class IngestJob
   end
 
   # determine if subsampling needs to be run based on file ingested and current study state
+  #
+  # * *yields*
+  #   - (IngestJob) => new ingest job for subsampling
   def launch_subsample_jobs
     case self.study_file.file_type
     when 'Cluster'
@@ -312,17 +327,29 @@ class IngestJob
   end
 
   # path to potential error file in study bucket
+  #
+  # * *returns*
+  #   - (String) => String representation of path to parse error file
   def error_filepath
     "parse_logs/#{self.study_file.id}/errors.txt"
   end
 
   # path to potential warnings file in study bucket
+  #
+  # * *returns*
+  #   - (String) => String representation of path to parse warnings file
   def warning_filepath
     "parse_logs/#{self.study_file.id}/warnings.txt"
   end
 
   # in case of an error, retrieve the contents of the warning or error file to email to the user
   # deletes the file immediately after being read
+  #
+  # * *params*
+  #   - +filepath+ (String) => relative path of file to read in bucket
+  #
+  # * *returns*
+  #   - (String) => Contents of file
   def read_parse_logfile(filepath)
     if Study.firecloud_client.workspace_file_exists?(self.study.bucket_id, filepath)
       file_contents = Study.firecloud_client.execute_gcloud_method(:read_workspace_file, 0, self.study.bucket_id, filepath)
@@ -331,7 +358,47 @@ class IngestJob
     end
   end
 
+  # generates parse completion email body
+  #
+  # * *returns*
+  #   - (Array) => List of message strings to print in a completion email
+  def generate_success_email_array
+    message = ["Total parse time: #{self.get_total_runtime}"]
+    case self.study_file.file_type
+    when /Matrix/
+      genes = Gene.where(study_id: self.study.id, study_file_id: self.study_file.id).count
+      message << "Gene-level entries created: #{genes}"
+    when 'Metadata'
+      cell_metadata = CellMetadatum.where(study_id: self.study.id, study_file_id: self.study_file.id)
+      message << "Entries created:"
+      cell_metadata.each do |metadata|
+        unless metadata.nil?
+          message << "#{metadata.name}: #{metadata.annotation_type}#{metadata.values.any? ? ' (' + metadata.values.join(', ') + ')' : nil}"
+        end
+      end
+    when 'Cluster'
+      cluster = ClusterGroup.find_by(study_id: self.study.id, study_file_id: self.study_file.id)
+      if self.action == :ingest_cluster
+        message << "Cluster created: #{cluster.name}, type: #{cluster.cluster_type}"
+        if cluster.cell_annotations.any?
+          message << "Annotations:"
+          cluster.cell_annotations.each do |annot|
+            message << "#{annot['name']}: #{annot['type']}#{annot['type'] == 'group' ? ' (' + annot['values'].join(',') + ')' : nil}"
+          end
+        end
+        message << "Total points in cluster: #{cluster.points}"
+      else
+        message << "Subsampling has completed for #{cluster.name}"
+        message << "Subsamples generated: #{cluster.subsample_thresholds_required.join(', ')}"
+      end
+    end
+    message
+  end
+
   # format an error email message body
+  #
+  # * *returns*
+  #  - (String) => Contents of error messages for parse failure email
   def generate_error_email_body
     error_contents = self.read_parse_logfile(self.error_filepath)
     warning_contents = self.read_parse_logfile(self.warning_filepath)
@@ -341,17 +408,15 @@ class IngestJob
       error_contents.each_line do |line|
         message_body += "#{line}<br />"
       end
-
-      if error_contents.size == 0
-        message_body += "<h3>Event Messages (since no errors were shown)</h3>"
-        message_body += "<ul>"
-        self.event_messages.each do |e|
-          message_body += "<li><pre>#{ERB::Util.html_escape(e)}</pre></li>"
-        end
-        message_body += "</ul>"
+    else
+      message_body += "<h3>Event Messages (since no errors were shown)</h3>"
+      message_body += "<ul>"
+      self.event_messages.each do |e|
+        message_body += "<li><pre>#{ERB::Util.html_escape(e)}</pre></li>"
       end
-
+      message_body += "</ul>"
     end
+
     if warning_contents.present?
       message_body += "<h3>Warnings</h3>"
       warning_contents.each_line do |line|
@@ -367,6 +432,9 @@ class IngestJob
   end
 
   # log all event messages to the log for eventual searching
+  #
+  # * *yields*
+  #   - Error log messages in event of parse failure
   def log_error_messages
     self.event_messages.each do |message|
       Rails.logger.error "#{self.pipeline_name} log: #{message}"

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -2085,7 +2085,7 @@ class Study
       filename = coordinate_file.upload_file_name
       coordinate_file.remove_local_copy
       coordinate_file.destroy
-      SingleCellMailer.notify_user_parse_fail(user.email, "Error: Coordinate Labels file: '#{filename}' parse has failed", error_message).deliver_now
+      SingleCellMailer.notify_user_parse_fail(user.email, "Error: Coordinate Labels file: '#{filename}' parse has failed", error_message, self).deliver_now
       raise StandardError, error_message
     end
 
@@ -2102,7 +2102,7 @@ class Study
         end
       end
       coordinate_file.destroy
-      SingleCellMailer.notify_user_parse_fail(user.email, "Error: Coordinate Labels file: '#{filename}' parse has failed", error_message).deliver_now
+      SingleCellMailer.notify_user_parse_fail(user.email, "Error: Coordinate Labels file: '#{filename}' parse has failed", error_message, self).deliver_now
       raise StandardError, error_message
     end
 
@@ -2211,7 +2211,7 @@ class Study
       cluster_study_file.invalidate_cache_by_file_type
 
       begin
-        SingleCellMailer.notify_user_parse_complete(user.email, "Coordinate Label file: '#{coordinate_file.upload_file_name}' has completed parsing", @message).deliver_now
+        SingleCellMailer.notify_user_parse_complete(user.email, "Coordinate Label file: '#{coordinate_file.upload_file_name}' has completed parsing", @message, self).deliver_now
       rescue => e
         ErrorTracker.report_exception(e, user, error_context)
         Rails.logger.error "#{Time.zone.now}: Unable to deliver email: #{e.message}"
@@ -2259,7 +2259,7 @@ class Study
       coordinate_file.destroy
       error_message = "#{@last_line} ERROR: #{e.message}"
       Rails.logger.info Time.zone.now.to_s + ': ' + error_message
-      SingleCellMailer.notify_user_parse_fail(user.email, "Error: Coordinate Labels file: '#{filename}' parse has failed", error_message).deliver_now
+      SingleCellMailer.notify_user_parse_fail(user.email, "Error: Coordinate Labels file: '#{filename}' parse has failed", error_message, self).deliver_now
 
     end
   end
@@ -2605,7 +2605,7 @@ class Study
       marker_file.destroy
       error_message = "#{@last_line} ERROR: #{e.message}"
       Rails.logger.info Time.zone.now.to_s + ': ' + error_message
-      SingleCellMailer.notify_user_parse_fail(user.email, "Error: Gene List file: '#{filename}' parse has failed", error_message).deliver_now
+      SingleCellMailer.notify_user_parse_fail(user.email, "Error: Gene List file: '#{filename}' parse has failed", error_message, self).deliver_now
       # raise standard error to halt execution
       raise StandardError, error_message
     end
@@ -2616,7 +2616,7 @@ class Study
       filename = marker_file.upload_file_name
       marker_file.destroy
       Rails.logger.info Time.zone.now.to_s + ': ' + error_message
-      SingleCellMailer.notify_user_parse_fail(user.email, "Error: Gene List file: '#{filename}' parse has failed", error_message).deliver_now
+      SingleCellMailer.notify_user_parse_fail(user.email, "Error: Gene List file: '#{filename}' parse has failed", error_message, self).deliver_now
       raise StandardError, error_message
     end
 
@@ -2683,7 +2683,7 @@ class Study
 
       # send email
       begin
-        SingleCellMailer.notify_user_parse_complete(user.email, "Gene list file: '#{marker_file.name}' has completed parsing", @message).deliver_now
+        SingleCellMailer.notify_user_parse_complete(user.email, "Gene list file: '#{marker_file.name}' has completed parsing", @message, self).deliver_now
       rescue => e
         ErrorTracker.report_exception(e, user, error_context)
         Rails.logger.error "#{Time.zone.now}: Unable to deliver email: #{e.message}"
@@ -2731,7 +2731,7 @@ class Study
       marker_file.destroy
       error_message = "#{@last_line} ERROR: #{e.message}"
       Rails.logger.info Time.zone.now.to_s + ': ' + error_message
-      SingleCellMailer.notify_user_parse_fail(user.email, "Error: Gene List file: '#{filename}' parse has failed", error_message).deliver_now
+      SingleCellMailer.notify_user_parse_fail(user.email, "Error: Gene List file: '#{filename}' parse has failed", error_message, self).deliver_now
     end
     true
   end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,9 +2,8 @@
 	<div class="col-md-12">
     <div class="row">
       <div class="col-md-offset-3 col-md-6">
-        <div class="bs-callout bs-callout-danger">
-          <h4>Returning Users with Non-Google Accounts</h4>
-          <p class="help-block">We have consolidated to Google-based authentication.  If you have been using a non Google-based account, please email <%= mail_to 'scp-support@broadinstitute.zendesk.com' %> about migrating your account.</p>
+        <div class="bs-callout bs-callout-info">
+          <h4 class="help-block text-center">Please sign in using a Google account</h4>
         </div>
       </div>
     </div>

--- a/app/views/single_cell_mailer/notify_user_parse_complete.html.erb
+++ b/app/views/single_cell_mailer/notify_user_parse_complete.html.erb
@@ -1,2 +1,3 @@
 <p>Your Single Cell Portal parse job has completed with the following results:</p>
 <%= @message.join('<br />').html_safe %>
+<p>Study URL: <%= legacy_study_url(identifier: @study.accession) %></p>

--- a/app/views/single_cell_mailer/notify_user_parse_complete.text.erb
+++ b/app/views/single_cell_mailer/notify_user_parse_complete.text.erb
@@ -1,3 +1,5 @@
 Your Single Cell Portal parse job has completed with the following results:
 
 <%= @message.join("\n") %>
+
+Study URL: <%= legacy_study_url(identifier: @study.accession) %>

--- a/app/views/single_cell_mailer/notify_user_parse_fail.html.erb
+++ b/app/views/single_cell_mailer/notify_user_parse_fail.html.erb
@@ -7,3 +7,5 @@
   <%= mail_to 'scp-support@broadinstitute.zendesk.com', 'scp-support@broadinstitute.zendesk.com', subject: "File Ingest Error" %>.
   Please copy and paste the "Details" section into the body of the email to help us diagnose your issue.
 </p>
+
+<p>Study URL: <%= legacy_study_url(identifier: @study.accession) %></p>

--- a/app/views/single_cell_mailer/notify_user_parse_fail.text.erb
+++ b/app/views/single_cell_mailer/notify_user_parse_fail.text.erb
@@ -4,3 +4,6 @@ Your Single Cell Portal parse job has failed with the following error:
 
 This file has been deleted from your study, and any child database records removed.
 If you have any questions about this error, you can contact the Single Cell Portal Team at scp-support@broadinstitute.zendesk.com.
+Please copy and paste the "Details" section into the body of the email to help us diagnose your issue.
+
+Study URL: <%= legacy_study_url(identifier: @study.accession) %>


### PR DESCRIPTION
Adding necessary context to parse completion/failure emails when using scp-ingest-pipeline.  Also alerts QA dev team for the time being on all parse failures to allow for more rapid debugging/QA efforts.

This satisfies [SCP-2027](https://broadworkbench.atlassian.net/browse/SCP-2027) and [SCP-2033](https://broadworkbench.atlassian.net/browse/SCP-2033)