### PR TITLE
adding error boundaries to search page

### DIFF
--- a/app/javascript/components/FacetControl.js
+++ b/app/javascript/components/FacetControl.js
@@ -5,6 +5,7 @@ import { StudySearchContext } from 'components/search/StudySearchProvider'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTimesCircle } from '@fortawesome/free-solid-svg-icons'
 import { SearchSelectionContext } from './search/SearchSelectionProvider'
+import { withErrorBoundary } from 'lib/ErrorBoundary'
 
 /**
  * Converts string value to lowercase, hyphen-delimited version
@@ -17,7 +18,7 @@ function slug(value) {
 /**
  * Button for facets, and associated functions
  */
-export default function FacetControl(props) {
+function RawFacetControl(props) {
   const [showFilters, setShowFilters] = useState(false)
 
   const facetName = props.facet.name
@@ -121,3 +122,6 @@ export default function FacetControl(props) {
     </span>
   )
 }
+
+const FacetControl = withErrorBoundary(RawFacetControl)
+export default FacetControl

--- a/app/javascript/components/HomePageContent.js
+++ b/app/javascript/components/HomePageContent.js
@@ -4,19 +4,26 @@ import ResultsPanel from './ResultsPanel'
 import StudySearchProvider from 'components/search/StudySearchProvider'
 import SearchFacetProvider from 'components/search/SearchFacetProvider'
 import UserProvider from 'components/UserProvider'
+import ErrorBoundary from 'lib/ErrorBoundary'
 
 /**
  * Wrapper component for search and result panels
  */
 export default function HomePageContent() {
   return (
-    <UserProvider>
-      <SearchFacetProvider>
-        <StudySearchProvider>
-          <SearchPanel/>
-          <ResultsPanel/>
-        </StudySearchProvider>
-      </SearchFacetProvider>
-    </UserProvider>
+    <ErrorBoundary>
+      <UserProvider>
+        <SearchFacetProvider>
+          <StudySearchProvider>
+            <ErrorBoundary>
+              <SearchPanel/>
+            </ErrorBoundary>
+            <ErrorBoundary>
+              <ResultsPanel/>
+            </ErrorBoundary>
+          </StudySearchProvider>
+        </SearchFacetProvider>
+      </UserProvider>
+    </ErrorBoundary>
   )
 }

--- a/app/javascript/components/ResultsPanel.js
+++ b/app/javascript/components/ResultsPanel.js
@@ -6,6 +6,7 @@ import { StudySearchContext } from 'components/search/StudySearchProvider'
 import { StudiesResults } from './StudyResultsContainer'
 import SearchQueryDisplay from './SearchQueryDisplay'
 
+
 /**
  * Component for Results displayed on the homepage
  */

--- a/app/javascript/lib/ErrorBoundary.js
+++ b/app/javascript/lib/ErrorBoundary.js
@@ -32,6 +32,7 @@ export default class ErrorBoundary extends Component {
   render() {
     if (this.state.error) {
       // consider using node_env to decide whether or not to render the full trace
+      // See related ticket SCP-2237
       return (
         <div className="alert-danger text-center error-boundary">
           <span className="font-italic ">Something went wrong.</span><br/>

--- a/app/javascript/lib/ErrorBoundary.js
+++ b/app/javascript/lib/ErrorBoundary.js
@@ -1,0 +1,53 @@
+import React, { Component } from 'react'
+import { logError } from 'lib/metrics-api'
+/* convert to readable message  e.g.
+ * "foobar is not defined    in ResultsPanel (at HomePageContent.js:22)"
+ */
+function readableErrorMessage(error, info) {
+  // the first line of info stack seems to always be blank,
+  // so add the second one to the message
+
+  // the error.stack is typically useless because EventBoundaries do NOT catch
+  // errors in event handlers, so the error.stack is just full of react internals
+  return error.message + info.componentStack.split('\n')[1]
+}
+
+/*
+ * See https://reactjs.org/docs/error-boundaries.html
+ * note that this must be a class component
+ * as hooks do not support componentDidCatch yet
+ */
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { error: null }
+  }
+
+  componentDidCatch(error, info) {
+
+    logError(readableErrorMessage(error, info))
+    this.setState({ error, info })
+  }
+
+  render() {
+    if (this.state.error) {
+      // consider using node_env to decide whether or not to render the full trace
+      return (
+        <div className="alert-danger text-center error-boundary">
+          <span className="font-italic ">Something went wrong.</span><br/>
+          {readableErrorMessage(this.state.error, this.state.info)}
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+// HOC for wrapping arbitrary components in error boundaries
+export function withErrorBoundary(Component) {
+  return props => (
+    <ErrorBoundary>
+      <Component {...props} />
+    </ErrorBoundary>
+  )
+}

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -76,6 +76,14 @@ function logClickButton(target) {
 }
 
 /**
+ * Log front-end error (e.g. uncaught ReferenceError)
+ */
+export function logError(text) {
+  const props = { text: text }
+  log('error', props)
+}
+
+/**
  * Get label elements for an input element
  *
  * From https://stackoverflow.com/a/15061155


### PR DESCRIPTION
See https://reactjs.org/docs/error-boundaries.html for the background.  Basically, if there's an error in component rendering (although this does NOT handle errors in event handlers), this will now show a nice error instead of the entire React UI disappearing

![image](https://user-images.githubusercontent.com/2800795/77381063-4d9bf100-6d53-11ea-9b07-8c62b099422a.png)
