### PR TITLE
Changing message_modal behavior, fixing gene search submit

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -546,7 +546,6 @@ function closeModalSpinner(spinnerTarget, modalTarget, callback) {
 
 // handles showing/hiding main message_modal and cleaning up state on full & partial page renders
 function showMessageModal(notice=null, alert=null) {
-    console.log('calling showMessageModal');
     // close any open modals
     if (OPEN_MODAL) {
         var modalTarget = $('#' + OPEN_MODAL);
@@ -574,7 +573,7 @@ function showMessageModal(notice=null, alert=null) {
     }
 
     // don't timeout alert messages
-    if (alert) {
+    if (!alert) {
         setTimeout(function() {
             $("#message_modal").modal("hide");
         }, 3000);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -544,6 +544,43 @@ function closeModalSpinner(spinnerTarget, modalTarget, callback) {
     $(modalTarget).modal('hide');
 }
 
+// handles showing/hiding main message_modal and cleaning up state on full & partial page renders
+function showMessageModal(notice=null, alert=null) {
+    console.log('calling showMessageModal');
+    // close any open modals
+    if (OPEN_MODAL) {
+        var modalTarget = $('#' + OPEN_MODAL);
+        var modalData = modalTarget.data('bs.modal');
+        if ( typeof modalData !== 'undefined' && modalData.isShown) {
+            modalTarget.modal("hide");
+        }
+    }
+
+    var noticeElement = $('#notice-content');
+    var alertElement = $('#alert-content');
+    if (notice) {
+        noticeElement.html(notice);
+    } else {
+        noticeElement.empty();
+    }
+    if (alert) {
+        alertElement.html("<strong>" + alert + "</strong>");
+    } else {
+        alertElement.empty();
+    }
+
+    if (notice || alert) {
+        $("#message_modal").modal("show");
+    }
+
+    // don't timeout alert messages
+    if (alert) {
+        setTimeout(function() {
+            $("#message_modal").modal("hide");
+        }, 3000);
+    }
+}
+
 // Propagate changes from the View Options sidebar to the Search Genes form.
 function updateSearchGeneParams() {
 

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -140,6 +140,7 @@ module Api
         @viewable = Study.viewable(current_api_user)
         # variable for determining how we will sort search results for relevance
         sort_type = :none
+
         # if search params are present, filter accordingly
         if params[:terms].present?
           sort_type = :keyword
@@ -177,8 +178,9 @@ module Api
           Rails.logger.info "Found #{@convention_accessions.count} matching studies from BQ job #{job_id}: #{@convention_accessions}"
           @studies = @studies.where(:accession.in => @convention_accessions)
         end
-        # determine sort order for pagination; minus sign (-) means a descending search
+
         @studies = @studies.to_a
+        # determine sort order for pagination; minus sign (-) means a descending search
         case sort_type
         when :keyword
           @studies = @studies.sort_by {|study| -study.search_weight(@search_terms.split) }
@@ -187,8 +189,8 @@ module Api
         when :facet
           @studies = @studies.sort_by {|study| -@studies_by_facet[study.accession][:facet_search_weight]}
         else
-          # we have sort_type of :none, so preserve original ordering of :view_order and :name, both ascending
-          @studies = @studies.order_by([:view_order.asc, :name.asc])
+          # we have sort_type of :none, so preserve original ordering of :view_order
+          @studies = @studies.sort_by(&:view_order)
         end
         # save list of study accessions for bulk_download/bulk_download_size calls, as well as caching query results
         @matching_accessions = @studies.map(&:accession)

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -178,13 +178,14 @@ module Api
           @studies = @studies.where(:accession.in => @convention_accessions)
         end
         # determine sort order for pagination; minus sign (-) means a descending search
+        @studies = @studies.to_a
         case sort_type
         when :keyword
-          @studies = @studies.to_a.sort_by {|study| -study.search_weight(@search_terms.split) }
+          @studies = @studies.sort_by {|study| -study.search_weight(@search_terms.split) }
         when :accession
-          @studies = @studies.to_a.sort_by {|study| possible_accessions.index(study.accession) }
+          @studies = @studies.sort_by {|study| possible_accessions.index(study.accession) }
         when :facet
-          @studies = @studies.to_a.sort_by {|study| -@studies_by_facet[study.accession][:facet_search_weight]}
+          @studies = @studies.sort_by {|study| -@studies_by_facet[study.accession][:facet_search_weight]}
         else
           # we have sort_type of :none, so preserve original ordering of :view_order and :name, both ascending
           @studies = @studies.order_by([:view_order.asc, :name.asc])

--- a/app/views/admin_configurations/deliver_users_email.js.erb
+++ b/app/views/admin_configurations/deliver_users_email.js.erb
@@ -1,3 +1,3 @@
 closeModalSpinner('#generic-modal-spinner', '#generic-modal', function () {
-    $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {notice: @notice, alert: @alert}) %>");
+    showMessageModal("<%= @notice.present? ? @notice.html_safe : nil %>", "<%= @alert.present? ? @alert.html_safe : nil %>");
 });

--- a/app/views/admin_configurations/refresh_api_connections.js.erb
+++ b/app/views/admin_configurations/refresh_api_connections.js.erb
@@ -1,3 +1,3 @@
 closeModalSpinner('#working-modal-spinner', '#working-modal', function() {
-    $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {notice: @notice, alert: @alert}) %>");
+    showMessageModal("<%= @notice.present? ? @notice.html_safe : nil %>", "<%= @alert.present? ? @alert.html_safe : nil %>");
 });

--- a/app/views/admin_configurations/reset_user_download_quotas.js.erb
+++ b/app/views/admin_configurations/reset_user_download_quotas.js.erb
@@ -1,3 +1,3 @@
 closeModalSpinner('#working-modal-spinner', '#working-modal', function() {
-    $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {notice: 'All user download quotas successfully reset to 0.'}) %>");
+    showMessageModal("<%= @notice.present? ? @notice.html_safe : nil %>", "<%= @alert.present? ? @alert.html_safe : nil %>");
 });

--- a/app/views/admin_configurations/restart_locked_jobs.js.erb
+++ b/app/views/admin_configurations/restart_locked_jobs.js.erb
@@ -1,3 +1,3 @@
 closeModalSpinner('#working-modal-spinner', '#working-modal', function() {
-    $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {notice: @message }) %>");
+    showMessageModal("<%= @notice.present? ? @notice.html_safe : nil %>", "<%= @alert.present? ? @alert.html_safe : nil %>");
 });

--- a/app/views/admin_configurations/sync_portal_user_group.js.erb
+++ b/app/views/admin_configurations/sync_portal_user_group.js.erb
@@ -6,6 +6,6 @@ closeModalSpinner('#working-modal-spinner', '#working-modal', function() {
       $('#generic-update-modal-body').html("<%= escape_javascript(render partial: 'user_group_sync_list') %>");
       $('#generic-update-modal').modal('show')
     <% else %>
-      $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {alert: @alert}) %>");
+      showMessageModal("<%= @notice.present? ? @notice.html_safe : nil %>", "<%= @alert.present? ? @alert.html_safe : nil %>");
     <% end %>
 });

--- a/app/views/admin_configurations/update_service_account_profile.js.erb
+++ b/app/views/admin_configurations/update_service_account_profile.js.erb
@@ -1,1 +1,1 @@
-$('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {notice: @notice, alert: @alert}) %>");
+showMessageModal("<%= @notice.present? ? @notice.html_safe : nil %>", "<%= @alert.present? ? @alert.html_safe : nil %>");

--- a/app/views/billing_projects/update_workspace_computes.js.erb
+++ b/app/views/billing_projects/update_workspace_computes.js.erb
@@ -3,7 +3,7 @@ var btn = $('#<%= @form_id %> .update-compute-permissions');
 btn.removeClass('disabled');
 
 <% if @error.nil? %>
-  $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {notice: "Compute permissions for #{@email} successfully updated."}) %>");
+  showMessageModal("Compute permissions for <%= @email %> successfully updated.", "");
 <% else %>
-  $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {alert: "Unable to update compute permissions for #{@email}: #{@error}"}) %>");
+  showMessageModal("", "Unable to update compute permissions for <%= @email %>: <%= @error %>");
 <% end %>

--- a/app/views/layouts/_notices.html.erb
+++ b/app/views/layouts/_notices.html.erb
@@ -1,28 +1,8 @@
-<% unless (notice.nil? || notice.blank?) && (alert.nil? || alert.blank?) %>
-	<div class="modal fade" id="message_modal" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-		<div class="modal-dialog">
-			<div class="modal-content">
-				<div class="modal-body">
-					<p class="text-success text-center" id="notice-content"><%= !notice.blank? ? notice.html_safe : nil %></p>
-					<p class="text-danger text-center" id="alert-content"><strong><%= !alert.blank? ? alert.html_safe : nil %></strong></p>
-				</div>
-				<div class="modal-footer">
-					<button class="close" data-dismiss="modal">×</button>
-				</div>
-			</div>
-		</div>
-	</div>
-
-  <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-		$("#message_modal").modal("show");
-
-		// don't timeout alert messages
-		if (<%= alert.nil? %>) {
-        setTimeout(function() {
-            $("#message_modal").modal("hide");
-        }, 3000);
+<script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+    if (<%= [alert, notice].compact.any? %>) {
+        showMessageModal("<%= notice.present? ? notice.html_safe : nil %>", "<%= alert.present? ? alert.html_safe : nil %>")
+    } else {
+        $('#notice-content').empty();
+        $('#alert-content').empty();
     }
-
-	</script>
-
-<% end %>
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,6 +67,19 @@
     <%= render '/layouts/nav' %>
 <%end %>
 <div id="notices-target">
+  <div class="modal fade" id="message_modal" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-body">
+          <p class="text-success text-center" id="notice-content"></p>
+          <p class="text-danger text-center" id="alert-content"><strong></strong></p>
+        </div>
+        <div class="modal-footer">
+          <button class="close" data-dismiss="modal">×</button>
+        </div>
+      </div>
+    </div>
+  </div>
   <%= render '/layouts/notices' %>
 </div>
 <% if controller_name == 'site' && action_name == 'index' %>

--- a/app/views/layouts/session_expired.js.erb
+++ b/app/views/layouts/session_expired.js.erb
@@ -1,8 +1,1 @@
-if (OPEN_MODAL !== '') {
-    console.log('closing open modal: ' + OPEN_MODAL);
-    closeModalSpinner("#" + OPEN_MODAL + ' div.spinner-target', '#' + OPEN_MODAL, function() {
-        $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {alert: @alert, notice: @notice}) %>");
-    });
-} else {
-    $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {alert: @alert, notice: @notice}) %>");
-}
+showMessageModal("<%= @notice.present? ? @notice.html_safe : nil %>", "<%= @alert.present? ? @alert.html_safe : nil %>");

--- a/app/views/profiles/update_firecloud_profile.js.erb
+++ b/app/views/profiles/update_firecloud_profile.js.erb
@@ -1,3 +1,2 @@
-$('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {notice: @notice, alert: @alert}) %>");
-$('#message_modal').modal('show')
+showMessageModal("<%= @notice.present? ? @notice.html_safe : nil %>", "<%= @alert.present? ? @alert.html_safe : nil %>");
 $('#profile-firecloud').html("<%= escape_javascript(render partial: 'user_firecloud_profile') %>")

--- a/app/views/reports/report_request.js.erb
+++ b/app/views/reports/report_request.js.erb
@@ -1,7 +1,7 @@
 $('#contact-modal').on('hidden.bs.modal', function() {
     $('#contact-modal').off('hidden.bs.modal'); // clear event to prevent queueing
     CKEDITOR.instances.report_request_message.setData(''); // clear contents of CKEditor
-    $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {notice: 'Your message has been successfully delivered.'}) %>");
+    showMessageModal("Your message has been successfully delivered.", "");
 });
 
 $('#contact-modal').modal('hide');

--- a/app/views/site/_search_options.html.erb
+++ b/app/views/site/_search_options.html.erb
@@ -66,7 +66,7 @@
                         });
                     });
                 });
-                $('#perform-gene-search').click(function(){
+                $('#perform-gene-search').on('click', function(event){
                     var fileInput = $('#search_upload')[0];
                     if (fileInput.files.length) {
                         var reader = new FileReader();
@@ -92,30 +92,40 @@
                                 });
                                 searchString = sanitizedContent.join(' ');
                                 $('#search_genes').val(searchString);
-                                $(fileInput).val("").change(submitGeneSearch());
+                                $(fileInput).val("").change(submitGeneSearch(event));
                             }
                         });
                     } else {
-                        submitGeneSearch();
+                        submitGeneSearch(event);
                     }
                 });
-                function submitGeneSearch() {
+                function submitGeneSearch(event) {
                     if ( $('#search_genes').val() == '' && $('#search_upload').val() == '' ) {
                         alert('You must specify at least one gene or upload a list of genes to search');
                         setErrorOnBlank($('.search-genes-input'));
                     } else {
                         $(window).off('resizeEnd');
-                        launchModalSpinner('#spinner_target', '#loading-modal', function() {
-                            var form = $('#search-genes-form');
-                            $.ajax({
-                                type: 'POST',
-                                url: form.attr('action'),
-                                data: form.serialize(),
-                                dataType: 'script'
+                        if (event.type == 'click') {
+                            launchModalSpinner('#spinner_target', '#loading-modal', function() {
+                                var form = $('#search-genes-form');
+                                $.ajax({
+                                    type: 'POST',
+                                    url: form.attr('action'),
+                                    data: form.serialize(),
+                                    dataType: 'script'
+                                });
                             });
-                        });
+                        } else if (event.type == 'submit') {
+                            launchModalSpinner('#spinner_target', '#loading-modal', function() {
+                                return true; // just return as submit event has fired
+                            });
+                        }
                     }
-                };
+                }
+                // handler to catch ENTER keypress and open modal
+                $('#search-genes-form').on('submit', function(submitEvent) {
+                    submitGeneSearch(submitEvent);
+                });
             </script>
           </div>
         </div>

--- a/app/views/site/notice.js.erb
+++ b/app/views/site/notice.js.erb
@@ -1,3 +1,14 @@
 closeModalSpinner("#" + OPEN_MODAL + ' div.spinner-target', '#' + OPEN_MODAL, function() {
-    $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {alert: @alert, notice: @notice}) %>");
+    // update modal content
+    $('#notice-content').html("<%= !@notice.blank? ? @notice.html_safe : nil %>");
+    $('#alert-content').html("<%= !@alert.blank? ? @alert.html_safe : nil %>");
+
+    $("#message_modal").modal("show");
+
+    // don't timeout alert messages
+    if (<%= alert.nil? %>) {
+        setTimeout(function() {
+            $("#message_modal").modal("hide");
+        }, 3000);
+    }
 });

--- a/app/views/site/study.js.erb
+++ b/app/views/site/study.js.erb
@@ -2,7 +2,7 @@ closeModalSpinner('#spinner_target', '#loading-modal', function () {
     $('#breadcrumbs').replaceWith("<%= escape_javascript(render partial: '/layouts/breadcrumbs') %>");
     $('#title-bar').html("<%= escape_javascript(render partial: 'study_title_bar') %>");
     $('#study-visualize').html("<%= escape_javascript(render partial: 'study_visualize') %>");
-    $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices') %>");
+    showMessageModal("<%= notice.present? ? notice.html_safe : nil %>", "<%= alert.present? ? alert.html_safe : nil %>")
     enableDefaultActions();
     var requestUrl = '<%= javascript_safe_url(request.fullpath) %>';
     gaTrack(requestUrl, 'Single Cell Portal');

--- a/app/views/site/update_study_settings.js.erb
+++ b/app/views/site/update_study_settings.js.erb
@@ -1,7 +1,7 @@
 closeModalSpinner('#update-study-settings-spinner', '#update-study-settings-modal', function() {
     $('#study-settings-form-target').html("<%= escape_javascript(render partial: 'study_settings_form') %>");
     <% if @study.valid? %>
-        $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {notice: 'Study successfully updated.'}) %>");
+        showMessageModal("Study successfully updated.", "");
 
         // update summary and visualize tabs
         $('#title-bar').html("<%= escape_javascript(render partial: 'study_title_bar') %>");
@@ -11,7 +11,7 @@ closeModalSpinner('#update-study-settings-spinner', '#update-study-settings-moda
           $('#study-visualize').html("<%= escape_javascript(render partial: 'study_visualize') %>");
         <% end %>
     <% else %>
-        $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {alert: "An error occurred while saving: <br />#{@study.errors.full_messages.join(', ')}".html_safe}) %>");
+        showMessageModal("", "An error occurred while saving: <br /><%= @study.errors.full_messages.join(', ').html_safe %>");
     <% end %>
     // scroll back to the top of the page
     window.scrollBy(0,-9999)

--- a/app/views/site/update_user_annotations.js.erb
+++ b/app/views/site/update_user_annotations.js.erb
@@ -1,7 +1,7 @@
 // reload the menu after saving a user annotation
 closeModalSpinner('#generic-modal-spinner', '#generic-modal', function () {
     $("#annotation").html("<%= escape_javascript(select_tag :annotation, grouped_options_for_select(@cluster_annotations, params[:annotation]), class: 'form-control' )%>");
-    $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {notice: @notice, alert: @alert}) %>");
+    showMessageModal("<%= @notice.present? ? @notice.html_safe : nil %>", "<%= @alert.present? ? @alert.html_safe : nil %>");
     <% if @user_annotation.errors.any? %>
       <% @user_annotation.errors.keys.each do |key| %>
           <% if key === :name %>

--- a/app/views/site/update_workspace_samples.js.erb
+++ b/app/views/site/update_workspace_samples.js.erb
@@ -4,5 +4,5 @@ closeModalSpinner('#generic-modal-spinner', "#generic-modal", function() {
         updateSampleTable([]);
     }
     $('#workflow_study_data').val('')
-    $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices', locals: {notice: @notice}) %>");
+    showMessageModal("<%= @notice.present? ? @notice.html_safe : nil %>", "<%= @alert.present? ? @alert.html_safe : nil %>");
 });

--- a/app/views/site/view_gene_expression.js.erb
+++ b/app/views/site/view_gene_expression.js.erb
@@ -2,7 +2,7 @@ closeModalSpinner('#spinner_target', '#loading-modal', function () {
     $('#breadcrumbs').replaceWith("<%= escape_javascript(render partial: '/layouts/breadcrumbs') %>");
     $('#title-bar').html("<%= escape_javascript(render partial: 'view_gene_expression_title_bar') %>");
     $('#study-visualize').html("<%= escape_javascript(render partial: 'view_gene_expression') %>");
-    $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices') %>");
+    showMessageModal("<%= notice.present? ? notice.html_safe : nil %>", "<%= alert.present? ? alert.html_safe : nil %>")
     enableDefaultActions();
     var requestUrl = "<%= javascript_safe_url(request.fullpath) %>";
     ga('send', 'event', 'engaged_user_action', 'study_gene_search_single');

--- a/app/views/site/view_gene_expression_heatmap.js.erb
+++ b/app/views/site/view_gene_expression_heatmap.js.erb
@@ -2,8 +2,7 @@ closeModalSpinner('#spinner_target', '#loading-modal', function () {
     $('#breadcrumbs').replaceWith("<%= escape_javascript(render partial: '/layouts/breadcrumbs') %>");
     $('#title-bar').html("<%= escape_javascript(render partial: 'view_gene_expression_heatmap_title_bar') %>");
     $('#study-visualize').html("<%= escape_javascript(render partial: 'view_gene_expression_heatmap') %>");
-    $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices') %>");
-    // clear any resize listeners
+    showMessageModal("<%= notice.present? ? notice.html_safe : nil %>", "<%= alert.present? ? alert.html_safe : nil %>")
     $(window).off('resizeEnd');
     enableDefaultActions();
     var requestUrl = "<%= javascript_safe_url(request.fullpath) %>";

--- a/app/views/site/view_precomputed_gene_expression_heatmap.js.erb
+++ b/app/views/site/view_precomputed_gene_expression_heatmap.js.erb
@@ -2,8 +2,7 @@ closeModalSpinner('#spinner_target', '#loading-modal', function () {
     $('#breadcrumbs').replaceWith("<%= escape_javascript(render partial: '/layouts/breadcrumbs') %>");
     $('#title-bar').html("<%= escape_javascript(render partial: 'view_precomputed_gene_expression_heatmap_title_bar') %>");
     $('#study-visualize').html("<%= escape_javascript(render partial: 'view_precomputed_gene_expression_heatmap') %>");
-    $('#notices-target').html("<%= escape_javascript(render partial: '/layouts/notices') %>");
-    // clear any resize listeners
+    showMessageModal("<%= notice.present? ? notice.html_safe : nil %>", "<%= alert.present? ? alert.html_safe : nil %>")
     $(window).off('resizeEnd');
     enableDefaultActions();
     var requestUrl = "<%= javascript_safe_url(request.fullpath) %>";


### PR DESCRIPTION
The default behavior of the main "message_modal" has changed to always render into the page, whether there is any content to display or not.  Showing/hiding the modal has been abstracted out into the `showMessageModal()` function.  This fixes the issue where removing the open modal from the DOM to show a new message wedges the UI, and cannot be recovered.

Also, fixing a regression with submitting a gene search by pressing enter, rather than clicking the "Search Genes" button.

This PR satisfies [SCP-1272](https://broadworkbench.atlassian.net/browse/SCP-1272).