### PR TITLE
Rescue errors when syncing submission outputs (SCP-2339)

### DIFF
--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -904,7 +904,13 @@ module Api
                   study_id: @study.id,
                   version: '4.6.1'
               }
-              AnalysisMetadatum.create!(metadata_attr)
+              begin
+                AnalysisMetadatum.create(metadata_attr)
+              rescue => e
+                error_context = ErrorTracker.format_extra_context(@study, {params: params, analysis_metadata: metadata_attr})
+                ErrorTracker.report_exception(e, current_api_user, error_context)
+                logger.error "Unable to create analysis metadatum for #{params[:submission_id]}: #{e.class.name}:: #{e.message}"
+              end
             end
           end
           @available_files = @unsynced_files.map {|f| {name: f.name, generation: f.generation, size: f.upload_file_size}}

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -323,7 +323,13 @@ class StudiesController < ApplicationController
               study_id: @study.id,
               version: '4.6.1'
           }
-          AnalysisMetadatum.create(metadata_attr)
+          begin
+            AnalysisMetadatum.create(metadata_attr)
+          rescue => e
+            error_context = ErrorTracker.format_extra_context(@study, {params: params, analysis_metadata: metadata_attr})
+            ErrorTracker.report_exception(e, current_user, error_context)
+            logger.error "Unable to create analysis metadatum for #{params[:submission_id]}: #{e.class.name}:: #{e.message}"
+          end
         end
       end
       @available_files = @unsynced_files.map {|f| {name: f.name, generation: f.generation, size: f.upload_file_size}}


### PR DESCRIPTION
Errors thrown at any point when attempting to sync submission outputs results in the user not being able to sync any outputs at all.  This fix rescues errors in creating AnalysisMetadata objects that would otherwise prevent a successful sync.  This is a temporary patch until a more holistic solution can be found.

This PR continues to attempt to satisfy SCP-2339.