### PR TITLE
fixing migration error by checking for presence of annotations/clusters (SCP-2307)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,7 +84,7 @@ class ApplicationController < ActionController::Base
     }
     unless @default_cluster.nil?
       @default_cluster_annotations['Cluster-based'] = @default_cluster.cell_annotations
-                                                          .keep_if {|annot| @cluster.can_visualize_cell_annotation?(annot)}
+                                                          .keep_if {|annot| @default_cluster.can_visualize_cell_annotation?(annot)}
                                                           .map {|annot| @default_cluster.formatted_cell_annotation(annot)}
     end
   end

--- a/db/migrate/20200330164113_reset_default_annotations.rb
+++ b/db/migrate/20200330164113_reset_default_annotations.rb
@@ -9,11 +9,11 @@ class ResetDefaultAnnotations < Mongoid::Migration
           case annotation_scope
           when 'study'
             annotation = study.cell_metadata.by_name_and_type(annotation_name, annotation_type)
-            can_visualize = annotation.can_visualize?
+            can_visualize = annotation.present? && annotation.can_visualize?
           when 'cluster'
             cluster = study.default_cluster
             annotation = cluster.cell_annotations.detect {|annot| annot[:name] == annotation_name}
-            can_visualize = cluster.can_visualize_cell_annotation?(annotation)
+            can_visualize = cluster.present? && annotation.present? && cluster.can_visualize_cell_annotation?(annotation)
           end
           # if we have a bad annotation, reset to the first available cell metadata annotation
           # that can visualize.  if nothing else is available, leave as-is


### PR DESCRIPTION
This fixes the error in the latest migration `20200330164113_reset_default_annotations.rb` where attempting to load a default annotation that has been removed threw a NoMethodError.  Update now checks for the presence of all objects first before trying to determine if the annotation needs to be changed.

This PR satisfies SCP-2307.