### PR TITLE
Fix log event category for download tracking

### DIFF
--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -143,5 +143,5 @@ export function logFilterSearch(facet, terms) {
  */
 export function logDownloadAuthorization() {
   log('download-authorization')
-  ga('send', 'event', 'faceted-search', 'download-authorization') // eslint-disable-line no-undef, max-len
+  ga('send', 'event', 'advanced-search', 'download-authorization') // eslint-disable-line no-undef, max-len
 }


### PR DESCRIPTION
This quick fix amends a Google Analytics event category.  It aligns the category for download with other GA logging, easing usage analysis.

This relates to SCP-2347.