### PR TITLE
Violin plot hotfix

### DIFF
--- a/app/assets/javascripts/kernel-functions.js
+++ b/app/assets/javascripts/kernel-functions.js
@@ -113,11 +113,6 @@ function createTracesAndLayout(arr, title, jitter='all', expressionLabel){
     }
     var layout = {
         title: title,
-
-        // Force axis labels, including number strings, to be treated as
-        // categories.  See Python docs (same generic API as JavaScript):
-        // https://plotly.com/python/axes/#forcing-an-axis-to-be-categorical
-        xaxis: 'category',
         yaxis: {
             zeroline: true,
             showline: true,
@@ -131,6 +126,3 @@ function createTracesAndLayout(arr, title, jitter='all', expressionLabel){
     };
     return [data, layout]
 }
-
-
-


### PR DESCRIPTION
Removing `xaxis: 'category'` due to `'t.match is not a function'` Plotly error breaking violin plots.