### PR TITLE
Clear all button for search panel

### DIFF
--- a/app/javascript/components/SearchQueryDisplay.js
+++ b/app/javascript/components/SearchQueryDisplay.js
@@ -1,18 +1,21 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { faSearch } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { getDisplayNameForFacet } from 'components/search/SearchFacetProvider'
+import Button from 'react-bootstrap/lib/Button'
+import { SearchSelectionContext } from './search/SearchSelectionProvider'
+import { StudySearchContext } from 'components/search/StudySearchProvider'
 
 
 function formattedJoinedList(itemTexts, itemClass, joinText) {
   return itemTexts.map((text, index) => {
-      return (
-        <span key={index}>
-          <span className={itemClass}>{text}</span>
-          { (index != itemTexts.length - 1) &&
+    return (
+      <span key={index}>
+        <span className={itemClass}>{text}</span>
+        { (index != itemTexts.length - 1) &&
             <span className="join-text">{joinText}</span>}
-        </span>
-      )
+      </span>
+    )
   })
 }
 
@@ -20,8 +23,8 @@ function formatFacet(facet, index, numFacets) {
   let facetContent
   if (Array.isArray(facet.filters)) {
     facetContent = formattedJoinedList(facet.filters.map(filter => filter.name),
-                                       'filter-name',
-                                       ' OR ')
+      'filter-name',
+      ' OR ')
   } else { // it's a numeric facet
     facetContent = (<span className="filter-name">
       {facet.filters.min} - {facet.filters.max} {facet.filters.unit ? facet.filters.unit : '' }
@@ -36,19 +39,36 @@ function formatFacet(facet, index, numFacets) {
     </span>
   )
 }
+export const ClearAllButton = () => {
+  const selectionContext = useContext(SearchSelectionContext)
+  const searchContext = useContext(StudySearchContext)
 
-export default function SearchQueryDisplay({terms, facets}) {
+  const clearSearch = () => {
+    const defaultSearchParams = {
+      terms: '',
+      facets: {}
+    }
+    selectionContext.performSearch()
+    searchContext.updateSearch(defaultSearchParams)
+    selectionContext.updateSelection(defaultSearchParams)
+  }
+  return (
+    <Button onClick = {clearSearch}>Clear All</Button>)
+}
+
+export default function SearchQueryDisplay({ terms, facets }) {
   const hasFacets = facets.length > 0
   const hasTerms = terms && terms.length > 0
+
   if (!hasFacets && !hasTerms) {
-    return <></>
+    return <><ClearAllButton/></>
   }
 
   let facetsDisplay = <span></span>
   let termsDisplay = <span></span>
 
   if (hasFacets) {
-    let FacetContainer = (props) => <>{props.children}</>
+    let FacetContainer = props => <>{props.children}</>
     if (hasTerms) {
       FacetContainer = props => (<>
         <span className="join-text"> AND </span>({props.children})
@@ -66,9 +86,10 @@ export default function SearchQueryDisplay({terms, facets}) {
       termsDisplay = <span>({termsDisplay})</span>
     }
   }
+
   return (
     <div className="search-query">
-      <FontAwesomeIcon icon={faSearch} />: {termsDisplay}{facetsDisplay}
+      <FontAwesomeIcon icon={faSearch} />: {termsDisplay}{facetsDisplay} <ClearAllButton/>
     </div>
   )
 }

--- a/app/javascript/components/SearchQueryDisplay.js
+++ b/app/javascript/components/SearchQueryDisplay.js
@@ -48,7 +48,6 @@ export const ClearAllButton = () => {
       terms: '',
       facets: {}
     }
-    selectionContext.performSearch()
     searchContext.updateSearch(defaultSearchParams)
     selectionContext.updateSelection(defaultSearchParams)
   }
@@ -61,7 +60,7 @@ export default function SearchQueryDisplay({ terms, facets }) {
   const hasTerms = terms && terms.length > 0
 
   if (!hasFacets && !hasTerms) {
-    return <><ClearAllButton/></>
+    return <></>
   }
 
   let facetsDisplay = <span></span>

--- a/app/javascript/components/search/StudySearchProvider.js
+++ b/app/javascript/components/search/StudySearchProvider.js
@@ -9,7 +9,7 @@ import {
 } from 'lib/scp-api'
 import SearchSelectionProvider from 'components/search/SearchSelectionProvider'
 
-const emptySearch = {
+export const emptySearch = {
   params: {
     terms: '',
     facets: {},

--- a/app/javascript/styles/_colors.scss
+++ b/app/javascript/styles/_colors.scss
@@ -3,6 +3,9 @@
 /* color for primary buttons, links, and other indicators that something is a clickable action */
 $action-color: #4d72aa;
 
+/* default background color */
+$default-background-color: #EEF2F5;
+
 /* non-fatal errors -- color palette borrowed from Terra */
 $warning-background-color: #feeed8;
 $warning-icon-color: #f6901b;

--- a/app/javascript/styles/_resultsPanel.scss
+++ b/app/javascript/styles/_resultsPanel.scss
@@ -3,12 +3,12 @@
 .results-panel {
   padding-top: 14px;
 
-  button{
+  button {
     color:$action-color;
     background-color: $default-background-color;
     border: none;
   }
-  button:hover{
+  button:hover {
     background-color: white;
   }
   .search-query {

--- a/app/javascript/styles/_resultsPanel.scss
+++ b/app/javascript/styles/_resultsPanel.scss
@@ -1,6 +1,16 @@
+@import './_colors.scss';
+
 .results-panel {
   padding-top: 14px;
 
+  button{
+    color:$action-color;
+    background-color: $default-background-color;
+    border: none;
+  }
+  button:hover{
+    background-color: white;
+  }
   .search-query {
     margin-left: 1em;
     .filter-name, .search-term {

--- a/test/js/resultsPanel.test.js
+++ b/test/js/resultsPanel.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import StudyResultsContainer, { StudyResults } from
+import { StudyResults } from
   '../../app/javascript/components/StudyResultsContainer'
 import { StudySearchContext } from
   '../../app/javascript/components/search/StudySearchProvider'

--- a/test/js/search/search-query-display.test.js
+++ b/test/js/search/search-query-display.test.js
@@ -1,26 +1,31 @@
-import React from 'react';
-import * as ReactAll from 'react';
-import { mount } from 'enzyme';
+import React from 'react'
+import * as ReactAll from 'react'
+import { mount } from 'enzyme'
 
-const fetch = require('node-fetch');
+const fetch = require('node-fetch')
 
-import SearchQueryDisplay from 'components/SearchQueryDisplay';
+import SearchQueryDisplay, { ClearAllButton } from 'components/SearchQueryDisplay'
+import { PropsStudySearchProvider } from 'components/search/StudySearchProvider'
+import KeywordSearch from 'components/KeywordSearch'
+
 
 const oneStringFacet = [
-  {id: 'species', filters: [{id: "NCBITaxon_9606", name: "Homo sapiens"}]}
+  { id: 'species', filters: [{ id: 'NCBITaxon_9606', name: 'Homo sapiens' }] }
 ]
 
 const twoStringFacets = [
-  {id: 'disease', filters: [{id: "id1", name: "disease1"}]},
-  {id: 'species', filters: [{id: "NCBITaxon_9606", name: "Homo sapiens"}]}
+  { id: 'disease', filters: [{ id: 'id1', name: 'disease1' }] },
+  { id: 'species', filters: [{ id: 'NCBITaxon_9606', name: 'Homo sapiens' }] }
 ]
 
 const stringAndNumericFacets = [
-  {id: 'species', filters: [
-    {id: "NCBITaxon_9606", name: "Homo sapiens"},
-    {id: "NCBITaxon_10090", name: "Mus musculus"}
-  ]},
-  {id: "organism_age", filters: {min: 14, max: 180, unit: "years"}}
+  {
+    id: 'species', filters: [
+      { id: 'NCBITaxon_9606', name: 'Homo sapiens' },
+      { id: 'NCBITaxon_10090', name: 'Mus musculus' }
+    ]
+  },
+  { id: 'organism_age', filters: { min: 14, max: 180, unit: 'years' } }
 ]
 
 describe('Search query display text', () => {
@@ -28,34 +33,47 @@ describe('Search query display text', () => {
     const wrapper = mount((
       <SearchQueryDisplay facets={oneStringFacet} terms={''}/>
     ))
-    expect(wrapper.text().trim()).toEqual(': Metadata contains (species: Homo sapiens)')
+    expect(wrapper.text().trim()).toEqual(': Metadata contains (species: Homo sapiens) Clear All')
   })
 
   it('renders multiple facets', async () => {
     const wrapper = mount((
       <SearchQueryDisplay facets={twoStringFacets} terms={''}/>
     ))
-    expect(wrapper.text().trim()).toEqual(': Metadata contains (disease: disease1) AND (species: Homo sapiens)')
+    expect(wrapper.text().trim()).toEqual(': Metadata contains (disease: disease1) AND (species: Homo sapiens) Clear All')
   })
 
   it('renders string and numeric facets', async () => {
     const wrapper = mount((
       <SearchQueryDisplay facets={stringAndNumericFacets} terms={''}/>
     ))
-    expect(wrapper.text().trim()).toEqual(': Metadata contains (species: Homo sapiens OR Mus musculus) AND (organism age: 14 - 180 years)')
+    expect(wrapper.text().trim()).toEqual(': Metadata contains (species: Homo sapiens OR Mus musculus) AND (organism age: 14 - 180 years) Clear All')
   })
 
   it('renders terms', async () => {
     const wrapper = mount((
       <SearchQueryDisplay facets={[]} terms={['foo']}/>
     ))
-    expect(wrapper.text().trim()).toEqual(': Text contains (foo)')
+    expect(wrapper.text().trim()).toEqual(': Text contains (foo) Clear All')
   })
 
   it('renders terms and a single facet', async () => {
     const wrapper = mount((
       <SearchQueryDisplay facets={oneStringFacet} terms={['foo', 'bar']}/>
     ))
-    expect(wrapper.text().trim()).toEqual(': (Text contains (foo OR bar)) AND (Metadata contains (species: Homo sapiens))')
+    expect(wrapper.text().trim()).toEqual(': (Text contains (foo OR bar)) AND (Metadata contains (species: Homo sapiens)) Clear All')
+  })
+})
+
+describe('Clearing search query', () => {
+  it('clears search params', () => {
+    const component = <PropsStudySearchProvider searchParams={{ terms: 'foo' }}>
+      <ClearAllButton/>
+      <KeywordSearch/>
+    </PropsStudySearchProvider>
+    const wrapper = mount(component)
+    expect(wrapper.find('input[name="keywordText"]').first().props().value).toEqual('foo')
+    wrapper.find(ClearAllButton).simulate('click')
+    expect(wrapper.find('input[name="keywordText"]').first().props().value).toEqual('')
   })
 })

--- a/test/js/search/search-query-display.test.js
+++ b/test/js/search/search-query-display.test.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import * as ReactAll from 'react'
 import { mount } from 'enzyme'
 
 const fetch = require('node-fetch')


### PR DESCRIPTION
This PR adds a 'Clear All' button to the results panel.  The button is always displayed. The clear all button removes all search/ed query terms ( keyword and facets) and updates the result panel to the default state. 

<img width="551" alt="Screen Shot 2020-03-27 at 2 06 30 PM" src="https://user-images.githubusercontent.com/37722472/77786471-34858f80-7034-11ea-89fe-ee71c0170517.png">


This PR satisfies [SCP-2220](https://broadworkbench.atlassian.net/browse/SCP-2220)
