### PR TITLE
adding validations to analysis_parameter_filters to prevent breaking UI (SCP-2327)

### DIFF
--- a/app/models/analysis_parameter_filter.rb
+++ b/app/models/analysis_parameter_filter.rb
@@ -7,6 +7,11 @@ class AnalysisParameterFilter
   field :multiple, type: Boolean, default: false
   field :multiple_values, type: Array, default: []
 
+  before_validation :sanitize_multiple_values_array
+  validates_presence_of :value, if: proc {|attributes| attributes.attribute_name.present?}
+  validates_presence_of :multiple_values, if: proc {|attributes| attributes.multiple?},
+                        message: ' cannot be empty if allowing multiple values'
+
   ASSOCIATED_MODEL_FILTER_ATTRS = [:ANALYSIS_PARAMETER_FILTER_ATTRIBUTE_NAME, :ANALYSIS_PARAMETER_FILTER_VALUE]
 
   # used to populate dropdowns in analysis_parameter_filters_form, not for use with user inputs
@@ -26,6 +31,15 @@ class AnalysisParameterFilter
       model::ANALYSIS_PARAMETER_FILTERS[self.attribute_name]
     else
       []
+    end
+  end
+
+  private
+
+  # ensure multiple_values does not have any blank entries
+  def sanitize_multiple_values_array
+    if self.multiple?
+      self.multiple_values.reject!(&:blank?)
     end
   end
 end

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -98,6 +98,7 @@ else
                     test/models/cell_metadatum_test.rb
                     test/models/analysis_configuration_test.rb
                     test/models/analysis_parameter_test.rb
+                    test/models/analysis_parameter_filter_test.rb
                     test/models/search_facet_test.rb
                     test/models/preset_search_test.rb
                     test/models/user_test.rb

--- a/test/models/analysis_parameter_filter_test.rb
+++ b/test/models/analysis_parameter_filter_test.rb
@@ -1,9 +1,28 @@
 require "test_helper"
 
-describe AnalysisParameterFilter do
-  let(:analysis_parameter_filter) { AnalysisParameterFilter.new }
+class AnalysisParameterFilterTest < ActiveSupport::TestCase
+  def setup
+    @analysis_configuration = AnalysisConfiguration.first
+  end
 
-  it "must be valid" do
-    value(analysis_parameter_filter).must_be :valid?
+  test 'should validate filter values' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    input_parameter = @analysis_configuration.analysis_parameters.inputs.first
+    param_filter = input_parameter.analysis_parameter_filters.build
+
+    # validate single filter value
+    param_filter.attribute_name = 'file_type'
+    refute param_filter.valid?, 'Should not validate filter if value is not set with attribute_name'
+    param_filter.value = 'Cluster'
+    assert param_filter.valid?, 'Should validate filter with value & attribute_name both present'
+
+    # validate multiple filter values
+    param_filter.multiple = true
+    refute param_filter.valid?, 'Should not validate filter if multiple_values is blank with multiple = true'
+    param_filter.multiple_values = %w(Cluster Metadata)
+    assert param_filter.valid?, 'Should validate filter with multiple = true & multiple_values present'
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 end


### PR DESCRIPTION
Adding filters to analysis parameters helps refine the UI when a user is trying to select inputs for a given analysis.  However, we had no validations attached to the `AnalysisParameterFilter` model, and therefore it was possible to save an "invalid" filter value that would then throw and error when trying to render the UI that was cryptic, at best.

This refinement adds standard presence/content validations to `AnalysisParameterFilter` and leverages the standard errors block in Rails forms to communicate the issue back the the pipeline curator.

This PR satisfies SCP-2327.