### PR TITLE
Removing running migrations in test environment

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -47,7 +47,6 @@ RAILS_ENV=test NODE_ENV=test bin/bundle exec rake assets:precompile
 echo "Generating random seed, seeding test database..."
 RANDOM_SEED=$(openssl rand -hex 16)
 echo $RANDOM_SEED > /home/app/webapp/.random_seed
-bundle exec rake RAILS_ENV=test db:migrate
 bundle exec rake RAILS_ENV=test db:seed || { echo "FAILED to seed test database!" >&2; exit 1; }
 bundle exec rake RAILS_ENV=test db:mongoid:create_indexes
 echo "Database initialized"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -115,24 +115,20 @@ AnalysisConfiguration.create(namespace: 'single-cell-portal', name: 'split-clust
                              configuration_snapshot: 2, description: 'This is a test description.')
 
 # SearchFacet seeds
-species = SearchFacet.find_or_initialize_by(identifier: 'species')
-species.filters = [{id: 'NCBITaxon_9606', name: 'Homo sapiens'}]
-species.save
-
-disease = SearchFacet.find_or_initialize_by(identifier: 'disease')
-disease.filters = [{id: 'MONDO_0000001', name: 'disease or disorder'}]
-disease.save
-
-age = SearchFacet.find_or_initialize_by(identifier: 'organism_age')
-age.name = 'Organism Age'
-age.data_type = 'number'
-age.is_ontology_based = false
-age.is_array_based = false
-age.big_query_id_column = 'organism_age'
-age.big_query_name_column = 'organism_age'
-age.big_query_conversion_column ='organism_age__seconds'
-age.convention_name = 'Alexandria Metadata Convention'
-age.convention_version = '1.1.3'
-age.save
+SearchFacet.create(name: 'Species', identifier: 'species', filters: [{id: 'NCBITaxon_9606', name: 'Homo sapiens'}],
+                   ontology_urls: [{name: 'NCBI organismal classification', url: 'https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon'}],
+                   data_type: 'string', is_ontology_based: true, is_array_based: false, big_query_id_column: 'species',
+                   big_query_name_column: 'species__ontology_label', convention_name: 'Alexandria Metadata Convention',
+                   convention_version: '1.1.3')
+SearchFacet.create(name: 'Disease', identifier: 'disease', filters: [{id: 'MONDO_0000001', name: 'disease or disorder'}],
+                   ontology_urls: [{name: 'Monarch Disease Ontology', url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo'},
+                                   {name: 'Phenotype And Trait Ontology', url: 'https://www.ebi.ac.uk/ols/ontologies/pato'}],
+                   data_type: 'string', is_ontology_based: true, is_array_based: true, big_query_id_column: 'disease',
+                   big_query_name_column: 'disease__ontology_label', convention_name: 'Alexandria Metadata Convention',
+                   convention_version: '1.1.3')
+SearchFacet.create(name: 'Organism Age', identifier: 'organism_age', big_query_id_column: 'organism_age', big_query_name_column: 'organism_age',
+                   big_query_conversion_column: 'organism_age__seconds', is_ontology_based: false, data_type: 'number',
+                   is_array_based: false, convention_name: 'Alexandria Metadata Convention', convention_version: '1.1.3',
+                   unit: 'years')
 
 BrandingGroup.create(name: 'Test Brand', user_id: api_user.id, font_family: 'Helvetica Neue, sans-serif', background_color: '#FFFFFF')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -115,6 +115,7 @@ AnalysisConfiguration.create(namespace: 'single-cell-portal', name: 'split-clust
                              configuration_snapshot: 2, description: 'This is a test description.')
 
 # SearchFacet seeds
+# These facets represent 3 of the main types: String-based (both for array- and non-array columns), and numeric
 SearchFacet.create(name: 'Species', identifier: 'species', filters: [{id: 'NCBITaxon_9606', name: 'Homo sapiens'}],
                    ontology_urls: [{name: 'NCBI organismal classification', url: 'https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon'}],
                    data_type: 'string', is_ontology_based: true, is_array_based: false, big_query_id_column: 'species',

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -121,7 +121,6 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
 
     # test single keyword first
-    study_count = Study.count
     execute_http_request(:get, api_v1_search_path(type: 'study', terms: @random_seed))
     assert_response :success
     expected_accessions = Study.pluck(:accession)


### PR DESCRIPTION
Removing command to run database migrations in the Rails `test` environment via `bin/run_tests.sh`.  This is to address issues with inconsistent test results via CI.

This PR satisfies SCP-2232.