### PR TITLE
Increasing query timeout to 2 min

### DIFF
--- a/app/models/big_query_client.rb
+++ b/app/models/big_query_client.rb
@@ -12,6 +12,7 @@ class BigQueryClient < Struct.new(:project, :service_account_credentials, :clien
     Google::Cloud::Bigquery.configure do |config|
       config.project_id  = COMPUTE_PROJECT
       config.credentials = SERVICE_ACCOUNT_KEY
+      config.timeout = 120
     end
     self.project = COMPUTE_PROJECT
     self.service_account_credentials = SERVICE_ACCOUNT_KEY


### PR DESCRIPTION
CI builds in Travis have shown that on rare occasion reads in BigQuery take longer than the default timeout of 60 seconds and will throw an error, causing a test to fail.  As this is not a true regression, increasing the timeout will hopefully reduce or eliminate this false positive.