### PR TITLE
Gating subsampling, adding cleanup

### DIFF
--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -316,15 +316,20 @@ class ClusterGroup
     SUBSAMPLE_THRESHOLDS.select {|sample| sample < self.points}
   end
 
+  # find all 'subsampled' data arrays
+  def find_subsampled_data_arrays
+    DataArray.where(study_id: self.study_id, study_file_id: self.study_file_id, linear_data_type: 'ClusterGroup',
+                    linear_data_id: self.id, :subsample_threshold.nin => [nil],
+                    :subsample_annotation.nin => [nil])
+  end
+
   # control gate for invoking subsampling
   def can_subsample?
     if self.points < SUBSAMPLE_THRESHOLDS.min || self.subsampled
       false
     else
       # check if there are any data arrays belonging to this cluster that have a subsample threshold & annotation
-      !DataArray.where(study_id: self.study_id, study_file_id: self.study_file_id, linear_data_type: 'ClusterGroup',
-                       linear_data_id: self.id, :subsample_threshold.nin => [nil],
-                       :subsample_annotation.nin => [nil]).any?
+      !self.find_subsampled_data_arrays.any?
     end
   end
 

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -313,12 +313,12 @@ class ClusterGroup
 
   # determine which subsampling levels are required for this cluster
   def subsample_thresholds_required
-    ClusterGroup::SUBSAMPLE_THRESHOLDS.select {|sample| sample < self.points}
+    SUBSAMPLE_THRESHOLDS.select {|sample| sample < self.points}
   end
 
   # control gate for invoking subsampling
   def can_subsample?
-    if self.points < 1000 || self.subsampled
+    if self.points < SUBSAMPLE_THRESHOLDS.min || self.subsampled
       false
     else
       # check if there are any data arrays belonging to this cluster that have a subsample threshold & annotation

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -65,7 +65,7 @@ class DeleteQueueJob < Struct.new(:object)
         # clean up all subsampled data, as it is now invalid and will be regenerated
         # once a user adds another metadata file
         ClusterGroup.where(study_id: study.id).each do |cluster_group|
-          delete_subsampled_data(study.id, cluster_group.study_file.id, cluster_group.id)
+          delete_subsampled_data(cluster_group)
         end
 
         delete_parsed_data(object.id, study.id, CellMetadatum, DataArray)
@@ -146,9 +146,7 @@ class DeleteQueueJob < Struct.new(:object)
 
   # remove all subsampling data when a user deletes a metadata file, as adding a new metadata file will cause all
   # subsamples to be regenerated
-  def delete_subsampled_data(study_id, study_file_id, cluster_group_id)
-    DataArray.where(study_id: study_id, study_file_id: study_file_id, linear_data_type: 'ClusterGroup',
-                    linear_data_id: cluster_group_id, :subsample_threshold.nin => [nil],
-                    :subsample_annotation.nin => [nil]).delete_all
+  def delete_subsampled_data(cluster)
+    cluster.find_subsampled_data_arrays.delete_all
   end
 end

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -64,8 +64,8 @@ class DeleteQueueJob < Struct.new(:object)
       when 'Metadata'
         # clean up all subsampled data, as it is now invalid and will be regenerated
         # once a user adds another metadata file
-        ClusterGroup.where(study_id: study.id).each do |cluster|
-          delete_subsampled_data(study.id, cluster.study_file.id, cluster.id)
+        ClusterGroup.where(study_id: study.id).each do |cluster_group|
+          delete_subsampled_data(study.id, cluster_group.study_file.id, cluster_group.id)
         end
 
         delete_parsed_data(object.id, study.id, CellMetadatum, DataArray)

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -64,7 +64,7 @@ class DeleteQueueJob < Struct.new(:object)
       when 'Metadata'
         # clean up all subsampled data, as it is now invalid and will be regenerated
         # once a user adds another metadata file
-        ClusterGroup.where(study.id).each do |cluster|
+        ClusterGroup.where(study_id: study.id).each do |cluster|
           delete_subsampled_data(study.id, cluster.study_file.id, cluster.id)
         end
 

--- a/db/migrate/20200103191405_set_subsampled_on_clusters.rb
+++ b/db/migrate/20200103191405_set_subsampled_on_clusters.rb
@@ -1,0 +1,15 @@
+class SetSubsampledOnClusters < Mongoid::Migration
+  def self.up
+    ClusterGroup.all.each do |cluster|
+      if cluster.points > 1000
+        cluster.update(subsampled: true)
+      end
+    end
+  end
+
+  def self.down
+    ClusterGroup.all.each do |cluster|
+      cluster.remove_attribute(:subsampled)
+    end
+  end
+end


### PR DESCRIPTION
Adding the `subsampled` flag to ClusterGroups to gate invocation of subsampling via ingest pipeline to avoid a race condition when both a cluster and cell metadata file finish parsing at roughly the same time.

Also, when deleting a cell metadata file, all subsampled data will be deleted as it will need to be regenerated once a new cell metadata file is added.

This PR satisfies [SCP-2050](https://broadworkbench.atlassian.net/browse/SCP-2050).