### PR TITLE
DRYing acceptFileTypes re:uploads, adding restrictions for misc files

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -49,6 +49,14 @@ var exploreMenusToggleState = {
   right: -1
 };
 
+// allowed file extension for upload forms
+var ALLOWED_FILE_TYPES = {
+    expression: /(\.|\/)(txt|text|mm|mtx|tsv|csv)(\.gz)?$/i,
+    plainText: /(\.|\/)(txt|text|tsv|csv)$/i,
+    primaryData: /((\.(fq|fastq)(\.tar)?\.gz$)|\.bam)/i,
+    bundled: /(\.|\/)(txt|text|tsv|csv|bam\.bai)(\.gz)?$/i,
+    miscellaneous: /(\.|\/)(txt|text|tsv|csv|jpg|jpeg|png|pdf|doc|docx|xls|xlsx|ppt|pptx|zip)(\.gz)?$/i
+};
 
 // options for Spin.js
 var opts = {

--- a/app/views/studies/_initialize_bundled_file_form.html.erb
+++ b/app/views/studies/_initialize_bundled_file_form.html.erb
@@ -59,7 +59,7 @@
 				url: "<%= upload_study_path(@study._id) %>",
 				maxChunkSize: 10000000,
 				type: 'PATCH',
-				acceptFileTypes: /(\.|\/)(txt|text|mm|mtx|tsv|csv|bam\.bai)(\.gz)?$/i,
+				acceptFileTypes: ALLOWED_FILE_TYPES['bundled'],
 				add: function (e, data) {
 					fileUploading = true;
 					var that = this;

--- a/app/views/studies/_initialize_expression_form.html.erb
+++ b/app/views/studies/_initialize_expression_form.html.erb
@@ -87,7 +87,7 @@
 				url: "<%= upload_study_path(@study._id) %>",
 				maxChunkSize: 10000000,
 				type: 'PATCH',
-				acceptFileTypes: /(\.|\/)(txt|text|mm|mtx|tsv|csv)(\.gz)?$/i,
+				acceptFileTypes: ALLOWED_FILE_TYPES['expression'],
 				add: function (e, data) {
 					fileUploading = true;
 					var that = this;

--- a/app/views/studies/_initialize_labels_form.html.erb
+++ b/app/views/studies/_initialize_labels_form.html.erb
@@ -78,7 +78,7 @@
 				url: "<%= upload_study_path(@study._id) %>",
 				maxChunkSize: 10000000,
 				type: 'PATCH',
-				acceptFileTypes: /(\.|\/)(txt|text)$/i,
+				acceptFileTypes: ALLOWED_FILE_TYPES['plainText'],
 				add: function (e, data) {
 					  fileUploading = true;
 					  var that = this;

--- a/app/views/studies/_initialize_marker_genes_form.html.erb
+++ b/app/views/studies/_initialize_marker_genes_form.html.erb
@@ -72,7 +72,7 @@
 				url: "<%= upload_study_path(@study._id) %>",
 				maxChunkSize: 10000000,
 				type: 'PATCH',
-				acceptFileTypes: /(\.|\/)(txt|text)$/i,
+				acceptFileTypes: ALLOWED_FILE_TYPES['plainText'],
 				add: function (e, data) {
 		  			fileUploading = true;
 	  				var that = this;

--- a/app/views/studies/_initialize_metadata_form.html.erb
+++ b/app/views/studies/_initialize_metadata_form.html.erb
@@ -68,7 +68,7 @@
 				url: "<%= upload_study_path(@study._id) %>",
 				maxChunkSize: 10000000, // 10 MB
 				type: 'PATCH',
-				acceptFileTypes: /(\.|\/)(txt|text|tsv|csv)$/i,
+				acceptFileTypes: ALLOWED_FILE_TYPES['plainText'],
 				add: function (e, data) {
 					fileUploading = true;
 					var that = this;

--- a/app/views/studies/_initialize_misc_form.html.erb
+++ b/app/views/studies/_initialize_misc_form.html.erb
@@ -55,7 +55,8 @@
 			$('#misc_form_<%= study_file._id %>').fileupload({
 				url: "<%= upload_study_path(@study._id) %>",
 				maxChunkSize: 10000000,
-				type: 'PATCH',
+        acceptFileTypes: ALLOWED_FILE_TYPES['miscellaneous'],
+        type: 'PATCH',
 				add: function (e, data) {
 					  fileUploading = true;
 					  var that = this;

--- a/app/views/studies/_initialize_ordinations_form.html.erb
+++ b/app/views/studies/_initialize_ordinations_form.html.erb
@@ -114,7 +114,7 @@
 				url: "<%= upload_study_path(@study._id) %>",
 				maxChunkSize: 10000000,
 				type: 'PATCH',
-				acceptFileTypes: /(\.|\/)(txt|text|tsv|csv)$/i,
+				acceptFileTypes: ALLOWED_FILE_TYPES['plainText'],
 				add: function (e, data) {
 					  fileUploading = true;
 					  var that = this;

--- a/app/views/studies/_initialize_primary_data_form.html.erb
+++ b/app/views/studies/_initialize_primary_data_form.html.erb
@@ -145,7 +145,7 @@
 				url: "<%= upload_study_path(@study._id) %>",
 				maxChunkSize: 10000000,
 				type: 'PATCH',
-				acceptFileTypes: /((\.(fq|fastq)(\.tar)?\.gz$)|\.bam)/i,
+				acceptFileTypes: ALLOWED_FILE_TYPES['primaryData'],
 				add: function (e, data) {
 					  fileUploading = true;
 					  var that = this;


### PR DESCRIPTION
DRYing references to file extensions for jQuery file uploader plugin `acceptFileTypes` parameter.  Also restricting file types for miscellaneous files to not allow all file extensions, but only reasonable extensions.

This PR satisfies [SCP-1976](https://broadworkbench.atlassian.net/browse/SCP-1976).