### PR TITLE
adding support to not show ontology ID-based annotations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,8 +79,7 @@ class ApplicationController < ActionController::Base
   def set_study_default_options
     @default_cluster = @study.default_cluster
     @default_cluster_annotations = {
-        'Study Wide' => @study.cell_metadata.keep_if {|meta| meta.can_visualize?}
-                            .map {|metadata| metadata.annotation_select_option }
+        'Study Wide' => @study.viewable_metadata.map {|metadata| metadata.annotation_select_option }
     }
     unless @default_cluster.nil?
       @default_cluster_annotations['Cluster-based'] = @default_cluster.cell_annotations

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -23,8 +23,8 @@ class StudiesController < ApplicationController
     check_access_settings
   end
   # special before_action to make sure FireCloud is available and pre-empt any calls when down
-  before_action :check_firecloud_status, except: [:index, :do_upload, :resume_upload, :update_status,
-                                                  :retrieve_wizard_upload, :parse]
+  #before_action :check_firecloud_status, except: [:index, :do_upload, :resume_upload, :update_status,
+  #                                                :retrieve_wizard_upload, :parse]
   before_action :check_study_detached, only: [:edit, :update, :initialize_study, :sync_study, :sync_submission_outputs]
 
   ###

--- a/app/models/cell_metadatum.rb
+++ b/app/models/cell_metadatum.rb
@@ -71,10 +71,16 @@ class CellMetadatum
 
   def can_visualize?
     if self.annotation_type == 'group'
-      GROUP_VIZ_THRESHOLD === self.values.count
+      GROUP_VIZ_THRESHOLD === self.values.count && !self.is_ontology_ids?
     else
       true
     end
+  end
+
+  # determine if there is another metadatum that represents labels that map to these IDs
+  # e.g. disease vs. disease__ontology_label
+  def is_ontology_ids?
+    self.class.where(study_id: self.study_id, annotation_type: 'group', name: self.name + '__ontology_label').exists?
   end
 
   ##

--- a/app/models/cell_metadatum.rb
+++ b/app/models/cell_metadatum.rb
@@ -83,6 +83,10 @@ class CellMetadatum
     self.class.where(study_id: self.study_id, annotation_type: 'group', name: self.name + '__ontology_label').exists?
   end
 
+  def is_ontology_labels?
+    self.name.end_with?('__ontology_label')
+  end
+
   ##
   #
   # CLASS INSTANCE METHODS

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -881,6 +881,23 @@ class Study
     self.can_visualize_clusters? || self.can_visualize_genome_data?
   end
 
+  # quick getter to return any cell metadata that can_visualize?
+  def viewable_metadata
+    viewable = []
+    all_metadata = self.cell_metadata
+    all_names = all_metadata.pluck(:name)
+    all_metadata.each do |meta|
+      if meta.annotation_type == 'numeric'
+        viewable << meta
+      else
+        if CellMetadatum::GROUP_VIZ_THRESHOLD === meta.values.size
+          viewable << meta unless all_names.include?(meta.name + '__ontology_label')
+        end
+      end
+    end
+    viewable
+  end
+
   ###
   #
   # DATA PATHS & URLS
@@ -1127,8 +1144,8 @@ class Study
   # dropdowns for selecting annotations.  can be scoped to one specific cluster, or return all with 'Cluster: ' prepended on the name
   def formatted_annotation_select(cluster: nil, annotation_type: nil)
     options = {}
-    meta_opts = annotation_type.nil? ? self.cell_metadata : self.cell_metadata.where(annotation_type: annotation_type)
-    metadata = meta_opts.keep_if(&:can_visualize?)
+    viewable = self.viewable_metadata
+    metadata = annotation_type.nil? ? viewable : viewable.select {|m| m.annotation_type == annotation_type}
     options['Study Wide'] = metadata.map(&:annotation_select_option)
     if cluster.present?
       options['Cluster-Based'] = cluster.cell_annotation_select_option(annotation_type)

--- a/app/views/site/_search_options.html.erb
+++ b/app/views/site/_search_options.html.erb
@@ -100,8 +100,10 @@
                     }
                 });
                 function submitGeneSearch(event) {
-                    if ( $('#search_genes').val() == '' && $('#search_upload').val() == '' ) {
-                        alert('You must specify at least one gene or upload a list of genes to search');
+                    // concatenate all inputs together to see if there is any value anywhere
+                    var allValues = $('#search_genes').val() + $('#search_upload').val() + $('#gene_set').val() + $('#expression').val();
+                    if ( allValues === '' ) {
+                        alert('You must specify at least one gene, gene list, or upload a list of genes to search');
                         setErrorOnBlank($('.search-genes-input'));
                     } else {
                         $(window).off('resizeEnd');

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -138,6 +138,11 @@
           <th>Name</th>
           <th>Type</th>
           <th>Size/Range</th>
+          <th class="slick-header-columns">
+            Viewable&nbsp;<span data-toggle="tooltip"
+                             title="Group-based annotations can only have 2-100 distinct values and not be based on ontology IDs to be viewable as annotations">
+            <i class="fas fa-question-circle"></i></span>
+          </th>
           <th>Values</th>
         </tr>
         </thead>
@@ -149,6 +154,7 @@
               <td><%= metadata.name %></td>
               <td><%= metadata.annotation_type %></td>
               <td><%= get_annotation_bounds(values: values, annotation_type: metadata.annotation_type) %></td>
+              <td><%= get_boolean_label(metadata.can_visualize?) %></td>
               <td><%= get_sorted_group_values(values: values, annotation_type: metadata.annotation_type) %></td>
             </tr>
           <% end %>
@@ -160,6 +166,7 @@
                 <td><%= annotation[:name] %></td>
                 <td><%= annotation[:type] %></td>
                 <td><%= get_annotation_bounds(values: values, annotation_type: annotation[:type]) %></td>
+                <td><%= get_boolean_label(cluster_group.can_visualize_cell_annotation?(annotation)) %></td>
                 <td><%= get_sorted_group_values(values: values, annotation_type: annotation[:type]) %></td>
               </tr>
             <% end %>

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -87,6 +87,7 @@ else
                     test/models/cluster_group_test.rb # deprecated, but needed to set up for user_annotation_test
                     test/models/user_annotation_test.rb
                     test/models/study_test.rb
+                    test/models/cell_metadatum_test.rb
                     test/models/analysis_configuration_test.rb
                     test/models/analysis_parameter_test.rb
                     test/models/search_facet_test.rb

--- a/test/models/cell_metadatum_test.rb
+++ b/test/models/cell_metadatum_test.rb
@@ -2,14 +2,13 @@ require "test_helper"
 
 class CellMetadatumTest < ActiveSupport::TestCase
 
-  def setup
+  test 'should not visualize unique group annotations over 100' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # setup
     annotation_values = []
     200.times { annotation_values << SecureRandom.uuid }
     @cell_metadatum = CellMetadatum.new(name: 'Group Count Test', annotation_type: 'group', values: annotation_values)
-  end
-
-  test 'should not visualize unique group annotations over 100' do
-    puts "#{File.basename(__FILE__)}: #{self.method_name}"
 
     # assert unique group annotations > 100 cannot visualize
     can_visualize = @cell_metadatum.can_visualize?
@@ -20,6 +19,37 @@ class CellMetadatumTest < ActiveSupport::TestCase
     @cell_metadatum.values = []
     can_visualize = @cell_metadatum.can_visualize?
     assert can_visualize, "Should be able to visualize numeric annotations at any level: #{can_visualize}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should not visualize ontology id based annotations' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # setup
+    study = Study.first
+    metadata_file = study.metadata_file
+    @disease = CellMetadatum.create(study_id: study.id, study_file_id: metadata_file.id, name: 'disease',
+                                    annotation_type: 'group', values: %w(MONDO_0000001))
+    @disease_labels = CellMetadatum.create(study_id: study.id, study_file_id: metadata_file.id, name: 'disease__ontology_label',
+                                           annotation_type: 'group', values: ['disease or disorder'])
+
+    # ensure id-based annotations do not visualize
+    assert @disease.is_ontology_ids?, "Did not correctly identify #{@disease.name} annotation as ontology ID based"
+    refute @disease_labels.is_ontology_ids?, "Incorrectly labelled #{@disease_labels.name} annotation as ontology ID based"
+    refute @disease.can_visualize?,
+           "Should not be able to view #{@disease.name} annotation: values: #{@disease.values.size}, is_ontology_ids?: #{@disease.is_ontology_ids?}"
+    refute @disease_labels.can_visualize?,
+           "Should not be able to view #{@disease_labels.name} annotation: values: #{@disease_labels.values.size}, is_ontology_ids?: #{@disease_labels.is_ontology_ids?}"
+
+    # update disease__ontology_label to have more than one value
+    @disease_labels.values << 'tuberculosis'
+    assert @disease_labels.can_visualize?,
+           "Should be able to view #{@disease_labels.name} annotation: values: #{@disease_labels.values.size}, is_ontology_ids?: #{@disease_labels.is_ontology_ids?}"
+
+    # clean up
+    @disease.destroy
+    @disease_labels.destroy
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end


### PR DESCRIPTION
Cell Metadata annotations that consist of ontology IDs (e.g. NCBITaxon_9606, MONDO_0000001) are no longer candidates for visualization if there is a corresponding "labels" annotation.  This is determined by the presence another group-based annotation with the same name, but suffixed with `__ontology_label`, as per the Alexandria metadata convention.  This also adds information to the "Study Details" page that will let the user know which annotations are "viewable", as well as a short tooltip to explain the criteria.

This also fixes a small regression with an alert incorrectly showing when a user selects a gene list to view from the study visualize tab.

This PR satisfies SCP-2227.
