### PR TITLE
Enable upload of .loom, .h5, .h5ad, and .h5an in "Miscellaneous" (SCP-2228)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -55,7 +55,7 @@ var ALLOWED_FILE_TYPES = {
     plainText: /(\.|\/)(txt|text|tsv|csv)$/i,
     primaryData: /((\.(fq|fastq)(\.tar)?\.gz$)|\.bam)/i,
     bundled: /(\.|\/)(txt|text|tsv|csv|bam\.bai)(\.gz)?$/i,
-    miscellaneous: /(\.|\/)(txt|text|tsv|csv|jpg|jpeg|png|pdf|doc|docx|xls|xlsx|ppt|pptx|zip)(\.gz)?$/i
+    miscellaneous: /(\.|\/)(txt|text|tsv|csv|jpg|jpeg|png|pdf|doc|docx|xls|xlsx|ppt|pptx|zip|loom|h5|h5ad|h5an)(\.gz)?$/i
 };
 
 // options for Spin.js


### PR DESCRIPTION
This enables upload of .loom, .h5, .h5ad, and .h5an files in the "Miscellaneous" tab of the upload wizard.  It is a hotfix, so merging into `master` is intentional.

I verified this change manually.

This satisfies SCP-2228.