### PR TITLE
Remove COVID-19 button from branded spaces (SCP-2310)

### DIFF
--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -9,7 +9,7 @@
         <li role="presentation" class="home-nav" id="search-genes-nav">
           <a href="#search-genes" class="home-nav-tab" data-toggle="tab"><span class="fas fa-dna"></span> Search Genes</a>
         </li>
-        <% if User.feature_flag_for_user(current_user, 'covid19_page') && @selected_branding_group == nil %>
+        <% if User.feature_flag_for_user(current_user, 'covid19_page') && @selected_branding_group.nil? %>
           <li role="presentation" class="home-nav" id="covid19-tab"
               style="float:right;
                      background: url(<%= image_url 'covid19-button.png' %>);

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -9,7 +9,7 @@
         <li role="presentation" class="home-nav" id="search-genes-nav">
           <a href="#search-genes" class="home-nav-tab" data-toggle="tab"><span class="fas fa-dna"></span> Search Genes</a>
         </li>
-        <% if User.feature_flag_for_user(current_user, 'covid19_page') %>
+        <% if User.feature_flag_for_user(current_user, 'covid19_page') && @selected_branding_group == nil %>
           <li role="presentation" class="home-nav" id="covid19-tab"
               style="float:right;
                      background: url(<%= image_url 'covid19-button.png' %>);


### PR DESCRIPTION
This hotfix removes the COVID-19 button from branded spaces, for now.

This satisfies SCP-2310.