### PR TITLE
Adding remote asset backup for user-uploaded assets (SCP-2374)

### DIFF
--- a/app/controllers/branding_groups_controller.rb
+++ b/app/controllers/branding_groups_controller.rb
@@ -32,6 +32,8 @@ class BrandingGroupsController < ApplicationController
 
     respond_to do |format|
       if @branding_group.save
+        # push all branding assets to remote to ensure consistency
+        UserAssetService.delay.push_assets_to_remote(asset_path: :branding_images)
         format.html { redirect_to merge_default_redirect_params(branding_group_path(@branding_group), scpbr: params[:scpbr]),
                                   notice: "Branding group '#{@branding_group.name}' was successfully created." }
         format.json { render :show, status: :created, location: @branding_group }

--- a/app/lib/user_asset_service.rb
+++ b/app/lib/user_asset_service.rb
@@ -1,0 +1,203 @@
+##
+# UserAssetService: manages uploading/localization of "user-provided" static asset files
+# Used primarily for BrandingGroup images, but also supports legacy CKEditor uploads
+##
+
+class UserAssetService
+
+  # GCP Compute project to run reads/writes in
+  COMPUTE_PROJECT = ENV['GOOGLE_CLOUD_PROJECT'].blank? ? '' : ENV['GOOGLE_CLOUD_PROJECT']
+  # Service account JSON credentials
+  SERVICE_ACCOUNT_KEY = !ENV['SERVICE_ACCOUNT_KEY'].blank? ? File.absolute_path(ENV['SERVICE_ACCOUNT_KEY']) : ''
+
+  # Asset Path helpers
+  RAILS_PUBLIC_PATH = Rails.root.join('public', 'single_cell')
+  ASSET_PATHS_BY_TYPE = {
+      ckeditor_pictures: RAILS_PUBLIC_PATH.join('ckeditor_assets', 'pictures'),
+      ckeditor_attachments: RAILS_PUBLIC_PATH.join('ckeditor_assets', 'attachments'),
+      branding_images: RAILS_PUBLIC_PATH.join('branding_groups')
+  }.with_indifferent_access
+  ASSET_TYPES = ASSET_PATHS_BY_TYPE.keys.freeze
+
+  # Bucket info
+  STORAGE_BUCKET_NAME = (COMPUTE_PROJECT.dup + '-asset-storage').freeze
+
+  # initialize GCS driver with same credentials as FireCloudClient
+  #
+  # * *yields*
+  #   - +Google::Cloud::Storage+
+  def self.initialize_storage_service
+    Google::Cloud::Storage.new(keyfile: SERVICE_ACCOUNT_KEY)
+  end
+
+  # getter for storage service object
+  #
+  # * *returns*
+  #   - +Google::Cloud::Storage+
+  def self.storage_service
+    @@storage_service ||= initialize_storage_service
+  end
+
+  # getter for storage bucket where assets are stored long-term
+  # if bucket is not found, it will create the bucket and return
+  #
+  # * *returns*
+  #   - +Google::Cloud::Storage::Bucket+
+  def self.get_storage_bucket
+    storage_service.bucket(STORAGE_BUCKET_NAME) || storage_service.create_bucket(STORAGE_BUCKET_NAME)
+  end
+
+  # get all entries in a directory, ignoring hidden files
+  #
+  # * *params*
+  #   - +pathname+ (String) => Absolute path to a directory
+  #
+  # * *returns*
+  #   - (Array<String>) => Array of filenames
+  def self.get_directory_entries(pathname: Dir.pwd)
+    Dir.entries(pathname).keep_if {|entry| !entry.start_with?('.')}
+  end
+  
+  # get a list of all local assets; can scope by asset type
+  #
+  # * *params*
+  #   - +asset_type+ (String, Symbol) => type of asset as declared by ASSET_PATHS_BY_TYPE.keys
+  #
+  # * *returns*
+  #   - (Array<Pathname>) => Array of Pathname objects
+  #
+  # * *raises*
+  #   - TypeError => invalid asset type
+  def self.get_local_assets(asset_type: nil)
+    verify_asset_type(asset_type)
+    local_files = []
+    asset_paths = asset_type.present? ? [ASSET_PATHS_BY_TYPE[asset_type]] : ASSET_PATHS_BY_TYPE.values
+    asset_paths.each do |asset_path|
+      sub_dirs = get_directory_entries(pathname: asset_path)
+      sub_dirs.each do |sub_dir|
+        current_dir = asset_path.join(sub_dir)
+        files = get_directory_entries(pathname: current_dir)
+        local_files += files.map {|file| Pathname.new(current_dir).join(file)}
+      end
+    end
+    local_files
+  end
+
+  # get a list of all local assets; can scope by asset type
+  #
+  # * *params*
+  #   - +asset_type+ (String, Symbol) => type of asset as declared by ASSET_PATHS_BY_TYPE.keys
+  #
+  # * *returns*
+  #   - (Google::Cloud::Storage::Bucket::List) => Array of GCS File objects
+  #
+  # * *raises*
+  #   - TypeError => invalid asset type
+  # get a list of remote assets; can scope by asset type
+  def self.get_remote_assets(asset_type: nil)
+    verify_asset_type(asset_type)
+    bucket = get_storage_bucket
+    # get prefix to filter remote assets by type, if specified
+    asset_prefix = asset_type.present? ? get_remote_path(ASSET_PATHS_BY_TYPE[asset_type]) : nil
+    bucket.files prefix: asset_prefix.to_s
+  end
+
+  # Push all local files to remote bucket storage; will overwrite any files in remote with current copy
+  #
+  # * *params*
+  #   - +asset_type+ (String, Symbol) => Type of assets to push; defaults to all
+  #
+  # * *returns*
+  #   - (TrueClass) => true upon completion
+  #
+  # * *raises*
+  #   - (TypeError) => Invalid asset type
+  #   - (ArgumentError) => Invalid path to local file
+  #   - (Google::Cloud::Error) => Error pushing file to bucket
+  def self.push_assets_to_remote(asset_type: nil)
+    verify_asset_type(asset_type)
+    bucket = get_storage_bucket
+    get_local_assets(asset_type: asset_type).each do |asset_path|
+      remote_path = get_remote_path(asset_path)
+      bucket.create_file asset_path.to_s, remote_path
+    end
+    true
+  end
+
+  # convert a local path into a remote path for a file in a bucket (removes RAILS_PUBLIC_PATH prefix)
+  #
+  # * *params*
+  #   - +pathname+ (Pathname) => Pathname of local file
+  #
+  # * *returns*
+  #   - (String) => String representation of remote filepath
+  def self.get_remote_path(pathname)
+    remote_path = pathname.to_s.split(RAILS_PUBLIC_PATH.to_s).last
+    remote_path.slice!(0, 1) # trim off leading /
+    remote_path.to_s
+  end
+
+  # pull down all assets from remote storage; will skip any files that already exist
+  # * *params*
+  #   - +asset_type+ (String, Symbol) => Type of assets to push; defaults to all
+  #
+  # * *returns*
+  #   - (Array<Pathname>) => Array of Pathnames pointing at files that were localized
+  #
+  # * *raises*
+  #   - (TypeError) => Invalid asset type
+  #   - (Google::Cloud::Error) => Error retrieving file from bucket
+  def self.localize_assets_from_remote(asset_type: nil)
+    verify_asset_type(asset_type)
+    localized_files = []
+    get_remote_assets(asset_type: asset_type).each do |remote_asset|
+      local_path = get_local_path(remote_asset.name)
+      unless File.exist?(local_path)
+        # we need to first make the directory where the file will go, otherwise this will throw an error
+        create_download_directory(remote_asset.name)
+        remote_asset.download local_path
+        localized_files << Pathname.new(local_path)
+      end
+    end
+    localized_files
+  end
+
+  # convert a remote path into a local path for a file to be localized from a bucket (prepends RAILS_PUBLIC_PATH prefix)
+  #
+  # * *params*
+  #   - +pathname+ (Pathname) => Pathname of remote file
+  #
+  # * *returns*
+  #   - (String) => String representation of local filepath
+  def self.get_local_path(pathname)
+    RAILS_PUBLIC_PATH.join(pathname).to_s
+  end
+
+  # create a local directory in which to localize a remote asset to prevent Errno::ENOENT errors
+  # * *params*
+  #   - +pathname+ (Pathname) => Pathname of remote file
+  #
+  # * *returns*
+  #   - (Pathname) => Pathname of local directory
+  def self.create_download_directory(pathname)
+    parent_dir = Pathname.new(pathname).parent
+    fullpath = RAILS_PUBLIC_PATH.join(parent_dir)
+    FileUtils.mkdir_p(fullpath) unless Dir.exists?(fullpath)
+    fullpath
+  end
+
+  private
+
+  # verify type of requested asset is valid
+  #
+  # * *params*
+  #   - +asset_type+ (String, Symbol) => type of asset as declared by ASSET_PATHS_BY_TYPE.keys
+  #
+  # * *raises*
+  #   - TypeError => invalid asset type
+  def self.verify_asset_type(asset_type)
+    if asset_type.present? && !ASSET_TYPES.include?(asset_type.to_s)
+      raise TypeError.new("#{asset_type} is not a registered asset type: #{ASSET_TYPES.join(', ')}")
+    end
+  end
+end

--- a/app/lib/user_asset_service.rb
+++ b/app/lib/user_asset_service.rb
@@ -20,22 +20,15 @@ class UserAssetService
   ASSET_TYPES = ASSET_PATHS_BY_TYPE.keys.freeze
 
   # Bucket info; each Rails environment per project has a bucket
-  STORAGE_BUCKET_NAME = (COMPUTE_PROJECT.dup + "-#{Rails.env}-asset-storage").freeze
+  STORAGE_BUCKET_NAME = "#{COMPUTE_PROJECT}-#{Rails.env}-asset-storage".freeze
 
   # initialize GCS driver with same credentials as FireCloudClient
+  # will return existing instance after first call is made (does not re-instantiate)
   #
   # * *yields*
   #   - +Google::Cloud::Storage+
-  def self.initialize_storage_service
-    Google::Cloud::Storage.new(keyfile: SERVICE_ACCOUNT_KEY)
-  end
-
-  # getter for storage service object
-  #
-  # * *returns*
-  #   - +Google::Cloud::Storage+
   def self.storage_service
-    @@storage_service ||= initialize_storage_service
+    @@storage_service ||= Google::Cloud::Storage.new(keyfile: SERVICE_ACCOUNT_KEY)
   end
 
   # get storage driver access token

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -104,6 +104,7 @@ else
                     test/models/user_test.rb
                     test/integration/lib/search_facet_populator_test.rb
                     test/integration/lib/summary_stats_utils_test.rb
+                    test/integration/lib/user_asset_service_test.rb
                     test/models/big_query_client_test.rb
   )
   for test_name in ${tests[*]}; do

--- a/db/migrate/20200513190742_backup_user_assets.rb
+++ b/db/migrate/20200513190742_backup_user_assets.rb
@@ -1,0 +1,10 @@
+class BackupUserAssets < Mongoid::Migration
+  def self.up
+    UserAssetService.push_assets_to_remote
+  end
+
+  def self.down
+    bucket = UserAssetService.get_storage_bucket
+    bucket.delete
+  end
+end

--- a/db/migrate/20200513190742_backup_user_assets.rb
+++ b/db/migrate/20200513190742_backup_user_assets.rb
@@ -4,7 +4,5 @@ class BackupUserAssets < Mongoid::Migration
   end
 
   def self.down
-    bucket = UserAssetService.get_storage_bucket
-    bucket.delete
   end
 end

--- a/rails_startup.bash
+++ b/rails_startup.bash
@@ -111,6 +111,10 @@ echo "*** ADDING DAILY RESET OF USER DOWNLOAD QUOTAS ***"
 (crontab -u app -l ; echo "@daily . /home/app/.cron_env ; cd /home/app/webapp/; /home/app/webapp/bin/rails runner -e $PASSENGER_APP_ENV \"User.update_all(daily_download_quota: 0)\" >> /home/app/webapp/log/cron_out.log 2>&1") | crontab -u app -
 echo "*** COMPLETED ***"
 
+echo "*** LOCALIZING USER ASSETS ***"
+/home/app/webapp/bin/rails runner -e $PASSENGER_APP_ENV "UserAssetService.delay.localize_assets_from_remote"
+echo "*** COMPLETED ***"
+
 echo "*** CLEARING CACHED USER OAUTH TOKENS ***"
 /home/app/webapp/bin/rails runner -e $PASSENGER_APP_ENV "User.update_all(refresh_token: nil, access_token: nil, api_access_token: nil)"
 echo "*** COMPLETED ***"

--- a/test/integration/lib/user_asset_service_test.rb
+++ b/test/integration/lib/user_asset_service_test.rb
@@ -15,11 +15,10 @@ class UserAssetServiceTest < ActiveSupport::TestCase
       end
       entries = UserAssetService.get_directory_entries(asset_path)
       if entries.empty?
-        TEST_FILES.each do |test_file|
-          object_id = Mongo::Operation::ObjectIdGenerator.new.generate.to_s
-          upload_dir = asset_path.join(object_id)
+        TEST_FILES.each_with_index do |test_file, index|
+          upload_dir = asset_path.join(index.to_s)
           FileUtils.mkdir_p(upload_dir)
-          new_path = asset_path.join(object_id, test_file)
+          new_path = upload_dir.join(test_file)
           source_file = TEST_DATA_DIR.join(test_file)
           FileUtils.copy_file(source_file, new_path, preserve: true)
         end

--- a/test/integration/lib/user_asset_service_test.rb
+++ b/test/integration/lib/user_asset_service_test.rb
@@ -1,0 +1,86 @@
+require "test_helper"
+
+class UserAssetServiceTest < ActiveSupport::TestCase
+
+  TEST_DATA_DIR = Rails.root.join('test', 'test_data', 'branding_groups')
+  TEST_FILES = UserAssetService.get_directory_entries(TEST_DATA_DIR)
+
+  # seed test data into public directory
+  # will not overwrite existing data if there, but in that case the test for pulling remote data will fail
+  # only intended for use in a CI environment
+  def populate_test_data
+    UserAssetService::ASSET_PATHS_BY_TYPE.values.each do |asset_path|
+      unless Dir.exists?(asset_path)
+        FileUtils.mkdir_p(asset_path)
+      end
+      entries = UserAssetService.get_directory_entries(asset_path)
+      if entries.empty?
+        TEST_FILES.each do |test_file|
+          object_id = Mongo::Operation::ObjectIdGenerator.new.generate.to_s
+          upload_dir = asset_path.join(object_id)
+          FileUtils.mkdir_p(upload_dir)
+          new_path = asset_path.join(object_id, test_file)
+          source_file = TEST_DATA_DIR.join(test_file)
+          FileUtils.copy_file(source_file, new_path, preserve: true)
+        end
+      end
+    end
+  end
+
+  test 'should instantiate client' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    storage_service = UserAssetService.storage_service
+    assert storage_service.present?, 'Did not initialize storage service'
+    # validate we're using the same service and not re-initializing every time
+    new_service = UserAssetService.storage_service
+    service_token = new_service.service.credentials.client.access_token
+    issue_date = new_service.service.credentials.client.issued_at
+
+    assert_equal UserAssetService.access_token, service_token
+                 "Access tokens are not the same: #{UserAssetService.access_token} != #{service_token}"
+    assert_equal UserAssetService.issued_at, issue_date,
+                 "Creation timestamps are not the same: #{UserAssetService.issued_at} != #{issue_date}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should get storage bucket' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    bucket = UserAssetService.get_storage_bucket
+    assert bucket.present?, "Did not get storage bucket"
+    assert_equal UserAssetService::STORAGE_BUCKET_NAME, bucket.name,
+                 "Incorrect bucket returned; should have been #{UserAssetService::STORAGE_BUCKET_NAME} but found #{bucket.name}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should push and pull assets from remote' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # seed test data into directory so we have idempotent results
+    populate_test_data
+    local_assets = UserAssetService.get_local_assets
+    assert_equal 9, local_assets.size,
+                 "Did not find correct number of files, expected 9 but found #{local_assets.size}"
+    filenames = local_assets.map {|asset| asset.basename.to_s}.uniq
+    assert_equal TEST_FILES.sort, filenames.sort,
+                 "Did not find correct files; expected #{TEST_FILES.sort} but found #{filenames.sort}"
+
+    # do remote push
+    pushed = UserAssetService.push_assets_to_remote
+    assert pushed, "Did not successfully push assets to remote bucket"
+    remote_assets = UserAssetService.get_remote_assets
+    assert_equal 9, remote_assets.size,
+                 "Did not find correct number of remote assets, expected 9 but found #{remote_assets.size}"
+
+    # now remote local assets and pull from remote
+    local_assets.each {|asset| File.delete(asset) }
+    new_local_assets = UserAssetService.localize_assets_from_remote
+    assert_equal local_assets.sort, new_local_assets.sort,
+                 "Did not successfully localize remotes, #{new_local_assets.sort} != #{local_assets.sort}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+end


### PR DESCRIPTION
Adds the `UserAssetService` to back up any user-provided assets (i.e. images) that are used either for branded spaces, or legacy support of previously uploaded images for study descriptions.  Assets will be backed up to a Google bucket after new branded spaces are created, and every time the portal reboots, the asset service will localize any files that are missing on disk.  This is mainly useful for when new host VMs are provisioned (which would have new persistent disks).

Each portal GCP project will have a bucket per Rails environment used.  Buckets are created on-demand, so no prior setup is required.  Also includes a migration to perform the initial backup of all assets present for each portal instance.

This PR satisfies SCP-2374.
