### PR TITLE
Fixing bug with NaN in scatter/violin plots (SCP-2079)

### DIFF
--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -42,12 +42,7 @@ module StudiesHelper
     when :group
       values.size
     when :numeric
-      # we need to check for NaN as minmax throws an ArgumentError
-      begin
-        values.minmax.join(', ')
-      rescue ArgumentError
-        values.keep_if {|value| !value.to_f.nan?}.minmax.join(', ') + ' (excluding NaN)'
-      end
+      RequestUtils.get_minmax(values).join(', ')
     end
   end
 

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -55,4 +55,13 @@ class RequestUtils
     end
     page_num
   end
+
+  # safely determine min/max bounds of an array, accounting for NaN value
+  def self.get_minmax(values_array)
+    begin
+      values_array.minmax
+    rescue TypeError, ArgumentError
+      values_array.dup.reject!(&:nan?).minmax
+    end
+  end
 end

--- a/test/integration/lib/request_utils_test.rb
+++ b/test/integration/lib/request_utils_test.rb
@@ -11,4 +11,12 @@ class RequestUtilsTest < ActiveSupport::TestCase
     assert_equal(1, RequestUtils.sanitize_page_param('0'))
     assert_equal(1, RequestUtils.sanitize_page_param('-6'))
   end
+
+  test 'should exclude NaN from minmax for numeric arrays' do
+    source = [Float::NAN, 1.0, 100.0]
+    numeric_array = 1000.times.map {source.sample}
+    min, max = RequestUtils.get_minmax(numeric_array)
+    assert_equal 1.0, min, "Did not get expected min of 1.0: #{min}"
+    assert_equal 100.0, min, "Did not get expected max of 100.0: #{max}"
+  end
 end


### PR DESCRIPTION
Arrays of numeric data that contain NaN values (which are technically `Float::NAN` instances in Ruby) will throw an error when trying to compute the min/max values, which are needed when trying to determine the bounds of Plotly axes.  This patch captures the error, and then sanitizes the array by rejecting any NaN values before calling minmax.  This is approach is taken as most of our arrays of numeric data do not contain NaN values, so calling `minmax` first rather than always sanitizing the array will reduce load times in most cases.

This PR does not address the issues raised regarding the UX and scientific validity of showing NaN values in plots - further refinement is needed on that front.  This simply handles the error to allow plots to render.  This PR satisfies the main goal of SCP-2079.