### PR TITLE
Allowing inferred searching using facets as keywords

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -138,6 +138,11 @@ module Api
 
       def index
         @viewable = Study.viewable(current_api_user)
+
+        # filter results by branding group, if specified
+        if @selected_branding_group.present?
+          @viewable = @viewable.where(branding_group_id: @selected_branding_group.id)
+        end
         # variable for determining how we will sort search results for relevance
         sort_type = :none
 
@@ -147,31 +152,25 @@ module Api
           @search_terms = sanitize_search_values(params[:terms])
           # determine if search values contain possible study accessions
           possible_accessions = StudyAccession.sanitize_accessions(@search_terms.split)
-          # next, determine which kind of search to use
-          # for keywords only, we can use the text index
-          # for exact phrases (or combination) we have to run a regex search manually on names/descriptions
+          # determine query case based off of search terms (either :keyword or :phrase)
           if @search_terms.include?("\"")
             @term_list = self.class.extract_phrases_from_search(query_string: @search_terms)
-            study_regex = self.class.escape_terms_for_regex(term_list: @term_list)
-            @studies = @viewable.any_of({name: study_regex}, {description: study_regex},
-                                        {:accession.in => possible_accessions})
+            logger.info "Performing phrase-based search using #{@term_list}"
+            @studies = self.class.generate_mongo_query_by_case(terms: @term_list, base_studies: @viewable,
+                                                               accessions: possible_accessions, query_case: :phrase)
           else
             @term_list = @search_terms.split
-            @studies = @viewable.any_of({:$text => {:$search => @search_terms}},
-                                        {:accession.in => possible_accessions})
+            logger.info "Performing keyword-based search using #{@term_list}"
+            @studies = self.class.generate_mongo_query_by_case(terms: @search_terms, base_studies: @viewable,
+                                                               accessions: possible_accessions, query_case: :keyword)
           end
           # all of our terms were accessions, so this is a "cached" query, and we want to return
           # results in the exact order specified in the accessions array
-          if possible_accessions.size == @search_terms.split.size
+          if possible_accessions.size == @term_list.size
             sort_type = :accession
           end
         else
           @studies = @viewable
-        end
-
-        # filter results by branding group, if specified
-        if @selected_branding_group.present?
-          @studies = @studies.where(branding_group_id: @selected_branding_group.id)
         end
 
         # only call BigQuery if list of possible studies is larger than 0 and we have matching facets to use
@@ -179,20 +178,19 @@ module Api
           sort_type = :facet
           @studies_by_facet = {}
           @big_query_search = self.class.generate_bq_query_string(@facets)
-          Rails.logger.info "Searching BigQuery using facet-based query: #{@big_query_search}"
+          logger.info "Searching BigQuery using facet-based query: #{@big_query_search}"
           query_results = ApplicationController.big_query_client.dataset(CellMetadatum::BIGQUERY_DATASET).query @big_query_search
           job_id = query_results.job_gapi.job_reference.job_id
           # build up map of study matches by facet & filter value (for adding labels in UI)
           @studies_by_facet = self.class.match_studies_by_facet(query_results, @facets)
           # uniquify result list as one study may match multiple facets/filters
           @convention_accessions = query_results.map {|match| match[:study_accession]}.uniq
-          Rails.logger.info "Found #{@convention_accessions.count} matching studies from BQ job #{job_id}: #{@convention_accessions}"
+          logger.info "Found #{@convention_accessions.count} matching studies from BQ job #{job_id}: #{@convention_accessions}"
           @studies = @studies.where(:accession.in => @convention_accessions)
         end
 
-        @studies = @studies.to_a
-
         # determine sort order for pagination; minus sign (-) means a descending search
+        @studies = @studies.to_a
         case sort_type
         when :keyword
           @studies = @studies.sort_by {|study| -study.search_weight(@term_list)[:total] }
@@ -204,21 +202,21 @@ module Api
           # we have sort_type of :none, so preserve original ordering of :view_order
           @studies = @studies.sort_by(&:view_order)
         end
-        # save list of study accessions for bulk_download/bulk_download_size calls, as well as caching query results
+
+        # save list of study accessions for bulk_download/bulk_download_size calls, in order of results
         @matching_accessions = @studies.map(&:accession)
 
-        # if a user only ran a faceted search, attempt to infer results by converting filter display values to keywords
-        if params[:terms].blank? && @facets.any?
-          @filter_keywords = self.class.convert_filters_for_inferred_search(facets: @facets)
-          filter_regex = self.class.escape_terms_for_regex(term_list: @filter_keywords)
-          base_studies = @selected_branding_group.present? ? @viewable.where(branding_group_id: @selected_branding_group.id) : @viewable
-          inferred_studies = base_studies.any_of({name: filter_regex}, {description: filter_regex}).
-              where(:accession.nin => @matching_accessions) # make sure we don't have any overlap in results
+        # if a user ran a faceted search, attempt to infer results by converting filter display values to keywords
+        if @facets.any?
+          # preserve existing search terms, if present
+          @filter_keywords = @term_list.present? ? @term_list.dup : []
+          @filter_keywords += self.class.convert_filters_for_inferred_search(facets: @facets)
+          inferred_studies = self.class.generate_mongo_query_by_case(terms: @filter_keywords, base_studies: @viewable,
+                                                                     accessions: @matching_accessions, query_case: :inferred)
           @inferred_accessions = inferred_studies.pluck(:accession)
           @matching_accessions += @inferred_accessions
           @studies += inferred_studies.sort_by {|study| -study.search_weight(@filter_keywords)[:total] }
         end
-
         @results = @studies.paginate(page: params[:page], per_page: Study.per_page)
       end
 
@@ -569,6 +567,27 @@ module Api
       def self.escape_terms_for_regex(term_list:)
         escaped_terms = term_list.map {|term| Regexp.quote term}
         /(#{escaped_terms.join('|')})/i
+      end
+
+      # generate a Mongoid::Criteria object to perform a keyword/exact phrase search based on use case
+      # supports the following cases: :keyword (individual terms), :phrase (quoted phrases & keywords)
+      # and :inferred (converting a facet-based query to keywords)
+      # will scope the query based off of :base_studies, and include/exclude studies matching
+      # :accessions based on the :query_case (included by default, but excluded in :inferred to avoid duplicates)
+      def self.generate_mongo_query_by_case(terms:, base_studies:, accessions:, query_case:)
+        case query_case
+        when :keyword
+          base_studies.any_of({:$text => {:$search => terms}}, {:accession.in => accessions})
+        when :phrase
+          study_regex = escape_terms_for_regex(term_list: terms)
+          base_studies.any_of({name: study_regex}, {description: study_regex}, {:accession.in => accessions})
+        when :inferred
+          filter_regex = escape_terms_for_regex(term_list: terms)
+          base_studies.any_of({name: filter_regex}, {description: filter_regex}).where(:accession.nin => accessions)
+        else
+          # no matching query case, so perform normal text-index search
+          base_studies.any_of({:$text => {:$search => terms}}, {:accession.in => accessions})
+        end
       end
 
       # generate query string for BQ

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -592,7 +592,7 @@ class Study
       key :description, 'Available StudyFiles for download, by type'
       StudyFile::BULK_DOWNLOAD_TYPES.each do |file_type|
         property file_type do
-          key :title, "#{file_type} Files"
+          key :description, "#{file_type} Files"
           key :type, :array
           items do
             key :title, 'StudyFile'

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -582,6 +582,10 @@ class Study
       key :type, :integer
       key :description, 'Relevance of term match'
     end
+    property :inferred_match do
+      key :type, :boolean
+      key :description, 'Indication if match is inferred (e.g. converting facet filter value to keyword search)'
+    end
     property :study_files do
       key :type, :object
       key :title, 'StudyFiles'

--- a/app/views/api/v1/search/_study.json.jbuilder
+++ b/app/views/api/v1/search/_study.json.jbuilder
@@ -15,6 +15,13 @@ if params[:terms].present?
   json.set! :term_matches, search_weight[:terms].keys
   json.set! :term_search_weight, search_weight[:total]
 end
+# if this is an inferred match, use :term_matches for highlighting, but set :inferred_match to true
+if @inferred_accessions.present? && @inferred_accessions.include?(study.accession)
+  json.set! :inferred_match, true
+  inferred_weight = study.search_weight(@filter_keywords)
+  json.set! :term_matches, inferred_weight[:terms].keys
+  json.set! :term_search_weight, inferred_weight[:total]
+end
 if study.detached
   json.set! :study_files, 'Unavailable (cannot load study workspace or bucket)'
 else

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -245,4 +245,38 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
+
+  test 'should run inferred search using facets' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    convention_study = Study.find_by(name: "Test Study #{@random_seed}")
+    other_study = Study.find_by(name: "API Test Study #{@random_seed}")
+    original_description = other_study.description.to_s.dup
+    species_facet = SearchFacet.find_by(identifier: 'species')
+    facet_query = "#{species_facet.identifier}:#{species_facet.filters.first[:id]}"
+    execute_http_request(:get, api_v1_search_path(type: 'study', facets: facet_query))
+    assert_response :success
+    expected_accessions = [convention_study.accession]
+    assert_equal expected_accessions, json['matching_accessions'],
+                 "Did not find expected accessions before inferred search, expected #{expected_accessions} but found #{json['matching_accessions']}"
+
+    # now update non-convention study to include a filter display value in its description
+    # this should be picked up by the "inferred" search
+    filter_name = species_facet.filters.first[:name]
+    other_study.update(description: filter_name)
+    facet_query = "#{species_facet.identifier}:#{species_facet.filters.first[:id]}"
+    execute_http_request(:get, api_v1_search_path(type: 'study', facets: facet_query))
+    assert_response :success
+    inferred_accessions = [convention_study.accession, other_study.accession]
+    assert_equal inferred_accessions, json['matching_accessions'],
+                 "Did not find expected accessions after inferred search, expected #{inferred_accessions} but found #{json['matching_accessions']}"
+    inferred_study = json['studies'].last # inferred matches should be at the end
+    assert inferred_study['inferred_match'],
+           "Did not mark last search results as inferred_match: #{inferred_study['inferred_match']} != true"
+
+    # reset description so other tests aren't broken
+    other_study.update(description: original_description)
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
 end

--- a/test/integration/study_validation_test.rb
+++ b/test/integration/study_validation_test.rb
@@ -72,7 +72,7 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
     seconds_slept = 60
     sleep seconds_slept
     sleep_increment = 15
-    max_seconds_to_sleep = 180
+    max_seconds_to_sleep = 300
     until ( example_files.values.all? { |e| ['parsed', 'failed'].include? e[:object].parse_status } ) do
       puts "After #{seconds_slept} seconds, " + (example_files.values.map { |e| "#{e[:name]} is #{e[:object].parse_status}"}).join(", ") + '.'
       if seconds_slept >= max_seconds_to_sleep


### PR DESCRIPTION
Non-numeric faceted searches will now attempt to "infer" results by converting filter values into exact phrases (using filter display names, e.g. "tuberculosis", or "Homo sapiens") and running a secondary search after all exact matches are found.  These studies are labeled with `inferred_match: true` in the response, and ordered after all exact matches have returned.  They will also list what terms matched using the standard `term_matches` parameter.  These results are weighted together, so higher confidence inferred matches are returned first (but still after all exact matches).  This PR also DRYs up the search logic somewhat by extracting MongoDB-based searches into a static method.

This PR satisfies SCP-2205.