### PR TITLE
Ensure blank values for unset inputs/outputs for analyses (SCP-2330)

### DIFF
--- a/app/models/analysis_configuration.rb
+++ b/app/models/analysis_configuration.rb
@@ -310,12 +310,13 @@ class AnalysisConfiguration
           parameter_name = vals.join('.')
           parameter_type = data_type == 'inputs' ? setting['inputType'] : setting['outputType']
           optional = setting['optional'] == true
+          param_val = repo_config['payloadObject'][data_type]["#{call_name}.#{parameter_name}"]
           config_attr = {
               data_type: data_type,
               parameter_type: parameter_type,
               call_name: call_name,
               parameter_name: parameter_name,
-              parameter_value: repo_config['payloadObject'][data_type]["#{call_name}.#{parameter_name}"],
+              parameter_value: param_val.blank? ? "" : param_val,
               optional: optional
           }
           last_config = config_attr.dup

--- a/app/models/analysis_parameter.rb
+++ b/app/models/analysis_parameter.rb
@@ -56,7 +56,7 @@ class AnalysisParameter
   # determine if values need to be scoped by a study or not
   def study_scoped?
     if self.associated_model.present?
-      self.associated_model_class.method_defined?(:study_id)
+      self.associated_model == "Study" || self.associated_model_class.method_defined?(:study_id)
     else
       false
     end


### PR DESCRIPTION
When configuring an analysis to use in SCP, optional input/output parameters (if not present in the methods repository configuration JSON inputs/outputs) will end up getting configured with a `null` value.  This causes a `400 Bad Request` error when trying to submit a workflow.  This patch ensures the default value of `""` if nothing is present for that given parameter.

This PR also addresses an issue with previewing workflow submission forms that have parameters directly associated with a study object, and not a file.

This PR satisfies SCP-2330.