### PR TITLE
Adding API integration for study external resources (SCP-2270)

### DIFF
--- a/app/controllers/api/v1/api_docs_controller.rb
+++ b/app/controllers/api/v1/api_docs_controller.rb
@@ -50,6 +50,10 @@ module Api
           key :description, 'DirectoryListing operations'
         end
         tag do
+          key :name, 'ExternalResources'
+          key :description, 'Study publication/data link operations'
+        end
+        tag do
           key :name, 'Schemas'
           key :description, 'Descriptions of SCP model schemas'
         end
@@ -85,11 +89,13 @@ module Api
           StudyFileBundle,
           Taxon,
           AnalysisConfiguration,
+          ExternalResource,
           Api::V1::StudiesController,
           Api::V1::StudyFilesController,
           Api::V1::StudyFileBundlesController,
           Api::V1::StudySharesController,
           Api::V1::DirectoryListingsController,
+          Api::V1::ExternalResourcesController,
           Api::V1::SchemasController,
           Api::V1::TaxonsController,
           Api::V1::StatusController,

--- a/app/controllers/api/v1/external_resources_controller.rb
+++ b/app/controllers/api/v1/external_resources_controller.rb
@@ -64,7 +64,7 @@ module Api
           key :tags, [
               'ExternalResources'
           ]
-          key :summary, 'Find a ExternalResource'
+          key :summary, 'Find an ExternalResource'
           key :description, 'Finds a single Study'
           key :operationId, 'study_external_resource_path'
           parameter do
@@ -113,7 +113,7 @@ module Api
           key :tags, [
               'ExternalResources'
           ]
-          key :summary, 'Create a ExternalResource'
+          key :summary, 'Create an ExternalResource'
           key :description, 'Creates and returns a single ExternalResource'
           key :operationId, 'create_study_external_resource_path'
           parameter do
@@ -171,7 +171,7 @@ module Api
           key :tags, [
               'ExternalResources'
           ]
-          key :summary, 'Update a ExternalResource'
+          key :summary, 'Update an ExternalResource'
           key :description, 'Updates and returns a single ExternalResource.'
           key :operationId, 'update_study_external_resource_path'
           parameter do
@@ -235,7 +235,7 @@ module Api
           key :tags, [
               'ExternalResources'
           ]
-          key :summary, 'Delete a ExternalResource'
+          key :summary, 'Delete an ExternalResource'
           key :description, 'Deletes a single ExternalResource'
           key :operationId, 'delete_study_external_resource_path'
           parameter do

--- a/app/controllers/api/v1/external_resources_controller.rb
+++ b/app/controllers/api/v1/external_resources_controller.rb
@@ -1,0 +1,312 @@
+module Api
+  module V1
+    class ExternalResourcesController < ApiBaseController
+
+      include Concerns::FireCloudStatus
+      include Concerns::Authenticator
+      include Swagger::Blocks
+
+      before_action :authenticate_api_user!
+      before_action :set_study
+      before_action :check_study_permission
+      before_action :set_external_resource, except: [:index, :create]
+
+      respond_to :json
+
+      swagger_path '/studies/{study_id}/external_resources' do
+        operation :get do
+          key :tags, [
+              'ExternalResources'
+          ]
+          key :summary, 'Find all ExternalResources in a Study'
+          key :description, 'Returns all ExternalResources for the given Study'
+          key :operationId, 'study_external_resources_path'
+          parameter do
+            key :name, :study_id
+            key :in, :path
+            key :description, 'ID of Study'
+            key :required, true
+            key :type, :string
+          end
+          response 200 do
+            key :description, 'Array of ExternalResource objects'
+            schema do
+              key :type, :array
+              key :title, 'Array'
+              items do
+                key :title, 'ExternalResource'
+                key :'$ref', :ExternalResource
+              end
+            end
+          end
+          response 401 do
+            key :description, ApiBaseController.unauthorized
+          end
+          response 403 do
+            key :description, ApiBaseController.forbidden('edit Study')
+          end
+          response 404 do
+            key :description, ApiBaseController.not_found(Study)
+          end
+          response 406 do
+            key :description, ApiBaseController.not_acceptable
+          end
+        end
+      end
+
+      # GET /single_cell/api/v1/studies/:study_id
+      def index
+        @external_resources = @study.external_resources
+      end
+
+      swagger_path '/studies/{study_id}/external_resources/{id}' do
+        operation :get do
+          key :tags, [
+              'ExternalResources'
+          ]
+          key :summary, 'Find a ExternalResource'
+          key :description, 'Finds a single Study'
+          key :operationId, 'study_external_resource_path'
+          parameter do
+            key :name, :study_id
+            key :in, :path
+            key :description, 'ID of Study'
+            key :required, true
+            key :type, :string
+          end
+          parameter do
+            key :name, :id
+            key :in, :path
+            key :description, 'ID of ExternalResource to fetch'
+            key :required, true
+            key :type, :string
+          end
+          response 200 do
+            key :description, 'ExternalResource object'
+            schema do
+              key :title, 'ExternalResource'
+              key :'$ref', :ExternalResource
+            end
+          end
+          response 401 do
+            key :description, ApiBaseController.unauthorized
+          end
+          response 403 do
+            key :description, ApiBaseController.forbidden('edit Study')
+          end
+          response 404 do
+            key :description, ApiBaseController.not_found(Study, ExternalResource)
+          end
+          response 406 do
+            key :description, ApiBaseController.not_acceptable
+          end
+        end
+      end
+
+      # GET /single_cell/api/v1/studies/:study_id/external_resources/:id
+      def show
+
+      end
+
+      swagger_path '/studies/{study_id}/external_resources' do
+        operation :post do
+          key :tags, [
+              'ExternalResources'
+          ]
+          key :summary, 'Create a ExternalResource'
+          key :description, 'Creates and returns a single ExternalResource'
+          key :operationId, 'create_study_external_resource_path'
+          parameter do
+            key :name, :study_id
+            key :in, :path
+            key :description, 'ID of Study'
+            key :required, true
+            key :type, :string
+          end
+          parameter do
+            key :name, :external_resource
+            key :in, :body
+            key :description, 'ExternalResource object'
+            key :required, true
+            schema do
+              key :'$ref', :ExternalResourceInput
+            end
+          end
+          response 200 do
+            key :description, 'Successful creation of ExternalResource object'
+            schema do
+              key :title, 'ExternalResource'
+              key :'$ref', :ExternalResource
+            end
+          end
+          response 401 do
+            key :description, ApiBaseController.unauthorized
+          end
+          response 403 do
+            key :description, ApiBaseController.forbidden('edit Study')
+          end
+          response 404 do
+            key :description, ApiBaseController.not_found(Study)
+          end
+          response 406 do
+            key :description, ApiBaseController.not_acceptable
+          end
+          extend SwaggerResponses::ValidationFailureResponse
+        end
+      end
+
+      # POST /single_cell/api/v1/studies/:study_id/external_resources
+      def create
+        @external_resource = @study.external_resources.build(external_resource_params)
+
+        if @external_resource.save
+          render :show
+        else
+          render json: {errors: @external_resource.errors}, status: :unprocessable_entity
+        end
+      end
+
+      swagger_path '/studies/{study_id}/external_resources/{id}' do
+        operation :patch do
+          key :tags, [
+              'ExternalResources'
+          ]
+          key :summary, 'Update a ExternalResource'
+          key :description, 'Updates and returns a single ExternalResource.'
+          key :operationId, 'update_study_external_resource_path'
+          parameter do
+            key :name, :study_id
+            key :in, :path
+            key :description, 'ID of Study'
+            key :required, true
+            key :type, :string
+          end
+          parameter do
+            key :name, :id
+            key :in, :path
+            key :description, 'ID of ExternalResource to update'
+            key :required, true
+            key :type, :string
+          end
+          parameter do
+            key :name, :external_resource
+            key :in, :body
+            key :description, 'ExternalResource object'
+            key :required, true
+            schema do
+              key :'$ref', :ExternalResourceInput
+            end
+          end
+          response 200 do
+            key :description, 'Successful update of ExternalResource object'
+            schema do
+              key :title, 'ExternalResource'
+              key :'$ref', :ExternalResource
+            end
+          end
+          response 401 do
+            key :description, ApiBaseController.unauthorized
+          end
+          response 403 do
+            key :description, ApiBaseController.forbidden('edit Study')
+          end
+          response 404 do
+            key :description, ApiBaseController.not_found(Study, ExternalResource)
+          end
+          response 406 do
+            key :description, ApiBaseController.not_acceptable
+          end
+          extend SwaggerResponses::ValidationFailureResponse
+        end
+      end
+
+      # PATCH /single_cell/api/v1/studies/:study_id/external_resources/:id
+      def update
+        sanitized_update_params = external_resource_params.to_unsafe_hash.keep_if {|k,v| !v.blank?}
+        if @external_resource.update(sanitized_update_params)
+          render :show
+        else
+          render json: {errors: @external_resource.errors}, status: :unprocessable_entity
+        end
+      end
+
+      swagger_path '/studies/{study_id}/external_resources/{id}' do
+        operation :delete do
+          key :tags, [
+              'ExternalResources'
+          ]
+          key :summary, 'Delete a ExternalResource'
+          key :description, 'Deletes a single ExternalResource'
+          key :operationId, 'delete_study_external_resource_path'
+          parameter do
+            key :name, :study_id
+            key :in, :path
+            key :description, 'ID of Study'
+            key :required, true
+            key :type, :string
+          end
+          parameter do
+            key :name, :id
+            key :in, :path
+            key :description, 'ID of ExternalResource to delete'
+            key :required, true
+            key :type, :string
+          end
+          response 204 do
+            key :description, 'Successful ExternalResource deletion'
+          end
+          response 401 do
+            key :description, ApiBaseController.unauthorized
+          end
+          response 403 do
+            key :description, ApiBaseController.forbidden('delete ExternalResource')
+          end
+          response 404 do
+            key :description, ApiBaseController.not_found(Study, ExternalResource)
+          end
+          response 406 do
+            key :description, ApiBaseController.not_acceptable
+          end
+        end
+      end
+
+      # DELETE /single_cell/api/v1/studies/:study_id/external_resources/:id
+      def destroy
+        begin
+          @external_resource.destroy
+          head 204
+        rescue => e
+          error_context = ErrorTracker.format_extra_context(@external_resource, {params: params})
+          ErrorTracker.report_exception(e, current_api_user, error_context)
+          render json: {error: e.message}, status: 500
+        end
+      end
+
+      private
+
+      def set_study
+        @study = Study.find_by(id: params[:study_id])
+        if @study.nil? || @study.queued_for_deletion?
+          head 404 and return
+        end
+      end
+
+      def set_external_resource
+        @external_resource = ExternalResource.find_by(id: params[:id])
+        if @external_resource.nil?
+          head 404 and return
+        end
+      end
+
+      def check_study_permission
+        head 403 unless @study.can_edit?(current_api_user)
+      end
+
+      # study file params whitelist
+      def external_resource_params
+        params.require(:external_resource).permit(:id, :study_id, :title, :description, :url, :publication_url)
+      end
+    end
+  end
+end
+

--- a/app/models/external_resource.rb
+++ b/app/models/external_resource.rb
@@ -6,9 +6,73 @@ class ExternalResource
   field :title, type: String
   field :description, type: String
   field :publication_url, type: Mongoid::Boolean, default: false
+  include Swagger::Blocks
 
   belongs_to :resource_links, polymorphic: true
 
   validates_presence_of :url, :title
   validates_uniqueness_of :title, scope: [:resource_links_id, :resource_links_type]
+
+  swagger_schema :ExternalResource do
+    key :required, [:url, :title]
+    key :name, 'ExternalResource'
+    property :id do
+      key :type, :string
+    end
+    property :resource_links_id do
+      key :type, :string
+      key :description, 'ID of object this ExternalResource belongs to'
+    end
+    property :resource_links_type do
+      key :type, :string
+      key :description, 'Class of object this ExternalResource belongs to'
+      key :enum, ['Study', 'AnalysisConfiguration']
+    end
+    property :url do
+      key :type, :string
+      key :description, 'URL of external resource'
+    end
+    property :title do
+      key :type, :string
+      key :description, 'Title of external resource (used as button text)'
+    end
+    property :description do
+      key :type, :string
+      key :description, 'Text description of external resource (used as tooltip)'
+    end
+    property :publication_url do
+      key :type, :boolean
+      key :description, 'Boolean indication whether this external resource link is to a publication'
+    end
+    property :created_at do
+      key :type, :string
+      key :format, :date_time
+      key :description, 'Creation timestamp'
+    end
+    property :updated_at do
+      key :type, :string
+      key :format, :date_time
+      key :description, 'Last update timestamp'
+    end
+  end
+
+  swagger_schema :ExternalResourceInput do
+    key :required, [:url, :title]
+    property :url do
+      key :type, :string
+      key :description, 'URL of external resource'
+    end
+    property :title do
+      key :type, :string
+      key :description, 'Title of external resource (used as button text)'
+    end
+    property :description do
+      key :type, :string
+      key :description, 'Text description of external resource (used as tooltip)'
+    end
+    property :publication_url do
+      key :type, :boolean
+      key :description, 'Boolean indication whether this external resource link is to a publication'
+    end
+  end
 end

--- a/app/views/api/v1/external_resources/_external_resource.json.jbuilder
+++ b/app/views/api/v1/external_resources/_external_resource.json.jbuilder
@@ -1,0 +1,5 @@
+external_resource.attributes.each do |name, value|
+  unless name == '_id' && !external_resource.persisted?
+    json.set! name, value
+  end
+end

--- a/app/views/api/v1/external_resources/index.json.jbuilder
+++ b/app/views/api/v1/external_resources/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @external_resources, partial: 'api/v1/external_resources/external_resource', as: :external_resource

--- a/app/views/api/v1/external_resources/show.json.jbuilder
+++ b/app/views/api/v1/external_resources/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'api/v1/external_resources/external_resource', locals: {external_resource: @external_resource}

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -82,6 +82,7 @@ else
                     test/api/study_file_bundles_controller_test.rb
                     test/api/study_shares_controller_test.rb
                     test/api/directory_listings_controller_test.rb
+                    test/api/external_resources_controller_test.rb
                     test/models/cluster_group_test.rb # deprecated, but needed to set up for user_annotation_test
                     test/models/user_annotation_test.rb
                     test/models/study_test.rb

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
           resources :study_file_bundles, only: [:index, :show, :create, :destroy]
           resources :study_shares, only: [:index, :show, :create, :update, :destroy]
           resources :directory_listings, only: [:index, :show, :create, :update, :destroy]
+          resources :external_resources, only: [:index, :show, :create, :update, :destroy]
           member do
             post 'sync', to: 'studies#sync_study'
           end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -106,6 +106,9 @@ DirectoryListing.create!(name: 'csvs', file_type: 'csv', files: [{name: 'foo.csv
 StudyFileBundle.create!(bundle_type: 'BAM', original_file_list: [{'name' => 'sample_1.bam', 'file_type' => 'BAM'},
                                                                  {'name' => 'sample_1.bam.bai', 'file_type' => 'BAM Index'}],
                         study_id: api_study.id)
+resource = api_study.external_resources.build(url: 'https://singlecell.broadinstitute.org', title: 'SCP',
+                                              description: 'Link to Single Cell Portal')
+resource.save!
 api_user = User.create!(email:'testing.user.2@gmail.com', password:'someotherpassword',
              api_access_token: {access_token: 'test-api-token-2', expires_in: 3600, expires_at: Time.zone.now + 1.hour})
 


### PR DESCRIPTION
Adding in support to the API for CRUDing `ExternalResource` objects, which are links to publications or any other "resource" that a study owner wants to include on their study page.  Following the established paradigm in the API, rather than allowing nested objects (like the normal `studies_controller` does), a separate controller and collection of endpoints has been added for managing all external resources for a given study.  This also adds seeds and integration tests like other study-related models.

This PR satisfies SCP-2270, and a related user request for this feature.