### PR TITLE
Ignoring study_name, default to accession (SCP-2422)

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -580,8 +580,11 @@ class StudiesController < ApplicationController
   # method to download files if study is private, will create temporary signed_url after checking user quota
   def download_private_file
     @study = Study.find_by(accession: params[:accession])
-    # make sure user is signed in
-    if !user_signed_in? || !@study.can_view?(current_user)
+    # make study exists, then ensure user is signed in
+    if @study.nil?
+      redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
+                  alert: 'The study you requested was not found.' and return
+    elsif !user_signed_in? || !@study.can_view?(current_user)
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
                   alert: 'You do not have permission to perform that action.' and return
     elsif @study.detached?

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -579,7 +579,7 @@ class StudiesController < ApplicationController
 
   # method to download files if study is private, will create temporary signed_url after checking user quota
   def download_private_file
-    @study = Study.find_by(accession: params[:accession], url_safe_name: params[:study_name])
+    @study = Study.find_by(accession: params[:accession])
     # make sure user is signed in
     if !user_signed_in? || !@study.can_view?(current_user)
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),


### PR DESCRIPTION
Always default to using the study accession when loading a study, regardless of what is provided for the study name.  Since this update affects only `download_private_file` (all other download/study viewing methods use only accession), no further refactoring is required.

This PR satisfies SCP-2422.