### PR TITLE
adding migration script for new BQ column

### DIFF
--- a/db/migrate/20200221193404_add_bq_organism_age_column.rb
+++ b/db/migrate/20200221193404_add_bq_organism_age_column.rb
@@ -1,0 +1,15 @@
+class AddBqOrganismAgeColumn < Mongoid::Migration
+  # note this operation is safe to run even if your BQ table already has the given column
+  def self.up
+    client = BigQueryClient.new.client
+    dataset = client.dataset(CellMetadatum::BIGQUERY_DATASET)
+    table = dataset.table(CellMetadatum::BIGQUERY_TABLE)
+    table.schema {|s| s.numeric('organism_age__seconds', mode: :nullable)}
+  end
+
+  def self.down
+    # BigQuery does not support column deletions except by dropping and recreating the table,
+    # so we'll cross that bridge when/if we come to it
+    # See https://cloud.google.com/bigquery/docs/manually-changing-schemas
+  end
+end


### PR DESCRIPTION
dropping columns in BQ is a huge pain, so let's make sure we reallllly like the column name 'organism_age__seconds' before we merge this :)

Corresponding ingest change is https://github.com/broadinstitute/scp-ingest-pipeline/pull/80