### PR TITLE
Roll back deployments (SCP-2385)

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -124,7 +124,7 @@ function main {
         echo "### determining requested release rollback tag on $GIT_BRANCH ###"
         run_remote_command "ROLLBACK_TAG=$(extract_release_attribute $TAG_OFFSET)" || exit_with_error_message "could not get rollback tag in $GIT_BRANCH"
         echo "### rolling back release to tag: $ROLLBACK_TAG on $GIT_BRANCH ###"
-        run_remote_command "git checkout tags/$ROLLBACK_TAG" || exit_with_error_message "could not checkout $GIT_BRANCH"
+        run_remote_command "git checkout tags/$ROLLBACK_TAG" || exit_with_error_message "could not checkout tags/$ROLLBACK_TAG on $GIT_BRANCH"
         echo "### COMPLETED ###"
     fi
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -123,7 +123,7 @@ function main {
         # checkout the requested tag (usually current release - 1)
         echo "### ROLLING BACK DEPLOYMENT BY $TAG_OFFSET RELEASE TAG ###"
         echo "### determining requested release rollback tag on $GIT_BRANCH ###"
-        ROLLBACK_TAG=$(extract_release_attribute $TAG_OFFSET) || exit_with_error_message "could not get rollback tag in $GIT_BRANCH"
+        ROLLBACK_TAG=$(extract_release_tag $TAG_OFFSET) || exit_with_error_message "could not get rollback tag in $GIT_BRANCH"
         echo "### rolling back release to tag: $ROLLBACK_TAG on $GIT_BRANCH ###"
         run_remote_command "git checkout tags/$ROLLBACK_TAG" || exit_with_error_message "could not checkout tags/$ROLLBACK_TAG on $GIT_BRANCH"
         echo "### COMPLETED ###"

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -122,7 +122,7 @@ function main {
         # checkout the requested tag (usually current release - 1)
         echo "### ROLLING BACK DEPLOYMENT BY $TAG_OFFSET RELEASE TAG ###"
         echo "### determining requested release rollback tag on $GIT_BRANCH ###"
-        run_remote_command "ROLLBACK_TAG=$(extract_release_attribute $TAG_OFFSET)" || exit_with_error_message "could not get rollback tag in $GIT_BRANCH"
+        ROLLBACK_TAG=$(extract_release_attribute $TAG_OFFSET) || exit_with_error_message "could not get rollback tag in $GIT_BRANCH"
         echo "### rolling back release to tag: $ROLLBACK_TAG on $GIT_BRANCH ###"
         run_remote_command "git checkout tags/$ROLLBACK_TAG" || exit_with_error_message "could not checkout tags/$ROLLBACK_TAG on $GIT_BRANCH"
         echo "### COMPLETED ###"

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
 # extract secrets from vault, copy to remote host, and launch boot script for deployment
+# can also roll back a broken deployment by calling with -R (
 
 THIS_DIR="$(cd "$(dirname "$0")"; pwd)"
 
 # common libraries
 . $THIS_DIR/bash_utils.sh
+. $THIS_DIR/github_releases.sh
 . $THIS_DIR/extract_vault_secrets.sh
 
 function main {
@@ -17,8 +19,10 @@ function main {
     PASSENGER_APP_ENV="production"
     BOOT_COMMAND="bin/remote_deploy.sh"
     SCP_REPO="https://github.com/broadinstitute/single_cell_portal_core.git"
+    ROLLBACK=false
+    TAG_OFFSET=1
 
-    while getopts "p:s:r:e:b:d:h:S:u:H" OPTION; do
+    while getopts "p:s:r:e:b:d:h:S:u:H:t:R" OPTION; do
         case $OPTION in
             p)
                 PORTAL_SECRETS_VAULT_PATH="$OPTARG"
@@ -46,6 +50,12 @@ function main {
                 ;;
             u)
                 SSH_USER="$OPTARG"
+                ;;
+            R)
+                ROLLBACK=true
+                ;;
+            t)
+                TAG_OFFSET="$OPTARG"
                 ;;
             H)
                 echo "$usage"
@@ -103,17 +113,26 @@ function main {
 
     # update source on remote host to pull in changes before deployment
     echo "### pulling updated source from git on branch $GIT_BRANCH ###"
-    run_remote_command "git fetch" || exit_with_error_message "could not checkout $GIT_BRANCH"
+    run_remote_command "git fetch --all --tags" || exit_with_error_message "could not checkout $GIT_BRANCH"
     run_remote_command "git checkout yarn.lock" || exit_with_error_message "could not reset yarn.lock file"
     run_remote_command "git checkout $GIT_BRANCH && git pull" || exit_with_error_message "could not checkout $GIT_BRANCH"
     echo "### COMPLETED ###"
+
+    if [[ $ROLLBACK ]]; then
+        # checkout the requested tag (usually current release - 1)
+        echo "### ROLLING BACK DEPLOYMENT BY $TAG_OFFSET RELEASE TAG ###"
+        echo "### determining requested release rollback tag on $GIT_BRANCH ###"
+        run_remote_command "ROLLBACK_TAG=$(extract_release_attribute $TAG_OFFSET)" || exit_with_error_message "could not get rollback tag in $GIT_BRANCH"
+        echo "### rolling back release to tag: $ROLLBACK_TAG on $GIT_BRANCH ###"
+        run_remote_command "git checkout tags/$ROLLBACK_TAG" || exit_with_error_message "could not checkout $GIT_BRANCH"
+        echo "### COMPLETED ###"
+    fi
 
     echo "### running remote deploy script ###"
     run_remote_command "$(set_remote_environment_vars) $BOOT_COMMAND" || exit_with_error_message "could not run $(set_remote_environment_vars) $BOOT_COMMAND on $DESTINATION_HOST:$DESTINATION_BASE_DIR"
     echo "### COMPLETED ###"
 }
 
-# TODO: Although I made minimum changes to clarify required vs optional parameters, this may now need rewording...
 usage=$(
 cat <<EOF
 USAGE:
@@ -122,17 +141,19 @@ USAGE:
 ### extract secrets from vault, copy to remote host, build/stop/remove docker container and launch boot script for deployment ###
 
 [REQUIRED PARAMETERS]
--p VALUE	set the path to configuration secrets in vault
--s VALUE	set the path to the main service account json in vault
--r VALUE	set the path to the read-only service account json in vault
+-p VALUE    set the path to configuration secrets in vault
+-s VALUE    set the path to the main service account json in vault
+-r VALUE    set the path to the read-only service account json in vault
 
 [OPTIONS]
--e VALUE	set the environment to boot the portal in
--b VALUE	set the branch to pull from git (defaults to master)
--d VALUE	set the target directory to deploy from (defaults to $DESTINATION_BASE_DIR)
--S VALUE	set the path to SSH_KEYFILE (private key for SSH auth, no default, not needing except for manual testing)
--h VALUE	set the DESTINATION_HOST (remote GCP VM to SSH into, no default)
--H COMMAND	print this text
+-e VALUE    set the environment to boot the portal in (defaults to production)
+-b VALUE    set the branch to pull from git (defaults to master)
+-d VALUE    set the target directory to deploy from (defaults to $DESTINATION_BASE_DIR)
+-S VALUE    set the path to SSH_KEYFILE (private key for SSH auth, no default, not needing except for manual testing)
+-h VALUE    set the DESTINATION_HOST (remote GCP VM to SSH into, no default)
+-R          set ROLLBACK to true to revert release to last known good release
+-t VALUE    set the TAG_OFFSET value for rolling back a release (defaults to 1, meaning release previous to the current)
+-H COMMAND  print this text
 EOF
 )
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 # extract secrets from vault, copy to remote host, and launch boot script for deployment
-# can also roll back a broken deployment by calling with -R (
+# can also roll back a broken deployment by calling with -R, and optionally -t OFFSET
+# to increase the amount of releases to roll back to
 
 THIS_DIR="$(cd "$(dirname "$0")"; pwd)"
 

--- a/bin/github_releases.sh
+++ b/bin/github_releases.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# functions for retrieving Github releases for SCP and extracting requested release attributes
+# by walking back through release history
+#
+# Requirements: curl, jq
+
+REPO_URL='https://api.github.com/repos/broadinstitute/single_cell_portal_core/releases'
+
+# Get all Github published releases for $REPO_URL
+function get_all_releases {
+  echo $(curl -X GET --header 'application/json' --silent $REPO_URL)
+}
+
+# extract an attribute from a Github release object JSON
+# will default to using "tag_name", and targeting the previous release from the most recent
+function extract_release_attribute {
+  OFFSET="$1"
+  RELEASE_ATTR="$2"
+  if [[ -z "$OFFSET" ]]; then
+    OFFSET="1"
+  fi
+  if [[ -z "$RELEASE_ATTR" ]]; then
+    RELEASE_ATTR="tag_name"
+  fi
+  echo $(get_all_releases | jq ".[$OFFSET].$RELEASE_ATTR" | sed 's/"//g')
+}

--- a/bin/github_releases.sh
+++ b/bin/github_releases.sh
@@ -1,27 +1,23 @@
 #!/usr/bin/env bash
 
-# functions for retrieving Github releases for SCP and extracting requested release attributes
+# functions for retrieving GitHub releases for SCP and extracting requested release tag names
 # by walking back through release history
 #
 # Requirements: curl, jq
 
 REPO_URL='https://api.github.com/repos/broadinstitute/single_cell_portal_core/releases'
 
-# Get all Github published releases for $REPO_URL
+# Get all GitHub published releases for $REPO_URL
 function get_all_releases {
   echo $(curl -X GET --header 'application/json' --silent $REPO_URL)
 }
 
-# extract an attribute from a Github release object JSON
-# will default to using "tag_name", and targeting the previous release from the most recent
-function extract_release_attribute {
+# extract a release tag name from a GitHub release JSON object
+# will default targeting the previous release from the most recent
+function extract_release_tag {
   OFFSET="$1"
-  RELEASE_ATTR="$2"
   if [[ -z "$OFFSET" ]]; then
     OFFSET="1"
   fi
-  if [[ -z "$RELEASE_ATTR" ]]; then
-    RELEASE_ATTR="tag_name"
-  fi
-  echo $(get_all_releases | jq ".[$OFFSET].$RELEASE_ATTR" | sed 's/"//g')
+  echo $(get_all_releases | jq ".[$OFFSET].tag_name" | sed 's/"//g')
 }

--- a/bin/remote_deploy.sh
+++ b/bin/remote_deploy.sh
@@ -62,7 +62,7 @@ function main {
     PORTAL_HOMEPAGE="https://$PROD_HOSTNAME/single_cell"
     echo "### ENSURING PORTAL IS AVAILABLE AT $PORTAL_HOMEPAGE ###"
     HOMEPAGE_COUNTER=0
-    while [[ $HOMEPAGE_COUNTER -lt 12 ]]; do
+    while [[ $HOMEPAGE_COUNTER -lt 24 ]]; do
 		    HOMEPAGE_COUNTER=$[$HOMEPAGE_COUNTER + 1]
 		    echo "home page not available on attempt $HOMEPAGE_COUNTER, waiting 15 seconds..."
 		    sleep 15


### PR DESCRIPTION
If a deployment of SCP to a remote host fails for some reason (portal fails to boot properly due to an error, or a showstopper bug is found during release verification), currently rollbacks have to be performed manually on the host itself using the SCP playbook.  Now, using our Jenkins server, we can automate a rollback by one (1) release using the Github [releases API endpoint](https://api.github.com/repos/broadinstitute/single_cell_portal_core/releases) for this repository and checking out the previous release tag on the remote host.  Rollbacks will be completely automated, not requiring any action from a portal administrator other than invoking the Jenkins job.  This will allow safe recovery of a broken instance while development staff investigate and prioritize a hotfix, without having to worry about users being blocked in the meantime.

The rollback can be customized by passing the `-t [OFFSET]` flag to `bin/deploy.sh` in the Jenkins configuration to increase the number of tags to roll back (default is one release, but can go back as many as are available, however due to ongoing schema/infrastructure changes, this is not advised unless absolutely necessary).

Also, this update increases the final portal health check timeout from 3 to 6 minutes to help account for increased JS asset compilation time, and eliminate any "false negative" failed builds when the deployment was a success, just not in the time allotted.

This PR satisfies SCP-2385.