### PR TITLE
Addressing issue with blank/non-file analysis_parameters

### DIFF
--- a/app/models/analysis_configuration.rb
+++ b/app/models/analysis_configuration.rb
@@ -153,7 +153,7 @@ class AnalysisConfiguration
 
   # display value for dropdown menus in user-facing forms
   def select_option_display
-    display_value = self.namespace + '/' + self.name + " [v.#{self.snapshot}]"
+    display_value = self.name + " [v.#{self.snapshot}]"
     display_value += self.synopsis.present? ? " (#{self.synopsis})" : ""
     display_value
   end

--- a/app/models/analysis_configuration.rb
+++ b/app/models/analysis_configuration.rb
@@ -153,7 +153,7 @@ class AnalysisConfiguration
 
   # display value for dropdown menus in user-facing forms
   def select_option_display
-    display_value = self.name + " [v.#{self.snapshot}]"
+    display_value = self.namespace + '/' + self.name + " [v.#{self.snapshot}]"
     display_value += self.synopsis.present? ? " (#{self.synopsis})" : ""
     display_value
   end

--- a/app/views/site/analysis/_submission_history.html.erb
+++ b/app/views/site/analysis/_submission_history.html.erb
@@ -21,7 +21,7 @@
           <td id="submission-<%= submission['submissionId'] %>-date" class="submission-date"><%= local_timestamp(submission['submissionDate']) %></td>
           <td id="submission-<%= submission['submissionId'] %>-user" class="submission-user"><%= submission['submitter'] %></td>
           <td id="submission-<%= submission['submissionId'] %>-id" class="submission-id"><%= link_to submission['submissionId'], @study.submission_url(submission['submissionId']), class: 'submission-bucket-link', target: :_blank, data: {toggle: 'tooltip'}, title: 'View submission directory'  %></td>
-          <td id="submission-<%= submission['submissionId'] %>-name" class="submission-name"><%= submission['methodConfigurationNamespace'] + '/' + submission['methodConfigurationName'] %></td>
+          <td id="submission-<%= submission['submissionId'] %>-name" class="submission-name"><%= submission['methodConfigurationName'] %></td>
           <td id="submission-<%= submission['submissionId'] %>-entity" class="submission-entity"><%= submission['submissionEntity'].present? ? submission['submissionEntity']['entityName'] : 'N/A' %></td>
           <td id="submission-<%= submission['submissionId'] %>-state" class="submission-state"><%= submission_status_label(submission['status']) %></td>
           <td id="submission-<%= submission['submissionId'] %>-status" class="submission-status"><%= workflow_status_labels(submission['workflowStatuses']) %></td>

--- a/app/views/site/analysis/_submission_history.html.erb
+++ b/app/views/site/analysis/_submission_history.html.erb
@@ -21,7 +21,7 @@
           <td id="submission-<%= submission['submissionId'] %>-date" class="submission-date"><%= local_timestamp(submission['submissionDate']) %></td>
           <td id="submission-<%= submission['submissionId'] %>-user" class="submission-user"><%= submission['submitter'] %></td>
           <td id="submission-<%= submission['submissionId'] %>-id" class="submission-id"><%= link_to submission['submissionId'], @study.submission_url(submission['submissionId']), class: 'submission-bucket-link', target: :_blank, data: {toggle: 'tooltip'}, title: 'View submission directory'  %></td>
-          <td id="submission-<%= submission['submissionId'] %>-name" class="submission-name"><%= submission['methodConfigurationName'] %></td>
+          <td id="submission-<%= submission['submissionId'] %>-name" class="submission-name"><%= submission['methodConfigurationNamespace'] + '/' + submission['methodConfigurationName'] %></td>
           <td id="submission-<%= submission['submissionId'] %>-entity" class="submission-entity"><%= submission['submissionEntity'].present? ? submission['submissionEntity']['entityName'] : 'N/A' %></td>
           <td id="submission-<%= submission['submissionId'] %>-state" class="submission-state"><%= submission_status_label(submission['status']) %></td>
           <td id="submission-<%= submission['submissionId'] %>-status" class="submission-status"><%= workflow_status_labels(submission['workflowStatuses']) %></td>

--- a/app/views/studies/sync_study.html.erb
+++ b/app/views/studies/sync_study.html.erb
@@ -14,7 +14,7 @@
   <div class="bs-callout bs-callout-default">
     <h4>Specialized Sync for: <span class="label label-primary"><%= params[:configuration_name] %></span></h4>
     <p class="lead">Based on the type of workflow, some output files have been configured with their correct types & associations.  You may edit descriptions,
-      but those pre-set file types and associations may have been locked as changing them will result in parse failures.</p>
+      but note that changing file types and associations can result in parse failures.</p>
   </div>
 <% end %>
 

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -88,6 +88,7 @@ else
                     test/models/user_annotation_test.rb
                     test/models/study_test.rb
                     test/models/analysis_configuration_test.rb
+                    test/models/analysis_parameter_test.rb
                     test/models/search_facet_test.rb
                     test/models/preset_search_test.rb
                     test/integration/lib/search_facet_populator_test.rb

--- a/test/controllers/analysis_configurations_controller_test.rb
+++ b/test/controllers/analysis_configurations_controller_test.rb
@@ -35,23 +35,29 @@ class AnalysisConfigurationsControllerTest < ActionDispatch::IntegrationTest
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
     analysis_configuration_params = {
         analysis_configuration: {
-            namespace: 'unity-benchmark-test',
-            name: 'test-analysis',
-            snapshot: 1,
+            namespace: 'single-cell-portal',
+            name: 'split-cluster',
+            snapshot: 3,
             user_id: @test_user.id,
-            configuration_namespace: 'unity-benchmark-test',
-            configuration_name: 'test-analysis',
-            configuration_snapshot: 2
+            configuration_namespace: 'single-cell-portal',
+            configuration_name: 'split-cluster',
+            configuration_snapshot: 4
         }
     }
     post analysis_configurations_path, params: analysis_configuration_params
     follow_redirect!
     assert_response 200, 'Did not redirect successfully after creating analysis configuration'
     get analysis_configurations_path
-    new_config = AnalysisConfiguration.find_by(namespace: 'unity-benchmark-test', name: 'test-analysis', snapshot: 1)
+    new_config = AnalysisConfiguration.find_by(namespace: 'single-cell-portal', name: 'split-cluster', snapshot: 3)
     assert new_config.present?, 'Analysis configuration did not persist'
-    assert new_config.analysis_parameters.size == 2,
-           "Did not find correct number of parameters, expected 2 but found #{new_config.analysis_parameters.size}"
+    inputs = new_config.analysis_parameters.inputs
+    assert inputs.size == 2, "Did not find correct number of input parameters, expected 2 but found #{inputs.size}"
+    outputs = new_config.analysis_parameters.outputs
+    assert outputs.size == 2, "Did not find correct number of outputs parameters, expected 2 but found #{outputs.size}"
+    file_param = outputs.detect {|p| p.parameter_name == 'run_split_cluster.output_clusters'}
+    non_file_param = outputs.detect {|p| p.parameter_name == 'run_split_cluster.output_path'}
+    assert file_param.is_output_file?, "Did not correct determine output file for #{file_param.config_param_name}"
+    assert !non_file_param.is_output_file?, "Did not correct determine non-output file for #{file_param.config_param_name}"
     delete analysis_configuration_path(new_config)
     follow_redirect!
     assert_response 200, 'Did not successfully redirect after deleting analysis configuration'

--- a/test/models/analysis_parameter_test.rb
+++ b/test/models/analysis_parameter_test.rb
@@ -1,9 +1,18 @@
 require "test_helper"
 
-describe AnalysisParameter do
-  let(:analysis_parameter) { AnalysisParameter.new }
+class AnalysisParameterTest < ActiveSupport::TestCase
+  def setup
+    @analysis_configuration = AnalysisConfiguration.first
+  end
 
-  it "must be valid" do
-    value(analysis_parameter).must_be :valid?
+  test 'should validate output file types' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    output_param = @analysis_configuration.analysis_parameters.outputs.first
+    assert output_param.is_output_file?, "Should have returned true for is_output_file?: #{output_param.is_output_file?}"
+    output_param.output_file_type = "Not a file"
+    assert !output_param.valid?, "Should not have validated with an invalid file type"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 end


### PR DESCRIPTION
Fixes an issue with output parameters who's data type includes a '?' which causes nil values to be passed if the parameter is not configured by an admin.  Now ignoring non-file outputs when syncing if no file can be resolved using the value of the output.

This PR satisfies SCP-2294. 