### PR TITLE
Disabling largely unique group annotations (SCP-2164, SCP-2202)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,10 +79,13 @@ class ApplicationController < ActionController::Base
   def set_study_default_options
     @default_cluster = @study.default_cluster
     @default_cluster_annotations = {
-        'Study Wide' => @study.cell_metadata.map {|metadata| metadata.annotation_select_option }.uniq
+        'Study Wide' => @study.cell_metadata.keep_if {|meta| meta.can_visualize?}
+                            .map {|metadata| metadata.annotation_select_option }
     }
     unless @default_cluster.nil?
-      @default_cluster_annotations['Cluster-based'] = @default_cluster.cell_annotations.map {|annot| ["#{annot[:name]}", "#{annot[:name]}--#{annot[:type]}--cluster"]}
+      @default_cluster_annotations['Cluster-based'] = @default_cluster.cell_annotations
+                                                          .keep_if {|annot| @cluster.can_visualize_cell_annotation?(annot)}
+                                                          .map {|annot| @default_cluster.formatted_cell_annotation(annot)}
     end
   end
 

--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -45,7 +45,7 @@ module StudiesHelper
       # we need to check for NaN as minmax throws an ArgumentError
       begin
         values.minmax.join(', ')
-      rescue ArgumentError => e
+      rescue ArgumentError
         values.keep_if {|value| !value.to_f.nan?}.minmax.join(', ') + ' (excluding NaN)'
       end
     end
@@ -53,11 +53,17 @@ module StudiesHelper
 
   # helper for displaying sorted, unique values from a given group annotation
   # if there are too many values (> 100), then only a count is displayed
-  def get_sorted_group_values(values)
-    if CellMetadatum::GROUP_VIZ_THRESHOLD === values.size || values.size == 1
-      Naturally.sort(values).join(', ')
-    else
-      "List to long (#{values.size} values)"
+  # does not return anything for numeric annotations
+  def get_sorted_group_values(values:, annotation_type:)
+    if annotation_type.to_sym == :group
+      if CellMetadatum::GROUP_VIZ_THRESHOLD === values.size || values.size == 1
+        Naturally.sort(values).join(', ')
+      else
+        label = "<big><span class='label label-warning' data-toggle='tooltip' " + \
+        "title='Group-based annotations with over 100 groups are not visualized for performance reasons'>" + \
+        "<i class='fas fa-exclamation-triangle'></i> List too long, will not visualize</span></big>"
+        label.html_safe
+      end
     end
   end
 end

--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -35,4 +35,29 @@ module StudiesHelper
   def get_convention_label
     "<span class='fas fa-copyright text-muted' aria-hidden='true' title='Convention Metadata' data-toggle='tooltip'></span>".html_safe
   end
+
+  # get either a count of values for group annotations, or bounds for numeric annotations
+  def get_annotation_bounds(values:, annotation_type:)
+    case annotation_type.to_sym
+    when :group
+      values.size
+    when :numeric
+      # we need to check for NaN as minmax throws an ArgumentError
+      begin
+        values.minmax.join(', ')
+      rescue ArgumentError => e
+        values.keep_if {|value| !value.to_f.nan?}.minmax.join(', ') + ' (excluding NaN)'
+      end
+    end
+  end
+
+  # helper for displaying sorted, unique values from a given group annotation
+  # if there are too many values (> 100), then only a count is displayed
+  def get_sorted_group_values(values)
+    if CellMetadatum::GROUP_VIZ_THRESHOLD === values.size || values.size == 1
+      Naturally.sort(values).join(', ')
+    else
+      "List to long (#{values.size} values)"
+    end
+  end
 end

--- a/app/models/cell_metadatum.rb
+++ b/app/models/cell_metadatum.rb
@@ -16,6 +16,12 @@ class CellMetadatum
   BIGQUERY_DATASET = "cell_metadata#{Rails.env != 'production' ? "_#{Rails.env}" : nil}"
   BIGQUERY_TABLE = 'alexandria_convention'
 
+  # range to determine whether a group annotation is "useful" to visualize
+  # an annotation must have 2-100 different groups.  only 1 label is not informative,
+  # and over 100 is difficult to comprehend and slows down rendering once the group count
+  # gets over a few hundred (both server- and client-side).
+  GROUP_VIZ_THRESHOLD = (2..100)
+
   belongs_to :study
   belongs_to :study_file
   has_many :data_arrays, as: :linear_data
@@ -63,7 +69,13 @@ class CellMetadatum
     [self.name, self.annotation_select_value]
   end
 
-
+  def can_visualize?
+    if self.annotation_type == 'group'
+      GROUP_VIZ_THRESHOLD === self.values.count
+    else
+      true
+    end
+  end
 
   ##
   #

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -124,7 +124,8 @@ class ClusterGroup
   # generate a formatted select box options array that corresponds to all this cluster_group's cell_annotations
   # can be scoped to cell_annotations of a specific type (group, numeric)
   def cell_annotation_select_option(annotation_type=nil, prepend_name=false)
-    annotations = annotation_type.nil? ? self.cell_annotations : self.cell_annotations.select {|annot| annot[:type] == annotation_type}
+    annot_opts = annotation_type.nil? ? self.cell_annotations : self.cell_annotations.select {|annot| annot[:type] == annotation_type}
+    annotations = annot_opts.keep_if {|annot| self.can_visualize_cell_annotation?(annot)}
     annotations.map {|annot| self.formatted_cell_annotation(annot, prepend_name)}
   end
 

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -133,6 +133,16 @@ class ClusterGroup
     self.cell_annotations.select {|annotation| annotation['type'] == type}.map {|annotation| annotation['name']}
   end
 
+  # determine if this annotation is "useful" to visualize
+  def can_visualize_cell_annotation?(annotation)
+    annot = annotation.with_indifferent_access
+    if annot[:type] == 'group'
+      CellMetadatum::GROUP_VIZ_THRESHOLD === annot[:values].count
+    else
+      true
+    end
+  end
+
   # method used during parsing to generate representative sub-sampled data_arrays for rendering
   #
   # annotation_name: name of annotation to subsample off of

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -259,7 +259,7 @@ class IngestJob
     case self.study_file.file_type
     when 'Metadata'
       if self.study.default_options[:annotation].blank?
-        cell_metadatum = study.cell_metadata.first
+        cell_metadatum = study.cell_metadata.keep_if {|meta| meta.can_visualize?}.first
         self.study.default_options[:annotation] = cell_metadatum.annotation_select_value
         if cell_metadatum.annotation_type == 'numeric'
           self.study.default_options[:color_profile] = 'Reds'
@@ -270,7 +270,7 @@ class IngestJob
         cluster = study.cluster_groups.by_name(self.study_file.name)
         self.study.default_options[:cluster] = cluster.name
         if self.study.default_options[:annotation].blank? && cluster.cell_annotations.any?
-          annotation = cluster.cell_annotations.first
+          annotation = cluster.cell_annotations.select {|annot| cluster.can_visualize_cell_annotation?(annot)}.first
           self.study.default_options[:annotation] = cluster.annotation_select_value(annotation)
           if annotation[:type] == 'numeric'
             self.study.default_options[:color_profile] = 'Reds'

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1124,7 +1124,8 @@ class Study
   # dropdowns for selecting annotations.  can be scoped to one specific cluster, or return all with 'Cluster: ' prepended on the name
   def formatted_annotation_select(cluster: nil, annotation_type: nil)
     options = {}
-    metadata = annotation_type.nil? ? self.cell_metadata : self.cell_metadata.where(annotation_type: annotation_type)
+    meta_opts = annotation_type.nil? ? self.cell_metadata : self.cell_metadata.where(annotation_type: annotation_type)
+    metadata = meta_opts.keep_if(&:can_visualize?)
     options['Study Wide'] = metadata.map(&:annotation_select_option)
     if cluster.present?
       options['Cluster-Based'] = cluster.cell_annotation_select_option(annotation_type)

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -143,22 +143,24 @@
         </thead>
         <tbody>
           <% @study.cell_metadata.each do |metadata| %>
+            <% values = metadata.annotation_type == 'group' ? metadata.values : metadata.cell_annotations.values %>
             <tr>
               <td>Cell Metadata</td>
               <td><%= metadata.name %></td>
               <td><%= metadata.annotation_type %></td>
-              <td><%= get_annotation_bounds(values: metadata.values, annotation_type: metadata.annotation_type) %></td>
-              <td><%= get_sorted_group_values(metadata.values) %></td>
+              <td><%= get_annotation_bounds(values: values, annotation_type: metadata.annotation_type) %></td>
+              <td><%= get_sorted_group_values(values: values, annotation_type: metadata.annotation_type) %></td>
             </tr>
           <% end %>
           <% @study.cluster_groups.keep_if {|c| c.cell_annotations.any?}.each do |cluster_group| %>
             <% cluster_group.cell_annotations.each do |annotation| %>
+              <% values = annotation[:type] == 'group' ? annotation[:values] : cluster_group.concatenate_data_arrays(annotation[:name], 'annotations') %>
               <tr>
                 <td class="actions">Cluster Annotation: <%= cluster_group.name %></td>
                 <td><%= annotation[:name] %></td>
                 <td><%= annotation[:type] %></td>
-                <td><%= get_annotation_bounds(values: annotation[:type] == 'group' ? annotation[:values] : cluster_group.concatenate_data_arrays(annotation[:name], 'annotations'), annotation_type: annotation[:type]) %></td>
-                <td><%= get_sorted_group_values(annotation[:values]) %></td>
+                <td><%= get_annotation_bounds(values: values, annotation_type: annotation[:type]) %></td>
+                <td><%= get_sorted_group_values(values: values, annotation_type: annotation[:type]) %></td>
               </tr>
             <% end %>
           <% end %>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -147,8 +147,8 @@
               <td>Cell Metadata</td>
               <td><%= metadata.name %></td>
               <td><%= metadata.annotation_type %></td>
-              <td><%= metadata.annotation_type == 'group' ? metadata.values.size : metadata.cell_annotations.values.minmax.join(', ') %></td>
-              <td><%= Naturally.sort(metadata.values).join(', ') %></td>
+              <td><%= get_annotation_bounds(values: metadata.values, annotation_type: metadata.annotation_type) %></td>
+              <td><%= get_sorted_group_values(metadata.values) %></td>
             </tr>
           <% end %>
           <% @study.cluster_groups.keep_if {|c| c.cell_annotations.any?}.each do |cluster_group| %>
@@ -157,8 +157,8 @@
                 <td class="actions">Cluster Annotation: <%= cluster_group.name %></td>
                 <td><%= annotation[:name] %></td>
                 <td><%= annotation[:type] %></td>
-                <td><%= annotation[:type] == 'group' ? annotation[:values].size : cluster_group.concatenate_data_arrays(annotation[:name], 'annotations').minmax.join(', ') %></td>
-                <td><%= Naturally.sort(annotation[:values]).join(', ') %></td>
+                <td><%= get_annotation_bounds(values: annotation[:type] == 'group' ? annotation[:values] : cluster_group.concatenate_data_arrays(annotation[:name], 'annotations'), annotation_type: annotation[:type]) %></td>
+                <td><%= get_sorted_group_values(annotation[:values]) %></td>
               </tr>
             <% end %>
           <% end %>

--- a/db/migrate/20200330164113_reset_default_annotations.rb
+++ b/db/migrate/20200330164113_reset_default_annotations.rb
@@ -1,0 +1,36 @@
+class ResetDefaultAnnotations < Mongoid::Migration
+  def self.up
+    Study.all.each do |study|
+      if study.default_annotation.present?
+        annotation_name, annotation_type, annotation_scope = study.default_annotation.split('--')
+        can_visualize = true
+        if annotation_type == 'group' # numeric annotations are fine, so skip
+          case annotation_scope
+          when 'study'
+            annotation = study.cell_metadatum.by_name_and_type(annotation_name, annotation_type)
+            can_visualize = annotation.can_visualize?
+          when 'cluster'
+            cluster = study.default_cluster
+            annotation = cluster.cell_annotations.detect {|annot| annot[:name] == annotation_name}
+            can_visualize = cluster.can_visualize_cell_annotation?(annotation)
+          end
+          # if we have a bad annotation, reset to the first available cell metadata annotation
+          # that can visualize.  if nothing else is available, leave as-is
+          if !can_visualize
+            study.cell_metadata.each do |metadata|
+              if metadata.can_visualize?
+                study.default_options[:annotation] = metadata.annotation_select_value
+                study.save
+                break
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def self.down
+    # we don't want to do anything as we'd be reintroducing issues/errors in visualization
+  end
+end

--- a/db/migrate/20200330164113_reset_default_annotations.rb
+++ b/db/migrate/20200330164113_reset_default_annotations.rb
@@ -7,7 +7,7 @@ class ResetDefaultAnnotations < Mongoid::Migration
         if annotation_type == 'group' # numeric annotations are fine, so skip
           case annotation_scope
           when 'study'
-            annotation = study.cell_metadatum.by_name_and_type(annotation_name, annotation_type)
+            annotation = study.cell_metadata.by_name_and_type(annotation_name, annotation_type)
             can_visualize = annotation.can_visualize?
           when 'cluster'
             cluster = study.default_cluster

--- a/rails_startup.bash
+++ b/rails_startup.bash
@@ -100,9 +100,12 @@ else
 fi
 echo "*** COMPLETED ***"
 
-echo "*** ADDING NIGHTLY ADMIN EMAIL ***"
-(crontab -u app -l ; echo "55 23 * * * . /home/app/.cron_env ; cd /home/app/webapp/; /home/app/webapp/bin/rails runner -e $PASSENGER_APP_ENV \"SingleCellMailer.nightly_admin_report.deliver_now\" >> /home/app/webapp/log/cron_out.log 2>&1") | crontab -u app -
-echo "*** COMPLETED ***"
+if [[ $PASSENGER_APP_ENV = "production" ]]
+then
+  echo "*** ADDING NIGHTLY ADMIN EMAIL ***"
+  (crontab -u app -l ; echo "55 23 * * * . /home/app/.cron_env ; cd /home/app/webapp/; /home/app/webapp/bin/rails runner -e $PASSENGER_APP_ENV \"SingleCellMailer.nightly_admin_report.deliver_now\" >> /home/app/webapp/log/cron_out.log 2>&1") | crontab -u app -
+  echo "*** COMPLETED ***"
+fi
 
 echo "*** ADDING DAILY RESET OF USER DOWNLOAD QUOTAS ***"
 (crontab -u app -l ; echo "@daily . /home/app/.cron_env ; cd /home/app/webapp/; /home/app/webapp/bin/rails runner -e $PASSENGER_APP_ENV \"User.update_all(daily_download_quota: 0)\" >> /home/app/webapp/log/cron_out.log 2>&1") | crontab -u app -

--- a/test/models/cell_metadatum_test.rb
+++ b/test/models/cell_metadatum_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class CellMetadatumTest < ActiveSupport::TestCase
+
+  def setup
+    annotation_values = []
+    200.times { annotation_values << SecureRandom.uuid }
+    @cell_metadatum = CellMetadatum.new(name: 'Group Count Test', annotation_type: 'group', values: annotation_values)
+  end
+
+  test 'should not visualize unique group annotations over 100' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # assert unique group annotations > 100 cannot visualize
+    can_visualize = @cell_metadatum.can_visualize?
+    assert !can_visualize, "Should not be able to visualize group annotation with more that 100 unique values: #{can_visualize}"
+
+    # check that numeric annotations are still fine
+    @cell_metadatum.annotation_type = 'numeric'
+    @cell_metadatum.values = []
+    can_visualize = @cell_metadatum.can_visualize?
+    assert can_visualize, "Should be able to visualize numeric annotations at any level: #{can_visualize}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+end

--- a/test/models/cluster_group_test.rb
+++ b/test/models/cluster_group_test.rb
@@ -1,13 +1,33 @@
 require "test_helper"
 
-# DEPRECATED
-# This test case is deprecated in favor of subsampling in scp-ingest-pipeline
-
 class ClusterGroupTest < ActiveSupport::TestCase
   def setup
     @cluster_group = ClusterGroup.first
   end
 
+  test 'should not visualize unique group annotations over 100' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    annotation_values = []
+    200.times { annotation_values << SecureRandom.uuid }
+    cell_annotation = {name: 'Group Annotation', type: 'group', values: annotation_values}
+    cluster = ClusterGroup.new(name: 'Group Count Test', cluster_type: '2d', cell_annotations: [cell_annotation])
+    can_visualize = cluster.can_visualize_cell_annotation?(cell_annotation)
+    assert !can_visualize, "Should not be able to visualize group cell annotation with more that 100 unique values: #{can_visualize}"
+
+    # check numeric annotations are still fine
+    new_cell_annotation = {name: 'Numeric Annotation', type: 'numeric', values: []}
+    cluster.cell_annotations << new_cell_annotation
+    can_visualize_numeric  = cluster.can_visualize_cell_annotation?(new_cell_annotation)
+    assert can_visualize_numeric, "Should be able to visualize numeric cell annotation at any level: #{can_visualize_numeric}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  # DEPRECATED
+  # This test case is deprecated in favor of subsampling in scp-ingest-pipeline, but is still necessary as a
+  # data loading function for downstream user annotation tests
+  #
   # test to validate that subsampling algorithm creates representative samples and also maintains relationships
   # checks for cluster-level annotations of type 'group'
   def test_generate_subsample_arrays_group_cluster


### PR DESCRIPTION
For group-based annotations with over 100 distinct groups, cluster plots are not useful as it is nearly impossible to determine different populations visually.  For group-based annotations with only one distinct value, the plot is uninformative, as it only shows one population without variation.  Also, as the number of distinct groups rises, page rendering slows exponentially, and breaks completely in the thousands of groups.

This update restricts group-based annotations (both from cell metadata and cluster files) to a range of 2-100 distinct groups.  Anything outside those bounds will not be available to visualize (although it will still be parsed into the database).

A quick check of the production database shows that for that 3007 group-based annotations from cell metadata files:

more than 50 groups: 132 (4.4%)
more than 100 groups: 93 (3.09%)
more than 200 groups: 76 (2.53%)
more than 500 groups: 75 (2.49%)
more than 1000 groups: 54 (1.80%)
more than 5000 groups: 31 (1.03%)
more than 10000 groups: 13 (0.43%)

A check of TTFB (time to first byte) on annotations of those sizes (with the default 10K cell subsample) shows why the decision was made to cut off at 100:

50 groups: ~1.5s, no render lag
100 groups: ~3.5s, very slight render lag
200 groups: ~29s, long render lag (> 5s once data is received)

This also includes a bugfix for numeric annotations with NaN values breaking the "Study Details" page, and disables sending the nightly admin report in all environments except production (to reduce confusion).

This PR satisfies SCP-2164 and SCP-2202.