### PR TITLE
moving feature flag defaults to database

### DIFF
--- a/app/controllers/admin_configurations_controller.rb
+++ b/app/controllers/admin_configurations_controller.rb
@@ -319,12 +319,12 @@ class AdminConfigurationsController < ApplicationController
   # because of the true/false/default structure, we have to have custom logic to handle the values
   def self.process_feature_flag_form_data(user, params)
     updated_flag_data = {}
-    User::DEFAULT_FEATURE_FLAGS.each do |key, _value|
+    FeatureFlag.all.each do |default_flag|
       # for each possible feature flag, check if the vaule was set on the form via a field name feature_flag_<<flag name>>
-      flag_form_val = params[('feature_flag_' + key).to_sym]
+      flag_form_val = params[('feature_flag_' + default_flag.name).to_sym]
       # if it was set, and not set to '-' (default), include it in the updated values
       if flag_form_val && flag_form_val != '-'
-        updated_flag_data[key] = flag_form_val == '1' ? true : false
+        updated_flag_data[default_flag.name] = flag_form_val == '1' ? true : false
       end
     end
     user.update!(feature_flags: updated_flag_data)

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -1,0 +1,22 @@
+class FeatureFlag
+
+  ###
+  #
+  # FeatureFlag: stores global default values for feature flags
+  #
+  ###
+
+  include Mongoid::Document
+
+  field :name, type: String
+  field :default_value, type: Boolean, default: false
+  field :description, type: String
+
+  # return a hash of name => default for all flags
+  def self.default_flag_hash
+    FeatureFlag.all.inject({}) do |hash, flag|
+      hash[flag.name] = flag.default_value;
+      hash
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,18 +98,9 @@ class User
   field :api_access_token, type: Hash
 
   # feature_flags should be a hash of true/false values.  If unspecified for a given flag, the
-  # value from DEFAULT_FEATURE_FLAGS should be used.  Accordingly, the helper method feature_flags_with_defaults
+  # default_value from the FeatureFlag should be used.  Accordingly, the helper method feature_flags_with_defaults
   # is provided
   field :feature_flags, default: {}
-
-  DEFAULT_FEATURE_FLAGS = {
-    # whether the home page uses React and the new search API
-    "advanced_search" => false,
-    # whether the facet search controls are shown
-    "faceted_search" => false,
-    # show covid-19 tab on homepage
-    "covid19_page" => true
-  }
 
   ###
   #
@@ -304,7 +295,7 @@ class User
   # merges the user flags with the defaults -- this should  always be used in place of feature_flags
   # for determining whether to enable a feature for a given user.
   def feature_flags_with_defaults
-    DEFAULT_FEATURE_FLAGS.merge(feature_flags ? feature_flags : {})
+    FeatureFlag.default_flag_hash.merge(feature_flags ? feature_flags : {})
   end
 
   # gets the feature flag value for a given user, and the default value if no user is given
@@ -312,14 +303,14 @@ class User
     if user.present?
       user.feature_flags_with_defaults[flag_key]
     else
-      DEFAULT_FEATURE_FLAGS[flag_key]
+      FeatureFlag.find_by(name: flag_key)
     end
   end
 
   # returns feature_flags_with_defaults for the user, or the default flags if no user is given
   def self.feature_flags_for_user(user)
     if user.nil?
-      return DEFAULT_FEATURE_FLAGS
+      return FeatureFlag.default_flag_hash
     end
     user.feature_flags_with_defaults
   end

--- a/app/views/admin_configurations/edit_user.html.erb
+++ b/app/views/admin_configurations/edit_user.html.erb
@@ -28,8 +28,10 @@
     </div>
   </div>
   <div class="form-group row">
-    <div class="col-md-12">
-      <label>Feature flags</label>
+    <div class="row">
+      <div class="col-md-12">
+        <label>Feature flags</label>
+      </div>
     </div>
     <% @user.feature_flags_with_defaults.each do |key, value| %>
       <% @default_flag =  FeatureFlag.find_by(name: key) %>

--- a/app/views/admin_configurations/edit_user.html.erb
+++ b/app/views/admin_configurations/edit_user.html.erb
@@ -32,16 +32,20 @@
       <label>Feature flags</label>
     </div>
     <% @user.feature_flags_with_defaults.each do |key, value| %>
+      <% @default_flag =  FeatureFlag.find_by(name: key) %>
       <div class="row <%= @user.feature_flags.key?(key) ? 'highlight' : '' %>">
         <div class="col-md-3 text-right">
           <label><%= key %>:</label>
         </div>
-        <div class="col-md-6">
+        <div class="col-md-2">
           <select name="feature_flag_<%= key %>">
             <option value="0" <%= @user.feature_flags[key] == false ? 'selected' : '' %>>False</option>
             <option value="1" <%= @user.feature_flags[key] == true ? 'selected' : '' %>>True</option>
-            <option value="-" <%= @user.feature_flags.key?(key) ? '' : 'selected' %>>Default (<%= User::DEFAULT_FEATURE_FLAGS[key] %>)</option>
+            <option value="-" <%= @user.feature_flags.key?(key) ? '' : 'selected' %>>Default (<%= @default_flag.default_value %>)</option>
           </select>
+        </div>
+        <div class="col-md-6">
+          <%= @default_flag.description %>
         </div>
       </div>
      <% end %>

--- a/db/migrate/20200413211749_add_feature_flag_defaults.rb
+++ b/db/migrate/20200413211749_add_feature_flag_defaults.rb
@@ -1,0 +1,32 @@
+
+
+
+
+class AddFeatureFlagDefaults < Mongoid::Migration
+  # mirror of FeatureFlag.rb, so this migration won't error if that class is renamed/altered
+  class FeatureFlagMigrator
+    include Mongoid::Document
+    store_in collection: 'feature_flags'
+    field :name, type: String
+    field :default_value, type: Boolean, default: false
+    field :description, type: String
+  end
+
+  def self.up
+    FeatureFlagMigrator.create!(name: 'advanced_search',
+                        default_value: false,
+                        description: 'whether to show the React-powered, ajax search UI')
+
+    FeatureFlagMigrator.create!(name: 'faceted_search',
+                        default_value: false,
+                        description: 'whether to show the facet controls in the advanced search')
+
+    FeatureFlagMigrator.create!(name: 'covid19_page',
+                        default_value: false,
+                        description: 'whether to show the COVID-19 link on the homepage')
+  end
+
+  def self.down
+    FeatureFlagMigrator.destroy_all
+  end
+end


### PR DESCRIPTION
In addition to moving the defaults to the db for deploy-free default changes, this also adds a 'description' for each flag to help with the admin UI.  Note that this PR *needs* the accompanying migration to be run, so we'll want to double-check that our environments don't have prior blocking migrations that prevent this from being run

![image](https://user-images.githubusercontent.com/2800795/79172893-02aa5200-7dc4-11ea-81df-37e8afc63ed2.png)

