### PR TITLE
Fixing AnalysisMetadatum, migration errors (SCP-2339)

### DIFF
--- a/app/models/analysis_metadatum.rb
+++ b/app/models/analysis_metadatum.rb
@@ -138,7 +138,8 @@ class AnalysisMetadatum
   # set a value based on the schema definition for a particular field
   def set_value_by_type(definitions, value)
     value_type = definitions['type']
-    case value_type
+    if value.present?
+      case value_type
       when 'string'
         value.gsub(/\"/, '')
       when 'integer'
@@ -152,6 +153,7 @@ class AnalysisMetadatum
         end
       else
         value
+      end
     end
   end
 
@@ -179,7 +181,7 @@ class AnalysisMetadatum
               # some fields are nested, so check first. do a conditional assignment in case we already have a value
               if location.include?('/')
                 parent, child = location.split('/')
-                call[property] ||= set_value_by_type(definitions, attributes[parent][child])
+                call[property] ||= set_value_by_type(definitions, attributes.dig(parent, child))
               else
                 call[property] ||= set_value_by_type(definitions, attributes[location])
               end

--- a/db/migrate/20200413153338_add_metadata_convention_version_to_bq.rb
+++ b/db/migrate/20200413153338_add_metadata_convention_version_to_bq.rb
@@ -4,12 +4,14 @@ class AddMetadataConventionVersionToBq < Mongoid::Migration
     client = BigQueryClient.new.client
     [CellMetadatum::BIGQUERY_DATASET, 'cell_metadata_test'].each do |dataset_name|
       dataset = client.dataset(dataset_name)
-      table = dataset.table(CellMetadatum::BIGQUERY_TABLE)
-      table.schema {|s| s.string('metadata_convention_version', mode: :nullable)}
-      update_command = "UPDATE #{CellMetadatum::BIGQUERY_TABLE} "
-      update_command += "SET metadata_convention_version = '1.1.3'"
-      update_command += "WHERE metadata_convention_version IS NULL"
-      dataset.query update_command
+      if dataset.present? # ensure test dataset exists to avoid migration failure
+        table = dataset.table(CellMetadatum::BIGQUERY_TABLE)
+        table.schema {|s| s.string('metadata_convention_version', mode: :nullable)}
+        update_command = "UPDATE #{CellMetadatum::BIGQUERY_TABLE} "
+        update_command += "SET metadata_convention_version = '1.1.3'"
+        update_command += "WHERE metadata_convention_version IS NULL"
+        dataset.query update_command
+      end
     end
   end
 
@@ -17,10 +19,12 @@ class AddMetadataConventionVersionToBq < Mongoid::Migration
     client = BigQueryClient.new.client
     [CellMetadatum::BIGQUERY_DATASET, 'cell_metadata_test'].each do |dataset_name|
       dataset = client.dataset(dataset_name)
-      update_command = "UPDATE #{CellMetadatum::BIGQUERY_TABLE} "
-      update_command += "SET metadata_convention_version = NULL"
-      update_command += "WHERE metadata_convention_version = '1.1.3'"
-      dataset.query update_command
+      if dataset.present? # ensure test dataset exists to avoid migration failure
+        update_command = "UPDATE #{CellMetadatum::BIGQUERY_TABLE} "
+        update_command += "SET metadata_convention_version = NULL"
+        update_command += "WHERE metadata_convention_version = '1.1.3'"
+        dataset.query update_command
+      end
     end
   end
 end

--- a/db/migrate/20200413161403_add_biosample_type_and_preservation_method_to_bq.rb
+++ b/db/migrate/20200413161403_add_biosample_type_and_preservation_method_to_bq.rb
@@ -3,9 +3,11 @@ class AddBiosampleTypeAndPreservationMethodToBq < Mongoid::Migration
     client = BigQueryClient.new.client
     [CellMetadatum::BIGQUERY_DATASET, 'cell_metadata_test'].each do |dataset_name|
       dataset = client.dataset(dataset_name)
-      table = dataset.table(CellMetadatum::BIGQUERY_TABLE)
-      table.schema {|s| s.string('biosample_type', mode: :nullable)}
-      table.schema {|s| s.string('preservation_method', mode: :nullable)}
+      if dataset.present? # ensure test dataset exists to avoid migration failure
+        table = dataset.table(CellMetadatum::BIGQUERY_TABLE)
+        table.schema {|s| s.string('biosample_type', mode: :nullable)}
+        table.schema {|s| s.string('preservation_method', mode: :nullable)}
+      end
     end
   end
 


### PR DESCRIPTION
Addressing issues with:

- NoMethodError when creating AnalysisMetadatum objects from Terra workflow submissions (prevents syncing outputs due to error being thrown)
- Migration failures due to non-existent BQ datasets in production environment.

This PR addresses further issues with SCP-2339.