### PR TITLE
Update logging to filter sensitive info

### DIFF
--- a/bin/load_env_secrets.sh
+++ b/bin/load_env_secrets.sh
@@ -112,6 +112,7 @@ fi
 # insert connection information for MongoDB if this is not a CI run
 COMMAND=$COMMAND" -m $MONGO_LOCALHOST -p $PROD_DATABASE_PASSWORD -M $MONGO_INTERNAL_IP"
 
-echo "RUNNING BOOT COMMAND: $COMMAND -e $PASSENGER_APP_ENV -N $PORTAL_NAMESPACE"
+# Filter credentials from log, just show Rails environment and Terra billing project
+echo "BOOTING PORTAL WITH: -e $PASSENGER_APP_ENV -N $PORTAL_NAMESPACE"
 # execute requested command
 $COMMAND -e $PASSENGER_APP_ENV -N $PORTAL_NAMESPACE


### PR DESCRIPTION
Removes inadvertent logging of non-production credentials during CI runs in Travis.  The script `load_env_secrets.sh` is only used in local development and in Travis, so there is no risk of production credentials being exposed.  Nevertheless, these debug logging statements have been filtered to only show non-sensitive information.