### PR TITLE
Correctly using matched filters in inferred search

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -178,6 +178,7 @@ module Api
 
         # only call BigQuery if list of possible studies is larger than 0 and we have matching facets to use
         if @studies.count > 0 && @facets.any?
+          logger.info "facets: #{@facets}"
           sort_type = :facet
           @studies_by_facet = {}
           @big_query_search = self.class.generate_bq_query_string(@facets)
@@ -661,7 +662,7 @@ module Api
           search_facet = SearchFacet.find(facet[:object_id])
           # only use non-numeric facets
           if !search_facet.is_numeric?
-            filter_terms += search_facet[:filters].map {|filter| filter[:name]}
+            filter_terms += facet[:filters].map {|filter| filter[:name]}
           end
         end
         filter_terms
@@ -672,17 +673,14 @@ module Api
         matches = {}
         query_results.each do |result|
           accession = result[:study_accession]
-          matches[accession] ||= {}
-          search_weight = 0
+          matches[accession] ||= {facet_search_weight: 0}
           result.keys.keep_if { |key| key != :study_accession }.each do |key|
             facet_name = key.to_s.chomp('_val')
             matching_filter = match_results_by_filter(search_result: result, result_key: key, facets: search_facets)
             matches[accession][facet_name] ||= []
             matches[accession][facet_name] << matching_filter unless matches[accession][facet_name].include?(matching_filter)
-            search_weight += 1
+            matches[accession][:facet_search_weight] += 1
           end
-          # compute a score for relevance weighting
-          matches[accession][:facet_search_weight] = search_weight
         end
         matches
       end

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -178,7 +178,6 @@ module Api
 
         # only call BigQuery if list of possible studies is larger than 0 and we have matching facets to use
         if @studies.count > 0 && @facets.any?
-          logger.info "facets: #{@facets}"
           sort_type = :facet
           @studies_by_facet = {}
           @big_query_search = self.class.generate_bq_query_string(@facets)


### PR DESCRIPTION
This addresses a bug in inferred search where all facet filters were used, rather than only the matching filters from the search request.  This was caused by using the facet object from the database, rather than the output of `set_search_facets_and_filters`.  Also, this fixes a bug in computing search weights for facets when a study matches more than one filter value.

This PR satisfies SCP-2245.