### PR TITLE
enabling admin accounts to download study files (SCP

### DIFF
--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -29,28 +29,31 @@
                   </thead>
                 </table>
               <% end %>
-            <% elsif @study.public? && !@user_embargoed %>
-                <p class="lead">To download all files using <code>curl</code>, click the button below to get the download command:</p>
-                <p class="lead command-container" id="command-container-all"><%= link_to "<i class='fas fa-download'></i> Get download command for all study data".html_safe, '#/', class: 'btn btn-default get-download-command', id: 'get-download-command_all' %></p>
-                <% if @directories.any? %>
-                    <p class="lead">To download all data files in a specific folder, use the following commands:</p>
-                    <table class="table table-condensed table-striped">
-                      <thead>
+            <% elsif @study.public? && !@user_embargoed || current_user.admin? %>
+              <p class="lead">To download all files using <code>curl</code>, click the button below to get the download command:</p>
+              <p class="lead command-container" id="command-container-all"><%= link_to "<i class='fas fa-download'></i> Get download command for all study data".html_safe, '#/', class: 'btn btn-default get-download-command', id: 'get-download-command_all' %></p>
+              <% if @directories.any? %>
+                <p class="lead">To download all data files in a specific folder, use the following commands:</p>
+                <table class="table table-condensed table-striped">
+                  <thead>
+                    <tr>
+                      <th>Folder</th>
+                      <th>Download command</th>
+                    </tr>
+                    <% @directories.each do |directory| %>
                       <tr>
-                        <th>Folder</th>
-                        <th>Download command</th>
+                        <td><%= directory.name %></td>
+                        <td class="command-container" id="command-container-<%= directory.name %>">
+                          <%= link_to "<i class='fas fa-download'></i> Get download command".html_safe, '#/', class: 'btn btn-default get-download-command', id: "get-download-command_#{directory.name}" %>
+                        </td>
                       </tr>
-                      <% @directories.each do |directory| %>
-                          <tr>
-                            <td><%= directory.name %></td>
-                            <td class="command-container" id="command-container-<%= directory.name %>">
-                              <%= link_to "<i class='fas fa-download'></i> Get download command".html_safe, '#/', class: 'btn btn-default get-download-command', id: "get-download-command_#{directory.name}" %>
-                            </td>
-                          </tr>
-                      <% end %>
-                    </thead>
-                    </table>
-                <% end %>
+                    <% end %>
+                  </thead>
+                </table>
+              <% else %>
+                <%# The user is trying to download a public study that is currently embargoed. %>
+                <p class="lead">No downloads are available to you for this study yet</p>
+              <% end %>
             <% end %>
           </div>
           <div class="modal-footer">


### PR DESCRIPTION
Fixes SCP-2401 (bulk download study modal sometimes empty) 
 
The issue here is that the check for showing modal contents for non-public studies (Study.has_bucket_access?) doesn't line up with the check for visibility of the study download button (@allow_downloads).  Specifically, allow_downloads allows anyone who can edit the study to download as long as Firecloud is up, and the can_edit? check includes an allowance for all admins.  The has_bucket_access? has no such admin allowance.  So the simplest fix is just to add the admin allowance in, but I'm not sure if there's not a more elegant refactoring to be had.  

Jon, you were the one that told me about this issue -- did it impact anyone that didn't have an admin account?  (i.e. do we need to look for other gaps in the has_bucket_access? method)