### PR TITLE
refining behavior of faceted search for numeric facets

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -666,9 +666,12 @@ module Api
         facets.each do |facet|
           search_facet = SearchFacet.find(facet[:object_id])
           # only use non-numeric facets
-          if !search_facet.is_numeric?
-            terms_by_facet[search_facet.identifier] = facet[:filters].map {|filter| filter[:name]}
+          if search_facet.is_numeric?
+            # we can't do inferred matching on numerics, and because the facets are ANDed,
+            # the presence of any numeric facets disables inferred search
+            return {}
           end
+          terms_by_facet[search_facet.identifier] = facet[:filters].map {|filter| filter[:name]}
         end
         terms_by_facet
       end


### PR DESCRIPTION
Jean and I spent awhile talking about this this morning, and this was our consensus for the best way to handle numeric facets for inferred search.  Otherwise, selecting a numeric range along with other facets means that studies that match the other facets, but have no numeric data at all, will be treated as 'inferred' matches, but there's nothing behind that inference.