### PR TITLE
Ensuring consistency of search logic for inferred matches (SCP-2250)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -595,8 +595,8 @@ module Api
           # in order to maintain the same behavior as normal facets, we run each facet separately and get matching accessions
           # this gives us an array of arrays of matching accessions; now find the intersection (:&)
           filters = terms.values.map {|keywords| escape_terms_for_regex(term_list: keywords)}
-          accessions_by_filter = filters.map {|filter| base_studies.any_of({name: filter}, {description: filter}).
-              where(:accession.nin => accessions).pluck(:accession)}
+          accessions_by_filter = filters.map {|filter| base_studies.any_of({name: filter}, {description: filter})
+                                                           .where(:accession.nin => accessions).pluck(:accession)}
           base_studies.where(:accession.in => accessions_by_filter.inject(:&))
         else
           # no matching query case, so perform normal text-index search

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -213,17 +213,18 @@ module Api
         # if a user ran a faceted search, attempt to infer results by converting filter display values to keywords
         if @facets.any?
           # preserve existing search terms, if present
-          @filter_keywords = @term_list.present? ? @term_list.dup : []
-          @filter_keywords += self.class.convert_filters_for_inferred_search(facets: @facets)
+          facets_to_keywords = @term_list.present? ? {keywords: @term_list.dup} : {}
+          facets_to_keywords.merge!(self.class.convert_filters_for_inferred_search(facets: @facets))
           # only run inferred search if we have extra keywords to run; numeric facets do not generate inferred searches
-          if @filter_keywords.any?
-            logger.info "Running inferred search using #{@filter_keywords}"
-            inferred_studies = self.class.generate_mongo_query_by_context(terms: @filter_keywords, base_studies: @viewable,
+          if facets_to_keywords.any?
+            @inferred_terms = facets_to_keywords.values.flatten
+            logger.info "Running inferred search using #{facets_to_keywords}"
+            inferred_studies = self.class.generate_mongo_query_by_context(terms: facets_to_keywords, base_studies: @viewable,
                                                                           accessions: @matching_accessions, query_context: :inferred)
             @inferred_accessions = inferred_studies.pluck(:accession)
             logger.info "Found #{@inferred_accessions.count} inferred matches: #{@inferred_accessions}"
             @matching_accessions += @inferred_accessions
-            @studies += inferred_studies.sort_by {|study| -study.search_weight(@filter_keywords)[:total] }
+            @studies += inferred_studies.sort_by {|study| -study.search_weight(@inferred_terms)[:total] }
           end
         end
         @results = @studies.paginate(page: params[:page], per_page: Study.per_page)
@@ -591,8 +592,12 @@ module Api
           study_regex = escape_terms_for_regex(term_list: terms)
           base_studies.any_of({name: study_regex}, {description: study_regex}, {:accession.in => accessions})
         when :inferred
-          filter_regex = escape_terms_for_regex(term_list: terms)
-          base_studies.any_of({name: filter_regex}, {description: filter_regex}).where(:accession.nin => accessions)
+          # in order to maintain the same behavior as normal facets, we run each facet separately and get matching accessions
+          # this gives us an array of arrays of matching accessions; now find the intersection (:&)
+          filters = terms.values.map {|keywords| escape_terms_for_regex(term_list: keywords)}
+          accessions_by_filter = filters.map {|filter| base_studies.any_of({name: filter}, {description: filter}).
+              where(:accession.nin => accessions).pluck(:accession)}
+          base_studies.where(:accession.in => accessions_by_filter.inject(:&))
         else
           # no matching query case, so perform normal text-index search
           base_studies.any_of({:$text => {:$search => terms}}, {:accession.in => accessions})
@@ -655,16 +660,17 @@ module Api
       end
 
       # convert a list of facet filters into a keyword search for inferred matching
+      # treats each facet separately so we can find intersection across all
       def self.convert_filters_for_inferred_search(facets:)
-        filter_terms = []
+        terms_by_facet = {}
         facets.each do |facet|
           search_facet = SearchFacet.find(facet[:object_id])
           # only use non-numeric facets
           if !search_facet.is_numeric?
-            filter_terms += facet[:filters].map {|filter| filter[:name]}
+            terms_by_facet[search_facet.identifier] = facet[:filters].map {|filter| filter[:name]}
           end
         end
-        filter_terms
+        terms_by_facet
       end
 
       # build a match of studies to facets/filters used in search (for labeling studies in UI with matches)
@@ -677,8 +683,10 @@ module Api
             facet_name = key.to_s.chomp('_val')
             matching_filter = match_results_by_filter(search_result: result, result_key: key, facets: search_facets)
             matches[accession][facet_name] ||= []
-            matches[accession][facet_name] << matching_filter unless matches[accession][facet_name].include?(matching_filter)
-            matches[accession][:facet_search_weight] += 1
+            if !matches[accession][facet_name].include?(matching_filter)
+              matches[accession][facet_name] << matching_filter
+              matches[accession][:facet_search_weight] += 1
+            end
           end
         end
         matches

--- a/app/views/api/v1/search/_study.json.jbuilder
+++ b/app/views/api/v1/search/_study.json.jbuilder
@@ -18,7 +18,7 @@ end
 # if this is an inferred match, use :term_matches for highlighting, but set :inferred_match to true
 if @inferred_accessions.present? && @inferred_accessions.include?(study.accession)
   json.set! :inferred_match, true
-  inferred_weight = study.search_weight(@filter_keywords)
+  inferred_weight = study.search_weight(@inferred_terms)
   json.set! :term_matches, inferred_weight[:terms].keys
   json.set! :term_search_weight, inferred_weight[:total]
 end

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -282,6 +282,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   test 'should run inferred search using facets and phrase' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
 
+    convention_study = Study.find_by(name: "Test Study #{@random_seed}")
     other_study = Study.find_by(name: "API Test Study #{@random_seed}")
     original_description = other_study.description.to_s.dup
     species_facet = SearchFacet.find_by(identifier: 'species')
@@ -289,10 +290,10 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     filter_name = species_facet.filters.first[:name]
     other_study.update(description: filter_name)
     search_phrase = "Study #{@random_seed}"
-    expected_accessions = Study.all.pluck(:accession).sort
+    expected_accessions = [convention_study.accession, other_study.accession]
     execute_http_request(:get, api_v1_search_path(type: 'study', facets: facet_query, terms: "\"#{search_phrase}\""))
     assert_response :success
-    found_accessions = json['matching_accessions'].sort
+    found_accessions = json['matching_accessions']
     assert_equal expected_accessions, found_accessions,
                  "Did not find expected accessions for phrase & facet search, expected #{expected_accessions} but found #{found_accessions}"
     # the combination of phrase + facet search is an AND, so 'API Test Study' will still be inferred as it does not
@@ -308,6 +309,38 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
                       "Did not find #{search_phrase} in term_matches for #{study['accession']}: #{study['term_matches']}"
     end
     # reset description so other tests aren't broken
+    other_study.update(description: original_description)
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should find intersection of facets on inferred search' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # update other_study to match one filter from facets; should not be inferred since it doesn't meet both criteria
+    convention_study = Study.find_by(name: "Test Study #{@random_seed}")
+    other_study = Study.find_by(name: "API Test Study #{@random_seed}")
+    original_description = other_study.description.to_s.dup
+    facets = SearchFacet.where(:identifier.in => %w(species disease))
+    facet_query = facets.map {|facet| "#{facet.identifier}:#{facet.filters.first[:id]}"}.join('+')
+    single_facet_name = facets.sample.filters.first[:name]
+    other_study.update(description: single_facet_name)
+    execute_http_request(:get, api_v1_search_path(type: 'study', facets: facet_query))
+    assert_response :success
+    expected_accessions = [convention_study.accession]
+    assert_equal expected_accessions, json['matching_accessions'],
+                 "Did not find expected accessions before inferred search, expected #{expected_accessions} but found #{json['matching_accessions']}"
+
+    # update to match both filters; should be inferred
+    double_facet_name = facets.map {|facet| facet.filters.first[:name]}.join(' ')
+    other_study.update(description: double_facet_name)
+    execute_http_request(:get, api_v1_search_path(type: 'study', facets: facet_query))
+    assert_response :success
+    inferred_accessions = [convention_study.accession, other_study.accession]
+    assert_equal inferred_accessions, json['matching_accessions'],
+                 "Did not find expected accessions after inferred search, expected #{inferred_accessions} but found #{json['matching_accessions']}"
+    inferred_study = json['studies'].last
+    assert inferred_study['inferred_match'], "Did not correctly mark #{other_study.accession} as inferred"
     other_study.update(description: original_description)
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"


### PR DESCRIPTION
Faceted queries in the search API use AND logic across facets, and OR logic within a given facet (if multiple filters were supplied).  This update applies the same logic to the inferred search feature by running each facet query separately to find matching studies (by converting a filter display name into keywords/phrases) and then finding the intersection of studies at the end.  Also, this fixes a small bug in computing search facet weights where all filters present were being weighted, regardless of the match.

This PR satisfies SCP-2250.