### PR TITLE
Removing mandatory yarn upgrade from setup script

### DIFF
--- a/rails_startup.bash
+++ b/rails_startup.bash
@@ -18,7 +18,7 @@ then
 elif [[ $PASSENGER_APP_ENV = "development" ]]; then
     echo "*** UPGRADING/COMPILING NODE MODULES ***"
     # force upgrade in local development to ensure yarn.lock is continually updated
-    sudo -E -u app -H yarn upgrade
+    sudo -E -u app -H yarn install
     sudo -E -u app -H /home/app/webapp/bin/webpack
 fi
 if [[ -n $TCELL_AGENT_APP_ID ]] && [[ -n $TCELL_AGENT_API_KEY ]] ; then


### PR DESCRIPTION
After discussion with Jon, monthly sounds like the right frequency for running yarn upgrade, rather than every build.  I've created a recurring monthly meeting to remind me to run the yarn upgrade and test what results . (Jon is also on that invitation as backup).

