### PR TITLE
fixing slider filter bug for blank inputs

### DIFF
--- a/app/javascript/components/FacetControl.js
+++ b/app/javascript/components/FacetControl.js
@@ -42,7 +42,7 @@ function RawFacetControl(props) {
       selectedFilterString = selectedFilters[0].name
     } else {
       // it's a numeric range filter
-      selectedFilterString = `${facetName}:
+      selectedFilterString = `${getDisplayNameForFacet(props.facet.id)}:
                               ${appliedSelection[0]}-${appliedSelection[1]}
                               ${appliedSelection[2]}`
     }

--- a/app/javascript/components/FilterSlider.js
+++ b/app/javascript/components/FilterSlider.js
@@ -38,17 +38,31 @@ export default function FilterSlider(props) {
 
 
   let propsSelection = _clone(props.selection)
+  // propsRange indicates the current numeric range for the slider
+  // it will always be numeric even if the text values are not (e.g. a text box is blank)
   let propsRange = []
   let propsUnit = ''
+  let minTextValue = propsSelection[0]
+  let maxTextValue = propsSelection[1]
 
   if (propsSelection && propsSelection.length === 3) {
     propsRange = propsSelection.slice(0, 2)
-    propsRange = propsRange.map(value => parseInt(value))
+    propsRange = propsRange.map((value, index) => {
+      const intVal = parseInt(value)
+      // convert blanks to min/max as appropriate so the slider can still render
+      if (isNaN(intVal) ) {
+        return domain[index]
+      }
+      return intVal
+    })
     propsUnit = propsSelection[2]
   } else {
     propsRange = domain.slice()
+    minTextValue = min
+    maxTextValue = max
     propsUnit = facet.unit
   }
+
 
   function handleUpdate(update) {
     if ('min' in update) {
@@ -85,7 +99,7 @@ export default function FilterSlider(props) {
         type="number"
         min={min}
         max={max}
-        value={propsRange[0]}
+        value={minTextValue}
         style={{ 'width': '60px' }}
       />
       <span style={{ 'margin': '0 4px 0 4px' }}>-</span>
@@ -95,7 +109,7 @@ export default function FilterSlider(props) {
         type='number'
         min={min}
         max={max}
-        value={propsRange[1]}
+        value={maxTextValue}
         style={{ 'width': '60px', 'marginRight': '8px' }}
       />
       { unitControl }

--- a/app/javascript/components/FiltersBox.js
+++ b/app/javascript/components/FiltersBox.js
@@ -55,6 +55,10 @@ function ApplyButton(props) {
 
 /**
  * Component for filter lists that have Apply and Clear
+ * We should revisit this structure if we ever have to add a
+ * type of control besides filter list and slider
+ * Currently, FiltersBox has to own a lot of logic about canApply and applyClick
+ * handling that is probably better encapsulated in the individual controls
  */
 export default function FiltersBox(props) {
   const searchContext = useContext(StudySearchContext)

--- a/app/javascript/components/FiltersBox.js
+++ b/app/javascript/components/FiltersBox.js
@@ -65,8 +65,12 @@ export default function FiltersBox(props) {
   const selection = props.selection
   const setSelection = props.setSelection
   const showClear = selection.length > 0
-  const canApply = !_isEqual(selection, appliedSelection) ||
-                   props.facet.type === 'number' && appliedSelection.length === 0
+  const isSelectionValid = props.facet.type != 'number' ||
+                             (!isNaN(parseInt(selection[0])) && !isNaN(parseInt(selection[1])))
+
+  const canApply = isSelectionValid &&
+                   (!_isEqual(selection, appliedSelection) ||
+                   props.facet.type === 'number' && appliedSelection.length === 0)
                    // allow application of number filters to default range
 
   const facetId = props.facet.id

--- a/app/javascript/components/SearchQueryDisplay.js
+++ b/app/javascript/components/SearchQueryDisplay.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { faSearch } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { getDisplayNameForFacet } from 'components/search/SearchFacetProvider'
 
 
 function formattedJoinedList(itemTexts, itemClass, joinText) {
@@ -28,7 +29,7 @@ function formatFacet(facet, index, numFacets) {
   }
   return (
     <span key={index}>
-      (<span className="facet-name">{facet.id}: </span>
+      (<span className="facet-name">{getDisplayNameForFacet(facet.id)}: </span>
       { facetContent })
       { (index != numFacets - 1) &&
         <span className="join-text"> AND </span>}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -97,7 +97,7 @@ class User
   field :feature_flags, default: {}
 
   DEFAULT_FEATURE_FLAGS = {
-    "faceted_search" => false
+    "faceted_search" => true
   }
 
   ###

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -97,7 +97,7 @@ class User
   field :feature_flags, default: {}
 
   DEFAULT_FEATURE_FLAGS = {
-    "faceted_search" => true
+    "faceted_search" => false
   }
 
   ###


### PR DESCRIPTION
Amazing how complex a slider input can be...  This fixes the bug where the textbox would break the filter if it was cleared, and also now prevents users from hitting 'apply' while there are non-numeric values in the box (e.g. '' or '50-3').  
Also cleans up some more cases where the frontend was displaying facetId rather than a name