### PR TITLE
making API errors log to console

### DIFF
--- a/app/controllers/api/v1/api_base_controller.rb
+++ b/app/controllers/api/v1/api_base_controller.rb
@@ -17,6 +17,7 @@ module Api
       # this is needed to get stack traces of view errors on the console in development
       # otherwise, e.g. errors in study_search_results_objects.rb would just be swallowed and returned as 500
       rescue_from StandardError do |exception|
+        ErrorTracker.report_exception(exception, current_user, params)
         logger.error ([exception.message] + exception.backtrace).join($/)
         if Rails.env.production?
           render json: {error: "An unexpected error has occurred"}, status: 500

--- a/app/controllers/api/v1/api_base_controller.rb
+++ b/app/controllers/api/v1/api_base_controller.rb
@@ -14,6 +14,17 @@ module Api
         render json: {error: exception.message}, status: 500
       end
 
+      # this is needed to get stack traces of view errors on the console in development
+      # otherwise, e.g. errors in study_search_results_objects.rb would just be swallowed and returned as 500
+      rescue_from StandardError do |exception|
+        logger.error ([exception.message] + exception.backtrace).join($/)
+        if Rails.env.production?
+          render json: {error: "An unexpected error has occurred"}, status: 500
+        else
+          render json: {error: exception.message}, status: 500
+        end
+      end
+
       ##
       # Generic message formatters to use in Swagger responses
       ##


### PR DESCRIPTION
This feels like it should be solvable in Rails config, but 15 minutes of googling didn't turn up anything useful.  

(this also puts the logs into development.log as per SCP-2293)
```otal matching accessions from all non-inferred searches: ["SCP182", "SCP159", "SCP160", "SCP163", "SCP164", "SCP165", "SCP166", "SCP167", "SCP169", "SCP170", "SCP174", "SCP175", "SCP178", "SCP179", "SCP149"]
Final list of matching studies: ["SCP182", "SCP159", "SCP160", "SCP163", "SCP164", "SCP165", "SCP166", "SCP167", "SCP169", "SCP170", "SCP174", "SCP175", "SCP178", "SCP179", "SCP149"]
undefined local variable or method `bar' for #<Api::V1::SearchController:0x00007f8cb2bc3928>
/Users/dbush/code/scp/single_cell_portal_core/app/controllers/api/v1/study_search_results_objects.rb:74:in `study_files_response_obj'
/Users/dbush/code/scp/single_cell_portal_core/app/controllers/api/v1/study_search_results_objects.rb:66:in `study_response_obj'
/Users/dbush/code/scp/single_cell_portal_core/app/controllers/api/v1/study_search_results_objects.rb:24:in `block in search_results_obj'
/Users/dbush/code/scp/single_cell_portal_core/app/controllers/api/v1/study_search_results_objects.rb:24:in `map'
/Users/dbush/code/scp/single_cell_portal_core/app/controllers/api/v1/study_search_results_objects.rb:24:in `search_results_obj'
/Users/dbush/code/scp/single_cell_portal_core/app/controllers/api/v1/search_controller.rb:297:in `index'
```