### PR TITLE
Skipping nil/optional outputs when syncing workflow submissions (SCP-2339)

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -303,13 +303,15 @@ class StudiesController < ApplicationController
                 process_workflow_output(output_name, output_file, remote_file, workflow, params[:submission_id], configuration)
               end
             end
-          else
+          elsif outputs.is_a?(String)
             file_location = outputs.gsub(/gs\:\/\/#{@study.bucket_id}\//, '')
             # get google instance of file
             remote_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, @study.bucket_id, file_location)
             if remote_file.present?
               process_workflow_output(output_name, outputs, remote_file, workflow, params[:submission_id], configuration)
             end
+          else
+            next # optional outputs can be nil so ignore
           end
         end
         metadata = AnalysisMetadatum.find_by(study_id: @study.id, submission_id: params[:submission_id])

--- a/app/models/analysis_metadatum.rb
+++ b/app/models/analysis_metadatum.rb
@@ -268,12 +268,14 @@ class AnalysisMetadatum
           outputs = []
           workflows.each do |workflow|
             outs = workflow['outputs'].values
-            outs.each do |o|
-              outputs << {
-                  'name' => o.split('/').last,
-                  'file_path' => o,
-                  'format' => o.split('.').last
-              }
+            if outs.present?
+              outs.each do |o|
+                outputs << {
+                    'name' => o.split('/').last,
+                    'file_path' => o,
+                    'format' => o.split('.').last
+                }
+              end
             end
           end
           value = set_value_by_type(definitions, outputs)

--- a/app/models/analysis_metadatum.rb
+++ b/app/models/analysis_metadatum.rb
@@ -268,14 +268,12 @@ class AnalysisMetadatum
           outputs = []
           workflows.each do |workflow|
             outs = workflow['outputs'].values
-            if outs.present?
-              outs.each do |o|
-                outputs << {
-                    'name' => o.split('/').last,
-                    'file_path' => o,
-                    'format' => o.split('.').last
-                }
-              end
+            outs&.each do |o|
+              outputs << {
+                  'name' => o.split('/').last,
+                  'file_path' => o,
+                  'format' => o.split('.').last
+              }
             end
           end
           value = set_value_by_type(definitions, outputs)


### PR DESCRIPTION
Syncing workflow submissions currently breaks if a submission had "optional" outputs the were not generated or defined.  To avoid throwing errors, the portal now skips any optional/nil outputs in workflows if they are not present.  This also addresses a similar issue when attempting to generate an `analysis.json` file with submission metadata.

This PR satisfies SCP-2339.
