### PR TITLE
Refresh button for Bulk Download UI (SCP-2121)

### DIFF
--- a/app/javascript/components/DownloadButton.js
+++ b/app/javascript/components/DownloadButton.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 import Modal from 'react-bootstrap/lib/Modal';
-import Tooltip from 'react-bootstrap/lib/Tooltip';
+// import Tooltip from 'react-bootstrap/lib/Tooltip'; // We'll need this when refining onClipboardCopySuccess
 import Clipboard from 'react-clipboard.js';
 
 import { fetchAuthCode } from 'lib/scp-api';

--- a/app/javascript/components/DownloadButton.js
+++ b/app/javascript/components/DownloadButton.js
@@ -12,8 +12,10 @@ import { fetchAuthCode } from 'lib/scp-api';
  *
  * @returns {Object} Object for auth code, time interval, and download command
  */
-async function generateDownloadConfig() {
-  const searchQuery = '&file_types=metadata,expression&accessions=SCP1,SCP2';
+async function generateDownloadConfig(matchingStudies) {
+
+  const accessions = matchingStudies.join(',');
+  const searchQuery = `&file_types=metadata,expression&accessions=${accessions}`;
 
   const {authCode, timeInterval} = await fetchAuthCode();
 
@@ -38,24 +40,25 @@ async function generateDownloadConfig() {
   };
 }
 
-function DownloadCommandContainer() {
+function DownloadCommandContainer(props) {
 
   const [downloadConfig, setDownloadConfig] = useState({});
 
-  async function updateDownloadConfig() {
+  async function updateDownloadConfig(matchingStudies) {
     const fetchData = async () => {
-      const dlConfig = await generateDownloadConfig();
+      const dlConfig = await generateDownloadConfig(matchingStudies);
       setDownloadConfig(dlConfig);
     };
     fetchData();
   }
 
   useEffect(() => {
-    updateDownloadConfig();
+    updateDownloadConfig(props.matchingStudies);
   }, []);
 
   function onClipboardCopySuccess(event) {
-
+    // TODO: Add polish to show "Copied!" upon clicking "Copy" button, then
+    // hide.  As in Bulk Download modal in study View / Explore.  (SCP-2164)
   }
 
   return (
@@ -137,7 +140,7 @@ export default function DownloadButton(props) {
           To download files matching your search, copy this command and paste it into your terminal:
           </p>
           <div className='lead command-container' id='command-container-all'>
-            <DownloadCommandContainer />
+            <DownloadCommandContainer matchingStudies={props.matchingStudies} />
           </div>
         </Modal.Body>
 

--- a/app/javascript/components/DownloadButton.js
+++ b/app/javascript/components/DownloadButton.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 import Modal from 'react-bootstrap/lib/Modal';
+import Tooltip from 'react-bootstrap/lib/Tooltip';
 import Clipboard from 'react-clipboard.js';
 
 import { fetchAuthCode } from 'lib/scp-api';
@@ -41,16 +42,20 @@ function DownloadCommandContainer() {
 
   const [downloadConfig, setDownloadConfig] = useState({});
 
-  useEffect(() => {
+  async function updateDownloadConfig() {
     const fetchData = async () => {
       const dlConfig = await generateDownloadConfig();
       setDownloadConfig(dlConfig);
     };
     fetchData();
+  }
+
+  useEffect(() => {
+    updateDownloadConfig();
   }, []);
 
-  function onSuccess() {
-    console.log('TODO (SCP-2121): Show "Copied!" tooltip');
+  function onClipboardCopySuccess(event) {
+
   }
 
   return (
@@ -65,7 +70,7 @@ function DownloadCommandContainer() {
         <span className='input-group-btn'>
             <Clipboard
               data-clipboard-target={'#command-' + downloadConfig.authCode}
-              onSuccess={onSuccess}
+              onSuccess={onClipboardCopySuccess}
               className='btn btn-default btn-copy'
               data-toggle='tooltip'
               button-title='Copy to clipboard'
@@ -76,6 +81,7 @@ function DownloadCommandContainer() {
             id={'refresh-button-' + downloadConfig.authCode}
             className='download-refresh-button btn btn-default btn-refresh glyphicon glyphicon-refresh'
             data-toggle='tooltip'
+            onClick={updateDownloadConfig}
             title='Refresh download command'>
           </button>
         </span>

--- a/app/javascript/components/DownloadButton.js
+++ b/app/javascript/components/DownloadButton.js
@@ -64,7 +64,7 @@ function DownloadCommandContainer() {
         <input
           id={'command-' + downloadConfig.authCode}
           className='form-control curl-download-command'
-          value={downloadConfig.downloadCommand}
+          value={downloadConfig.downloadCommand || ''}
           readOnly
         />
         <span className='input-group-btn'>

--- a/app/javascript/components/DownloadButton.js
+++ b/app/javascript/components/DownloadButton.js
@@ -58,7 +58,7 @@ function DownloadCommandContainer(props) {
 
   function onClipboardCopySuccess(event) {
     // TODO: Add polish to show "Copied!" upon clicking "Copy" button, then
-    // hide.  As in Bulk Download modal in study View / Explore.  (SCP-2164)
+    // hide.  As in Bulk Download modal in study View / Explore.  (SCP-2167)
   }
 
   return (

--- a/app/javascript/components/SearchPanel.js
+++ b/app/javascript/components/SearchPanel.js
@@ -31,12 +31,16 @@ export default function SearchPanel() {
   // This search component is currently specific to the "Studies" tab, but
   // could possibly also enable search for "Genes" and "Cells" tabs.
 
+  // TODO (SCP-2169): Remove this crude mock data with a prop when
+  // 1) HomePage component is merged and and 2) /search response is updated.
+  const matchingStudies = ['SCP1', 'SCP2'];
+
   return (
     <SearchContext.Provider value={searchContexts.study}>
       <div className='container-fluid' id='search-panel'>
         <KeywordSearch />
         <FacetsPanel />
-        <DownloadButton />
+        <DownloadButton matchingStudies={matchingStudies} />
       </div>
     </SearchContext.Provider>
   );

--- a/app/javascript/components/SearchPanel.js
+++ b/app/javascript/components/SearchPanel.js
@@ -23,7 +23,7 @@ export const SearchContext = React.createContext(searchContexts.study);
 /**
  * Component for SCP faceted search UI
  *
- * This is the entry point into React code from the traditional JS code
+ * This is an entry point into React code from the traditional JS code
  * See related integration at /app/javascript/packs/application.js
  */
 export default function SearchPanel() {

--- a/app/javascript/components/SearchPanel.js
+++ b/app/javascript/components/SearchPanel.js
@@ -33,6 +33,7 @@ export default function SearchPanel() {
 
   // TODO (SCP-2169): Remove this crude mock data with a prop when
   // 1) HomePage component is merged and and 2) /search response is updated.
+  // Note: matchingStudies will be called matching_accessions in upstream API
   const matchingStudies = ['SCP1', 'SCP2'];
 
   return (


### PR DESCRIPTION
This adds a Refresh button for the Bulk Download UI.  It also implements [a suggestion](https://github.com/broadinstitute/single_cell_portal_core/pull/392#discussion_r379563599) from from PR #392, in which the `/search/auth_code` API endpoint was integrated.

This satisfies SCP-2121.  

Follow ups to integrate more upcoming API updates: SCP-2169, polish: SCP-2167.