### PR TITLE
Adding migrations for new BQ columns (SCP-2280)

### DIFF
--- a/db/migrate/20200413153338_add_metadata_convention_version_to_bq.rb
+++ b/db/migrate/20200413153338_add_metadata_convention_version_to_bq.rb
@@ -1,0 +1,26 @@
+class AddMetadataConventionVersionToBq < Mongoid::Migration
+  def self.up
+    # do portal table first, then test dataset
+    client = BigQueryClient.new.client
+    [CellMetadatum::BIGQUERY_DATASET, 'cell_metadata_test'].each do |dataset_name|
+      dataset = client.dataset(dataset_name)
+      table = dataset.table(CellMetadatum::BIGQUERY_TABLE)
+      table.schema {|s| s.string('metadata_convention_version', mode: :nullable)}
+      update_command = "UPDATE #{CellMetadatum::BIGQUERY_TABLE} "
+      update_command += "SET metadata_convention_version = '1.1.3'"
+      update_command += "WHERE metadata_convention_version IS NULL"
+      dataset.query update_command
+    end
+  end
+
+  def self.down
+    client = BigQueryClient.new.client
+    [CellMetadatum::BIGQUERY_DATASET, 'cell_metadata_test'].each do |dataset_name|
+      dataset = client.dataset(dataset_name)
+      update_command = "UPDATE #{CellMetadatum::BIGQUERY_TABLE} "
+      update_command += "SET metadata_convention_version = NULL"
+      update_command += "WHERE metadata_convention_version = '1.1.3'"
+      dataset.query update_command
+    end
+  end
+end

--- a/db/migrate/20200413161403_add_biosample_type_and_preservation_method_to_bq.rb
+++ b/db/migrate/20200413161403_add_biosample_type_and_preservation_method_to_bq.rb
@@ -1,0 +1,14 @@
+class AddBiosampleTypeAndPreservationMethodToBq < Mongoid::Migration
+  def self.up
+    client = BigQueryClient.new.client
+    [CellMetadatum::BIGQUERY_DATASET, 'cell_metadata_test'].each do |dataset_name|
+      dataset = client.dataset(dataset_name)
+      table = dataset.table(CellMetadatum::BIGQUERY_TABLE)
+      table.schema {|s| s.string('biosample_type', mode: :nullable)}
+      table.schema {|s| s.string('preservation_method', mode: :nullable)}
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
3 new columns are being added to BigQuery as a part of the Alexandria metadata convention `2.0.0` release:

- metadata_convention_version (string, nullable)
- biosample_type (string, nullable)
- preservation_method (string, nullable)

This also backfills all existing entries with a `metadata_convention_version` value of `1.1.3`, so that when `2.0.0` is released, all legacy data will be correctly versioned.  In addition, the test schema for each instance of the portal will also be updated so any unit/integration tests for BigQuery will also use the updated schema.

This PR satisfies SCP-2280.