### PR TITLE
Fixing bug with @download_quota variable not set 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,7 +58,7 @@ class ApplicationController < ActionController::Base
 
   # retrieve the current download quota
   def get_download_quota
-    self.class.get_download_quota
+    @download_quota = self.class.get_download_quota
   end
 
   #see if deployment has been scheduled


### PR DESCRIPTION
This PR fixes a regression where the `@download_quota` variable is not being set in the ApplicationController, which causes auto-generated download links to fail when trying to check the impact against a user's download quota.