### PR TITLE
Refactoring usage of Mongoid associations for DataArrays, Genes (SCP-2439)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -309,11 +309,7 @@ module Api
               @study.default_options[:cluster] = @study_file.name
               @study.save
             end
-            old_name = @cluster.name.dup
             @cluster.update(name: @study_file.name)
-            # also update data_arrays, using declared indices rather than Mongoid association for better performance
-            DataArray.where(study_id: @study.id, study_file_id: @cluster.study_file.id, cluster_name: old_name,
-                            linear_data_type: 'ClusterGroup', linear_data_id: @cluster.id).update_all(cluster_name: @study_file.name)
           elsif ['Expression Matrix', 'MM Coordinate Matrix'].include?(study_file_params[:file_type]) && !study_file_params[:y_axis_label].blank?
             # if user is supplying an expression axis label, update default options hash
             @study.update(default_options: @study.default_options.merge(expression_label: study_file_params[:y_axis_label]))

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -309,7 +309,11 @@ module Api
               @study.default_options[:cluster] = @study_file.name
               @study.save
             end
+            old_name = @cluster.name.dup
             @cluster.update(name: @study_file.name)
+            # also update data_arrays, using declared indices rather than Mongoid association for better performance
+            DataArray.where(study_id: @study.id, study_file_id: @cluster.study_file.id, cluster_name: old_name,
+                            linear_data_type: 'ClusterGroup', linear_data_id: @cluster.id).update_all(cluster_name: @study_file.name)
           elsif ['Expression Matrix', 'MM Coordinate Matrix'].include?(study_file_params[:file_type]) && !study_file_params[:y_axis_label].blank?
             # if user is supplying an expression axis label, update default options hash
             @study.update(default_options: @study.default_options.merge(expression_label: study_file_params[:y_axis_label]))

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -310,7 +310,7 @@ class SiteController < ApplicationController
     @directories = @study.directory_listings.are_synced
     @primary_data = @study.directory_listings.primary_data
     @other_data = @study.directory_listings.non_primary_data
-    @unique_genes = @study.genes.unique_genes
+    @unique_genes = @study.unique_genes
 
     # double check on download availability: first, check if administrator has disabled downloads
     # then check individual statuses to see what to enable/disable

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -684,9 +684,11 @@ class StudiesController < ApplicationController
           @study.default_options[:cluster] = @study_file.name
           @study.save
         end
+        old_name = @cluster.name.dup
         @cluster.update(name: @study_file.name)
-        # also update data_arrays
-        @cluster.data_arrays.update_all(cluster_name: @study_file.name)
+        # also update data_arrays, using declared indices rather than Mongoid association for better performance
+        DataArray.where(study_id: @study.id, study_file_id: @cluster.study_file.id, cluster_name: old_name,
+                        linear_data_type: 'ClusterGroup', linear_data_id: @cluster.id).update_all(cluster_name: @study_file.name)
       elsif ['Expression Matrix', 'MM Coordinate Matrix'].include?(study_file_params[:file_type]) && !study_file_params[:y_axis_label].blank?
         # if user is supplying an expression axis label, update default options hash
         @study.update(default_options: @study.default_options.merge(expression_label: study_file_params[:y_axis_label]))
@@ -741,7 +743,11 @@ class StudiesController < ApplicationController
           @study.default_options[:cluster] = @study_file.name
           @study.save
         end
+        old_name = @cluster.name.dup
         @cluster.update(name: @study_file.name)
+        # also update data_arrays, using declared indices rather than Mongoid association for better performance
+        DataArray.where(study_id: @study.id, study_file_id: @cluster.study_file.id, cluster_name: old_name,
+                        linear_data_type: 'ClusterGroup', linear_data_id: @cluster.id).update_all(cluster_name: @study_file.name)
       elsif study_file_params[:file_type] == 'Expression Matrix' && !study_file_params[:y_axis_label].blank?
         # if user is supplying an expression axis label, update default options hash
         @study.update(default_options: @study.default_options.merge(expression_label: study_file_params[:y_axis_label]))

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -686,9 +686,6 @@ class StudiesController < ApplicationController
         end
         old_name = @cluster.name.dup
         @cluster.update(name: @study_file.name)
-        # also update data_arrays, using declared indices rather than Mongoid association for better performance
-        DataArray.where(study_id: @study.id, study_file_id: @cluster.study_file.id, cluster_name: old_name,
-                        linear_data_type: 'ClusterGroup', linear_data_id: @cluster.id).update_all(cluster_name: @study_file.name)
       elsif ['Expression Matrix', 'MM Coordinate Matrix'].include?(study_file_params[:file_type]) && !study_file_params[:y_axis_label].blank?
         # if user is supplying an expression axis label, update default options hash
         @study.update(default_options: @study.default_options.merge(expression_label: study_file_params[:y_axis_label]))
@@ -743,11 +740,7 @@ class StudiesController < ApplicationController
           @study.default_options[:cluster] = @study_file.name
           @study.save
         end
-        old_name = @cluster.name.dup
         @cluster.update(name: @study_file.name)
-        # also update data_arrays, using declared indices rather than Mongoid association for better performance
-        DataArray.where(study_id: @study.id, study_file_id: @cluster.study_file.id, cluster_name: old_name,
-                        linear_data_type: 'ClusterGroup', linear_data_id: @cluster.id).update_all(cluster_name: @study_file.name)
       elsif study_file_params[:file_type] == 'Expression Matrix' && !study_file_params[:y_axis_label].blank?
         # if user is supplying an expression axis label, update default options hash
         @study.update(default_options: @study.default_options.merge(expression_label: study_file_params[:y_axis_label]))

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -65,8 +65,8 @@ class ClusterGroup
   def concatenate_data_arrays(array_name, array_type, subsample_threshold=nil, subsample_annotation=nil)
     if subsample_threshold.nil?
       data_arrays = DataArray.where(name: array_name, array_type: array_type, linear_data_type: 'ClusterGroup',
-                                    cluster_name: self.name, linear_data_id: self.id, subsample_threshold: nil,
-                                    subsample_annotation: nil).order(:array_index => 'asc')
+                                    linear_data_id: self.id, subsample_threshold: nil, subsample_annotation: nil)
+                        .order(:array_index => 'asc')
       all_values = []
       data_arrays.each do |array|
         all_values += array.values
@@ -74,7 +74,7 @@ class ClusterGroup
       all_values
     else
       data_array = DataArray.find_by(name: array_name, array_type: array_type, linear_data_type: 'ClusterGroup',
-                                     cluster_name: self.name, linear_data_id: self.id, subsample_threshold: subsample_threshold,
+                                     linear_data_id: self.id, subsample_threshold: subsample_threshold,
                                      subsample_annotation: subsample_annotation)
       if data_array.nil?
         # rather than returning [], default to the full resolution array
@@ -332,11 +332,14 @@ class ClusterGroup
     SUBSAMPLE_THRESHOLDS.select {|sample| sample < self.points}
   end
 
+  # getter method to return Mongoid::Criteria for all data arrays belonging to this cluster
+  def find_all_data_arrays
+    DataArray.where(study_id: self.study_id, study_file_id: self.study_file_id, linear_data_type: 'ClusterGroup', linear_data_id: self.id)
+  end
+
   # find all 'subsampled' data arrays
   def find_subsampled_data_arrays
-    DataArray.where(study_id: self.study_id, study_file_id: self.study_file_id, linear_data_type: 'ClusterGroup',
-                    linear_data_id: self.id, :subsample_threshold.nin => [nil],
-                    :subsample_annotation.nin => [nil])
+    self.find_all_data_arrays.where(:subsample_threshold.nin => [nil], :subsample_annotation.nin => [nil])
   end
 
   # control gate for invoking subsampling

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -246,7 +246,7 @@ class IngestJob
         SearchFacet.delay.update_all_facet_filters
       end
     when /Matrix/
-      self.study.set_gene_count
+      self.study.delay.set_gene_count
     when 'Cluster'
       self.set_study_default_options
       self.launch_subsample_jobs

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1106,11 +1106,7 @@ class Study
 
   # get all unique gene names for a study; leverage index on Gene model to improve performance
   def unique_genes
-    genes = []
-    self.expression_matrix_files.each do |file|
-      genes += Gene.where(study_id: self.id, study_file_id: file.id).pluck(:name)
-    end
-    genes.uniq
+    Gene.where(study_id: self.id, :study_file_id.in => self.expression_matrix_files.map(&:id)).pluck(:name).uniq
   end
 
   # return a count of the number of fastq files both uploaded and referenced via directory_listings for a study

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -124,10 +124,6 @@ class Study
         merged_scores
       end
     end
-
-    def unique_genes
-      pluck(:name).uniq
-    end
   end
 
   has_many :precomputed_scores, dependent: :delete do
@@ -1095,15 +1091,26 @@ class Study
   # helper method to get number of unique single cells
   def set_cell_count
     cell_count = self.all_cells_array.size
-    self.update(cell_count: cell_count)
     Rails.logger.info "Setting cell count in #{self.name} to #{cell_count}"
+    self.update(cell_count: cell_count)
+    Rails.logger.info "Cell count set for #{self.name}"
   end
 
   # helper method to set the number of unique genes in this study
   def set_gene_count
-    gene_count = self.genes.pluck(:name).uniq.count
+    gene_count = self.unique_genes
     Rails.logger.info "Setting gene count in #{self.name} to #{gene_count}"
     self.update(gene_count: gene_count)
+    Rails.logger.info "Gene count set for #{self.name}"
+  end
+
+  # get all unique gene names for a study; leverage index on Gene model to improve performance
+  def unique_genes
+    genes = []
+    self.expression_matrix_files.each do |file|
+      genes += Gene.where(study_id: self.id, study_file_id: file.id).pluck(:name)
+    end
+    genes.uniq
   end
 
   # return a count of the number of fastq files both uploaded and referenced via directory_listings for a study
@@ -1707,13 +1714,15 @@ class Study
       # add processed cells to known cells
       cells.each_slice(DataArray::MAX_ENTRIES).with_index do |slice, index|
         Rails.logger.info "#{Time.zone.now}: Create known cells array ##{index + 1} for #{expression_file.name}:#{expression_file.id} in #{self.name}"
-        known_cells = self.data_arrays.build(name: "#{expression_file.name} Cells", cluster_name: expression_file.name,
-                                             array_type: 'cells', array_index: index + 1, values: slice,
-                                             study_file_id: expression_file.id, study_id: self.id)
+        # use DataArray model & indices directly for better performance; calling study.data_arrays can lead to collection walk
+        known_cells = DataArray.new(study_id: self.id, name: "#{expression_file.name} Cells", cluster_name: expression_file.name,
+                                    array_type: 'cells', array_index: index + 1, values: slice, study_file_id: expression_file.id,
+                                    linear_data_type: 'Study', linear_data_id: self.id)
         known_cells.save
       end
 
-      self.set_gene_count
+      # run in background to reduce load on job since setting gene count can be expensive both in RAM and execution time
+      self.delay.set_gene_count
 
       # set the default expression label if the user supplied one
       if !self.has_expression_label? && !expression_file.y_axis_label.blank?

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1024,9 +1024,9 @@ class StudyFile
             msg = "#{Time.zone.now}: Create known cells array ##{index + 1} for #{self.name}:#{self.id} in #{study.name}"
             puts msg
             Rails.logger.info msg
-            known_cells = study.data_arrays.build(name: "#{self.name} Cells", cluster_name: self.name,
-                                                  array_type: 'cells', array_index: index + 1, values: slice,
-                                                  study_file_id: self.id, study_id: self.study_id)
+            known_cells = DataArray.new(name: "#{self.name} Cells", cluster_name: self.name, array_type: 'cells',
+                                        array_index: index + 1, values: slice, study_file_id: self.id, study_id: self.study_id,
+                                        linear_data_type: 'Study', linear_data_id: self.study_id)
             known_cells.save
           end
           msg = "#{Time.zone.now}: removing local copy of #{download_location}"

--- a/app/models/user_annotation.rb
+++ b/app/models/user_annotation.rb
@@ -333,12 +333,11 @@ class UserAnnotation
         if !data_array.subsample_annotation.nil?
           Rails.logger.info "#{Time.zone.now}: Creating new data array for #{annot_name} in study: #{data_array.study.name}, cluster: #{cluster.name} at subsample_threshold #{data_array.subsample_threshold}"
           subsample_annotation = annot_name + '--group--cluster'
-          new_data_array = cluster.data_arrays.build(
-              name: data_array.name, cluster_name: cluster.name, array_type: data_array.array_type,
-              array_index: data_array.array_index, values: data_array.values,
-              subsample_annotation: subsample_annotation, subsample_threshold: data_array.subsample_threshold,
-              study_id: cluster.study_id, study_file_id: cluster.study_file_id
-          )
+          new_data_array = DataArray.new(name: data_array.name, cluster_name: cluster.name, array_type: data_array.array_type,
+                                         array_index: data_array.array_index, values: data_array.values,
+                                         subsample_annotation: subsample_annotation, subsample_threshold: data_array.subsample_threshold,
+                                         study_id: cluster.study_id, study_file_id: cluster.study_file_id,
+                                         linear_data_type: 'ClusterGroup', linear_data_id: cluster.id)
           if new_data_array.save
             Rails.logger.info "#{Time.zone.now}: Data Array for #{annot_name} created in study: #{data_array.study.name}, cluster: #{cluster.name}"
           else
@@ -347,11 +346,10 @@ class UserAnnotation
         else
           if data_array.array_type == 'annotations'
             Rails.logger.info "#{Time.zone.now}: Creating data array for #{annot_name} in study: #{data_array.study.name}, cluster: #{cluster.name}"
-            new_data_array = cluster.data_arrays.build(
-                name: data_array.name, cluster_name: cluster.name, array_type: data_array.array_type,
-                array_index: data_array.array_index, values: data_array.values,
-                study_id: cluster.study_id, study_file_id: cluster.study_file_id
-            )
+            new_data_array = DataArray.new(name: data_array.name, cluster_name: cluster.name, array_type: data_array.array_type,
+                                           array_index: data_array.array_index, values: data_array.values,
+                                           study_id: cluster.study_id, study_file_id: cluster.study_file_id,
+                                           linear_data_type: 'ClusterGroup', linear_data_id: cluster.id)
             if new_data_array.save
               Rails.logger.info "#{Time.zone.now}: Data Array for #{annot_name} created in study: #{data_array.study.name}, cluster: #{cluster.name}"
             else


### PR DESCRIPTION
Rather than using the auto-generated Mongoid association, this change directly leverages the DataArray and Gene models and their declared indices for better performance when creating, reading, and updating individual records.  This also changes the behavior of both getting unique genes for a study, and setting the unique gene count.  These updates are intended to ameliorate any potential runaway queries or inserts that can cause stability issues with the portal as a whole.

In addition, this update removes unnecessary updates to DataArrays when clusters are renamed, as the `cluster_name` value does not need to be used in the query to leverage the index (`linear_data_id` resolve to the same object).

This PR satisfies SCP-2439.