### PR TITLE
handle clusters with percent signs (SCP-2110)

### DIFF
--- a/app/views/site/_study_visualize.html.erb
+++ b/app/views/site/_study_visualize.html.erb
@@ -127,7 +127,7 @@
         var currSubsample = $('#subsample').val();
         // get new annotation options and re-render
         $.ajax({
-            url: "<%= get_new_annotations_path(accession: @study.accession, study_name: @study.url_safe_name)%>?cluster=" + newCluster + '&subsample=' + currSubsample,
+            url: "<%= get_new_annotations_path(accession: @study.accession, study_name: @study.url_safe_name)%>?cluster=" + encodeURIComponent(newCluster) + '&subsample=' + encodeURIComponent(currSubsample),
             method: 'GET',
             dataType: 'script',
             success: function (data) {

--- a/app/views/site/render_global_gene_expression_plots.js.erb
+++ b/app/views/site/render_global_gene_expression_plots.js.erb
@@ -81,7 +81,7 @@ $("#<%= @target %>-cluster").change(function() {
     var currAnnot = $('#<%= @target %>-annotation').val();
     // get new annotation options and re-render
     $.ajax({
-        url: "<%= get_new_annotations_path(study_name: @study.url_safe_name)%>?cluster=" + newCluster + '&target=<%= @target %>',
+        url: "<%= get_new_annotations_path(study_name: @study.url_safe_name)%>?cluster=" + encodeURIComponent(newCluster) + '&target=<%= @target %>',
         method: 'GET',
         dataType: 'script',
         success: function (data) {


### PR DESCRIPTION
because of the difficulty of setting up local test data for this, this was tested by modding the production site JS in the browser, with Jon as an impartial observer to confirm that it worked with the study that caused this ticket.  We also agreed that automated tests weren't worth the trouble for this, as % in cluster names is not permitted

Side note -- I recommend we come to a consensus on automatic whitespace formatting in our editors so that PRs are cleaner