### PR TITLE
Adding service account workspace owner user group (SCP-2399)

### DIFF
--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -226,10 +226,13 @@ class AdminConfiguration
     ws_owner_group = groups.detect {|group| group['groupName'] == FireCloudClient::WS_OWNER_GROUP_NAME &&
         group['role'] == 'Admin'}
     # create group if not found
-    unless ws_owner_group.present?
-      ws_owner_group = Study.firecloud_client.create_user_group(FireCloudClient::WS_OWNER_GROUP_NAME)
+    if ws_owner_group.present?
+      ws_owner_group
+    else
+      # create and return group
+      Study.firecloud_client.create_user_group(FireCloudClient::WS_OWNER_GROUP_NAME)
+      Study.firecloud_client.get_user_group(FireCloudClient::WS_OWNER_GROUP_NAME)
     end
-    ws_owner_group
   end
 
   # getter to return all configuration options as a hash

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -224,7 +224,7 @@ class AdminConfiguration
   def self.find_or_create_ws_user_group!
     groups = Study.firecloud_client.get_user_groups
     ws_owner_group = groups.detect {|group| group['groupName'] == FireCloudClient::WS_OWNER_GROUP_NAME &&
-        group['role'].downcase == 'owner'}
+        group['role'] == 'Admin'}
     # create group if not found
     unless ws_owner_group.present?
       ws_owner_group = Study.firecloud_client.create_user_group(FireCloudClient::WS_OWNER_GROUP_NAME)

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -221,6 +221,17 @@ class AdminConfiguration
     end
   end
 
+  def self.find_or_create_ws_user_group!
+    groups = Study.firecloud_client.get_user_groups
+    ws_owner_group = groups.detect {|group| group['groupName'] == FireCloudClient::WS_OWNER_GROUP_NAME &&
+        group['role'].downcase == 'owner'}
+    # create group if not found
+    unless ws_owner_group.present?
+      ws_owner_group = Study.firecloud_client.create_user_group(FireCloudClient::WS_OWNER_GROUP_NAME)
+    end
+    ws_owner_group
+  end
+
   # getter to return all configuration options as a hash
   def options
     opts = {}

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -43,6 +43,10 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   # List of projects where computes are not permitted (sets canCompute to false for all users by default, can only be overridden
   # by PROJECT_OWNER)
   COMPUTE_BLACKLIST = %w(single-cell-portal)
+  # Name of user group to set as workspace owner for user-controlled billing projects.  Reduces the amount of
+  # groups the portal service account needs to be a member of
+  # defaults to the Terra billing project this instance is configured against, plus "-sa-owner-group"
+  WS_OWNER_GROUP_NAME = "#{PORTAL_NAMESPACE}-sa-owner-group"
 
   ##
   # SERVICE NAMES AND DESCRIPTIONS

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -3313,8 +3313,7 @@ class Study
     # only perform check if this is not the default portal project
     if self.firecloud_project != FireCloudClient::PORTAL_NAMESPACE
       begin
-        groups = Study.firecloud_client.get_user_groups
-        sa_owner_group = groups.detect {|group| group['groupName'] == FireCloudClient::WS_OWNER_GROUP_NAME}
+        sa_owner_group = AdminConfiguration.find_or_create_ws_user_group!
         client = FireCloudClient.new(self.user, self.firecloud_project)
         group_email = sa_owner_group['groupEmail']
         acl = client.create_workspace_acl(group_email, 'OWNER', true, false)

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -102,6 +102,7 @@ else
                     test/models/search_facet_test.rb
                     test/models/preset_search_test.rb
                     test/models/user_test.rb
+                    test/models/admin_configuration_test.rb
                     test/integration/lib/search_facet_populator_test.rb
                     test/integration/lib/summary_stats_utils_test.rb
                     test/integration/lib/user_asset_service_test.rb

--- a/db/migrate/20200518190036_set_sa_group_owner_on_workspaces.rb
+++ b/db/migrate/20200518190036_set_sa_group_owner_on_workspaces.rb
@@ -5,24 +5,18 @@
 class SetSaGroupOwnerOnWorkspaces < Mongoid::Migration
   def self.up
     client = FireCloudClient.new
-    groups = client.get_user_groups
-    sa_owner_group = groups.detect {|group| group['groupName'] == FireCloudClient::WS_OWNER_GROUP_NAME &&
-        group['role'].downcase == 'owner'}
-    # create group if not found
-    unless sa_owner_group.present?
-      sa_owner_group = client.create_user_group(FireCloudClient::WS_OWNER_GROUP_NAME)
-    end
+    ws_owner_group = AdminConfiguration.find_or_create_ws_user_group!
     Study.where(:firecloud_project.ne => FireCloudClient::PORTAL_NAMESPACE, detached: false).each do |study|
       # put in begin/rescue block in case there is a problem accessing the workspace, e.g. expired credits
       # all of these studies should already be marked as 'detached' but there could be some outliers
       begin
         puts "Updating workspace acl on #{study.firecloud_project}/#{study.firecloud_workspace}"
-        acl = client.create_workspace_acl(sa_owner_group['groupEmail'], 'OWNER')
+        acl = client.create_workspace_acl(ws_owner_group['groupEmail'], 'OWNER')
         client.update_workspace_acl(study.firecloud_project, study.firecloud_workspace, acl)
         puts "Update on #{study.firecloud_project}/#{study.firecloud_workspace} complete"
       rescue => e
         puts "Error updating workspace acl for #{study.firecloud_project}/#{study.firecloud_workspace}"
-        context = ErrorTracker.format_extra_context(study, acl)
+        context = ErrorTracker.format_extra_context(study, acl, ws_owner_group)
         ErrorTracker.report_exception(e, client.issuer, context)
       end
     end

--- a/db/migrate/20200518190036_set_sa_group_owner_on_workspaces.rb
+++ b/db/migrate/20200518190036_set_sa_group_owner_on_workspaces.rb
@@ -1,4 +1,4 @@
-# Backfilling persmisions on existing workspaces not in the 'default' portal project by adding a
+# Backfilling permissions on existing workspaces not in the 'default' portal project by adding a
 # Service Account owned user group to all workspaces
 # This is in preparation of revoking all direct SA ownerships on workspaces
 

--- a/db/migrate/20200518190036_set_sa_group_owner_on_workspaces.rb
+++ b/db/migrate/20200518190036_set_sa_group_owner_on_workspaces.rb
@@ -1,0 +1,33 @@
+# Backfilling persmisions on existing workspaces not in the 'default' portal project by adding a
+# Service Account owned user group to all workspaces
+# This is in preparation of revoking all direct SA ownerships on workspaces
+
+class SetSaGroupOwnerOnWorkspaces < Mongoid::Migration
+  def self.up
+    client = FireCloudClient.new
+    groups = client.get_user_groups
+    sa_owner_group = groups.detect {|group| group['groupName'] == FireCloudClient::WS_OWNER_GROUP_NAME &&
+        group['role'].downcase == 'owner'}
+    # create group if not found
+    unless sa_owner_group.present?
+      sa_owner_group = client.create_user_group(FireCloudClient::WS_OWNER_GROUP_NAME)
+    end
+    Study.where(:firecloud_project.ne => FireCloudClient::PORTAL_NAMESPACE, detached: false).each do |study|
+      # put in begin/rescue block in case there is a problem accessing the workspace, e.g. expired credits
+      # all of these studies should already be marked as 'detached' but there could be some outliers
+      begin
+        puts "Updating workspace acl on #{study.firecloud_project}/#{study.firecloud_workspace}"
+        acl = client.create_workspace_acl(sa_owner_group['groupEmail'], 'OWNER')
+        client.update_workspace_acl(study.firecloud_project, study.firecloud_workspace, acl)
+        puts "Update on #{study.firecloud_project}/#{study.firecloud_workspace} complete"
+      rescue => e
+        puts "Error updating workspace acl for #{study.firecloud_project}/#{study.firecloud_workspace}"
+        context = ErrorTracker.format_extra_context(study, acl)
+        ErrorTracker.report_exception(e, client.issuer, context)
+      end
+    end
+  end
+
+  def self.down
+  end
+end

--- a/test/models/admin_configuration_test.rb
+++ b/test/models/admin_configuration_test.rb
@@ -1,7 +1,32 @@
 require "test_helper"
 
 class AdminConfigurationTest < ActiveSupport::TestCase
-  def admin_configuration
-    @admin_configuration = nil
+  def setup
+    @client = FireCloudClient.new
+  end
+
+  # since the migration SetSaGroupOwnerOnWorkspaces will have already run, we are ensuring that calling
+  # AdminConfiguration.find_or_create_ws_user_group! retrieves the user group rather than creating a new one
+  test 'should create or retrieve service account workspace owner group' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    first_sa_group = AdminConfiguration.find_or_create_ws_user_group!
+    assert_not_nil first_sa_group, 'Did not create/retrieve service account workspace owner group'
+
+    groups = @client.get_user_groups
+    found_group = groups.detect {|group| group['groupName'] == FireCloudClient::WS_OWNER_GROUP_NAME}
+    assert_not_nil found_group, 'Did not find service account workspace owner group in groups'
+
+    second_sa_group = AdminConfiguration.find_or_create_ws_user_group!
+    assert_equal first_sa_group, second_sa_group,
+                 "Service account workspace owner groups not the same: #{first_sa_group} != #{second_sa_group}"
+
+    second_groups = @client.get_user_groups
+    first_group_names = groups.map {|group| group['groupName']}.sort
+    second_group_names = second_groups.map {|group| group['groupName']}.sort
+    assert_equal first_group_names, second_group_names,
+                 "Groups are not the same: #{first_group_names} != #{second_group_names}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 end


### PR DESCRIPTION
All Google accounts (including service accounts) have a quota on memberships in Google groups (2000 direct memberships, 5000 indirect memberships), and being added to the ACL on a Terra workspace adds that account to a user group that is specific to that workspace that grants the requested permission.  This means that we would have in effect a hard limit of 2000 studies in SCP (per instance) unless we begin pooling service accounts.  As part of ameliorating the impact on that quota, this update will add a single user group that will be an owner of all workspaces registered in the portal that are _not_ part of the "default" free Terra billing project.

Future work will be needed to redact all direct service account permissions on portal workspaces, but additional upstream work in the Terra Orchestration API is needed before that work can commence.

This PR satisfies SCP-2399.