### PR TITLE
Deploy script tweak

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -90,7 +90,7 @@ function main {
     echo "export READ_ONLY_SERVICE_ACCOUNT_KEY=/home/app/webapp/config/$READ_ONLY_SERVICE_ACCOUNT_FILENAME" >> $CONFIG_FILENAME
     echo "### COMPLETED ###"
 
-    # init repo if this is the first deploy on this host
+    # init folder/repo if this is the first deploy on this host
     $SSH_COMMAND "if [ ! -d $DESTINATION_BASE_DIR ]; then sudo mkdir -p $DESTINATION_BASE_DIR && sudo chown -R $SSH_USER: $DESTINATION_BASE_DIR; fi"
     run_remote_command "if [ ! -d .git ]; then sudo rm -rf ./* && git clone $SCP_REPO .; fi"
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -91,6 +91,7 @@ function main {
     echo "### COMPLETED ###"
 
     # init repo if this is the first deploy on this host
+    $SSH_COMMAND "if [ ! -d $DESTINATION_BASE_DIR ]; then mkdir -p $DESTINATION_BASE_DIR; fi"
     run_remote_command "if [ ! -d .git ]; then sudo rm -rf ./* && git clone $SCP_REPO .; fi"
 
     # move secrets to remote host

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -91,7 +91,7 @@ function main {
     echo "### COMPLETED ###"
 
     # init repo if this is the first deploy on this host
-    $SSH_COMMAND "if [ ! -d $DESTINATION_BASE_DIR ]; then mkdir -p $DESTINATION_BASE_DIR; fi"
+    $SSH_COMMAND "if [ ! -d $DESTINATION_BASE_DIR ]; then sudo mkdir -p $DESTINATION_BASE_DIR && sudo chown -R $SSH_USER: $DESTINATION_BASE_DIR; fi"
     run_remote_command "if [ ! -d .git ]; then sudo rm -rf ./* && git clone $SCP_REPO .; fi"
 
     # move secrets to remote host

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -91,7 +91,7 @@ function main {
     echo "### COMPLETED ###"
 
     # init repo if this is the first deploy on this host
-    run_remote_command "if [ ! -d .git ]; then rm -rf ./* && git clone $SCP_REPO .; fi"
+    run_remote_command "if [ ! -d .git ]; then sudo rm -rf ./* && git clone $SCP_REPO .; fi"
 
     # move secrets to remote host
     echo "### migrating secrets to remote host ###"


### PR DESCRIPTION
Added some logic to ensure the deploy script works for newly provisioned instances.
Specifically, if `/home/docker-user/deployments/single_cell_portal_core` or whatever `DESTINATION_BASE_DIR` is overwritten to does not exist, it is created and chown-ed by the correct user.