### PR TITLE
API endpoint for bulk download of search results

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,7 +391,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    swagger-blocks (2.0.2)
+    swagger-blocks (3.0.0)
     swagger_ui_engine (1.1.2)
       rails (>= 4.2)
       sass-rails

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -241,7 +241,7 @@ module Api
       def create_auth_code
         half_hour = 1800 # seconds
         otac_and_ti = current_api_user.create_totat(half_hour)
-        auth_code_response = {auth_code: otac_and_ti[:totat], time_interval: otac_and_ti[:ti]}
+        auth_code_response = {auth_code: otac_and_ti[:totat], time_interval: otac_and_ti[:time_interval]}
         render json: auth_code_response
       end
 
@@ -317,67 +317,40 @@ module Api
 
         # sanitize study accessions and file types
         sanitized_accessions = StudyAccession.sanitize_accessions(accessions)
+        valid_accessions = Study.where(:accession.in => sanitized_accessions).map(&:accession)
         sanitized_file_types = StudyFile::BULK_DOWNLOAD_TYPES & file_types # find array intersection
 
         # validate request parameters
         if totat.blank? || valid_totat == false
           render json: {error: 'Invalid authorization token'}, status: 403 and return
-        elsif sanitized_accessions.blank?
+        elsif valid_accessions.blank?
           render json: {error: 'Invalid request parameters; study accessions not found'}, status: 400 and return
         end
 
         # load the user from the auth token
         requested_user = valid_totat
 
-        # replace 'Expression' with both dense & sparse matrix file types
-        if sanitized_file_types.include?('Expression')
-          sanitized_file_types.delete_if {|file_type| file_type == 'Expression'}
-          sanitized_file_types += ['Expression Matrix', 'MM Coordinate Matrix']
-        end
-
         # get requested files
-        studies = Study.where(:accession.in => sanitized_accessions)
-        if sanitized_file_types.present?
-          files_requested = studies.map {
-              |study| study.study_files.by_type(sanitized_file_types)
-          }.flatten
-        else
-          files_requested = studies.map(&:study_files).flatten
+        # reference BulkDownloadService as ::BulkDownloadService to avoid NameError when resolving reference
+        files_requested = ::BulkDownloadService.get_requested_files(file_types: sanitized_file_types,
+                                                                    study_accessions: sanitized_accessions)
+
+        # determine quota impact & update user's download quota
+        # will throw a RuntimeError if the download exceeds the user's daily quota
+        begin
+          ::BulkDownloadService.update_user_download_quota(user: requested_user, files: files_requested)
+        rescue RuntimeError => e
+          render json: {error: e.message}, status: 403 and return
         end
 
-        # determine quota impact
-        download_quota = ApplicationController.get_download_quota
-        bytes_requested = files_requested.map(&:upload_file_size).reduce(:+)
-        user_bytes_allowed = requested_user.daily_download_quota + bytes_requested
-        if user_bytes_allowed > download_quota
-          render json: {error: 'Requested total file size exceeds user download quota'}, status: 403 and return
-        end
-
+        # generate curl config file
         logger.info "Beginning creation of curl configuration for user_id, auth token: #{requested_user.id}, #{totat}"
-        curl_configs = ['--create-dirs', '--compressed']
         start_time = Time.zone.now
-
-        # Get signed URLs for all files in the requested download objects, and update user quota
-        Parallel.map(files_requested, in_threads: 100) do |study_file|
-          client = FireCloudClient.new
-          curl_configs << self.class.get_curl_config(file: study_file, fc_client: client)
-          # send along any bundled files along with the parent
-          if study_file.is_bundle_parent?
-            study_file.bundled_files.each do |bundled_file|
-              curl_configs << self.class.get_curl_config(file: bundled_file, fc_client: client)
-            end
-          end
-        end
-        requested_user.update(daily_download_quota: bytes_requested)
-
-        # log results
+        @configuration = ::BulkDownloadService.generate_curl_configuration(study_files: files_requested, user: requested_user)
         end_time = Time.zone.now
         runtime = TimeDifference.between(start_time, end_time).humanize
         logger.info "Curl configs generated for studies #{sanitized_accessions}, #{files_requested.size} total files"
         logger.info "Total time in generating curl configuration: #{runtime}"
-
-        # send configuration file
-        @configuration = curl_configs.join("\n\n")
         send_data @configuration, type: 'text/plain', filename: 'cfg.txt'
       end
 
@@ -490,35 +463,6 @@ module Api
           matches[accession][:facet_search_weight] = search_weight
         end
         matches
-      end
-
-      # Helper method for generating a curl command to download a file from a bucket.  Returns file's curl config, size.
-      def self.get_curl_config(file:, fc_client: )
-
-        fc_client ||= Study.firecloud_client
-        # if a file is a StudyFile, use bucket_location, otherwise the :name key will contain its location (if DirectoryListing)
-        file_location = file.bucket_location
-        study = file.study
-        output_path = file.bulk_download_pathname
-
-        begin
-          signed_url = fc_client.execute_gcloud_method(:generate_signed_url, 0, study.bucket_id, file_location,
-                                                       expires: 1.day.to_i) # 1 day in seconds, 86400
-          curl_config = [
-              'url="' + signed_url + '"',
-              'output="' + output_path + '"'
-          ]
-        rescue => e
-          error_context = ErrorTracker.format_extra_context(study, file)
-          ErrorTracker.report_exception(e, current_user, error_context)
-          logger.error "Error generating signed url for #{output_path}; #{e.message}"
-          curl_config = [
-              '# Error downloading ' + output_path + '.  ' +
-                  'Did you delete the file in the bucket and not sync it in Single Cell Portal?'
-          ]
-        end
-
-        curl_config.join("\n")
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,13 +58,7 @@ class ApplicationController < ActionController::Base
 
   # retrieve the current download quota
   def get_download_quota
-    config_entry = AdminConfiguration.find_by(config_type: 'Daily User Download Quota')
-    if config_entry.nil? || config_entry.value_type != 'Numeric'
-      # fallback in case entry cannot be found or is set to wrong type
-      @download_quota = 2.terabytes
-    else
-      @download_quota = config_entry.convert_value_by_type
-    end
+    self.class.get_download_quota
   end
 
   #see if deployment has been scheduled
@@ -154,6 +148,17 @@ class ApplicationController < ActionController::Base
   def set_csrf_headers
     if request.xhr?
       cookies['XSRF-TOKEN'] = form_authenticity_token if cookies['XSRF-TOKEN'].blank?
+    end
+  end
+
+  # protected method to allow access from other controllers
+  def self.get_download_quota
+    config_entry = AdminConfiguration.find_by(config_type: 'Daily User Download Quota')
+    if config_entry.nil? || config_entry.value_type != 'Numeric'
+      # fallback in case entry cannot be found or is set to wrong type
+      @download_quota = 2.terabytes
+    else
+      @download_quota = config_entry.convert_value_by_type
     end
   end
 end

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -1,0 +1,118 @@
+##
+# BulkDownloadService: helper class for generating curl configuration files for initiating bulk downloads from
+# keyword and faceted search
+
+class BulkDownloadService
+
+  extend ErrorTracker
+
+  # Generate a String representation of a configuration file containing URLs and output paths to pass to
+  # curl for initiating bulk downloads
+  #
+  # * *params*
+  #   - +study_files+ (Array<StudyFile>) => Array of StudyFiles to be downloaded
+  #   - +user+ (User) => User requesting download
+  #
+  # * *return*
+  #   - (String) => String representation of signed URLs and output filepaths to pass to curl
+  def self.generate_curl_configuration(study_files:, user:)
+    curl_configs = ['--create-dirs', '--compressed']
+    # Get signed URLs for all files in the requested download objects, and update user quota
+    Parallel.map(study_files, in_threads: 100) do |study_file|
+      client = FireCloudClient.new
+      curl_configs << self.get_single_curl_command(file: study_file, fc_client: client, user: user)
+      # send along any bundled files along with the parent
+      if study_file.is_bundle_parent?
+        study_file.bundled_files.each do |bundled_file|
+          curl_configs << self.get_single_curl_command(file: bundled_file, fc_client: client, user: user)
+        end
+      end
+    end
+    curl_configs.join("\n\n")
+  end
+
+  # Update a user's download quota after assembling the list of files requested
+  # Since the download happens outside the purview of the portal, the quota impact is front-loaded
+  #
+  # * *params*
+  #   - +user+ (User) => User performing bulk download action
+  #   - +files+ (Array<StudyFile>) => Array of files requested
+  #
+  # * *raises*
+  #   - (RuntimeError) => User download quota exceeded
+  def self.update_user_download_quota(user:, files:)
+    download_quota = ApplicationController.get_download_quota
+    bytes_requested = files.map(&:upload_file_size).reduce(:+)
+    bytes_allowed = download_quota - user.daily_download_quota
+    if bytes_requested > bytes_allowed
+      raise RuntimeError.new "Total file size exceeds user download quota: #{bytes_requested} bytes requested, #{bytes_allowed} bytes allowed"
+    else
+      Rails.logger.info "Adding #{bytes_requested} bytes to user: #{user.id} download quota for bulk download"
+      user.daily_download_quota += bytes_requested
+      user.save
+    end
+  end
+
+  # Runs a pipeline.  Will call sub-methods to instantiate required objects to pass to
+  # Google::Apis::GenomicsV2alpha1::GenomicsService.run_pipeline
+  #
+  # * *params*
+  #   - +file_types+ (Array<String>) => Array of requested file types to be ingested
+  #   - +study_accessions+ (Array<String>) => Array of StudyAccession values from which to pull files
+  #
+  # * *return*
+  #   - (Array<StudyFile>) => Array of StudyFiles to pass to #generate_curl_config
+  def self.get_requested_files(file_types: [], study_accessions:)
+    # replace 'Expression' with both dense & sparse matrix file types
+    if file_types.include?('Expression')
+      file_types.delete_if {|file_type| file_type == 'Expression'}
+      file_types += ['Expression Matrix', 'MM Coordinate Matrix']
+    end
+
+    # get requested files
+    studies = Study.where(:accession.in => study_accessions)
+    if file_types.present?
+      return studies.map {
+          |study| study.study_files.by_type(file_types)
+      }.flatten
+    else
+      return studies.map(&:study_files).flatten
+    end
+  end
+
+  # Generate a String representation of a configuration file containing URLs and output paths to pass to
+  # curl for initiating bulk downloads
+  #
+  # * *params*
+  #   - +file+ (StudyFile) => StudyFiles to be downloaded
+  #   - +fc_client+ (FireCloudClient) => Client to call GCS and generate signed_url
+  #   - +user+ (User) => User requesting download
+  #
+  # * *return*
+  #   - (String) => String representation of single signed URL and output filepath to pass to curl
+  def self.get_single_curl_command(file:, fc_client:, user:)
+    fc_client ||= Study.firecloud_client
+    # if a file is a StudyFile, use bucket_location, otherwise the :name key will contain its location (if DirectoryListing)
+    file_location = file.bucket_location
+    study = file.study
+    output_path = file.bulk_download_pathname
+
+    begin
+      signed_url = fc_client.execute_gcloud_method(:generate_signed_url, 0, study.bucket_id, file_location,
+                                                   expires: 1.day.to_i) # 1 day in seconds, 86400
+      curl_config = [
+          'url="' + signed_url + '"',
+          'output="' + output_path + '"'
+      ]
+    rescue => e
+      error_context = ErrorTracker.format_extra_context(study, file)
+      ErrorTracker.report_exception(e, user, error_context)
+      Rails.logger.error "Error generating signed url for #{output_path}; #{e.message}"
+      curl_config = [
+          '# Error downloading ' + output_path + '.  ' +
+              'Did you delete the file in the bucket and not sync it in Single Cell Portal?'
+      ]
+    end
+    curl_config.join("\n")
+  end
+end

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -71,6 +71,7 @@ else
                     test/integration/tos_acceptance_test.rb
                     test/integration/study_creation_test.rb
                     test/api/search_controller_test.rb # running search test here to use data from study_creation_test
+                    test/models/bulk_download_service_test.rb
                     test/integration/study_validation_test.rb
                     test/integration/taxons_controller_test.rb
                     test/controllers/analysis_configurations_controller_test.rb
@@ -85,7 +86,6 @@ else
                     test/models/user_annotation_test.rb
                     test/models/analysis_configuration_test.rb
                     test/models/search_facet_test.rb
-                    test/models/bulk_download_service_test.rb
                     test/models/big_query_client_test.rb
   )
   for test_name in ${tests[*]}; do

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -85,6 +85,7 @@ else
                     test/models/user_annotation_test.rb
                     test/models/analysis_configuration_test.rb
                     test/models/search_facet_test.rb
+                    test/models/bulk_download_service_test.rb
                     test/models/big_query_client_test.rb
   )
   for test_name in ${tests[*]}; do

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,8 @@ module SingleCellPortal
 
     config.autoload_paths << Rails.root.join('lib')
     config.eager_load_paths << Rails.root.join('lib')
+    config.autoload_paths << Rails.root.join('app/lib')
+    config.eager_load_paths << Rails.root.join('app/lib')
 
     config.time_zone = 'Eastern Time (US & Canada)'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,8 @@ Rails.application.routes.draw do
         scope :search do
           get 'facets', to: 'search#facets', as: :search_facets
           get 'facet_filters', to: 'search#facet_filters', as: :search_facet_filters
+          post 'auth_code', to: 'search#create_auth_code', as: :create_auth_code
+          get 'bulk_download', to: 'search#bulk_download', as: :search_bulk_download
           get '/', to: 'search#index', as: :search
         end
       end

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -87,8 +87,8 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
     execute_http_request(:post, api_v1_create_auth_code_path)
     assert_response :success
-    assert_not_nil json['totat'], "Did not generate auth code; missing 'totat' field: #{json}"
-    auth_code = json['totat']
+    assert_not_nil json['auth_code'], "Did not generate auth code; missing 'totat' field: #{json}"
+    auth_code = json['auth_code']
     @user.reload
     assert_equal auth_code, @user.totat
 
@@ -103,7 +103,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     file_types = %w(Expression Metadata).join(',')
     execute_http_request(:post, api_v1_create_auth_code_path)
     assert_response :success
-    auth_code = json['totat']
+    auth_code = json['auth_code']
 
     files = study.study_files.by_type(['Expression Matrix', 'Metadata'])
     execute_http_request(:get, api_v1_search_bulk_download_path(

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -106,7 +106,6 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     auth_code = json['totat']
 
     files = study.study_files.by_type(['Expression Matrix', 'Metadata'])
-    filenames = files.map(&:upload_file_name)
     execute_http_request(:get, api_v1_search_bulk_download_path(
         auth_code: auth_code, accessions: study.accession, file_types: file_types)
     )

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -6,7 +6,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   include Requests::HttpHelpers
 
   setup do
-    @user = User.first
+    @user = User.find_by(email: 'testing.user.2@gmail.com')
     OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
                                                                            :provider => 'google_oauth2',
                                                                            :uid => '123545',
@@ -77,6 +77,48 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     result_count = json['studies'].size
     assert_equal study_count, result_count, "Did not find correct number of studies, expected #{study_count} but found #{result_count}"
     assert_equal @random_seed, json['studies'].first['term_matches']
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  # should generate an auth code for a given user
+  test 'should generate auth code' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    execute_http_request(:post, api_v1_create_auth_code_path)
+    assert_response :success
+    assert_not_nil json['totat'], "Did not generate auth code; missing 'totat' field: #{json}"
+    auth_code = json['totat']
+    @user.reload
+    assert_equal auth_code, @user.totat
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  # should generate a config text file to pass to curl for bulk download
+  test 'should generate curl config for bulk download' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    study = Study.find_by(name: "Test Study #{@random_seed}")
+    file_types = %w(Expression Metadata).join(',')
+    execute_http_request(:post, api_v1_create_auth_code_path)
+    assert_response :success
+    auth_code = json['totat']
+
+    files = study.study_files.by_type(['Expression Matrix', 'Metadata'])
+    filenames = files.map(&:upload_file_name)
+    execute_http_request(:get, api_v1_search_bulk_download_path(
+        auth_code: auth_code, accessions: study.accession, file_types: file_types)
+    )
+    assert_response :success
+
+    config_file = json
+    files.each do |file|
+      filename = file.upload_file_name
+      assert config_file.include?(filename), "Did not find URL for filename: #{filename}"
+      output_path = file.bulk_download_pathname
+      assert config_file.include?(output_path), "Did not correctly set output path for #{filename} to #{output_path}"
+    end
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/test/api_test_helper.rb
+++ b/test/api_test_helper.rb
@@ -6,7 +6,11 @@ module Requests
   module JsonHelpers
     # parse a response body as JSON
     def json
-      JSON.parse(@response.body)
+      if @response.content_type == 'application/json'
+        JSON.parse(@response.body)
+      else
+        @response.body
+      end
     end
   end
 

--- a/test/models/bulk_download_service_test.rb
+++ b/test/models/bulk_download_service_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class BulkDownloadServiceTest < ActiveSupport::TestCase
+
+  def setup
+    @user = User.find_by(email: 'testing.user.2@gmail.com')
+    @random_seed = File.open(Rails.root.join('.random_seed')).read.strip
+    @study = Study.find_by(name: "Test Study #{@random_seed}")
+  end
+
+  test 'should update user download quota' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    files = @study.study_files
+    starting_quota = @user.daily_download_quota
+    bytes_requested = files.map(&:upload_file_size).reduce(:+)
+    BulkDownloadService.update_user_download_quota(user: @user, files: files)
+    @user.reload
+    current_quota = @user.daily_download_quota
+    assert current_quota > starting_quota, "User download quota did not increase"
+    assert_equal current_quota, (starting_quota + bytes_requested),
+                 "User download quota did not increase by correct amount: #{current_quota} != #{starting_quota + bytes_requested}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should load requested files' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    requested_file_types = %w(Metadata Expression)
+    files = BulkDownloadService.get_requested_files(file_types: requested_file_types, study_accessions: [@study.accession])
+    assert_equal 2, files.size, "Did not find correct number of files, expected 2 but found #{files.size}"
+    expected_files = @study.study_files.by_type(['Metadata', 'Expression Matrix']).map(&:name).sort
+    found_files = files.map(&:name).sort
+    assert_equal expected_files, found_files, "Did not find the correct files, expected: #{expected_files} but found #{found_files}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  # should return curl configuration file contents
+  # mock call to GCS as this is covered in API/SearchControllerTest
+  test 'should generate curl configuration' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    study_file = @study.metadata_file
+    signed_url = "https://storage.googleapis.com/#{@study.bucket_id}/#{study_file.upload_file_name}"
+    output_path = study_file.bulk_download_pathname
+
+    # mock call to GCS
+    mock = Minitest::Mock.new
+    mock.expect :execute_gcloud_method, signed_url, [:generate_signed_url, Integer, String, String, Hash]
+
+    FireCloudClient.stub :new, mock do
+      configuration = BulkDownloadService.generate_curl_configuration(study_files: [study_file], user: @user)
+      mock.verify
+      assert configuration.include?(signed_url), "Configuration does not include expected signed URL (#{signed_url}): #{configuration}"
+      assert configuration.include?(output_path), "Configuration does not include expected output path (#{output_path}): #{configuration}"
+    end
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+end


### PR DESCRIPTION
Enabling bulk download of files from multiple studies as returned by keyword and faceted search from the search API.  Results are returned via the current `curl` configuration file feature, and downloads files in the following directory structure: <study_accession>/<file_type>/<filename>.  Also includes API endpoint for generating one-time authentication tokens (OTACs) to use in download requests.

This PR satisfies [SCP-2046](https://broadworkbench.atlassian.net/browse/SCP-2046).  