### PR TITLE
Adding feature flags for users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,6 +91,15 @@ class User
   field :registered_for_firecloud, type: Boolean, default: false
   field :api_access_token, type: Hash
 
+  # feature_flags should be a hash of true/false values.  If unspecified for a given flag, the
+  # value from DEFAULT_FEATURE_FLAGS should be used.  Accordingly, the helper method feature_flags_with_defaults
+  # is provided
+  field :feature_flags, default: {}
+
+  DEFAULT_FEATURE_FLAGS = {
+    "faceted_search" => false
+  }
+
   ###
   #
   # OAUTH2 METHODS
@@ -259,6 +268,12 @@ class User
       Study.firecloud_client.add_user_to_group(group_name, 'member', self.email)
       Rails.logger.info "#{Time.zone.now}: user group registration complete"
     end
+  end
+
+  # merges the user flags with the defaults -- this should  always be used in place of feature_flags
+  # for determining whether to enable a feature for a given user.
+  def feature_flags_with_defaults
+    DEFAULT_FEATURE_FLAGS.merge(feature_flags ? feature_flags : {})
   end
 
   # helper method to migrate study ownership & shares from old email to new email

--- a/app/views/admin_configurations/edit_user.html.erb
+++ b/app/views/admin_configurations/edit_user.html.erb
@@ -29,6 +29,25 @@
   </div>
   <div class="form-group row">
     <div class="col-md-12">
+      <label>Feature flags</label>
+    </div>
+    <% @user.feature_flags_with_defaults.each do |key, value| %>
+      <div class="row <%= @user.feature_flags.key?(key) ? 'highlight' : '' %>">
+        <div class="col-md-3 text-right">
+          <label><%= key %>:</label>
+        </div>
+        <div class="col-md-6">
+          <select name="feature_flag_<%= key %>">
+            <option value="0" <%= @user.feature_flags[key] == false ? 'selected' : '' %>>False</option>
+            <option value="1" <%= @user.feature_flags[key] == true ? 'selected' : '' %>>True</option>
+            <option value="-" <%= @user.feature_flags.key?(key) ? '' : 'selected' %>>Default (<%= User::DEFAULT_FEATURE_FLAGS[key] %>)</option>
+          </select>
+        </div>
+      </div>
+     <% end %>
+  </div>
+  <div class="form-group row">
+    <div class="col-md-12">
       <%= f.submit 'Update User', class: 'btn btn-lg btn-success', id: 'save-user' %>
     </div>
   </div>

--- a/test/controllers/admin_configurations_controller_test.rb
+++ b/test/controllers/admin_configurations_controller_test.rb
@@ -1,0 +1,28 @@
+require "integration_test_helper"
+
+class AdminConfigurationsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+  # this test creates its own user since it needs to modify it as part of the test
+  def setup
+    @test_user = User.create(email: 'test_flags_user@gmail.com',
+                             password: 'password',
+                             password_confirmation: 'password')
+  end
+
+  def teardown
+    User.find_by(email: 'test_flags_user@gmail.com').destroy
+  end
+
+  test 'should process feature flag data correctly' do
+    @test_user.update!(feature_flags: {})
+
+    AdminConfigurationsController.process_feature_flag_form_data(@test_user, {feature_flag_faceted_search: '1'})
+    assert_equal({'faceted_search' => true}, @test_user.reload.feature_flags)
+
+    AdminConfigurationsController.process_feature_flag_form_data(@test_user, {feature_flag_faceted_search: '0'})
+    assert_equal({'faceted_search' => false}, @test_user.reload.feature_flags)
+
+    AdminConfigurationsController.process_feature_flag_form_data(@test_user, {faceted_search: '-'})
+    assert_equal({}, @test_user.reload.feature_flags)
+  end
+end


### PR DESCRIPTION
This should let us keep the advanced search branch on development, and then turn it on/off for demos, previews to lab users, etc...
The feature flags for a user can be updated via admin user UI.

![image](https://user-images.githubusercontent.com/2800795/73570517-82b65200-443a-11ea-9fd4-13eb683618cb.png)
