### PR TITLE
Fix staging deploys

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -2,4 +2,14 @@ const { environment } = require('@rails/webpacker')
 
 environment.loaders.delete('nodeModules')
 
+// Set the max parallelization for the minification pipeline
+// See https://github.com/webpack-contrib/terser-webpack-plugin/issues/143#issuecomment-573954013
+//      for a description of the issue
+// See https://github.com/rails/webpacker/issues/2131 for discussion on how the configuration
+//      is applied through webpacker
+if (environment.config.optimization) {
+  environment.config.optimization.minimizer.find(m => m.constructor.name === 'TerserPlugin').options.terserOptions.parallel = 4
+}
+
+
 module.exports = environment

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -9,6 +9,7 @@ environment.loaders.delete('nodeModules')
 //      is applied through webpacker
 if (environment.config.optimization) {
   environment.config.optimization.minimizer.find(m => m.constructor.name === 'TerserPlugin').options.terserOptions.parallel = 4
+  environment.config.optimization.minimizer.find(m => m.constructor.name === 'TerserPlugin').options.parallel = 4
 }
 
 

--- a/rails_startup.bash
+++ b/rails_startup.bash
@@ -10,6 +10,8 @@ echo "*** COMPLETED ***"
 if [[ $PASSENGER_APP_ENV = "production" ]] || [[ $PASSENGER_APP_ENV = "staging" ]] || [[ $PASSENGER_APP_ENV = "pentest" ]]
 then
     echo "*** PRECOMPILING ASSETS ***"
+    # see https://github.com/rails/webpacker/issues/1189#issuecomment-359360326
+    export NODE_OPTIONS="--max-old-space-size=4096"
     sudo -E -u app -H bundle exec rake NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV SECRET_KEY_BASE=$SECRET_KEY_BASE yarn:install
     sudo -E -u app -H bundle exec rake NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV SECRET_KEY_BASE=$SECRET_KEY_BASE assets:clean
     sudo -E -u app -H bundle exec rake NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV SECRET_KEY_BASE=$SECRET_KEY_BASE assets:precompile


### PR DESCRIPTION
This seems silly that compiling assets takes >1GB of memory, but that's what the internet says is table stakes for this.  There are fine scale optimizations we can and should do around excluding certain large files from our bundle, but this works for now.
