### PR TITLE
Ensure categorical labels in violin plot x-axis labels (SCP-2213)

### DIFF
--- a/app/assets/javascripts/kernel-functions.js
+++ b/app/assets/javascripts/kernel-functions.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 /* Advanced Rule of thumb bandwidth selector from :
     https://en.wikipedia.org/wiki/Kernel_density_estimation#Bandwidth_selection
     and https://stat.ethz.ch/R-manual/R-devel/library/stats/html/bandwidth.html
@@ -111,6 +113,7 @@ function createTracesAndLayout(arr, title, jitter='all', expressionLabel){
     }
     var layout = {
         title: title,
+        xaxis: 'category',
         yaxis: {
             zeroline: true,
             showline: true,

--- a/app/assets/javascripts/kernel-functions.js
+++ b/app/assets/javascripts/kernel-functions.js
@@ -113,6 +113,10 @@ function createTracesAndLayout(arr, title, jitter='all', expressionLabel){
     }
     var layout = {
         title: title,
+
+        // Force axis labels, including number strings, to be treated as
+        // categories.  See Python docs (same generic API as JavaScript):
+        // https://plotly.com/python/axes/#forcing-an-axis-to-be-categorical
         xaxis: 'category',
         yaxis: {
             zeroline: true,


### PR DESCRIPTION
This fixes Plotly violin plots so "group" type annotations with numeric values are honored as "group".  Previously, if x-axis labels were integer strings ("1", "2", ..., "10"), some labels would be omitted.  Now, all labels are shown as intended.

I tested this manually.

This satisfies SCP-2213.