### PR TITLE
Annotation dropdown timing/logic refactoring

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1061,3 +1061,10 @@ function renderWithNewCluster(updateStatusText, renderCallback, setAnnotation=tr
         renderCallback();
     }
 }
+
+// extract out identifier for global gene search by trimming off last -cluster, -annotation, or -subsample
+function extractIdentifierFromId(domId) {
+    var idParts = domId.split('-');
+    idParts.pop();
+    return idParts.join('-');
+}

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1048,3 +1048,16 @@ function reopenUiTab(navTarget) {
         $(navTarget + ' a[href="' + tab + '"]').tab('show');
     }
 }
+
+// re-render a plot after a user selects a new cluster from the dropdown menu, usually called from a complete() callback
+// in an $.ajax() function
+function renderWithNewCluster(updateStatusText, renderCallback, setAnnotation=true) {
+    if (updateStatusText === 'success') {
+        if (setAnnotation) {
+            var an = $('#annotation').val();
+            $('#search_annotation').val(an);
+            $('#gene_set_annotation').val(an);
+        }
+        renderCallback();
+    }
+}

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -479,7 +479,7 @@ class SiteController < ApplicationController
       subsample = params[:subsample].blank? ? nil : params[:subsample].to_i
       @gene = load_best_gene_match(matches, params[:gene])
       @identifier = params[:identifier] # unique identifer for each plot for namespacing JS variables/functions (@gene.id)
-      @target = 'study-' + @study.url_safe_name + '-gene-' + params[:gene].gsub(/\W/, '-')
+      @target = 'study-' + @study.id + '-gene-' + @identifier
       @y_axis_title = load_expression_axis_title
       if @selected_annotation[:type] == 'group'
         @values = load_expression_boxplot_data_array_scores(@selected_annotation, subsample)

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -671,6 +671,8 @@ class SiteController < ApplicationController
   def get_new_annotations
     @cluster_annotations = load_cluster_group_annotations
     @target = params[:target].blank? ? nil : params[:target] + '-'
+    # used to match value of previous annotation with new values
+    @flattened_annotations = @cluster_annotations.values.map {|coll| coll.map(&:last)}.flatten
   end
 
   # return JSON representation of selected annotation

--- a/app/views/site/_study_visualize.html.erb
+++ b/app/views/site/_study_visualize.html.erb
@@ -130,7 +130,7 @@
             method: 'GET',
             dataType: 'script',
             complete: function (jqXHR, textStatus) {
-                renderWithNewCluster(textStatus, renderScatter());
+                renderWithNewCluster(textStatus, renderScatter);
             }
         });
     });

--- a/app/views/site/_study_visualize.html.erb
+++ b/app/views/site/_study_visualize.html.erb
@@ -123,25 +123,20 @@
         $('#search_cluster').val(newCluster);
         $('#gene_set_cluster').val(newCluster);
         // grab currently selected annotation
-        var currAnnot = $('#annotation').val();
         var currSubsample = $('#subsample').val();
         // get new annotation options and re-render
         $.ajax({
             url: "<%= get_new_annotations_path(accession: @study.accession, study_name: @study.url_safe_name)%>?cluster=" + encodeURIComponent(newCluster) + '&subsample=' + encodeURIComponent(currSubsample),
             method: 'GET',
             dataType: 'script',
-            success: function (data) {
-                // parse response as a string and see if currently selected annotation exists in new annotations
-                if (data.indexOf(currAnnot) >= 0) {
-                    $('#annotation').val(currAnnot);
-                }
-                $(document).ready(function () {
+            complete: function (jqXHR, textStatus) {
+                if (textStatus === 'success') {
                     // since we now have new annotations, we need to set them in the search form for persistence
                     var an = $('#annotation').val();
                     $('#search_annotation').val(an);
                     $('#gene_set_annotation').val(an);
                     renderScatter();
-                });
+                }
             }
         });
     });

--- a/app/views/site/_study_visualize.html.erb
+++ b/app/views/site/_study_visualize.html.erb
@@ -130,13 +130,7 @@
             method: 'GET',
             dataType: 'script',
             complete: function (jqXHR, textStatus) {
-                if (textStatus === 'success') {
-                    // since we now have new annotations, we need to set them in the search form for persistence
-                    var an = $('#annotation').val();
-                    $('#search_annotation').val(an);
-                    $('#gene_set_annotation').val(an);
-                    renderScatter();
-                }
+                renderWithNewCluster(textStatus, renderScatter());
             }
         });
     });

--- a/app/views/site/_view_gene_expression.html.erb
+++ b/app/views/site/_view_gene_expression.html.erb
@@ -122,7 +122,7 @@
           $('#gene_set_cluster').val(newCluster);
           // get new annotation options and re-render
           $.ajax({
-              url: "<%= get_new_annotations_path(accession: params[:accession], study_name: params[:study_name])%>?cluster=" + newCluster,
+              url: "<%= get_new_annotations_path(accession: params[:accession], study_name: params[:study_name])%>?cluster=" + encodeURIComponent(newCluster),
               method: 'GET',
               dataType: 'script',
               complete: function (jqXHR, textStatus) {

--- a/app/views/site/_view_gene_expression.html.erb
+++ b/app/views/site/_view_gene_expression.html.erb
@@ -126,13 +126,7 @@
               method: 'GET',
               dataType: 'script',
               complete: function (jqXHR, textStatus) {
-                  if (textStatus === 'success') {
-                      // since we now have new annotations, we need to set them in the search form for persistence
-                      var an = $('#annotation').val();
-                      $('#search_annotation').val(an);
-                      $('#gene_set_annotation').val(an);
-                      renderGeneExpressionPlots();
-                  }
+                  renderWithNewCluster(textStatus, renderGeneExpressionPlots());
               }
           });
       });

--- a/app/views/site/_view_gene_expression.html.erb
+++ b/app/views/site/_view_gene_expression.html.erb
@@ -120,25 +120,19 @@
           // keep track for search purposes
           $('#search_cluster').val(newCluster);
           $('#gene_set_cluster').val(newCluster);
-          // grab currently selected annotation
-          var currAnnot = $('#annotation').val();
           // get new annotation options and re-render
           $.ajax({
               url: "<%= get_new_annotations_path(accession: params[:accession], study_name: params[:study_name])%>?cluster=" + newCluster,
               method: 'GET',
               dataType: 'script',
-              success: function (data) {
-                  // parse response as a string and see if currently selected annotation exists in new annotations
-                  if (data.indexOf(currAnnot) >= 0) {
-                      $('#annotation').val(currAnnot);
-                  }
-                  $(document).ready(function () {
+              complete: function (jqXHR, textStatus) {
+                  if (textStatus === 'success') {
                       // since we now have new annotations, we need to set them in the search form for persistence
                       var an = $('#annotation').val();
                       $('#search_annotation').val(an);
                       $('#gene_set_annotation').val(an);
                       renderGeneExpressionPlots();
-                  });
+                  }
               }
           });
       });

--- a/app/views/site/_view_gene_expression.html.erb
+++ b/app/views/site/_view_gene_expression.html.erb
@@ -126,7 +126,7 @@
               method: 'GET',
               dataType: 'script',
               complete: function (jqXHR, textStatus) {
-                  renderWithNewCluster(textStatus, renderGeneExpressionPlots());
+                  renderWithNewCluster(textStatus, renderGeneExpressionPlots);
               }
           });
       });

--- a/app/views/site/_view_gene_expression_heatmap.html.erb
+++ b/app/views/site/_view_gene_expression_heatmap.html.erb
@@ -153,7 +153,7 @@
             method: 'GET',
             dataType: 'script',
             complete: function (jqXHR, textStatus) {
-                renderWithNewCluster(textStatus, drawHeatmap());
+                renderWithNewCluster(textStatus, drawHeatmap);
             }
         });
     });

--- a/app/views/site/_view_gene_expression_heatmap.html.erb
+++ b/app/views/site/_view_gene_expression_heatmap.html.erb
@@ -152,18 +152,14 @@
             url: "<%= get_new_annotations_path(study: params[:study])%>?cluster=" + newCluster,
             method: 'GET',
             dataType: 'script',
-            success: function (data) {
-                // parse response as a string and see if currently selected annotation exists in new annotations
-                if (data.indexOf(currAnnot) >= 0) {
-                    $('#annotation').val(currAnnot);
-                }
-                $(document).ready(function () {
+            complete: function (jqXHR, textStatus) {
+                if (textStatus === 'success') {
                     // since we now have new annotations, we need to set them in the search form for persistence
                     var an = $('#annotation').val();
                     $('#search_annotation').val(an);
                     $('#gene_set_annotation').val(an);
                     drawHeatmap();
-                });
+                }
             }
         });
     });

--- a/app/views/site/_view_gene_expression_heatmap.html.erb
+++ b/app/views/site/_view_gene_expression_heatmap.html.erb
@@ -153,13 +153,7 @@
             method: 'GET',
             dataType: 'script',
             complete: function (jqXHR, textStatus) {
-                if (textStatus === 'success') {
-                    // since we now have new annotations, we need to set them in the search form for persistence
-                    var an = $('#annotation').val();
-                    $('#search_annotation').val(an);
-                    $('#gene_set_annotation').val(an);
-                    drawHeatmap();
-                }
+                renderWithNewCluster(textStatus, drawHeatmap());
             }
         });
     });

--- a/app/views/site/_view_gene_expression_heatmap.html.erb
+++ b/app/views/site/_view_gene_expression_heatmap.html.erb
@@ -81,8 +81,8 @@
         $('#search_annotation').val(''); // clear value first
         $("#search_annotation").val(selectedAnnot);
         var requestToken = '<%= user_signed_in? ? current_user.id.to_s + ':' + current_user.authentication_token : nil %>';
-        dataPath += '&cluster=' + cluster + '&request_user_token=' + requestToken;
-        var newAnnotPath = '<%= annotation_query_path(accession: params[:accession], study_name: params[:study_name]) %>?cluster=' + cluster + '&annotation=' + selectedAnnot + '&request_user_token=' + requestToken;
+        dataPath += '&cluster=' + encodeURIComponent(cluster) + '&request_user_token=' + requestToken;
+        var newAnnotPath = '<%= annotation_query_path(accession: params[:accession], study_name: params[:study_name]) %>?cluster=' + encodeURIComponent(cluster) + '&annotation=' + encodeURIComponent(selectedAnnot) + '&request_user_token=' + requestToken;
         var colorScalingMode = 'relative';
         // determine whether to scale row colors globally or by row
         if (heatmap_row_centering !== '') {

--- a/app/views/site/get_new_annotations.js.erb
+++ b/app/views/site/get_new_annotations.js.erb
@@ -7,6 +7,6 @@ selectedAnnotationElement.html("<%= escape_javascript(select_tag :annotation, gr
 // also reload subsampling options as they may have changed
 selectedSubsampleElement.html("<%= escape_javascript(select_tag :subsample, options_for_select(subsampling_options(@cluster.points), params[:subsample]), {include_blank: 'All Cells', class: 'form-control'}) %>");
 
-if (annotationData.indexOf(selectedAnnotation) >= 0) {
+if (annotationData.includes(selectedAnnotation)) {
     selectedAnnotationElement.val(selectedAnnotation);
 }

--- a/app/views/site/get_new_annotations.js.erb
+++ b/app/views/site/get_new_annotations.js.erb
@@ -1,3 +1,10 @@
+// dump out annotation dropdown values to see if we have a match for the existing selected annotation
+var annotationData = <%= raw @cluster_annotations.values.map {|coll| coll.map(&:last)}.flatten %>;
+var selectedAnnotation = $("#<%= @target %>annotation").val();
 $("#<%= @target %>annotation").html("<%= escape_javascript(select_tag :annotation, grouped_options_for_select(@cluster_annotations, params[:annotation]), class: 'form-control' )%>");
 // also reload subsampling options as they may have changed
 $("#<%= @target %>subsample").html("<%= escape_javascript(select_tag :subsample, options_for_select(subsampling_options(@cluster.points), params[:subsample]), {include_blank: 'All Cells', class: 'form-control'}) %>");
+
+if (annotationData.indexOf(selectedAnnotation) >= 0) {
+    $("#<%= @target %>annotation").val(selectedAnnotation);
+}

--- a/app/views/site/get_new_annotations.js.erb
+++ b/app/views/site/get_new_annotations.js.erb
@@ -1,10 +1,12 @@
 // dump out annotation dropdown values to see if we have a match for the existing selected annotation
-var annotationData = <%= raw @cluster_annotations.values.map {|coll| coll.map(&:last)}.flatten %>;
-var selectedAnnotation = $("#<%= @target %>annotation").val();
-$("#<%= @target %>annotation").html("<%= escape_javascript(select_tag :annotation, grouped_options_for_select(@cluster_annotations, params[:annotation]), class: 'form-control' )%>");
+var annotationData = <%= raw @flattened_annotations %>;
+var selectedAnnotationElement = $("#<%= @target %>annotation");
+var selectedAnnotation = selectedAnnotationElement.val();
+var selectedSubsampleElement = $("#<%= @target %>subsample");
+selectedAnnotationElement.html("<%= escape_javascript(select_tag :annotation, grouped_options_for_select(@cluster_annotations, params[:annotation]), class: 'form-control' )%>");
 // also reload subsampling options as they may have changed
-$("#<%= @target %>subsample").html("<%= escape_javascript(select_tag :subsample, options_for_select(subsampling_options(@cluster.points), params[:subsample]), {include_blank: 'All Cells', class: 'form-control'}) %>");
+selectedSubsampleElement.html("<%= escape_javascript(select_tag :subsample, options_for_select(subsampling_options(@cluster.points), params[:subsample]), {include_blank: 'All Cells', class: 'form-control'}) %>");
 
 if (annotationData.indexOf(selectedAnnotation) >= 0) {
-    $("#<%= @target %>annotation").val(selectedAnnotation);
+    selectedAnnotationElement.val(selectedAnnotation);
 }

--- a/app/views/site/render_global_gene_expression_plots.js.erb
+++ b/app/views/site/render_global_gene_expression_plots.js.erb
@@ -57,7 +57,7 @@ function renderDistribution<%= @identifier %>() {
     var annotation = $('#<%= @target %>-annotation').val();
     var subsample = $('#<%= @target %>-subsample').val();
     var identifier = '<%= @identifier %>'
-    url += 'cluster=' + cluster + '&annotation=' + annotation + '&subsample=' + subsample + '&identifier=' + identifier;
+    url += 'cluster=' + encodeURIComponent(cluster) + '&annotation=' + encodeURIComponent(annotation) + '&subsample=' + subsample + '&identifier=' + identifier;
     // append request token to validate XHR requests
     var requestToken = '<%= params[:request_user_token] %>'
     url += '&request_user_token=' + requestToken;
@@ -78,22 +78,16 @@ $("#<%= @target %>-annotation, #<%= @target %>-subsample").change(function() {
 $("#<%= @target %>-cluster").change(function() {
     $('#cluster-plot').data('rendered', false);
     var newCluster = $(this).val();
-    var currAnnot = $('#<%= @target %>-annotation').val();
     // get new annotation options and re-render
     $.ajax({
         url: "<%= get_new_annotations_path(study_name: @study.url_safe_name)%>?cluster=" + encodeURIComponent(newCluster) + '&target=<%= @target %>',
         method: 'GET',
         dataType: 'script',
-        success: function (data) {
+        complete: function (jqXHR, textStatus) {
             // parse response as a string and see if currently selected annotation exists in new annotations
-            if (data.indexOf(currAnnot) >= 0) {
-                $('#<%= @target %>-annotation').val(currAnnot);
+            if (textStatus === 'success') {
+                renderDistribution<%= @identifier %>();
             }
-            $(document).ready(function () {
-                // since we now have new annotations, we need to set them in the search form for persistence
-                var an = $('#annotation').val();
-                renderDistribution<%= @identifier %>()
-            });
         }
     });
 });

--- a/app/views/site/render_global_gene_expression_plots.js.erb
+++ b/app/views/site/render_global_gene_expression_plots.js.erb
@@ -45,48 +45,4 @@ var expressionData_<%= @identifier %> = [];
     Plotly.newPlot(exp_target_<%= @identifier %>, expressionData_<%= @identifier %>, expressionLayout_<%= @identifier %>);
 <% end %>
 
-
-function renderDistribution<%= @identifier %>() {
-    var target = document.getElementById('study-<%= @study.url_safe_name %>-gene-<%= params[:gene] %>-plot');
-    $(target).data('rendered', false);
-    // no need to store spinners in data attribute as entire plot div will be re-rendered
-    new Spinner(opts).spin(target);
-
-    var url = '<%= render_global_gene_expression_plots_path(accession: @study.accession, study_name: @study.url_safe_name, gene: params[:gene]) %>?';
-    var cluster = $('#<%= @target %>-cluster').val();
-    var annotation = $('#<%= @target %>-annotation').val();
-    var subsample = $('#<%= @target %>-subsample').val();
-    var identifier = '<%= @identifier %>'
-    url += 'cluster=' + encodeURIComponent(cluster) + '&annotation=' + encodeURIComponent(annotation) + '&subsample=' + subsample + '&identifier=' + identifier;
-    // append request token to validate XHR requests
-    var requestToken = '<%= params[:request_user_token] %>'
-    url += '&request_user_token=' + requestToken;
-
-    // make call to load distribution plot
-    $.ajax({
-        url: url,
-        method: 'GET',
-        dataType: 'script'
-    });
-}
-
-// listener for cluster nav, specific to study page
-$("#<%= @target %>-annotation, #<%= @target %>-subsample").change(function() {
-    renderDistribution<%= @identifier %>()
-});
-
-$("#<%= @target %>-cluster").change(function() {
-    $('#cluster-plot').data('rendered', false);
-    var newCluster = $(this).val();
-    // get new annotation options and re-render
-    $.ajax({
-        url: "<%= get_new_annotations_path(study_name: @study.url_safe_name)%>?cluster=" + encodeURIComponent(newCluster) + '&target=<%= @target %>',
-        method: 'GET',
-        dataType: 'script',
-        complete: function (jqXHR, textStatus) {
-            renderWithNewCluster(textStatus, renderDistribution<%= @identifier %>(), false);
-        }
-    });
-});
-
-$('#' + exp_target_<%= @identifier %>).data('rendered', true)
+$('#' + exp_target_<%= @identifier %>).data('rendered', true);

--- a/app/views/site/render_global_gene_expression_plots.js.erb
+++ b/app/views/site/render_global_gene_expression_plots.js.erb
@@ -84,10 +84,7 @@ $("#<%= @target %>-cluster").change(function() {
         method: 'GET',
         dataType: 'script',
         complete: function (jqXHR, textStatus) {
-            // parse response as a string and see if currently selected annotation exists in new annotations
-            if (textStatus === 'success') {
-                renderDistribution<%= @identifier %>();
-            }
+            renderWithNewCluster(textStatus, renderDistribution<%= @identifier %>(), false);
         }
     });
 });

--- a/app/views/site/search/_gene_result.html.erb
+++ b/app/views/site/search/_gene_result.html.erb
@@ -1,4 +1,4 @@
-<div class="panel panel-default gene-panel" id="study-<%= study.url_safe_name %>-gene-<%= gene.name.gsub(/\W/, '-') %>">
+<div class="panel panel-default gene-panel" id="study-<%= study.id %>-gene-<%= gene.id %>" data-study="study-<%= study.url_safe_name %>">
   <div class="panel-heading">
     <div class="panel-title">
       <h4><%= gene.name %></h4>
@@ -6,9 +6,9 @@
   </div>
   <div class="panel-body">
     <div class="row">
-      <div class="col-md-10 gene-result-view-plot" id="study-<%= study.url_safe_name %>-gene-<%= gene.name.gsub(/\W/, '-') %>-plot"></div>
+      <div class="col-md-10 gene-result-view-plot" id="study-<%= study.id %>-gene-<%= gene.id %>-plot"></div>
       <div class="col-md-2">
-        <div id="study-<%= study.url_safe_name %>-gene-<%= gene.name.gsub(/\W/, '-') %>-options" class="top-pad"></div>
+        <div id="study-<%= study.id %>-gene-<%= gene.id %>-options" class="top-pad"></div>
       </div>
     </div>
   </div>
@@ -16,29 +16,38 @@
 
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
 
-    $('#study-<%= study.url_safe_name %>-gene-<%= gene.name.gsub(/\W/, '-') %>-plot').data('rendered', false);
+    var geneSearchKey = "study-<%= study.id %>-gene-<%= gene.id %>";
+    var resultsIdentifier = geneSearchKey + '-plot';
+    $('#' + resultsIdentifier).data('rendered', false);
+    var geneId = '<%= gene.id %>';
 
-    var url = '<%= render_global_gene_expression_plots_path(accession: study.accession, study_name: study.url_safe_name, gene: gene.name) %>?';
+    var renderUrl = '<%= render_global_gene_expression_plots_path(accession: study.accession, study_name: study.url_safe_name, gene: gene.name) %>';
+    var annotationUrl = '<%= get_new_annotations_path(accession: study.accession, study_name: study.url_safe_name)%>';
+    window.GLOBAL_GENE_SEARCH_RESULTS[geneSearchKey] = {
+        renderUrl: renderUrl,
+        annotationUrl: annotationUrl,
+        geneId: geneId
+    };
+
     var cluster = '<%= study.default_cluster.name %>';
     var annotation = '<%= study.default_annotation %>';
-    var identifier = '<%= identifier %>';
-    url += 'cluster=' + encodeURIComponent(cluster) + '&annotation=' + encodeURIComponent(annotation) + '&identifier=' + identifier;
+    renderUrl += '?cluster=' + encodeURIComponent(cluster) + '&annotation=' + encodeURIComponent(annotation) + '&identifier=' + geneId;
     // append request token to validate XHR requests
     var requestToken = '<%= user_signed_in? ? current_user.id.to_s + ':' + current_user.authentication_token : nil %>';
-    url += '&request_user_token=' + requestToken;
+    renderUrl += '&request_user_token=' + requestToken;
     // subsample if necessary
     if (<%= study.default_cluster.points >= 10000 %>) {
-        url += '&subsample=10000'
+        renderUrl += '&subsample=10000'
     }
 
-    var target1 = document.getElementById('study-<%= study.url_safe_name %>-gene-<%= gene.name %>-plot');
+    var spinTarget = document.getElementById(resultsIdentifier);
 
     // no need to store spinners in data attribute as entire plot div will be re-rendered
-    new Spinner(opts).spin(target1);
+    new Spinner(opts).spin(spinTarget);
 
     // make call to load distribution plot
     $.ajax({
-        url: url,
+        url: renderUrl,
         method: 'GET',
         dataType: 'script'
     });

--- a/app/views/site/search/_gene_result.html.erb
+++ b/app/views/site/search/_gene_result.html.erb
@@ -22,7 +22,7 @@
     var cluster = '<%= study.default_cluster.name %>';
     var annotation = '<%= study.default_annotation %>';
     var identifier = '<%= identifier %>';
-    url += 'cluster=' + cluster + '&annotation=' + annotation + '&identifier=' + identifier;
+    url += 'cluster=' + encodeURIComponent(cluster) + '&annotation=' + encodeURIComponent(annotation) + '&identifier=' + identifier;
     // append request token to validate XHR requests
     var requestToken = '<%= user_signed_in? ? current_user.id.to_s + ':' + current_user.authentication_token : nil %>';
     url += '&request_user_token=' + requestToken;

--- a/app/views/site/search/_gene_result_view_options.html.erb
+++ b/app/views/site/search/_gene_result_view_options.html.erb
@@ -1,14 +1,14 @@
 <div class="form-group">
   <%= label_tag "#{@target}-cluster".to_sym, 'Load cluster' %><br />
-  <%= select_tag "#{@target}-cluster".to_sym, options_for_select(@options, set_cluster_value(@study, params)), class: 'form-control cluster-select' %>
+  <%= select_tag "#{@target}-cluster".to_sym, options_for_select(@options, set_cluster_value(@study, params)), class: 'form-control cluster-select global-gene-cluster' %>
 </div>
 
 <div class="form-group">
   <%= label_tag "#{@target}-annotation".to_sym, 'Select annotation' %><br />
-  <%= select_tag "#{@target}-annotation".to_sym, grouped_options_for_select(@cluster_annotations, set_annotation_value(@study, params)), class: 'form-control annotation-select' %>
+  <%= select_tag "#{@target}-annotation".to_sym, grouped_options_for_select(@cluster_annotations, set_annotation_value(@study, params)), class: 'form-control annotation-select global-gene-annotation' %>
 </div>
 
 <div class="form-group">
   <%= label_tag "#{@target}-subsample".to_sym, 'Subsampling threshold' %>&nbsp;<i class='fas fa-question-circle' title="Take a representative subsample of the current cluster.  Choosing all cells may dramatically increase rendering time." data-toggle="tooltip"></i><br />
-  <%= select_tag "#{@target}-subsample".to_sym, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), {include_blank: @cluster.points < ClusterGroup::MAX_THRESHOLD ? 'All Cells' : false, class: 'form-control subsample-select'} %>
+  <%= select_tag "#{@target}-subsample".to_sym, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), {include_blank: @cluster.points < ClusterGroup::MAX_THRESHOLD ? 'All Cells' : false, class: 'form-control subsample-select global-gene-subsample'} %>
 </div>

--- a/app/views/site/search/_search_genes.html.erb
+++ b/app/views/site/search/_search_genes.html.erb
@@ -37,6 +37,7 @@
             alert('Please enter a term before searching.');
             return false;
         } else {
+            window.GLOBAL_GENE_SEARCH_RESULTS = {};
             $('#page').val('1');
             $("#gene-search-results").empty();
             $('#gene-search-results-count').html($('div.gene-panel').length);
@@ -60,6 +61,56 @@
             ga('send', 'event', 'engaged_user_action', 'global_gene_search');
             return true;
         }
+    });
+
+    function renderDistribution(identifier) {
+        var studyAttr = window.GLOBAL_GENE_SEARCH_RESULTS[identifier];
+        var geneExpUrl = studyAttr.renderUrl;
+        var targetPlot = document.getElementById(identifier + '-plot');
+        var geneId = studyAttr.geneId;
+
+        $(targetPlot).data('rendered', false);
+        // no need to store spinners in data attribute as entire plot div will be re-rendered
+        new Spinner(opts).spin(targetPlot);
+
+        var cluster = $('#' + identifier + '-cluster').val();
+        var annotation = $('#' + identifier + '-annotation').val();
+        var subsample = $('#' + identifier + '-subsample').val();
+        geneExpUrl += '?cluster=' + encodeURIComponent(cluster) + '&annotation=' + encodeURIComponent(annotation) +
+        '&subsample=' + subsample + '&identifier=' + geneId;
+        // append request token to validate XHR requests
+        var requestToken = '<%= user_signed_in? ? current_user.id.to_s + ':' + current_user.authentication_token : nil %>';
+        geneExpUrl += '&request_user_token=' + requestToken;
+
+        // make call to load distribution plot
+        $.ajax({
+            url: geneExpUrl,
+            method: 'GET',
+            dataType: 'script'
+        });
+    }
+
+    // listener for cluster nav, specific to study page
+    $('#gene-search-results').on('change', '.global-gene-annotation, global-gene-subsample', function () {
+        var identifier = extractIdentifierFromId($(this).attr('id'));
+        renderDistribution(identifier);
+    });
+
+    $('#gene-search-results').on('change', '.global-gene-cluster', function() {
+        var newCluster = $(this).val();
+        var identifier = extractIdentifierFromId($(this).attr('id'));
+        var annotUrl = window.GLOBAL_GENE_SEARCH_RESULTS[identifier].annotationUrl;
+        var that = $(this); // store original context
+        // get new annotation options and re-render
+        $.ajax({
+            url: annotUrl + "?cluster=" + encodeURIComponent(newCluster) + '&target=' + identifier,
+            method: 'GET',
+            dataType: 'script',
+            complete: function (jqXHR, textStatus) {
+                var callback = $.proxy(renderDistribution, that, identifier);
+                renderWithNewCluster(textStatus, callback, false);
+            }
+        });
     });
 
 </script>

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -3146,10 +3146,14 @@ class UiTestSuite < Test::Unit::TestCase
     submit = @driver.find_element(:id, 'submit-gene-search')
     submit.click
     # wait until the plot has rendered
-    panel_id = "study-test-study-#{$random_seed}-gene-#{gene}"
+    panel = @driver.find_element(:xpath, "//div[@data-study='study-test-study-#{$random_seed}']")
+    panel_id = panel['id']
     plot_id = panel_id + '-plot'
-    while !element_present?(:id, plot_id)
+    counter = 0
+    while !element_present?(:id, plot_id) && counter < 5
       scroll_to(:bottom) # pagination test
+      sleep 5
+      count += 1
     end
     @wait.until {wait_for_plotly_render('#' + plot_id, 'rendered')}
     panel_div = @driver.find_element(:id, panel_id)
@@ -3178,12 +3182,15 @@ class UiTestSuite < Test::Unit::TestCase
     second_search_genes_form.send_keys(gene)
     submit = @driver.find_element(:id, 'submit-gene-search')
     submit.click
-    while !element_present?(:id, plot_id)
-      scroll_to(:bottom)
+    while !element_present?(:id, plot_id) && counter < 5
+      scroll_to(:bottom) # pagination test
+      sleep 5
+      count += 1
     end
     @wait.until {wait_for_plotly_render('#' + plot_id, 'rendered')}
     # wait until the plot has rendered
-    private_panel_id = "study-private-study-#{$random_seed}-gene-#{gene}"
+    private_panel = @driver.find_element(:xpath, "//div[@data-study='study-private-study-#{$random_seed}']")
+    private_panel_id = private_panel['id']
     private_plot_id = private_panel_id + '-plot'
     @wait.until {wait_for_plotly_render('#' + private_plot_id, 'rendered')}
     private_panel_div = @driver.find_element(:id, private_panel_id)


### PR DESCRIPTION
Refactoring the timing and logic of how the `get_new_annotations` is handled by moving the code to update the value of the dropdown menu itself into the JS response view, and then moving the subsequent call to re-render a cluster/heatmap/violin/dot plot into the `complete` handler, rather than the `success` handler.

Also addressing lingering issues with % encoding of parameters in URLs.

This PR satisfies [SCP-2118](https://broadworkbench.atlassian.net/browse/SCP-2118).