### PR TITLE
Setting branding group query parameter on search results (SCP-2295)

### DIFF
--- a/app/views/api/v1/search/_study.json.jbuilder
+++ b/app/views/api/v1/search/_study.json.jbuilder
@@ -5,7 +5,7 @@ json.set! :public, study.public
 json.set! :detached, study.detached
 json.set! :cell_count, study.cell_count
 json.set! :gene_count, study.gene_count
-json.set! :study_url, view_study_path(accession: study.accession, study_name: study.url_safe_name)
+json.set! :study_url, scp_url_for(view_study_path(accession: study.accession, study_name: study.url_safe_name), params[:scpbr])
 if @studies_by_facet.present?
   # faceted search was run, so append filter matches
   json.set! :facet_matches, @studies_by_facet[study.accession]

--- a/app/views/api/v1/search/_study.json.jbuilder
+++ b/app/views/api/v1/search/_study.json.jbuilder
@@ -5,7 +5,7 @@ json.set! :public, study.public
 json.set! :detached, study.detached
 json.set! :cell_count, study.cell_count
 json.set! :gene_count, study.gene_count
-json.set! :study_url, scp_url_for(view_study_path(accession: study.accession, study_name: study.url_safe_name), params[:scpbr])
+json.set! :study_url, view_study_path(accession: study.accession, study_name: study.url_safe_name) + (params[:scpbr].present? ? "?scpbr=#{params[:scpbr]}" : '')
 if @studies_by_facet.present?
   # faceted search was run, so append filter matches
   json.set! :facet_matches, @studies_by_facet[study.accession]

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -236,6 +236,9 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     result_count = json['studies'].size
     assert_equal 1, result_count, "Did not find correct number of studies, expected 1 but found #{result_count}"
+    found_study = json['studies'].first
+    assert found_study['study_url'].include?("scpbr=#{branding_group.name_as_id}"),
+           "Did not append branding group identifier to end of study URL: #{found_study['study_url']}"
 
     # remove study from group and search again - should get 0 results
     study.update(branding_group_id: nil)


### PR DESCRIPTION
If a search request is submitted with a branding group query parameter (scpbr), then the auto-generated links to study results will include this parameter appended to the end to maintain the branding group through the page load for the study.

This PR satisfies SCP-2295