### PR TITLE
Include "Authorization: Bearer" via SCP API JS client (SCP-2231)

### DIFF
--- a/app/javascript/components/UserProvider.js
+++ b/app/javascript/components/UserProvider.js
@@ -1,8 +1,8 @@
 import React, { useContext } from 'react'
 
 // window.SCP is not available when running via Jest tests,
-// so default such cases to a blank string
-export const accessToken = 'SCP' in window ? window.SCP.userAccessToken : ''
+// so default such cases to a string "test"
+export const accessToken = 'SCP' in window ? window.SCP.userAccessToken : 'test'
 
 const user = {
   accessToken

--- a/app/javascript/components/UserProvider.js
+++ b/app/javascript/components/UserProvider.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react'
 
 // window.SCP is not available when running via Jest tests,
 // so default such cases to a blank string
-const accessToken = 'SCP' in window ? window.SCP.userAccessToken : ''
+export const accessToken = 'SCP' in window ? window.SCP.userAccessToken : ''
 
 const user = {
   accessToken

--- a/app/javascript/components/UserProvider.js
+++ b/app/javascript/components/UserProvider.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react'
 
 // window.SCP is not available when running via Jest tests,
 // so default such cases to a string "test"
-export const accessToken = 'SCP' in window ? window.SCP.userAccessToken : 'test'
+export const accessToken = ('SCP' in window) ? window.SCP.userAccessToken : 'test'
 
 const user = {
   accessToken

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -23,7 +23,9 @@ const defaultInit = {
   }
 }
 
-if (globalMock === false) {
+if (
+  accessToken !== '' // accessToken is a blank string when not signed in
+) {
   defaultInit.headers = Object.assign(defaultInit.headers, {
     'Authorization': `Bearer ${accessToken}`
   })

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -8,6 +8,11 @@
 import camelcaseKeys from 'camelcase-keys'
 import _compact from 'lodash/compact'
 
+import { accessToken } from './../components/UserProvider'
+
+// If true, returns mock data for all API responses.  Only for dev.
+let globalMock = false
+
 const defaultBasePath = '/single_cell/api/v1'
 
 const defaultInit = {
@@ -16,6 +21,12 @@ const defaultInit = {
     'Content-Type': 'application/json',
     'Accept': 'application/json'
   }
+}
+
+if (globalMock === false) {
+  defaultInit.headers = Object.assign(defaultInit.headers, {
+    'Authorization': `Bearer ${accessToken}`
+  })
 }
 
 /**
@@ -37,12 +48,8 @@ const defaultInit = {
 export async function fetchAuthCode(mock=false) {
   let init = defaultInit
   if (mock === false && globalMock === false) {
-    const customHeaders = Object.assign(defaultInit.headers, {
-      'Authorization': `Bearer ${window.SCP.userAccessToken}`
-    })
     init = {
-      method: 'POST',
-      headers: customHeaders
+      method: 'POST'
     }
   }
   return await scpApi('/search/auth_code', init, mock)
@@ -57,12 +64,8 @@ export async function fetchAuthCode(mock=false) {
  * @returns {Promise} Promise object containing camel-cased data from API
  */
 export async function fetchFacets(mock=false) {
-  const init = defaultInit
   return await scpApi('/search/facets', defaultInit, mock)
 }
-
-// If true, returns mock data for all API responses.  Only for dev.
-let globalMock = false
 
 /**
  * Sets flag on whether to use mock data for all API responses.

--- a/test/js/scp-api.test.js
+++ b/test/js/scp-api.test.js
@@ -27,6 +27,8 @@ describe('JavaScript client for SCP REST API', () => {
   // Note: tests that mock global.fetch must be put after tests that don't
   // mock it.  jest.restoreAllMocks() doesn't clear everything as expected,
   // nor does anything else.
+  //
+  // Consider using isolateModules for this type of thing
   it('includes `Authorization: Bearer` in requests when signed in', done => {
     // Spy on `fetch()` and its contingent methods like `json()`,
     // because we want to intercept the outgoing request

--- a/test/js/scp-api.test.js
+++ b/test/js/scp-api.test.js
@@ -4,7 +4,8 @@ const fetch = require('node-fetch')
 
 import {
   fetchAuthCode,
-  fetchFacetFilters
+  fetchFacetFilters,
+  setGlobalMockFlag
 } from '../../app/javascript/lib/scp-api'
 
 describe('JavaScript client for SCP REST API', () => {
@@ -21,5 +22,39 @@ describe('JavaScript client for SCP REST API', () => {
   it('returns 10 filters from fetchFacetFilters', async () => {
     const apiData = await fetchFacetFilters('disease', 'tuberculosis')
     expect(apiData.filters).toHaveLength(10)
+  })
+
+  // Note: tests that mock global.fetch must be put after tests that don't
+  // mock it.  jest.restoreAllMocks() doesn't clear everything as expected,
+  // nor does anything else.
+  it('includes `Authorization: Bearer` in requests when signed in', done => {
+    // Spy on `fetch()` and its contingent methods like `json()`,
+    // because we want to intercept the outgoing request
+    const mockSuccessResponse = {}
+    const mockJsonPromise = Promise.resolve(mockSuccessResponse)
+    const mockFetchPromise = Promise.resolve({
+      json: () => {mockJsonPromise}
+    })
+    jest.spyOn(global, 'fetch').mockImplementation(() => {
+      mockFetchPromise
+    })
+
+    fetchFacetFilters('disease', 'tuberculosis')
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'Authorization': 'Bearer test'
+        }
+      })
+    )
+    process.nextTick(() => {
+      jest.restoreAllMocks()
+      done()
+    })
   })
 })


### PR DESCRIPTION
This ensures the `Authorization: Bearer` HTTP header is included in requests from the SCP API JS client when the user is signed in.  It enables faceted search results to include private studies.

I've manually verified this, in addition to the new automated test.

This satisfies SCP-2231.