### PR TITLE
Supporting keyword and exact phrase searching

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -147,8 +147,19 @@ module Api
           @search_terms = sanitize_search_values(params[:terms])
           # determine if search values contain possible study accessions
           possible_accessions = StudyAccession.sanitize_accessions(@search_terms.split)
-          @studies = @viewable.any_of({:$text => {:$search => @search_terms}},
-                                      {:accession.in => possible_accessions})
+          # next, determine which kind of search to use
+          # for keywords only, we can use the text index
+          # for exact phrases (or combination) we have to run a regex search manually on names/descriptions
+          if @search_terms.include?("\"")
+            @term_list = self.class.split_query_string_by_context(query_string: @search_terms)
+            study_regex = /(#{@term_list.join('|')})/i
+            @studies = @viewable.any_of({name: study_regex}, {description: study_regex},
+                                        {:accession.in => possible_accessions})
+          else
+            @term_list = @search_terms.split
+            @studies = @viewable.any_of({:$text => {:$search => @search_terms}},
+                                        {:accession.in => possible_accessions})
+          end
           # all of our terms were accessions, so this is a "cached" query, and we want to return
           # results in the exact order specified in the accessions array
           if possible_accessions.size == @search_terms.split.size
@@ -183,7 +194,7 @@ module Api
         # determine sort order for pagination; minus sign (-) means a descending search
         case sort_type
         when :keyword
-          @studies = @studies.sort_by {|study| -study.search_weight(@search_terms.split) }
+          @studies = @studies.sort_by {|study| -study.search_weight(@term_list)[:total] }
         when :accession
           @studies = @studies.sort_by {|study| possible_accessions.index(study.accession) }
         when :facet
@@ -523,6 +534,18 @@ module Api
         else
           view_context.sanitize(terms)
         end
+      end
+
+      def self.split_query_string_by_context(query_string:)
+        terms = []
+        query_string.split("\"").each do |substring|
+          if substring.start_with?(' ') || substring.end_with?(' ')
+            terms += substring.strip.split
+          else
+            terms << substring
+          end
+        end
+        terms
       end
 
       # generate query string for BQ

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -571,8 +571,12 @@ class Study
       key :description, 'SearchFacet filter matches'
     end
     property :term_matches do
-      key :type, :string
+      key :type, :array
       key :description, 'Keyword term matches'
+      items do
+        key :title, 'TermMatch'
+        key :type, :string
+      end
     end
     property :term_search_weight do
       key :type, :integer
@@ -819,12 +823,19 @@ class Study
 
   # compute a simplistic relevance score by counting instances of terms in names/descriptions
   def search_weight(terms)
-    score = 0
+    weights = {
+        total: 0,
+        terms: {}
+    }
     terms.each do |term|
       text_blob = "#{self.name} #{self.description}"
-      score += text_blob.scan(/#{term}/i).size
+      score = text_blob.scan(/#{term}/i).size
+      if score > 0
+        weights[:total] += score
+        weights[:terms][term] = score
+      end
     end
-    score
+    weights
   end
 
   ###

--- a/app/views/api/v1/search/_study.json.jbuilder
+++ b/app/views/api/v1/search/_study.json.jbuilder
@@ -11,8 +11,9 @@ if @studies_by_facet.present?
   json.set! :facet_matches, @studies_by_facet[study.accession]
 end
 if params[:terms].present?
-  json.set! :term_matches, @search_terms
-  json.set! :term_search_weight, study.search_weight(@search_terms.split)
+  search_weight = study.search_weight(@term_list)
+  json.set! :term_matches, search_weight[:terms].keys
+  json.set! :term_search_weight, search_weight[:total]
 end
 if study.detached
   json.set! :study_files, 'Unavailable (cannot load study workspace or bucket)'

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -135,10 +135,10 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     search_phrase = "\"API Test Study\""
     execute_http_request(:get, api_v1_search_path(type: 'study', terms: search_phrase))
     assert_response :success
-    expected_accessions = Study.where(name: "API Test Study #{@random_seed}").pluck(:accession)
-    matching_accessions = json['matching_accessions'] # no need to sort as there should only be one result
-    assert_equal expected_accessions, matching_accessions,
-                 "Did not return correct array of matching accessions, expected #{expected_accessions} but found #{matching_accessions}"
+    quoted_accessions = Study.where(name: "API Test Study #{@random_seed}").pluck(:accession)
+    found_accessions = json['matching_accessions'] # no need to sort as there should only be one result
+    assert_equal quoted_accessions, found_accessions,
+                 "Did not return correct array of matching accessions, expected #{quoted_accessions} but found #{found_accessions}"
 
     assert_equal search_phrase.gsub(/\"/, ''), json['studies'].first['term_matches'].first
 
@@ -146,13 +146,13 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     search_phrase += " testing"
     execute_http_request(:get, api_v1_search_path(type: 'study', terms: search_phrase))
     assert_response :success
-    expected_accessions = Study.any_of({name: "API Test Study #{@random_seed}"},
+    mixed_accessions = Study.any_of({name: "API Test Study #{@random_seed}"},
                                        {name: "Testing Study #{@random_seed}"}).pluck(:accession).sort
-    matching_accessions = json['matching_accessions'].sort
-    assert_equal expected_accessions, matching_accessions,
-                 "Did not return correct array of matching accessions, expected #{expected_accessions} but found #{matching_accessions}"
-    assert_equal search_phrase.gsub(/\"/, ''), json['studies'].first['term_matches'].first
-    assert_equal "testing", json['studies'].last['term_matches'].first
+    found_mixed_accessions = json['matching_accessions'].sort
+    assert_equal mixed_accessions, found_mixed_accessions,
+                 "Did not return correct array of matching accessions, expected #{found_mixed_accessions} but found #{mixed_accessions}"
+    assert_equal "testing", json['studies'].first['term_matches'].first
+    assert_equal "API Test Study", json['studies'].last['term_matches'].first
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -120,6 +120,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   test 'should return search results using keywords' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
 
+    # test single keyword first
     study_count = Study.count
     execute_http_request(:get, api_v1_search_path(type: 'study', terms: @random_seed))
     assert_response :success
@@ -128,9 +129,30 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_accessions, matching_accessions,
                  "Did not return correct array of matching accessions, expected #{expected_accessions} but found #{matching_accessions}"
 
-    result_count = json['studies'].size
-    assert_equal study_count, result_count, "Did not find correct number of studies, expected #{study_count} but found #{result_count}"
     assert_equal @random_seed, json['studies'].first['term_matches']
+
+    # test exact phrase
+    search_phrase = "\"API Test Study\""
+    execute_http_request(:get, api_v1_search_path(type: 'study', terms: search_phrase))
+    assert_response :success
+    expected_accessions = Study.where(name: "API Test Study #{@random_seed}").pluck(:accession)
+    matching_accessions = json['matching_accessions'] # no need to sort as there should only be one result
+    assert_equal expected_accessions, matching_accessions,
+                 "Did not return correct array of matching accessions, expected #{expected_accessions} but found #{matching_accessions}"
+
+    assert_equal search_phrase.gsub(/\"/, ''), json['studies'].first['term_matches'].first
+
+    # test combination
+    search_phrase += " testing"
+    execute_http_request(:get, api_v1_search_path(type: 'study', terms: search_phrase))
+    assert_response :success
+    expected_accessions = Study.any_of({name: "API Test Study #{@random_seed}"},
+                                       {name: "Testing Study #{@random_seed}"}).pluck(:accession).sort
+    matching_accessions = json['matching_accessions'].sort
+    assert_equal expected_accessions, matching_accessions,
+                 "Did not return correct array of matching accessions, expected #{expected_accessions} but found #{matching_accessions}"
+    assert_equal search_phrase.gsub(/\"/, ''), json['studies'].first['term_matches'].first
+    assert_equal "testing", json['studies'].last['term_matches'].first
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -129,7 +129,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_accessions, matching_accessions,
                  "Did not return correct array of matching accessions, expected #{expected_accessions} but found #{matching_accessions}"
 
-    assert_equal @random_seed, json['studies'].first['term_matches']
+    assert_equal @random_seed, json['studies'].first['term_matches'].first
 
     # test exact phrase
     search_phrase = "\"API Test Study\""


### PR DESCRIPTION
Previously, searching only supported keyword or a single phrase when performing searches.  We will now be able to do multiple phrases, or a combination of phrase and keyword.  Also, study matches will report which terms matched during search (before it just returned all search terms).

This PR satisfies SCP-2217.