### PR TITLE
Enabling gzip_proxied for serving compressed assets to GCP LB (SCP-2252)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -75,7 +75,7 @@ http {
 	gzip_disable "msie6";
 
 	# gzip_vary on;
-	# gzip_proxied any;
+	gzip_proxied any;
 	# gzip_comp_level 6;
 	# gzip_buffers 16 8k;
 	# gzip_http_version 1.1;


### PR DESCRIPTION
In production, our compiled JS assets are not being served compressed, which is causing a huge spike in bytes served and slows down page rendering.  The issue is that behind a GCP load balancer, nginx does not trust proxies to be able to handle gzipped responses.  The solution is to enable `gzip_proxied` so that nginx will serve the compressed files back to the LB.

From: https://docs.nginx.com/nginx/admin-guide/web-server/compression/
From: https://stackoverflow.com/a/36003231

This PR satisfies SCP-2252.