### PR TITLE
SCP-2219 - updating home page search style

### DIFF
--- a/app/javascript/components/Study.js
+++ b/app/javascript/components/Study.js
@@ -1,0 +1,36 @@
+import React from 'react'
+
+const descriptionCharLimit = 750
+
+export function formatDescription(rawDescription) {
+
+  let textDescription = stripTags(rawDescription)
+  let suffixString = ''
+  if (textDescription.length > descriptionCharLimit) {
+    suffixString = '... (continued)'
+  }
+  return `${textDescription.substring(0, descriptionCharLimit)}${suffixString}`
+}
+
+function stripTags(rawString) {
+  let tempDiv = document.createElement('div');
+  // Set the HTML content with the providen
+  tempDiv.innerHTML = rawString;
+  // Retrieve the text property of the element
+  return tempDiv.textContent || '';
+}
+
+export default function Study(props) {
+  const studyDescription = { __html: formatDescription(props.study.description) }
+
+  return (
+    <div key={props.study.accession}>
+      <label htmlFor={props.study.name} id= 'result-title'>
+        <a href={props.study.study_url}>{props.study.name} </a></label>
+      <div>
+        <span id='cell-count' className='badge badge-secondary'>{props.study.cell_count} Cells </span>
+      </div>
+      <span dangerouslySetInnerHTML={studyDescription} id='descrition-text-area' disabled accession = {props.study.name}></span>
+    </div>
+  )
+}

--- a/app/javascript/components/Study.js
+++ b/app/javascript/components/Study.js
@@ -1,36 +1,52 @@
 import React from 'react'
 
-const descriptionCharLimit = 750
+const descriptionWordLimit = 100
 
+/* converts description into text snippet */
 export function formatDescription(rawDescription) {
+  const textDescription = stripTags(rawDescription)
+  return shortenDescription(textDescription)
+}
 
-  let textDescription = stripTags(rawDescription)
-  let suffixString = ''
-  if (textDescription.length > descriptionCharLimit) {
-    suffixString = '... (continued)'
+// return the first 100 words, with a '...' appended if needed'
+// this returns a node, not text, so we can italicize 'continued'
+function shortenDescription(textDescription) {
+  const wordArray = textDescription.split(' ')
+  const numWords = wordArray.length
+  // take the first 100 words, or the whole thing if shorter
+  const shortenedText = wordArray.slice(0, descriptionWordLimit - 1)
+                                 .join(' ')
+
+  let suffixTag = <></>
+  if (numWords > descriptionWordLimit) {
+    suffixTag = <span className="detail"> ...(continued)</span>
   }
-  return `${textDescription.substring(0, descriptionCharLimit)}${suffixString}`
+  return <span>{shortenedText}{suffixTag}</span>
 }
 
+/* removes html tags from a string */
 function stripTags(rawString) {
-  let tempDiv = document.createElement('div');
+  const tempDiv = document.createElement('div')
   // Set the HTML content with the providen
-  tempDiv.innerHTML = rawString;
+  tempDiv.innerHTML = rawString
   // Retrieve the text property of the element
-  return tempDiv.textContent || '';
+  return tempDiv.textContent || ''
 }
 
+/* displays a brief summary of a study, with a link to the study page */
 export default function Study(props) {
-  const studyDescription = { __html: formatDescription(props.study.description) }
+  const studyDescription = formatDescription(props.study.description)
 
   return (
     <div key={props.study.accession}>
       <label htmlFor={props.study.name} id= 'result-title'>
         <a href={props.study.study_url}>{props.study.name} </a></label>
       <div>
-        <span id='cell-count' className='badge badge-secondary'>{props.study.cell_count} Cells </span>
+        <span id='cell-count' className='badge badge-secondary'>
+          {props.study.cell_count} Cells
+        </span>
       </div>
-      <span dangerouslySetInnerHTML={studyDescription} id='descrition-text-area' disabled accession = {props.study.name}></span>
+      {studyDescription}
     </div>
   )
 }

--- a/app/javascript/components/StudyResults.js
+++ b/app/javascript/components/StudyResults.js
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faAngleDoubleLeft, faAngleLeft, faAngleRight, faAngleDoubleRight
 } from '@fortawesome/free-solid-svg-icons'
+import Study from './Study'
 
 /**
  * Wrapper component for studies on homepage
@@ -123,24 +124,4 @@ const PagingControl = ({
   )
 }
 
-const Study = props => {
-  const studyDescription = { __html: props.study.description }
-
-  return (
-    <div key={props.study.accession}>
-      <label htmlFor={props.study.name} id= 'result-title'>
-        <a href={props.study.study_url}>{props.study.name} </a></label>
-      <div>
-        <span id='cell-count' className='badge badge-secondary'>
-          {props.study.cell_count} Cells
-        </span>
-      </div>
-      <span
-        disabled
-        dangerouslySetInnerHTML={studyDescription}
-        id='descrition-text-area'
-        accession={props.study.name}></span>
-    </div>
-  )
-}
 export default StudyResults

--- a/app/javascript/components/StudyResults.js
+++ b/app/javascript/components/StudyResults.js
@@ -20,7 +20,6 @@ const StudyResults = ({ results, changePage }) => {
       study: <Study
         study={result}
         key={result.accession}
-        className='card'
       />
     }
   )

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -442,6 +442,11 @@ h4, .h4, h5, .h5, h6, .h6 {
   margin-bottom: 2px;
 }
 
+.detail {
+  font-style: italic;
+  color: #888;
+}
+
 @media (min-width: 768px) {
   #view-options .col-sm-4, #view-options .col-md-3, #view-options .col-xs-12 {
     width: inherit;

--- a/app/javascript/styles/_resultsPanel.scss
+++ b/app/javascript/styles/_resultsPanel.scss
@@ -17,11 +17,10 @@
 }
 
 .results-content {
-  background-color: white;
-  border-left: 1px solid #d8dde6;
-  border-right: 1px solid #d8dde6;
-  padding: 10px;
   min-height: 50vh;
+  > table {
+    width: 100%;
+  }
   .loading-panel, .error-panel {
     box-shadow: none;
     padding-top: 1em;
@@ -34,16 +33,12 @@
 }
 
 .result-row {
-  background-color: #fff;
-  border-radius: 5px;
-  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.12), 0 3px 2px 0 rgba(0, 0, 0, 0.12);
-  margin: 0 auto;
-  margin-top: 10px;
-  padding: 15px;
   width: 100%;
-
-  #result-cell{
+  border-bottom: 7px solid #eee;
+  #result-cell {
     padding: 10px;
+    background: #fff;
+    border-radius: 5px;
   }
   #result-title {
     font-size: 16px;
@@ -72,7 +67,7 @@
   button {
     border: none;
     color: $action-color;
-    background-color: #eee;
+    background-color: #fff;
     border-radius: 3px;
     cursor: pointer;
     margin: 0 0.2em;


### PR DESCRIPTION
This adds space between studies, adds a 750-character limit on descriptions (the current home page has a 100-word limit, but 750 characters is about the same length, and will be more consistent across studies.), and strips html tags.  

![image](https://user-images.githubusercontent.com/2800795/76273740-f545f900-6254-11ea-8471-73b72cbbfbd1.png)
