### PR TITLE
harmonizing API "timeouts" with devise User.timeout_in threshold (SCP-2304)

### DIFF
--- a/app/controllers/api/v1/concerns/authenticator.rb
+++ b/app/controllers/api/v1/concerns/authenticator.rb
@@ -27,10 +27,12 @@ module Api
                 token_url = "https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=#{api_access_token}"
                 response = RestClient.get token_url
                 credentials = JSON.parse response.body
+                now = Time.zone.now
                 token_values = {
                     'access_token' => api_access_token,
                     'expires_in' => credentials['expires_in'],
-                    'expires_at' => Time.zone.now + credentials['expires_in'].to_i
+                    'expires_at' => now + credentials['expires_in'].to_i,
+                    'last_access_at' => now
                 }
                 email = credentials['email']
                 user = User.find_by(email: email)

--- a/app/controllers/api/v1/concerns/authenticator.rb
+++ b/app/controllers/api/v1/concerns/authenticator.rb
@@ -50,15 +50,19 @@ module Api
                 Rails.logger.error "Error retrieving user api credentials: #{e.class.name}: #{e.message}"
               end
             end
-            # check for token expiry and unset user if expired
-            if user.api_access_token_expired?
+            # check for token expiry and unset user if expired/timed out
+            if user.api_access_token_expired? || user.api_access_token_timed_out?
               nil
             else
+              # update last_access_at
+              user.update_api_last_access_at!
               user
             end
           elsif controller_name == 'search' && action_name == 'bulk_download'
             Rails.logger.info "Authenticating user via auth_token: #{params[:auth_code]}"
-            User.find_by(totat: params[:auth_code].to_i)
+            user = User.find_by(totat: params[:auth_code].to_i)
+            user.update_api_last_access_at!
+            user
           end
         end
 

--- a/app/controllers/api/v1/concerns/authenticator.rb
+++ b/app/controllers/api/v1/concerns/authenticator.rb
@@ -55,13 +55,13 @@ module Api
               nil
             else
               # update last_access_at
-              user.update_api_last_access_at!
+              user.update_last_access_at!
               user
             end
           elsif controller_name == 'search' && action_name == 'bulk_download'
             Rails.logger.info "Authenticating user via auth_token: #{params[:auth_code]}"
             user = User.find_by(totat: params[:auth_code].to_i)
-            user.update_api_last_access_at!
+            user.update_last_access_at!
             user
           end
         end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,6 +36,9 @@ class ApplicationController < ActionController::Base
   around_action :set_current_user
   def set_current_user
     Current.user = current_user
+    if current_user.present?
+      current_user.update_api_last_access_at!
+    end
     yield
   ensure
     # to address the thread variable leak issues in Puma/Thin webserver

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ class ApplicationController < ActionController::Base
   def set_current_user
     Current.user = current_user
     if current_user.present?
-      current_user.update_api_last_access_at!
+      current_user.update_last_access_at!
     end
     yield
   ensure

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -187,14 +187,14 @@ class User
       # if token has been used in last 30 min (User.timeout_in), then timestamp + timeout_in > now
       # therefore, make sure last_access + timeout_in is in the future
       last_access = self.api_access_token[:last_access_at]
-      last_access.present? ? (last_access + self.timeout_in) < Time.now.in_time_zone(self.get_token_timezone(:api_access_token, :last_access_at)) : true
+      last_access.present? ? (last_access + self.timeout_in) < Time.now.in_time_zone(self.get_token_timezone(:api_access_token)) : true
     end
   end
 
   # refresh API token last_access_at, if token is present
   def update_api_last_access_at!
     if self.api_access_token.present?
-      self.api_access_token[:last_access_at] = Time.now.in_time_zone(self.get_token_timezone(:api_access_token, :last_access_at))
+      self.api_access_token[:last_access_at] = Time.now.in_time_zone(self.get_token_timezone(:api_access_token))
       self.save
     end
   end
@@ -205,8 +205,8 @@ class User
   end
 
   # extract timezone from an access token to allow correct date math
-  def get_token_timezone(token_method, timestamp=:expires_at)
-    self.send(token_method)[timestamp].zone
+  def get_token_timezone(token_method)
+    self.send(token_method)[:expires_at].zone
   end
 
   ###

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -192,7 +192,7 @@ class User
   end
 
   # refresh API token last_access_at, if token is present
-  def update_api_last_access_at!
+  def update_last_access_at!
     if self.api_access_token.present?
       self.api_access_token[:last_access_at] = Time.now.in_time_zone(self.get_token_timezone(:api_access_token))
       self.save

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -91,6 +91,7 @@ else
                     test/models/analysis_parameter_test.rb
                     test/models/search_facet_test.rb
                     test/models/preset_search_test.rb
+                    test/models/user_test.rb
                     test/integration/lib/search_facet_populator_test.rb
                     test/integration/lib/summary_stats_utils_test.rb
                     test/models/big_query_client_test.rb

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -389,7 +389,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
     # make sure user is "active" by updating last_access_at
     @user = User.first
-    @user.update_api_last_access_at!
+    @user.update_last_access_at!
     # mark study as false to show if a user is signed in or not
     api_test_study = Study.find_by(name: /API Test Study/)
     api_test_study.update(public: false)
@@ -411,7 +411,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_empty accessions, "Did not successfully time out session, accessions were found: #{accessions}"
     # clean up
     api_test_study.update(public: true)
-    @user.update_api_last_access_at!
+    @user.update_last_access_at!
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -14,6 +14,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
                                                                        })
     sign_in @user
     @random_seed = File.open(Rails.root.join('.random_seed')).read.strip
+    @user.update_last_access_at! # ensure user is marked as active
   end
 
   test 'should get all search facets' do

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -383,4 +383,36 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
+
+  test 'should log out user after inactivity' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # make sure user is "active" by updating last_access_at
+    @user = User.first
+    @user.update_api_last_access_at!
+    # mark study as false to show if a user is signed in or not
+    api_test_study = Study.find_by(name: /API Test Study/)
+    api_test_study.update(public: false)
+    search_terms = "\"API Test Study\""
+    execute_http_request(:get, api_v1_search_path(type: 'study', terms: search_terms))
+    assert_response :success
+    expected_results = [api_test_study.accession]
+    assert_equal expected_results, json['matching_accessions'],
+                 "Found wrong study with keywords search; expected #{expected_results} but found #{json['matching_accessions']}"
+    # now simulate a user "timing out" by back-dating last_access_at timestamp by double the timeout threshold
+    # and then re-run search
+    last_access = @user.api_access_token[:last_access_at]
+    timed_out_stamp = last_access - User.timeout_in * 2
+    @user.api_access_token[:last_access_at] = timed_out_stamp
+    @user.save
+    execute_http_request(:get, api_v1_search_path(type: 'study', terms: search_terms))
+    assert_response :success
+    accessions = json['matching_accessions']
+    assert_empty accessions, "Did not successfully time out session, accessions were found: #{accessions}"
+    # clean up
+    api_test_study.update(public: true)
+    @user.update_api_last_access_at!
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,6 +2,27 @@ require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
   def setup
-    @user = nil
+    @user = User.first
+  end
+
+  test 'should time out token after inactivity' do
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
+
+    @user.update_api_last_access_at!
+    last_access = @user.api_access_token[:last_access_at]
+    now = Time.now.in_time_zone(@user.get_token_timezone(:api_access_token, :last_access_at))
+    refute @user.api_access_token_timed_out?,
+           "API access token should not have timed out, #{last_access} is within #{User.timeout_in} seconds of #{now}"
+    # back-date access token last_access_at
+    invalid_access = now - 1.hour
+    @user.api_access_token[:last_access_at] = invalid_access
+    @user.save
+    @user.reload
+    assert @user.api_access_token_timed_out?,
+           "API access token should have timed out, #{invalid_access} is outside #{User.timeout_in} seconds of #{now}"
+    # clean up
+    @user.update_api_last_access_at!
+
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -8,7 +8,7 @@ class UserTest < ActiveSupport::TestCase
   test 'should time out token after inactivity' do
     puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
-    @user.update_api_last_access_at!
+    @user.update_last_access_at!
     last_access = @user.api_access_token[:last_access_at]
     now = Time.now.in_time_zone(@user.get_token_timezone(:api_access_token))
     refute @user.api_access_token_timed_out?,
@@ -21,7 +21,7 @@ class UserTest < ActiveSupport::TestCase
     assert @user.api_access_token_timed_out?,
            "API access token should have timed out, #{invalid_access} is outside #{User.timeout_in} seconds of #{now}"
     # clean up
-    @user.update_api_last_access_at!
+    @user.update_last_access_at!
 
     puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -10,7 +10,7 @@ class UserTest < ActiveSupport::TestCase
 
     @user.update_api_last_access_at!
     last_access = @user.api_access_token[:last_access_at]
-    now = Time.now.in_time_zone(@user.get_token_timezone(:api_access_token, :last_access_at))
+    now = Time.now.in_time_zone(@user.get_token_timezone(:api_access_token))
     refute @user.api_access_token_timed_out?,
            "API access token should not have timed out, #{last_access} is within #{User.timeout_in} seconds of #{now}"
     # back-date access token last_access_at


### PR DESCRIPTION
Synchronizing API "session" length with user session timeouts in the UI.  Currently, API requests only validate that the OAuth token is within the standard 1 hour window.  This now adds a secondary check to validate that the user has used this access token within the configured timeout window (currently 30 minutes, as set in `config/initializers/devise.rb`, and accessible via `User.timeout_in`).  As functionality migrates from the standard Rails UI to API calls + React, this will be required in order to maintain application security guidelines of logging out "idle" users as per FISMA Moderate.

This PR satisfies SCP-2304.