### PR TITLE
Prevent loading missing subsampled clusters (SCP-2409)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -222,9 +222,10 @@ module ApplicationHelper
   end
 
   # return an array of values to use for subsampling dropdown scaled to number of cells in study
-  # only options allowed are 1000, 10000, 20000
-  def subsampling_options(max_cells)
-    ClusterGroup::SUBSAMPLE_THRESHOLDS.select {|sample| sample < max_cells}
+  # only options allowed are 1000, 10000, 20000, and 100000
+  # will only provide options if subsampling has completed for a cluster
+  def subsampling_options(cluster)
+    ExpressionRenderingService.subsampling_options(cluster)
   end
 
   # get a label for a workflow status code

--- a/app/lib/expression_rendering_service.rb
+++ b/app/lib/expression_rendering_service.rb
@@ -17,7 +17,7 @@ class ExpressionRenderingService
     end
     render_data[:options] = load_cluster_group_options(study)
     render_data[:cluster_annotations] = load_cluster_group_annotations(study, cluster, current_user)
-    render_data[:subsampling_options] = subsampling_options(cluster.points)
+    render_data[:subsampling_options] = subsampling_options(cluster)
 
     render_data[:rendered_cluster] = cluster.name
     render_data[:rendered_annotation] = "#{selected_annotation[:name]}--#{selected_annotation[:type]}--#{selected_annotation[:scope]}"
@@ -151,8 +151,13 @@ class ExpressionRenderingService
   end
 
   # return an array of values to use for subsampling dropdown scaled to number of cells in study
-  # only options allowed are 1000, 10000, 20000
-  def self.subsampling_options(max_cells)
-    ClusterGroup::SUBSAMPLE_THRESHOLDS.select {|sample| sample < max_cells}
+  # only options allowed are 1000, 10000, 20000, and 100000
+  # will only provide options if subsampling has completed for a cluster
+  def self.subsampling_options(cluster)
+    if cluster.is_subsampling?
+      []
+    else
+      ClusterGroup::SUBSAMPLE_THRESHOLDS.select {|sample| sample < cluster.points}
+    end
   end
 end

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -12,7 +12,11 @@ class ClusterGroup
   field :cluster_type, type: String
   field :cell_annotations, type: Array
   field :domain_ranges, type: Hash
+  # subsampling flags
+  # :subsampled => whether subsampling has completed
+  # :is_subsampling => whether subsampling has been initiated
   field :subsampled, type: Boolean, default: false
+  field :is_subsampling, type: Boolean, default: false
 
   validates_uniqueness_of :name, scope: :study_id
   validates_presence_of :name, :cluster_type

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -71,15 +71,16 @@ class ClusterGroup
       data_arrays.each do |array|
         all_values += array.values
       end
-      return all_values
+      all_values
     else
       data_array = DataArray.find_by(name: array_name, array_type: array_type, linear_data_type: 'ClusterGroup',
                                      cluster_name: self.name, linear_data_id: self.id, subsample_threshold: subsample_threshold,
                                      subsample_annotation: subsample_annotation)
       if data_array.nil?
-        return []
+        # rather than returning [], default to the full resolution array
+        self.concatenate_data_arrays(array_name, array_type)
       else
-        return data_array.values
+        data_array.values
       end
     end
   end

--- a/app/views/site/_study_visualize.html.erb
+++ b/app/views/site/_study_visualize.html.erb
@@ -89,8 +89,8 @@
           $('#study-tabs a[href="#' + tab + '"]').tab('show');
       }
       $('#cluster-plot').data('camera', baseCamera);
-      // set default subsample option of 10K or all cells
-      if (<%= @cluster.points > 10000 %>) {
+      // set default subsample option of 10K (if subsampled) or all cells
+      if (<%= @cluster.points > 10000 && @cluster.subsampled? %>) {
           $('#subsample').val(10000);
           $('#search_subsample').val(10000);
       }

--- a/app/views/site/_subsample_warning.html.erb
+++ b/app/views/site/_subsample_warning.html.erb
@@ -1,0 +1,3 @@
+<% if cluster.is_subsampling? %>
+  <p class="text-warning"><i class="fa fa-exclamation-triangle"></i> Subsamples are still being computed for this cluster.</p>
+<% end %>

--- a/app/views/site/_view_options.html.erb
+++ b/app/views/site/_view_options.html.erb
@@ -29,10 +29,11 @@
                     data-toggle="tooltip"></i>
                   <br />
                   <% if /view_gene_(set_)?expression$/.match(action_name) %>
-                  <%= select_tag :subsample, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), {include_blank: @cluster.points < ClusterGroup::MAX_THRESHOLD ? 'All Cells' : false, class: 'form-control'} %>
+                  <%= select_tag :subsample, options_for_select(subsampling_options(@cluster), set_subsample_value(params) ), {include_blank: @cluster.points < ClusterGroup::MAX_THRESHOLD ? 'All Cells' : false, class: 'form-control'} %>
                   <% else %>
-                  <%= select_tag :subsample, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), include_blank: 'All Cells', class: 'form-control' %>
+                  <%= select_tag :subsample, options_for_select(subsampling_options(@cluster), set_subsample_value(params) ), include_blank: 'All Cells', class: 'form-control' %>
                   <% end %>
+                  <%= render partial: 'subsample_warning', locals: {cluster: @cluster} %>
                 </div>
                 <!-- end -->
             </div>

--- a/app/views/site/get_new_annotations.js.erb
+++ b/app/views/site/get_new_annotations.js.erb
@@ -5,7 +5,7 @@ var selectedAnnotation = selectedAnnotationElement.val();
 var selectedSubsampleElement = $("#<%= @target %>subsample");
 selectedAnnotationElement.html("<%= escape_javascript(select_tag :annotation, grouped_options_for_select(@cluster_annotations, params[:annotation]), class: 'form-control' )%>");
 // also reload subsampling options as they may have changed
-selectedSubsampleElement.html("<%= escape_javascript(select_tag :subsample, options_for_select(subsampling_options(@cluster.points), params[:subsample]), {include_blank: 'All Cells', class: 'form-control'}) %>");
+selectedSubsampleElement.html("<%= escape_javascript(select_tag :subsample, options_for_select(subsampling_options(@cluster), params[:subsample]), {include_blank: 'All Cells', class: 'form-control'}) %>");
 
 if (annotationData.includes(selectedAnnotation)) {
     selectedAnnotationElement.val(selectedAnnotation);

--- a/app/views/site/search/_gene_result_view_options.html.erb
+++ b/app/views/site/search/_gene_result_view_options.html.erb
@@ -10,5 +10,6 @@
 
 <div class="form-group">
   <%= label_tag "#{@target}-subsample".to_sym, 'Subsampling threshold' %>&nbsp;<i class='fas fa-question-circle' title="Take a representative subsample of the current cluster.  Choosing all cells may dramatically increase rendering time." data-toggle="tooltip"></i><br />
-  <%= select_tag "#{@target}-subsample".to_sym, options_for_select(subsampling_options(@cluster.points), set_subsample_value(params) ), {include_blank: @cluster.points < ClusterGroup::MAX_THRESHOLD ? 'All Cells' : false, class: 'form-control subsample-select global-gene-subsample'} %>
+  <%= select_tag "#{@target}-subsample".to_sym, options_for_select(subsampling_options(@cluster), set_subsample_value(params) ), {include_blank: @cluster.points < ClusterGroup::MAX_THRESHOLD ? 'All Cells' : false, class: 'form-control subsample-select global-gene-subsample'} %>
+  <%= render partial: 'subsample_warning', locals: {cluster: @cluster} %>
 </div>


### PR DESCRIPTION
Since subsampling happens after a cluster has finished parsing, it is currently possible for users to request subsampled clustering data before it has finished computing.  This leads to both empty cluster plots, and errors when trying to view gene expression data.  This patch removes all subsampling options from the Subsampling threshold dropdown menu, and provides a small warning telling users that the cluster has not completed subsampling yet.  Also, if a request is somehow made for subsampled data that does not exist, the cluster will fall back to full-resolution data (i.e. "All Cells") instead of returning an empty array.

This PR satisfies SCP-2409.