### PR TITLE
Db fix accession search

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -250,7 +250,7 @@ module Api
             accession_index = possible_accessions.index(study.accession)
             if accession_index.nil?
               # study was not a true accession match, it matches the accession term in its description
-              # make this appear after the proper accession matches, in order of wieght match
+              # make this appear after the proper accession matches, in order of weight match
               accession_index = 9999 - study.search_weight(@term_list)[:total]
             end
             accession_index

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -246,7 +246,15 @@ module Api
         when :keyword
           @studies = @studies.sort_by {|study| -study.search_weight(@term_list)[:total] }
         when :accession
-          @studies = @studies.sort_by {|study| possible_accessions.index(study.accession) }
+          @studies = @studies.sort_by do |study|
+            accession_index = possible_accessions.index(study.accession)
+            if accession_index.nil?
+              # study was not a true accession match, it matches the accession term in its description
+              # make this appear after the proper accession matches, in order of wieght match
+              accession_index = 9999 - study.search_weight(@term_list)[:total]
+            end
+            accession_index
+          end
         when :whitelist
           @studies = @studies.sort_by {|study| @whitelist.index(study.accession) }
         when :facet

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -157,6 +157,20 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 
+  test 'should return search results using accessions' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # test single accession
+    term = Study.where(public: true).first.accession
+    execute_http_request(:get, api_v1_search_path(type: 'study', terms: term))
+    assert_response :success
+    expected_accessions = [term]
+    assert_equal expected_accessions, json['matching_accessions'],
+                 "Did not return correct array of matching accessions, expected #{expected_accessions} but found #{json['matching_accessions']}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
   # should generate an auth code for a given user
   test 'should generate auth code' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}"


### PR DESCRIPTION
The production query that triggered this was a keyword search for 'SCP-502', which gets treated differently by the accession matcher and the term splitter.  We may want a separate ticket to handle the underlying treatment of '-' in terms, but this at least makes the method not error.