### PR TITLE
fixing infinite render loop in advanced search results

### DIFF
--- a/app/javascript/components/search/results/StudyResults.js
+++ b/app/javascript/components/search/results/StudyResults.js
@@ -3,17 +3,19 @@ import { useTable, usePagination } from 'react-table'
 
 import PagingControl from './PagingControl'
 
+// define these outside the render loop so they don't cause rerender loops
+// if they ever need to be dynamic, make sure to use useMemo
+const columns = [{ accessor: 'study' }]
+
 /**
  * Component for the content of the 'Studies' tab
  */
 export default function StudyResults({ results, changePage, StudyComponent }) {
-  const columns = React.useMemo(
-    () => [{
-      accessor: 'study'
-    }])
-
   // convert to an array of objects with a 'study' property for react-table
-  const data = results.studies.map(study => {return { study }})
+  const data = React.useMemo(
+    () => results.studies.map(study => {return { study }}),
+    [results]
+  )
 
   const {
     getTableProps,
@@ -27,7 +29,7 @@ export default function StudyResults({ results, changePage, StudyComponent }) {
     data,
     // holds pagination states
     initialState: {
-      pageIndex: results.currentPage -1,
+      pageIndex: results.currentPage - 1,
       // This will change when there's a way to determine amount of results
       // per page via API endpoint
       pageSize: 5

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react-compound-slider": "^3.0.0-beta.1",
     "react-dom": "^16.12.0",
     "react-scripts": "^3.4.0",
-    "react-table": "^7.0.0-rc.16",
+    "react-table": "^7.1.0",
     "spin.js": "^4.0.0",
     "stylelint-config-sass-guidelines": "^7.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,10 +1559,10 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@scarf/scarf@^0.1.5":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-0.1.7.tgz#e6ffb3660bda77f96037f8c4e21174177fed2d97"
-  integrity sha512-XUBa8nl9J1XGyyA+wul1ko5v5ioNU1s/pUPODnPzJ4+uUOwwYZm197KQoxxzOAsypldlFGnAlQ8nkjTjoQV9GQ==
+"@scarf/scarf@^1.0.4":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-1.0.5.tgz#accee0bce88a9047672f7c8faf3cada59c996b81"
+  integrity sha512-9WKaGVpQH905Aqkk+BczFEeLQxS07rl04afFRPUG9IcSlOwmo5EVVuuNu0d4M9LMYucObvK0LoAe+5HfMW2QhQ==
 
 "@sheerun/mutationobserver-shim@^0.3.3":
   version "0.3.3"
@@ -12355,12 +12355,12 @@ react-scripts@^3.4.0:
   optionalDependencies:
     fsevents "2.1.2"
 
-react-table@^7.0.0-rc.16:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.0.4.tgz#456838661982c83c3682f156c59a41b4339a2120"
-  integrity sha512-Uqpj+VnUIvsNWNtNFD1z2i7OCHdlhoJtQt0DWx3XOkZnvDyI/eCghK8YBfA9mY4TW7vEgCDLaRCcREC/fmcx6Q==
+react-table@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.1.0.tgz#c975cd67e917c54190b6c9df29f085285b0c3f4e"
+  integrity sha512-AZpgW0Xpo6Z7jxXZIBovzCGoYVkuBwATsJh7X4+JXwq9JtDaorOmxWC9gKx5Hui4d+n+I99enyyJS+LRtKydxA==
   dependencies:
-    "@scarf/scarf" "^0.1.5"
+    "@scarf/scarf" "^1.0.4"
 
 react-test-renderer@^16.0.0-0:
   version "16.13.1"


### PR DESCRIPTION
The real issue was the columns weren't actually memo-ized.  Since no second argument was provided to useMemo, they were getting recreated every time.  We could solve this by providing an empty array for the second argument, but that seemed like a long-winded (and not particularly well-documented) way of specifying a constant, so I just moved them out. 

 I also memo-ized the data for good hygiene as that's what React-Table says to do, and upgraded to the latest release.