### PR TITLE
Access tokens for FireCloud API calls (SCP-2383)

### DIFF
--- a/app/controllers/api/v1/concerns/authenticator.rb
+++ b/app/controllers/api/v1/concerns/authenticator.rb
@@ -52,8 +52,10 @@ module Api
                 Rails.logger.error "Error retrieving user api credentials: #{e.class.name}: #{e.message}"
               end
             end
-            # check for token expiry and unset user if expired/timed out
+            # check for token expiry and unset user && api_access_token if expired/timed out
+            # unsetting token prevents downstream FireCloud API calls from using an expired/invalid token
             if user.api_access_token_expired? || user.api_access_token_timed_out?
+              user.update(api_access_token: nil)
               nil
             else
               # update last_access_at

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -106,18 +106,8 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
     else
       self.user = user
       self.project = project
-      # when initializing with a user, pull access token from user object and set desired project
-      if user.refresh_token.nil? && user.api_access_token.present?
-        # as this client is only getting instantiated for a single request via the API, set expiration timestamp
-        # to 5 minutes, as this is the length of an HTTP request
-        expiration_timestamp = Time.now + 5.minutes
-        self.access_token = {
-            'access_token' => user.api_access_token, 'expires_in' => 5.minutes.to_i, 'expires_at' => expiration_timestamp
-        }
-      else
-        self.access_token = user.valid_access_token
-      end
-
+      # user.token_for_api_call will retrieve valid access token to use, if present
+      self.access_token = user.token_for_api_call
       self.expires_at = self.access_token['expires_at']
 
       # use user-defined project instead of portal default
@@ -134,7 +124,6 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
 
       self.storage = Google::Cloud::Storage.new(storage_attr)
     end
-
     # set FireCloud API base url
     self.api_root = BASE_URL
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -201,6 +201,16 @@ class User
     self.send(token_method)[:expires_at].zone
   end
 
+  # determine which access token is best to use for a FireCloud API request
+  # once an api_access_token expires/times out, it is unset, so checking .present? will ensure a valid token
+  def token_for_api_call
+    if self.refresh_token.nil? && self.api_access_token.present?
+      self.api_access_token
+    else
+      self.valid_access_token
+    end
+  end
+
   ###
   #
   # OTHER AUTHENTICATION METHODS


### PR DESCRIPTION
Refining the logic for which access tokens to use when making FireCloud API requests.  Since all client-based requests will have a valid user session to pull from, this mainly affects usage in the REST API.  The `current_api_user` method now will revoke expired or timed-out access tokens, which will unset any idle users and prevent calling the FireCloud API with an expired token (which results in a 401 error being thrown, which then comes back to the user as an unhelpful 500 since it is an uncaught exception).  Furthermore, the logic surrounding which access token to use for requests has been refined for maintainability.  

This PR satisfies SCP-2383.