### PR TITLE
Updating ingest email messages, auth error logging (SCP-2420, SCP-2423)

### DIFF
--- a/app/controllers/api/v1/concerns/authenticator.rb
+++ b/app/controllers/api/v1/concerns/authenticator.rb
@@ -3,6 +3,7 @@ module Api
     module Concerns
       module Authenticator
         extend ActiveSupport::Concern
+        OAUTH_V3_TOKEN_INFO = 'https://www.googleapis.com/oauth2/v3/tokeninfo'
 
         def authenticate_api_user!
           head 401 unless api_user_signed_in?
@@ -24,8 +25,7 @@ module Api
             if user.nil?
               # extract user info from access_token
               begin
-                token_url = "https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=#{api_access_token}"
-                response = RestClient.get token_url
+                response = RestClient.get OAUTH_V3_TOKEN_INFO + "?access_token=#{api_access_token}"
                 credentials = JSON.parse response.body
                 now = Time.zone.now
                 token_values = {
@@ -40,17 +40,23 @@ module Api
                   # store api_access_token to speed up retrieval next time
                   user.update(api_access_token: token_values)
                 else
-                  Rails.logger.error "Unable to retrieve user info from access token: #{api_access_token}"
+                  Rails.logger.error "Unable to retrieve user info from access token; user not present: #{email}"
+                  return nil # no user is logged in because we don't have an account that matches the email
                 end
+              rescue RestClient::BadRequest => e
+                Rails.logger.info 'Access token expired, cannot decode user info'
+                return nil
               rescue => e
+                # we should only get here if a real error occurs, not if a token expires
                 error_context = {
                     auth_response_body: response.present? ? response.body : nil,
                     auth_response_code: response.present? ? response.code : nil,
                     auth_response_headers: response.present? ? response.headers : nil,
-                    api_access_token: api_access_token
+                    token_present: api_access_token.present?
                 }
-                ErrorTracker.report_exception(e, user, error_context)
+                ErrorTracker.report_exception(e, nil, error_context)
                 Rails.logger.error "Error retrieving user api credentials: #{e.class.name}: #{e.message}"
+                return nil
               end
             end
             # check for token expiry and unset user && api_access_token if expired/timed out
@@ -81,7 +87,6 @@ module Api
             token
           end
         end
-
       end
     end
   end

--- a/app/controllers/api/v1/concerns/authenticator.rb
+++ b/app/controllers/api/v1/concerns/authenticator.rb
@@ -46,7 +46,8 @@ module Api
                 error_context = {
                     auth_response_body: response.present? ? response.body : nil,
                     auth_response_code: response.present? ? response.code : nil,
-                    auth_response_headers: response.present? ? response.headers : nil
+                    auth_response_headers: response.present? ? response.headers : nil,
+                    api_access_token: api_access_token
                 }
                 ErrorTracker.report_exception(e, user, error_context)
                 Rails.logger.error "Error retrieving user api credentials: #{e.class.name}: #{e.message}"

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -481,21 +481,22 @@ class IngestJob
   # *returns*
   #  - (String) => String showing annotation information for email
   def get_annotation_message(annotation_source:, cell_annotation: nil)
+    max_values = CellMetadatum::GROUP_VIZ_THRESHOLD.max
     case annotation_source.class
     when CellMetadatum
       message = "#{annotation_source.name}: #{annotation_source.annotation_type}"
-      if annotation_source.values.size < CellMetadatum::GROUP_VIZ_THRESHOLD.max || annotation_source.annotation_type == 'numeric'
+      if annotation_source.values.size < max_values || annotation_source.annotation_type == 'numeric'
         values = annotation_source.values.any? ? ' (' + annotation_source.values.join(', ') + ')' : ''
       else
-        values = ' (List too large for email)'
+        values = " (List too large for email -- #{annotation_source.values.size} values present, max is #{max_values})"
       end
       message + values
     when ClusterGroup
       message = "#{cell_annotation['name']}: #{cell_annotation['type']}"
-      if cell_annotation['values'].size < CellMetadatum::GROUP_VIZ_THRESHOLD.max || cell_annotation['type'] == 'numeric'
+      if cell_annotation['values'].size < max_values || cell_annotation['type'] == 'numeric'
         values = cell_annotation['type'] == 'group' ? ' (' + cell_annotation['values'].join(',') + ')' : ''
       else
-        values = ' (List too large for email)'
+        values = " (List too large for email -- #{cell_annotation['values'].size} values present, max is #{max_values})"
       end
       message + values
     end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -484,7 +484,7 @@ class IngestJob
     case annotation_source.class
     when CellMetadatum
       message = "#{annotation_source.name}: #{annotation_source.annotation_type}"
-      if annotation_source.can_visualize? || annotation_source.values.size == 1
+      if annotation_source.values.size < CellMetadatum::GROUP_VIZ_THRESHOLD.max
         values = annotation_source.values.any? ? ' (' + annotation_source.values.join(', ') + ')' : ''
       else
         values = ' (List too large for email)'
@@ -492,14 +492,12 @@ class IngestJob
       message + values
     when ClusterGroup
       message = "#{cell_annotation['name']}: #{cell_annotation['type']}"
-      if annotation_source.can_visualize_cell_annotation?(cell_annotation) || cell_annotation['values'].size == 1
+      if cell_annotation['values'].size < CellMetadatum::GROUP_VIZ_THRESHOLD.max
         values = cell_annotation['type'] == 'group' ? ' (' + cell_annotation['values'].join(',') + ')' : ''
       else
         values = ' (List too large for email)'
       end
       message + values
-    else
-      nil
     end
   end
 end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -484,7 +484,7 @@ class IngestJob
     case annotation_source.class
     when CellMetadatum
       message = "#{annotation_source.name}: #{annotation_source.annotation_type}"
-      if annotation_source.values.size < CellMetadatum::GROUP_VIZ_THRESHOLD.max
+      if annotation_source.values.size < CellMetadatum::GROUP_VIZ_THRESHOLD.max || annotation_source.annotation_type == 'numeric'
         values = annotation_source.values.any? ? ' (' + annotation_source.values.join(', ') + ')' : ''
       else
         values = ' (List too large for email)'
@@ -492,7 +492,7 @@ class IngestJob
       message + values
     when ClusterGroup
       message = "#{cell_annotation['name']}: #{cell_annotation['type']}"
-      if cell_annotation['values'].size < CellMetadatum::GROUP_VIZ_THRESHOLD.max
+      if cell_annotation['values'].size < CellMetadatum::GROUP_VIZ_THRESHOLD.max || cell_annotation['type'] == 'numeric'
         values = cell_annotation['type'] == 'group' ? ' (' + cell_annotation['values'].join(',') + ')' : ''
       else
         values = ' (List too large for email)'


### PR DESCRIPTION
Ingest success emails will now report all annotation values parsed from a file, unless they are over 100 entries long, in which case the default `list too long for email` message will still appear.  This patch also updates error logging for API auth failures to include the auth token to allow for better error debugging.

This PR satisfies SCP-2420, SCP-2423.