### PR TITLE
Fixing issue re: deleting studies w/o metadata files

### DIFF
--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -12,7 +12,9 @@ class DeleteQueueJob < Struct.new(:object)
     case object.class.name
     when 'Study'
       # first check if we have convention metadata to delete
-      delete_convention_data(study: object, metadata_file: object.metadata_file)
+      if object.metadata_file.present?
+        delete_convention_data(study: object, metadata_file: object.metadata_file)
+      end
       # mark for deletion, rename study to free up old name for use, and restrict access by removing owner
       new_name = "DELETE-#{object.data_dir}"
       object.update!(public: false, name: new_name, url_safe_name: new_name)


### PR DESCRIPTION
Addressing an issue in `DeleteQueueJob` where deleting a study without a metadata file throws an error, and does not delete the study.

This PR satisfies SCP-2234.