### PR TITLE
Adding branding group filter to search API

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,6 +31,7 @@
 //= require scp-igv
 //= require scp-ideogram
 //= require scp-dot-plot
+//= require react_rails/bulkDownloadClipboard
 
 var fileUploading = false;
 var PAGE_RENDERED = false;

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,7 +31,6 @@
 //= require scp-igv
 //= require scp-ideogram
 //= require scp-dot-plot
-//= require react_rails/bulkDownloadClipboard
 
 var fileUploading = false;
 var PAGE_RENDERED = false;

--- a/app/controllers/api/v1/api_docs_controller.rb
+++ b/app/controllers/api/v1/api_docs_controller.rb
@@ -57,7 +57,7 @@ module Api
           key :name, 'Taxons'
           key :description, 'List of available species, genome assemblies & annotations'
         end
-        key :host, "#{ENV['HOSTNAME']}"
+        key :host, "#{ENV['HOSTNAME']}#{ENV['NOT_DOCKERIZED'] ? ':3000' : nil}"
         key :basePath, '/single_cell/api/v1'
         key :consumes, ['application/json']
         key :produces, ['application/json']

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -7,6 +7,7 @@ module Api
       before_action :set_current_api_user!
       before_action :set_search_facet, only: :facet_filters
       before_action :set_search_facets_and_filters, only: :index
+      before_action :set_branding_group, only: :index
 
       swagger_path '/search' do
         operation :get do
@@ -38,6 +39,13 @@ module Api
             key :required, false
             key :type, :string
           end
+          parameter do
+            key :name, :scpbr
+            key :in, :query
+            key :description, 'Requested branding group (to filter results on)'
+            key :reqired, false
+            key :type, :string
+          end
           response 200 do
             key :description, 'Search parameters, Studies and StudyFiles'
             schema do
@@ -50,9 +58,21 @@ module Api
                 key :type, :string
                 key :title, 'Keywords used in search'
               end
-              property :page do
+              property :current_page do
+                key :type, :integer
+                key :title, 'Current page of paginated studies'
+              end
+              property :total_pages do
+                key :type, :integer
+                key :title, 'Total number of pages of studies'
+              end
+              property :total_entries do
+                key :type, :integer
+                key :title, 'Total number of studies matching search'
+              end
+              property :scpbr do
                 key :type, :string
-                key :title, 'Pagination control'
+                key :description, 'Requested branding group id'
               end
               property :facets do
                 key :type, :array
@@ -115,6 +135,11 @@ module Api
           @studies = @viewable
         end
 
+        # filter results by branding group, if specified
+        if @selected_branding_group.present?
+          @studies = @viewable.where(branding_group_id: @selected_branding_group.id)
+        end
+
         # only call BigQuery if list of possible studies is larger than 0 and we have matching facets to use
         if @studies.count > 0 && @facets.any?
           @studies_by_facet = {}
@@ -130,7 +155,7 @@ module Api
           @studies = @studies.where(:accession.in => @convention_accessions).order_by {|study| @studies_by_facet[study.accession][:facet_search_weight]}
         end
         # paginate results
-        @studies.paginate(page: params[:page], per_page: Study.per_page)
+        @results = @studies.paginate(page: params[:page], per_page: Study.per_page)
       end
 
       swagger_path '/search/facets' do
@@ -208,6 +233,10 @@ module Api
       end
 
       private
+
+      def set_branding_group
+        @selected_branding_group = BrandingGroup.find_by(name_as_id: params[:scpbr])
+      end
 
       def set_search_facet
         @search_facet = SearchFacet.find_by(identifier: params[:facet])

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -33,7 +33,7 @@ class StudyFile
   ASSEMBLY_REQUIRED_TYPES = ['BAM', 'Ideogram Annotations']
   GZIP_MAGIC_NUMBER = "\x1f\x8b".force_encoding(Encoding::ASCII_8BIT)
   REQUIRED_ATTRIBUTES = %w(file_type name)
-  BULK_DOWNLOAD_TYPES = ['Expression', 'Metadata', 'Cluster', 'Coordinate Labels','Fastq', 'BAM', 'Documentation',
+  BULK_DOWNLOAD_TYPES = ['Expression', 'Metadata', 'Cluster', 'Coordinate Labels', 'Fastq', 'BAM', 'Documentation',
                          'Other', 'Analysis Output', 'Ideogram Annotations']
 
   # Constants for scoping values for AnalysisParameter inputs/outputs

--- a/app/views/api/v1/search/_study.json.jbuilder
+++ b/app/views/api/v1/search/_study.json.jbuilder
@@ -18,11 +18,16 @@ if study.detached
   json.set! :study_files, 'Unavailable (cannot load study workspace or bucket)'
 else
   json.study_files do
-    json.set! :Metadata do
-      json.array! study.study_files.by_type('Metadata'), partial: 'api/v1/search/study_file', as: :study_file, locals: {study: study}
-    end
-    json.set! :Expression do
-      json.array! study.study_files.by_type(['Expression Matrix', 'MM Coordinate Matrix']), partial: 'api/v1/search/study_file', as: :study_file, locals: {study: study}
+    StudyFile::BULK_DOWNLOAD_TYPES.each do |file_category|
+      if file_category == 'Expression'
+        json.set! :Expression do
+          json.array! study.study_files.by_type(['Expression Matrix', 'MM Coordinate Matrix']), partial: 'api/v1/search/study_file', as: :study_file, locals: {study: study}
+        end
+      else
+        json.set! file_category do
+          json.array! study.study_files.by_type(file_category), partial: 'api/v1/search/study_file', as: :study_file, locals: {study: study}
+        end
+      end
     end
   end
 end

--- a/app/views/api/v1/search/index.json.jbuilder
+++ b/app/views/api/v1/search/index.json.jbuilder
@@ -1,5 +1,11 @@
 json.set! :type, params[:type]
 json.set! :terms, params[:terms]
+json.set! :current_page, @results.current_page.to_i
+json.set! :total_entries, @results.total_entries
+json.set! :total_pages, @results.total_pages
+if @selected_branding_group.present?
+  json.set! :scpbr, @selected_branding_group.name_as_id
+end
 json.facets do
   json.array! @facets do |facet|
     json.set! :id, facet[:id]
@@ -7,5 +13,5 @@ json.facets do
   end
 end
 json.studies do
-  json.array! @studies, partial: 'api/v1/search/study', as: :study
+  json.array! @results, partial: 'api/v1/search/study', as: :study
 end

--- a/config/filebeat/filebeat-Dockerfile
+++ b/config/filebeat/filebeat-Dockerfile
@@ -7,4 +7,5 @@ RUN chown root:filebeat /usr/share/filebeat/filebeat.yml
 RUN mkdir /usr/share/filebeat/conf.d
 COPY config/filebeat/nginx.yml config/filebeat/rails.yml /usr/share/filebeat/conf.d/
 RUN chown root:filebeat -R /usr/share/filebeat/conf.d
+RUN usermod -o -u 1004 filebeat
 USER filebeat

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -103,7 +103,7 @@ DirectoryListing.create!(name: 'csvs', file_type: 'csv', files: [{name: 'foo.csv
 StudyFileBundle.create!(bundle_type: 'BAM', original_file_list: [{'name' => 'sample_1.bam', 'file_type' => 'BAM'},
                                                                  {'name' => 'sample_1.bam.bai', 'file_type' => 'BAM Index'}],
                         study_id: api_study.id)
-User.create!(email:'testing.user.2@gmail.com', password:'someotherpassword',
+api_user = User.create!(email:'testing.user.2@gmail.com', password:'someotherpassword',
              api_access_token: {access_token: 'test-api-token-2', expires_in: 3600, expires_at: Time.zone.now + 1.hour})
 
 # Analysis Configuration seeds
@@ -121,3 +121,4 @@ SearchFacet.create(name: 'Disease', identifier: 'disease', filters: [{id: 'MONDO
                                    {name: 'Phenotype And Trait Ontology', url: 'https://www.ebi.ac.uk/ols/ontologies/pato'}],
                    is_ontology_based: true, is_array_based: true, big_query_id_column: 'disease', big_query_name_column: 'disease__ontology_label',
                    convention_name: 'alexandria_convention', convention_version: '1.1.3')
+BrandingGroup.create(name: 'Test Brand', user_id: api_user.id, font_family: 'Helvetica Neue, sans-serif', background_color: '#FFFFFF')

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -80,4 +80,27 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
+
+  test 'should filter search results by branding group' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # add study to branding group and search - should get 1 result
+    study = Study.find_by(name: "Test Study #{@random_seed}")
+    branding_group = BrandingGroup.first
+    study.update(branding_group_id: branding_group.id)
+
+    query_parameters = {type: 'study', terms: @random_seed, scpbr: branding_group.name_as_id}
+    execute_http_request(:get, api_v1_search_path(query_parameters))
+    assert_response :success
+    result_count = json['studies'].size
+    assert_equal 1, result_count, "Did not find correct number of studies, expected 1 but found #{result_count}"
+
+    # remove study from group and search again - should get 0 results
+    study.update(branding_group_id: nil)
+    execute_http_request(:get, api_v1_search_path(query_parameters))
+    assert_response :success
+    assert_empty json['studies'], "Did not find correct number of studies, expected 0 but found #{json['studies'].size}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
 end


### PR DESCRIPTION
Preserving behavior that if a user is inside a branding group, that filter will be applied to all search requests.  Only studies inside that branding group matching the search criteria will be returned.

This also includes fixes for pagination of search results, and returns all file types for search results to allow the UI to filter down what files the user would like to download.

This PR satisfies [SCP-2129](https://broadworkbench.atlassian.net/browse/SCP-2129).