### PR TITLE
Bugfixes for deployments re: yarn, subsampling cleanup

### DIFF
--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -71,7 +71,6 @@ class DeleteQueueJob < Struct.new(:object)
         # once a user adds another metadata file
         ClusterGroup.where(study_id: study.id).each do |cluster_group|
           delete_subsampled_data(cluster_group)
-          cluster_group.update(subsampled: false)
         end
 
         delete_parsed_data(object.id, study.id, CellMetadatum, DataArray)
@@ -154,5 +153,6 @@ class DeleteQueueJob < Struct.new(:object)
   # subsamples to be regenerated
   def delete_subsampled_data(cluster)
     cluster.find_subsampled_data_arrays.delete_all
+    cluster.update(subsampled: false)
   end
 end

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -71,6 +71,7 @@ class DeleteQueueJob < Struct.new(:object)
         # once a user adds another metadata file
         ClusterGroup.where(study_id: study.id).each do |cluster_group|
           delete_subsampled_data(cluster_group)
+          cluster_group.update(subsampled: false)
         end
 
         delete_parsed_data(object.id, study.id, CellMetadatum, DataArray)

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -96,6 +96,7 @@ function main {
     # update source on remote host to pull in changes before deployment
     echo "### pulling updated source from git on branch $GIT_BRANCH ###"
     run_remote_command "git fetch" || exit_with_error_message "could not checkout $GIT_BRANCH"
+    run_remote_command "git checkout yarn.lock" || exit_with_error_message "could not reset yarn.lock file"
     run_remote_command "git checkout $GIT_BRANCH && git pull" || exit_with_error_message "could not checkout $GIT_BRANCH"
     echo "### COMPLETED ###"
 


### PR DESCRIPTION
When running deploy.sh, the script now checks out a fresh copy of the `yarn.lock` file in case it was changed after deployment and differs from what is in source.  Also, when deleting metadata files and cleaning up subsampled data, clusters now have their `subsampled` flag correctly set to `false` after the cleanup to allow future subsampling when new metadata is provided.