### PR TITLE
add keyword-only clear -- revert clear all

### DIFF
--- a/app/javascript/components/KeywordSearch.js
+++ b/app/javascript/components/KeywordSearch.js
@@ -2,9 +2,10 @@ import React, { useContext } from 'react'
 import Button from 'react-bootstrap/lib/Button'
 import InputGroup from 'react-bootstrap/lib/InputGroup'
 import Form from 'react-bootstrap/lib/Form'
-import { faSearch } from '@fortawesome/free-solid-svg-icons'
+import { faSearch, faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { SearchSelectionContext } from './search/SearchSelectionProvider'
+import { StudySearchContext } from './search/StudySearchProvider'
 
 /**
  * Component to search using a keyword value
@@ -13,12 +14,21 @@ import { SearchSelectionContext } from './search/SearchSelectionProvider'
 export default function KeywordSearch({keywordPrompt}) {
   const placeholder = keywordPrompt ? keywordPrompt : "Enter keyword"
   const selectionContext = useContext(SearchSelectionContext)
+  const searchContext = useContext(StudySearchContext)
+  // show clear button after a search has been done,
+  //  as long as the text hasn't been updated
+  const showClear = searchContext.params.terms === selectionContext.terms
+                    && selectionContext.terms != ''
   /**
    * Updates terms in search context upon submitting keyword search
    */
   function handleSubmit(event) {
     event.preventDefault()
-    selectionContext.performSearch()
+    if (showClear) {
+      selectionContext.updateSelection({terms: ''}, true)
+    } else {
+      selectionContext.performSearch()
+    }
   }
 
   function handleKeywordChange(newValue) {
@@ -42,7 +52,7 @@ export default function KeywordSearch({keywordPrompt}) {
           name="keywordText"/>
         <div className="input-group-append">
           <Button type='submit'>
-            <FontAwesomeIcon icon={faSearch} />
+            <FontAwesomeIcon icon={ showClear ? faTimes : faSearch } />
           </Button>
         </div>
       </InputGroup>

--- a/app/javascript/components/SearchQueryDisplay.js
+++ b/app/javascript/components/SearchQueryDisplay.js
@@ -1,21 +1,18 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { faSearch } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { getDisplayNameForFacet } from 'components/search/SearchFacetProvider'
-import Button from 'react-bootstrap/lib/Button'
-import { SearchSelectionContext } from './search/SearchSelectionProvider'
-import { StudySearchContext } from 'components/search/StudySearchProvider'
 
 
 function formattedJoinedList(itemTexts, itemClass, joinText) {
   return itemTexts.map((text, index) => {
-    return (
-      <span key={index}>
-        <span className={itemClass}>{text}</span>
-        { (index != itemTexts.length - 1) &&
+      return (
+        <span key={index}>
+          <span className={itemClass}>{text}</span>
+          { (index != itemTexts.length - 1) &&
             <span className="join-text">{joinText}</span>}
-      </span>
-    )
+        </span>
+      )
   })
 }
 
@@ -23,8 +20,8 @@ function formatFacet(facet, index, numFacets) {
   let facetContent
   if (Array.isArray(facet.filters)) {
     facetContent = formattedJoinedList(facet.filters.map(filter => filter.name),
-      'filter-name',
-      ' OR ')
+                                       'filter-name',
+                                       ' OR ')
   } else { // it's a numeric facet
     facetContent = (<span className="filter-name">
       {facet.filters.min} - {facet.filters.max} {facet.filters.unit ? facet.filters.unit : '' }
@@ -39,36 +36,19 @@ function formatFacet(facet, index, numFacets) {
     </span>
   )
 }
-export const ClearAllButton = () => {
-  const selectionContext = useContext(SearchSelectionContext)
-  const searchContext = useContext(StudySearchContext)
 
-  const clearSearch = () => {
-    const defaultSearchParams = {
-      terms: '',
-      facets: {}
-    }
-    selectionContext.performSearch()
-    searchContext.updateSearch(defaultSearchParams)
-    selectionContext.updateSelection(defaultSearchParams)
-  }
-  return (
-    <Button onClick = {clearSearch}>Clear All</Button>)
-}
-
-export default function SearchQueryDisplay({ terms, facets }) {
+export default function SearchQueryDisplay({terms, facets}) {
   const hasFacets = facets.length > 0
   const hasTerms = terms && terms.length > 0
-
   if (!hasFacets && !hasTerms) {
-    return <><ClearAllButton/></>
+    return <></>
   }
 
   let facetsDisplay = <span></span>
   let termsDisplay = <span></span>
 
   if (hasFacets) {
-    let FacetContainer = props => <>{props.children}</>
+    let FacetContainer = (props) => <>{props.children}</>
     if (hasTerms) {
       FacetContainer = props => (<>
         <span className="join-text"> AND </span>({props.children})
@@ -86,10 +66,9 @@ export default function SearchQueryDisplay({ terms, facets }) {
       termsDisplay = <span>({termsDisplay})</span>
     }
   }
-
   return (
     <div className="search-query">
-      <FontAwesomeIcon icon={faSearch} />: {termsDisplay}{facetsDisplay} <ClearAllButton/>
+      <FontAwesomeIcon icon={faSearch} />: {termsDisplay}{facetsDisplay}
     </div>
   )
 }

--- a/app/javascript/components/SearchQueryDisplay.js
+++ b/app/javascript/components/SearchQueryDisplay.js
@@ -48,6 +48,7 @@ export const ClearAllButton = () => {
       terms: '',
       facets: {}
     }
+    selectionContext.performSearch()
     searchContext.updateSearch(defaultSearchParams)
     selectionContext.updateSelection(defaultSearchParams)
   }
@@ -60,7 +61,7 @@ export default function SearchQueryDisplay({ terms, facets }) {
   const hasTerms = terms && terms.length > 0
 
   if (!hasFacets && !hasTerms) {
-    return <></>
+    return <><ClearAllButton/></>
   }
 
   let facetsDisplay = <span></span>

--- a/app/javascript/components/search/SearchSelectionProvider.js
+++ b/app/javascript/components/search/SearchSelectionProvider.js
@@ -23,8 +23,12 @@ export default function SearchSelectionProvider(props) {
   selection.performSearch = performSearch
 
   /** merges the update into the current selection */
-  function updateSelection(value) {
-    setSelection(Object.assign({}, selection, value))
+  function updateSelection(value, searchNow) {
+    const newSelection = Object.assign({}, selection, value)
+    if (searchNow) {
+      searchContext.updateSearch(newSelection)
+    }
+    setSelection(newSelection)
   }
 
   /** merges the facet update into the current selection */

--- a/app/javascript/components/search/StudySearchProvider.js
+++ b/app/javascript/components/search/StudySearchProvider.js
@@ -9,7 +9,7 @@ import {
 } from 'lib/scp-api'
 import SearchSelectionProvider from 'components/search/SearchSelectionProvider'
 
-export const emptySearch = {
+const emptySearch = {
   params: {
     terms: '',
     facets: {},

--- a/app/javascript/styles/_colors.scss
+++ b/app/javascript/styles/_colors.scss
@@ -3,9 +3,6 @@
 /* color for primary buttons, links, and other indicators that something is a clickable action */
 $action-color: #4d72aa;
 
-/* default background color */
-$default-background-color: #EEF2F5;
-
 /* non-fatal errors -- color palette borrowed from Terra */
 $warning-background-color: #feeed8;
 $warning-icon-color: #f6901b;

--- a/app/javascript/styles/_resultsPanel.scss
+++ b/app/javascript/styles/_resultsPanel.scss
@@ -1,16 +1,6 @@
-@import './_colors.scss';
-
 .results-panel {
   padding-top: 14px;
 
-  button{
-    color:$action-color;
-    background-color: $default-background-color;
-    border: none;
-  }
-  button:hover{
-    background-color: white;
-  }
   .search-query {
     margin-left: 1em;
     .filter-name, .search-term {

--- a/app/javascript/styles/_resultsPanel.scss
+++ b/app/javascript/styles/_resultsPanel.scss
@@ -3,12 +3,12 @@
 .results-panel {
   padding-top: 14px;
 
-  button {
+  button{
     color:$action-color;
     background-color: $default-background-color;
     border: none;
   }
-  button:hover {
+  button:hover{
     background-color: white;
   }
   .search-query {

--- a/test/js/keywordSearch.test.js
+++ b/test/js/keywordSearch.test.js
@@ -1,11 +1,26 @@
 import React from 'react'
-import KeywordSearch from '../../app/javascript/components/KeywordSearch'
+import * as Reach from '@reach/router'
 import { mount } from 'enzyme'
 
+import KeywordSearch from '../../app/javascript/components/KeywordSearch'
+import { PropsStudySearchProvider } from 'components/search/StudySearchProvider';
 
 describe('<KeywordSearch/> rendering>', () => {
   it('should render </KeywordSearch> elements', () => {
     const example = mount(<KeywordSearch/>)
     expect(example.exists('.study-keyword-search')).toEqual(true)
+    expect(example.find('svg.svg-inline--fa').hasClass('fa-search')).toEqual(true)
+  })
+
+  it('should show the clear button after a search with keyword', () => {
+    const routerNav = jest.spyOn(Reach, 'navigate')
+    const example = mount(
+      <PropsStudySearchProvider searchParams={{terms: 'foobar'}}>
+        <KeywordSearch/>
+      </PropsStudySearchProvider>
+    )
+    expect(example.find('svg.svg-inline--fa').hasClass('fa-times')).toEqual(true)
+    example.find('form').simulate('submit')
+    expect(routerNav).toHaveBeenLastCalledWith('?type=study&page=1')
   })
 })

--- a/test/js/resultsPanel.test.js
+++ b/test/js/resultsPanel.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { StudyResults } from
+import StudyResultsContainer, { StudyResults } from
   '../../app/javascript/components/StudyResultsContainer'
 import { StudySearchContext } from
   '../../app/javascript/components/search/StudySearchProvider'

--- a/test/js/search/combined-search.test.js
+++ b/test/js/search/combined-search.test.js
@@ -65,7 +65,7 @@ describe('Apply applies all changes made in the search panel', () => {
     speciesControl().find('input#speciesId5').simulate('change', {target: {checked: true}})
     speciesControl().find('button.facet-apply-button').simulate('click')
 
-    expect(routerNav).toHaveBeenLastCalledWith('?type=study&terms=test123&facets=species%3AspeciesId5&page=1')
+    expect(routerNav).toHaveBeenLastCalledWith('?type=study&page=1&terms=test123&facets=species%3AspeciesId5')
   })
 
   it('applies facet changes when keyword searching', async () => {
@@ -96,6 +96,6 @@ describe('Apply applies all changes made in the search panel', () => {
     keywordInput().simulate('change', {target: { value: 'test345'}});
     keywordInput().simulate('submit')
 
-    expect(routerNav).toHaveBeenLastCalledWith('?type=study&terms=test345&facets=species%3AspeciesId2%2Bdisease%3Adisease4&page=1')
+    expect(routerNav).toHaveBeenLastCalledWith('?type=study&page=1&terms=test345&facets=species%3AspeciesId2%2Bdisease%3Adisease4')
   })
 })

--- a/test/js/search/facet-control.test.js
+++ b/test/js/search/facet-control.test.js
@@ -62,7 +62,7 @@ describe('Facet control handles selections appropriately', () => {
 
     // apply sends a routing request to the right url
     speciesControl().find('button.facet-apply-button').simulate('click')
-    expect(routerNav).toHaveBeenLastCalledWith('?type=study&terms=&facets=species%3AspeciesId3%2CspeciesId6&page=1')
+    expect(routerNav).toHaveBeenLastCalledWith('?type=study&page=1&facets=species%3AspeciesId3%2CspeciesId6')
   })
 })
 
@@ -120,6 +120,6 @@ describe('Facet control handles facets with many filters', () => {
     expect(speciesControl().find('button.facet-apply-button').hasClass('active')).toEqual(true)
 
     speciesControl().find('button.facet-apply-button').simulate('click')
-    expect(routerNav).toHaveBeenLastCalledWith('?type=study&terms=&facets=species%3AspeciesId2&page=1')
+    expect(routerNav).toHaveBeenLastCalledWith('?type=study&page=1&facets=species%3AspeciesId2')
   })
 })

--- a/test/js/search/filter-slider.test.js
+++ b/test/js/search/filter-slider.test.js
@@ -57,7 +57,7 @@ describe('Filter slider works with facet with no units', () => {
     })
     expect(bmiFacet().find('button.facet-apply-button').hasClass('active')).toEqual(true)
     bmiFacet().find('button.facet-apply-button').simulate('click')
-    expect(routerNav).toHaveBeenLastCalledWith('?type=study&terms=&facets=bmi%3A30%2C50%2C&page=1')
+    expect(routerNav).toHaveBeenLastCalledWith('?type=study&page=1&facets=bmi%3A30%2C50%2C')
   });
 });
 
@@ -84,7 +84,7 @@ describe('Filter slider behavior', () => {
     })
     expect(ageFacet().find('button.facet-apply-button').hasClass('active')).toEqual(true)
     ageFacet().find('button.facet-apply-button').simulate('click')
-    expect(routerNav).toHaveBeenLastCalledWith('?type=study&terms=&facets=age%3A30%2C150%2Cyears&page=1')
+    expect(routerNav).toHaveBeenLastCalledWith('?type=study&page=1&facets=age%3A30%2C150%2Cyears')
   });
 });
 

--- a/test/js/search/more-facets.test.js
+++ b/test/js/search/more-facets.test.js
@@ -63,7 +63,7 @@ describe('Basic "More Facets" capability for faceted search', () => {
     expect(wrapper.find('#facet-sex button.facet-apply-button').hasClass('active')).toEqual(true)
 
     wrapper.find('#facet-sex button.facet-apply-button').simulate('click')
-    expect(routerNav).toHaveBeenLastCalledWith('?type=study&terms=&facets=sex%3Afemale&page=1')
+    expect(routerNav).toHaveBeenLastCalledWith('?type=study&page=1&facets=sex%3Afemale')
   });
 });
 
@@ -93,7 +93,7 @@ describe('Filter slider works within more facets', () => {
     })
     expect(ageFacet().find('button.facet-apply-button').hasClass('active')).toEqual(true)
     ageFacet().find('button.facet-apply-button').simulate('click')
-    expect(routerNav).toHaveBeenLastCalledWith('?type=study&terms=&facets=organism_age%3A50%2C180%2Cyears&page=1')
+    expect(routerNav).toHaveBeenLastCalledWith('?type=study&page=1&facets=organism_age%3A50%2C180%2Cyears')
   });
 });
 

--- a/test/js/search/search-query-display.test.js
+++ b/test/js/search/search-query-display.test.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import * as ReactAll from 'react'
 import { mount } from 'enzyme'
 
 const fetch = require('node-fetch')

--- a/test/js/search/search-query-display.test.js
+++ b/test/js/search/search-query-display.test.js
@@ -1,31 +1,26 @@
-import React from 'react'
-import * as ReactAll from 'react'
-import { mount } from 'enzyme'
+import React from 'react';
+import * as ReactAll from 'react';
+import { mount } from 'enzyme';
 
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
-import SearchQueryDisplay, { ClearAllButton } from 'components/SearchQueryDisplay'
-import { PropsStudySearchProvider } from 'components/search/StudySearchProvider'
-import KeywordSearch from 'components/KeywordSearch'
-
+import SearchQueryDisplay from 'components/SearchQueryDisplay';
 
 const oneStringFacet = [
-  { id: 'species', filters: [{ id: 'NCBITaxon_9606', name: 'Homo sapiens' }] }
+  {id: 'species', filters: [{id: "NCBITaxon_9606", name: "Homo sapiens"}]}
 ]
 
 const twoStringFacets = [
-  { id: 'disease', filters: [{ id: 'id1', name: 'disease1' }] },
-  { id: 'species', filters: [{ id: 'NCBITaxon_9606', name: 'Homo sapiens' }] }
+  {id: 'disease', filters: [{id: "id1", name: "disease1"}]},
+  {id: 'species', filters: [{id: "NCBITaxon_9606", name: "Homo sapiens"}]}
 ]
 
 const stringAndNumericFacets = [
-  {
-    id: 'species', filters: [
-      { id: 'NCBITaxon_9606', name: 'Homo sapiens' },
-      { id: 'NCBITaxon_10090', name: 'Mus musculus' }
-    ]
-  },
-  { id: 'organism_age', filters: { min: 14, max: 180, unit: 'years' } }
+  {id: 'species', filters: [
+    {id: "NCBITaxon_9606", name: "Homo sapiens"},
+    {id: "NCBITaxon_10090", name: "Mus musculus"}
+  ]},
+  {id: "organism_age", filters: {min: 14, max: 180, unit: "years"}}
 ]
 
 describe('Search query display text', () => {
@@ -33,47 +28,34 @@ describe('Search query display text', () => {
     const wrapper = mount((
       <SearchQueryDisplay facets={oneStringFacet} terms={''}/>
     ))
-    expect(wrapper.text().trim()).toEqual(': Metadata contains (species: Homo sapiens) Clear All')
+    expect(wrapper.text().trim()).toEqual(': Metadata contains (species: Homo sapiens)')
   })
 
   it('renders multiple facets', async () => {
     const wrapper = mount((
       <SearchQueryDisplay facets={twoStringFacets} terms={''}/>
     ))
-    expect(wrapper.text().trim()).toEqual(': Metadata contains (disease: disease1) AND (species: Homo sapiens) Clear All')
+    expect(wrapper.text().trim()).toEqual(': Metadata contains (disease: disease1) AND (species: Homo sapiens)')
   })
 
   it('renders string and numeric facets', async () => {
     const wrapper = mount((
       <SearchQueryDisplay facets={stringAndNumericFacets} terms={''}/>
     ))
-    expect(wrapper.text().trim()).toEqual(': Metadata contains (species: Homo sapiens OR Mus musculus) AND (organism age: 14 - 180 years) Clear All')
+    expect(wrapper.text().trim()).toEqual(': Metadata contains (species: Homo sapiens OR Mus musculus) AND (organism age: 14 - 180 years)')
   })
 
   it('renders terms', async () => {
     const wrapper = mount((
       <SearchQueryDisplay facets={[]} terms={['foo']}/>
     ))
-    expect(wrapper.text().trim()).toEqual(': Text contains (foo) Clear All')
+    expect(wrapper.text().trim()).toEqual(': Text contains (foo)')
   })
 
   it('renders terms and a single facet', async () => {
     const wrapper = mount((
       <SearchQueryDisplay facets={oneStringFacet} terms={['foo', 'bar']}/>
     ))
-    expect(wrapper.text().trim()).toEqual(': (Text contains (foo OR bar)) AND (Metadata contains (species: Homo sapiens)) Clear All')
-  })
-})
-
-describe('Clearing search query', () => {
-  it('clears search params', () => {
-    const component = <PropsStudySearchProvider searchParams={{ terms: 'foo' }}>
-      <ClearAllButton/>
-      <KeywordSearch/>
-    </PropsStudySearchProvider>
-    const wrapper = mount(component)
-    expect(wrapper.find('input[name="keywordText"]').first().props().value).toEqual('foo')
-    wrapper.find(ClearAllButton).simulate('click')
-    expect(wrapper.find('input[name="keywordText"]').first().props().value).toEqual('')
+    expect(wrapper.text().trim()).toEqual(': (Text contains (foo OR bar)) AND (Metadata contains (species: Homo sapiens))')
   })
 })


### PR DESCRIPTION
The 'clear all' button didn't work to clear facets, so this reverts that change.  

Vicky had asked to make sure we have a way of clearing keystrokes before the launch.  So this adds a quick 'x' to clear keystrokes, very similar to the mockup. The 'x' replaces the search icon after a search is performed.  (and reverts to the search icon if the text is changed)

![image](https://user-images.githubusercontent.com/2800795/77838244-1efd8c00-7140-11ea-9a55-eb596ba6ef0e.png)
