### PR TITLE
Adding data_type to SearchFacet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'minitest-rails'
 gem 'minitest-reporters'
 
-group :development do
+group :development, :test do
   # Access an IRB console on exception pages or by using <%= console %> in views
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
@@ -46,16 +46,12 @@ group :development do
   gem 'byebug'
 end
 
-group :test do
-  gem 'byebug'
-end
-
 gem 'devise'
 gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection'
 gem 'googleauth'
 gem 'google-cloud-storage', require: 'google/cloud/storage'
-gem 'google-cloud-bigquery', require: "google/cloud/bigquery"
+gem 'google-cloud-bigquery', require: 'google/cloud/bigquery'
 gem 'selenium-webdriver'
 gem 'jquery-ui-rails'
 gem 'bootstrap-sass', :git => 'https://github.com/twbs/bootstrap-sass'

--- a/app/lib/search_facet_populator.rb
+++ b/app/lib/search_facet_populator.rb
@@ -40,7 +40,7 @@ class SearchFacetPopulator
       # check if response has expected keys; if not, default to URL for name value
       ontology_name = ontology.dig('config', 'title') ? ontology['config']['title'] : url
       updated_facet.ontology_urls = [{name: ontology_name, url: url}]
-      end
+    end
     updated_facet.save!
     updated_facet
   end

--- a/app/lib/search_facet_populator.rb
+++ b/app/lib/search_facet_populator.rb
@@ -43,7 +43,6 @@ class SearchFacetPopulator
       updated_facet.ontology_urls = [{name: ontology_name, url: url}]
       end
     updated_facet.save!
-    updated_facet.update_filter_values!
     updated_facet
   end
 

--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -32,7 +32,9 @@ class SearchFacet
   validates_presence_of :name, :identifier, :data_type, :big_query_id_column, :big_query_name_column, :convention_name, :convention_version
   validates_uniqueness_of :big_query_id_column, scope: [:convention_name, :convention_version]
   validate :ensure_ontology_url_format, if: proc {|attributes| attributes[:is_ontology_based]}
-  before_create :set_data_type_and_array, if: proc {|attributes| attributes[:is_array_based].blank? || attributes[:data_type].blank?}
+  before_validation :set_data_type_and_array, on: :create,
+                    if: proc {|attr| (attr[:is_array_based].blank? || attr[:data_type].blank?) && attr[:big_query_id_column].present?}
+  after_create :update_filter_values!
 
   swagger_schema :SearchFacet do
     key :required, [:name, :identifier, :data_type, :big_query_id_column, :big_query_name_column, :convention_name, :convention_version]

--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -15,20 +15,27 @@ class SearchFacet
   field :filters, type: Array, default: []
   field :is_ontology_based, type: Boolean, default: false
   field :ontology_urls, type: Array, default: []
+  field :data_type, type: String
   field :is_array_based, type: Boolean
-  field :is_numeric, type: Boolean, default: false
   field :big_query_id_column, type: String
   field :big_query_name_column, type: String
   field :convention_name, type: String
   field :convention_version, type: String
+  field :unit, type: String # unit represented by values in number-based facets
+  field :min, type: Float # minimum allowed value for number-based facets
+  field :max, type: Float # maximum allowed value for number-based facets
 
-  validates_presence_of :name, :identifier, :big_query_id_column, :big_query_name_column, :convention_name, :convention_version
+  DATA_TYPES = %w(string number boolean)
+  BQ_DATA_TYPES = %w(STRING FLOAT64 BOOL)
+  BQ_TO_FACET_TYPES = Hash[BQ_DATA_TYPES.zip(DATA_TYPES)]
+
+  validates_presence_of :name, :identifier, :data_type, :big_query_id_column, :big_query_name_column, :convention_name, :convention_version
   validates_uniqueness_of :big_query_id_column, scope: [:convention_name, :convention_version]
   validate :ensure_ontology_url_format, if: proc {|attributes| attributes[:is_ontology_based]}
-  before_create :set_is_array_based_from_bq, if: proc {|attributes| attributes[:is_array_based].nil?}
+  before_create :set_data_type_and_array, if: proc {|attributes| attributes[:is_array_based].blank? || attributes[:data_type].blank?}
 
   swagger_schema :SearchFacet do
-    key :required, [:name, :identifier, :big_query_id_column, :big_query_name_column, :convention_name, :convention_version]
+    key :required, [:name, :identifier, :data_type, :big_query_id_column, :big_query_name_column, :convention_name, :convention_version]
     key :name, 'SearchFacet'
     property :name do
       key :type, :string
@@ -37,6 +44,11 @@ class SearchFacet
     property :identifier do
       key :type, :string
       key :description, 'ID of facet from convention JSON'
+    end
+    property :data_type do
+      key :type, :string
+      key :description, 'Data type of column entries'
+      key :enum, DATA_TYPES
     end
     property :filters do
       key :type, :array
@@ -107,6 +119,20 @@ class SearchFacet
       key :type, :string
       key :description, 'ID of facet from convention JSON'
     end
+    property :type do
+      key :type, :string
+      key :description, 'Data type of column entries'
+      key :enum, DATA_TYPES
+    end
+    property :items do
+      key :title, 'ArrayItems'
+      key :type, :object
+      key :description, 'Individual item properties (if array based)'
+      property :type do
+        key :type, :string
+        key :description, 'Data type of individual array items'
+      end
+    end
     property :filters do
       key :type, :array
       key :description, 'Array of filter values for facet'
@@ -139,6 +165,18 @@ class SearchFacet
         end
       end
     end
+    property :unit do
+      key :type, :string
+      key :description, 'Unit represented by numeric values'
+    end
+    property :min do
+      key :type, :float
+      key :description, 'Minumum allowed value for numeric columns'
+    end
+    property :max do
+      key :type, :float
+      key :description, 'Maximum allowed value for numeric columns'
+    end
   end
 
   swagger_schema :SearchFacetQuery do
@@ -147,6 +185,11 @@ class SearchFacet
     property :name do
       key :type, :string
       key :description, 'ID of facet from convention JSON'
+    end
+    property :type do
+      key :type, :string
+      key :description, 'Data type of column entries'
+      key :enum, DATA_TYPES
     end
     property :query do
       key :type, :string
@@ -205,6 +248,10 @@ class SearchFacet
     end
   end
 
+  # helper to know if column is numeric
+  def is_numeric?
+    self.data_type == 'number'
+  end
 
   # retrieve unique values from BigQuery and format an array of hashes with :name and :id values to populate :filters attribute
   def get_unique_filter_values
@@ -274,9 +321,12 @@ class SearchFacet
   private
 
   # determine if this facet references array-based data in BQ as data_type will look like "ARRAY<STRING>"
-  def set_is_array_based_from_bq
+  def set_data_type_and_array
     column_schema = SearchFacet.get_table_schema(column_name: self.big_query_id_column)
-    self.is_array_based = column_schema[:data_type].include?('ARRAY')
+    detected_type = column_schema[:data_type]
+    self.is_array_based = detected_type.include?('ARRAY')
+    item_type = BQ_DATA_TYPES.detect {|d| detected_type.match(d).present?}
+    self.data_type = BQ_TO_FACET_TYPES[item_type]
   end
 
   # custom validator for checking ontology_urls array

--- a/app/views/api/v1/search/_search_facet_config.json.jbuilder
+++ b/app/views/api/v1/search/_search_facet_config.json.jbuilder
@@ -1,4 +1,17 @@
 json.set! :name, search_facet_config.name
+if search_facet_config.is_array_based?
+  json.set! :type, :array
+  json.items do
+    json.set! :type, search_facet_config.data_type
+  end
+else
+  json.set! :type, search_facet_config.data_type
+end
 json.set! :id, search_facet_config.identifier
 json.set! :links, search_facet_config.ontology_urls
 json.set! :filters, search_facet_config.filters
+if search_facet_config.is_numeric?
+  json.set! :unit, search_facet_config.unit
+  json.set! :max, search_facet_config.max
+  json.set! :min, search_facet_config.min
+end

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -86,6 +86,7 @@ else
                     test/models/user_annotation_test.rb
                     test/models/analysis_configuration_test.rb
                     test/models/search_facet_test.rb
+                    test/integration/lib/search_facet_populator_test.rb
                     test/models/big_query_client_test.rb
   )
   for test_name in ${tests[*]}; do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -117,11 +117,11 @@ AnalysisConfiguration.create(namespace: 'single-cell-portal', name: 'split-clust
 # SearchFacet seeds
 SearchFacet.create(name: 'Species', identifier: 'species', filters: [{id: 'NCBITaxon_9606', name: 'Homo sapiens'}],
                    ontology_urls: [{name: 'NCBI organismal classification', url: 'https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon'}],
-                   is_ontology_based: true, is_array_based: false, big_query_id_column: 'species', big_query_name_column: 'species__ontology_label',
-                   convention_name: 'alexandria_convention', convention_version: '1.1.3')
+                   data_type: 'string', is_ontology_based: true, is_array_based: false, big_query_id_column: 'species',
+                   big_query_name_column: 'species__ontology_label', convention_name: 'alexandria_convention', convention_version: '1.1.3')
 SearchFacet.create(name: 'Disease', identifier: 'disease', filters: [{id: 'MONDO_0000001', name: 'disease or disorder'}],
                    ontology_urls: [{name: 'Monarch Disease Ontology', url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo'},
                                    {name: 'Phenotype And Trait Ontology', url: 'https://www.ebi.ac.uk/ols/ontologies/pato'}],
-                   is_ontology_based: true, is_array_based: true, big_query_id_column: 'disease', big_query_name_column: 'disease__ontology_label',
-                   convention_name: 'alexandria_convention', convention_version: '1.1.3')
+                   data_type: 'string', is_ontology_based: true, is_array_based: true, big_query_id_column: 'disease',
+                   big_query_name_column: 'disease__ontology_label', convention_name: 'alexandria_convention', convention_version: '1.1.3')
 BrandingGroup.create(name: 'Test Brand', user_id: api_user.id, font_family: 'Helvetica Neue, sans-serif', background_color: '#FFFFFF')

--- a/test/integration/lib/search_facet_populator_test.rb
+++ b/test/integration/lib/search_facet_populator_test.rb
@@ -13,6 +13,7 @@ class SearchFacetPopulatorTest < ActionDispatch::IntegrationTest
     assert_equal true, disease_facet.is_ontology_based
     assert_equal true, disease_facet.is_array_based
     assert_equal 'https://www.ebi.ac.uk/ols/api/ontologies/mondo', disease_facet.ontology_urls.first['url']
+    assert_equal 'MONDO: Monarch Disease Ontology', disease_facet.ontology_urls.first['name']
 
     sex_facet = SearchFacet.find_by(name: 'sex')
     assert_equal false, sex_facet.is_ontology_based
@@ -31,7 +32,7 @@ class SearchFacetPopulatorTest < ActionDispatch::IntegrationTest
                         big_query_name_column: 'disease__ontology_label',
                         convention_name: 'alexandria_convention',
                         convention_version: '1.1.3',
-                        ontology_urls: [{name: 'to.do.com', url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo'}])
+                        ontology_urls: [{name: 'MONDO: Monarch Disease Ontology', url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo'}])
     SearchFacetPopulator.populate_from_schema
     assert_equal 7, SearchFacet.count
 
@@ -40,5 +41,6 @@ class SearchFacetPopulatorTest < ActionDispatch::IntegrationTest
     assert_equal true, disease_facet.is_ontology_based
     assert_equal true, disease_facet.is_array_based
     assert_equal 'https://www.ebi.ac.uk/ols/api/ontologies/mondo', disease_facet.ontology_urls.first['url']
+    assert_equal 'MONDO: Monarch Disease Ontology', disease_facet.ontology_urls.first['name']
   end
 end

--- a/test/integration/lib/search_facet_populator_test.rb
+++ b/test/integration/lib/search_facet_populator_test.rb
@@ -6,7 +6,7 @@ class SearchFacetPopulatorTest < ActionDispatch::IntegrationTest
   test 'populate facets from alexandria convention data' do
     SearchFacet.destroy_all
     SearchFacetPopulator.populate_from_schema
-    assert_equal 10, SearchFacet.count
+    assert_equal 7, SearchFacet.count
 
     # spot-check a couple of facets
     disease_facet = SearchFacet.find_by(name: 'disease')
@@ -33,7 +33,7 @@ class SearchFacetPopulatorTest < ActionDispatch::IntegrationTest
                         convention_version: '1.1.3',
                         ontology_urls: [{name: 'to.do.com', url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo'}])
     SearchFacetPopulator.populate_from_schema
-    assert_equal 10, SearchFacet.count
+    assert_equal 7, SearchFacet.count
 
     # spot-check a couple of facets
     disease_facet = SearchFacet.find_by(name: 'disease')


### PR DESCRIPTION
Adding the data_type attribute to SearchFacets for controlling query & UI rendering behavior for faceted search.  Currently supported data_types are `string`, `number`, and `boolean`.  SearchFacets now have the ability to auto-detect data type upon creation.  Also, the behavior of updating facet filter values is changed so that facets automatically updated their filters upon creation.

This PR satisfies [SCP-2151](https://broadworkbench.atlassian.net/browse/SCP-2151).