### PR TITLE
updating to scp-ingest-pipeline:1.2.1

### DIFF
--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -19,7 +19,7 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   # GCP Compute project to run pipelines in
   COMPUTE_PROJECT = ENV['GOOGLE_CLOUD_PROJECT'].blank? ? '' : ENV['GOOGLE_CLOUD_PROJECT']
   # Docker image in GCP project to pull for running ingest jobs
-  INGEST_DOCKER_IMAGE = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.2.0'
+  INGEST_DOCKER_IMAGE = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.2.1'
   # Network and sub-network names, if needed
   GCP_NETWORK_NAME = ENV['GCP_NETWORK_NAME']
   GCP_SUB_NETWORK_NAME = ENV['GCP_SUB_NETWORK_NAME']


### PR DESCRIPTION
Updating to the latest release of scp-ingest-pipeline (1.2.1).  This addresses a bug with optional metadata columns and `nan` values.

This PR satisfies SCP-2137.