### PR TITLE
Adding Preset Searches

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -162,7 +162,7 @@ module Api
         # variable for determining how we will sort search results for relevance
         sort_type = :none
 
-        # if a user is requested a preset search, override search parameters to load the requested query
+        # if a user requested a preset search, override search parameters to load the requested query
         if @preset_search.present?
           params[:terms] = "#{@preset_search.keyword_query_string} #{params[:terms]}".strip
           @facets = @preset_search.matching_facets_and_filters if @preset_search.search_facets.any?

--- a/app/controllers/preset_searches_controller.rb
+++ b/app/controllers/preset_searches_controller.rb
@@ -1,0 +1,78 @@
+class PresetSearchesController < ApplicationController
+  before_action :set_preset_search, only: [:show, :edit, :update, :destroy]
+  before_action do
+    authenticate_user!
+    authenticate_admin
+  end
+
+  # GET /preset_searches
+  # GET /preset_searches.json
+  def index
+    @preset_searches = PresetSearch.all
+  end
+
+  # GET /preset_searches/1
+  # GET /preset_searches/1.json
+  def show
+  end
+
+  # GET /preset_searches/new
+  def new
+    @preset_search = PresetSearch.new
+  end
+
+  # GET /preset_searches/1/edit
+  def edit
+  end
+
+  # POST /preset_searches
+  # POST /preset_searches.json
+  def create
+    @preset_search = PresetSearch.new(preset_search_params)
+
+    respond_to do |format|
+      if @preset_search.save
+        format.html { redirect_to @preset_search, notice: 'Stored search was successfully created.' }
+        format.json { render :show, status: :created, location: @preset_search }
+      else
+        format.html { render :new }
+        format.json { render json: @preset_search.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /preset_searches/1
+  # PATCH/PUT /preset_searches/1.json
+  def update
+    respond_to do |format|
+      if @preset_search.update(preset_search_params)
+        format.html { redirect_to @preset_search, notice: 'Stored search was successfully updated.' }
+        format.json { render :show, status: :ok, location: @preset_search }
+      else
+        format.html { render :edit }
+        format.json { render json: @preset_search.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /preset_searches/1
+  # DELETE /preset_searches/1.json
+  def destroy
+    @preset_search.destroy
+    respond_to do |format|
+      format.html { redirect_to preset_searches_url, notice: 'Stored search was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_preset_search
+      @preset_search = PresetSearch.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def preset_search_params
+      params.require(:preset_search).permit(:name, :identifier, :accession_whitelist, :search_terms, :facet_filters, :public)
+    end
+end

--- a/app/controllers/preset_searches_controller.rb
+++ b/app/controllers/preset_searches_controller.rb
@@ -28,7 +28,8 @@ class PresetSearchesController < ApplicationController
   # POST /preset_searches
   # POST /preset_searches.json
   def create
-    @preset_search = PresetSearch.new(preset_search_params)
+    serialized_params = serialize_preset_search_params
+    @preset_search = PresetSearch.new(serialized_params)
 
     respond_to do |format|
       if @preset_search.save
@@ -44,8 +45,9 @@ class PresetSearchesController < ApplicationController
   # PATCH/PUT /preset_searches/1
   # PATCH/PUT /preset_searches/1.json
   def update
+    serialized_params = serialize_preset_search_params
     respond_to do |format|
-      if @preset_search.update(preset_search_params)
+      if @preset_search.update(serialized_params)
         format.html { redirect_to @preset_search, notice: 'Stored search was successfully updated.' }
         format.json { render :show, status: :ok, location: @preset_search }
       else
@@ -66,13 +68,37 @@ class PresetSearchesController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_preset_search
-      @preset_search = PresetSearch.find(params[:id])
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_preset_search
+    @preset_search = PresetSearch.find(params[:id])
+  end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def preset_search_params
-      params.require(:preset_search).permit(:name, :identifier, :accession_whitelist, :search_terms, :facet_filters, :public)
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def preset_search_params
+    params.require(:preset_search).permit(:name, :public, :accession_whitelist, :search_terms, :facet_filters)
+  end
+
+  # convert text fields into arrays for saving
+  # TODO: figure out a way to leverage this natively using array serialization w/ forms because this is gross as hell
+  def serialize_preset_search_params
+    form_params = preset_search_params.to_unsafe_hash
+    accessions = form_params[:accession_whitelist].blank? ? [] : form_params[:accession_whitelist].split.map(&:strip)
+    facets = form_params[:facet_filters].blank? ? [] : form_params[:facet_filters].split('+').map(&:strip)
+    terms = []
+    if form_params[:search_terms].present? && form_params[:search_terms].include?("\"")
+      form_params[:search_terms].split("\"").each do |substring|
+        if substring.start_with?(' ') || substring.end_with?(' ')
+          terms += substring.strip.split
+        else
+          terms << substring
+        end
+      end
+    else
+      terms = form_params[:search_terms].split if form_params[:search_terms].present?
     end
+    form_params[:search_terms] = terms.map(&:strip).delete_if(&:blank?)
+    form_params[:accession_whitelist] = accessions
+    form_params[:facet_filters] = facets
+    form_params
+  end
 end

--- a/app/helpers/preset_searches_helper.rb
+++ b/app/helpers/preset_searches_helper.rb
@@ -1,0 +1,11 @@
+module PresetSearchesHelper
+
+  def facet_query_label(facet_data)
+    labels = []
+    facet_data[:filters].each do |filter|
+      label = "<big><span class='label label-primary' data-toggle='tooltip' title='#{filter[:id]}'>#{facet_data[:id]}: #{filter[:name]}</span></big>"
+      labels << label
+    end
+    labels.join("&nbsp;")
+  end
+end

--- a/app/models/preset_search.rb
+++ b/app/models/preset_search.rb
@@ -65,6 +65,11 @@ class PresetSearch
     Study.where(:accession.in => self.accession_whitelist)
   end
 
+  # helper for determining if this search does not contain keywords/facets
+  def whitelist_only?
+    self.facet_filters.empty? && self.search_terms.empty?
+  end
+
   # get an array of matching facets & filters based off of the facet_filters query string
   # this method mimics SearchController#set_search_facets_and_filters and is needed because
   # the above method runs as a :before_filter and cannot be overridden

--- a/app/models/preset_search.rb
+++ b/app/models/preset_search.rb
@@ -26,6 +26,7 @@ class PresetSearch
   validates_presence_of :name
   validates_uniqueness_of :name
   before_validation :set_identifier, on: :create, if: proc {|attributes| attributes[:name].present?}
+  before_validation :sanitize_array_attributes
   validate :ensure_search_terms_are_unique, if: proc {|attributes| attributes[:search_terms].any?}
   validate :ensure_facet_filters_are_unique, if: proc {|attributes| attributes[:facet_filters].any?}
   validate :whitelisted_studies_exist
@@ -86,6 +87,12 @@ class PresetSearch
   # sets a url-safe version of name (for API requests)
   def set_identifier
     self.identifier = self.name.downcase.gsub(/[^a-zA-Z0-9]+/, '-').chomp('-')
+  end
+
+  def sanitize_array_attributes
+    self.accession_whitelist.reject!(&:blank?)
+    self.search_terms.reject!(&:blank?)
+    self.facet_filters.reject!(&:blank?)
   end
 
   # validate all terms are unique - only find duplicates if size mismatch is found on search_terms.uniq call

--- a/app/models/preset_search.rb
+++ b/app/models/preset_search.rb
@@ -1,0 +1,129 @@
+##
+# PresetSearch: a collection for storing a "canned" query for a group of studies.  Will always prioritize the studies
+# included in the :accession_whitelist over other query results. :search_terms and :facet_filters are arrays of individual
+# keyword/phrase or facet filters exactly as they would be passed to the search API
+#
+# examples of :search_terms and :facet_filters to find HIV human blood studies:
+#
+#     preset_search.search_terms = ["HIV", "Human", "blood"]
+#     preset_search.facet_filters = ["disease:MONDO_0005109", "species:NCBITaxon_9606", "organ:UBERON_0000178"]
+#
+# It should be noted that the AND logic of keywords + facets in the search API would mean that using the above values
+# together would likely result in too few studies being matched - rather one or the other would be a better approach
+##
+
+class PresetSearch
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :name, type: String
+  field :identifier, type: String
+  field :accession_whitelist, type: Array, default: []
+  field :search_terms, type: Array, default: []
+  field :facet_filters, type: Array, default: []
+  field :public, type: Mongoid::Boolean, default: true
+
+  validates_presence_of :name
+  validates_uniqueness_of :name
+  before_validation :set_identifier, on: :create, if: proc {|attributes| attributes[:name].present?}
+  validate :ensure_search_terms_are_unique, if: proc {|attributes| attributes[:search_terms].any?}
+  validate :ensure_facet_filters_are_unique, if: proc {|attributes| attributes[:facet_filters].any?}
+  validate :whitelisted_studies_exist
+  validate :can_return_results
+
+  # format search terms into a query string to use with search API
+  def keyword_query_string
+    processed_terms = []
+    self.search_terms.each do |search_val|
+      # spaces or dashes (-) need to be quoted to be treated as single values
+      term = search_val.match?(/[\s-]/) ? "\"#{search_val}\"" : search_val
+      processed_terms << term
+    end
+    processed_terms.join(' ')
+  end
+
+  def facet_query_string
+    self.facet_filters.join('+')
+  end
+
+  # extract search_facet identifiers from facet_filters query string
+  def get_facet_identifiers
+    self.facet_filters.map {|facet_data| facet_data.split(':').first}.flatten
+  end
+
+  # extract all filter values
+  def get_filter_values
+    self.facet_filters.map {|facet_data| facet_data.split(':').last.split(',')}.flatten
+  end
+
+  def search_facets
+    SearchFacet.where(:identifier.in => self.get_facet_identifiers)
+  end
+
+  def study_whitelist
+    Study.where(:accession.in => self.accession_whitelist)
+  end
+
+  # get an array of matching facets & filters based off of the facet_filters query string
+  # this method mimics SearchController#set_search_facets_and_filters and is needed because
+  # the above method runs as a :before_filter and cannot be overridden
+  def matching_facets_and_filters
+    facets_and_filters = []
+    self.search_facets.each do |search_facet|
+      facet = {id: search_facet.identifier, filters: [], object_id: search_facet.id}
+      filter_query = self.facet_filters.detect {|f| f.starts_with?(search_facet.identifier)}
+      filter_query.split(':').last.split(',').each do |filter|
+        matching_filter = search_facet.filters.detect {|f| f[:id] == filter}
+        facet[:filters] << matching_filter if matching_filter.present?
+      end
+      facets_and_filters << facet if facet[:filters].any?
+    end
+    facets_and_filters
+  end
+
+  private
+
+  # sets a url-safe version of name (for API requests)
+  def set_identifier
+    self.identifier = self.name.downcase.gsub(/[^a-zA-Z0-9]+/, '-').chomp('-')
+  end
+
+  # validate all terms are unique - only find duplicates if size mismatch is found on search_terms.uniq call
+  def ensure_search_terms_are_unique
+    uniques = self.search_terms.dup.uniq
+    if uniques != self.search_terms
+      duplicates = find_duplicates(self.search_terms)
+      errors.add(:search_terms, "contains duplicated values: #{duplicates.join(', ')}")
+    end
+  end
+
+  # validate requested facets/filters are unique and have no duplicates
+  def ensure_facet_filters_are_unique
+    duplicate_ids = find_duplicates(self.get_facet_identifiers)
+    duplicate_filters = find_duplicates(self.get_filter_values)
+    if duplicate_ids.any? || duplicate_filters.any?
+      errors.add(:facet_filters, "contains duplicated identifiers/filters: #{[duplicate_ids, duplicate_filters].flatten.compact.join(', ')}")
+    end
+  end
+
+  # validate that whitelisted studies exist on save
+  def whitelisted_studies_exist
+    unless self.study_whitelist.count == self.accession_whitelist.count
+      missing = (self.accession_whitelist - self.study_whitelist.pluck(:accession)).join(', ')
+      errors.add(:accession_whitelist, "contains missing studies: #{missing}")
+    end
+  end
+
+  # validate that this search has potential to return results; it must have an accession_whitelist, search_terms,
+  # or facet_filters
+  def can_return_results
+    if self.accession_whitelist.blank? && self.search_terms.empty? && self.facet_filters.empty?
+      errors.add(:base, "You must supply either search terms, facet filters, or an accession whitelist")
+    end
+  end
+
+  def find_duplicates(terms)
+    unique_terms = terms.dup.uniq
+    unique_terms.map {|t| t if terms.count(t) > 1}.compact
+  end
+end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -586,6 +586,10 @@ class Study
       key :type, :boolean
       key :description, 'Indication if match is inferred (e.g. converting facet filter value to keyword search)'
     end
+    property :preset_match do
+      key :type, :boolean
+      key :description, 'Indication this study was whitelisted by a preset search'
+    end
     property :study_files do
       key :type, :object
       key :title, 'StudyFiles'

--- a/app/views/api/v1/search/_study.json.jbuilder
+++ b/app/views/api/v1/search/_study.json.jbuilder
@@ -22,6 +22,9 @@ if @inferred_accessions.present? && @inferred_accessions.include?(study.accessio
   json.set! :term_matches, inferred_weight[:terms].keys
   json.set! :term_search_weight, inferred_weight[:total]
 end
+if @preset_search.present? && @preset_search.accession_whitelist.include?(study.accession)
+  json.set! :preset_match, true
+end
 if study.detached
   json.set! :study_files, 'Unavailable (cannot load study workspace or bucket)'
 else

--- a/app/views/api/v1/search/index.json.jbuilder
+++ b/app/views/api/v1/search/index.json.jbuilder
@@ -5,6 +5,7 @@ json.set! :current_page, @results.current_page.to_i
 json.set! :total_studies, @results.total_entries
 json.set! :total_pages, @results.total_pages
 json.set! :matching_accessions, @matching_accessions
+json.set! :preset_search, params[:preset_search]
 if @selected_branding_group.present?
   json.set! :scpbr, @selected_branding_group.name_as_id
 end

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -31,6 +31,7 @@
             <% if current_user.admin? %>
               <li><%= link_to "<span class='fas fa-lock fa-fw'></span> Admin Config".html_safe, admin_configurations_path, class: 'check-upload', id: 'admin-nav' %></li>
               <li><%= link_to "<span class='fas fa-flask fa-fw'></span> Analyses".html_safe, analysis_configurations_path, class: 'check-upload', id: 'analysis-nav' %></li>
+              <li><%= link_to "<span class='fas fa-search fa-fw'></span> Preset Searches".html_safe, preset_searches_path, class: 'check-upload', id: 'preset-nav' %></li>
               <li><%= link_to "<span class='fas fa-dna fa-fw'></span> Species".html_safe, taxons_path, class: 'check-upload', id: 'species-nav' %></li>
               <li><%= scp_link_to "<span class='fas fa-copyright fa-fw'></span> Branding Groups".html_safe, branding_groups_path, class: 'check-upload', id: 'branding-groups-nav' %>
             <% end %>

--- a/app/views/preset_searches/_form.html.erb
+++ b/app/views/preset_searches/_form.html.erb
@@ -1,0 +1,47 @@
+<%= form_with(model: preset_search, local: true) do |form| %>
+  <% if preset_search.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(preset_search.errors.count, "error") %> prohibited this preset_search from being saved:</h2>
+
+      <ul>
+      <% preset_search.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :identifier %>
+    <%= form.text_field :identifier %>
+  </div>
+
+  <div class="field">
+    <%= form.label :accession_whitelist %>
+    <%= form.text_field :accession_whitelist %>
+  </div>
+
+  <div class="field">
+    <%= form.label :search_terms %>
+    <%= form.text_field :search_terms %>
+  </div>
+
+  <div class="field">
+    <%= form.label :facet_filters %>
+    <%= form.text_field :facet_filters %>
+  </div>
+
+  <div class="field">
+    <%= form.label :public %>
+    <%= form.check_box :public %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/preset_searches/_form.html.erb
+++ b/app/views/preset_searches/_form.html.erb
@@ -1,8 +1,7 @@
-<%= form_with(model: preset_search, local: true) do |form| %>
+<%= form_with(model: preset_search, local: true, html: {class: 'form', id: 'preset-search-form'}) do |form| %>
   <% if preset_search.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(preset_search.errors.count, "error") %> prohibited this preset_search from being saved:</h2>
-
+    <div class="bs-callout bs-callout-danger">
+      <h4><%= pluralize(preset_search.errors.count, "error") %> prohibited this preset search from being saved:</h4>
       <ul>
       <% preset_search.errors.full_messages.each do |message| %>
         <li><%= message %></li>
@@ -10,38 +9,71 @@
       </ul>
     </div>
   <% end %>
+  <div class="panel panel-info">
+    <div class="panel-heading">
+      <h4>
+        <a href="#preset-search-help" data-toggle="collapse">
+          Form Instructions <span class="fas fa-chevron-<%= @preset_search.new_record? ? 'down' : 'right' %> toggle-glyph"></span>
+        </a>
+      </h4>
+    </div>
+    <div id="preset-search-help" class="panel-collapse collapse <%= @preset_search.new_record? ? 'in' : nil %>">
+      <div class="panel-body">
+        <h5>Whitelist</h5>
+        <p>
+          Enter study accessions, space-delimited (no commas).  These studies will <strong>always</strong> be returned in results first.<br />
+          <span class="help-block">Example: <code>SCP1 SCP2 SCP3</code></span>
+        </p>
+        <h5>Search Terms</h5>
+        <p>
+          Enter individual terms or "quoted phrases", space-delimited (no commas).  This is used for keyword search.<br/>
+          <span class="help-block">Example: <code>cancer human "COVID-19" "synovial sarcoma"</code></span>
+        </p>
+        <h5>Facets</h5>
+        <p>
+          Enter facet identifers and filter IDs, plus-delimited (+) between facets, colons between identifiers and filters,
+          commas between filter values.
+          <%= link_to "List of Available Facets <i class='fas fa-external-link-alt'></i>".html_safe,
+                      api_swagger_ui_engine_path + '#/Search/search_facets_path',
+                      class: 'btn btn-default btn-xs', target: :_blank %><br />
+          <span class="help-block">Example: <code>disease:MONDO_0000001,MONDO_0018076+species:NCBITaxon_9606,NCBITaxon_10090</code></span>
+        </p>
+      </div>
+    </div>
 
-  <div class="field">
-    <%= form.label :name %>
-    <%= form.text_field :name %>
   </div>
 
-  <div class="field">
-    <%= form.label :identifier %>
-    <%= form.text_field :identifier %>
+  <div class="form-group row">
+    <div class="col-sm-4">
+      <%= form.label :name %>
+      <%= form.text_field :name, class: 'form-control', autocomplete: 'no' %>
+    </div>
+    <div class="col-sm-2">
+      <%= form.label :public %>
+      <%= form.select :public, options_for_select([['Yes',1],['No',0]], @preset_search.public? ? 1 : 0), {}, class: 'form-control' %>
+    </div>
+    <div class="col-sm-6">
+      <%= form.label :accession_whitelist, 'Whitelist' %>
+      <%= form.text_field :accession_whitelist, class: 'form-control' %>
+    </div>
   </div>
 
-  <div class="field">
-    <%= form.label :accession_whitelist %>
-    <%= form.text_field :accession_whitelist %>
+  <div class="form-group row">
+    <div class="col-sm-6">
+      <%= form.label :search_terms, 'Search Terms' %>
+      <%= form.text_field :search_terms, value: @preset_search.keyword_query_string, class: 'form-control' %>
+    </div>
+
+    <div class="col-sm-6">
+      <%= form.label :facet_filters, 'Facets' %>
+      <%= form.text_field :facet_filters, value: @preset_search.facet_query_string,class: 'form-control' %>
+    </div>
   </div>
 
-  <div class="field">
-    <%= form.label :search_terms %>
-    <%= form.text_field :search_terms %>
-  </div>
 
-  <div class="field">
-    <%= form.label :facet_filters %>
-    <%= form.text_field :facet_filters %>
-  </div>
-
-  <div class="field">
-    <%= form.label :public %>
-    <%= form.check_box :public %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit %>
+  <div class="form-group row">
+    <div class="col-sm-12">
+      <%= form.submit 'Save', class: 'btn btn-lg btn-success', id: 'save-preset-search' %>
+    </div>
   </div>
 <% end %>

--- a/app/views/preset_searches/_preset_search.json.jbuilder
+++ b/app/views/preset_searches/_preset_search.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! preset_search, :id, :name, :identifier, :accession_whitelist, :search_terms, :facet_filters, :public, :created_at, :updated_at
+json.url preset_search_url(stored_search, format: :json)

--- a/app/views/preset_searches/edit.html.erb
+++ b/app/views/preset_searches/edit.html.erb
@@ -1,8 +1,8 @@
-<h1>Editing Stored Search</h1>
+<h1>Editing "<%= @preset_search.name %>"</h1>
 
 <%= render 'form', preset_search: @preset_search %>
 
 <p>
-  <%= scp_link_to "<i class='fas fa-search'></i> Info".html_safe, preset_search_path(@preset_search), class: 'btn btn-xs btn-info' %>
+  <%= scp_link_to "<i class='fas fa-search'></i> Info".html_safe, preset_search_path(@preset_search), class: 'btn btn-info' %>
   <%= scp_link_to "<span class='fas fa-chevron-left'></span> Back".html_safe, preset_searches_path, class: 'btn btn-warning' %>
 </p>

--- a/app/views/preset_searches/edit.html.erb
+++ b/app/views/preset_searches/edit.html.erb
@@ -1,0 +1,8 @@
+<h1>Editing Stored Search</h1>
+
+<%= render 'form', preset_search: @preset_search %>
+
+<p>
+  <%= scp_link_to "<i class='fas fa-search'></i> Info".html_safe, preset_search_path(@preset_search), class: 'btn btn-xs btn-info' %>
+  <%= scp_link_to "<span class='fas fa-chevron-left'></span> Back".html_safe, preset_searches_path, class: 'btn btn-warning' %>
+</p>

--- a/app/views/preset_searches/index.html.erb
+++ b/app/views/preset_searches/index.html.erb
@@ -35,9 +35,13 @@
               </td>
               <td><%= get_boolean_label(preset_search.public) %></td>
               <td class="actions">
-                <%= scp_link_to "<i class='fas fa-search'></i> Info".html_safe, preset_search_path(preset_search), class: "btn btn-xs btn-info #{preset_search.identifier}-show" %>
-                <%= scp_link_to "<i class='fas fa-edit'></i> Edit".html_safe, edit_preset_search_path(preset_search) , class: "btn btn-xs btn-primary #{preset_search.identifier}-edit" %>
-                <%= scp_link_to "<i class='fas fa-trash'></i> Destroy".html_safe, preset_search_path(preset_search), method: :delete, class: "btn btn-xs btn-danger delete-btn #{preset_search.identifier}-delete" %>
+                <%= scp_link_to "<i class='fas fa-search'></i> Info".html_safe, preset_search_path(preset_search),
+                                class: "btn btn-xs btn-info #{preset_search.identifier}-show" %>
+                <%= scp_link_to "<i class='fas fa-edit'></i> Edit".html_safe, edit_preset_search_path(preset_search),
+                                class: "btn btn-xs btn-primary #{preset_search.identifier}-edit" %>
+                <%= scp_link_to "<i class='fas fa-trash'></i> Destroy".html_safe, preset_search_path(preset_search),
+                                method: :delete, data: {confirm: "Are you sure you want to delete the search '#{preset_search.name}'?"},
+                                class: "btn btn-xs btn-danger delete-btn #{preset_search.identifier}-delete" %>
               </td>
             </tr>
           <% end %>

--- a/app/views/preset_searches/index.html.erb
+++ b/app/views/preset_searches/index.html.erb
@@ -1,0 +1,65 @@
+<h1>Preset Searches</h1>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="table-responsive">
+      <div class="well">
+        <table class="table table-striped" id="searches">
+          <thead>
+          <tr>
+            <th>Name</th>
+            <th>Identifier</th>
+            <th>Whitelist</th>
+            <th>Search Terms</th>
+            <th>Facets</th>
+            <th>Public?</th>
+            <th>Actions</th>
+          </tr>
+          </thead>
+
+          <tbody>
+          <% @preset_searches.each do |preset_search| %>
+            <tr>
+              <td><%= preset_search.name %></td>
+              <td><%= preset_search.identifier %></td>
+              <td>
+                <% preset_search.accession_whitelist.each do |accession| %>
+                  <span class="btn btn-default"><%= scp_link_to accession, legacy_study_path(identifier: accession), target: :_blank %></span>
+                <% end %>
+              </td>
+              <td><%= preset_search.search_terms.join(', ') %></td>
+              <td>
+                <% preset_search.matching_facets_and_filters.each do |facet| %>
+                  <%= facet_query_label(facet).html_safe %><br />
+                <% end %>
+              </td>
+              <td><%= get_boolean_label(preset_search.public) %></td>
+              <td class="actions">
+                <%= scp_link_to "<i class='fas fa-search'></i> Info".html_safe, preset_search_path(preset_search), class: "btn btn-xs btn-info #{preset_search.identifier}-show" %>
+                <%= scp_link_to "<i class='fas fa-edit'></i> Edit".html_safe, edit_preset_search_path(preset_search) , class: "btn btn-xs btn-primary #{preset_search.identifier}-edit" %>
+                <%= scp_link_to "<i class='fas fa-trash'></i> Destroy".html_safe, preset_search_path(preset_search), method: :delete, class: "btn btn-xs btn-danger delete-btn #{preset_search.identifier}-delete" %>
+              </td>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<p><%= scp_link_to "<i class='fas fa-plus'></i> New Preset Search".html_safe, new_preset_search_path,
+                   class: 'btn btn-lg btn-success', id: 'new-preset-search' %></p>
+
+<script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+
+    $('#searches').dataTable({
+        pagingType: "full_numbers",
+        pageLength: 10,
+        order: [[0, 'asc']],
+        language: {
+            search: "Filter Results By: "
+        }
+    });
+
+</script>

--- a/app/views/preset_searches/index.json.jbuilder
+++ b/app/views/preset_searches/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @preset_searches, partial: 'preset_searches/preset_search', as: :preset_search

--- a/app/views/preset_searches/new.html.erb
+++ b/app/views/preset_searches/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Stored Search</h1>
+
+<%= render 'form', preset_search: @preset_search %>
+
+<p><%= scp_link_to "<span class='fas fa-chevron-left'></span> Back".html_safe, preset_searches_path, class: 'btn btn-warning' %></p>

--- a/app/views/preset_searches/new.html.erb
+++ b/app/views/preset_searches/new.html.erb
@@ -1,4 +1,4 @@
-<h1>New Stored Search</h1>
+<h1>New Preset Search</h1>
 
 <%= render 'form', preset_search: @preset_search %>
 

--- a/app/views/preset_searches/show.html.erb
+++ b/app/views/preset_searches/show.html.erb
@@ -1,0 +1,49 @@
+<h1><%= @preset_search.name %></h1>
+
+<dl class="dl-horizontal">
+  <dt>Identifier</dt>
+  <dd><%= @preset_search.identifier %></dd>
+  <dt>Whitelist</dt>
+  <dd><%= @preset_search.accession_whitelist.join(', ') %></dd>
+  <dt>Search Terms</dt>
+  <dd><%= @preset_search.search_terms.join(', ') %></dd>
+  <dt>Facets</dt>
+  <dd>
+    <% @preset_search.matching_facets_and_filters.each do |facet| %>
+      <%= facet_query_label(facet).html_safe %>&nbsp;
+    <% end %>
+  </dd>
+  <dt>Public?</dt>
+  <dd><%= get_boolean_label(@preset_search.public) %></dd>
+  <dt>Query Results</dt>
+  <dd id="preset-search-results"><i class="fas fa-spinner fa-spin"></i></dd>
+</dl>
+
+<p>
+  <%= scp_link_to "<span class='fas fa-edit'></span> Edit".html_safe, edit_preset_search_path(@preset_search), class: 'btn btn-info' %>
+  <%= scp_link_to "<span class='fas fa-chevron-left'></span> Back".html_safe, preset_searches_path, class: 'btn btn-warning' %>
+</p>
+
+
+<script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+   var baseUrl = "<%= site_url %>/study/";
+   var resultsTarget = $('#preset-search-results')
+   $(document).ready(function() {
+       $.ajax({
+           url: '<%= javascript_safe_url(api_v1_search_path(type: 'study', preset_search: @preset_search.identifier)) %>',
+           method: 'GET',
+           dataType: 'json',
+           headers: {'Authorization': 'Bearer ' + window.SCP.userAccessToken},
+           success: function(data) {
+               var accessions = data.matching_accessions;
+               resultsTarget.empty();
+               $.each(accessions, function(index, accession) {
+                   var studyUrl = baseUrl + accession;
+                   var studyBtn = "<span class='btn btn-default'><a href='" + studyUrl + "' target='_blank'>" + accession + "</a></span>";
+                   resultsTarget.append(studyBtn + "&nbsp;")
+               })
+           }
+       })
+   });
+
+</script>

--- a/app/views/preset_searches/show.html.erb
+++ b/app/views/preset_searches/show.html.erb
@@ -28,9 +28,10 @@
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
    var baseUrl = "<%= site_url %>/study/";
    var resultsTarget = $('#preset-search-results')
+   var searchUrl = '<%= javascript_safe_url(api_v1_search_path(type: 'study', preset_search: @preset_search.identifier)) %>';
    $(document).ready(function() {
        $.ajax({
-           url: '<%= javascript_safe_url(api_v1_search_path(type: 'study', preset_search: @preset_search.identifier)) %>',
+           url: searchUrl,
            method: 'GET',
            dataType: 'json',
            headers: {'Authorization': 'Bearer ' + window.SCP.userAccessToken},

--- a/app/views/preset_searches/show.html.erb
+++ b/app/views/preset_searches/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @preset_search.name %></h1>
 
-<dl class="dl-horizontal">
+<dl class="dl-horizontal" id="preset-search-attributes">
   <dt>Identifier</dt>
   <dd><%= @preset_search.identifier %></dd>
   <dt>Whitelist</dt>

--- a/app/views/preset_searches/show.json.jbuilder
+++ b/app/views/preset_searches/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "preset_searches/preset_search", preset_search: @preset_search

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -88,6 +88,7 @@ else
                     test/models/study_test.rb
                     test/models/analysis_configuration_test.rb
                     test/models/search_facet_test.rb
+                    test/models/preset_search_test.rb
                     test/integration/lib/search_facet_populator_test.rb
                     test/integration/lib/summary_stats_utils_test.rb
                     test/models/big_query_client_test.rb

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -76,6 +76,7 @@ else
                     test/integration/taxons_controller_test.rb
                     test/controllers/analysis_configurations_controller_test.rb
                     test/controllers/site_controller_test.rb
+                    test/controllers/preset_searches_controller_test.rb
                     test/api/site_controller_test.rb
                     test/api/studies_controller_test.rb
                     test/api/study_files_controller_test.rb

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
     post 'admin/deployment', to: 'admin_configurations#create_deployment_notification', as: :create_deployment_notification
     delete 'admin/deployment', to: 'admin_configurations#delete_deployment_notification', as: :delete_deployment_notification
     resources :admin_configurations, path: 'admin'
+    resources :preset_searches, path: 'admin/search'
 
     resources :taxons, path: 'species'
     get 'species/:id/download_genome_annotation', to: 'taxons#download_genome_annotation', as: :download_genome_annotation

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,7 +78,7 @@ Rails.application.routes.draw do
     post 'admin/deployment', to: 'admin_configurations#create_deployment_notification', as: :create_deployment_notification
     delete 'admin/deployment', to: 'admin_configurations#delete_deployment_notification', as: :delete_deployment_notification
     resources :admin_configurations, path: 'admin'
-    resources :preset_searches, path: 'admin/search'
+    resources :preset_searches
 
     resources :taxons, path: 'species'
     get 'species/:id/download_genome_annotation', to: 'taxons#download_genome_annotation', as: :download_genome_annotation

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -136,3 +136,7 @@ SearchFacet.create(name: 'Organism Age', identifier: 'organism_age', big_query_i
                    unit: 'years')
 
 BrandingGroup.create(name: 'Test Brand', user_id: api_user.id, font_family: 'Helvetica Neue, sans-serif', background_color: '#FFFFFF')
+
+# Preset search seeds
+PresetSearch.create!(name: 'Test Search', search_terms: ['Test Study'], facet_filters: ['species:NCBITaxon_9606'],
+                     accession_whitelist: %w(SCP1))

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -138,5 +138,5 @@ SearchFacet.create(name: 'Organism Age', identifier: 'organism_age', big_query_i
 BrandingGroup.create(name: 'Test Brand', user_id: api_user.id, font_family: 'Helvetica Neue, sans-serif', background_color: '#FFFFFF')
 
 # Preset search seeds
-PresetSearch.create!(name: 'Test Search', search_terms: ['Test Study'], facet_filters: ['species:NCBITaxon_9606'],
-                     accession_whitelist: %w(SCP1))
+PresetSearch.create!(name: 'Test Search', search_terms: ["Test Study"],
+                     facet_filters: ['species:NCBITaxon_9606', 'disease:MONDO_0000001'], accession_whitelist: %w(SCP1))

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -349,17 +349,34 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   test 'should run preset search' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
 
-    @preset_search = PresetSearch.first
-    convention_study = Study.find_by(name: "Test Study #{@random_seed}")
+    # run whitelist only search
+    @preset_search = PresetSearch.create!(name: 'Preset Search Test', accession_whitelist: %w(SCP1))
     whitelisted_study = Study.first
     execute_http_request(:get, api_v1_search_path(type: 'study', preset_search: @preset_search.identifier))
     assert_response :success
-    preset_accessions = [whitelisted_study.accession, convention_study.accession]
-    assert json['matching_accessions'] == preset_accessions,
-           "Did not return correct studies for preset search; expected #{preset_accessions} but found #{json['matching_accessions']}"
+    whitelist_accessions = %w(SCP1)
+    assert json['matching_accessions'] == whitelist_accessions,
+           "Did not return correct studies for whitelisted preset search; expected #{whitelist_accessions} but found #{json['matching_accessions']}"
     found_preset = json['studies'].first
-    assert whitelisted_study.accession == @preset_search.accession_whitelist.first
+    assert found_preset['accession'] == whitelisted_study.accession
     assert found_preset['preset_match'], "Did not correctly mark whitelisted study as preset match; #{found_preset['preset_match']}"
+
+    # update to use user-search terms as well, include all studies to widen search
+    all_accessions = Study.pluck(:accession)
+    @preset_search.update(accession_whitelist: all_accessions)
+    @preset_search.reload
+    search_terms = "\"API Test Study\""
+    execute_http_request(:get, api_v1_search_path(type: 'study', preset_search: @preset_search.identifier, terms: search_terms))
+    assert_response :success
+    api_test_study = Study.find_by(name: /API Test Study/)
+    assert_equal 1, json['studies'].count, "Found wrong number of studies; should be 1 but found #{json['studies'].count}"
+    expected_results = [api_test_study.accession]
+    assert_equal expected_results, json['matching_accessions'],
+                 "Found wrong study with keywords & preset search; expected #{expected_results} but found #{json['matching_accessions']}"
+    found_study = json['studies'].first
+    assert found_study['preset_match']
+    assert_equal ['API Test Study'], found_study['term_matches'], "Did not correctly match on #{search_terms}: #{found_study['term_matches']}"
+    @preset_search.destroy # clean up
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -345,4 +345,22 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
+
+  test 'should run preset search' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    @preset_search = PresetSearch.first
+    convention_study = Study.find_by(name: "Test Study #{@random_seed}")
+    whitelisted_study = Study.first
+    execute_http_request(:get, api_v1_search_path(type: 'study', preset_search: @preset_search.identifier))
+    assert_response :success
+    preset_accessions = [whitelisted_study.accession, convention_study.accession]
+    assert json['matching_accessions'] == preset_accessions,
+           "Did not return correct studies for preset search; expected #{preset_accessions} but found #{json['matching_accessions']}"
+    found_preset = json['studies'].first
+    assert whitelisted_study.accession == @preset_search.accession_whitelist.first
+    assert found_preset['preset_match'], "Did not correctly mark whitelisted study as preset match; #{found_preset['preset_match']}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
 end

--- a/test/controllers/preset_searches_controller_test.rb
+++ b/test/controllers/preset_searches_controller_test.rb
@@ -1,46 +1,107 @@
-require "test_helper"
+require "integration_test_helper"
 
-describe PresetSearchesController do
-  let(:stored_search) { stored_searches :one }
+class PresetSearchesControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
 
-  it "gets index" do
-    get stored_searches_url
-    value(response).must_be :success?
+  def setup
+    @test_user = User.first
+    auth_as_user(@test_user)
+    sign_in @test_user
+    @search = PresetSearch.first
   end
 
-  it "gets new" do
-    get new_stored_search_url
-    value(response).must_be :success?
+  test "gets index" do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    get preset_searches_path
+    assert_response :success
+    assert_select 'table#searches', 1, 'Did not preset search table'
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 
-  it "creates stored_search" do
-    expect {
-      post stored_searches_url, params: { stored_search: { accession_whitelist: stored_search.accession_whitelist, facet_filters: stored_search.facet_filters, identifier: stored_search.identifier, name: stored_search.name, public: stored_search.public, search_terms: stored_search.search_terms } }
-    }.must_change "StoredSearch.count"
+  test "gets new" do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
 
-    must_redirect_to stored_search_path(PresetSearch.last)
+    get new_preset_search_path
+    assert_response :success
+    assert_select 'form#preset-search-form', 1, 'Did not find preset search form'
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 
-  it "shows stored_search" do
-    get stored_search_url(stored_search)
-    value(response).must_be :success?
+  test "creates updates and deletes preset search" do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    study_accession = Study.all.sample.accession
+    terms = "test data \"this is a phrase\""
+    facets = 'disease:MONDO_0000001+species:NCBITaxon_9606'
+    preset_search_params = {
+        preset_search: {
+            name: 'My Preset Search',
+            accession_whitelist: study_accession,
+            search_terms: terms,
+            facet_filters: facets
+        }
+    }
+    post preset_searches_path, params: preset_search_params
+    follow_redirect!
+    assert_response :success
+    @preset_search = PresetSearch.find_by(name: 'My Preset Search')
+    assert @preset_search.present?, "Preset search did not get created"
+    assert_equal @preset_search.accession_whitelist, [study_accession],
+                 "Did not properly set whitelist: #{study_accession} is not in #{@preset_search.accession_whitelist}"
+    assert_equal @preset_search.keyword_query_string, terms,
+                 "Search terms not correctly set: #{@preset_search.keyword_query_string} != #{terms}"
+    assert_equal @preset_search.facet_query_string, facets,
+                 "Facets not correctly set: #{@preset_search.facet_query_string} != #{facets}"
+
+    new_terms = 'update'
+    update_params = {
+        preset_search: {
+            search_terms: new_terms,
+            facet_filters: facets,
+            accession_whitelist: study_accession
+        }
+    }
+    patch preset_search_path(@preset_search), params: update_params
+    follow_redirect!
+    assert_response :success
+    @preset_search.reload
+    assert @preset_search.present?, "Preset search did not get loaded"
+    assert_equal @preset_search.keyword_query_string, new_terms,
+                 "Search terms did not update: #{new_terms} is not in #{@preset_search.keyword_query_string}"
+    assert_equal @preset_search.accession_whitelist, [study_accession],
+                 "Accession whitelist changed when it shouldn't have; #{study_accession} is not in #{@preset_search.accession_whitelist}"
+    assert_equal @preset_search.facet_query_string, facets,
+                 "Facets were changed when they shouldn't have; #{facets} != #{@preset_search.facet_query_string}"
+
+
+    delete preset_search_path(@preset_search)
+    follow_redirect!
+    assert_response :success
+    assert_equal 1, PresetSearch.count, "Did not delete search, expected count of 1 but found #{PresetSearch.count}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 
-  it "gets edit" do
-    get edit_stored_search_url(stored_search)
-    value(response).must_be :success?
+  test "shows preset search" do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    get preset_search_path(@search)
+    assert_response :success
+    assert_select 'dl#preset-search-attributes', 1, 'Did not find preset search attributes'
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 
-  it "updates stored_search" do
-    patch stored_search_url(stored_search), params: { stored_search: { accession_whitelist: stored_search.accession_whitelist, facet_filters: stored_search.facet_filters, identifier: stored_search.identifier, name: stored_search.name, public: stored_search.public, search_terms: stored_search.search_terms } }
-    must_redirect_to stored_search_path(stored_search)
-  end
+  test "gets edit for preset search" do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
 
-  it "destroys stored_search" do
-    expect {
-      delete stored_search_url(stored_search)
-    }.must_change "StoredSearch.count", -1
+    get edit_preset_search_path(@search)
+    assert_response :success
+    assert_select 'form#preset-search-form', 1, 'Did not find preset search form'
 
-    must_redirect_to stored_searches_path
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 end

--- a/test/controllers/preset_searches_controller_test.rb
+++ b/test/controllers/preset_searches_controller_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+describe PresetSearchesController do
+  let(:stored_search) { stored_searches :one }
+
+  it "gets index" do
+    get stored_searches_url
+    value(response).must_be :success?
+  end
+
+  it "gets new" do
+    get new_stored_search_url
+    value(response).must_be :success?
+  end
+
+  it "creates stored_search" do
+    expect {
+      post stored_searches_url, params: { stored_search: { accession_whitelist: stored_search.accession_whitelist, facet_filters: stored_search.facet_filters, identifier: stored_search.identifier, name: stored_search.name, public: stored_search.public, search_terms: stored_search.search_terms } }
+    }.must_change "StoredSearch.count"
+
+    must_redirect_to stored_search_path(PresetSearch.last)
+  end
+
+  it "shows stored_search" do
+    get stored_search_url(stored_search)
+    value(response).must_be :success?
+  end
+
+  it "gets edit" do
+    get edit_stored_search_url(stored_search)
+    value(response).must_be :success?
+  end
+
+  it "updates stored_search" do
+    patch stored_search_url(stored_search), params: { stored_search: { accession_whitelist: stored_search.accession_whitelist, facet_filters: stored_search.facet_filters, identifier: stored_search.identifier, name: stored_search.name, public: stored_search.public, search_terms: stored_search.search_terms } }
+    must_redirect_to stored_search_path(stored_search)
+  end
+
+  it "destroys stored_search" do
+    expect {
+      delete stored_search_url(stored_search)
+    }.must_change "StoredSearch.count", -1
+
+    must_redirect_to stored_searches_path
+  end
+end

--- a/test/models/preset_search_test.rb
+++ b/test/models/preset_search_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+
+class PresetSearchTest < ActiveSupport::TestCase
+
+  def setup
+    @random_seed = File.open(Rails.root.join('.random_seed')).read.strip
+    @preset_search = PresetSearch.first
+    @species_facet = SearchFacet.find_by(identifier: 'species')
+    @disease_facet = SearchFacet.find_by(identifier: 'disease')
+    @matching_facets = [
+        {:id=>"species", :filters=>[{"id"=>"NCBITaxon_9606", "name"=>"Homo sapiens"}], :object_id=>@species_facet.id},
+        {:id=>"disease", :filters=>[{"id"=>"MONDO_0000001", "name"=>"disease or disorder"}], :object_id=>@disease_facet.id}
+    ]
+  end
+
+  test 'should return correct keyword query string' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    expected_query = "\"Test Study\""
+    assert expected_query == @preset_search.keyword_query_string
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should return correct facet query string' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    expected_query = 'species:NCBITaxon_9606+disease:MONDO_0000001'
+    assert expected_query == @preset_search.facet_query_string
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should return correct matching facets' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    assert @matching_facets == @preset_search.matching_facets_and_filters
+    associated_facet = @preset_search.search_facets.first
+    assert @species_facet == associated_facet
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should validate new preset search' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # create valid preset search
+    @terms = ['test', "Study #{@random_seed}"]
+    @filters = 'species:NCBITaxon_10090'
+    @new_preset = PresetSearch.new(name: 'Another Search', search_terms: @terms, facet_filters: [@filters])
+    assert @new_preset.valid?
+
+    # create invalid preset search, test validations
+    @invalid_preset = PresetSearch.new
+    assert !@invalid_preset.valid?
+    errors = @invalid_preset.errors
+    expected_errors = [:name, :base]
+    assert_equal expected_errors, errors.messages.keys,
+                 "Did not find correct errors; should be #{expected_errors}, found #{errors.messages.keys}"
+
+    # duplicate search terms
+    @invalid_preset.name = 'New Search'
+    @invalid_preset.search_terms = %w(test test)
+    assert !@invalid_preset.valid?
+    expected_error = 'Search terms contains duplicated values: test'
+    found_error = @invalid_preset.errors.full_messages.first
+    assert_equal expected_error, found_error, "Did not correctly find duplicated search term: #{found_error}"
+
+    # duplicate facets
+    @invalid_preset.search_terms = %w(test)
+    invalid_filters = %w(disease:MONDO_0000001 disease:MONDO_0000001)
+    @invalid_preset.facet_filters = invalid_filters
+    assert !@invalid_preset.valid?
+    expected_facet_error = 'Facet filters contains duplicated identifiers/filters: disease, MONDO_0000001'
+    found_facet_error = @invalid_preset.errors.full_messages.first
+    assert_equal expected_facet_error, found_facet_error, "Did not correctly find duplicated facets: #{found_facet_error}"
+
+    # non-existent studies in whitelist
+    @invalid_preset.facet_filters = %w(disease:MONDO_0000001)
+    @invalid_preset.accession_whitelist = %w(SCP0)
+    assert !@invalid_preset.valid?
+    expected_accession_error = 'Accession whitelist contains missing studies: SCP0'
+    found_accession_error = @invalid_preset.errors.full_messages.first
+    assert_equal expected_accession_error, found_accession_error, "Did not correctly find missing studies: #{found_accession_error}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+end


### PR DESCRIPTION
Adding the `PresetSearch` model and associated functionality for running "canned" queries that include keyword/facet parameters, as well as an `accession_whitelist` which always return any declared studies at the top of the results.  This also includes an administrative UI for CRUDing searches to allow for easier and faster configuration.  Preset searches are invoked in the search API by passing a single identifier, which then loads any keywords/facets/whitelisted studies and then runs a normal search.

Whitelist-only searches (e.g. no search terms or facets provided) will return the whitelisted studies only.

This PR satisfies SCP-2264.