### PR TITLE
Bugfix for updating array-based facet filters

### DIFF
--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -12,7 +12,9 @@ class DeleteQueueJob < Struct.new(:object)
     case object.class.name
     when 'Study'
       # first check if we have convention metadata to delete
-      delete_convention_data(study: object, metadata_file: object.metadata_file)
+      if object.metadata_file.present?
+        delete_convention_data(study: object, metadata_file: object.metadata_file)
+      end
       # mark for deletion, rename study to free up old name for use, and restrict access by removing owner
       new_name = "DELETE-#{object.data_dir}"
       object.update!(public: false, name: new_name, url_safe_name: new_name)

--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -311,25 +311,14 @@ class SearchFacet
   # retrieve unique values from BigQuery and format an array of hashes with :name and :id values to populate :filters attribute
   def get_unique_filter_values
     Rails.logger.info "Updating filter values for SearchFacet: #{self.name} using id: #{self.big_query_id_column} and name: #{self.big_query_name_column}"
-    queries = []
-    if self.is_array_based
-      queries << self.generate_array_query(self.big_query_id_column, 'id')
-      queries << self.generate_array_query(self.big_query_name_column, 'name')
-    elsif self.is_numeric?
-      queries << self.generate_minmax_query
-    else
-      queries << self.generate_non_array_query
-    end
+    query_string = self.generate_query_string_by_type
     begin
-      results = []
-      queries.each do |query_string|
-        Rails.logger.info "Executing query: #{query_string}"
-        results << SearchFacet.big_query_dataset.query(query_string)
-      end
-      return self.is_numeric? ? results.flatten.first : assemble_filters_array(results)
+      Rails.logger.info "Executing query: #{query_string}"
+      results = SearchFacet.big_query_dataset.query(query_string)
+      self.is_numeric? ? results.first : results
     rescue => e
       Rails.logger.error "Error retrieving unique values for #{CellMetadatum::BIGQUERY_TABLE}: #{e.class.name}:#{e.message}"
-      error_context = ErrorTracker.format_extra_context({queries: queries})
+      error_context = ErrorTracker.format_extra_context({query_string: query_string})
       ErrorTracker.report_exception(e, nil, error_context)
       []
     end
@@ -349,13 +338,22 @@ class SearchFacet
     end
   end
 
+  # return the correct query string for updating filter values from BQ based on facet type
+  def generate_query_string_by_type
+    if self.is_array_based
+      self.generate_array_query
+    elsif self.is_numeric?
+      self.generate_minmax_query
+    else
+      self.generate_non_array_query
+    end
+  end
+
   # generate a single query to get DISTINCT values from an array-based column, preserving order
-  # this way we can do two queries, and stitch them together in a hash as the order will be the same
-  # e.g. IDs will line up with NAMEs
-  def generate_array_query(column_name, identifier)
-    "SELECT DISTINCT #{identifier} FROM(SELECT array_col AS #{identifier}, " + \
-    "FROM #{CellMetadatum::BIGQUERY_TABLE}, UNNEST(#{column_name}) AS array_col " + \
-    "WITH OFFSET AS offset ORDER BY offset)"
+  def generate_array_query
+    "SELECT DISTINCT id, name FROM(SELECT id_col AS id, name_col as name " + \
+    "FROM #{CellMetadatum::BIGQUERY_TABLE}, UNNEST(#{self.big_query_id_column}) AS id_col WITH OFFSET id_pos, " + \
+    "UNNEST(#{self.big_query_name_column}) as name_col WITH OFFSET name_pos WHERE id_pos = name_pos)"
   end
 
   # generate query string to retrieve distinct values for non-array based facets
@@ -366,22 +364,6 @@ class SearchFacet
   # generate a minmax query string to set bounds for numeric facets
   def generate_minmax_query
     "SELECT MIN(#{self.big_query_id_column}) AS MIN, MAX(#{self.big_query_id_column}) AS MAX FROM #{CellMetadatum::BIGQUERY_TABLE}"
-  end
-
-  # stitch together results into the formatted filters array based on whether or not we ran one or two queries
-  def assemble_filters_array(results_array)
-    if results_array.size == 1
-      results_array.first # already in the correct form, so just return
-    else
-      # we have two hashes we need to merge together
-      filters_array = []
-      id_array = results_array.first
-      name_array = results_array.last
-      id_array.each_with_index do |filter_hash, index|
-        filters_array << filter_hash.merge(name_array[index])
-      end
-      filters_array
-    end
   end
 
   private

--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -311,7 +311,7 @@ class SearchFacet
   # retrieve unique values from BigQuery and format an array of hashes with :name and :id values to populate :filters attribute
   def get_unique_filter_values
     Rails.logger.info "Updating filter values for SearchFacet: #{self.name} using id: #{self.big_query_id_column} and name: #{self.big_query_name_column}"
-    query_string = self.generate_query_string_by_type
+    query_string = self.generate_bq_query_string
     begin
       Rails.logger.info "Executing query: #{query_string}"
       results = SearchFacet.big_query_dataset.query(query_string)
@@ -339,7 +339,7 @@ class SearchFacet
   end
 
   # return the correct query string for updating filter values from BQ based on facet type
-  def generate_query_string_by_type
+  def generate_bq_query_string
     if self.is_array_based
       self.generate_array_query
     elsif self.is_numeric?

--- a/test/models/search_facet_test.rb
+++ b/test/models/search_facet_test.rb
@@ -40,15 +40,15 @@ class SearchFacetTest < ActiveSupport::TestCase
   test 'should generate correct distinct queries' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
 
-    non_array_query = @search_facet.generate_query_string_by_type
+    non_array_query = @search_facet.generate_bq_query_string
     non_array_match = /DISTINCT #{@search_facet.big_query_id_column}/
     assert_match non_array_match, non_array_query, "Non-array query did not contain correct DISTINCT clause: #{non_array_query}"
     array_facet = SearchFacet.find_by(identifier: 'disease')
-    array_query = array_facet.generate_query_string_by_type
+    array_query = array_facet.generate_bq_query_string
     array_match = /SELECT DISTINCT id.*UNNEST\(#{array_facet.big_query_id_column}\) AS id_col WITH OFFSET id_pos.*WHERE id_pos = name_pos/
     assert_match array_match, array_query, "Array query did not correctly unnest column or match offset positions: #{array_query}"
     numeric_facet = SearchFacet.find_by(identifier: 'organism_age')
-    numeric_query = numeric_facet.generate_query_string_by_type
+    numeric_query = numeric_facet.generate_bq_query_string
     numeric_match = /MIN\(#{numeric_facet.big_query_id_column}\).*MAX\(#{numeric_facet.big_query_id_column}\)/
     assert_match numeric_match, numeric_query, "MinMax query did not contain MIN or MAX calls for correct columns: #{numeric_query}"
 


### PR DESCRIPTION
Fixing a bug where querying for distinct IDs and names from array-based columns in BigQuery returned inconsistent results - sometimes IDs and names would line up, but not always, as this was done across two separate queries.  This has been updated to a single query which unnests both columns with offsets for each column, and specifically checks for both offsets to be equal before returning results.  This has an added benefit of simplifying the code or SearchFacet#get_unique_filter_values.

This PR satisfies SCP-2236.