### PR TITLE
Encoding request URLs for analytics, allowing comma-delimited gene lists (SCP-1238, SCP-2272)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -216,7 +216,7 @@ $(document).on('change', '#panel-genes-search input, #panel-genes-search select'
   $('#perform-gene-search').click();
 });
 
-// split a string on spaces, used for extractLast()
+// split a string on spaces/commas, used for extractLast()
 function split(val) {
     return val.split(/[\s,]/);
 }

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -224,9 +224,7 @@ function split(val) {
 // extract last term from a string of autocomplete entries
 function extractLast(term) {
     sanitizedTerm = term.trim().replace(/,$/, ''); // remove trailing whitespace/comma to prevent returning all results
-    var returned = split(sanitizedTerm).pop();
-    console.log('extractLast: ' + returned);
-    return returned;
+    return split(sanitizedTerm).pop();
 }
 
 var keydownIsFromAutocomplete = false;

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -218,13 +218,15 @@ $(document).on('change', '#panel-genes-search input, #panel-genes-search select'
 
 // split a string on spaces, used for extractLast()
 function split(val) {
-    return val.split(/\s/);
+    return val.split(/[\s,]/);
 }
 
 // extract last term from a string of autocomplete entries
 function extractLast(term) {
-    sanitizedTerm = term.trim(); // remove trailing whitespace to prevent returning all results
-    return split(sanitizedTerm).pop();
+    sanitizedTerm = term.trim().replace(/,$/, ''); // remove trailing whitespace/comma to prevent returning all results
+    var returned = split(sanitizedTerm).pop();
+    console.log('extractLast: ' + returned);
+    return returned;
 }
 
 var keydownIsFromAutocomplete = false;

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -2077,7 +2077,7 @@ class SiteController < ApplicationController
     if sanitized_terms.is_a?(Array)
       sanitized_terms.map(&:strip)
     else
-      sanitized_terms.split(/[\n\s]/).map(&:strip)
+      sanitized_terms.split(/[\n\s,]/).map(&:strip)
     end
   end
 

--- a/app/views/site/view_gene_expression.js.erb
+++ b/app/views/site/view_gene_expression.js.erb
@@ -4,7 +4,8 @@ closeModalSpinner('#spinner_target', '#loading-modal', function () {
     $('#study-visualize').html("<%= escape_javascript(render partial: 'view_gene_expression') %>");
     showMessageModal("<%= notice.present? ? notice.html_safe : nil %>", "<%= alert.present? ? alert.html_safe : nil %>")
     enableDefaultActions();
-    var requestUrl = "<%= javascript_safe_url(request.fullpath) %>";
+    var requestUrl = "<%= request.fullpath %>";
+    var encodedUrl = encodeURI(requestUrl);
     ga('send', 'event', 'engaged_user_action', 'study_gene_search_single');
-    gaTrack(requestUrl, 'Single Cell Portal');
+    gaTrack(encodedUrl, 'Single Cell Portal');
 });

--- a/app/views/site/view_gene_expression_heatmap.js.erb
+++ b/app/views/site/view_gene_expression_heatmap.js.erb
@@ -5,7 +5,8 @@ closeModalSpinner('#spinner_target', '#loading-modal', function () {
     showMessageModal("<%= notice.present? ? notice.html_safe : nil %>", "<%= alert.present? ? alert.html_safe : nil %>")
     $(window).off('resizeEnd');
     enableDefaultActions();
-    var requestUrl = "<%= javascript_safe_url(request.fullpath) %>";
+    var requestUrl = "<%= request.fullpath %>";
+    var encodedUrl = encodeURI(requestUrl);
     ga('send', 'event', 'engaged_user_action', 'study_gene_search_multiple')
-    gaTrack(requestUrl, 'Single Cell Portal');
+    gaTrack(encodedUrl, 'Single Cell Portal');
 });

--- a/app/views/site/view_precomputed_gene_expression_heatmap.js.erb
+++ b/app/views/site/view_precomputed_gene_expression_heatmap.js.erb
@@ -5,6 +5,7 @@ closeModalSpinner('#spinner_target', '#loading-modal', function () {
     showMessageModal("<%= notice.present? ? notice.html_safe : nil %>", "<%= alert.present? ? alert.html_safe : nil %>")
     $(window).off('resizeEnd');
     enableDefaultActions();
-    var requestUrl = "<%= javascript_safe_url(request.fullpath) %>";
-    gaTrack(requestUrl, 'Single Cell Portal');
+    var requestUrl = "<%= request.fullpath %>";
+    var encodedUrl = encodeURI(requestUrl);
+    gaTrack(encodedUrl, 'Single Cell Portal');
 });


### PR DESCRIPTION
Addressing two small issues:

1. Fixing URL encoding when reporting some requests to Google Analytics - lists of genes sometimes included control characters (^R, ^M) that would break when trying to convert
1. Allowing gene searches to delimit by both space and comma

This PR satisfies both SCP-1238 and SCP-2272.