### PR TITLE
fixing reference to study object for email delivery

### DIFF
--- a/app/models/parse_utils.rb
+++ b/app/models/parse_utils.rb
@@ -212,7 +212,7 @@ class ParseUtils
       matrix_study_file.destroy
       genes_study_file.destroy
       barcodes_study_file.destroy
-      SingleCellMailer.notify_user_parse_fail(user.email, "Gene-barcode matrix expression data in #{study.name} parse has failed", error_message, self).deliver_now
+      SingleCellMailer.notify_user_parse_fail(user.email, "Gene-barcode matrix expression data in #{study.name} parse has failed", error_message, study).deliver_now
       false
     end
   end
@@ -291,17 +291,17 @@ class ParseUtils
               Delayed::Job.enqueue(UploadCleanupJob.new(study, study_file, 0), run_at: run_at)
             end
           else
-            SingleCellMailer.notify_user_parse_fail(user.email, "Error: Zipfile extraction from inferCNV submission #{archive_file.options[:submission_id]} in #{study.name}", study_file.errors.full_messages.join(', '), self).deliver_now
+            SingleCellMailer.notify_user_parse_fail(user.email, "Error: Zipfile extraction from inferCNV submission #{archive_file.options[:submission_id]} in #{study.name}", study_file.errors.full_messages.join(', '), study).deliver_now
           end
         end
         # email user that file extraction is complete
         message = ['The following files were extracted from the Ideogram zip archive and added to your study:']
         files_created.each {|file| message << file}
-        SingleCellMailer.notify_user_parse_complete(user.email, "Zipfile extraction of inferCNV submission #{archive_file.options[:submission_id]} outputs has completed", message, self).deliver_now
+        SingleCellMailer.notify_user_parse_complete(user.email, "Zipfile extraction of inferCNV submission #{archive_file.options[:submission_id]} outputs has completed", message, study).deliver_now
       end
     rescue => e
       remove_extracted_archive_files(study, archive_file, extracted_files)
-      SingleCellMailer.notify_user_parse_fail(user.email, "Error: Zipfile extraction from inferCNV submission #{archive_file.options[:submission_id]} in #{study.name} has failed", e.message, self).deliver_now
+      SingleCellMailer.notify_user_parse_fail(user.email, "Error: Zipfile extraction from inferCNV submission #{archive_file.options[:submission_id]} in #{study.name} has failed", e.message, study).deliver_now
     end
   end
 


### PR DESCRIPTION
Fixing further broken references to the study object when parsing MTX files.

This PR addresses an issue found in Sentry: https://sentry.io/organizations/broad-institute/issues/1511302336/?environment=production&project=1424198