### PR TITLE
Backfill organism age data

### DIFF
--- a/app/lib/search_facet_populator.rb
+++ b/app/lib/search_facet_populator.rb
@@ -73,7 +73,7 @@ class SearchFacetPopulator
       facet.is_array_based = false
       facet.big_query_id_column = 'species'
       facet.big_query_name_column = 'species__ontology_label'
-      facet.convention_name = 'Alexandria Convention'
+      facet.convention_name = 'Alexandria Metadata Convention'
       facet.convention_version = '1.1.3'
       facet.ontology_urls = [{name: 'NCBI organismal classification', url: 'https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon'}]
     end
@@ -83,7 +83,7 @@ class SearchFacetPopulator
       facet.is_array_based = false
       facet.big_query_id_column = 'sex'
       facet.big_query_name_column = 'sex'
-      facet.convention_name = 'alexandria_convention'
+      facet.convention_name = 'Alexandria Metadata Convention'
       facet.convention_version = '1.1.3'
     end
 
@@ -93,7 +93,7 @@ class SearchFacetPopulator
       facet.is_array_based = false
       facet.big_query_id_column = 'organ'
       facet.big_query_name_column = 'organ__ontology_label'
-      facet.convention_name = 'alexandria_convention'
+      facet.convention_name = 'Alexandria Metadata Convention'
       facet.convention_version = '1.1.3'
       facet.ontology_urls = [{name: 'Uber-anatomy ontology', url: 'https://www.ebi.ac.uk/ols/api/ontologies/uberon'}]
     end
@@ -104,7 +104,7 @@ class SearchFacetPopulator
       facet.is_array_based = true
       facet.big_query_id_column = 'disease'
       facet.big_query_name_column = 'disease__ontology_label'
-      facet.convention_name = 'alexandria_convention'
+      facet.convention_name = 'Alexandria Metadata Convention'
       facet.convention_version = '1.1.3'
       facet.ontology_urls = [{name: 'MONDO: Monarch Disease Ontology', url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo'}]
     end
@@ -115,7 +115,7 @@ class SearchFacetPopulator
       facet.is_array_based = false
       facet.big_query_id_column = 'library_preparation_protocol'
       facet.big_query_name_column = 'library_preparation_protocol__ontology_label'
-      facet.convention_name = 'alexandria_convention'
+      facet.convention_name = 'Alexandria Metadata Convention'
       facet.convention_version = '1.1.3'
       facet.ontology_urls = [{name: 'Experimental Factor Ontology', url: 'https://www.ebi.ac.uk/ols/api/ontologies/efo'}]
     end

--- a/app/lib/search_facet_populator.rb
+++ b/app/lib/search_facet_populator.rb
@@ -73,7 +73,7 @@ class SearchFacetPopulator
       facet.is_array_based = false
       facet.big_query_id_column = 'species'
       facet.big_query_name_column = 'species__ontology_label'
-      facet.convention_name = 'alexandria_convention'
+      facet.convention_name = 'Alexandria Convention'
       facet.convention_version = '1.1.3'
       facet.ontology_urls = [{name: 'NCBI organismal classification', url: 'https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon'}]
     end

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -47,6 +47,7 @@ RAILS_ENV=test NODE_ENV=test bin/bundle exec rake assets:precompile
 echo "Generating random seed, seeding test database..."
 RANDOM_SEED=$(openssl rand -hex 16)
 echo $RANDOM_SEED > /home/app/webapp/.random_seed
+bundle exec rake RAILS_ENV=test db:migrate
 bundle exec rake RAILS_ENV=test db:seed || { echo "FAILED to seed test database!" >&2; exit 1; }
 bundle exec rake RAILS_ENV=test db:mongoid:create_indexes
 echo "Database initialized"

--- a/db/migrate/20200304203650_create_organism_age_facet_and_backfill_data.rb
+++ b/db/migrate/20200304203650_create_organism_age_facet_and_backfill_data.rb
@@ -4,7 +4,7 @@ class CreateOrganismAgeFacetAndBackfillData < Mongoid::Migration
     bq_dataset = SearchFacet.big_query_dataset
     update_command = "UPDATE #{CellMetadatum::BIGQUERY_TABLE} "
     update_command += "SET organism_age__seconds = CAST((organism_age * #{SearchFacet::TIME_MULTIPLIERS['years']}) AS NUMERIC) "
-    update_command += "WHERE organism_age IS NOT NULL and organism_age__seconds IS NULL"
+    update_command += "WHERE organism_age IS NOT NULL and organism_age__seconds IS NULL AND organism_age__unit_label = 'year'"
     bq_dataset.query update_command
     SearchFacet.create(name: 'Organism Age', identifier: 'organism_age', big_query_id_column: 'organism_age',
                        big_query_name_column: 'organism_age', big_query_conversion_column: 'organism_age__seconds',

--- a/db/migrate/20200304203650_create_organism_age_facet_and_backfill_data.rb
+++ b/db/migrate/20200304203650_create_organism_age_facet_and_backfill_data.rb
@@ -1,0 +1,21 @@
+class CreateOrganismAgeFacetAndBackfillData < Mongoid::Migration
+  def self.up
+    SearchFacet.where(identifier: 'organism_age').destroy
+    bq_dataset = SearchFacet.big_query_dataset
+    update_command = "UPDATE #{CellMetadatum::BIGQUERY_TABLE} "
+    update_command += "SET organism_age__seconds = CAST((organism_age * #{SearchFacet::TIME_MULTIPLIERS['years']}) AS NUMERIC) "
+    update_command += "WHERE organism_age IS NOT NULL and organism_age__seconds IS NULL"
+    bq_dataset.query update_command
+    SearchFacet.create(name: 'Organism Age', identifier: 'organism_age', big_query_id_column: 'organism_age',
+                       big_query_name_column: 'organism_age', big_query_conversion_column: 'organism_age__seconds',
+                       is_ontology_based: false, data_type: 'number', is_array_based: false,
+                       convention_name: 'Alexandria Metadata Convention', convention_version: '1.1.3', unit: 'years')
+  end
+
+  def self.down
+    SearchFacet.where(identifier: 'organism_age').destroy
+    bq_dataset = SearchFacet.big_query_dataset
+    update_command = "UPDATE #{CellMetadatum::BIGQUERY_TABLE} SET organism_age__seconds = NULL WHERE organism_age IS NOT NULL"
+    bq_dataset.query update_command
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -115,41 +115,24 @@ AnalysisConfiguration.create(namespace: 'single-cell-portal', name: 'split-clust
                              configuration_snapshot: 2, description: 'This is a test description.')
 
 # SearchFacet seeds
-SearchFacet.find_or_create_by!(identifier: 'species') do |facet|
-  facet.name = 'Species'
-  facet.filters = [{id: 'NCBITaxon_9606', name: 'Homo sapiens'}]
-  facet.ontology_urls = [{name: 'NCBI organismal classification', url: 'https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon'}]
-  facet.data_type = 'string'
-  facet.is_ontology_based = true
-  facet.is_array_based = false
-  facet.big_query_id_column = 'species'
-  facet.big_query_name_column = 'species__ontology_label'
-  facet.convention_name = 'Alexandria Metadata Convention'
-  facet.convention_version = '1.1.3'
-end
+species = SearchFacet.find_or_initialize_by(identifier: 'species')
+species.filters = [{id: 'NCBITaxon_9606', name: 'Homo sapiens'}]
+species.save
 
-SearchFacet.find_or_create_by!(identifier: 'disease') do |facet|
-    facet.name = 'Disease'
-    facet.filters = [{id: 'MONDO_0000001', name: 'disease or disorder'}]
-    facet.ontology_urls = [{name: 'Monarch Disease Ontology', url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo'},
-                           {name: 'Phenotype And Trait Ontology', url: 'https://www.ebi.ac.uk/ols/ontologies/pato'}]
-    facet.data_type = 'string'
-    facet.is_ontology_based = true
-    facet.is_array_based = true
-    facet.big_query_id_column = 'disease'
-    facet.big_query_name_column = 'disease__ontology_label'
-    facet.convention_name = 'Alexandria Metadata Convention'
-    facet.convention_version = '1.1.3'
-end
-SearchFacet.find_or_create_by!(identifier: 'organism_age') do |facet|
-    facet.name = 'Organism Age'
-    facet.data_type = 'number'
-    facet.is_ontology_based = false
-    facet.is_array_based = false
-    facet.big_query_id_column = 'organism_age'
-    facet.big_query_name_column = 'organism_age'
-    facet.big_query_conversion_column ='organism_age__seconds'
-    facet.convention_name = 'Alexandria Metadata Convention'
-    facet.convention_version = '1.1.3'
-end
+disease = SearchFacet.find_or_initialize_by(identifier: 'disease')
+disease.filters = [{id: 'MONDO_0000001', name: 'disease or disorder'}]
+disease.save
+
+age = SearchFacet.find_or_initialize_by(identifier: 'organism_age')
+age.name = 'Organism Age'
+age.data_type = 'number'
+age.is_ontology_based = false
+age.is_array_based = false
+age.big_query_id_column = 'organism_age'
+age.big_query_name_column = 'organism_age'
+age.big_query_conversion_column ='organism_age__seconds'
+age.convention_name = 'Alexandria Metadata Convention'
+age.convention_version = '1.1.3'
+age.save
+
 BrandingGroup.create(name: 'Test Brand', user_id: api_user.id, font_family: 'Helvetica Neue, sans-serif', background_color: '#FFFFFF')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -115,16 +115,41 @@ AnalysisConfiguration.create(namespace: 'single-cell-portal', name: 'split-clust
                              configuration_snapshot: 2, description: 'This is a test description.')
 
 # SearchFacet seeds
-SearchFacet.create(name: 'Species', identifier: 'species', filters: [{id: 'NCBITaxon_9606', name: 'Homo sapiens'}],
-                   ontology_urls: [{name: 'NCBI organismal classification', url: 'https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon'}],
-                   data_type: 'string', is_ontology_based: true, is_array_based: false, big_query_id_column: 'species',
-                   big_query_name_column: 'species__ontology_label', convention_name: 'alexandria_convention', convention_version: '1.1.3')
-SearchFacet.create(name: 'Disease', identifier: 'disease', filters: [{id: 'MONDO_0000001', name: 'disease or disorder'}],
-                   ontology_urls: [{name: 'Monarch Disease Ontology', url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo'},
-                                   {name: 'Phenotype And Trait Ontology', url: 'https://www.ebi.ac.uk/ols/ontologies/pato'}],
-                   data_type: 'string', is_ontology_based: true, is_array_based: true, big_query_id_column: 'disease',
-                   big_query_name_column: 'disease__ontology_label', convention_name: 'alexandria_convention', convention_version: '1.1.3')
-SearchFacet.create(name: 'Organism Age', identifier: 'organism_age', big_query_id_column: 'organism_age', big_query_name_column: 'organism_age',
-                   big_query_conversion_column: 'organism_age__seconds', is_ontology_based: false, data_type: 'number',
-                   is_array_based: false, convention_name: 'alexandria_convention', convention_version: '1.1.3', unit: 'years')
+SearchFacet.find_or_create_by!(identifier: 'species') do |facet|
+  facet.name = 'Species'
+  facet.filters = [{id: 'NCBITaxon_9606', name: 'Homo sapiens'}]
+  facet.ontology_urls = [{name: 'NCBI organismal classification', url: 'https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon'}]
+  facet.data_type = 'string'
+  facet.is_ontology_based = true
+  facet.is_array_based = false
+  facet.big_query_id_column = 'species'
+  facet.big_query_name_column = 'species__ontology_label'
+  facet.convention_name = 'Alexandria Metadata Convention'
+  facet.convention_version = '1.1.3'
+end
+
+SearchFacet.find_or_create_by!(identifier: 'disease') do |facet|
+    facet.name = 'Disease'
+    facet.filters = [{id: 'MONDO_0000001', name: 'disease or disorder'}]
+    facet.ontology_urls = [{name: 'Monarch Disease Ontology', url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo'},
+                           {name: 'Phenotype And Trait Ontology', url: 'https://www.ebi.ac.uk/ols/ontologies/pato'}]
+    facet.data_type = 'string'
+    facet.is_ontology_based = true
+    facet.is_array_based = true
+    facet.big_query_id_column = 'disease'
+    facet.big_query_name_column = 'disease__ontology_label'
+    facet.convention_name = 'Alexandria Metadata Convention'
+    facet.convention_version = '1.1.3'
+end
+SearchFacet.find_or_create_by!(identifier: 'organism_age') do |facet|
+    facet.name = 'Organism Age'
+    facet.data_type = 'number'
+    facet.is_ontology_based = false
+    facet.is_array_based = false
+    facet.big_query_id_column = 'organism_age'
+    facet.big_query_name_column = 'organism_age'
+    facet.big_query_conversion_column ='organism_age__seconds'
+    facet.convention_name = 'Alexandria Metadata Convention'
+    facet.convention_version = '1.1.3'
+end
 BrandingGroup.create(name: 'Test Brand', user_id: api_user.id, font_family: 'Helvetica Neue, sans-serif', background_color: '#FFFFFF')

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -71,7 +71,12 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     study = Study.find_by(name: "Test Study #{@random_seed}")
     facets = SearchFacet.where(data_type: 'string')
     # format facet query string; this will be done by the search UI in production
-    facet_queries = facets.map {|facet| [facet.identifier, facet.filters.map {|f| f[:id]}.join(',')]}
+    facet_queries = []
+    facets.each do |facet|
+      if facet.filters.any?
+        facet_queries << [facet.identifier, facet.filters.map {|f| f[:id]}.join(',')]
+      end
+    end
     facet_query = facet_queries.map {|query| query.join(':')}.join('+')
     execute_http_request(:get, api_v1_search_path(type: 'study', facets: facet_query))
     assert_response :success

--- a/test/integration/lib/search_facet_populator_test.rb
+++ b/test/integration/lib/search_facet_populator_test.rb
@@ -30,7 +30,7 @@ class SearchFacetPopulatorTest < ActionDispatch::IntegrationTest
                         is_array_based: false,
                         big_query_id_column: 'disease',
                         big_query_name_column: 'disease__ontology_label',
-                        convention_name: 'alexandria_convention',
+                        convention_name: 'Alexandria Metadata Convention',
                         convention_version: '1.1.3',
                         ontology_urls: [{name: 'MONDO: Monarch Disease Ontology', url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo'}])
     SearchFacetPopulator.populate_from_schema

--- a/test/models/search_facet_test.rb
+++ b/test/models/search_facet_test.rb
@@ -88,7 +88,7 @@ class SearchFacetTest < ActiveSupport::TestCase
           big_query_id_column: 'number_of_reads',
           big_query_name_column: 'number_of_reads',
           is_ontology_based: false,
-          convention_name: 'alexandria_convention',
+          convention_name: 'Alexandria Metadata Convention',
           convention_version: '1.1.3'
       )
       mock.verify

--- a/test/models/search_facet_test.rb
+++ b/test/models/search_facet_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class SearchFacetTest < ActiveSupport::TestCase
 
   def setup
-    @search_facet = SearchFacet.first
+    @search_facet = SearchFacet.find_by(identifier: 'species')
 
     # filter_results to return from mock call to BigQuery
     @filter_results = [
@@ -42,7 +42,7 @@ class SearchFacetTest < ActiveSupport::TestCase
     non_array_query = @search_facet.generate_non_array_query
     non_array_match = /DISTINCT #{@search_facet.big_query_id_column}/
     assert_match non_array_match, non_array_query, "Non-array query did not contain correct DISTINCT clause: #{non_array_query}"
-    array_facet = SearchFacet.find_by(name: 'Disease')
+    array_facet = SearchFacet.find_by(identifier: 'disease')
     column = array_facet.big_query_id_column
     identifier = 'id'
     array_query = array_facet.generate_array_query(column, identifier)


### PR DESCRIPTION
Back filling data for the `organism_age__seconds` column in BigQuery to use with an Organism Age facet.  This is handled via a reversible Rails database migration.

Also fixing an issue with test schemas not being updated with migrations.

This PR satisfies SCP-2206.