### PR TITLE
Refine user ID, page view tracking; COVID-19 analytics (SCP-2287, SCP-2282)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 // This is a manifest file that'll be compiled into application.js, which will include all the files
 // listed below.
 //

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -35,21 +35,21 @@ if ('SCP' in window) {
 /**
  * Log page view, i.e. page load
  */
-export function logPageView(props={}) {
-  log('page:view', props)
+export function logPageView() {
+  log('page:view')
 }
 
 /** Log click on page.  Delegates to more element-specific loggers. */
-export function logClick(event, props={}) {
+export function logClick(event) {
   const target = event.target
   const tag = target.localName.toLowerCase() // local tag name
 
   if (tag === 'a') {
-    logClickLink(target, props)
+    logClickLink(target)
   } else if (tag === 'button') {
-    logClickButton(target, props)
+    logClickButton(target)
   } else if (tag === 'input') {
-    logClickInput(target, props)
+    logClickInput(target)
   } else {
     // Perhaps uncomment when Mixpanel quota increases
     // logClickOther(target)
@@ -59,16 +59,16 @@ export function logClick(event, props={}) {
 /**
  * Log click on link, i.e. anchor (<a ...) tag
  */
-function logClickLink(target, props) {
-  props = Object.assign(props, { text: target.text })
+function logClickLink(target) {
+  const props = { text: target.text }
   log('click:link', props)
 }
 
 /**
  * Log click on button, e.g. for pagination, "Apply", etc.
  */
-function logClickButton(target, props) {
-  props = Object.assign(props, { text: target.text })
+function logClickButton(target) {
+  const props = { text: target.text }
   log('click:button', props)
 
   // Google Analytics fallback: remove once Bard and Mixpanel are ready for SCP
@@ -104,13 +104,13 @@ function getLabelsForInputElement(element) {
 /**
  * Log click on input by type, e.g. text, number, checkbox
  */
-function logClickInput(target, props) {
+function logClickInput(target) {
   const domLabels = getLabelsForInputElement(target)
 
   // User-facing label
   const label = domLabels.length > 0 ? domLabels[0].innerText : ''
 
-  props = Object.assign(props, { label })
+  const props = { label }
   const element = `input-${target.type}`
   log(`click:${element}`, props)
 
@@ -121,8 +121,8 @@ function logClickInput(target, props) {
 /**
  * Log clicks on elements that are not otherwise classified
  */
-function logClickOther(target, props) { // eslint-disable-line no-unused-vars
-  props = Object.assign(props, { text: target.text })
+function logClickOther(target) { // eslint-disable-line no-unused-vars
+  const props = { text: target.text }
   log('click:other', props)
 
   // Google Analytics fallback: remove once Bard and Mixpanel are ready for SCP
@@ -160,6 +160,11 @@ export function log(name, props={}) {
     distinct_id: userId, // Needed for Mixpanel "Distinct ID" (Bard papercut)
     env
   })
+
+  if ('SCP' in window && 'featuredSpace' in window.SCP) {
+    // For e.g. COVID-19 featured space
+    props['featureSpace'] = window.SCP.featuredSpace
+  }
 
   const body = {
     body: JSON.stringify({

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -163,7 +163,7 @@ export function log(name, props={}) {
 
   if ('SCP' in window && 'featuredSpace' in window.SCP) {
     // For e.g. COVID-19 featured space
-    props['featureSpace'] = window.SCP.featuredSpace
+    props['featuredSpace'] = window.SCP.featuredSpace
   }
 
   const body = {

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -36,7 +36,7 @@ if ('SCP' in window) {
  * Log page view, i.e. page load
  */
 export function logPageView(props={}) {
-  log('page:view')
+  log('page:view', props)
 }
 
 /** Log click on page.  Delegates to more element-specific loggers. */
@@ -172,7 +172,7 @@ export function log(name, props={}) {
   // Remove once Bard and Mixpanel are ready for SCP
   if (
     'SCP' in window && window.SCP.environment !== 'production' &&
-    accessToken === '' // Remove once Bard supports unregistered users
+    accessToken !== '' // Remove once Bard supports unregistered users
   ) {
     fetch(`${bardDomain}/api/event`, init)
   }

--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -71,7 +71,7 @@ function getFriendlyFilterListByFacet(facets) {
 /**
  * Log study search metrics.  Might support gene, cell search in future.
  */
-export function logSearch(type, terms, facets, page) {
+export function logSearch(type, searchParams) {
   if (isPageLoadSearch === true) {
     // This prevents over-reporting searches.
     // Loading home page triggers search, which is a side-effect / artifact
@@ -81,6 +81,12 @@ export function logSearch(type, terms, facets, page) {
     return
   }
 
+  const terms = searchParams.terms
+  const facets = searchParams.facets
+  const page = searchParams.page
+
+  const preset = searchParams.preset
+
   const numTerms = getNumberOfTerms(terms)
   const [numFacets, numFilters] = getNumFacetsAndFilters(facets)
   const facetList = Object.keys(facets)
@@ -88,16 +94,20 @@ export function logSearch(type, terms, facets, page) {
   const filterListByFacet = getFriendlyFilterListByFacet(facets)
 
   const simpleProps = {
-    type, terms, page,
+    type, terms, page, preset,
     numTerms, numFacets, numFilters, facetList
   }
   const props = Object.assign(simpleProps, filterListByFacet)
 
   log('search', props)
 
+  let gaEventCategory = 'advanced-search'
+  // e.g. advanced-search-covid19
+  if (preset !== '') gaEventCategory += `-${preset}`
+
   // Google Analytics fallback: remove once Bard and Mixpanel are ready for SCP
   ga( // eslint-disable-line no-undef
-    'send', 'event', 'faceted-search', 'study-search',
+    'send', 'event', gaEventCategory, 'study-search',
     'num-terms', numTerms
   )
 }
@@ -114,7 +124,7 @@ export function logFilterSearch(facet, terms) {
 
   // Google Analytics fallback: remove once Bard and Mixpanel are ready for SCP
   ga( // eslint-disable-line no-undef
-    'send', 'event', 'faceted-search', 'search-filter',
+    'send', 'event', 'advanced-search', 'search-filter',
     'num-terms', numTerms
   )
 }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
     })
   }
   if (document.getElementById('covid19-page-content')) {
-    logPageView({ preset: 'covid19' })
+    logPageView({ featuredSpace: 'covid19' })
 
     ReactDOM.render(
       <Covid19PageContent />, document.getElementById('covid19-page-content')
@@ -60,7 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Only logs clicks for home page with faceted search UI
     $(document).on('click', 'body', event => {
-      logClick(event, { preset: 'covid19' })
+      logClick(event, { featuredSpace: 'covid19' })
     })
   }
 })

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
     })
   }
   if (document.getElementById('covid19-page-content')) {
-    logPageView({ featuredSpace: 'covid19' })
+    logPageView()
 
     ReactDOM.render(
       <Covid19PageContent />, document.getElementById('covid19-page-content')
@@ -60,7 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Only logs clicks for home page with faceted search UI
     $(document).on('click', 'body', event => {
-      logClick(event, { featuredSpace: 'covid19' })
+      logClick(event)
     })
   }
 })

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -26,7 +26,7 @@ import morpheus from 'morpheus-app'
 import Ideogram from 'ideogram'
 // Per https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/advanced-setup.html#scenario-1-integrating-existing-builds
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic'
-import { faVirus } from '@fortawesome/free-solid-svg-icons'
+
 
 // Below import resolves to '/app/javascript/components/HomePageContent.js'
 import HomePageContent from 'components/HomePageContent'
@@ -52,9 +52,16 @@ document.addEventListener('DOMContentLoaded', () => {
     })
   }
   if (document.getElementById('covid19-page-content')) {
+    logPageView({ preset: 'covid19' })
+
     ReactDOM.render(
       <Covid19PageContent />, document.getElementById('covid19-page-content')
     )
+
+    // Only logs clicks for home page with faceted search UI
+    $(document).on('click', 'body', event => {
+      logClick(event, { preset: 'covid19' })
+    })
   }
 })
 

--- a/app/views/layouts/_ga_script.js.erb
+++ b/app/views/layouts/_ga_script.js.erb
@@ -1,3 +1,1 @@
-var trackingID = '<%= ENV['GA_TRACKING_ID'] %>';
-gaTracker(trackingID);
 gaTrack('<%= javascript_safe_url(request.fullpath) %>', 'Single Cell Portal');

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,6 +35,10 @@
 
       window.SCP.hasLoggedPageView = false;
 
+      <% if controller_name == 'site' && action_name == 'covid19' %>
+      window.SCP.featuredSpace = 'covid19'
+      <% end %>
+
       // Set the unique cookie for tracking user IDs in GA.  Also used in Mixpanel.
       // This is not personally identifiable, lasts for 1 year or until cleared.
       if ( typeof Cookies.get('user_id') === 'undefined' ) {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
     /*! js-cookie v2.2.1 | MIT */
     !function(a){var b;if("function"==typeof define&&define.amd&&(define(a),b=!0),"object"==typeof exports&&(module.exports=a(),b=!0),!b){var c=window.Cookies,d=window.Cookies=a();d.noConflict=function(){return window.Cookies=c,d}}}(function(){function a(){for(var a=0,b={};a<arguments.length;a++){var c=arguments[a];for(var d in c)b[d]=c[d]}return b}function b(a){return a.replace(/(%[0-9A-Z]{2})+/g,decodeURIComponent)}function c(d){function e(){}function f(b,c,f){if("undefined"!=typeof document){f=a({path:"/"},e.defaults,f),"number"==typeof f.expires&&(f.expires=new Date(1*new Date+864e5*f.expires)),f.expires=f.expires?f.expires.toUTCString():"";try{var g=JSON.stringify(c);/^[\{\[]/.test(g)&&(c=g)}catch(j){}c=d.write?d.write(c,b):encodeURIComponent(c+"").replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g,decodeURIComponent),b=encodeURIComponent(b+"").replace(/%(23|24|26|2B|5E|60|7C)/g,decodeURIComponent).replace(/[\(\)]/g,escape);var h="";for(var i in f)f[i]&&(h+="; "+i,!0!==f[i]&&(h+="="+f[i].split(";")[0]));return document.cookie=b+"="+c+h}}function g(a,c){if("undefined"!=typeof document){for(var e={},f=document.cookie?document.cookie.split("; "):[],g=0;g<f.length;g++){var h=f[g].split("="),i=h.slice(1).join("=");c||'"'!==i.charAt(0)||(i=i.slice(1,-1));try{var j=b(h[0]);if(i=(d.read||d)(i,j)||b(i),c)try{i=JSON.parse(i)}catch(k){}if(e[j]=i,a===j)break}catch(k){}}return a?e[a]:e}}return e.set=f,e.get=function(a){return g(a,!1)},e.getJSON=function(a){return g(a,!0)},e.remove=function(b,c){f(b,"",a(c,{expires:-1}))},e.defaults={},e.withConverter=c,e}return c(function(){})});
   </script>
+  <script nonce="<%= content_security_policy_script_nonce %>" src="https://www.google-analytics.com/analytics.js"></script>
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
 
       window.SCP = {};
@@ -19,6 +20,8 @@
       window.MAX_GENE_SEARCH = <%= Gene::MAX_GENE_SEARCH %>;
       window.MAX_GENE_SEARCH_MSG = '<%= Gene::MAX_GENE_SEARCH_MSG %>';
       window.uniqueGenes = <%= @unique_genes.present? ? raw(@unique_genes) : [] %>;
+
+      window.SCP.gaTrackingId = '<%= ENV['GA_TRACKING_ID'] %>';
 
       // if we had search forms to preserve, recall and resubmit
       if ( localStorage.getItem('previous-search-url') ) {
@@ -30,6 +33,8 @@
       window.SCP.userAccessToken = '<%= get_user_access_token(current_user) %>';
       window.SCP.environment = '<%= Rails.env %>';
 
+      window.SCP.hasLoggedPageView = false;
+
       // Set the unique cookie for tracking user IDs in GA.  Also used in Mixpanel.
       // This is not personally identifiable, lasts for 1 year or until cleared.
       if ( typeof Cookies.get('user_id') === 'undefined' ) {
@@ -40,7 +45,10 @@
       // set userId in Google Analytics
       // Where else is `userId` used?  Consider removing this raw global.
       var userId = window.SCP.userId;
-      ga('set', 'userId', window.SCP.userId);
+
+      window.ga=window.ga||function() {(ga.q=ga.q||[]).push(arguments)}; ga.l=+new Date
+      ga('create', window.SCP.gaTrackingId, 'auto')
+      ga('set', 'userId', window.SCP.userId)
 
   </script>
 
@@ -76,7 +84,7 @@
   <%= nonced_javascript_include_tag "https://cdn.plot.ly/plotly-1.47.4.min.js" %>
   <%= nonced_javascript_include_tag "https://cdn.datatables.net/plug-ins/1.10.15/sorting/natural.js" %>
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-      <%= render '/layouts/ga_script.js' %>
+      gaTrack('<%= javascript_safe_url(request.fullpath) %>', 'Single Cell Portal');
   </script>
 
 <% if DeploymentNotification.present?  %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,6 +37,11 @@
       }
       window.SCP.userId = Cookies.get('user_id');
 
+      // set userId in Google Analytics
+      // Where else is `userId` used?  Consider removing this raw global.
+      var userId = window.SCP.userId;
+      ga('set', 'userId', window.SCP.userId);
+
   </script>
 
   <script type="text/javascript"  nonce="<%= content_security_policy_script_nonce %>">
@@ -172,11 +177,6 @@
   <% end %>
 </div>
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-
-    // set userId in Google Analytics
-    // Where else is `userId` used?  Consider removing this raw global.
-    var userId = window.SCP.userId;
-    ga('set', 'userId', window.SCP.userId);
 
     // variable used mostly for testing
     PAGE_RENDERED = true;


### PR DESCRIPTION
This fixes long-standing bugs in user ID and page view tracking, and also enhances analytics to ease measurements of COVID-19 space impact.

This satisfies SCP-2287 and SCP-2282.  See those tickets for more context.