### PR TITLE
adding study population helper method

### DIFF
--- a/app/lib/synthetic_study_populator.rb
+++ b/app/lib/synthetic_study_populator.rb
@@ -55,4 +55,14 @@ class SyntheticStudyPopulator
       FileParseService.run_parse_job(study_file, study, user)
     end
   end
+
+  # utility method to generate a study_info.json file string from an existing study
+  # useful for, e.g., downloading all the files from a production study to your local machine,
+  # and then using SyntheticStudyPopulator to ingest it
+  def self.generate_study_info_json(study)
+    info = {}
+    info['study'] = {name: study.name, description: study.description, data_dir: 'test'}
+    info['files'] = study.study_files.map{|f| { filename: f.name, type: f.file_type}}
+    puts JSON.pretty_generate(info)
+  end
 end


### PR DESCRIPTION
I'm currently slurping studies from production to help test gene search, and it would have been faster if this method was already on the prod server :)

The workflow I'm imagining is you ssh into prod, run this method on the prod study (or we could provide an internal admin API to make this visible) to generate the info file SynthStudyPopulator needs to populate the study locally.  Also very open to hear any other quick ways of getting prod/staging studies into your local instance.