### PR TITLE
Preview download size and file types, better indicate disabled download (SCP-2167)

### DIFF
--- a/app/javascript/components/DownloadButton.js
+++ b/app/javascript/components/DownloadButton.js
@@ -10,6 +10,9 @@ import Clipboard from 'react-clipboard.js'
 import { useContextStudySearch } from './search/StudySearchProvider'
 import { useContextUser } from './UserProvider'
 import { fetchAuthCode } from 'lib/scp-api'
+import {
+  getNumFacetsAndFilters, getNumberOfTerms
+} from '../lib/scp-api-metrics'
 
 /**
  * Fetch auth code, build download command, return configuration object
@@ -169,8 +172,12 @@ function getLeadText(downloadSize) {
   `)
 }
 
+/** Determine if search has any parameters, i.e. terms or filters */
 function hasSearchParams(searchContext) {
-  return true
+  const params = searchContext.params
+  const numTerms = getNumberOfTerms(params.terms)
+  const [numFacets, numFilters] = getNumFacetsAndFilters(params.facets)
+  return (numTerms + numFacets + numFilters) > 0
 }
 
 /**

--- a/app/javascript/components/DownloadButton.js
+++ b/app/javascript/components/DownloadButton.js
@@ -203,10 +203,6 @@ export default function DownloadButton(props) {
     hasSearchParams(searchContext.params)
   )
 
-  function showModalAndFetchDownloadCommand() {
-    if (active) setShow(!show)
-  }
-
   let hint = 'To download, first do a search'
   if (active) hint = 'Download files for your search results'
 
@@ -222,7 +218,7 @@ export default function DownloadButton(props) {
           id='download-button'
           className={`btn btn-primary ${active ? 'active' : 'disabled'}`}
         >
-          <span onClick={showModalAndFetchDownloadCommand}>
+          <span onClick={() => {if (active) setShow(!show)}}>
             <FontAwesomeIcon className="icon-left" icon={faDownload}/>
           Download
           </span>

--- a/app/javascript/components/DownloadButton.js
+++ b/app/javascript/components/DownloadButton.js
@@ -2,9 +2,8 @@ import React, { useState, useEffect } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDownload } from '@fortawesome/free-solid-svg-icons'
 import Modal from 'react-bootstrap/lib/Modal'
-
-// We'll need this when refining onClipboardCopySuccess
 import Tooltip from 'react-bootstrap/lib/Tooltip'
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger'
 import Clipboard from 'react-clipboard.js'
 
 import { useContextStudySearch } from './search/StudySearchProvider'
@@ -173,8 +172,7 @@ function getLeadText(downloadSize) {
 }
 
 /** Determine if search has any parameters, i.e. terms or filters */
-function hasSearchParams(searchContext) {
-  const params = searchContext.params
+function hasSearchParams(params) {
   const numTerms = getNumberOfTerms(params.terms)
   const [numFacets, numFilters] = getNumFacetsAndFilters(params.facets)
   return (numTerms + numFacets + numFilters) > 0
@@ -202,28 +200,34 @@ export default function DownloadButton(props) {
   const active = (
     userContext.accessToken !== '' &&
     matchingAccessions.length > 0 &&
-    hasSearchParams(searchContext)
+    hasSearchParams(searchContext.params)
   )
 
   function showModalAndFetchDownloadCommand() {
     if (active) setShow(!show)
   }
 
+  let hint = 'To download, first do a search'
+  if (active) hint = 'Download files for your search results'
+
   const handleClose = () => setShow(false)
 
   return (
     <>
-      <span
-        id='download-button'
-        className={active ? 'active' : 'disabled'}
-        data-toggle="tooltip"
-        title={active ? 'Download files for your search results' : 'Do a search to get results to download'}
+      <OverlayTrigger
+        placement="top"
+        overlay={<Tooltip id="download-tooltip">{hint}</Tooltip>}
       >
-        <span onClick={showModalAndFetchDownloadCommand}>
-          <FontAwesomeIcon className="icon-left" icon={faDownload}/>
+        <button
+          id='download-button'
+          className={`btn btn-primary ${active ? 'active' : 'disabled'}`}
+        >
+          <span onClick={showModalAndFetchDownloadCommand}>
+            <FontAwesomeIcon className="icon-left" icon={faDownload}/>
           Download
-        </span>
-      </span>
+          </span>
+        </button>
+      </OverlayTrigger>
       <Modal
         id='bulk-download-modal'
         show={show}

--- a/app/javascript/components/DownloadButton.js
+++ b/app/javascript/components/DownloadButton.js
@@ -7,6 +7,7 @@ import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger'
 
 import { useContextStudySearch } from './search/StudySearchProvider'
 import { useContextUser } from './UserProvider'
+import { useContextDownload } from './search/DownloadProvider'
 import { fetchAuthCode } from 'lib/scp-api'
 import {
   getNumFacetsAndFilters, getNumberOfTerms
@@ -28,7 +29,7 @@ async function generateDownloadConfig(matchingAccessions) {
   // Gets a curl configuration ("cfg.txt") containing signed
   // URLs and output names for all files in the download object.
   const baseUrl = `${window.origin}/single_cell/api/v1/`
-  const url = `${baseUrl}/search/bulk_download${queryString}`
+  const url = `${baseUrl}search/bulk_download${queryString}`
 
   // "-k" === "--insecure"
   const curlSecureFlag = (window.location.host === 'localhost') ? 'k' : ''
@@ -203,24 +204,27 @@ function hasSearchParams(params) {
  *
  * UI spec: https://projects.invisionapp.com/d/main#/console/19272801/402387755/preview
  */
-export default function DownloadButton() {
+export default function DownloadButton(props) {
   const searchContext = useContextStudySearch()
   const userContext = useContextUser()
+  const downloadContext = useContextDownload({ results: searchContext.results })
 
   const [show, setShow] = useState(false)
 
   const matchingAccessions = searchContext.results.matchingAccessions || []
-  const downloadSize = searchContext.downloadSize
+  const downloadSize = downloadContext.downloadSize
 
   /**
    * Reports whether Download button should be active,
    * i.e. user is signed in, has search results,
    * and search has parameters (i.e. user would not download all studies)
+   * and download context (i.e. download size preview) has loaded
    */
   const active = (
     userContext.accessToken !== '' &&
     matchingAccessions.length > 0 &&
-    hasSearchParams(searchContext.params)
+    hasSearchParams(searchContext.params) &&
+    downloadContext.isLoaded
   )
 
   let hint = 'To download, first do a search'

--- a/app/javascript/components/DownloadButton.js
+++ b/app/javascript/components/DownloadButton.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDownload } from '@fortawesome/free-solid-svg-icons'
 import Modal from 'react-bootstrap/lib/Modal'
+
 // We'll need this when refining onClipboardCopySuccess
 // import Tooltip from 'react-bootstrap/lib/Tooltip';
 import Clipboard from 'react-clipboard.js'

--- a/app/javascript/components/DownloadButton.js
+++ b/app/javascript/components/DownloadButton.js
@@ -240,7 +240,7 @@ export default function DownloadButton(props) {
         <button
           id='download-button'
           className={`btn btn-primary ${active ? 'active' : 'disabled'}`}>
-          <span onClick={() => {if (active) setShow(!show)}}>
+          <span onClick={() => {setShow(true)}}>
             <FontAwesomeIcon className="icon-left" icon={faDownload}/>
           Download
           </span>

--- a/app/javascript/components/HomePageContent.js
+++ b/app/javascript/components/HomePageContent.js
@@ -6,7 +6,7 @@ import SearchFacetProvider from 'components/search/SearchFacetProvider'
 import UserProvider from 'components/UserProvider'
 
 /**
- * Wrapper component search and result panels
+ * Wrapper component for search and result panels
  */
 export default function HomePageContent() {
   return (

--- a/app/javascript/components/SearchPanel.js
+++ b/app/javascript/components/SearchPanel.js
@@ -3,7 +3,7 @@ import React from 'react'
 import KeywordSearch from './KeywordSearch'
 import FacetsPanel from './FacetsPanel'
 import DownloadButton from './DownloadButton'
-
+import DownloadProvider from 'components/search/DownloadProvider'
 
 /**
  * Component for SCP faceted search UI
@@ -17,7 +17,9 @@ export default function SearchPanel() {
     <div className='container-fluid' id='search-panel'>
       <KeywordSearch/>
       <FacetsPanel/>
-      <DownloadButton />
+      <DownloadProvider>
+        <DownloadButton />
+      </DownloadProvider>
     </div>
   )
 }

--- a/app/javascript/components/search/DownloadProvider.js
+++ b/app/javascript/components/search/DownloadProvider.js
@@ -1,0 +1,51 @@
+import React, { useContext, useState } from 'react'
+import { useContextStudySearch } from './StudySearchProvider'
+
+import { fetchDownloadSize } from './../../lib/scp-api'
+
+export const DownloadContext = React.createContext({
+  searchResults: {},
+  downloadSize: {}
+})
+
+/** Wrapper for deep mocking via Jest / Enzyme */
+export function useContextDownload(props) {
+  DownloadContext.searchResults = props.results
+  return useContext(DownloadContext)
+}
+
+/** Provides loading status and fetched data for Bulk Download components */
+export default function DownloadProvider(props) {
+  const studyContext = useContextStudySearch()
+
+  const [downloadState, setDownloadState] = useState({
+    searchResults: props.results,
+    downloadSize: {},
+    isLoaded: false
+  })
+
+  /** Update size preview for bulk download */
+  async function updateDownloadSize(results) {
+    const accessions = results.matchingAccessions
+    const fileTypes = ['Expression', 'Metadata']
+    const size = await fetchDownloadSize(accessions, fileTypes)
+
+    setDownloadState({
+      isLoaded: true,
+      downloadSize: size
+    })
+  }
+
+  if (
+    !studyContext.isLoading && studyContext.isLoaded &&
+    !downloadState.isLoaded
+  ) {
+    updateDownloadSize(studyContext.results)
+  }
+
+  return (
+    <DownloadContext.Provider value={downloadState}>
+      { props.children }
+    </DownloadContext.Provider>
+  )
+}

--- a/app/javascript/components/search/StudySearchProvider.js
+++ b/app/javascript/components/search/StudySearchProvider.js
@@ -5,8 +5,7 @@ import { Router, navigate } from '@reach/router'
 import * as queryString from 'query-string'
 
 import {
-  fetchSearch, buildSearchQueryString, buildFacetsFromQueryString,
-  fetchDownloadSize
+  fetchSearch, buildSearchQueryString, buildFacetsFromQueryString
 } from 'lib/scp-api'
 import SearchSelectionProvider from 'components/search/SearchSelectionProvider'
 
@@ -21,10 +20,6 @@ const emptySearch = {
   isLoading: false,
   isLoaded: false,
   isError: false,
-
-  downloadSize: {},
-  isLoadingDownloadSize: false,
-  isLoadedDownloadSize: false,
 
   updateSearch: () => {
     throw new Error(
@@ -48,7 +43,6 @@ export function PropsStudySearchProvider(props) {
   const defaultState = _cloneDeep(emptySearch)
   defaultState.updateSearch = updateSearch
   const [searchState, setSearchState] = useState(defaultState)
-  const downloadSize = emptySearch.downloadSize
   const searchParams = props.searchParams
 
   /**
@@ -63,27 +57,6 @@ export function PropsStudySearchProvider(props) {
     const page = newParams.page ? newParams.page : 1
     const queryString = buildSearchQueryString('study', terms, facets, page)
     navigate(`?${queryString}`)
-  }
-
-  /** Update size preview for bulk download */
-  async function updateDownloadSize(params, results) {
-    const accessions = results.matchingAccessions
-    const fileTypes = ['Expression', 'Metadata']
-    const size = await fetchDownloadSize(accessions, fileTypes)
-
-    setSearchState({
-      params,
-      isError: false,
-      isLoading: false,
-      isLoaded: true,
-
-      isLoadingDownloadSize: false,
-      isLoadedDownloadSize: true,
-      downloadSize: size,
-
-      results,
-      updateSearch
-    })
   }
 
   /** perform the actual API search */
@@ -101,14 +74,9 @@ export function PropsStudySearchProvider(props) {
       isError: false,
       isLoading: false,
       isLoaded: true,
-      isLoadingDownloadSize: true,
-      isLoadedDownloadSize: false,
       results,
-      downloadSize: {},
       updateSearch
     })
-
-    updateDownloadSize(params, results)
   }
 
   // Search done on initial page load
@@ -122,10 +90,7 @@ export function PropsStudySearchProvider(props) {
       isError: false,
       isLoading: true,
       isLoaded: false,
-      isLoadingDownloadSize: false,
-      isLoadedDownloadSize: false,
       results: [],
-      downloadSize,
       updateSearch
     })
   }

--- a/app/javascript/components/search/StudySearchProvider.js
+++ b/app/javascript/components/search/StudySearchProvider.js
@@ -18,6 +18,8 @@ const emptySearch = {
   isLoading: false,
   isLoaded: false,
   isError: false,
+  isLoadingDownloadPreview: false,
+  isLoadedDownloadPreview: false,
   updateSearch: () => {
     throw new Error(
       'You are trying to use this context outside of a Provider container'
@@ -58,29 +60,37 @@ export function PropsStudySearchProvider(props) {
   async function performSearch(params) {
     // reset the scroll in case they scrolled down to read prior results
     window.scrollTo(0, 0)
+
     const results = await fetchSearch('study',
       params.terms,
       params.facets,
       params.page)
+
     setSearchState({
       params,
       isError: false,
       isLoading: false,
       isLoaded: true,
+      isLoadingDownloadPreview: true,
+      isLoadedDownloadPreview: false,
       results,
       updateSearch
     })
   }
 
+  // Search done on initial page load
   if (!_isEqual(searchParams, searchState.params) ||
       !searchState.isLoading &&
       !searchState.isLoaded) {
     performSearch(searchParams)
+
     setSearchState({
       params: searchParams,
       isError: false,
       isLoading: true,
       isLoaded: false,
+      isLoadingDownloadPreview: false,
+      isLoadedDownloadPreview: false,
       results: [],
       updateSearch
     })

--- a/app/javascript/components/search/StudySearchProvider.js
+++ b/app/javascript/components/search/StudySearchProvider.js
@@ -35,9 +35,11 @@ const emptySearch = {
 
 export const StudySearchContext = React.createContext(emptySearch)
 
+/** Wrapper for deep mocking via Jest / Enzyme */
 export function useContextStudySearch() {
   return useContext(StudySearchContext)
 }
+
 /**
   * renders a StudySearchContext tied to its props,
   * fires route navigate on changes to params
@@ -137,10 +139,10 @@ export function PropsStudySearchProvider(props) {
 }
 
 /**
-  * Self-contained component for providing a url-routable
-  * StudySearchContext and rendering children.
-  * The routing is all via query params
-  */
+ * Self-contained component for providing a url-routable
+ * StudySearchContext and rendering children.
+ * The routing is all via query params
+ */
 export default function StudySearchProvider(props) {
   // create a wrapper component for the search display since <Router>
   // assumes that all of its unwrapped children (even nested) be routes

--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -41,7 +41,7 @@ export function mapFiltersForLogging(facetsOrFilters, isFacets=false) {
 /**
  * Count terms, i.e. space-delimited strings, and consider [""] to have 0 terms
  */
-function getNumberOfTerms(terms) {
+export function getNumberOfTerms(terms) {
   let numTerms = 0
   const splitTerms = terms.split(' ')
   if (splitTerms.length > 0 && splitTerms[0] !== '') {
@@ -53,7 +53,7 @@ function getNumberOfTerms(terms) {
 /**
  * Counts facets (e.g. species, disease) and filters (e.g. human, COVID-19)
  */
-function getNumFacetsAndFilters(facets) {
+export function getNumFacetsAndFilters(facets) {
   const numFacets = Object.keys(facets).length
   const numFilters =
     Object.values(facets).reduce((prevNumFilters, filterArray) => {

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -165,6 +165,26 @@ export async function fetchFacetFilters(facet, query, mock=false) {
 }
 
 /**
+ *  Returns number of files and bytes (by file type), to preview bulk download
+ *
+ * Docs:
+ * https://singlecell.broadinstitute.org/single_cell/api/swagger_docs/v1#!/Search/search_bulk_download_size_path
+ *
+ * @param {Array} List of study accessions to preview download
+ * @param {Array} fileTypes List of file types in studies to preview download
+ *
+ * @example returns Promise for JSON
+ * {"Expression":{"total_files":4,"total_bytes":1797720765},"Metadata":{"total_files":2,"total_bytes":865371}}
+ * fetchDownloadSize([SCP200, SCP201], ["Expression", "Metadata"])
+ */
+export async function fetchDownloadSize(accessions, fileTypes, mock=false) {
+  const fileTypesString = fileTypes.join(',')
+  const queryString = `?accessions=${accessions}&file_types=${fileTypesString}`
+  const pathAndQueryString = `/search/bulk_download_size/${queryString}`
+  return await scpApi(pathAndQueryString)
+}
+
+/**
  * Returns a list of matching studies given a keyword and facets
  *
  * Docs: https:///singlecell.broadinstitute.org/single_cell/api/swagger_docs/v1#!/Search/search_facet_filters_path

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -158,7 +158,7 @@ export async function fetchDownloadSize(accessions, fileTypes, mock=false) {
   const fileTypesString = fileTypes.join(',')
   const queryString = `?accessions=${accessions}&file_types=${fileTypesString}`
   const pathAndQueryString = `/search/bulk_download_size/${queryString}`
-  return await scpApi(pathAndQueryString)
+  return await scpApi(pathAndQueryString, defaultInit, mock)
 }
 
 /**

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -73,7 +73,6 @@
     border-radius: 15px;
     border: 0.64px solid #4d72aa;
     box-sizing: border-box;
-    cursor: pointer;
   }
   #more-facets-button > span,
   #download-button > span {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "query-string": "^6.11.0",
     "react": "^16.12.0",
     "react-bootstrap": "^0.33.1",
-    "react-clipboard.js": "^2.0.16",
     "react-compound-slider": "^3.0.0-beta.1",
     "react-dom": "^16.12.0",
     "react-scripts": "^3.4.0",

--- a/test/js/download.test.js
+++ b/test/js/download.test.js
@@ -9,6 +9,8 @@ import DownloadButton from '../../app/javascript/components/DownloadButton'
 import * as UserProvider from '../../app/javascript/components/UserProvider'
 import * as StudySearchProvider
   from '../../app/javascript/components/search/StudySearchProvider'
+import * as DownloadProvider
+  from '../../app/javascript/components/search/DownloadProvider'
 
 describe('Download components for faceted search', () => {
   beforeAll(() => {
@@ -16,7 +18,24 @@ describe('Download components for faceted search', () => {
 
     const userContext = { accessToken: 'test' }
     const studySearchContext = {
-      results: { matchingAccessions: ['SCP1', 'SCP2'] }
+      results: { matchingAccessions: ['SCP1', 'SCP2'] },
+      params: {
+        terms: 'test',
+        facets: {},
+        page: 1
+      }
+    }
+    const downloadContext = {
+      downloadSize: {
+        metadata: { total_bytes: 200, total_files: 2 },
+        expression: { total_bytes: 201, total_files: 3 },
+        isLoaded: true
+      },
+      params: {
+        terms: 'test',
+        facets: {},
+        page: 1
+      }
     }
 
     jest.spyOn(UserProvider, 'useContextUser')
@@ -27,6 +46,11 @@ describe('Download components for faceted search', () => {
     jest.spyOn(StudySearchProvider, 'useContextStudySearch')
       .mockImplementation(() => {
         return studySearchContext
+      })
+
+    jest.spyOn(DownloadProvider, 'useContextDownload')
+      .mockImplementation(() => {
+        return downloadContext
       })
   })
 
@@ -43,7 +67,6 @@ describe('Download components for faceted search', () => {
     // more succinct approach that captures updates.
     expect(wrapper.find('Modal').first().prop('show')).toEqual(false)
     wrapper.find('#download-button > span').simulate('click')
-
     expect(wrapper.find('Modal').first().prop('show')).toEqual(true)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1600,11 +1600,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/clipboard@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@types/clipboard/-/clipboard-2.0.1.tgz#75a74086c293d75b12bc93ff13bc7797fef05a40"
-  integrity sha512-gJJX9Jjdt3bIAePQRRjYWG20dIhAgEqonguyHxXuqALxsoDsDLimihqrSg8fXgVTJ4KZCzkfglKtwsh/8dLfbA==
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -3341,15 +3336,6 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
-clipboard@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.4.tgz#836dafd66cf0fea5d71ce5d5b0bf6e958009112d"
-  integrity sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==
-  dependencies:
-    good-listener "^1.2.2"
-    select "^1.1.2"
-    tiny-emitter "^2.0.0"
-
 cliui@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
@@ -4398,11 +4384,6 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
-
-delegate@^3.1.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
-  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -6187,13 +6168,6 @@ gonzales-pe@^4.0.3:
   integrity sha512-v0Ts/8IsSbh9n1OJRnSfa7Nlxi4AkXIsWB6vPept8FDbL4bXn3FNuxjYtO/nmBGu7GDkL9MFeGebeSu6l55EPQ==
   dependencies:
     minimist "1.1.x"
-
-good-listener@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
-  integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
-  dependencies:
-    delegate "^3.1.2"
 
 got@^6.7.1:
   version "6.7.1"
@@ -11474,7 +11448,7 @@ prop-types-extra@^1.0.1:
     react-is "^16.3.2"
     warning "^4.0.0"
 
-prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -11713,15 +11687,6 @@ react-bootstrap@^0.33.1:
     react-transition-group "^2.0.0"
     uncontrollable "^7.0.2"
     warning "^3.0.0"
-
-react-clipboard.js@^2.0.16:
-  version "2.0.16"
-  resolved "https://registry.yarnpkg.com/react-clipboard.js/-/react-clipboard.js-2.0.16.tgz#45a60684dd6a36ff97e40c53069a27e97a4b6c9c"
-  integrity sha512-COwmnbrRbl8y4f/SjtonnJTeBRD03YzsHBL5on8iL/uyjERsMkKC7djtfmns7iRAbzadn/84MdpaqaQ3ITP47g==
-  dependencies:
-    "@types/clipboard" "^2.0.1"
-    clipboard "^2.0.0"
-    prop-types "^15.5.0"
 
 react-compound-slider@^3.0.0-beta.1:
   version "3.0.0-beta.1"
@@ -12671,11 +12636,6 @@ select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
-
-select@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
-  integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
 
 selfsigned@^1.10.7:
   version "1.10.7"
@@ -13814,11 +13774,6 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
-
-tiny-emitter@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
-  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
This improves the Bulk Download UI to show how large the impending download is, and what file types are in it.  It also refines the display of the "Download" button's disabled state, to align with the look and feel of other disabled buttons.

I've updated automated tests to handle the new download context, and verified manually.

Size and file types in download preview:
<img width="1162" alt="download_size_and_file_types_ui_scp_2020-03-19" src="https://user-images.githubusercontent.com/1334561/77077095-24820600-69cb-11ea-8330-c751be5034ee.png">

Better disabled "Download" button UI:
<img width="1163" alt="better_disabled_download_button_ui_scp_2020-03-19" src="https://user-images.githubusercontent.com/1334561/77077092-22b84280-69cb-11ea-8108-42de1c8fd5ad.png">

This satisfies SCP-2167.