### PR TITLE
Updates for Ruby 2.6 support (SCP-2411)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM singlecellportal/rails-baseimage:1.0.2
+FROM singlecellportal/rails-baseimage:1.0.3
 
 # Set ruby version
-RUN bash -lc 'rvm --default use ruby-2.5.7'
+RUN bash -lc 'rvm --default use ruby-2.6.5'
 RUN bash -lc 'rvm rvmrc warning ignore /home/app/webapp/Gemfile'
 
 # Set up project dir, install gems, set up script to migrate database and precompile static assets on run

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.5.7'
+ruby '2.6.5'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '5.2.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,9 +112,9 @@ GEM
     connection_pool (2.2.2)
     crass (1.0.6)
     daemons (1.2.6)
-    debase (0.2.2)
+    debase (0.2.4.1)
       debase-ruby_core_source (>= 0.10.2)
-    debase-ruby_core_source (0.10.3)
+    debase-ruby_core_source (0.10.9)
     declarative (0.0.10)
     declarative-option (0.1.0)
     delayed_job (4.1.5)
@@ -506,7 +506,7 @@ DEPENDENCIES
   will_paginate_mongoid
 
 RUBY VERSION
-   ruby 2.5.7p206
+   ruby 2.6.5p114
 
 BUNDLED WITH
    2.1.4

--- a/webapp.conf
+++ b/webapp.conf
@@ -50,7 +50,7 @@ server {
 		proxy_read_timeout	300;
 
 		# If this is a Ruby app, specify a Ruby version:
-		passenger_ruby	/usr/bin/ruby2.5;
+		passenger_ruby	/usr/bin/ruby2.6;
 		# For Ruby 2.0
 		# passenger_ruby /usr/bin/ruby2.0;
 		# For Ruby 1.9.3 (you can ignore the "1.9.1" suffix)


### PR DESCRIPTION
Updating version of Ruby to `2.6.5`, as `2.5` is EOL.  Also updates base image to `1.0.3` to pull in regular security patches to Ubuntu base image.

Once [phusion/passenger](https://github.com/phusion/passenger-docker) updates to support Ruby 2.7 (specifically 2.7.1 or later), we will update again to pull in security patches to the JSON library, among others.  Currently, there are significant issues with deprecation warnings flooding `stderr` and some required gems (`tcell_raven`) do not function on 2.7.  Another option would be to update to `2.6.6` to pull in these security updates, but there are problems installing this version of Ruby manually with `rvm` inside the image.  There is an open [issue](https://github.com/phusion/passenger-docker/issues/289) in the phusion repo to pull in these updates, so waiting for the next release appears to be the best option.

This PR satisfies SCP-2411.