### PR TITLE
Report uncompressed size in download UI (SCP-2323)

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -2855,7 +2855,6 @@ class Study
       # store generation tag to know whether a file has been updated in GCP
       Rails.logger.info "#{Time.zone.now}: Updating #{file.bucket_location}:#{file.id} with generation tag: #{remote_file.generation} after successful upload"
       file.update(generation: remote_file.generation)
-      file.update(upload_file_size: remote_file.size)
       Rails.logger.info "#{Time.zone.now}: Upload of #{file.bucket_location}:#{file.id} complete, scheduling cleanup job"
       # schedule the upload cleanup job to run in two minutes
       run_at = 2.minutes.from_now


### PR DESCRIPTION
This changes the reported size for files in download UIs.  Previously, the compressed (gzipped) file size was reported.  This accurately reflects the _transferred_ file size, but not the file size as it will exist on the user's disk.  Now, we report the uncompressed file size -- optimizing for the latter use case.

I tested this manually.

Separately, this revealed a need for better non-Dockerized support for file uploads -- a new ticket is being added to the infrastructure backlog for that.

This satisfies SCP-2323.  