### PR TITLE
UX Updates for Convention Metadata

### DIFF
--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -31,4 +31,8 @@ module StudiesHelper
 			site_path(order: order_val, search_terms: search_val)
 		end
 	end
+
+  def get_convention_label
+		"<span class='fas fa-copyright text-muted' aria-hidden='true' title='Convention Metadata' data-toggle='tooltip'></span>".html_safe
+	end
 end

--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -1,38 +1,38 @@
 module StudiesHelper
   # formatted label for boolean values
-	def get_boolean_label(field)
-		field ? "<span class='fas fa-check text-success'></span>".html_safe : "<span class='fas fa-times text-danger'></span>".html_safe
-	end
+  def get_boolean_label(field)
+    field ? "<span class='fas fa-check text-success'></span>".html_safe : "<span class='fas fa-times text-danger'></span>".html_safe
+  end
 
   # formatted label for parse status of uploaded files
-	def get_parse_label(parse_status)
-		case parse_status
-			when 'unparsed'
-				"<span class='fas fa-times text-danger' title='Unparsed' data-toggle='tooltip'></span>".html_safe
-			when 'parsing'
-				"<span class='fas fa-sync-alt text-warning' title='Parsing' data-toggle='tooltip'></span>".html_safe
-			when 'parsed'
-				"<span class='fas fa-check text-success' title='Parsed' data-toggle='tooltip'></span>".html_safe
-			else
-				"<span class='fas fa-times text-danger' title='Unparsed' data-toggle='tooltip'></span>".html_safe
-		end
-	end
+  def get_parse_label(parse_status)
+    case parse_status
+      when 'unparsed'
+        "<span class='fas fa-times text-danger' title='Unparsed' data-toggle='tooltip'></span>".html_safe
+      when 'parsing'
+        "<span class='fas fa-sync-alt text-warning' title='Parsing' data-toggle='tooltip'></span>".html_safe
+      when 'parsed'
+        "<span class='fas fa-check text-success' title='Parsed' data-toggle='tooltip'></span>".html_safe
+      else
+        "<span class='fas fa-times text-danger' title='Unparsed' data-toggle='tooltip'></span>".html_safe
+    end
+  end
 
   # formatted label for NA values
-	def get_na_label
-		"<span class='label label-default'><i class='fas fa-ban' aria-hidden='true'></i> N/A</span>".html_safe
-	end
+  def get_na_label
+    "<span class='label label-default'><i class='fas fa-ban' aria-hidden='true'></i> N/A</span>".html_safe
+  end
 
   # return formatted path with parameters for main site_path url
-	def get_site_path_with_params(search_val, order_val)
-		if search_val.blank?
-			site_path(order: order_val)
-		else
-			site_path(order: order_val, search_terms: search_val)
-		end
-	end
+  def get_site_path_with_params(search_val, order_val)
+    if search_val.blank?
+      site_path(order: order_val)
+    else
+      site_path(order: order_val, search_terms: search_val)
+    end
+  end
 
   def get_convention_label
-		"<span class='fas fa-copyright text-muted' aria-hidden='true' title='Convention Metadata' data-toggle='tooltip'></span>".html_safe
-	end
+    "<span class='fas fa-copyright text-muted' aria-hidden='true' title='Convention Metadata' data-toggle='tooltip'></span>".html_safe
+  end
 end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -378,6 +378,9 @@ class IngestJob
       genes = Gene.where(study_id: self.study.id, study_file_id: self.study_file.id).count
       message << "Gene-level entries created: #{genes}"
     when 'Metadata'
+      if self.study_file.use_metadata_convention
+        message << "This metadata file was validated against the current <a href='https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-Convention'>Metadata Convention</a>"
+      end
       cell_metadata = CellMetadatum.where(study_id: self.study.id, study_file_id: self.study_file.id)
       message << "Entries created:"
       cell_metadata.each do |metadata|

--- a/app/views/studies/_initialize_metadata_form.html.erb
+++ b/app/views/studies/_initialize_metadata_form.html.erb
@@ -20,13 +20,13 @@
 			<%= f.text_field :file_type, readonly: true, class: 'form-control file-type' %>
 		</div>
 		<div class="col-sm-5 upload-field">
+      <div class="col-sm-5">
+        <%= f.label :use_metadata_convention, "Use Metadata Convention?" %> <%= render partial: 'metadata_convention_help_popover', locals: {id: f.object.id.to_s} %><br />
+        <%= f.select :use_metadata_convention, options_for_select([['Yes', true],['No', false]], study_file.use_metadata_convention), {}, class: 'form-control use-metadata-convention', disabled: !study_file.new_record? %>
+      </div>
       <% if !study_file.upload_file_name.nil? %>
         <p><label>Link to file </label><br /><%= render partial: '/layouts/download_link', locals: {study: @study, study_file: study_file} %></p>
       <% else %>
-        <div class="col-sm-5">
-        <%= f.label :use_metadata_convention, "Use Metadata Convention?" %> <%= render partial: 'metadata_convention_help_popover', locals: {id: f.object.id.to_s} %><br />
-        <%= f.select :use_metadata_convention, options_for_select([['Yes', true],['No', false]], study_file.use_metadata_convention), {}, class: 'form-control use-metadata-convention' %>
-      </div>
         <%= f.label :upload, 'Upload Data File' %><br />
         <%= f.file_field :upload, class: 'btn btn-info fileinput-button', id: 'upload-metadata' %>
         <%= f.hidden_field :status, value: study_file.new_record? ? 'uploading' : 'uploaded' %>

--- a/app/views/studies/_metadata_file_fields.html.erb
+++ b/app/views/studies/_metadata_file_fields.html.erb
@@ -1,0 +1,6 @@
+<div class="form-group row">
+  <div class="col-sm-4">
+    <%= f.label :use_metadata_convention, "Use Metadata Convention?" %> <%= render partial: 'metadata_convention_help_popover', locals: {id: f.object.id.to_s} %><br />
+    <%= f.select :use_metadata_convention, options_for_select([['Yes', true],['No', false]], f.object.use_metadata_convention), {}, class: 'form-control use-metadata-convention', disabled: !f.object.new_record? %>
+  </div>
+</div>

--- a/app/views/studies/_orphaned_study_file_form.html.erb
+++ b/app/views/studies/_orphaned_study_file_form.html.erb
@@ -33,6 +33,8 @@
   <div id="study-file-<%= study_file._id %>-extra-info">
     <% if study_file.file_type == 'Cluster'  %>
       <%= render partial: 'cluster_axis_fields', locals: {f: f.dup} %>
+    <% elsif study_file.file_type == 'Metadata' %>
+      <%= render partial: 'metadata_file_fields', locals: {f: f.dup} %>
     <% elsif study_file.file_type == 'Expression Matrix' || study_file.file_type == 'MM Coordinate Matrix' %>
       <%= render partial: 'expression_file_fields', locals: {f: f.dup} %>
     <% end %>

--- a/app/views/studies/_shared_sync_functions.js.erb
+++ b/app/views/studies/_shared_sync_functions.js.erb
@@ -13,6 +13,10 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', function() {
     if (fileType === 'Cluster') {
         extraInfo.html("<%= j(render partial: 'cluster_axis_fields', locals: {f: f.dup}) %>");
         nameField.attr('readonly', false);
+    } else if (fileType === 'Metadata') {
+        extraInfo.html("<%= j(render partial: 'metadata_file_fields', locals: {f: f.dup}) %>");
+        nameField.val(fileName);
+        nameField.attr('readonly', 'readonly');
     } else if (fileType === 'Expression Matrix') {
         extraInfo.html("<%= j(render partial: 'expression_file_fields', locals: {f: f.dup}) %>");
         taxonTarget.html("<%= j(render partial: 'taxon_fields', locals: {f: f.dup}) %>");

--- a/app/views/studies/_study_file_form.html.erb
+++ b/app/views/studies/_study_file_form.html.erb
@@ -29,6 +29,8 @@
   <div id="study-file-<%= study_file._id %>-extra-info">
     <% if study_file.file_type == 'Cluster'  %>
       <%= render partial: 'cluster_axis_fields', locals: {f: f.dup} %>
+    <% elsif study_file.file_type == 'Metadata' %>
+      <%= render partial: 'metadata_file_fields', locals: {f: f.dup} %>
     <% elsif study_file.file_type == 'Expression Matrix' || study_file.file_type == 'MM Coordinate Matrix' %>
       <%= render partial: 'expression_file_fields', locals: {f: f.dup} %>
     <% elsif study_file.file_type == '10X Genes File' || study_file.file_type == '10X Barcodes File' %>

--- a/app/views/studies/_synced_study_file_form.html.erb
+++ b/app/views/studies/_synced_study_file_form.html.erb
@@ -25,6 +25,8 @@
   <div id="study-file-<%= study_file._id %>-extra-info">
     <% if study_file.file_type == 'Cluster'  %>
       <%= render partial: 'cluster_axis_fields', locals: {f: f.dup} %>
+    <% elsif study_file.file_type == 'Metadata' %>
+      <%= render partial: 'metadata_file_fields', locals: {f: f.dup} %>
     <% elsif study_file.file_type == 'Expression Matrix' || study_file.file_type == 'MM Coordinate Matrix' %>
       <%= render partial: 'expression_file_fields', locals: {f: f.dup} %>
     <% end %>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -228,7 +228,7 @@
             <tr id="study-file-<%= study_file.id %>">
               <td class="study-file-name"><%= study_file.name %></td>
               <td class="study-file-description"><%= study_file.description %></td>
-              <td class="study-file-file-type"><%= study_file.file_type %></td>
+              <td class="study-file-file-type"><%= study_file.file_type %>&nbsp;<%= study_file.use_metadata_convention ? get_convention_label : nil %></td>
               <td class="study-file-species-info">
                 <% if study_file.taxon.present? %>
                   <%= study_file.species_name %> <%= study_file.genome_assembly.present? ? " (#{study_file.genome_assembly_name})" : nil %>


### PR DESCRIPTION
Addressing some UX paper cuts with uploading convention metadata files:

1. Dropdown disappearing after upload
2. Unable to specify convention metadata on sync
3. Adding indication in "Study Info" page of convention metadata
4. Adding line to parse success email indicating this was a convention metadata file (failure emails have the command line, which will say `--validate-convention`)

This PR satisfies SCP-2225 and SCP-2226