### PR TITLE
fixing bug with search with no keywords

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -140,6 +140,7 @@ module Api
         @viewable = Study.viewable(current_api_user)
         # variable for determining how we will sort search results for relevance
         sort_type = :keyword
+
         # if search params are present, filter accordingly
         if params[:terms].present?
           @search_terms = sanitize_search_values(params[:terms])
@@ -176,14 +177,16 @@ module Api
           Rails.logger.info "Found #{@convention_accessions.count} matching studies from BQ job #{job_id}: #{@convention_accessions}"
           @studies = @studies.where(:accession.in => @convention_accessions)
         end
+
+        @studies = @studies.to_a
         # determine sort order for pagination; minus sign (-) means a descending search
         case sort_type
-        when :keyword
-          @studies = @studies.to_a.sort_by {|study| -study.search_weight(@search_terms.split) }
-        when :accession
-          @studies = @studies.to_a.sort_by {|study| possible_accessions.index(study.accession) }
+        when :keyword && params[:terms].present?
+          @studies = @studies.sort_by {|study| -study.search_weight(@search_terms.split) }
+        when :accession && params[:terms].present?
+          @studies = @studies.sort_by {|study| possible_accessions.index(study.accession) }
         when :facet
-          @studies = @studies.to_a.sort_by {|study| -@studies_by_facet[study.accession][:facet_search_weight]}
+          @studies = @studies.sort_by {|study| -@studies_by_facet[study.accession][:facet_search_weight]}
         end
         # save list of study accessions for bulk_download/bulk_download_size calls, as well as caching query results
         @matching_accessions = @studies.map(&:accession)

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -46,6 +46,25 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     puts "#{File.basename(__FILE__)}: #{self.method_name} completed!"
   end
 
+  test 'should return viewable studies on empty search' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    execute_http_request(:get, api_v1_search_path(type: 'study'))
+    assert_response :success
+    expected_studies = Study.viewable(@user).pluck(:accession).sort
+    found_studies = json['matching_accessions'].sort
+    assert_equal expected_studies, found_studies, "Did not return correct studies; expected #{expected_studies} but found #{found_studies}"
+
+    sign_out @user
+    execute_http_request(:get, api_v1_search_path(type: 'study'))
+    assert_response :success
+    expected_studies = Study.viewable(nil).pluck(:accession).sort
+    public_studies = json['matching_accessions'].sort
+    assert_equal expected_studies, public_studies, "Did not return correct studies; expected #{expected_studies} but found #{public_studies}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
   test 'should return search results using facets' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
 


### PR DESCRIPTION
fixes a nil error on the @search_terms.split that would happen if no search terms were specified.  

@bistline this seems like a case that we should have automated testing to catch (sorry I missed it on peer review).  Can you (1) pull the business logic of the search into a static method, and then (2) add a few tests so that we've got coverage for the various permutations of empty keyword, empty facets, etc... (and we can write them without requiring http requests in the tests)