### PR TITLE
fixing more facets bug and allowing more facet data display

### DIFF
--- a/app/javascript/components/FacetControl.js
+++ b/app/javascript/components/FacetControl.js
@@ -4,7 +4,7 @@ import FiltersBoxSearchable from './FiltersBoxSearchable';
 import { StudySearchContext } from 'components/search/StudySearchProvider';
 import _filter from 'lodash/filter'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 
 /**
  * Converts string value to lowercase, hyphen-delimited version
@@ -74,7 +74,7 @@ export default function FacetControl(props) {
 
   let controlContent = facetName
   if (selectedFilterString) {
-    controlContent = <>{ selectedFilterString } <button ref={clearNode} className="facet-clear" onClick={ clearFacet }><FontAwesomeIcon icon={faTimes}/></button></>
+    controlContent = <>{ selectedFilterString } <button ref={clearNode} className="facet-clear" onClick={ clearFacet }><FontAwesomeIcon icon={faTimesCircle}/></button></>
   }
 
   return (

--- a/app/javascript/components/FacetsAccordion.js
+++ b/app/javascript/components/FacetsAccordion.js
@@ -1,30 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PanelGroup from 'react-bootstrap/lib/PanelGroup';
 import Panel from 'react-bootstrap/lib/Panel';
 
-import FiltersBox from './FiltersBox'
+import FacetControl from './FacetControl'
 
 export default function FacetsAccordion(props) {
-
   return (
     <PanelGroup accordion id='facets-accordion'>
       {
         props.facets.map((facet, i) => {
           return (
-            <Panel key={i} eventKey={i}>
-              <Panel.Heading >
-                <Panel.Title toggle>
-                  {facet.name}
-                </Panel.Title>
-              </Panel.Heading>
-              <Panel.Body collapsible>
-                <FiltersBox
-                  facet={facet}
-                  filters={facet.filters}
-                  setShow={props.setShow}
-                />
-              </Panel.Body>
-            </Panel>
+            <FacetControl facet={facet} key={i}/>
           );
         })
       }

--- a/app/javascript/components/FiltersBox.js
+++ b/app/javascript/components/FiltersBox.js
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useEffect } from 'react';
-import isEqual from 'lodash/isEqual';
+import _isEqual from 'lodash/isEqual';
 import Button from 'react-bootstrap/lib/Button';
 
 import { StudySearchContext } from 'components/search/StudySearchProvider';
@@ -45,11 +45,12 @@ function ApplyButton(props) {
 export default function FiltersBox(props) {
   const searchContext = useContext(StudySearchContext);
 
-  const appliedSelection = searchContext.params.facets[props.facet.id]
+  let appliedSelection = searchContext.params.facets[props.facet.id]
+  appliedSelection = appliedSelection ? appliedSelection : []
   const selection = props.selection
   const setSelection = props.setSelection
   const showClear = selection.length > 0;
-  const canApply = !isEqual(selection, appliedSelection)
+  const canApply = !_isEqual(selection, appliedSelection)
 
   // TODO: Get opinions, perhaps move to a UI code style guide.
   //
@@ -90,8 +91,7 @@ export default function FiltersBox(props) {
   }
 
   function handleApplyClick(event) {
-    const applyButtonClasses = Array.from(event.target.classList);
-    if (applyButtonClasses.includes('disabled')) return;
+    if (!canApply) return;
 
     let updatedFacetValue = {};
     updatedFacetValue[facetId] = selection

--- a/app/javascript/components/FiltersBoxSearchable.js
+++ b/app/javascript/components/FiltersBoxSearchable.js
@@ -59,28 +59,34 @@ export default function FiltersBoxSearchable(props) {
     return filtersSummary;
   }
 
+  const showSearchBar = props.facet.links.length > 0
+
   return (
     <div className={componentName} id={componentId} style={{display: props.show ? '' : 'none'}}>
-      <div className='facet-ontology-links'>
-          {
-          props.facet.links.map((link, i) => {
-            return (
-              <a key={`link-${i}`} href={link.url} target='_blank'>
-                {link.name}&nbsp;&nbsp;<FontAwesomeIcon icon={faExternalLinkAlt}/>
-              </a>
-            );
-          })
-          }
-      </div>
-      <FiltersSearchBar
-        filtersBoxId={componentId}
-        searchFilters={searchFilters}
-      />
-      <p className='filters-box-header'>
-        <span className='default-filters-list-name'>
-          {getFiltersSummary()}
-        </span>
-      </p>
+      { showSearchBar && (
+        <>
+          <div className='facet-ontology-links'>
+            {
+            props.facet.links.map((link, i) => {
+              return (
+                <a key={`link-${i}`} href={link.url} target='_blank'>
+                  {link.name}&nbsp;&nbsp;<FontAwesomeIcon icon={faExternalLinkAlt}/>
+                </a>
+              );
+            })
+            }
+          </div>
+          <FiltersSearchBar
+            filtersBoxId={componentId}
+            searchFilters={searchFilters}
+          />
+          <p className='filters-box-header'>
+            <span className='default-filters-list-name'>
+              {getFiltersSummary()}
+            </span>
+          </p>
+        </>
+      )}
       <FiltersBox
         facet={props.facet}
         filters={matchingFilters}

--- a/app/javascript/components/MoreFacetsButton.js
+++ b/app/javascript/components/MoreFacetsButton.js
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSlidersH } from '@fortawesome/free-solid-svg-icons';
 
 import FacetsAccordion from './FacetsAccordion';
+import { useContextStudySearch } from 'components/search/StudySearchProvider';
 
 /**
  * Component for "More Facets" button.  Clicking shows facets accordion box.
@@ -11,7 +12,7 @@ import FacetsAccordion from './FacetsAccordion';
  * UI spec: https://projects.invisionapp.com/d/main#/console/19272801/402387756/preview
  */
 export default function MoreFacetsButton(props) {
-
+  let searchContext = useContextStudySearch();
   const [show, setShow] = useState(false);
 
   // const facetName = props.facet.name;
@@ -39,15 +40,20 @@ export default function MoreFacetsButton(props) {
     setShow(false)
   };
 
+  const numFacetsApplied = props.facets.filter((facet) => {
+    return searchContext.params.facets[facet.id] && searchContext.params.facets[facet.id].length
+  }).length
+  const facetCountString = numFacetsApplied > 0 ? `(${numFacetsApplied})` : ''
+
   return (
       <span
         id='more-facets-button'
-        className={`${show ? 'active' : ''} facet`}
+        className={`${show || numFacetsApplied ? 'active' : ''} facet`}
         ref={node}>
         <a
           onClick={handleClick}>
           <FontAwesomeIcon className="icon-left" icon={faSlidersH}/>
-          More Facets
+          More Facets { facetCountString }
         </a>
         {show && <FacetsAccordion facets={props.facets} setShow={setShow} />}
       </span>

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -143,7 +143,12 @@
       display: block;
       margin: 5px 2px;
       .filters-box-searchable {
-        margin-left: 50px;
+        position: relative;
+        width: 98%;
+        border: none;
+        margin-top: -2px;
+        border-top-left-radius: 0px;
+        border-top-right-radius: 0px;
       }
     }
   }

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -56,12 +56,12 @@
     }
 
     .facet-clear {
-      margin-left: 1em;
-      background: #fff;
-      color: $action-color;
-      border-radius: 1em;
+      float: right;
+      padding: 0px;
+      background-color: $action-color;
+      margin-left: 0.5em;
+      color: #fff;
       border: none;
-      font-size: 0.8em;
     }
   }
   #download-button {
@@ -126,7 +126,7 @@
   }
 
   .filters-box-searchable, #facets-accordion {
-    width: 400px;
+    width: 250px;
     border: 1px solid #aaa;
     background: #fff;
     position: absolute;
@@ -134,6 +134,18 @@
     border-radius: 5px;
     padding: 2px;
     margin-top: 2px;
+  }
+
+  #facets-accordion {
+    background: #eff2f5;
+    .facet {
+      width: 98%;
+      display: block;
+      margin: 5px 2px;
+      .filters-box-searchable {
+        margin-left: 50px;
+      }
+    }
   }
 
   .filters-box-header {


### PR DESCRIPTION
This fixes the nasty bug, and also adds a lot of capability for showing when and which of the "more facets" are selected (e.g. showing how many facets are selected).  It takes them out of the accordion display though, so the transition isn't as smooth.  After talking with Eric, we think this approach is 'good enough for now', but is worth reviewing with the UI team to see if it's worth the extra effort to restore the accordion.  (Eric, you'll see from the screenshot that after our talk, I did some minor css tweaks to restore the inline display of the filters when shown, so all we're missing is style polish and the accordion-like animation)

![image](https://user-images.githubusercontent.com/2800795/76032952-03201500-5f09-11ea-84a4-4f5b7a6e8c1c.png)



