### PR TITLE
Changing wording in Terms of Service (SCP-2183)

### DIFF
--- a/app/views/site/_tos_content.html.erb
+++ b/app/views/site/_tos_content.html.erb
@@ -106,6 +106,6 @@
   competent jurisdiction. For all purposes of this Agreement, the parties consent to exclusive jurisdiction and venue in
   the state or federal courts located in, respectively, Middlesex County, Massachusetts, or the District of Massachusetts.
   Any arbitration under these Terms will take place on an individual basis: class arbitrations and class actions are not
-  permitted. YOU UNDERSTAND AND AGREE THAT BY ENTERING INTO THESE TERMS, YOU AND BENCHLING ARE EACH WAIVING THE RIGHT TO
+  permitted. YOU UNDERSTAND AND AGREE THAT BY ENTERING INTO THESE TERMS, YOU AND BROAD ARE EACH WAIVING THE RIGHT TO
   TRIAL BY JURY OR TO PARTICIPATE IN A CLASS ACTION.</p>
 <p class="lead help-block">Broad Institute, revised [<%= TosAcceptance.current_version %>]</p>


### PR DESCRIPTION
Replacing BENCHLING with BROAD under the Choice of Law heading at the end of the Terms of Service.  This does not require new ToS acceptance per legal, therefore the ToS version has not incremented.

This PR satisfies SCP-2183.