### PR TITLE
API endpoints for metadata convention schemas (SCP-2322)

### DIFF
--- a/app/controllers/api/v1/api_docs_controller.rb
+++ b/app/controllers/api/v1/api_docs_controller.rb
@@ -54,6 +54,10 @@ module Api
           key :description, 'Study publication/data link operations'
         end
         tag do
+          key :name, 'MetadataSchemas'
+          key :description, 'Metadata Convention schema definitions'
+        end
+        tag do
           key :name, 'Schemas'
           key :description, 'Descriptions of SCP model schemas'
         end
@@ -97,6 +101,7 @@ module Api
           Api::V1::DirectoryListingsController,
           Api::V1::ExternalResourcesController,
           Api::V1::SchemasController,
+          Api::V1::MetadataSchemasController,
           Api::V1::TaxonsController,
           Api::V1::StatusController,
           Api::V1::SiteController,

--- a/app/controllers/api/v1/concerns/convention_schemas.rb
+++ b/app/controllers/api/v1/concerns/convention_schemas.rb
@@ -1,0 +1,24 @@
+module Api
+  module V1
+    module Concerns
+      module ConventionSchemas
+        extend ActiveSupport::Concern
+
+        SCHEMAS_BASE_DIR = Rails.root.join('lib', 'assets', 'metadata_schemas')
+
+        # load available metadata convention schemas from libdir
+        def set_available_schemas
+          schemas = {}
+          projects = Dir.entries(SCHEMAS_BASE_DIR).delete_if {|entry| entry.start_with?('.')}
+          projects.each do |project_name|
+            snapshots_path = SCHEMAS_BASE_DIR + "#{project_name}/snapshot"
+            snapshots = Dir.entries(snapshots_path).delete_if {|entry| entry.start_with?('.')}
+            versions = %w(latest) + Naturally.sort(snapshots).reverse
+            schemas[project_name] = versions
+          end
+          schemas
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/metadata_schemas_controller.rb
+++ b/app/controllers/api/v1/metadata_schemas_controller.rb
@@ -103,10 +103,9 @@ module Api
         schema_version = params[:version]
         @schema_pathname = SCHEMAS_BASE_DIR + project_name
         if schema_version != 'latest'
-          @schema_pathname += "snapshots/#{params[:version]}"
+          @schema_pathname += "snapshot/#{params[:version]}"
         end
         @schema_pathname += @schema_filename
-        @schema_pathname
       end
 
       def set_response_type

--- a/app/controllers/api/v1/metadata_schemas_controller.rb
+++ b/app/controllers/api/v1/metadata_schemas_controller.rb
@@ -1,0 +1,126 @@
+module Api
+  module V1
+    class MetadataSchemasController < ApiBaseController
+      include Swagger::Blocks
+      before_action :set_available_schemas, only: :index
+      before_action :set_schema_filename, only: :load_schema
+      before_action :set_schema_filepath, only: :load_schema
+      before_action :set_response_type, only: :load_schema
+
+      SCHEMAS_BASE_DIR = Rails.root.join('lib', 'assets', 'metadata_schemas')
+
+      swagger_path '/metadata_schemas' do
+        operation :get do
+          key :tags, [
+              'MetadataSchemas'
+          ]
+          key :summary, 'List all available metadata schemas'
+          key :description, 'Returns a list of all available metadata schemas, by project & version'
+          key :operationId, 'metadata_schemas_path'
+          response 200 do
+            key :description, 'list of available metadata convention schemas'
+          end
+        end
+      end
+
+      def index
+        render json: @schemas
+      end
+
+      swagger_path '/metadata_schemas/{project_name}/{version}/{schema_format}' do
+        operation :get do
+          key :tags, [
+              'MetadataSchemas'
+          ]
+          key :summary, 'Load a metadata convention schema file'
+          key :description, 'Returns a schema definition file for the requested metadata convention, in JSON or TSV format'
+          key :operationId, 'metadata_schemas_load_schema_path'
+          parameter do
+            key :name, :project_name
+            key :in, :path
+            key :description, 'Project name of metadata convention'
+            key :required, true
+            key :enum, %w(alexandria_convention)
+            key :type, :string
+          end
+          parameter do
+            key :name, :version
+            key :in, :path
+            key :description, 'Version of requested convention'
+            key :required, true
+            key :enum, %w(latest 2.0.0 1.1.5 1.1.4 1.1.3)
+            key :type, :string
+          end
+          parameter do
+            key :name, :schema_format
+            key :in, :path
+            key :description, 'File format of convention schema, either JSON or TSV'
+            key :required, true
+            key :enum, %w(json tsv)
+            key :type, :string
+          end
+          response 200 do
+            key :description, 'Metadata convention schema file in requested format'
+          end
+          response 404 do
+            key :description, ApiBaseController.not_found('Convention Metadata Schema')
+          end
+          response 500 do
+            key :description, 'Server error'
+          end
+        end
+      end
+
+      def load_schema
+        if File.exists?(@schema_pathname)
+          send_file @schema_pathname, type: @response_type, filename: @schema_filename
+        else
+          head 404 and return
+        end
+      end
+
+      private
+
+      def set_available_schemas
+        @schemas = {}
+        projects = Dir.entries(SCHEMAS_BASE_DIR).delete_if {|entry| entry.start_with?('.')}
+        projects.each do |project_name|
+          snapshots_path = SCHEMAS_BASE_DIR + "#{project_name}/snapshot"
+          snapshots = Dir.entries(snapshots_path).delete_if {|entry| entry.start_with?('.')}
+          versions = %w(latest) + Naturally.sort(snapshots).reverse
+          @schemas[project_name] = versions
+        end
+      end
+
+      def set_schema_filename
+        project_name = params[:project_name]
+        schema_format = params[:schema_format]
+        @schema_filename = "#{project_name}_schema.#{schema_format}"
+      end
+
+      def set_schema_filepath
+        project_name = params[:project_name]
+        schema_version = params[:version]
+        @schema_pathname = SCHEMAS_BASE_DIR + project_name
+        if schema_version != 'latest'
+          @schema_pathname += "snapshots/#{params[:version]}"
+        end
+        @schema_pathname += @schema_filename
+        @schema_pathname
+      end
+
+      def set_response_type
+        schema_format = params[:schema_format]
+        case schema_format
+        when 'json'
+          @response_type = 'application/json'
+        when 'tsv'
+          @response_type = 'text/plain'
+        else
+          @response_type = 'application/json'
+        end
+      end
+    end
+  end
+end
+

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -84,6 +84,7 @@ else
                     test/api/study_shares_controller_test.rb
                     test/api/directory_listings_controller_test.rb
                     test/api/external_resources_controller_test.rb
+                    test/api/metadata_schemas_controller_test.rb
                     test/models/cluster_group_test.rb # deprecated, but needed to set up for user_annotation_test
                     test/models/user_annotation_test.rb
                     test/models/study_test.rb

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,11 @@ Rails.application.routes.draw do
           get 'study_shares'
           get 'directory_listings'
         end
+        # convention metadata schemas endpoints
+        scope :metadata_schemas do
+          get '/', to: 'metadata_schemas#index', as: :metadata_schemas
+          get ':project_name/:version/:schema_format', to: 'metadata_schemas#load_schema', as: :metadata_schemas_load_convention_schema
+        end
         resources :taxons, only: [:index, :show]
         resources :studies, only: [:index, :show, :create, :update, :destroy] do
           post 'study_files/bundle', to: 'study_files#bundle', as: :study_files_bundle_files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,8 @@ Rails.application.routes.draw do
         # convention metadata schemas endpoints
         scope :metadata_schemas do
           get '/', to: 'metadata_schemas#index', as: :metadata_schemas
-          get ':project_name/:version/:schema_format', to: 'metadata_schemas#load_schema', as: :metadata_schemas_load_convention_schema
+          get ':project_name/:version/:schema_format', to: 'metadata_schemas#load_schema', as: :metadata_schemas_load_convention_schema,
+              constraints: {version: /.*/}
         end
         resources :taxons, only: [:index, :show]
         resources :studies, only: [:index, :show, :create, :update, :destroy] do

--- a/lib/assets/metadata_schemas/alexandria_convention/alexandria_convention_schema.json
+++ b/lib/assets/metadata_schemas/alexandria_convention/alexandria_convention_schema.json
@@ -1,0 +1,698 @@
+{
+    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata-schema/alexandria_convention/2.0.0/alexandria_convention_schema.json",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "dependencies": {
+        "cell_type__ontology_label": [
+            "cell_type"
+        ],
+        "culture_duration": [
+            "culture_duration__unit"
+        ],
+        "culture_duration__unit": [
+            "culture_duration"
+        ],
+        "culture_duration__unit_label": [
+            "culture_duration__unit"
+        ],
+        "development_stage__ontology_label": [
+            "development_stage"
+        ],
+        "disease__intracellular_pathogen": [
+            "disease"
+        ],
+        "disease__intracellular_pathogen__ontology_label": [
+            "disease__intracellular_pathogen"
+        ],
+        "disease__ontology_label": [
+            "disease"
+        ],
+        "disease__time_since_onset": [
+            "disease",
+            "disease__time_since_onset__unit"
+        ],
+        "disease__time_since_onset__unit": [
+            "disease__time_since_onset"
+        ],
+        "disease__time_since_onset__unit_label": [
+            "disease__time_since_onset__unit"
+        ],
+        "disease__time_since_treatment_start": [
+            "disease__treatment",
+            "disease__time_since_treatment_start__unit"
+        ],
+        "disease__time_since_treatment_start__unit": [
+            "disease__time_since_treatment_start"
+        ],
+        "disease__time_since_treatment_start__unit_label": [
+            "disease__time_since_treatment_start__unit"
+        ],
+        "disease__treated": [
+            "disease"
+        ],
+        "disease__treatment": [
+            "disease__treated"
+        ],
+        "enrichment__cell_type": [
+            "enrichment_method"
+        ],
+        "enrichment__cell_type__ontology_label": [
+            "enrichment__cell_type"
+        ],
+        "enrichment__facs_markers": [
+            "enrichment_method"
+        ],
+        "ethnicity__ontology_label": [
+            "ethnicity"
+        ],
+        "gene_perturbation__direction": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__dynamics": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__method": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__ontology_label": [
+            "gene_perturbation"
+        ],
+        "geographical_region__ontology_label": [
+            "geographical_region"
+        ],
+        "growth_factor_perturbation__concentration": [
+            "growth_factor_perturbation",
+            "growth_factor_perturbation__concentration__unit"
+        ],
+        "growth_factor_perturbation__concentration__unit": [
+            "growth_factor_perturbation__concentration"
+        ],
+        "growth_factor_perturbation__concentration__unit_label": [
+            "growth_factor_perturbation__concentration__unit"
+        ],
+        "growth_factor_perturbation__ontology_label": [
+            "growth_factor_perturbation"
+        ],
+        "growth_factor_perturbation__solvent": [
+            "growth_factor_perturbation"
+        ],
+        "growth_factor_perturbation__source": [
+            "growth_factor_perturbation"
+        ],
+        "library_preparation_protocol__ontology_label": [
+            "library_preparation_protocol"
+        ],
+        "mouse_strain__ontology_label": [
+            "mouse_strain"
+        ],
+        "organ__ontology_label": [
+            "organ"
+        ],
+        "organism_age": [
+            "organism_age__unit"
+        ],
+        "organism_age__unit": [
+            "organism_age"
+        ],
+        "organism_age__unit_label": [
+            "organism_age__unit"
+        ],
+        "race__ontology_label": [
+            "race"
+        ],
+        "sequencing_instrument_manufacturer_model__ontology_label": [
+            "sequencing_instrument_manufacturer_model"
+        ],
+        "small_molecule_perturbation__concentration": [
+            "small_molecule_perturbation",
+            "small_molecule_perturbation__concentration__unit"
+        ],
+        "small_molecule_perturbation__concentration__unit": [
+            "small_molecule_perturbation__concentration"
+        ],
+        "small_molecule_perturbation__concentration__unit_label": [
+            "small_molecule_perturbation__concentration__unit"
+        ],
+        "small_molecule_perturbation__ontology_label": [
+            "small_molecule_perturbation"
+        ],
+        "small_molecule_perturbation__solvent": [
+            "small_molecule_perturbation"
+        ],
+        "small_molecule_perturbation__source": [
+            "small_molecule_perturbation"
+        ],
+        "species__ontology_label": [
+            "species"
+        ],
+        "spike_in_concentration": [
+            "spike_in_kit"
+        ],
+        "vaccination__adjuvants": [
+            "vaccination"
+        ],
+        "vaccination__dosage": [
+            "vaccination"
+        ],
+        "vaccination__ontology_label": [
+            "vaccination"
+        ],
+        "vaccination__route": [
+            "vaccination"
+        ],
+        "vaccination__time_since": [
+            "vaccination",
+            "vaccination__time_since__unit"
+        ],
+        "vaccination__time_since__unit": [
+            "vaccination__time_since"
+        ],
+        "vaccination__time_since__unit_label": [
+            "vaccination__time_since__unit"
+        ]
+    },
+    "description": "metadata convention for the alexandria project",
+    "properties": {
+        "CellID": {
+            "description": "Cell ID",
+            "type": "string"
+        },
+        "biosample_id": {
+            "description": "Biosample ID",
+            "type": "string"
+        },
+        "biosample_type": {
+            "description": "Type of Biosample",
+            "enum": ["CellLine","DerivedType_Organoid","DerivedType_InVitroDifferentiated","DerivedType_InducedPluripotentStemCell","PrimaryBioSample","PrimaryBioSample_BodyFluid","PrimaryBioSample_CellFreeDNA","PrimaryBioSample_PrimaryCell","PrimaryBioSample_PrimaryCulture","PrimaryBioSample_Stool","PrimaryBioSample_Tissue"],
+            "type": "string"
+        },
+        "bmi": {
+            "description": "BMI of organism",
+            "type": "number"
+        },
+        "cell_type": {
+            "description": "Cell type name determined via unsupervised clustering and marker genes",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/cl",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "cell_type__ontology_label": {
+            "description": "cell_type__ontology_label",
+            "type": "string"
+        },
+        "culture_duration": {
+            "dependency_condition": "sample_type in cell line, organoid, cultured primary cells",
+            "description": "length of time cells have been in culture",
+            "type": "number"
+        },
+        "culture_duration__unit": {
+            "description": "culture_duration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "culture_duration__unit_label": {
+            "description": "culture_duration__unit_label",
+            "type": "string"
+        },
+        "development_stage": {
+            "description": "A classification of the developmental stage of the organism",
+            "ontology": "http://www.ebi.ac.uk/ols/api/ontologies/hsapdv",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "development_stage__ontology_label": {
+            "description": "development_stage__ontology_label",
+            "type": "string"
+        },
+        "disease": {
+            "description": "The disease state(s) of the individual donating the sample at the time of donation",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/mondo,https://www.ebi.ac.uk/ols/api/ontologies/pato",
+            "type": "array"
+        },
+        "disease__intracellular_pathogen": {
+            "description": "If evidence of a pathogen is detected in this cell",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/mondo",
+            "type": "array"
+        },
+        "disease__intracellular_pathogen__ontology_label": {
+            "description": "disease__intracellular_pathogen__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "disease__ontology_label": {
+            "description": "disease__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "disease__time_since_onset": {
+            "description": "Amount of time since disease onset",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "disease__time_since_onset__unit": {
+            "description": "disease__time_since_onset__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "disease__time_since_onset__unit_label": {
+            "description": "disease__time_since_onset__unit_label",
+            "type": "string"
+        },
+        "disease__time_since_treatment_start": {
+            "description": "Amount of time since treatment was started (for drugs/continuous treatment) or performed (for surgery/immediate intervention)",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "disease__time_since_treatment_start__unit": {
+            "description": "disease__time_since_treatment_start__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "disease__time_since_treatment_start__unit_label": {
+            "description": "disease__time_since_treatment_start__unit_label",
+            "type": "string"
+        },
+        "disease__treated": {
+            "description": "If the donor was treated at the time the sample was collected",
+            "items": {
+                "type": "boolean"
+            },
+            "type": "array"
+        },
+        "disease__treatment": {
+            "description": "A description of the treatment given to this donor",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "donor_id": {
+            "description": "Donor ID",
+            "type": "string"
+        },
+        "end_bias": {
+            "description": "The end bias of the library preparation protocol used",
+            "enum": ["3 prime tag", "3 prime end bias", "5 prime tag", "5 prime end bias", "full length"],
+            "type": "string"
+        },
+        "enrichment__cell_type": {
+            "description": "The cell type that was sorted via an enrichment technique such as flow cytometry.",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/cl",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "enrichment__cell_type__ontology_label": {
+            "description": "enrichment__cell_type__ontology_label",
+            "type": "string"
+        },
+        "enrichment__facs_markers": {
+            "description": "The surface markers that were sorted on to enrich for the enriched cell type if flow cytometry was used",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "enrichment_method": {
+            "description": "Method used to enrich cells before running library preparation. This could be flow cytometry, column enrichments, etc.",
+            "items": {
+                "enum": ["cell size selection", "fluorescence-activated cell sorting", "magnetic affinity cell sorting", "laser capture microdissection", "density gradient centrifugation", "Ficoll-Hypaque method", "enrichment of methylated DNA"],
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "ethnicity": {
+            "dependency_condition": "species == NCBITaxon_9606",
+            "description": "The ethnicity or ethnicities of the human donor if known",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/hancestro",
+            "type": "array"
+        },
+        "ethnicity__ontology_label": {
+            "description": "ethnicity__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "gene_perturbation": {
+            "description": "A perturbation to a gene done to a cell culture",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ogg",
+            "type": "array"
+        },
+        "gene_perturbation__direction": {
+            "description": "The type of perturbation of the gene defined in gene_perturbation. Knock in and knock out are complete additions/depletions of the gene, activation and repression refer to changes in magnitude of expression.",
+            "enum": ["knock in", "knock out","activation","repression"],
+            "type": "string"
+        },
+        "gene_perturbation__dynamics": {
+            "description": "Description of the timing with respect to sequencing and other logistical considerations of the gene perturbation",
+            "type": "string"
+        },
+        "gene_perturbation__method": {
+            "description": "Process by which the gene was perturbed. Ex. CRISPR knock-out",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "gene_perturbation__ontology_label": {
+            "description": "gene_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "geographical_region": {
+            "description": "Location where the sample was collected/donated",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/gaz",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "geographical_region__ontology_label": {
+            "description": "geographical_region__ontology_label",
+            "type": "string"
+        },
+        "growth_factor_perturbation": {
+            "dependency_condition": "sample_type in cell line, organoid, cultured primary cells",
+            "description": "a growth factor added to a cell culture media",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/pr",
+            "type": "array"
+        },
+        "growth_factor_perturbation__concentration": {
+            "description": "Concentration of of each growth factor in the final tissue culture media. Order should be consistent with growth_factor_perturbation",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__concentration__unit": {
+            "description": "growth_factor_perturbation__concentration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "growth_factor_perturbation__concentration__unit_label": {
+            "description": "growth_factor_perturbation__concentration__unit_label",
+            "type": "string"
+        },
+        "growth_factor_perturbation__ontology_label": {
+            "description": "growth_factor_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__solvent": {
+            "description": "Solvent in which the growth factor was added to the cells. Ex. the base media.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__source": {
+            "description": "Source from which the growth factor was purchased",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "is_living": {
+            "description": "Whether organism was alive at time of biomaterial collection",
+            "enum": ["yes", "no", "unknown"],
+            "type": "string"
+        },
+        "library_preparation_protocol": {
+            "description": "The single cell RNA-sequencing protocol used for Library preparation",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/efo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "library_preparation_protocol__ontology_label": {
+            "description": "library_preparation_protocol__ontology_label",
+            "type": "string"
+        },
+        "mhc_genotype": {
+            "description": "MHC genotype for humans and other species",
+            "type": "string"
+        },
+        "mouse_strain": {
+            "dependency_condition": "species == NCBITaxon_10090",
+            "description": "Mouse strain of the donor organism (ex. C57BL/6, BALB/c, 129, undetermined)",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncit",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "mouse_strain__ontology_label": {
+            "description": "mouse_strain__ontology_label",
+            "type": "string"
+        },
+        "number_of_reads": {
+            "description": "Number of reads mapped to that cell",
+            "type": "number"
+        },
+        "organ": {
+            "description": "The organ that the biomaterial came from",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uberon",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "organ__ontology_label": {
+            "description": "organ__ontology_label",
+            "type": "string"
+        },
+        "organism_age": {
+            "description": "Age of the organism at time of sample collection.",
+            "type": "number"
+        },
+        "organism_age__unit": {
+            "description": "organism_age__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "organism_age__unit_label": {
+            "description": "organism_age__unit_label",
+            "type": "string"
+        },
+        "paired_ends": {
+            "description": "true if the sequence library has paired end data (false for 10x)",
+            "type": "boolean"
+        },
+        "preservation_method": {
+            "description": "Method used for sample preservation",
+            "enum": ["Cryopreservation","FFPE","Fresh","Frozen","OCT-embedded","Snap","Frozen"],
+            "type": "string"
+        },
+        "primer": {
+            "description": "Primer used for cDNA synthesis from RNA",
+            "enum": ["poly-dT","random"],
+            "type": "string"
+        },
+        "race": {
+            "dependency_condition": "species == NCBITaxon_9606",
+            "description": "An arbitrary classification of a taxonomic group that is a division of a species",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncit",
+            "type": "array"
+        },
+        "race__ontology_label": {
+            "description": "race__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "read_length": {
+            "description": "the read structure of the sequencing run",
+            "type": "string"
+        },
+        "sequencing_instrument_manufacturer_model": {
+            "description": "name of sequencing instrument manufacturer",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/efo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "sequencing_instrument_manufacturer_model__ontology_label": {
+            "description": "sequencing_instrument_manufacturer_model__ontology_label",
+            "type": "string"
+        },
+        "sex": {
+            "description": "Biological sex",
+            "enum": ["male", "female", "mixed", "unknown"],
+            "type": "string"
+        },
+        "small_molecule_perturbation": {
+            "description": "a small molecule added to a cell culture (ex. A drug) growth factor (and if it is recombinant, concentration), gene)",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/chebi",
+            "type": "array"
+        },
+        "small_molecule_perturbation__concentration": {
+            "description": "Concentration of each small molecule in the final tissue culture media. Order should be consistent with small_molecule_perturbation",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__concentration__unit": {
+            "description": "small_molecule_perturbation__concentration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "small_molecule_perturbation__concentration__unit_label": {
+            "description": "small_molecule_perturbation__concentration__unit_label",
+            "type": "string"
+        },
+        "small_molecule_perturbation__ontology_label": {
+            "description": "small_molecule_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__solvent": {
+            "description": "Solvent in which the small molecule was added to the cells. Ex. the base media.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__source": {
+            "description": "Source from which the small molecule was purchased",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "species": {
+            "description": "The scientific binomial name for the species of the organism.",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "species__ontology_label": {
+            "description": "species__ontology_label",
+            "type": "string"
+        },
+        "spike_in_concentration": {
+            "description": "spike in concentration",
+            "type": "string"
+        },
+        "spike_in_kit": {
+            "description": "name of spike in kit",
+            "type": "string"
+        },
+        "strand": {
+            "description": "library strandedness",
+            "enum": ["first","second","unstranded"],
+            "type": "string"
+        },
+        "vaccination": {
+            "description": "Any known vaccines administered to the donor organism. NOT a full vaccine history",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/vo",
+            "type": "array"
+        },
+        "vaccination__adjuvants": {
+            "description": "Any adjuvants administered in the vaccine",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__dosage": {
+            "description": "The dosage and units for the vaccine",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__ontology_label": {
+            "description": "vaccination__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__route": {
+            "description": "Intradermal, Intranasal, Intravenous, Aerosol",
+            "items": {
+                "enum": ["intradermal", "intranasal", "intravenous", "aerosol", "intramuscular", "mucosal", "oral"],
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__time_since": {
+            "description": "Amount of time since vaccine was administered",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "vaccination__time_since__unit": {
+            "description": "Time since each vaccine in the vaccination field was administered",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "vaccination__time_since__unit_label": {
+            "description": "vaccination__time_since__unit_label",
+            "type": "string"
+        }
+    },
+    "required": [
+        "biosample_id",
+        "biosample_type",
+        "CellID",
+        "disease",
+        "disease__ontology_label",
+        "donor_id",
+        "library_preparation_protocol",
+        "library_preparation_protocol__ontology_label",
+        "organ",
+        "organ__ontology_label",
+        "sex",
+        "species",
+        "species__ontology_label"
+    ],
+    "title": "alexandria metadata convention"
+}

--- a/lib/assets/metadata_schemas/alexandria_convention/alexandria_convention_schema.json
+++ b/lib/assets/metadata_schemas/alexandria_convention/alexandria_convention_schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata_schemas/alexandria_convention/2.0.0/json",
+    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata_schemas/alexandria_convention/latest/json",
     "$schema": "https://json-schema.org/draft-07/schema#",
     "dependencies": {
         "cell_type__ontology_label": [

--- a/lib/assets/metadata_schemas/alexandria_convention/alexandria_convention_schema.json
+++ b/lib/assets/metadata_schemas/alexandria_convention/alexandria_convention_schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata-schema/alexandria_convention/2.0.0/alexandria_convention_schema.json",
+    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata_schemas/alexandria_convention/2.0.0/json",
     "$schema": "https://json-schema.org/draft-07/schema#",
     "dependencies": {
         "cell_type__ontology_label": [

--- a/lib/assets/metadata_schemas/alexandria_convention/alexandria_convention_schema.tsv
+++ b/lib/assets/metadata_schemas/alexandria_convention/alexandria_convention_schema.tsv
@@ -1,0 +1,87 @@
+attribute	required	type	array	class	ontology	ontology_root	controlled_list_entries	dependency	dependency_condition	dependent	attribute_description
+biosample_id	Yes	string									Biosample ID
+biosample_type	Yes	string		enum			"[""CellLine"",""DerivedType_Organoid"",""DerivedType_InVitroDifferentiated"",""DerivedType_InducedPluripotentStemCell"",""PrimaryBioSample"",""PrimaryBioSample_BodyFluid"",""PrimaryBioSample_CellFreeDNA"",""PrimaryBioSample_PrimaryCell"",""PrimaryBioSample_PrimaryCulture"",""PrimaryBioSample_Stool"",""PrimaryBioSample_Tissue""]"				Type of Biosample
+CellID	Yes	string									Cell ID
+disease	Yes	string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/mondo,https://www.ebi.ac.uk/ols/api/ontologies/pato	MONDO_0000001					The disease state(s) of the individual donating the sample at the time of donation
+disease__ontology_label	Yes	string	TRUE	ontology_label				disease			disease__ontology_label
+donor_id	Yes	string									Donor ID
+library_preparation_protocol	Yes	string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/efo	OBI_0000711					The single cell RNA-sequencing protocol used for Library preparation
+library_preparation_protocol__ontology_label	Yes	string		ontology_label				library_preparation_protocol			library_preparation_protocol__ontology_label
+organ	Yes	string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uberon	UBERON_0000465					The organ that the biomaterial came from
+organ__ontology_label	Yes	string		ontology_label				organ			organ__ontology_label
+sex	Yes	string		enum			"[""male"", ""female"", ""mixed"", ""unknown""]"				Biological sex
+species	Yes	string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon	NCBITaxon_2759					The scientific binomial name for the species of the organism.
+species__ontology_label	Yes	string		ontology_label				species			species__ontology_label
+bmi		number									BMI of organism
+cell_type		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/cl	CL_0000548					Cell type name determined via unsupervised clustering and marker genes
+cell_type__ontology_label		string		ontology_label				cell_type			cell_type__ontology_label
+culture_duration		number							sample_type in cell line, organoid, cultured primary cells	culture_duration__unit	length of time cells have been in culture
+culture_duration__unit		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		culture_duration			culture_duration__unit
+culture_duration__unit_label		string		unit_label				culture_duration__unit			culture_duration__unit_label
+development_stage		string		ontology	http://www.ebi.ac.uk/ols/api/ontologies/hsapdv						A classification of the developmental stage of the organism
+development_stage__ontology_label		string		ontology_label				development_stage			development_stage__ontology_label
+disease__intracellular_pathogen		string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/mondo	MONDO_0005550		disease			If evidence of a pathogen is detected in this cell
+disease__intracellular_pathogen__ontology_label		string	TRUE	ontology_label				disease__intracellular_pathogen			disease__intracellular_pathogen__ontology_label
+disease__time_since_onset		number	TRUE					disease		disease__time_since_onset__unit	Amount of time since disease onset
+disease__time_since_onset__unit		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		disease__time_since_onset			disease__time_since_onset__unit
+disease__time_since_onset__unit_label		string		unit_label				disease__time_since_onset__unit			disease__time_since_onset__unit_label
+disease__time_since_treatment_start		number	TRUE					disease__treatment		disease__time_since_treatment_start__unit	Amount of time since treatment was started (for drugs/continuous treatment) or performed (for surgery/immediate intervention)
+disease__time_since_treatment_start__unit		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		disease__time_since_treatment_start			disease__time_since_treatment_start__unit
+disease__time_since_treatment_start__unit_label		string		unit_label				disease__time_since_treatment_start__unit			disease__time_since_treatment_start__unit_label
+disease__treated		boolean	TRUE					disease			If the donor was treated at the time the sample was collected
+disease__treatment		string	TRUE					disease__treated			A description of the treatment given to this donor
+end_bias		string		enum			"[""3 prime tag"", ""3 prime end bias"", ""5 prime tag"", ""5 prime end bias"", ""full length""]"				The end bias of the library preparation protocol used
+enrichment__cell_type		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/cl	CL_0000548		enrichment_method			The cell type that was sorted via an enrichment technique such as flow cytometry.
+enrichment__cell_type__ontology_label		string		ontology_label				enrichment__cell_type			enrichment__cell_type__ontology_label
+enrichment__facs_markers		string	TRUE					enrichment_method			The surface markers that were sorted on to enrich for the enriched cell type if flow cytometry was used
+enrichment_method		string	TRUE	enum			"[""cell size selection"", ""fluorescence-activated cell sorting"", ""magnetic affinity cell sorting"", ""laser capture microdissection"", ""density gradient centrifugation"", ""Ficoll-Hypaque method"", ""enrichment of methylated DNA""]"				Method used to enrich cells before running library preparation. This could be flow cytometry, column enrichments, etc.
+ethnicity		string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/hancestro	HANCESTRO:0004			species == NCBITaxon_9606		The ethnicity or ethnicities of the human donor if known
+ethnicity__ontology_label		string	TRUE	ontology_label				ethnicity			ethnicity__ontology_label
+gene_perturbation		string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/ogg	OGG_0000000002					A perturbation to a gene done to a cell culture
+gene_perturbation__direction		string		enum			"[""knock in"", ""knock out"",""activation"",""repression""]"	gene_perturbation			The type of perturbation of the gene defined in gene_perturbation. Knock in and knock out are complete additions/depletions of the gene, activation and repression refer to changes in magnitude of expression.
+gene_perturbation__dynamics		string						gene_perturbation			Description of the timing with respect to sequencing and other logistical considerations of the gene perturbation
+gene_perturbation__method		string	TRUE					gene_perturbation			Process by which the gene was perturbed. Ex. CRISPR knock-out
+gene_perturbation__ontology_label		string	TRUE	ontology_label				gene_perturbation			gene_perturbation__ontology_label
+geographical_region		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/gaz	GAZ_00000013					Location where the sample was collected/donated
+geographical_region__ontology_label		string		ontology_label				geographical_region			geographical_region__ontology_label
+growth_factor_perturbation		string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/pr	PR_000000001			sample_type in cell line, organoid, cultured primary cells		a growth factor added to a cell culture media
+growth_factor_perturbation__concentration		number	TRUE					growth_factor_perturbation		growth_factor_perturbation__concentration__unit	Concentration of of each growth factor in the final tissue culture media. Order should be consistent with growth_factor_perturbation
+growth_factor_perturbation__concentration__unit		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		growth_factor_perturbation__concentration			growth_factor_perturbation__concentration__unit
+growth_factor_perturbation__concentration__unit_label		string		unit_label				growth_factor_perturbation__concentration__unit			growth_factor_perturbation__concentration__unit_label
+growth_factor_perturbation__ontology_label		string	TRUE	ontology_label				growth_factor_perturbation			growth_factor_perturbation__ontology_label
+growth_factor_perturbation__solvent		string	TRUE					growth_factor_perturbation			Solvent in which the growth factor was added to the cells. Ex. the base media.
+growth_factor_perturbation__source		string	TRUE					growth_factor_perturbation			Source from which the growth factor was purchased
+is_living		string		enum			"[""yes"", ""no"", ""unknown""]"				Whether organism was alive at time of biomaterial collection
+mhc_genotype		string									MHC genotype for humans and other species
+mouse_strain		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncit	"NCIT_C14420 "			species == NCBITaxon_10090		Mouse strain of the donor organism (ex. C57BL/6, BALB/c, 129, undetermined)
+mouse_strain__ontology_label		string		ontology_label				mouse_strain			mouse_strain__ontology_label
+number_of_reads		number									Number of reads mapped to that cell
+organism_age		number								organism_age__unit	Age of the organism at time of sample collection.
+organism_age__unit		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		organism_age			organism_age__unit
+organism_age__unit_label		string		unit_label				organism_age__unit			organism_age__unit_label
+paired_ends		boolean									true if the sequence library has paired end data (false for 10x)
+preservation_method		string		enum			"[""Cryopreservation"",""FFPE"",""Fresh"",""Frozen"",""OCT-embedded"",""Snap"",""Frozen""]"				Method used for sample preservation
+primer		string		enum			"[""poly-dT"",""random""]"				Primer used for cDNA synthesis from RNA
+race		string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncit	NCIT:C17049			species == NCBITaxon_9606		An arbitrary classification of a taxonomic group that is a division of a species
+race__ontology_label		string	TRUE	ontology_label				race			race__ontology_label
+read_length		string									the read structure of the sequencing run
+sequencing_instrument_manufacturer_model		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/efo	EFO_0003739					name of sequencing instrument manufacturer
+sequencing_instrument_manufacturer_model__ontology_label		string		ontology_label				sequencing_instrument_manufacturer_model			sequencing_instrument_manufacturer_model__ontology_label
+small_molecule_perturbation		string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/chebi	CHEBI_24431					a small molecule added to a cell culture (ex. A drug) growth factor (and if it is recombinant, concentration), gene)
+small_molecule_perturbation__concentration		number	TRUE					small_molecule_perturbation		small_molecule_perturbation__concentration__unit	Concentration of each small molecule in the final tissue culture media. Order should be consistent with small_molecule_perturbation
+small_molecule_perturbation__concentration__unit		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		small_molecule_perturbation__concentration			small_molecule_perturbation__concentration__unit
+small_molecule_perturbation__concentration__unit_label		string		unit_label				small_molecule_perturbation__concentration__unit			small_molecule_perturbation__concentration__unit_label
+small_molecule_perturbation__ontology_label		string	TRUE	ontology_label				small_molecule_perturbation			small_molecule_perturbation__ontology_label
+small_molecule_perturbation__solvent		string	TRUE					small_molecule_perturbation			Solvent in which the small molecule was added to the cells. Ex. the base media.
+small_molecule_perturbation__source		string	TRUE					small_molecule_perturbation			Source from which the small molecule was purchased
+spike_in_concentration		string						spike_in_kit			spike in concentration
+spike_in_kit		string									name of spike in kit
+strand		string		enum			"[""first"",""second"",""unstranded""]"				library strandedness
+vaccination		string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/vo	VO_0000001					Any known vaccines administered to the donor organism. NOT a full vaccine history
+vaccination__adjuvants		string	TRUE					vaccination			Any adjuvants administered in the vaccine
+vaccination__dosage		string	TRUE					vaccination			The dosage and units for the vaccine
+vaccination__ontology_label		string	TRUE	ontology_label				vaccination			vaccination__ontology_label
+vaccination__route		string	TRUE	enum			"[""intradermal"", ""intranasal"", ""intravenous"", ""aerosol"", ""intramuscular"", ""mucosal"", ""oral""]"	vaccination			Intradermal, Intranasal, Intravenous, Aerosol
+vaccination__time_since		number	TRUE					vaccination		vaccination__time_since__unit	Amount of time since vaccine was administered
+vaccination__time_since__unit		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		vaccination__time_since			Time since each vaccine in the vaccination field was administered
+vaccination__time_since__unit_label		string		unit_label				vaccination__time_since__unit			vaccination__time_since__unit_label

--- a/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.3/alexandria_convention_schema.json
+++ b/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.3/alexandria_convention_schema.json
@@ -1,0 +1,695 @@
+{
+    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata-schemas/Alexandria.schema.json",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "dependencies": {
+        "cell_type__ontology_label": [
+            "cell_type"
+        ],
+        "culture_duration": [
+            "culture_duration__unit"
+        ],
+        "culture_duration__unit": [
+            "culture_duration"
+        ],
+        "culture_duration__unit_label": [
+            "culture_duration__unit"
+        ],
+        "development_stage__ontology_label": [
+            "development_stage"
+        ],
+        "disease__intracellular_pathogen": [
+            "disease"
+        ],
+        "disease__intracellular_pathogen__ontology_label": [
+            "disease__intracellular_pathogen"
+        ],
+        "disease__ontology_label": [
+            "disease"
+        ],
+        "disease__time_since_onset": [
+            "disease",
+            "disease__time_since_onset__unit"
+        ],
+        "disease__time_since_onset__unit": [
+            "disease__time_since_onset"
+        ],
+        "disease__time_since_onset__unit_label": [
+            "disease__time_since_onset__unit"
+        ],
+        "disease__time_since_treatment_start": [
+            "disease__treatment",
+            "disease__time_since_treatment_start__unit"
+        ],
+        "disease__time_since_treatment_start__unit": [
+            "disease__time_since_treatment_start"
+        ],
+        "disease__time_since_treatment_start__unit_label": [
+            "disease__time_since_treatment_start__unit"
+        ],
+        "disease__treated": [
+            "disease"
+        ],
+        "disease__treatment": [
+            "disease__treated"
+        ],
+        "enrichment__cell_type": [
+            "enrichment_method"
+        ],
+        "enrichment__cell_type__ontology_label": [
+            "enrichment__cell_type"
+        ],
+        "enrichment__facs_markers": [
+            "enrichment_method"
+        ],
+        "ethnicity__ontology_label": [
+            "ethnicity"
+        ],
+        "gene_perturbation__direction": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__dynamics": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__method": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__ontology_label": [
+            "gene_perturbation"
+        ],
+        "geographical_region__ontology_label": [
+            "geographical_region"
+        ],
+        "growth_factor_perturbation__concentration": [
+            "growth_factor_perturbation",
+            "growth_factor_perturbation__concentration__unit"
+        ],
+        "growth_factor_perturbation__concentration__unit": [
+            "growth_factor_perturbation__concentration"
+        ],
+        "growth_factor_perturbation__concentration__unit_label": [
+            "growth_factor_perturbation__concentration__unit"
+        ],
+        "growth_factor_perturbation__ontology_label": [
+            "growth_factor_perturbation"
+        ],
+        "growth_factor_perturbation__solvent": [
+            "growth_factor_perturbation"
+        ],
+        "growth_factor_perturbation__source": [
+            "growth_factor_perturbation"
+        ],
+        "library_preparation_protocol__ontology_label": [
+            "library_preparation_protocol"
+        ],
+        "mouse_strain__ontology_label": [
+            "mouse_strain"
+        ],
+        "organ__ontology_label": [
+            "organ"
+        ],
+        "organism_age": [
+            "organism_age__unit"
+        ],
+        "organism_age__unit": [
+            "organism_age"
+        ],
+        "organism_age__unit_label": [
+            "organism_age__unit"
+        ],
+        "race__ontology_label": [
+            "race"
+        ],
+        "sequencing_instrument_manufacturer_model__ontology_label": [
+            "sequencing_instrument_manufacturer_model"
+        ],
+        "small_molecule_perturbation__concentration": [
+            "small_molecule_perturbation",
+            "small_molecule_perturbation__concentration__unit"
+        ],
+        "small_molecule_perturbation__concentration__unit": [
+            "small_molecule_perturbation__concentration"
+        ],
+        "small_molecule_perturbation__concentration__unit_label": [
+            "small_molecule_perturbation__concentration__unit"
+        ],
+        "small_molecule_perturbation__ontology_label": [
+            "small_molecule_perturbation"
+        ],
+        "small_molecule_perturbation__solvent": [
+            "small_molecule_perturbation"
+        ],
+        "small_molecule_perturbation__source": [
+            "small_molecule_perturbation"
+        ],
+        "species__ontology_label": [
+            "species"
+        ],
+        "spike_in_concentration": [
+            "spike_in_kit"
+        ],
+        "vaccination__adjuvants": [
+            "vaccination"
+        ],
+        "vaccination__dosage": [
+            "vaccination"
+        ],
+        "vaccination__ontology_label": [
+            "vaccination"
+        ],
+        "vaccination__route": [
+            "vaccination"
+        ],
+        "vaccination__time_since": [
+            "vaccination",
+            "vaccination__time_since__unit"
+        ],
+        "vaccination__time_since__unit": [
+            "vaccination__time_since"
+        ],
+        "vaccination__time_since__unit_label": [
+            "vaccination__time_since__unit"
+        ]
+    },
+    "description": "Metadata convention for the Alexandria project",
+    "properties": {
+        "CellID": {
+            "description": "Cell ID",
+            "type": "string"
+        },
+        "biosample_id": {
+            "type": "string"
+        },
+        "bmi": {
+            "description": "BMI of organism",
+            "type": "number"
+        },
+        "cell_type": {
+            "description": "Cell type name determined via unsupervised clustering and marker genes",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/cl",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "cell_type__ontology_label": {
+            "description": "cell_type__ontology_label",
+            "type": "string"
+        },
+        "culture_duration": {
+            "dependency_condition": "sample_type in cell line, organoid, cultured primary cells",
+            "description": "length of time cells have been in culture",
+            "type": "number"
+        },
+        "culture_duration__unit": {
+            "description": "culture_duration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "culture_duration__unit_label": {
+            "description": "culture_duration__unit_label",
+            "type": "string"
+        },
+        "development_stage": {
+            "description": "A classification of the developmental stage of the organism",
+            "ontology": "http://www.ebi.ac.uk/ols/api/ontologies/hsapdv",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "development_stage__ontology_label": {
+            "description": "development_stage__ontology_label",
+            "type": "string"
+        },
+        "disease": {
+            "default": "MONDO_0000001",
+            "description": "The disease state(s) of the individual donating the sample at the time of donation",
+            "items": {
+                "pattern": "^[A-Za-z]+[_:][0-9]",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/mondo",
+            "type": "array"
+        },
+        "disease__intracellular_pathogen": {
+            "description": "If evidence of a pathogen is detected in this cell",
+            "items": {
+                "pattern": "^[A-Za-z]+[_:][0-9]",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/mondo",
+            "type": "array"
+        },
+        "disease__intracellular_pathogen__ontology_label": {
+            "description": "disease__intracellular_pathogen__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "disease__ontology_label": {
+            "description": "disease__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "disease__time_since_onset": {
+            "description": "Amount of time since disease onset",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "disease__time_since_onset__unit": {
+            "description": "disease__time_since_onset__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "disease__time_since_onset__unit_label": {
+            "description": "disease__time_since_onset__unit_label",
+            "type": "string"
+        },
+        "disease__time_since_treatment_start": {
+            "description": "Amount of time since treatment was started (for drugs/continuous treatment) or performed (for surgery/immediate intervention)",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "disease__time_since_treatment_start__unit": {
+            "description": "disease__time_since_treatment_start__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "disease__time_since_treatment_start__unit_label": {
+            "description": "disease__time_since_treatment_start__unit_label",
+            "type": "string"
+        },
+        "disease__treated": {
+            "description": "If the donor was treated at the time the sample was collected",
+            "items": {
+                "type": "boolean"
+            },
+            "type": "array"
+        },
+        "disease__treatment": {
+            "description": "A description of the treatment given to this donor",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "donor_id": {
+            "description": "Donor ID",
+            "type": "string"
+        },
+        "end_bias": {
+            "description": "The end bias of the library preparation protocol used",
+            "enum": ["3 prime tag", "3 prime end bias", "5 prime tag", "5 prime end bias", "full length"],
+            "type": "string"
+        },
+        "enrichment__cell_type": {
+            "description": "The cell type that was sorted via an enrichment technique such as flow cytometry.",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/cl",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "enrichment__cell_type__ontology_label": {
+            "description": "enrichment__cell_type__ontology_label",
+            "type": "string"
+        },
+        "enrichment__facs_markers": {
+            "description": "The surface markers that were sorted on to enrich for the enriched cell type if flow cytometry was used",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "enrichment_method": {
+            "description": "Method used to enrich cells before running library preparation. This could be flow cytometry, column enrichments, etc.",
+            "items": {
+                "enum": ["cell size selection", "fluorescence-activated cell sorting", "magnetic affinity cell sorting", "laser capture microdissection", "density gradient centrifugation", "Ficoll-Hypaque method", "enrichment of methylated DNA"],
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "ethnicity": {
+            "dependency_condition": "species == NCBITaxon_9606",
+            "description": "The ethnicity or ethnicities of the human donor if known",
+            "items": {
+                "pattern": "^[A-Za-z]+[_:][0-9]",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/hancestro",
+            "type": "array"
+        },
+        "ethnicity__ontology_label": {
+            "description": "ethnicity__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "gene_perturbation": {
+            "description": "A perturbation to a gene done to a cell culture",
+            "items": {
+                "pattern": "^[A-Za-z]+[_:][0-9]",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ogg",
+            "type": "array"
+        },
+        "gene_perturbation__direction": {
+            "description": "The type of perturbation of the gene defined in gene_perturbation. Knock in and knock out are complete additions/depletions of the gene, activation and repression refer to changes in magnitude of expression.",
+            "enum": ["knock in", "knock out","activation","repression"],
+            "type": "string"
+        },
+        "gene_perturbation__dynamics": {
+            "description": "Description of the timing with respect to sequencing and other logistical considerations of the gene perturbation",
+            "type": "string"
+        },
+        "gene_perturbation__method": {
+            "description": "Process by which the gene was perturbed. Ex. CRISPR knock-out",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "gene_perturbation__ontology_label": {
+            "description": "gene_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "geographical_region": {
+            "description": "Location where the sample was collected/donated",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/gaz",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "geographical_region__ontology_label": {
+            "description": "geographical_region__ontology_label",
+            "type": "string"
+        },
+        "growth_factor_perturbation": {
+            "dependency_condition": "sample_type in cell line, organoid, cultured primary cells",
+            "description": "a growth factor added to a cell culture media",
+            "items": {
+                "pattern": "^[A-Za-z]+[_:][0-9]",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/pr",
+            "type": "array"
+        },
+        "growth_factor_perturbation__concentration": {
+            "description": "Concentration of of each growth factor in the final tissue culture media. Order should be consistent with growth_factor_perturbation",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__concentration__unit": {
+            "description": "growth_factor_perturbation__concentration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "growth_factor_perturbation__concentration__unit_label": {
+            "description": "growth_factor_perturbation__concentration__unit_label",
+            "type": "string"
+        },
+        "growth_factor_perturbation__ontology_label": {
+            "description": "growth_factor_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__solvent": {
+            "description": "Solvent in which the growth factor was added to the cells. Ex. the base media.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__source": {
+            "description": "Source from which the growth factor was purchased",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "is_living": {
+            "description": "Whether organism was alive at time of biomaterial collection",
+            "enum": ["yes", "no", "unknown"],
+            "type": "string"
+        },
+        "library_preparation_protocol": {
+            "description": "The single cell RNA-sequencing protocol used for Library preparation",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/efo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "library_preparation_protocol__ontology_label": {
+            "description": "library_preparation_protocol__ontology_label",
+            "type": "string"
+        },
+        "mhc_genotype": {
+            "description": "MHC genotype for humans and other species",
+            "type": "string"
+        },
+        "mouse_strain": {
+            "dependency_condition": "species == NCBITaxon_10090",
+            "description": "Mouse strain of the donor organism (ex. C57BL/6, BALB/c, 129, undetermined)",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncit",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "mouse_strain__ontology_label": {
+            "description": "mouse_strain__ontology_label",
+            "type": "string"
+        },
+        "number_of_reads": {
+            "description": "Number of reads mapped to that cell",
+            "type": "number"
+        },
+        "organ": {
+            "description": "The organ that the biomaterial came from",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uberon",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "organ__ontology_label": {
+            "description": "organ__ontology_label",
+            "type": "string"
+        },
+        "organism_age": {
+            "description": "Age of the organism at time of sample collection.",
+            "type": "number"
+        },
+        "organism_age__unit": {
+            "description": "organism_age__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "organism_age__unit_label": {
+            "description": "organism_age__unit_label",
+            "type": "string"
+        },
+        "paired_ends": {
+            "description": "true if the sequence library has paired end data (false for 10x)",
+            "type": "boolean"
+        },
+        "primer": {
+            "description": "Primer used for cDNA synthesis from RNA",
+            "enum": ["poly-dT","random"],
+            "type": "string"
+        },
+        "race": {
+            "dependency_condition": "species == NCBITaxon_9606",
+            "description": "An arbitrary classification of a taxonomic group that is a division of a species",
+            "items": {
+                "pattern": "^[A-Za-z]+[_:][0-9]",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncit",
+            "type": "array"
+        },
+        "race__ontology_label": {
+            "description": "race__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "read_length": {
+            "description": "the read structure of the sequencing run",
+            "type": "string"
+        },
+        "sample_type": {
+            "description": "one of: cell line, organoid, direct from donor (fresh), direct from donor (frozen), cultured primary cells",
+            "enum": ["cell line", "organoid", "direct from donor - fresh", "direct from donor - frozen", "cultured primary cells"],
+            "type": "string"
+        },
+        "sequencing_instrument_manufacturer_model": {
+            "description": "name of sequencing instrument manufacturer",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/efo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "sequencing_instrument_manufacturer_model__ontology_label": {
+            "description": "sequencing_instrument_manufacturer_model__ontology_label",
+            "type": "string"
+        },
+        "sex": {
+            "default": "unknown",
+            "description": "Biological sex",
+            "enum": ["male", "female", "mixed", "unknown"],
+            "type": "string"
+        },
+        "small_molecule_perturbation": {
+            "description": "a small molecule added to a cell culture (ex. A drug) growth factor (and if it is recombinant, concentration), gene)",
+            "items": {
+                "pattern": "^[A-Za-z]+[_:][0-9]",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/chebi",
+            "type": "array"
+        },
+        "small_molecule_perturbation__concentration": {
+            "description": "Concentration of each small molecule in the final tissue culture media. Order should be consistent with small_molecule_perturbation",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__concentration__unit": {
+            "description": "small_molecule_perturbation__concentration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "small_molecule_perturbation__concentration__unit_label": {
+            "description": "small_molecule_perturbation__concentration__unit_label",
+            "type": "string"
+        },
+        "small_molecule_perturbation__ontology_label": {
+            "description": "small_molecule_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__solvent": {
+            "description": "Solvent in which the small molecule was added to the cells. Ex. the base media.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__source": {
+            "description": "Source from which the small molecule was purchased",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "species": {
+            "description": "The scientific binomial name for the species of the organism.",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "species__ontology_label": {
+            "description": "species__ontology_label",
+            "type": "string"
+        },
+        "spike_in_concentration": {
+            "description": "spike in concentration",
+            "type": "string"
+        },
+        "spike_in_kit": {
+            "description": "name of spike in kit",
+            "type": "string"
+        },
+        "strand": {
+            "description": "library strandedness",
+            "enum": ["first","second","unstranded"],
+            "type": "string"
+        },
+        "vaccination": {
+            "description": "Any known vaccines administered to the donor organism. NOT a full vaccine history",
+            "items": {
+                "pattern": "^[A-Za-z]+[_:][0-9]",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/vo",
+            "type": "array"
+        },
+        "vaccination__adjuvants": {
+            "description": "Any adjuvants administered in the vaccine",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__dosage": {
+            "description": "The dosage and units for the vaccine",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__ontology_label": {
+            "description": "vaccination__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__route": {
+            "description": "Intradermal, Intranasal, Intravenous, Aerosol",
+            "items": {
+                "enum": ["intradermal", "intranasal", "intravenous", "aerosol", "intramuscular", "mucosal", "oral"],
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__time_since": {
+            "description": "Amount of time since vaccine was administered",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "vaccination__time_since__unit": {
+            "description": "Time since each vaccine in the vaccination field was administered",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "vaccination__time_since__unit_label": {
+            "description": "vaccination__time_since__unit_label",
+            "type": "string"
+        }
+    },
+    "required": [
+        "species",
+        "species__ontology_label",
+        "sex",
+        "is_living",
+        "biosample_id",
+        "organ",
+        "organ__ontology_label",
+        "sample_type",
+        "disease",
+        "disease__ontology_label",
+        "library_preparation_protocol",
+        "library_preparation_protocol__ontology_label",
+        "CellID",
+        "donor_id"
+    ],
+    "title": "Alexandria Metadata Convention"
+}

--- a/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.3/alexandria_convention_schema.json
+++ b/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.3/alexandria_convention_schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata-schemas/Alexandria.schema.json",
+    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata_schemas/alexandria_convention/1.1.3/json",
     "$schema": "https://json-schema.org/draft-07/schema#",
     "dependencies": {
         "cell_type__ontology_label": [

--- a/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.3/alexandria_convention_schema.tsv
+++ b/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.3/alexandria_convention_schema.tsv
@@ -1,0 +1,86 @@
+attribute	required	default	type	array	class	ontology	ontology_root	controlled_list_entries	dependency	dependency_condition	dependent	attribute_description		20190822 index
+species	Yes		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon	NCBITaxon_2759					The scientific binomial name for the species of the organism.		2
+species__ontology_label	Yes		string		ontology_label				species			species__ontology_label		3
+ethnicity			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/hancestro	HANCESTRO:0004			species == NCBITaxon_9606		The ethnicity or ethnicities of the human donor if known		4
+ethnicity__ontology_label			string	TRUE	ontology_label				ethnicity			ethnicity__ontology_label		5
+race			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncit	NCIT:C17049			species == NCBITaxon_9606		An arbitrary classification of a taxonomic group that is a division of a species		6
+race__ontology_label			string	TRUE	ontology_label				race			race__ontology_label		7
+mouse_strain			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncit	"NCIT_C14420 "			species == NCBITaxon_10090		Mouse strain of the donor organism (ex. C57BL/6, BALB/c, 129, undetermined)		8
+mouse_strain__ontology_label			string		ontology_label				mouse_strain			mouse_strain__ontology_label		9
+vaccination			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/vo	VO_0000001					Any known vaccines administered to the donor organism. NOT a full vaccine history		10
+vaccination__ontology_label			string	TRUE	ontology_label				vaccination			vaccination__ontology_label		11
+vaccination__route			string	TRUE	enum			"[""intradermal"", ""intranasal"", ""intravenous"", ""aerosol"", ""intramuscular"", ""mucosal"", ""oral""]"	vaccination			Intradermal, Intranasal, Intravenous, Aerosol		12
+vaccination__dosage			string	TRUE					vaccination			The dosage and units for the vaccine		13
+vaccination__adjuvants			string	TRUE					vaccination			Any adjuvants administered in the vaccine		14
+vaccination__time_since			number	TRUE					vaccination		vaccination__time_since__unit	Amount of time since vaccine was administered		15
+vaccination__time_since__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		vaccination__time_since			Time since each vaccine in the vaccination field was administered		16
+vaccination__time_since__unit_label			string		unit_label				vaccination__time_since__unit			vaccination__time_since__unit_label		17
+sex	Yes	unknown	string		enum			"[""male"", ""female"", ""mixed"", ""unknown""]"				Biological sex		18
+is_living	Yes		string		enum			"[""yes"", ""no"", ""unknown""]"				Whether organism was alive at time of biomaterial collection		19
+geographical_region			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/gaz	GAZ_00000013					Location where the sample was collected/donated		20
+geographical_region__ontology_label			string		ontology_label				geographical_region			geographical_region__ontology_label		21
+mhc_genotype			string									MHC genotype for humans and other species		22
+organism_age			number								organism_age__unit	Age of the organism at time of sample collection.		23
+organism_age__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		organism_age			organism_age__unit		24
+organism_age__unit_label			string		unit_label				organism_age__unit			organism_age__unit_label		25
+bmi			number									BMI of organism		26
+biosample_id	Yes		string											27
+organ	Yes		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uberon	UBERON_0000465					The organ that the biomaterial came from		28
+organ__ontology_label	Yes		string		ontology_label				organ			organ__ontology_label		29
+sample_type	Yes		string		enum			"[""cell line"", ""organoid"", ""direct from donor - fresh"", ""direct from donor - frozen"", ""cultured primary cells""]"				one of: cell line, organoid, direct from donor (fresh), direct from donor (frozen), cultured primary cells		30
+culture_duration			number							sample_type in cell line, organoid, cultured primary cells	culture_duration__unit	length of time cells have been in culture		31
+culture_duration__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		culture_duration			culture_duration__unit		32
+culture_duration__unit_label			string		unit_label				culture_duration__unit			culture_duration__unit_label		33
+enrichment_method			string	TRUE	enum			"[""cell size selection"", ""fluorescence-activated cell sorting"", ""magnetic affinity cell sorting"", ""laser capture microdissection"", ""density gradient centrifugation"", ""Ficoll-Hypaque method"", ""enrichment of methylated DNA""]"				Method used to enrich cells before running library preparation. This could be flow cytometry, column enrichments, etc.		34
+enrichment__cell_type			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/cl	CL_0000548		enrichment_method			The cell type that was sorted via an enrichment technique such as flow cytometry.		35
+enrichment__cell_type__ontology_label			string		ontology_label				enrichment__cell_type			enrichment__cell_type__ontology_label		36
+enrichment__facs_markers			string	TRUE					enrichment_method			The surface markers that were sorted on to enrich for the enriched cell type if flow cytometry was used		37
+disease	Yes	MONDO_0000001	string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/mondo	MONDO_0000001					The disease state(s) of the individual donating the sample at the time of donation		38
+disease__ontology_label	Yes		string	TRUE	ontology_label				disease			disease__ontology_label		39
+disease__time_since_onset			number	TRUE					disease		disease__time_since_onset__unit	Amount of time since disease onset		40
+disease__time_since_onset__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		disease__time_since_onset			disease__time_since_onset__unit		41
+disease__time_since_onset__unit_label			string		unit_label				disease__time_since_onset__unit			disease__time_since_onset__unit_label		42
+disease__treated			boolean	TRUE					disease			If the donor was treated at the time the sample was collected		43
+disease__treatment			string	TRUE					disease__treated			A description of the treatment given to this donor		44
+disease__time_since_treatment_start			number	TRUE					disease__treatment		disease__time_since_treatment_start__unit	Amount of time since treatment was started (for drugs/continuous treatment) or performed (for surgery/immediate intervention)		45
+disease__time_since_treatment_start__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		disease__time_since_treatment_start			disease__time_since_treatment_start__unit		46
+disease__time_since_treatment_start__unit_label			string		unit_label				disease__time_since_treatment_start__unit			disease__time_since_treatment_start__unit_label		47
+disease__intracellular_pathogen			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/mondo	MONDO_0005550		disease			If evidence of a pathogen is detected in this cell		48
+disease__intracellular_pathogen__ontology_label			string	TRUE	ontology_label				disease__intracellular_pathogen			disease__intracellular_pathogen__ontology_label		49
+spike_in_kit			string									name of spike in kit		50
+spike_in_concentration			string						spike_in_kit			spike in concentration		51
+development_stage			string		ontology	http://www.ebi.ac.uk/ols/api/ontologies/hsapdv						A classification of the developmental stage of the organism		52
+development_stage__ontology_label			string		ontology_label				development_stage			development_stage__ontology_label		53
+end_bias			string		enum			"[""3 prime tag"", ""3 prime end bias"", ""5 prime tag"", ""5 prime end bias"", ""full length""]"				The end bias of the library preparation protocol used		54
+library_preparation_protocol	Yes		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/efo	EFO_0001457					The single cell RNA-sequencing protocol used for Library preparation		55
+library_preparation_protocol__ontology_label	Yes		string		ontology_label				library_preparation_protocol			library_preparation_protocol__ontology_label		56
+primer			string		enum			"[""poly-dT"",""random""]"				Primer used for cDNA synthesis from RNA		57
+strand			string		enum			"[""first"",""second"",""unstranded""]"				library strandedness		58
+sequencing_instrument_manufacturer_model			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/efo	EFO_0003739					name of sequencing instrument manufacturer		59
+sequencing_instrument_manufacturer_model__ontology_label			string		ontology_label				sequencing_instrument_manufacturer_model			sequencing_instrument_manufacturer_model__ontology_label		60
+paired_ends			boolean									true if the sequence library has paired end data (false for 10x)		61
+read_length			string									the read structure of the sequencing run		62
+small_molecule_perturbation			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/chebi	CHEBI_24431					a small molecule added to a cell culture (ex. A drug) growth factor (and if it is recombinant, concentration), gene)		63
+small_molecule_perturbation__ontology_label			string	TRUE	ontology_label				small_molecule_perturbation			small_molecule_perturbation__ontology_label		64
+small_molecule_perturbation__concentration			number	TRUE					small_molecule_perturbation		small_molecule_perturbation__concentration__unit	Concentration of each small molecule in the final tissue culture media. Order should be consistent with small_molecule_perturbation		65
+small_molecule_perturbation__concentration__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		small_molecule_perturbation__concentration			small_molecule_perturbation__concentration__unit		66
+small_molecule_perturbation__concentration__unit_label			string		unit_label				small_molecule_perturbation__concentration__unit			small_molecule_perturbation__concentration__unit_label		67
+small_molecule_perturbation__solvent			string	TRUE					small_molecule_perturbation			Solvent in which the small molecule was added to the cells. Ex. the base media.		68
+small_molecule_perturbation__source			string	TRUE					small_molecule_perturbation			Source from which the small molecule was purchased		69
+growth_factor_perturbation			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/pr	PR_000000001			sample_type in cell line, organoid, cultured primary cells		a growth factor added to a cell culture media		70
+growth_factor_perturbation__ontology_label			string	TRUE	ontology_label				growth_factor_perturbation			growth_factor_perturbation__ontology_label		71
+growth_factor_perturbation__concentration			number	TRUE					growth_factor_perturbation		growth_factor_perturbation__concentration__unit	Concentration of of each growth factor in the final tissue culture media. Order should be consistent with growth_factor_perturbation		72
+growth_factor_perturbation__concentration__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		growth_factor_perturbation__concentration			growth_factor_perturbation__concentration__unit		73
+growth_factor_perturbation__concentration__unit_label			string		unit_label				growth_factor_perturbation__concentration__unit			growth_factor_perturbation__concentration__unit_label		74
+growth_factor_perturbation__solvent			string	TRUE					growth_factor_perturbation			Solvent in which the growth factor was added to the cells. Ex. the base media.		75
+growth_factor_perturbation__source			string	TRUE					growth_factor_perturbation			Source from which the growth factor was purchased		76
+gene_perturbation			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/ogg	OGG_0000000002					A perturbation to a gene done to a cell culture		77
+gene_perturbation__ontology_label			string	TRUE	ontology_label				gene_perturbation			gene_perturbation__ontology_label		78
+gene_perturbation__method			string	TRUE					gene_perturbation			Process by which the gene was perturbed. Ex. CRISPR knock-out		79
+gene_perturbation__direction			string		enum			"[""knock in"", ""knock out"",""activation"",""repression""]"	gene_perturbation			The type of perturbation of the gene defined in gene_perturbation. Knock in and knock out are complete additions/depletions of the gene, activation and repression refer to changes in magnitude of expression.		80
+gene_perturbation__dynamics			string						gene_perturbation			Description of the timing with respect to sequencing and other logistical considerations of the gene perturbation		81
+CellID	Yes		string									Cell ID		82
+cell_type			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/cl	CL_0000548					Cell type name determined via unsupervised clustering and marker genes		83
+cell_type__ontology_label			string		ontology_label				cell_type			cell_type__ontology_label		84
+number_of_reads			number									Number of reads mapped to that cell		85
+donor_id	Yes		string									Donor ID		87

--- a/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.4/alexandria_convention_schema.json
+++ b/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.4/alexandria_convention_schema.json
@@ -1,0 +1,695 @@
+{
+    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata-schema/1.1.4/alexandria_convention_schema.json",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "dependencies": {
+        "cell_type__ontology_label": [
+            "cell_type"
+        ],
+        "culture_duration": [
+            "culture_duration__unit"
+        ],
+        "culture_duration__unit": [
+            "culture_duration"
+        ],
+        "culture_duration__unit_label": [
+            "culture_duration__unit"
+        ],
+        "development_stage__ontology_label": [
+            "development_stage"
+        ],
+        "disease__intracellular_pathogen": [
+            "disease"
+        ],
+        "disease__intracellular_pathogen__ontology_label": [
+            "disease__intracellular_pathogen"
+        ],
+        "disease__ontology_label": [
+            "disease"
+        ],
+        "disease__time_since_onset": [
+            "disease",
+            "disease__time_since_onset__unit"
+        ],
+        "disease__time_since_onset__unit": [
+            "disease__time_since_onset"
+        ],
+        "disease__time_since_onset__unit_label": [
+            "disease__time_since_onset__unit"
+        ],
+        "disease__time_since_treatment_start": [
+            "disease__treatment",
+            "disease__time_since_treatment_start__unit"
+        ],
+        "disease__time_since_treatment_start__unit": [
+            "disease__time_since_treatment_start"
+        ],
+        "disease__time_since_treatment_start__unit_label": [
+            "disease__time_since_treatment_start__unit"
+        ],
+        "disease__treated": [
+            "disease"
+        ],
+        "disease__treatment": [
+            "disease__treated"
+        ],
+        "enrichment__cell_type": [
+            "enrichment_method"
+        ],
+        "enrichment__cell_type__ontology_label": [
+            "enrichment__cell_type"
+        ],
+        "enrichment__facs_markers": [
+            "enrichment_method"
+        ],
+        "ethnicity__ontology_label": [
+            "ethnicity"
+        ],
+        "gene_perturbation__direction": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__dynamics": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__method": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__ontology_label": [
+            "gene_perturbation"
+        ],
+        "geographical_region__ontology_label": [
+            "geographical_region"
+        ],
+        "growth_factor_perturbation__concentration": [
+            "growth_factor_perturbation",
+            "growth_factor_perturbation__concentration__unit"
+        ],
+        "growth_factor_perturbation__concentration__unit": [
+            "growth_factor_perturbation__concentration"
+        ],
+        "growth_factor_perturbation__concentration__unit_label": [
+            "growth_factor_perturbation__concentration__unit"
+        ],
+        "growth_factor_perturbation__ontology_label": [
+            "growth_factor_perturbation"
+        ],
+        "growth_factor_perturbation__solvent": [
+            "growth_factor_perturbation"
+        ],
+        "growth_factor_perturbation__source": [
+            "growth_factor_perturbation"
+        ],
+        "library_preparation_protocol__ontology_label": [
+            "library_preparation_protocol"
+        ],
+        "mouse_strain__ontology_label": [
+            "mouse_strain"
+        ],
+        "organ__ontology_label": [
+            "organ"
+        ],
+        "organism_age": [
+            "organism_age__unit"
+        ],
+        "organism_age__unit": [
+            "organism_age"
+        ],
+        "organism_age__unit_label": [
+            "organism_age__unit"
+        ],
+        "race__ontology_label": [
+            "race"
+        ],
+        "sequencing_instrument_manufacturer_model__ontology_label": [
+            "sequencing_instrument_manufacturer_model"
+        ],
+        "small_molecule_perturbation__concentration": [
+            "small_molecule_perturbation",
+            "small_molecule_perturbation__concentration__unit"
+        ],
+        "small_molecule_perturbation__concentration__unit": [
+            "small_molecule_perturbation__concentration"
+        ],
+        "small_molecule_perturbation__concentration__unit_label": [
+            "small_molecule_perturbation__concentration__unit"
+        ],
+        "small_molecule_perturbation__ontology_label": [
+            "small_molecule_perturbation"
+        ],
+        "small_molecule_perturbation__solvent": [
+            "small_molecule_perturbation"
+        ],
+        "small_molecule_perturbation__source": [
+            "small_molecule_perturbation"
+        ],
+        "species__ontology_label": [
+            "species"
+        ],
+        "spike_in_concentration": [
+            "spike_in_kit"
+        ],
+        "vaccination__adjuvants": [
+            "vaccination"
+        ],
+        "vaccination__dosage": [
+            "vaccination"
+        ],
+        "vaccination__ontology_label": [
+            "vaccination"
+        ],
+        "vaccination__route": [
+            "vaccination"
+        ],
+        "vaccination__time_since": [
+            "vaccination",
+            "vaccination__time_since__unit"
+        ],
+        "vaccination__time_since__unit": [
+            "vaccination__time_since"
+        ],
+        "vaccination__time_since__unit_label": [
+            "vaccination__time_since__unit"
+        ]
+    },
+    "description": "metadata convention for the alexandria project",
+    "properties": {
+        "CellID": {
+            "description": "Cell ID",
+            "type": "string"
+        },
+        "biosample_id": {
+            "type": "string"
+        },
+        "bmi": {
+            "description": "BMI of organism",
+            "type": "number"
+        },
+        "cell_type": {
+            "description": "Cell type name determined via unsupervised clustering and marker genes",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/cl",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "cell_type__ontology_label": {
+            "description": "cell_type__ontology_label",
+            "type": "string"
+        },
+        "culture_duration": {
+            "dependency_condition": "sample_type in cell line, organoid, cultured primary cells",
+            "description": "length of time cells have been in culture",
+            "type": "number"
+        },
+        "culture_duration__unit": {
+            "description": "culture_duration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "culture_duration__unit_label": {
+            "description": "culture_duration__unit_label",
+            "type": "string"
+        },
+        "development_stage": {
+            "description": "A classification of the developmental stage of the organism",
+            "ontology": "http://www.ebi.ac.uk/ols/api/ontologies/hsapdv",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "development_stage__ontology_label": {
+            "description": "development_stage__ontology_label",
+            "type": "string"
+        },
+        "disease": {
+            "default": "MONDO_0000001",
+            "description": "The disease state(s) of the individual donating the sample at the time of donation",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/mondo",
+            "type": "array"
+        },
+        "disease__intracellular_pathogen": {
+            "description": "If evidence of a pathogen is detected in this cell",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/mondo",
+            "type": "array"
+        },
+        "disease__intracellular_pathogen__ontology_label": {
+            "description": "disease__intracellular_pathogen__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "disease__ontology_label": {
+            "description": "disease__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "disease__time_since_onset": {
+            "description": "Amount of time since disease onset",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "disease__time_since_onset__unit": {
+            "description": "disease__time_since_onset__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "disease__time_since_onset__unit_label": {
+            "description": "disease__time_since_onset__unit_label",
+            "type": "string"
+        },
+        "disease__time_since_treatment_start": {
+            "description": "Amount of time since treatment was started (for drugs/continuous treatment) or performed (for surgery/immediate intervention)",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "disease__time_since_treatment_start__unit": {
+            "description": "disease__time_since_treatment_start__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "disease__time_since_treatment_start__unit_label": {
+            "description": "disease__time_since_treatment_start__unit_label",
+            "type": "string"
+        },
+        "disease__treated": {
+            "description": "If the donor was treated at the time the sample was collected",
+            "items": {
+                "type": "boolean"
+            },
+            "type": "array"
+        },
+        "disease__treatment": {
+            "description": "A description of the treatment given to this donor",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "donor_id": {
+            "description": "Donor ID",
+            "type": "string"
+        },
+        "end_bias": {
+            "description": "The end bias of the library preparation protocol used",
+            "enum": ["3 prime tag", "3 prime end bias", "5 prime tag", "5 prime end bias", "full length"],
+            "type": "string"
+        },
+        "enrichment__cell_type": {
+            "description": "The cell type that was sorted via an enrichment technique such as flow cytometry.",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/cl",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "enrichment__cell_type__ontology_label": {
+            "description": "enrichment__cell_type__ontology_label",
+            "type": "string"
+        },
+        "enrichment__facs_markers": {
+            "description": "The surface markers that were sorted on to enrich for the enriched cell type if flow cytometry was used",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "enrichment_method": {
+            "description": "Method used to enrich cells before running library preparation. This could be flow cytometry, column enrichments, etc.",
+            "items": {
+                "enum": ["cell size selection", "fluorescence-activated cell sorting", "magnetic affinity cell sorting", "laser capture microdissection", "density gradient centrifugation", "Ficoll-Hypaque method", "enrichment of methylated DNA"],
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "ethnicity": {
+            "dependency_condition": "species == NCBITaxon_9606",
+            "description": "The ethnicity or ethnicities of the human donor if known",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/hancestro",
+            "type": "array"
+        },
+        "ethnicity__ontology_label": {
+            "description": "ethnicity__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "gene_perturbation": {
+            "description": "A perturbation to a gene done to a cell culture",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ogg",
+            "type": "array"
+        },
+        "gene_perturbation__direction": {
+            "description": "The type of perturbation of the gene defined in gene_perturbation. Knock in and knock out are complete additions/depletions of the gene, activation and repression refer to changes in magnitude of expression.",
+            "enum": ["knock in", "knock out","activation","repression"],
+            "type": "string"
+        },
+        "gene_perturbation__dynamics": {
+            "description": "Description of the timing with respect to sequencing and other logistical considerations of the gene perturbation",
+            "type": "string"
+        },
+        "gene_perturbation__method": {
+            "description": "Process by which the gene was perturbed. Ex. CRISPR knock-out",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "gene_perturbation__ontology_label": {
+            "description": "gene_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "geographical_region": {
+            "description": "Location where the sample was collected/donated",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/gaz",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "geographical_region__ontology_label": {
+            "description": "geographical_region__ontology_label",
+            "type": "string"
+        },
+        "growth_factor_perturbation": {
+            "dependency_condition": "sample_type in cell line, organoid, cultured primary cells",
+            "description": "a growth factor added to a cell culture media",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/pr",
+            "type": "array"
+        },
+        "growth_factor_perturbation__concentration": {
+            "description": "Concentration of of each growth factor in the final tissue culture media. Order should be consistent with growth_factor_perturbation",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__concentration__unit": {
+            "description": "growth_factor_perturbation__concentration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "growth_factor_perturbation__concentration__unit_label": {
+            "description": "growth_factor_perturbation__concentration__unit_label",
+            "type": "string"
+        },
+        "growth_factor_perturbation__ontology_label": {
+            "description": "growth_factor_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__solvent": {
+            "description": "Solvent in which the growth factor was added to the cells. Ex. the base media.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__source": {
+            "description": "Source from which the growth factor was purchased",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "is_living": {
+            "description": "Whether organism was alive at time of biomaterial collection",
+            "enum": ["yes", "no", "unknown"],
+            "type": "string"
+        },
+        "library_preparation_protocol": {
+            "description": "The single cell RNA-sequencing protocol used for Library preparation",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/efo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "library_preparation_protocol__ontology_label": {
+            "description": "library_preparation_protocol__ontology_label",
+            "type": "string"
+        },
+        "mhc_genotype": {
+            "description": "MHC genotype for humans and other species",
+            "type": "string"
+        },
+        "mouse_strain": {
+            "dependency_condition": "species == NCBITaxon_10090",
+            "description": "Mouse strain of the donor organism (ex. C57BL/6, BALB/c, 129, undetermined)",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncit",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "mouse_strain__ontology_label": {
+            "description": "mouse_strain__ontology_label",
+            "type": "string"
+        },
+        "number_of_reads": {
+            "description": "Number of reads mapped to that cell",
+            "type": "number"
+        },
+        "organ": {
+            "description": "The organ that the biomaterial came from",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uberon",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "organ__ontology_label": {
+            "description": "organ__ontology_label",
+            "type": "string"
+        },
+        "organism_age": {
+            "description": "Age of the organism at time of sample collection.",
+            "type": "number"
+        },
+        "organism_age__unit": {
+            "description": "organism_age__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "organism_age__unit_label": {
+            "description": "organism_age__unit_label",
+            "type": "string"
+        },
+        "paired_ends": {
+            "description": "true if the sequence library has paired end data (false for 10x)",
+            "type": "boolean"
+        },
+        "primer": {
+            "description": "Primer used for cDNA synthesis from RNA",
+            "enum": ["poly-dT","random"],
+            "type": "string"
+        },
+        "race": {
+            "dependency_condition": "species == NCBITaxon_9606",
+            "description": "An arbitrary classification of a taxonomic group that is a division of a species",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncit",
+            "type": "array"
+        },
+        "race__ontology_label": {
+            "description": "race__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "read_length": {
+            "description": "the read structure of the sequencing run",
+            "type": "string"
+        },
+        "sample_type": {
+            "description": "one of: cell line, organoid, direct from donor (fresh), direct from donor (frozen), cultured primary cells",
+            "enum": ["cell line", "organoid", "direct from donor - fresh", "direct from donor - frozen", "cultured primary cells"],
+            "type": "string"
+        },
+        "sequencing_instrument_manufacturer_model": {
+            "description": "name of sequencing instrument manufacturer",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/efo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "sequencing_instrument_manufacturer_model__ontology_label": {
+            "description": "sequencing_instrument_manufacturer_model__ontology_label",
+            "type": "string"
+        },
+        "sex": {
+            "default": "unknown",
+            "description": "Biological sex",
+            "enum": ["male", "female", "mixed", "unknown"],
+            "type": "string"
+        },
+        "small_molecule_perturbation": {
+            "description": "a small molecule added to a cell culture (ex. A drug) growth factor (and if it is recombinant, concentration), gene)",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/chebi",
+            "type": "array"
+        },
+        "small_molecule_perturbation__concentration": {
+            "description": "Concentration of each small molecule in the final tissue culture media. Order should be consistent with small_molecule_perturbation",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__concentration__unit": {
+            "description": "small_molecule_perturbation__concentration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "small_molecule_perturbation__concentration__unit_label": {
+            "description": "small_molecule_perturbation__concentration__unit_label",
+            "type": "string"
+        },
+        "small_molecule_perturbation__ontology_label": {
+            "description": "small_molecule_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__solvent": {
+            "description": "Solvent in which the small molecule was added to the cells. Ex. the base media.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__source": {
+            "description": "Source from which the small molecule was purchased",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "species": {
+            "description": "The scientific binomial name for the species of the organism.",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "species__ontology_label": {
+            "description": "species__ontology_label",
+            "type": "string"
+        },
+        "spike_in_concentration": {
+            "description": "spike in concentration",
+            "type": "string"
+        },
+        "spike_in_kit": {
+            "description": "name of spike in kit",
+            "type": "string"
+        },
+        "strand": {
+            "description": "library strandedness",
+            "enum": ["first","second","unstranded"],
+            "type": "string"
+        },
+        "vaccination": {
+            "description": "Any known vaccines administered to the donor organism. NOT a full vaccine history",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/vo",
+            "type": "array"
+        },
+        "vaccination__adjuvants": {
+            "description": "Any adjuvants administered in the vaccine",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__dosage": {
+            "description": "The dosage and units for the vaccine",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__ontology_label": {
+            "description": "vaccination__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__route": {
+            "description": "Intradermal, Intranasal, Intravenous, Aerosol",
+            "items": {
+                "enum": ["intradermal", "intranasal", "intravenous", "aerosol", "intramuscular", "mucosal", "oral"],
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__time_since": {
+            "description": "Amount of time since vaccine was administered",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "vaccination__time_since__unit": {
+            "description": "Time since each vaccine in the vaccination field was administered",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "vaccination__time_since__unit_label": {
+            "description": "vaccination__time_since__unit_label",
+            "type": "string"
+        }
+    },
+    "required": [
+        "species",
+        "species__ontology_label",
+        "sex",
+        "is_living",
+        "biosample_id",
+        "organ",
+        "organ__ontology_label",
+        "sample_type",
+        "disease",
+        "disease__ontology_label",
+        "library_preparation_protocol",
+        "library_preparation_protocol__ontology_label",
+        "CellID",
+        "donor_id"
+    ],
+    "title": "alexandria metadata convention"
+}

--- a/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.4/alexandria_convention_schema.json
+++ b/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.4/alexandria_convention_schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata-schema/1.1.4/alexandria_convention_schema.json",
+    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata_schemas/alexandria_convention/1.1.4/json",
     "$schema": "https://json-schema.org/draft-07/schema#",
     "dependencies": {
         "cell_type__ontology_label": [

--- a/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.4/alexandria_convention_schema.tsv
+++ b/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.4/alexandria_convention_schema.tsv
@@ -1,0 +1,86 @@
+attribute	required	default	type	array	class	ontology	ontology_root	controlled_list_entries	dependency	dependency_condition	dependent	attribute_description		20190822 index
+species	Yes		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon	NCBITaxon_2759					The scientific binomial name for the species of the organism.		2
+species__ontology_label	Yes		string		ontology_label				species			species__ontology_label		3
+ethnicity			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/hancestro	HANCESTRO:0004			species == NCBITaxon_9606		The ethnicity or ethnicities of the human donor if known		4
+ethnicity__ontology_label			string	TRUE	ontology_label				ethnicity			ethnicity__ontology_label		5
+race			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncit	NCIT:C17049			species == NCBITaxon_9606		An arbitrary classification of a taxonomic group that is a division of a species		6
+race__ontology_label			string	TRUE	ontology_label				race			race__ontology_label		7
+mouse_strain			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncit	"NCIT_C14420 "			species == NCBITaxon_10090		Mouse strain of the donor organism (ex. C57BL/6, BALB/c, 129, undetermined)		8
+mouse_strain__ontology_label			string		ontology_label				mouse_strain			mouse_strain__ontology_label		9
+vaccination			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/vo	VO_0000001					Any known vaccines administered to the donor organism. NOT a full vaccine history		10
+vaccination__ontology_label			string	TRUE	ontology_label				vaccination			vaccination__ontology_label		11
+vaccination__route			string	TRUE	enum			"[""intradermal"", ""intranasal"", ""intravenous"", ""aerosol"", ""intramuscular"", ""mucosal"", ""oral""]"	vaccination			Intradermal, Intranasal, Intravenous, Aerosol		12
+vaccination__dosage			string	TRUE					vaccination			The dosage and units for the vaccine		13
+vaccination__adjuvants			string	TRUE					vaccination			Any adjuvants administered in the vaccine		14
+vaccination__time_since			number	TRUE					vaccination		vaccination__time_since__unit	Amount of time since vaccine was administered		15
+vaccination__time_since__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		vaccination__time_since			Time since each vaccine in the vaccination field was administered		16
+vaccination__time_since__unit_label			string		unit_label				vaccination__time_since__unit			vaccination__time_since__unit_label		17
+sex	Yes	unknown	string		enum			"[""male"", ""female"", ""mixed"", ""unknown""]"				Biological sex		18
+is_living	Yes		string		enum			"[""yes"", ""no"", ""unknown""]"				Whether organism was alive at time of biomaterial collection		19
+geographical_region			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/gaz	GAZ_00000013					Location where the sample was collected/donated		20
+geographical_region__ontology_label			string		ontology_label				geographical_region			geographical_region__ontology_label		21
+mhc_genotype			string									MHC genotype for humans and other species		22
+organism_age			number								organism_age__unit	Age of the organism at time of sample collection.		23
+organism_age__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		organism_age			organism_age__unit		24
+organism_age__unit_label			string		unit_label				organism_age__unit			organism_age__unit_label		25
+bmi			number									BMI of organism		26
+biosample_id	Yes		string											27
+organ	Yes		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uberon	UBERON_0000465					The organ that the biomaterial came from		28
+organ__ontology_label	Yes		string		ontology_label				organ			organ__ontology_label		29
+sample_type	Yes		string		enum			"[""cell line"", ""organoid"", ""direct from donor - fresh"", ""direct from donor - frozen"", ""cultured primary cells""]"				one of: cell line, organoid, direct from donor (fresh), direct from donor (frozen), cultured primary cells		30
+culture_duration			number							sample_type in cell line, organoid, cultured primary cells	culture_duration__unit	length of time cells have been in culture		31
+culture_duration__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		culture_duration			culture_duration__unit		32
+culture_duration__unit_label			string		unit_label				culture_duration__unit			culture_duration__unit_label		33
+enrichment_method			string	TRUE	enum			"[""cell size selection"", ""fluorescence-activated cell sorting"", ""magnetic affinity cell sorting"", ""laser capture microdissection"", ""density gradient centrifugation"", ""Ficoll-Hypaque method"", ""enrichment of methylated DNA""]"				Method used to enrich cells before running library preparation. This could be flow cytometry, column enrichments, etc.		34
+enrichment__cell_type			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/cl	CL_0000548		enrichment_method			The cell type that was sorted via an enrichment technique such as flow cytometry.		35
+enrichment__cell_type__ontology_label			string		ontology_label				enrichment__cell_type			enrichment__cell_type__ontology_label		36
+enrichment__facs_markers			string	TRUE					enrichment_method			The surface markers that were sorted on to enrich for the enriched cell type if flow cytometry was used		37
+disease	Yes	MONDO_0000001	string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/mondo	MONDO_0000001					The disease state(s) of the individual donating the sample at the time of donation		38
+disease__ontology_label	Yes		string	TRUE	ontology_label				disease			disease__ontology_label		39
+disease__time_since_onset			number	TRUE					disease		disease__time_since_onset__unit	Amount of time since disease onset		40
+disease__time_since_onset__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		disease__time_since_onset			disease__time_since_onset__unit		41
+disease__time_since_onset__unit_label			string		unit_label				disease__time_since_onset__unit			disease__time_since_onset__unit_label		42
+disease__treated			boolean	TRUE					disease			If the donor was treated at the time the sample was collected		43
+disease__treatment			string	TRUE					disease__treated			A description of the treatment given to this donor		44
+disease__time_since_treatment_start			number	TRUE					disease__treatment		disease__time_since_treatment_start__unit	Amount of time since treatment was started (for drugs/continuous treatment) or performed (for surgery/immediate intervention)		45
+disease__time_since_treatment_start__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		disease__time_since_treatment_start			disease__time_since_treatment_start__unit		46
+disease__time_since_treatment_start__unit_label			string		unit_label				disease__time_since_treatment_start__unit			disease__time_since_treatment_start__unit_label		47
+disease__intracellular_pathogen			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/mondo	MONDO_0005550		disease			If evidence of a pathogen is detected in this cell		48
+disease__intracellular_pathogen__ontology_label			string	TRUE	ontology_label				disease__intracellular_pathogen			disease__intracellular_pathogen__ontology_label		49
+spike_in_kit			string									name of spike in kit		50
+spike_in_concentration			string						spike_in_kit			spike in concentration		51
+development_stage			string		ontology	http://www.ebi.ac.uk/ols/api/ontologies/hsapdv						A classification of the developmental stage of the organism		52
+development_stage__ontology_label			string		ontology_label				development_stage			development_stage__ontology_label		53
+end_bias			string		enum			"[""3 prime tag"", ""3 prime end bias"", ""5 prime tag"", ""5 prime end bias"", ""full length""]"				The end bias of the library preparation protocol used		54
+library_preparation_protocol	Yes		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/efo	EFO_0001457					The single cell RNA-sequencing protocol used for Library preparation		55
+library_preparation_protocol__ontology_label	Yes		string		ontology_label				library_preparation_protocol			library_preparation_protocol__ontology_label		56
+primer			string		enum			"[""poly-dT"",""random""]"				Primer used for cDNA synthesis from RNA		57
+strand			string		enum			"[""first"",""second"",""unstranded""]"				library strandedness		58
+sequencing_instrument_manufacturer_model			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/efo	EFO_0003739					name of sequencing instrument manufacturer		59
+sequencing_instrument_manufacturer_model__ontology_label			string		ontology_label				sequencing_instrument_manufacturer_model			sequencing_instrument_manufacturer_model__ontology_label		60
+paired_ends			boolean									true if the sequence library has paired end data (false for 10x)		61
+read_length			string									the read structure of the sequencing run		62
+small_molecule_perturbation			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/chebi	CHEBI_24431					a small molecule added to a cell culture (ex. A drug) growth factor (and if it is recombinant, concentration), gene)		63
+small_molecule_perturbation__ontology_label			string	TRUE	ontology_label				small_molecule_perturbation			small_molecule_perturbation__ontology_label		64
+small_molecule_perturbation__concentration			number	TRUE					small_molecule_perturbation		small_molecule_perturbation__concentration__unit	Concentration of each small molecule in the final tissue culture media. Order should be consistent with small_molecule_perturbation		65
+small_molecule_perturbation__concentration__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		small_molecule_perturbation__concentration			small_molecule_perturbation__concentration__unit		66
+small_molecule_perturbation__concentration__unit_label			string		unit_label				small_molecule_perturbation__concentration__unit			small_molecule_perturbation__concentration__unit_label		67
+small_molecule_perturbation__solvent			string	TRUE					small_molecule_perturbation			Solvent in which the small molecule was added to the cells. Ex. the base media.		68
+small_molecule_perturbation__source			string	TRUE					small_molecule_perturbation			Source from which the small molecule was purchased		69
+growth_factor_perturbation			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/pr	PR_000000001			sample_type in cell line, organoid, cultured primary cells		a growth factor added to a cell culture media		70
+growth_factor_perturbation__ontology_label			string	TRUE	ontology_label				growth_factor_perturbation			growth_factor_perturbation__ontology_label		71
+growth_factor_perturbation__concentration			number	TRUE					growth_factor_perturbation		growth_factor_perturbation__concentration__unit	Concentration of of each growth factor in the final tissue culture media. Order should be consistent with growth_factor_perturbation		72
+growth_factor_perturbation__concentration__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		growth_factor_perturbation__concentration			growth_factor_perturbation__concentration__unit		73
+growth_factor_perturbation__concentration__unit_label			string		unit_label				growth_factor_perturbation__concentration__unit			growth_factor_perturbation__concentration__unit_label		74
+growth_factor_perturbation__solvent			string	TRUE					growth_factor_perturbation			Solvent in which the growth factor was added to the cells. Ex. the base media.		75
+growth_factor_perturbation__source			string	TRUE					growth_factor_perturbation			Source from which the growth factor was purchased		76
+gene_perturbation			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/ogg	OGG_0000000002					A perturbation to a gene done to a cell culture		77
+gene_perturbation__ontology_label			string	TRUE	ontology_label				gene_perturbation			gene_perturbation__ontology_label		78
+gene_perturbation__method			string	TRUE					gene_perturbation			Process by which the gene was perturbed. Ex. CRISPR knock-out		79
+gene_perturbation__direction			string		enum			"[""knock in"", ""knock out"",""activation"",""repression""]"	gene_perturbation			The type of perturbation of the gene defined in gene_perturbation. Knock in and knock out are complete additions/depletions of the gene, activation and repression refer to changes in magnitude of expression.		80
+gene_perturbation__dynamics			string						gene_perturbation			Description of the timing with respect to sequencing and other logistical considerations of the gene perturbation		81
+CellID	Yes		string									Cell ID		82
+cell_type			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/cl	CL_0000548					Cell type name determined via unsupervised clustering and marker genes		83
+cell_type__ontology_label			string		ontology_label				cell_type			cell_type__ontology_label		84
+number_of_reads			number									Number of reads mapped to that cell		85
+donor_id	Yes		string									Donor ID		87

--- a/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.5/alexandria_convention_schema.json
+++ b/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.5/alexandria_convention_schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata-schema/1.1.5/alexandria_convention_schema.json",
+    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata_schemas/alexandria_convention/1.1.5/json",
     "$schema": "https://json-schema.org/draft-07/schema#",
     "dependencies": {
         "cell_type__ontology_label": [

--- a/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.5/alexandria_convention_schema.json
+++ b/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.5/alexandria_convention_schema.json
@@ -1,0 +1,695 @@
+{
+    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata-schema/1.1.5/alexandria_convention_schema.json",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "dependencies": {
+        "cell_type__ontology_label": [
+            "cell_type"
+        ],
+        "culture_duration": [
+            "culture_duration__unit"
+        ],
+        "culture_duration__unit": [
+            "culture_duration"
+        ],
+        "culture_duration__unit_label": [
+            "culture_duration__unit"
+        ],
+        "development_stage__ontology_label": [
+            "development_stage"
+        ],
+        "disease__intracellular_pathogen": [
+            "disease"
+        ],
+        "disease__intracellular_pathogen__ontology_label": [
+            "disease__intracellular_pathogen"
+        ],
+        "disease__ontology_label": [
+            "disease"
+        ],
+        "disease__time_since_onset": [
+            "disease",
+            "disease__time_since_onset__unit"
+        ],
+        "disease__time_since_onset__unit": [
+            "disease__time_since_onset"
+        ],
+        "disease__time_since_onset__unit_label": [
+            "disease__time_since_onset__unit"
+        ],
+        "disease__time_since_treatment_start": [
+            "disease__treatment",
+            "disease__time_since_treatment_start__unit"
+        ],
+        "disease__time_since_treatment_start__unit": [
+            "disease__time_since_treatment_start"
+        ],
+        "disease__time_since_treatment_start__unit_label": [
+            "disease__time_since_treatment_start__unit"
+        ],
+        "disease__treated": [
+            "disease"
+        ],
+        "disease__treatment": [
+            "disease__treated"
+        ],
+        "enrichment__cell_type": [
+            "enrichment_method"
+        ],
+        "enrichment__cell_type__ontology_label": [
+            "enrichment__cell_type"
+        ],
+        "enrichment__facs_markers": [
+            "enrichment_method"
+        ],
+        "ethnicity__ontology_label": [
+            "ethnicity"
+        ],
+        "gene_perturbation__direction": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__dynamics": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__method": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__ontology_label": [
+            "gene_perturbation"
+        ],
+        "geographical_region__ontology_label": [
+            "geographical_region"
+        ],
+        "growth_factor_perturbation__concentration": [
+            "growth_factor_perturbation",
+            "growth_factor_perturbation__concentration__unit"
+        ],
+        "growth_factor_perturbation__concentration__unit": [
+            "growth_factor_perturbation__concentration"
+        ],
+        "growth_factor_perturbation__concentration__unit_label": [
+            "growth_factor_perturbation__concentration__unit"
+        ],
+        "growth_factor_perturbation__ontology_label": [
+            "growth_factor_perturbation"
+        ],
+        "growth_factor_perturbation__solvent": [
+            "growth_factor_perturbation"
+        ],
+        "growth_factor_perturbation__source": [
+            "growth_factor_perturbation"
+        ],
+        "library_preparation_protocol__ontology_label": [
+            "library_preparation_protocol"
+        ],
+        "mouse_strain__ontology_label": [
+            "mouse_strain"
+        ],
+        "organ__ontology_label": [
+            "organ"
+        ],
+        "organism_age": [
+            "organism_age__unit"
+        ],
+        "organism_age__unit": [
+            "organism_age"
+        ],
+        "organism_age__unit_label": [
+            "organism_age__unit"
+        ],
+        "race__ontology_label": [
+            "race"
+        ],
+        "sequencing_instrument_manufacturer_model__ontology_label": [
+            "sequencing_instrument_manufacturer_model"
+        ],
+        "small_molecule_perturbation__concentration": [
+            "small_molecule_perturbation",
+            "small_molecule_perturbation__concentration__unit"
+        ],
+        "small_molecule_perturbation__concentration__unit": [
+            "small_molecule_perturbation__concentration"
+        ],
+        "small_molecule_perturbation__concentration__unit_label": [
+            "small_molecule_perturbation__concentration__unit"
+        ],
+        "small_molecule_perturbation__ontology_label": [
+            "small_molecule_perturbation"
+        ],
+        "small_molecule_perturbation__solvent": [
+            "small_molecule_perturbation"
+        ],
+        "small_molecule_perturbation__source": [
+            "small_molecule_perturbation"
+        ],
+        "species__ontology_label": [
+            "species"
+        ],
+        "spike_in_concentration": [
+            "spike_in_kit"
+        ],
+        "vaccination__adjuvants": [
+            "vaccination"
+        ],
+        "vaccination__dosage": [
+            "vaccination"
+        ],
+        "vaccination__ontology_label": [
+            "vaccination"
+        ],
+        "vaccination__route": [
+            "vaccination"
+        ],
+        "vaccination__time_since": [
+            "vaccination",
+            "vaccination__time_since__unit"
+        ],
+        "vaccination__time_since__unit": [
+            "vaccination__time_since"
+        ],
+        "vaccination__time_since__unit_label": [
+            "vaccination__time_since__unit"
+        ]
+    },
+    "description": "metadata convention for the alexandria project",
+    "properties": {
+        "CellID": {
+            "description": "Cell ID",
+            "type": "string"
+        },
+        "biosample_id": {
+            "type": "string"
+        },
+        "bmi": {
+            "description": "BMI of organism",
+            "type": "number"
+        },
+        "cell_type": {
+            "description": "Cell type name determined via unsupervised clustering and marker genes",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/cl",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "cell_type__ontology_label": {
+            "description": "cell_type__ontology_label",
+            "type": "string"
+        },
+        "culture_duration": {
+            "dependency_condition": "sample_type in cell line, organoid, cultured primary cells",
+            "description": "length of time cells have been in culture",
+            "type": "number"
+        },
+        "culture_duration__unit": {
+            "description": "culture_duration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "culture_duration__unit_label": {
+            "description": "culture_duration__unit_label",
+            "type": "string"
+        },
+        "development_stage": {
+            "description": "A classification of the developmental stage of the organism",
+            "ontology": "http://www.ebi.ac.uk/ols/api/ontologies/hsapdv",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "development_stage__ontology_label": {
+            "description": "development_stage__ontology_label",
+            "type": "string"
+        },
+        "disease": {
+            "default": "MONDO_0000001",
+            "description": "The disease state(s) of the individual donating the sample at the time of donation",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/mondo,https://www.ebi.ac.uk/ols/api/ontologies/pato",
+            "type": "array"
+        },
+        "disease__intracellular_pathogen": {
+            "description": "If evidence of a pathogen is detected in this cell",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/mondo",
+            "type": "array"
+        },
+        "disease__intracellular_pathogen__ontology_label": {
+            "description": "disease__intracellular_pathogen__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "disease__ontology_label": {
+            "description": "disease__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "disease__time_since_onset": {
+            "description": "Amount of time since disease onset",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "disease__time_since_onset__unit": {
+            "description": "disease__time_since_onset__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "disease__time_since_onset__unit_label": {
+            "description": "disease__time_since_onset__unit_label",
+            "type": "string"
+        },
+        "disease__time_since_treatment_start": {
+            "description": "Amount of time since treatment was started (for drugs/continuous treatment) or performed (for surgery/immediate intervention)",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "disease__time_since_treatment_start__unit": {
+            "description": "disease__time_since_treatment_start__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "disease__time_since_treatment_start__unit_label": {
+            "description": "disease__time_since_treatment_start__unit_label",
+            "type": "string"
+        },
+        "disease__treated": {
+            "description": "If the donor was treated at the time the sample was collected",
+            "items": {
+                "type": "boolean"
+            },
+            "type": "array"
+        },
+        "disease__treatment": {
+            "description": "A description of the treatment given to this donor",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "donor_id": {
+            "description": "Donor ID",
+            "type": "string"
+        },
+        "end_bias": {
+            "description": "The end bias of the library preparation protocol used",
+            "enum": ["3 prime tag", "3 prime end bias", "5 prime tag", "5 prime end bias", "full length"],
+            "type": "string"
+        },
+        "enrichment__cell_type": {
+            "description": "The cell type that was sorted via an enrichment technique such as flow cytometry.",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/cl",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "enrichment__cell_type__ontology_label": {
+            "description": "enrichment__cell_type__ontology_label",
+            "type": "string"
+        },
+        "enrichment__facs_markers": {
+            "description": "The surface markers that were sorted on to enrich for the enriched cell type if flow cytometry was used",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "enrichment_method": {
+            "description": "Method used to enrich cells before running library preparation. This could be flow cytometry, column enrichments, etc.",
+            "items": {
+                "enum": ["cell size selection", "fluorescence-activated cell sorting", "magnetic affinity cell sorting", "laser capture microdissection", "density gradient centrifugation", "Ficoll-Hypaque method", "enrichment of methylated DNA"],
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "ethnicity": {
+            "dependency_condition": "species == NCBITaxon_9606",
+            "description": "The ethnicity or ethnicities of the human donor if known",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/hancestro",
+            "type": "array"
+        },
+        "ethnicity__ontology_label": {
+            "description": "ethnicity__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "gene_perturbation": {
+            "description": "A perturbation to a gene done to a cell culture",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ogg",
+            "type": "array"
+        },
+        "gene_perturbation__direction": {
+            "description": "The type of perturbation of the gene defined in gene_perturbation. Knock in and knock out are complete additions/depletions of the gene, activation and repression refer to changes in magnitude of expression.",
+            "enum": ["knock in", "knock out","activation","repression"],
+            "type": "string"
+        },
+        "gene_perturbation__dynamics": {
+            "description": "Description of the timing with respect to sequencing and other logistical considerations of the gene perturbation",
+            "type": "string"
+        },
+        "gene_perturbation__method": {
+            "description": "Process by which the gene was perturbed. Ex. CRISPR knock-out",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "gene_perturbation__ontology_label": {
+            "description": "gene_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "geographical_region": {
+            "description": "Location where the sample was collected/donated",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/gaz",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "geographical_region__ontology_label": {
+            "description": "geographical_region__ontology_label",
+            "type": "string"
+        },
+        "growth_factor_perturbation": {
+            "dependency_condition": "sample_type in cell line, organoid, cultured primary cells",
+            "description": "a growth factor added to a cell culture media",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/pr",
+            "type": "array"
+        },
+        "growth_factor_perturbation__concentration": {
+            "description": "Concentration of of each growth factor in the final tissue culture media. Order should be consistent with growth_factor_perturbation",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__concentration__unit": {
+            "description": "growth_factor_perturbation__concentration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "growth_factor_perturbation__concentration__unit_label": {
+            "description": "growth_factor_perturbation__concentration__unit_label",
+            "type": "string"
+        },
+        "growth_factor_perturbation__ontology_label": {
+            "description": "growth_factor_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__solvent": {
+            "description": "Solvent in which the growth factor was added to the cells. Ex. the base media.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__source": {
+            "description": "Source from which the growth factor was purchased",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "is_living": {
+            "description": "Whether organism was alive at time of biomaterial collection",
+            "enum": ["yes", "no", "unknown"],
+            "type": "string"
+        },
+        "library_preparation_protocol": {
+            "description": "The single cell RNA-sequencing protocol used for Library preparation",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/efo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "library_preparation_protocol__ontology_label": {
+            "description": "library_preparation_protocol__ontology_label",
+            "type": "string"
+        },
+        "mhc_genotype": {
+            "description": "MHC genotype for humans and other species",
+            "type": "string"
+        },
+        "mouse_strain": {
+            "dependency_condition": "species == NCBITaxon_10090",
+            "description": "Mouse strain of the donor organism (ex. C57BL/6, BALB/c, 129, undetermined)",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncit",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "mouse_strain__ontology_label": {
+            "description": "mouse_strain__ontology_label",
+            "type": "string"
+        },
+        "number_of_reads": {
+            "description": "Number of reads mapped to that cell",
+            "type": "number"
+        },
+        "organ": {
+            "description": "The organ that the biomaterial came from",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uberon",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "organ__ontology_label": {
+            "description": "organ__ontology_label",
+            "type": "string"
+        },
+        "organism_age": {
+            "description": "Age of the organism at time of sample collection.",
+            "type": "number"
+        },
+        "organism_age__unit": {
+            "description": "organism_age__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "organism_age__unit_label": {
+            "description": "organism_age__unit_label",
+            "type": "string"
+        },
+        "paired_ends": {
+            "description": "true if the sequence library has paired end data (false for 10x)",
+            "type": "boolean"
+        },
+        "primer": {
+            "description": "Primer used for cDNA synthesis from RNA",
+            "enum": ["poly-dT","random"],
+            "type": "string"
+        },
+        "race": {
+            "dependency_condition": "species == NCBITaxon_9606",
+            "description": "An arbitrary classification of a taxonomic group that is a division of a species",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncit",
+            "type": "array"
+        },
+        "race__ontology_label": {
+            "description": "race__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "read_length": {
+            "description": "the read structure of the sequencing run",
+            "type": "string"
+        },
+        "sample_type": {
+            "description": "one of: cell line, organoid, direct from donor (fresh), direct from donor (frozen), cultured primary cells",
+            "enum": ["cell line", "organoid", "direct from donor - fresh", "direct from donor - frozen", "cultured primary cells"],
+            "type": "string"
+        },
+        "sequencing_instrument_manufacturer_model": {
+            "description": "name of sequencing instrument manufacturer",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/efo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "sequencing_instrument_manufacturer_model__ontology_label": {
+            "description": "sequencing_instrument_manufacturer_model__ontology_label",
+            "type": "string"
+        },
+        "sex": {
+            "default": "unknown",
+            "description": "Biological sex",
+            "enum": ["male", "female", "mixed", "unknown"],
+            "type": "string"
+        },
+        "small_molecule_perturbation": {
+            "description": "a small molecule added to a cell culture (ex. A drug) growth factor (and if it is recombinant, concentration), gene)",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/chebi",
+            "type": "array"
+        },
+        "small_molecule_perturbation__concentration": {
+            "description": "Concentration of each small molecule in the final tissue culture media. Order should be consistent with small_molecule_perturbation",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__concentration__unit": {
+            "description": "small_molecule_perturbation__concentration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "small_molecule_perturbation__concentration__unit_label": {
+            "description": "small_molecule_perturbation__concentration__unit_label",
+            "type": "string"
+        },
+        "small_molecule_perturbation__ontology_label": {
+            "description": "small_molecule_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__solvent": {
+            "description": "Solvent in which the small molecule was added to the cells. Ex. the base media.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__source": {
+            "description": "Source from which the small molecule was purchased",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "species": {
+            "description": "The scientific binomial name for the species of the organism.",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "species__ontology_label": {
+            "description": "species__ontology_label",
+            "type": "string"
+        },
+        "spike_in_concentration": {
+            "description": "spike in concentration",
+            "type": "string"
+        },
+        "spike_in_kit": {
+            "description": "name of spike in kit",
+            "type": "string"
+        },
+        "strand": {
+            "description": "library strandedness",
+            "enum": ["first","second","unstranded"],
+            "type": "string"
+        },
+        "vaccination": {
+            "description": "Any known vaccines administered to the donor organism. NOT a full vaccine history",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/vo",
+            "type": "array"
+        },
+        "vaccination__adjuvants": {
+            "description": "Any adjuvants administered in the vaccine",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__dosage": {
+            "description": "The dosage and units for the vaccine",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__ontology_label": {
+            "description": "vaccination__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__route": {
+            "description": "Intradermal, Intranasal, Intravenous, Aerosol",
+            "items": {
+                "enum": ["intradermal", "intranasal", "intravenous", "aerosol", "intramuscular", "mucosal", "oral"],
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__time_since": {
+            "description": "Amount of time since vaccine was administered",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "vaccination__time_since__unit": {
+            "description": "Time since each vaccine in the vaccination field was administered",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "vaccination__time_since__unit_label": {
+            "description": "vaccination__time_since__unit_label",
+            "type": "string"
+        }
+    },
+    "required": [
+        "species",
+        "species__ontology_label",
+        "sex",
+        "is_living",
+        "biosample_id",
+        "organ",
+        "organ__ontology_label",
+        "sample_type",
+        "disease",
+        "disease__ontology_label",
+        "library_preparation_protocol",
+        "library_preparation_protocol__ontology_label",
+        "CellID",
+        "donor_id"
+    ],
+    "title": "alexandria metadata convention"
+}

--- a/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.5/alexandria_convention_schema.tsv
+++ b/lib/assets/metadata_schemas/alexandria_convention/snapshot/1.1.5/alexandria_convention_schema.tsv
@@ -1,0 +1,86 @@
+attribute	required	default	type	array	class	ontology	ontology_root	controlled_list_entries	dependency	dependency_condition	dependent	attribute_description		20190822 index
+species	Yes		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon	NCBITaxon_2759					The scientific binomial name for the species of the organism.		2
+species__ontology_label	Yes		string		ontology_label				species			species__ontology_label		3
+ethnicity			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/hancestro	HANCESTRO:0004			species == NCBITaxon_9606		The ethnicity or ethnicities of the human donor if known		4
+ethnicity__ontology_label			string	TRUE	ontology_label				ethnicity			ethnicity__ontology_label		5
+race			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncit	NCIT:C17049			species == NCBITaxon_9606		An arbitrary classification of a taxonomic group that is a division of a species		6
+race__ontology_label			string	TRUE	ontology_label				race			race__ontology_label		7
+mouse_strain			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncit	"NCIT_C14420 "			species == NCBITaxon_10090		Mouse strain of the donor organism (ex. C57BL/6, BALB/c, 129, undetermined)		8
+mouse_strain__ontology_label			string		ontology_label				mouse_strain			mouse_strain__ontology_label		9
+vaccination			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/vo	VO_0000001					Any known vaccines administered to the donor organism. NOT a full vaccine history		10
+vaccination__ontology_label			string	TRUE	ontology_label				vaccination			vaccination__ontology_label		11
+vaccination__route			string	TRUE	enum			"[""intradermal"", ""intranasal"", ""intravenous"", ""aerosol"", ""intramuscular"", ""mucosal"", ""oral""]"	vaccination			Intradermal, Intranasal, Intravenous, Aerosol		12
+vaccination__dosage			string	TRUE					vaccination			The dosage and units for the vaccine		13
+vaccination__adjuvants			string	TRUE					vaccination			Any adjuvants administered in the vaccine		14
+vaccination__time_since			number	TRUE					vaccination		vaccination__time_since__unit	Amount of time since vaccine was administered		15
+vaccination__time_since__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		vaccination__time_since			Time since each vaccine in the vaccination field was administered		16
+vaccination__time_since__unit_label			string		unit_label				vaccination__time_since__unit			vaccination__time_since__unit_label		17
+sex	Yes	unknown	string		enum			"[""male"", ""female"", ""mixed"", ""unknown""]"				Biological sex		18
+is_living	Yes		string		enum			"[""yes"", ""no"", ""unknown""]"				Whether organism was alive at time of biomaterial collection		19
+geographical_region			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/gaz	GAZ_00000013					Location where the sample was collected/donated		20
+geographical_region__ontology_label			string		ontology_label				geographical_region			geographical_region__ontology_label		21
+mhc_genotype			string									MHC genotype for humans and other species		22
+organism_age			number								organism_age__unit	Age of the organism at time of sample collection.		23
+organism_age__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		organism_age			organism_age__unit		24
+organism_age__unit_label			string		unit_label				organism_age__unit			organism_age__unit_label		25
+bmi			number									BMI of organism		26
+biosample_id	Yes		string											27
+organ	Yes		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uberon	UBERON_0000465					The organ that the biomaterial came from		28
+organ__ontology_label	Yes		string		ontology_label				organ			organ__ontology_label		29
+sample_type	Yes		string		enum			"[""cell line"", ""organoid"", ""direct from donor - fresh"", ""direct from donor - frozen"", ""cultured primary cells""]"				one of: cell line, organoid, direct from donor (fresh), direct from donor (frozen), cultured primary cells		30
+culture_duration			number							sample_type in cell line, organoid, cultured primary cells	culture_duration__unit	length of time cells have been in culture		31
+culture_duration__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		culture_duration			culture_duration__unit		32
+culture_duration__unit_label			string		unit_label				culture_duration__unit			culture_duration__unit_label		33
+enrichment_method			string	TRUE	enum			"[""cell size selection"", ""fluorescence-activated cell sorting"", ""magnetic affinity cell sorting"", ""laser capture microdissection"", ""density gradient centrifugation"", ""Ficoll-Hypaque method"", ""enrichment of methylated DNA""]"				Method used to enrich cells before running library preparation. This could be flow cytometry, column enrichments, etc.		34
+enrichment__cell_type			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/cl	CL_0000548		enrichment_method			The cell type that was sorted via an enrichment technique such as flow cytometry.		35
+enrichment__cell_type__ontology_label			string		ontology_label				enrichment__cell_type			enrichment__cell_type__ontology_label		36
+enrichment__facs_markers			string	TRUE					enrichment_method			The surface markers that were sorted on to enrich for the enriched cell type if flow cytometry was used		37
+disease	Yes	MONDO_0000001	string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/mondo,https://www.ebi.ac.uk/ols/api/ontologies/pato	MONDO_0000001					The disease state(s) of the individual donating the sample at the time of donation		38
+disease__ontology_label	Yes		string	TRUE	ontology_label				disease			disease__ontology_label		39
+disease__time_since_onset			number	TRUE					disease		disease__time_since_onset__unit	Amount of time since disease onset		40
+disease__time_since_onset__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		disease__time_since_onset			disease__time_since_onset__unit		41
+disease__time_since_onset__unit_label			string		unit_label				disease__time_since_onset__unit			disease__time_since_onset__unit_label		42
+disease__treated			boolean	TRUE					disease			If the donor was treated at the time the sample was collected		43
+disease__treatment			string	TRUE					disease__treated			A description of the treatment given to this donor		44
+disease__time_since_treatment_start			number	TRUE					disease__treatment		disease__time_since_treatment_start__unit	Amount of time since treatment was started (for drugs/continuous treatment) or performed (for surgery/immediate intervention)		45
+disease__time_since_treatment_start__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		disease__time_since_treatment_start			disease__time_since_treatment_start__unit		46
+disease__time_since_treatment_start__unit_label			string		unit_label				disease__time_since_treatment_start__unit			disease__time_since_treatment_start__unit_label		47
+disease__intracellular_pathogen			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/mondo	MONDO_0005550		disease			If evidence of a pathogen is detected in this cell		48
+disease__intracellular_pathogen__ontology_label			string	TRUE	ontology_label				disease__intracellular_pathogen			disease__intracellular_pathogen__ontology_label		49
+spike_in_kit			string									name of spike in kit		50
+spike_in_concentration			string						spike_in_kit			spike in concentration		51
+development_stage			string		ontology	http://www.ebi.ac.uk/ols/api/ontologies/hsapdv						A classification of the developmental stage of the organism		52
+development_stage__ontology_label			string		ontology_label				development_stage			development_stage__ontology_label		53
+end_bias			string		enum			"[""3 prime tag"", ""3 prime end bias"", ""5 prime tag"", ""5 prime end bias"", ""full length""]"				The end bias of the library preparation protocol used		54
+library_preparation_protocol	Yes		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/efo	EFO_0001457					The single cell RNA-sequencing protocol used for Library preparation		55
+library_preparation_protocol__ontology_label	Yes		string		ontology_label				library_preparation_protocol			library_preparation_protocol__ontology_label		56
+primer			string		enum			"[""poly-dT"",""random""]"				Primer used for cDNA synthesis from RNA		57
+strand			string		enum			"[""first"",""second"",""unstranded""]"				library strandedness		58
+sequencing_instrument_manufacturer_model			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/efo	EFO_0003739					name of sequencing instrument manufacturer		59
+sequencing_instrument_manufacturer_model__ontology_label			string		ontology_label				sequencing_instrument_manufacturer_model			sequencing_instrument_manufacturer_model__ontology_label		60
+paired_ends			boolean									true if the sequence library has paired end data (false for 10x)		61
+read_length			string									the read structure of the sequencing run		62
+small_molecule_perturbation			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/chebi	CHEBI_24431					a small molecule added to a cell culture (ex. A drug) growth factor (and if it is recombinant, concentration), gene)		63
+small_molecule_perturbation__ontology_label			string	TRUE	ontology_label				small_molecule_perturbation			small_molecule_perturbation__ontology_label		64
+small_molecule_perturbation__concentration			number	TRUE					small_molecule_perturbation		small_molecule_perturbation__concentration__unit	Concentration of each small molecule in the final tissue culture media. Order should be consistent with small_molecule_perturbation		65
+small_molecule_perturbation__concentration__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		small_molecule_perturbation__concentration			small_molecule_perturbation__concentration__unit		66
+small_molecule_perturbation__concentration__unit_label			string		unit_label				small_molecule_perturbation__concentration__unit			small_molecule_perturbation__concentration__unit_label		67
+small_molecule_perturbation__solvent			string	TRUE					small_molecule_perturbation			Solvent in which the small molecule was added to the cells. Ex. the base media.		68
+small_molecule_perturbation__source			string	TRUE					small_molecule_perturbation			Source from which the small molecule was purchased		69
+growth_factor_perturbation			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/pr	PR_000000001			sample_type in cell line, organoid, cultured primary cells		a growth factor added to a cell culture media		70
+growth_factor_perturbation__ontology_label			string	TRUE	ontology_label				growth_factor_perturbation			growth_factor_perturbation__ontology_label		71
+growth_factor_perturbation__concentration			number	TRUE					growth_factor_perturbation		growth_factor_perturbation__concentration__unit	Concentration of of each growth factor in the final tissue culture media. Order should be consistent with growth_factor_perturbation		72
+growth_factor_perturbation__concentration__unit			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		growth_factor_perturbation__concentration			growth_factor_perturbation__concentration__unit		73
+growth_factor_perturbation__concentration__unit_label			string		unit_label				growth_factor_perturbation__concentration__unit			growth_factor_perturbation__concentration__unit_label		74
+growth_factor_perturbation__solvent			string	TRUE					growth_factor_perturbation			Solvent in which the growth factor was added to the cells. Ex. the base media.		75
+growth_factor_perturbation__source			string	TRUE					growth_factor_perturbation			Source from which the growth factor was purchased		76
+gene_perturbation			string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/ogg	OGG_0000000002					A perturbation to a gene done to a cell culture		77
+gene_perturbation__ontology_label			string	TRUE	ontology_label				gene_perturbation			gene_perturbation__ontology_label		78
+gene_perturbation__method			string	TRUE					gene_perturbation			Process by which the gene was perturbed. Ex. CRISPR knock-out		79
+gene_perturbation__direction			string		enum			"[""knock in"", ""knock out"",""activation"",""repression""]"	gene_perturbation			The type of perturbation of the gene defined in gene_perturbation. Knock in and knock out are complete additions/depletions of the gene, activation and repression refer to changes in magnitude of expression.		80
+gene_perturbation__dynamics			string						gene_perturbation			Description of the timing with respect to sequencing and other logistical considerations of the gene perturbation		81
+CellID	Yes		string									Cell ID		82
+cell_type			string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/cl	CL_0000548					Cell type name determined via unsupervised clustering and marker genes		83
+cell_type__ontology_label			string		ontology_label				cell_type			cell_type__ontology_label		84
+number_of_reads			number									Number of reads mapped to that cell		85
+donor_id	Yes		string									Donor ID		87

--- a/lib/assets/metadata_schemas/alexandria_convention/snapshot/2.0.0/alexandria_convention_schema.json
+++ b/lib/assets/metadata_schemas/alexandria_convention/snapshot/2.0.0/alexandria_convention_schema.json
@@ -1,0 +1,698 @@
+{
+    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata-schema/alexandria_convention/2.0.0/alexandria_convention_schema.json",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "dependencies": {
+        "cell_type__ontology_label": [
+            "cell_type"
+        ],
+        "culture_duration": [
+            "culture_duration__unit"
+        ],
+        "culture_duration__unit": [
+            "culture_duration"
+        ],
+        "culture_duration__unit_label": [
+            "culture_duration__unit"
+        ],
+        "development_stage__ontology_label": [
+            "development_stage"
+        ],
+        "disease__intracellular_pathogen": [
+            "disease"
+        ],
+        "disease__intracellular_pathogen__ontology_label": [
+            "disease__intracellular_pathogen"
+        ],
+        "disease__ontology_label": [
+            "disease"
+        ],
+        "disease__time_since_onset": [
+            "disease",
+            "disease__time_since_onset__unit"
+        ],
+        "disease__time_since_onset__unit": [
+            "disease__time_since_onset"
+        ],
+        "disease__time_since_onset__unit_label": [
+            "disease__time_since_onset__unit"
+        ],
+        "disease__time_since_treatment_start": [
+            "disease__treatment",
+            "disease__time_since_treatment_start__unit"
+        ],
+        "disease__time_since_treatment_start__unit": [
+            "disease__time_since_treatment_start"
+        ],
+        "disease__time_since_treatment_start__unit_label": [
+            "disease__time_since_treatment_start__unit"
+        ],
+        "disease__treated": [
+            "disease"
+        ],
+        "disease__treatment": [
+            "disease__treated"
+        ],
+        "enrichment__cell_type": [
+            "enrichment_method"
+        ],
+        "enrichment__cell_type__ontology_label": [
+            "enrichment__cell_type"
+        ],
+        "enrichment__facs_markers": [
+            "enrichment_method"
+        ],
+        "ethnicity__ontology_label": [
+            "ethnicity"
+        ],
+        "gene_perturbation__direction": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__dynamics": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__method": [
+            "gene_perturbation"
+        ],
+        "gene_perturbation__ontology_label": [
+            "gene_perturbation"
+        ],
+        "geographical_region__ontology_label": [
+            "geographical_region"
+        ],
+        "growth_factor_perturbation__concentration": [
+            "growth_factor_perturbation",
+            "growth_factor_perturbation__concentration__unit"
+        ],
+        "growth_factor_perturbation__concentration__unit": [
+            "growth_factor_perturbation__concentration"
+        ],
+        "growth_factor_perturbation__concentration__unit_label": [
+            "growth_factor_perturbation__concentration__unit"
+        ],
+        "growth_factor_perturbation__ontology_label": [
+            "growth_factor_perturbation"
+        ],
+        "growth_factor_perturbation__solvent": [
+            "growth_factor_perturbation"
+        ],
+        "growth_factor_perturbation__source": [
+            "growth_factor_perturbation"
+        ],
+        "library_preparation_protocol__ontology_label": [
+            "library_preparation_protocol"
+        ],
+        "mouse_strain__ontology_label": [
+            "mouse_strain"
+        ],
+        "organ__ontology_label": [
+            "organ"
+        ],
+        "organism_age": [
+            "organism_age__unit"
+        ],
+        "organism_age__unit": [
+            "organism_age"
+        ],
+        "organism_age__unit_label": [
+            "organism_age__unit"
+        ],
+        "race__ontology_label": [
+            "race"
+        ],
+        "sequencing_instrument_manufacturer_model__ontology_label": [
+            "sequencing_instrument_manufacturer_model"
+        ],
+        "small_molecule_perturbation__concentration": [
+            "small_molecule_perturbation",
+            "small_molecule_perturbation__concentration__unit"
+        ],
+        "small_molecule_perturbation__concentration__unit": [
+            "small_molecule_perturbation__concentration"
+        ],
+        "small_molecule_perturbation__concentration__unit_label": [
+            "small_molecule_perturbation__concentration__unit"
+        ],
+        "small_molecule_perturbation__ontology_label": [
+            "small_molecule_perturbation"
+        ],
+        "small_molecule_perturbation__solvent": [
+            "small_molecule_perturbation"
+        ],
+        "small_molecule_perturbation__source": [
+            "small_molecule_perturbation"
+        ],
+        "species__ontology_label": [
+            "species"
+        ],
+        "spike_in_concentration": [
+            "spike_in_kit"
+        ],
+        "vaccination__adjuvants": [
+            "vaccination"
+        ],
+        "vaccination__dosage": [
+            "vaccination"
+        ],
+        "vaccination__ontology_label": [
+            "vaccination"
+        ],
+        "vaccination__route": [
+            "vaccination"
+        ],
+        "vaccination__time_since": [
+            "vaccination",
+            "vaccination__time_since__unit"
+        ],
+        "vaccination__time_since__unit": [
+            "vaccination__time_since"
+        ],
+        "vaccination__time_since__unit_label": [
+            "vaccination__time_since__unit"
+        ]
+    },
+    "description": "metadata convention for the alexandria project",
+    "properties": {
+        "CellID": {
+            "description": "Cell ID",
+            "type": "string"
+        },
+        "biosample_id": {
+            "description": "Biosample ID",
+            "type": "string"
+        },
+        "biosample_type": {
+            "description": "Type of Biosample",
+            "enum": ["CellLine","DerivedType_Organoid","DerivedType_InVitroDifferentiated","DerivedType_InducedPluripotentStemCell","PrimaryBioSample","PrimaryBioSample_BodyFluid","PrimaryBioSample_CellFreeDNA","PrimaryBioSample_PrimaryCell","PrimaryBioSample_PrimaryCulture","PrimaryBioSample_Stool","PrimaryBioSample_Tissue"],
+            "type": "string"
+        },
+        "bmi": {
+            "description": "BMI of organism",
+            "type": "number"
+        },
+        "cell_type": {
+            "description": "Cell type name determined via unsupervised clustering and marker genes",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/cl",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "cell_type__ontology_label": {
+            "description": "cell_type__ontology_label",
+            "type": "string"
+        },
+        "culture_duration": {
+            "dependency_condition": "sample_type in cell line, organoid, cultured primary cells",
+            "description": "length of time cells have been in culture",
+            "type": "number"
+        },
+        "culture_duration__unit": {
+            "description": "culture_duration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "culture_duration__unit_label": {
+            "description": "culture_duration__unit_label",
+            "type": "string"
+        },
+        "development_stage": {
+            "description": "A classification of the developmental stage of the organism",
+            "ontology": "http://www.ebi.ac.uk/ols/api/ontologies/hsapdv",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "development_stage__ontology_label": {
+            "description": "development_stage__ontology_label",
+            "type": "string"
+        },
+        "disease": {
+            "description": "The disease state(s) of the individual donating the sample at the time of donation",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/mondo,https://www.ebi.ac.uk/ols/api/ontologies/pato",
+            "type": "array"
+        },
+        "disease__intracellular_pathogen": {
+            "description": "If evidence of a pathogen is detected in this cell",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/mondo",
+            "type": "array"
+        },
+        "disease__intracellular_pathogen__ontology_label": {
+            "description": "disease__intracellular_pathogen__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "disease__ontology_label": {
+            "description": "disease__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "disease__time_since_onset": {
+            "description": "Amount of time since disease onset",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "disease__time_since_onset__unit": {
+            "description": "disease__time_since_onset__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "disease__time_since_onset__unit_label": {
+            "description": "disease__time_since_onset__unit_label",
+            "type": "string"
+        },
+        "disease__time_since_treatment_start": {
+            "description": "Amount of time since treatment was started (for drugs/continuous treatment) or performed (for surgery/immediate intervention)",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "disease__time_since_treatment_start__unit": {
+            "description": "disease__time_since_treatment_start__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "disease__time_since_treatment_start__unit_label": {
+            "description": "disease__time_since_treatment_start__unit_label",
+            "type": "string"
+        },
+        "disease__treated": {
+            "description": "If the donor was treated at the time the sample was collected",
+            "items": {
+                "type": "boolean"
+            },
+            "type": "array"
+        },
+        "disease__treatment": {
+            "description": "A description of the treatment given to this donor",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "donor_id": {
+            "description": "Donor ID",
+            "type": "string"
+        },
+        "end_bias": {
+            "description": "The end bias of the library preparation protocol used",
+            "enum": ["3 prime tag", "3 prime end bias", "5 prime tag", "5 prime end bias", "full length"],
+            "type": "string"
+        },
+        "enrichment__cell_type": {
+            "description": "The cell type that was sorted via an enrichment technique such as flow cytometry.",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/cl",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "enrichment__cell_type__ontology_label": {
+            "description": "enrichment__cell_type__ontology_label",
+            "type": "string"
+        },
+        "enrichment__facs_markers": {
+            "description": "The surface markers that were sorted on to enrich for the enriched cell type if flow cytometry was used",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "enrichment_method": {
+            "description": "Method used to enrich cells before running library preparation. This could be flow cytometry, column enrichments, etc.",
+            "items": {
+                "enum": ["cell size selection", "fluorescence-activated cell sorting", "magnetic affinity cell sorting", "laser capture microdissection", "density gradient centrifugation", "Ficoll-Hypaque method", "enrichment of methylated DNA"],
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "ethnicity": {
+            "dependency_condition": "species == NCBITaxon_9606",
+            "description": "The ethnicity or ethnicities of the human donor if known",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/hancestro",
+            "type": "array"
+        },
+        "ethnicity__ontology_label": {
+            "description": "ethnicity__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "gene_perturbation": {
+            "description": "A perturbation to a gene done to a cell culture",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ogg",
+            "type": "array"
+        },
+        "gene_perturbation__direction": {
+            "description": "The type of perturbation of the gene defined in gene_perturbation. Knock in and knock out are complete additions/depletions of the gene, activation and repression refer to changes in magnitude of expression.",
+            "enum": ["knock in", "knock out","activation","repression"],
+            "type": "string"
+        },
+        "gene_perturbation__dynamics": {
+            "description": "Description of the timing with respect to sequencing and other logistical considerations of the gene perturbation",
+            "type": "string"
+        },
+        "gene_perturbation__method": {
+            "description": "Process by which the gene was perturbed. Ex. CRISPR knock-out",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "gene_perturbation__ontology_label": {
+            "description": "gene_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "geographical_region": {
+            "description": "Location where the sample was collected/donated",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/gaz",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "geographical_region__ontology_label": {
+            "description": "geographical_region__ontology_label",
+            "type": "string"
+        },
+        "growth_factor_perturbation": {
+            "dependency_condition": "sample_type in cell line, organoid, cultured primary cells",
+            "description": "a growth factor added to a cell culture media",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/pr",
+            "type": "array"
+        },
+        "growth_factor_perturbation__concentration": {
+            "description": "Concentration of of each growth factor in the final tissue culture media. Order should be consistent with growth_factor_perturbation",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__concentration__unit": {
+            "description": "growth_factor_perturbation__concentration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "growth_factor_perturbation__concentration__unit_label": {
+            "description": "growth_factor_perturbation__concentration__unit_label",
+            "type": "string"
+        },
+        "growth_factor_perturbation__ontology_label": {
+            "description": "growth_factor_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__solvent": {
+            "description": "Solvent in which the growth factor was added to the cells. Ex. the base media.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "growth_factor_perturbation__source": {
+            "description": "Source from which the growth factor was purchased",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "is_living": {
+            "description": "Whether organism was alive at time of biomaterial collection",
+            "enum": ["yes", "no", "unknown"],
+            "type": "string"
+        },
+        "library_preparation_protocol": {
+            "description": "The single cell RNA-sequencing protocol used for Library preparation",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/efo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "library_preparation_protocol__ontology_label": {
+            "description": "library_preparation_protocol__ontology_label",
+            "type": "string"
+        },
+        "mhc_genotype": {
+            "description": "MHC genotype for humans and other species",
+            "type": "string"
+        },
+        "mouse_strain": {
+            "dependency_condition": "species == NCBITaxon_10090",
+            "description": "Mouse strain of the donor organism (ex. C57BL/6, BALB/c, 129, undetermined)",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncit",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "mouse_strain__ontology_label": {
+            "description": "mouse_strain__ontology_label",
+            "type": "string"
+        },
+        "number_of_reads": {
+            "description": "Number of reads mapped to that cell",
+            "type": "number"
+        },
+        "organ": {
+            "description": "The organ that the biomaterial came from",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uberon",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "organ__ontology_label": {
+            "description": "organ__ontology_label",
+            "type": "string"
+        },
+        "organism_age": {
+            "description": "Age of the organism at time of sample collection.",
+            "type": "number"
+        },
+        "organism_age__unit": {
+            "description": "organism_age__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "organism_age__unit_label": {
+            "description": "organism_age__unit_label",
+            "type": "string"
+        },
+        "paired_ends": {
+            "description": "true if the sequence library has paired end data (false for 10x)",
+            "type": "boolean"
+        },
+        "preservation_method": {
+            "description": "Method used for sample preservation",
+            "enum": ["Cryopreservation","FFPE","Fresh","Frozen","OCT-embedded","Snap","Frozen"],
+            "type": "string"
+        },
+        "primer": {
+            "description": "Primer used for cDNA synthesis from RNA",
+            "enum": ["poly-dT","random"],
+            "type": "string"
+        },
+        "race": {
+            "dependency_condition": "species == NCBITaxon_9606",
+            "description": "An arbitrary classification of a taxonomic group that is a division of a species",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncit",
+            "type": "array"
+        },
+        "race__ontology_label": {
+            "description": "race__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "read_length": {
+            "description": "the read structure of the sequencing run",
+            "type": "string"
+        },
+        "sequencing_instrument_manufacturer_model": {
+            "description": "name of sequencing instrument manufacturer",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/efo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "sequencing_instrument_manufacturer_model__ontology_label": {
+            "description": "sequencing_instrument_manufacturer_model__ontology_label",
+            "type": "string"
+        },
+        "sex": {
+            "description": "Biological sex",
+            "enum": ["male", "female", "mixed", "unknown"],
+            "type": "string"
+        },
+        "small_molecule_perturbation": {
+            "description": "a small molecule added to a cell culture (ex. A drug) growth factor (and if it is recombinant, concentration), gene)",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/chebi",
+            "type": "array"
+        },
+        "small_molecule_perturbation__concentration": {
+            "description": "Concentration of each small molecule in the final tissue culture media. Order should be consistent with small_molecule_perturbation",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__concentration__unit": {
+            "description": "small_molecule_perturbation__concentration__unit",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "small_molecule_perturbation__concentration__unit_label": {
+            "description": "small_molecule_perturbation__concentration__unit_label",
+            "type": "string"
+        },
+        "small_molecule_perturbation__ontology_label": {
+            "description": "small_molecule_perturbation__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__solvent": {
+            "description": "Solvent in which the small molecule was added to the cells. Ex. the base media.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "small_molecule_perturbation__source": {
+            "description": "Source from which the small molecule was purchased",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "species": {
+            "description": "The scientific binomial name for the species of the organism.",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "species__ontology_label": {
+            "description": "species__ontology_label",
+            "type": "string"
+        },
+        "spike_in_concentration": {
+            "description": "spike in concentration",
+            "type": "string"
+        },
+        "spike_in_kit": {
+            "description": "name of spike in kit",
+            "type": "string"
+        },
+        "strand": {
+            "description": "library strandedness",
+            "enum": ["first","second","unstranded"],
+            "type": "string"
+        },
+        "vaccination": {
+            "description": "Any known vaccines administered to the donor organism. NOT a full vaccine history",
+            "items": {
+                "pattern": "^[-A-Za-z0-9]+[_:][-A-Za-z0-9]+",
+                "type": "string"
+            },
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/vo",
+            "type": "array"
+        },
+        "vaccination__adjuvants": {
+            "description": "Any adjuvants administered in the vaccine",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__dosage": {
+            "description": "The dosage and units for the vaccine",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__ontology_label": {
+            "description": "vaccination__ontology_label",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__route": {
+            "description": "Intradermal, Intranasal, Intravenous, Aerosol",
+            "items": {
+                "enum": ["intradermal", "intranasal", "intravenous", "aerosol", "intramuscular", "mucosal", "oral"],
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "vaccination__time_since": {
+            "description": "Amount of time since vaccine was administered",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "vaccination__time_since__unit": {
+            "description": "Time since each vaccine in the vaccination field was administered",
+            "ontology": "https://www.ebi.ac.uk/ols/api/ontologies/uo",
+            "pattern": "^[A-Za-z]+[_:][0-9]",
+            "type": "string"
+        },
+        "vaccination__time_since__unit_label": {
+            "description": "vaccination__time_since__unit_label",
+            "type": "string"
+        }
+    },
+    "required": [
+        "biosample_id",
+        "biosample_type",
+        "CellID",
+        "disease",
+        "disease__ontology_label",
+        "donor_id",
+        "library_preparation_protocol",
+        "library_preparation_protocol__ontology_label",
+        "organ",
+        "organ__ontology_label",
+        "sex",
+        "species",
+        "species__ontology_label"
+    ],
+    "title": "alexandria metadata convention"
+}

--- a/lib/assets/metadata_schemas/alexandria_convention/snapshot/2.0.0/alexandria_convention_schema.json
+++ b/lib/assets/metadata_schemas/alexandria_convention/snapshot/2.0.0/alexandria_convention_schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata-schema/alexandria_convention/2.0.0/alexandria_convention_schema.json",
+    "$id": "https://singlecell.broadinstitute.org/single_cell/api/v1/metadata_schemas/alexandria_convention/2.0.0/json",
     "$schema": "https://json-schema.org/draft-07/schema#",
     "dependencies": {
         "cell_type__ontology_label": [

--- a/lib/assets/metadata_schemas/alexandria_convention/snapshot/2.0.0/alexandria_convention_schema.tsv
+++ b/lib/assets/metadata_schemas/alexandria_convention/snapshot/2.0.0/alexandria_convention_schema.tsv
@@ -1,0 +1,87 @@
+attribute	required	type	array	class	ontology	ontology_root	controlled_list_entries	dependency	dependency_condition	dependent	attribute_description
+biosample_id	Yes	string									Biosample ID
+biosample_type	Yes	string		enum			"[""CellLine"",""DerivedType_Organoid"",""DerivedType_InVitroDifferentiated"",""DerivedType_InducedPluripotentStemCell"",""PrimaryBioSample"",""PrimaryBioSample_BodyFluid"",""PrimaryBioSample_CellFreeDNA"",""PrimaryBioSample_PrimaryCell"",""PrimaryBioSample_PrimaryCulture"",""PrimaryBioSample_Stool"",""PrimaryBioSample_Tissue""]"				Type of Biosample
+CellID	Yes	string									Cell ID
+disease	Yes	string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/mondo,https://www.ebi.ac.uk/ols/api/ontologies/pato	MONDO_0000001					The disease state(s) of the individual donating the sample at the time of donation
+disease__ontology_label	Yes	string	TRUE	ontology_label				disease			disease__ontology_label
+donor_id	Yes	string									Donor ID
+library_preparation_protocol	Yes	string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/efo	OBI_0000711					The single cell RNA-sequencing protocol used for Library preparation
+library_preparation_protocol__ontology_label	Yes	string		ontology_label				library_preparation_protocol			library_preparation_protocol__ontology_label
+organ	Yes	string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uberon	UBERON_0000465					The organ that the biomaterial came from
+organ__ontology_label	Yes	string		ontology_label				organ			organ__ontology_label
+sex	Yes	string		enum			"[""male"", ""female"", ""mixed"", ""unknown""]"				Biological sex
+species	Yes	string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon	NCBITaxon_2759					The scientific binomial name for the species of the organism.
+species__ontology_label	Yes	string		ontology_label				species			species__ontology_label
+bmi		number									BMI of organism
+cell_type		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/cl	CL_0000548					Cell type name determined via unsupervised clustering and marker genes
+cell_type__ontology_label		string		ontology_label				cell_type			cell_type__ontology_label
+culture_duration		number							sample_type in cell line, organoid, cultured primary cells	culture_duration__unit	length of time cells have been in culture
+culture_duration__unit		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		culture_duration			culture_duration__unit
+culture_duration__unit_label		string		unit_label				culture_duration__unit			culture_duration__unit_label
+development_stage		string		ontology	http://www.ebi.ac.uk/ols/api/ontologies/hsapdv						A classification of the developmental stage of the organism
+development_stage__ontology_label		string		ontology_label				development_stage			development_stage__ontology_label
+disease__intracellular_pathogen		string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/mondo	MONDO_0005550		disease			If evidence of a pathogen is detected in this cell
+disease__intracellular_pathogen__ontology_label		string	TRUE	ontology_label				disease__intracellular_pathogen			disease__intracellular_pathogen__ontology_label
+disease__time_since_onset		number	TRUE					disease		disease__time_since_onset__unit	Amount of time since disease onset
+disease__time_since_onset__unit		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		disease__time_since_onset			disease__time_since_onset__unit
+disease__time_since_onset__unit_label		string		unit_label				disease__time_since_onset__unit			disease__time_since_onset__unit_label
+disease__time_since_treatment_start		number	TRUE					disease__treatment		disease__time_since_treatment_start__unit	Amount of time since treatment was started (for drugs/continuous treatment) or performed (for surgery/immediate intervention)
+disease__time_since_treatment_start__unit		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		disease__time_since_treatment_start			disease__time_since_treatment_start__unit
+disease__time_since_treatment_start__unit_label		string		unit_label				disease__time_since_treatment_start__unit			disease__time_since_treatment_start__unit_label
+disease__treated		boolean	TRUE					disease			If the donor was treated at the time the sample was collected
+disease__treatment		string	TRUE					disease__treated			A description of the treatment given to this donor
+end_bias		string		enum			"[""3 prime tag"", ""3 prime end bias"", ""5 prime tag"", ""5 prime end bias"", ""full length""]"				The end bias of the library preparation protocol used
+enrichment__cell_type		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/cl	CL_0000548		enrichment_method			The cell type that was sorted via an enrichment technique such as flow cytometry.
+enrichment__cell_type__ontology_label		string		ontology_label				enrichment__cell_type			enrichment__cell_type__ontology_label
+enrichment__facs_markers		string	TRUE					enrichment_method			The surface markers that were sorted on to enrich for the enriched cell type if flow cytometry was used
+enrichment_method		string	TRUE	enum			"[""cell size selection"", ""fluorescence-activated cell sorting"", ""magnetic affinity cell sorting"", ""laser capture microdissection"", ""density gradient centrifugation"", ""Ficoll-Hypaque method"", ""enrichment of methylated DNA""]"				Method used to enrich cells before running library preparation. This could be flow cytometry, column enrichments, etc.
+ethnicity		string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/hancestro	HANCESTRO:0004			species == NCBITaxon_9606		The ethnicity or ethnicities of the human donor if known
+ethnicity__ontology_label		string	TRUE	ontology_label				ethnicity			ethnicity__ontology_label
+gene_perturbation		string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/ogg	OGG_0000000002					A perturbation to a gene done to a cell culture
+gene_perturbation__direction		string		enum			"[""knock in"", ""knock out"",""activation"",""repression""]"	gene_perturbation			The type of perturbation of the gene defined in gene_perturbation. Knock in and knock out are complete additions/depletions of the gene, activation and repression refer to changes in magnitude of expression.
+gene_perturbation__dynamics		string						gene_perturbation			Description of the timing with respect to sequencing and other logistical considerations of the gene perturbation
+gene_perturbation__method		string	TRUE					gene_perturbation			Process by which the gene was perturbed. Ex. CRISPR knock-out
+gene_perturbation__ontology_label		string	TRUE	ontology_label				gene_perturbation			gene_perturbation__ontology_label
+geographical_region		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/gaz	GAZ_00000013					Location where the sample was collected/donated
+geographical_region__ontology_label		string		ontology_label				geographical_region			geographical_region__ontology_label
+growth_factor_perturbation		string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/pr	PR_000000001			sample_type in cell line, organoid, cultured primary cells		a growth factor added to a cell culture media
+growth_factor_perturbation__concentration		number	TRUE					growth_factor_perturbation		growth_factor_perturbation__concentration__unit	Concentration of of each growth factor in the final tissue culture media. Order should be consistent with growth_factor_perturbation
+growth_factor_perturbation__concentration__unit		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		growth_factor_perturbation__concentration			growth_factor_perturbation__concentration__unit
+growth_factor_perturbation__concentration__unit_label		string		unit_label				growth_factor_perturbation__concentration__unit			growth_factor_perturbation__concentration__unit_label
+growth_factor_perturbation__ontology_label		string	TRUE	ontology_label				growth_factor_perturbation			growth_factor_perturbation__ontology_label
+growth_factor_perturbation__solvent		string	TRUE					growth_factor_perturbation			Solvent in which the growth factor was added to the cells. Ex. the base media.
+growth_factor_perturbation__source		string	TRUE					growth_factor_perturbation			Source from which the growth factor was purchased
+is_living		string		enum			"[""yes"", ""no"", ""unknown""]"				Whether organism was alive at time of biomaterial collection
+mhc_genotype		string									MHC genotype for humans and other species
+mouse_strain		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncit	"NCIT_C14420 "			species == NCBITaxon_10090		Mouse strain of the donor organism (ex. C57BL/6, BALB/c, 129, undetermined)
+mouse_strain__ontology_label		string		ontology_label				mouse_strain			mouse_strain__ontology_label
+number_of_reads		number									Number of reads mapped to that cell
+organism_age		number								organism_age__unit	Age of the organism at time of sample collection.
+organism_age__unit		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		organism_age			organism_age__unit
+organism_age__unit_label		string		unit_label				organism_age__unit			organism_age__unit_label
+paired_ends		boolean									true if the sequence library has paired end data (false for 10x)
+preservation_method		string		enum			"[""Cryopreservation"",""FFPE"",""Fresh"",""Frozen"",""OCT-embedded"",""Snap"",""Frozen""]"				Method used for sample preservation
+primer		string		enum			"[""poly-dT"",""random""]"				Primer used for cDNA synthesis from RNA
+race		string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/ncit	NCIT:C17049			species == NCBITaxon_9606		An arbitrary classification of a taxonomic group that is a division of a species
+race__ontology_label		string	TRUE	ontology_label				race			race__ontology_label
+read_length		string									the read structure of the sequencing run
+sequencing_instrument_manufacturer_model		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/efo	EFO_0003739					name of sequencing instrument manufacturer
+sequencing_instrument_manufacturer_model__ontology_label		string		ontology_label				sequencing_instrument_manufacturer_model			sequencing_instrument_manufacturer_model__ontology_label
+small_molecule_perturbation		string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/chebi	CHEBI_24431					a small molecule added to a cell culture (ex. A drug) growth factor (and if it is recombinant, concentration), gene)
+small_molecule_perturbation__concentration		number	TRUE					small_molecule_perturbation		small_molecule_perturbation__concentration__unit	Concentration of each small molecule in the final tissue culture media. Order should be consistent with small_molecule_perturbation
+small_molecule_perturbation__concentration__unit		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		small_molecule_perturbation__concentration			small_molecule_perturbation__concentration__unit
+small_molecule_perturbation__concentration__unit_label		string		unit_label				small_molecule_perturbation__concentration__unit			small_molecule_perturbation__concentration__unit_label
+small_molecule_perturbation__ontology_label		string	TRUE	ontology_label				small_molecule_perturbation			small_molecule_perturbation__ontology_label
+small_molecule_perturbation__solvent		string	TRUE					small_molecule_perturbation			Solvent in which the small molecule was added to the cells. Ex. the base media.
+small_molecule_perturbation__source		string	TRUE					small_molecule_perturbation			Source from which the small molecule was purchased
+spike_in_concentration		string						spike_in_kit			spike in concentration
+spike_in_kit		string									name of spike in kit
+strand		string		enum			"[""first"",""second"",""unstranded""]"				library strandedness
+vaccination		string	TRUE	ontology	https://www.ebi.ac.uk/ols/api/ontologies/vo	VO_0000001					Any known vaccines administered to the donor organism. NOT a full vaccine history
+vaccination__adjuvants		string	TRUE					vaccination			Any adjuvants administered in the vaccine
+vaccination__dosage		string	TRUE					vaccination			The dosage and units for the vaccine
+vaccination__ontology_label		string	TRUE	ontology_label				vaccination			vaccination__ontology_label
+vaccination__route		string	TRUE	enum			"[""intradermal"", ""intranasal"", ""intravenous"", ""aerosol"", ""intramuscular"", ""mucosal"", ""oral""]"	vaccination			Intradermal, Intranasal, Intravenous, Aerosol
+vaccination__time_since		number	TRUE					vaccination		vaccination__time_since__unit	Amount of time since vaccine was administered
+vaccination__time_since__unit		string		ontology	https://www.ebi.ac.uk/ols/api/ontologies/uo	UO_0000003		vaccination__time_since			Time since each vaccine in the vaccination field was administered
+vaccination__time_since__unit_label		string		unit_label				vaccination__time_since__unit			vaccination__time_since__unit_label

--- a/test/api/metadata_schemas_controller_test.rb
+++ b/test/api/metadata_schemas_controller_test.rb
@@ -1,0 +1,53 @@
+require 'api_test_helper'
+
+class MetadataSchemasControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+  include Requests::JsonHelpers
+  include Requests::HttpHelpers
+
+  SCHEMAS_BASE_DIR = Api::V1::MetadataSchemasController::SCHEMAS_BASE_DIR
+
+  setup do
+    @schemas = {}
+    projects = Dir.entries(SCHEMAS_BASE_DIR).delete_if {|entry| entry.start_with?('.')}
+    projects.each do |project_name|
+      snapshots_path = SCHEMAS_BASE_DIR + "#{project_name}/snapshot"
+      snapshots = Dir.entries(snapshots_path).delete_if {|entry| entry.start_with?('.')}
+      versions = %w(latest) + Naturally.sort(snapshots).reverse
+      @schemas[project_name] = versions
+    end
+  end
+
+  test 'should load all available schemas' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    execute_http_request(:get, api_v1_metadata_schemas_path)
+    assert_response 200, "Did not get any metadata schemas"
+    assert_equal @schemas, json, "Did not find correct projects/schemas, exepected #{@schemas} but found #{json}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should load requested schema' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    project = @schemas.keys.sample
+    schema_version = @schemas[project].sample
+    schema_format = %w(json tsv).sample
+    schema_filename = "#{project}_schema.#{schema_format}"
+    if schema_version == 'latest'
+      schema_filepath = Rails.root.join(SCHEMAS_BASE_DIR, project, schema_filename)
+    else
+      schema_filepath = Rails.root.join(SCHEMAS_BASE_DIR, project, 'snapshot',
+                                        schema_version, schema_filename)
+    end
+    convention_schema = JSON.parse(File.open(schema_filepath).read)
+    execute_http_request(:get, api_v1_metadata_schemas_load_convention_schema_path(project_name: project, version: schema_version,
+                                                                                   schema_format:  schema_format))
+    assert_response 200, "Did not load requested convention metadata schema: #{project}/#{schema_version}/#{schema_filename}"
+    assert_equal convention_schema, json,
+                 "Convention schema does not match requested schema: #{convention_schema}\n\n#{json}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+end

--- a/test/api/metadata_schemas_controller_test.rb
+++ b/test/api/metadata_schemas_controller_test.rb
@@ -4,18 +4,12 @@ class MetadataSchemasControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
   include Requests::JsonHelpers
   include Requests::HttpHelpers
+  include Api::V1::Concerns::ConventionSchemas
 
   SCHEMAS_BASE_DIR = Api::V1::MetadataSchemasController::SCHEMAS_BASE_DIR
 
   setup do
-    @schemas = {}
-    projects = Dir.entries(SCHEMAS_BASE_DIR).delete_if {|entry| entry.start_with?('.')}
-    projects.each do |project_name|
-      snapshots_path = SCHEMAS_BASE_DIR + "#{project_name}/snapshot"
-      snapshots = Dir.entries(snapshots_path).delete_if {|entry| entry.start_with?('.')}
-      versions = %w(latest) + Naturally.sort(snapshots).reverse
-      @schemas[project_name] = versions
-    end
+    @schemas = set_available_schemas
   end
 
   test 'should load all available schemas' do
@@ -33,7 +27,7 @@ class MetadataSchemasControllerTest < ActionDispatch::IntegrationTest
 
     project = @schemas.keys.sample
     schema_version = @schemas[project].sample
-    schema_format = %w(json tsv).sample
+    schema_format ='json'
     schema_filename = "#{project}_schema.#{schema_format}"
     if schema_version == 'latest'
       schema_filepath = Rails.root.join(SCHEMAS_BASE_DIR, project, schema_filename)

--- a/test/api_test_helper.rb
+++ b/test/api_test_helper.rb
@@ -18,7 +18,9 @@ module Requests
     # execute an HTTP call of the specified method to a given path (with optional payload), setting accept & content_type
     # to :json and prepending the authorization bearer token to the headers
     def execute_http_request(method, path, request_payload={})
-      send(method.to_sym, path, params: request_payload, as: :json, headers: {authorization: "Bearer #{@user.api_access_token[:access_token]}"})
+      token = @user.present? ? "Bearer #{@user.api_access_token[:access_token]}" : nil
+      headers = token.present? ? {authorization: "Bearer #{token}"} : {}
+      send(method.to_sym, path, params: request_payload, as: :json, headers: headers)
     end
   end
 end


### PR DESCRIPTION
Adding API endpoint to serve up metadata convention schema files, in JSON and TSV format.  Will include all previous "snapshots", as well as a stable URL that will always point to the latest version of any convention.

This PR satisfies SCP-2322.