### PR TITLE
Migrate from Google Analytics to Mixpanel (SCP-2326, SCP-2382)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,19 @@ module.exports = {
     ],
     'globals': {
         'Atomics': 'readonly',
-        'SharedArrayBuffer': 'readonly'
+        'SharedArrayBuffer': 'readonly',
+        '$': 'readonly',
+        'jQuery': 'readonly',
+        'd3': 'readonly',
+        'ClassicEditor': 'readonly',
+        'Spinner': 'readonly',
+        'morpheus': 'readonly',
+        'igv': 'readonly',
+        'Ideogram': 'readonly',
+        'createTracesAndLayout': 'readonly',
+        'ga': 'readonly',
+        'log': 'readonly',
+        'bamAndBaiFiles': 'readonly'
     },
     'parser': 'babel-eslint',
     'parserOptions': {

--- a/app/assets/javascripts/scp-dot-plot.js
+++ b/app/assets/javascripts/scp-dot-plot.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 /**
  * @fileoverview Functions for rendering dot plots using Morpheus.js
  *

--- a/app/assets/javascripts/scp-dot-plot.js
+++ b/app/assets/javascripts/scp-dot-plot.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+
 /**
  * @fileoverview Functions for rendering dot plots using Morpheus.js
  *
@@ -13,19 +15,18 @@
  * https://github.com/cmap/morpheus.js
  */
 
-var dotPlotColorScheme = {
+const dotPlotColorScheme = {
   // Blue, purple, red.  These red and blue hues are accessible, per WCAG.
   colors: ['#0000BB', '#CC0088', '#FF0000'],
 
   // TODO: Incorporate expression units, once such metadata is available.
   values: [0, 0.5, 1]
-};
+}
 
 /**
  * Returns SVG comprising the dot plot legend.
  */
 function getLegendSvg(rects) {
-
   // Sarah N. asked for a note about non-zero in the legend, but it's unclear
   // if Morpheus supports non-zero.  It might, per the Collapse properties
   //
@@ -37,7 +38,7 @@ function getLegendSvg(rects) {
   // legend until we can clarify.
   //
   // var nonzeroNote = '<text x="9" y="66">(non-zero)</text>';
-  var nonzeroNote = '';
+  const nonzeroNote = ''
 
   // TODO:
   // Develop more robust coordinate offsets for colors and related text.
@@ -63,7 +64,7 @@ function getLegendSvg(rects) {
         ${nonzeroNote}
       </g>
     <svg>`
-  );
+  )
 }
 
 /**
@@ -79,11 +80,10 @@ function renderDotPlotLegend(dotPlotTarget, legendTarget) {
     dotPlotTarget = '#dot-plot'
   }
 
-  $(legendTarget).remove();
-  var scheme = dotPlotColorScheme;
-  var rects = scheme.colors.map((color, i) => {
-
-    var value = scheme.values[i]; // Expression threshold value
+  $(legendTarget).remove()
+  const scheme = dotPlotColorScheme
+  const rects = scheme.colors.map((color, i) => {
+    const value = scheme.values[i] // Expression threshold value
 
     // TODO:
     // A more robust, yet more complicated way to get textOffset this would
@@ -94,28 +94,39 @@ function renderDotPlotLegend(dotPlotTarget, legendTarget) {
     //
     // But that robust approach only adds value over this simple approach
     // when we need to support dynamic values.  Defer this TODO until SCP-1738.
-    var textOffset = 4 - (String(value).length - 1) * 3;
+    const textOffset = 4 - (String(value).length - 1) * 3
 
     return (
       `<g transform="translate(${i * 30}, 0)">
         <rect fill="${color}" width="15" height="15"/>
         <text x="${textOffset}" y="30">${value}</text>
       </g>`
-    );
-  }).join();
+    )
+  }).join()
 
-  var legend = getLegendSvg(rects);
+  const legend = getLegendSvg(rects)
 
-  $(dotPlotTarget).append('<div id="' + legendTarget.substring(1) + '" style="position: relative; top: 30px; left: 70px;"></div>');
-  document.querySelector(legendTarget).innerHTML = legend;
+  $(dotPlotTarget).append(`
+    <div
+      id="${legendTarget.substring(1)}"
+      style="position: relative; top: 30px; left: 70px;">
+    </div>
+  `)
+  document.querySelector(legendTarget).innerHTML = legend
 }
 
-function renderMorpheusDotPlot(dataPath, annotPath, selectedAnnot, selectedAnnotType, target, annotations, fitType, dotHeight, legendTarget) {
-  console.log('render status of ' + target + ' at start: ' + $(target).data('rendered'));
-  $(target).empty();
+/** Render Morpheus dot plot */
+function renderMorpheusDotPlot(
+  dataPath, annotPath, selectedAnnot, selectedAnnotType,
+  target, annotations, fitType, dotHeight, legendTarget
+) {
+  console.log(`
+    render status of ${target} at start: ${$(target).data('rendered')}
+  `)
+  $(target).empty()
 
   // Collapse by median
-  var tools = [{
+  const tools = [{
     name: 'Collapse',
     params: {
       shape: 'circle',
@@ -126,9 +137,9 @@ function renderMorpheusDotPlot(dataPath, annotPath, selectedAnnot, selectedAnnot
       percentile: '100',
       compute_percent: true
     }
-  }];
+  }]
 
-  var config = {
+  const config = {
     shape: 'circle',
     dataset: dataPath,
     el: $(target),
@@ -136,27 +147,27 @@ function renderMorpheusDotPlot(dataPath, annotPath, selectedAnnot, selectedAnnot
     colorScheme: {
       scalingMode: 'relative'
     },
-    tools: tools
-  };
+    tools
+  }
 
   // Set height if specified, otherwise use default setting of 500 px
   if (dotHeight !== undefined) {
-    config.height = dotHeight;
+    config.height = dotHeight
   } else {
-    config.height = 500;
+    config.height = 500
   }
 
   // Fit rows, columns, or both to screen
   if (fitType === 'cols') {
-    config.columnSize = 'fit';
+    config.columnSize = 'fit'
   } else if (fitType === 'rows') {
-    config.rowSize = 'fit';
+    config.rowSize = 'fit'
   } else if (fitType === 'both') {
-    config.columnSize = 'fit';
-    config.rowSize = 'fit';
+    config.columnSize = 'fit'
+    config.rowSize = 'fit'
   } else {
-    config.columnSize = null;
-    config.rowSize = null;
+    config.columnSize = null
+    config.rowSize = null
   }
 
   // Load annotations if specified
@@ -166,98 +177,109 @@ function renderMorpheusDotPlot(dataPath, annotPath, selectedAnnot, selectedAnnot
       datasetField: 'id',
       fileField: 'NAME',
       include: [selectedAnnot]
-    }];
+    }]
     config.columnSortBy = [
-      {field: selectedAnnot, order: 0}
-    ];
+      { field: selectedAnnot, order: 0 }
+    ]
     config.columns = [
-      {field: selectedAnnot, display: 'text'}
-    ];
+      { field: selectedAnnot, display: 'text' }
+    ]
     config.rows = [
-      {field: 'id', display: 'text'}
-    ];
+      { field: 'id', display: 'text' }
+    ]
 
     // Create mapping of selected annotations to colorBrewer colors
-    var annotColorModel = {};
-    annotColorModel[selectedAnnot] = {};
-    var sortedAnnots = annotations['values'].sort();
+    const annotColorModel = {}
+    annotColorModel[selectedAnnot] = {}
+    const sortedAnnots = annotations['values'].sort()
 
-    // Calling % 27 will always return to the beginning of colorBrewerSet once we use all 27 values
-    $(sortedAnnots).each(function(index, annot) {
-      annotColorModel[selectedAnnot][annot] = colorBrewerSet[index % 27];
-    });
-    config.columnColorModel = annotColorModel;
+    // Calling % 27 will always return to the beginning of colorBrewerSet
+    // once we use all 27 values
+    $(sortedAnnots).each((index, annot) => {
+      annotColorModel[selectedAnnot][annot] = colorBrewerSet[index % 27]
+    })
+    config.columnColorModel = annotColorModel
   }
 
-  config.colorScheme = dotPlotColorScheme;
+  config.colorScheme = dotPlotColorScheme
 
   // Log dot plot initialization in Google Analytics
   if (typeof window.dotPlot === 'undefined') {
     // Consistent with e.g. IGV, Ideogram
-    ga('send', 'event', 'dot-plot', 'initialize');
+    ga('send', 'event', 'dot-plot', 'initialize')
   }
 
   // Instantiate dot plot and embed in DOM element
-  window.dotPlot = new morpheus.HeatMap(config);
-  window.dotPlot.tabManager.setOptions({autohideTabBar: true});
-  $(target).off();
-  $(target).on('heatMapLoaded', function (e, heatMap) {
-
+  window.dotPlot = new morpheus.HeatMap(config)
+  window.dotPlot.tabManager.setOptions({ autohideTabBar: true })
+  $(target).off()
+  $(target).on('heatMapLoaded', (e, heatMap) => {
     // Remove verbose tab atop Morpheus dot plot
-    var tabItems = dotPlot.tabManager.getTabItems();
-    window.dotPlot.tabManager.setActiveTab(tabItems[1].id);
-    window.dotPlot.tabManager.remove(tabItems[0].id);
+    const tabItems = dotPlot.tabManager.getTabItems()
+    window.dotPlot.tabManager.setActiveTab(tabItems[1].id)
+    window.dotPlot.tabManager.remove(tabItems[0].id)
 
-    renderDotPlotLegend(target, legendTarget);
+    renderDotPlotLegend(target, legendTarget)
 
     // Remove "Options" toolbar button until legend can be updated upon
     // changing default options for size and color (SCP-1738).
     // setTimeout is a kludge, but seemingly the only way to do this.
-    setTimeout(function() {
-      var options = $('#dot-plots [data-action="Options"]');
-      options.next('.morpheus-button-divider').remove();
-      options.remove();
-    }, 50);
-  });
+    setTimeout(() => {
+      const options = $('#dot-plots [data-action="Options"]')
+      options.next('.morpheus-button-divider').remove()
+      options.remove()
+    }, 50)
+  })
 
   // Set render variable to true for tests
-  $(target).data('morpheus', dotPlot);
-  $(target).data('rendered', true);
-  console.log('render status of ' + target + ' at end: ' + $(target).data('rendered'));
+  $(target).data('morpheus', dotPlot)
+  $(target).data('rendered', true)
+  console.log(`
+    render status of ${target} at end: ${$(target).data('rendered')}
+  `)
 }
 
-function drawDotplot(height) {
-  $(window).off('resizeEnd');
+/** High-level function called from _expression_plots_view.html.erb */
+function drawDotplot(height) { // eslint-disable-line no-unused-vars
+  $(window).off('resizeEnd')
 
   // Clear out previous stored dotplot object
-  $('#dot-plot').data('dotplot', null);
+  $('#dot-plot').data('dotplot', null)
 
   // If height isn't specified, pull from stored value, defaults to 500
   if (height === undefined) {
-    height = $('#dot-plot').data('height');
+    height = $('#dot-plot').data('height')
   }
 
   // Pull fit type as well, defaults to ''
-  var fit = $('#dot-plot').data('fit');
+  const fit = $('#dot-plot').data('fit')
 
-  var selectedAnnot = $('#annotation').val();
-  var annotName = selectedAnnot.split('--')[0];
-  var annotType = selectedAnnot.split('--')[1];
+  const selectedAnnot = $('#annotation').val()
+  const annotName = selectedAnnot.split('--')[0]
+  const annotType = selectedAnnot.split('--')[1]
 
-  var cluster = $('#cluster').val();
-  $('#search_cluster').val(cluster);
-  $('#search_annotation').val(''); // clear value first
-  $('#search_annotation').val(selectedAnnot);
+  const cluster = $('#cluster').val()
+  $('#search_cluster').val(cluster)
+  $('#search_annotation').val('') // clear value first
+  $('#search_annotation').val(selectedAnnot)
 
-  var newAnnotPath = dotPlotAnnotPathBase + '?cluster=' + cluster + '&annotation=' + selectedAnnot + '&request_user_token=' + requestToken;
+  const newAnnotPath = `
+    ${dotPlotAnnotPathBase}
+    ?cluster=${cluster}&
+    annotation=${selectedAnnot}&
+    request_user_token=${requestToken}`
 
-  var renderUrlParams = getRenderUrlParams();
-  // Get annotation values to set color values in Morpheus and draw dotplot in callback
+  const renderUrlParams = getRenderUrlParams()
+  // Get annotation values to set color values in Morpheus and
+  // draw dotplot in callback
   $.ajax({
-    url: dotPlotAnnotValuesPath + '?' + renderUrlParams,
+    url: `${dotPlotAnnotValuesPath}?${renderUrlParams}`,
     dataType: 'JSON',
-    success: function(annotations) {
-      renderMorpheusDotPlot(dataPath, newAnnotPath, annotName, annotType, '#dot-plot', annotations, fit, height);
+    success(annotations) {
+      renderMorpheusDotPlot(
+        dataPath, newAnnotPath, annotName, annotType, '#dot-plot',
+        annotations, fit, height
+      )
     }
-  });
+  })
 }

--- a/app/assets/javascripts/scp-dot-plot.js
+++ b/app/assets/javascripts/scp-dot-plot.js
@@ -207,6 +207,7 @@ function renderMorpheusDotPlot(
   if (typeof window.dotPlot === 'undefined') {
     // Consistent with e.g. IGV, Ideogram
     ga('send', 'event', 'dot-plot', 'initialize')
+    log('dot-plot-initialize')
   }
 
   // Instantiate dot plot and embed in DOM element

--- a/app/assets/javascripts/scp-dot-plot.js
+++ b/app/assets/javascripts/scp-dot-plot.js
@@ -207,7 +207,7 @@ function renderMorpheusDotPlot(
   if (typeof window.dotPlot === 'undefined') {
     // Consistent with e.g. IGV, Ideogram
     ga('send', 'event', 'dot-plot', 'initialize')
-    log('dot-plot-initialize')
+    log('dot-plot:initialize')
   }
 
   // Instantiate dot plot and embed in DOM element

--- a/app/assets/javascripts/scp-ideogram.js
+++ b/app/assets/javascripts/scp-ideogram.js
@@ -1,3 +1,6 @@
+/* eslint-disable no-undef */
+/* eslint-disable no-unused-vars */
+
 //    Not used currently, but perhaps later.
 //   function getGenomicRange(annot) {
 //     var chr, start, stop, startString, stopString, genomicRange;
@@ -84,45 +87,57 @@
 //     $('#ideogram-container').append(table);
 //   }
 
-var legend = [{
+let ideogram
+let checkboxes
+
+const legend = [{
   name: 'Expression level',
   rows: [
-    {name: 'Low', color: '#00B'},
-    {name: 'Normal', color: '#DDD'},
-    {name: 'High', color: '#F00'}
+    { name: 'Low', color: '#00B' },
+    { name: 'Normal', color: '#DDD' },
+    { name: 'High', color: '#F00' }
   ]
-}];
+}]
 
+/** Get ideogram heatmap tracks selected via checkbox */
 function getSelectedTracks() {
-  var selectedTracks = [];
+  const selectedTracks = []
 
-  checkboxes.forEach(function(checkbox) {
-    var trackIndex = parseInt(checkbox.getAttribute('id').split('_')[1]);
+  checkboxes.forEach(checkbox => {
+    const trackIndex = parseInt(checkbox.getAttribute('id').split('_')[1])
     if (checkbox.checked) {
-      selectedTracks.push(trackIndex);
+      selectedTracks.push(trackIndex)
     }
-  });
+  })
 
-  return selectedTracks;
+  return selectedTracks
 }
 
+/** Set selected tracks as displayed tracks */
 function updateTracks() {
-  var selectedTracks = getSelectedTracks();
-  ideogram.updateDisplayedTracks(selectedTracks);
+  const selectedTracks = getSelectedTracks()
+  ideogram.updateDisplayedTracks(selectedTracks)
 }
 
+/** Update space between chromosomes; called upon updating related slider */
 function updateMargin(event) {
-  window.chrMargin = parseInt(event.target.value);
-  ideoConfig.chrMargin = chrMargin;
-  ideogram = new Ideogram(ideoConfig);
+  window.chrMargin = parseInt(event.target.value)
+  ideoConfig.chrMargin = chrMargin
+  ideogram = new Ideogram(ideoConfig)
 }
 
+/** Create a slider to adjust space between chromosomes */
 function addMarginControl() {
   chrMargin = (typeof chrMargin === 'undefined' ? 10 : chrMargin)
-    marginSlider =
-      `<label id="chrMarginContainer" style="float:left; position: relative; top: 50px; left: -130px;">
+  marginSlider =
+      `<label
+          id="chrMarginContainer"
+          style="float:left; position: relative; top: 50px; left: -130px;">
         Chromosome margin
-      <input type="range" id="chrMargin" list="chrMarginList" value="` + chrMargin + `">
+      <input
+        type="range"
+        id="chrMargin"
+        list="chrMarginList" value="${chrMargin}">
       </label>
       <datalist id="chrMarginList">
         <option value="0" label="0%">
@@ -136,45 +151,60 @@ function addMarginControl() {
         <option value="80">
         <option value="90">
         <option value="100" label="100%">
-      </datalist>`;
-    d3.select('#_ideogramLegend').node().innerHTML += marginSlider;
+      </datalist>`
+  d3.select('#_ideogramLegend').node().innerHTML += marginSlider
 }
 
+/** Change expression threshold; called upon updating related slider */
 function updateThreshold(event) {
-  var thresholds, newThreshold, numThresholds, i;
+  let newThreshold
 
-  window.expressionThreshold = parseInt(event.target.value);
+  window.expressionThreshold = parseInt(event.target.value)
 
-  window.adjustedExpressionThreshold = Math.round(expressionThreshold/10 - 4);
-  thresholds = window.originalHeatmapThresholds;
-  numThresholds = thresholds.length;
-  ideoConfig.heatmapThresholds = [];
+  window.adjustedExpressionThreshold = Math.round(expressionThreshold/10 - 4)
+  const thresholds = window.originalHeatmapThresholds
+  const numThresholds = thresholds.length
+  ideoConfig.heatmapThresholds = []
 
-  // If expressionThreshold > 1, increase thresholds above middle, decrease below
-  // If expressionThreshold < 1, decrease thresholds above middle, increase below
-  for (i = 0; i < numThresholds; i++) {
+  // If expressionThreshold > 1,
+  //    increase thresholds above middle, decrease below
+  // If expressionThreshold < 1,
+  //    decrease thresholds above middle, increase below
+  for (let i = 0; i < numThresholds; i++) {
     if (i + 1 > numThresholds/2) {
-      newThreshold = thresholds[i + adjustedExpressionThreshold];
+      newThreshold = thresholds[i + adjustedExpressionThreshold]
     } else {
-      newThreshold = thresholds[i - adjustedExpressionThreshold];
+      newThreshold = thresholds[i - adjustedExpressionThreshold]
     }
-    ideoConfig.heatmapThresholds.push(newThreshold);
+    ideoConfig.heatmapThresholds.push(newThreshold)
   }
-  ideogram = new Ideogram(ideoConfig);
+  ideogram = new Ideogram(ideoConfig)
 }
 
+/** Create slider to adjust expression threshold for "gain" or "loss" calls */
 function addThresholdControl() {
   if (typeof(expressionThreshold) === 'undefined') {
-    expressionThreshold = 50;
-    window.originalHeatmapThresholds = ideogram.rawAnnots.metadata.heatmapThresholds;
+    expressionThreshold = 50
+    window.originalHeatmapThresholds =
+      ideogram.rawAnnots.metadata.heatmapThresholds
   }
 
   expressionThresholdSlider =
     `<label id="expressionThresholdContainer" style="float: left">
-      <span class="glossary" title="Denoiser.  Adjusts mapping between inferCNV's output heatmap threshold values and normal vs. loss/gain signal.  Analogous to inferCNV denoise parameters, e.g. --noise_filter." style="cursor: help;">
+      <span
+        class="glossary"
+        title="Denoiser.  Adjusts mapping between inferCNV's output heatmap
+          threshold values and normal vs. loss/gain signal.  Analogous to
+          inferCNV denoise parameters, e.g. --noise_filter."
+        style="cursor: help;">
       Expression threshold
       </span>
-      <input type="range" id="expressionThreshold" list="expressionThresholdList" value="` + expressionThreshold + `">
+      <input
+        type="range"
+        id="expressionThreshold"
+        list="expressionThresholdList"
+        value="${expressionThreshold}"
+      >
       <datalist id="expressionThresholdList">
         <option value="0" label="0.">
         <option value="10">
@@ -188,94 +218,101 @@ function addThresholdControl() {
         <option value="90">
         <option value="100" label="1.5">
       </datalist>
-      <br/><br/>`;
-  d3.select('#_ideogramLegend').node().innerHTML += expressionThresholdSlider;
+      <br/><br/>`
+  d3.select('#_ideogramLegend').node().innerHTML += expressionThresholdSlider
 }
 
+/** Handle updates to slider controls for ideogram display */
 function ideoRangeChangeEventHandler(event) {
-  var id = event.target.id;
-  if (id === 'expressionThreshold') updateThreshold(event);
-  if (id === 'chrMargin') updateMargin(event);
+  const id = event.target.id
+  if (id === 'expressionThreshold') updateThreshold(event)
+  if (id === 'chrMargin') updateMargin(event)
 }
 
+/** Add sliders to adjust ideogram display */
 function addIdeoRangeControls() {
-  addThresholdControl();
-  addMarginControl();
+  addThresholdControl()
+  addMarginControl()
 
-  document.removeEventListener('change', ideoRangeChangeEventHandler);
-  document.addEventListener('change', ideoRangeChangeEventHandler);
+  document.removeEventListener('change', ideoRangeChangeEventHandler)
+  document.addEventListener('change', ideoRangeChangeEventHandler)
 }
 
+/** Create interactive filters for ideogram tracks */
 function createTrackFilters() {
-  var i, listItems, trackLabels, content, checked;
+  let i; let listItems; let checked
 
-  addIdeoRangeControls();
+  addIdeoRangeControls()
 
   // Only apply this function once
-  if (document.querySelector('#filter_1')) return;
-  listItems = '';
-  trackLabels = ideogram.rawAnnots.keys.slice(6,);
-  displayedTracks = ideogram.config.annotationsDisplayedTracks;
+  if (document.querySelector('#filter_1')) return
+  listItems = ''
+  const trackLabels = ideogram.rawAnnots.keys.slice(6)
+  const displayedTracks = ideogram.config.annotationsDisplayedTracks
   for (i = 0; i < trackLabels.length; i++) {
-    checked = (displayedTracks.includes(i + 1)) ? 'checked' : '';
+    checked = (displayedTracks.includes(i + 1)) ? 'checked' : ''
     listItems +=
-      '<li>' +
-        '<label for="filter_' + (i + 1) + '">' +
-          '<input type="checkbox" id="filter_'  + (i + 1) + '" ' + checked + '/>' +
-          trackLabels[i] +
-        '</label>' +
-      '</li>';
+      `${'<li>' +
+        '<label for="filter_'}${i + 1}">` +
+          `<input type="checkbox" id="filter_${i + 1}" ${checked}/>${
+            trackLabels[i]
+          }</label>` +
+      `</li>`
   }
-  content = 'Tracks ' + listItems;
-  document.querySelector('#tracks-to-display').innerHTML = content;
+  const content = `Tracks ${listItems}`
+  document.querySelector('#tracks-to-display').innerHTML = content
 
 
-  $('#filters-container').after('<div id="ideogramTitle">Copy number variation inference</div>');
+  $('#filters-container').after(
+    '<div id="ideogramTitle">Copy number variation inference</div>'
+  )
 
-  checkboxes = document.querySelectorAll('input[type=checkbox]');
-  checkboxes.forEach(function(checkbox) {
-    checkbox.addEventListener('click', function() {
-      updateTracks();
-    });
-  });
+  checkboxes = document.querySelectorAll('input[type=checkbox]')
+  checkboxes.forEach(checkbox => {
+    checkbox.addEventListener('click', () => {
+      updateTracks()
+    })
+  })
 }
- 
+
+/**
+ * Note ideogram is unavailable for this numeric cluster
+ *
+ * Used in render_cluster.js.erb
+ */
 function warnIdeogramOfNumericCluster() {
-  var cluster, cellAnnot, warning;
+  const cluster = $('#cluster option:selected').val()
+  const cellAnnot = $('#annotation option:selected').val()
 
-  cluster = $('#cluster option:selected').val();
-  cellAnnot = $('#annotation option:selected').val();
+  const warning =
+    `${'<div id="ideogramWarning" style="height: 400px; margin-left: 20px;">' +
+      'Ideogram not available for selected cluster ("'}${cluster}") and ` +
+      `cell annotation ("${cellAnnot}").` +
+    `</div>`
 
-  warning =
-    '<div id="ideogramWarning" style="height: 400px; margin-left: 20px;">' +
-      'Ideogram not available for selected cluster ("' + cluster + '") and ' +
-      'cell annotation ("' + cellAnnot + '").' +
-    '</div>';
-
-    $('#tracks-to-display, #_ideogramOuterWrap').html('');
-    $('#ideogramWarning, #ideogramTitle').remove();
-    $('#ideogram-container').append(warning);
+  $('#tracks-to-display, #_ideogramOuterWrap').html('')
+  $('#ideogramWarning, #ideogramTitle').remove()
+  $('#ideogram-container').append(warning)
 }
 
+/** Initialize ideogram to visualize genomic heatmap from inferCNV  */
 function initializeIdeogram(url) {
-
   if (typeof window.ideogram !== 'undefined') {
-    delete window.ideogram;
-    $('#tracks-to-display').html('');
-    $('#_ideogramOuterWrap').html('');
+    delete window.ideogram
+    $('#tracks-to-display').html('')
+    $('#_ideogramOuterWrap').html('')
   }
 
-  $('#ideogramWarning, #ideogramTitle').remove();
+  $('#ideogramWarning, #ideogramTitle').remove()
 
   window.ideoConfig = {
     container: '#ideogram-container',
     organism: ideogramInferCnvSettings.organism.toLowerCase(),
     assembly: ideogramInferCnvSettings.assembly,
-    chrHeight: 400,
     dataDir: 'https://unpkg.com/ideogram@1.11.0/dist/data/bands/native/',
     annotationsPath: url,
     annotationsLayout: 'heatmap',
-    legend: legend,
+    legend,
     onDrawAnnots: createTrackFilters,
     debug: true,
     rotatable: false,
@@ -286,8 +323,8 @@ function initializeIdeogram(url) {
     orientation: 'horizontal'
   }
 
-  window.ideogram = new Ideogram(window.ideoConfig);
+  ideogram = new Ideogram(window.ideoConfig)
 
-    // Log Ideogram.js initialization in Google Analytics
-    ga('send', 'event', 'ideogram', 'initialize');
+  // Log Ideogram.js initialization in Google Analytics
+  ga('send', 'event', 'ideogram', 'initialize')
 }

--- a/app/assets/javascripts/scp-ideogram.js
+++ b/app/assets/javascripts/scp-ideogram.js
@@ -1,94 +1,10 @@
-/* eslint-disable no-undef */
 /* eslint-disable no-unused-vars */
-
-//    Not used currently, but perhaps later.
-//   function getGenomicRange(annot) {
-//     var chr, start, stop, startString, stopString, genomicRange;
-//
-//     // Get genomic range
-//     chr = annot.chr;
-//     start = annot.start;
-//     stop = start + annot.length;
-//     startString = start.toLocaleString();
-//     stopString = stop.toLocaleString();
-//     genomicRange = 'chr' + chr + ':' + startString + '-' + stopString;
-//
-//     return genomicRange;
-//   }
-//
-//   function getEnsemblLink(annot) {
-//     var url, link;
-//     url = 'https://www.ensembl.org/' + annot.id;
-//     link = '<a target="_blank" href="' + url + '">' + annot.name + '</a>';
-//     return link;
-//   }
-//
-//   function writeAnnotsTable() {
-//
-//     var chr, annots, datum, row, header, table, annotsContainer, keys,
-//         genomicRange, ensemblLink, key, i, j, k, displayKeys;
-//
-//     rows = [];
-//
-//     annotsContainer = ideogram.annots;
-//
-//     keys = ideogram.rawAnnots.keys;
-//
-//     for (i = 0; i < annotsContainer.length; i++) {
-//       chr = annotsContainer[i].chr;
-//       annots = annotsContainer[i].annots;
-//       for (j = 0; j < annots.length; j++) {
-//         annot = annots[j];
-//         row = [];
-//
-//         genomicRange = getGenomicRange(annot);
-//         ensemblLink = getEnsemblLink(annot);
-//
-//         for (k = 0; k < keys.length; k++) {
-//           key = keys[k];
-//           if (key === 'name') {
-//             datum = ensemblLink;
-//           } else if (key === 'start') {
-//             datum = genomicRange;
-//           } else if (key === 'id') {
-//             continue;
-//           } else {
-//             datum = annot[key];
-//           }
-//           row.push(datum)
-//
-//         }
-//         row = '<tr><td>' + row.join('</td><td>') + '</td></tr>';
-//         rows.push(row);
-//       }
-//     }
-//
-//     displayKeys = [];
-//     for (i = 0; i < keys.length; i++) {
-//       key = keys[i];
-//       if (key == 'start') {
-//         key = 'Genomic range';
-//       } else if (key === 'id') {
-//         continue;
-//       } else {
-//         key = key[0].toUpperCase() + key.slice(1);
-//       }
-//       displayKeys.push(key)
-//     }
-//
-//     header = '<tr><th>' + displayKeys.join('</th><th>') + '</th></tr>';
-//
-//     table =
-//       '<table class="table table-striped table-sm">' +
-//         '<thead>' + header + '</thead>' +
-//         '<tbody>' + rows + '</tbody>' +
-//       '</table>';
-//
-//     $('#ideogram-container').append(table);
-//   }
 
 let ideogram
 let checkboxes
+let ideoConfig
+let adjustedExpressionThreshold
+let chrMargin
 
 const legend = [{
   name: 'Expression level',
@@ -121,7 +37,7 @@ function updateTracks() {
 
 /** Update space between chromosomes; called upon updating related slider */
 function updateMargin(event) {
-  window.chrMargin = parseInt(event.target.value)
+  chrMargin = parseInt(event.target.value)
   ideoConfig.chrMargin = chrMargin
   ideogram = new Ideogram(ideoConfig)
 }
@@ -129,7 +45,7 @@ function updateMargin(event) {
 /** Create a slider to adjust space between chromosomes */
 function addMarginControl() {
   chrMargin = (typeof chrMargin === 'undefined' ? 10 : chrMargin)
-  marginSlider =
+  const marginSlider =
       `<label
           id="chrMarginContainer"
           style="float:left; position: relative; top: 50px; left: -130px;">
@@ -159,9 +75,9 @@ function addMarginControl() {
 function updateThreshold(event) {
   let newThreshold
 
-  window.expressionThreshold = parseInt(event.target.value)
+  const expressionThreshold = parseInt(event.target.value)
 
-  window.adjustedExpressionThreshold = Math.round(expressionThreshold/10 - 4)
+  adjustedExpressionThreshold = Math.round(expressionThreshold/10 - 4)
   const thresholds = window.originalHeatmapThresholds
   const numThresholds = thresholds.length
   ideoConfig.heatmapThresholds = []
@@ -184,12 +100,12 @@ function updateThreshold(event) {
 /** Create slider to adjust expression threshold for "gain" or "loss" calls */
 function addThresholdControl() {
   if (typeof(expressionThreshold) === 'undefined') {
-    expressionThreshold = 50
+    window.expressionThreshold = 50
     window.originalHeatmapThresholds =
       ideogram.rawAnnots.metadata.heatmapThresholds
   }
 
-  expressionThresholdSlider =
+  const expressionThresholdSlider =
     `<label id="expressionThresholdContainer" style="float: left">
       <span
         class="glossary"
@@ -203,7 +119,7 @@ function addThresholdControl() {
         type="range"
         id="expressionThreshold"
         list="expressionThresholdList"
-        value="${expressionThreshold}"
+        value="${window.expressionThreshold}"
       >
       <datalist id="expressionThresholdList">
         <option value="0" label="0.">
@@ -305,11 +221,11 @@ function initializeIdeogram(url) {
 
   $('#ideogramWarning, #ideogramTitle').remove()
 
-  window.ideoConfig = {
+  ideoConfig = {
     container: '#ideogram-container',
-    organism: ideogramInferCnvSettings.organism.toLowerCase(),
-    assembly: ideogramInferCnvSettings.assembly,
-    dataDir: 'https://unpkg.com/ideogram@1.11.0/dist/data/bands/native/',
+    organism: window.ideogramInferCnvSettings.organism.toLowerCase(),
+    assembly: window.ideogramInferCnvSettings.assembly,
+    dataDir: 'https://unpkg.com/ideogram@1.20.0/dist/data/bands/native/',
     annotationsPath: url,
     annotationsLayout: 'heatmap',
     legend,
@@ -323,7 +239,7 @@ function initializeIdeogram(url) {
     orientation: 'horizontal'
   }
 
-  ideogram = new Ideogram(window.ideoConfig)
+  ideogram = new Ideogram(ideoConfig)
 
   // Log Ideogram.js initialization in Google Analytics
   ga('send', 'event', 'ideogram', 'initialize')

--- a/app/assets/javascripts/scp-ideogram.js
+++ b/app/assets/javascripts/scp-ideogram.js
@@ -327,4 +327,6 @@ function initializeIdeogram(url) {
 
   // Log Ideogram.js initialization in Google Analytics
   ga('send', 'event', 'ideogram', 'initialize')
+
+  log('ideogram:initialize')
 }

--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -157,7 +157,7 @@ function initializeIgv() {
 
   // Log igv.js initialization in Google Analytics
   ga('send', 'event', 'igv', 'initialize')
-  log('igv-initialize')
+  log('igv:initialize')
 }
 
 $(document).on('click', '#genome-tab-nav > a', event => {

--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 /* eslint-disable no-invalid-this */
 /* eslint-disable guard-for-in */
 
@@ -12,10 +11,8 @@
 // default view, then searches a gene.
 window.hasDisplayedIgv = false
 
-window.bamsToViewInIgv = []
-window.selectedBams = {}
-
-window.genomeAssemblyInView = ''
+const bamsToViewInIgv = []
+const selectedBams = {}
 
 /**
  * Upon clicking 'Browse in genome', show selected BAM in igv.js in Genome tab.
@@ -72,7 +69,7 @@ function getBamTracks() {
     bamTrack = {
       url: bam.url,
       indexURL: bam.indexUrl,
-      oauthToken: accessToken,
+      oauthToken: window.accessToken,
       label: bamFileName
     }
     bamTracks.push(bamTrack)
@@ -99,7 +96,7 @@ function getGenesTrack(genome, genesTrackName) {
     order: 0,
     visibilityWindow: 300000000,
     displayMode: 'EXPANDED',
-    oauthToken: accessToken // Assigned in _genome.html.erb
+    oauthToken: window.accessToken // Assigned in _genome.html.erb
   }
 
   return genesTrack

--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -1,3 +1,7 @@
+/* eslint-disable no-undef */
+/* eslint-disable no-invalid-this */
+/* eslint-disable guard-for-in */
+
 /**
  * @fileoverview Functions and event handlers for igv.js genome browser.
  * Provides a way to view nucleotide sequencing reads in genomic context.
@@ -6,90 +10,88 @@
 // Persists 'Genome' tab and IGV embed across view states.
 // Ensures that IGV doesn't disappear when user clicks 'Browse in genome' in
 // default view, then searches a gene.
-window.hasDisplayedIgv = false;
+window.hasDisplayedIgv = false
 
-window.bamsToViewInIgv = [];
-window.selectedBams = {};
+window.bamsToViewInIgv = []
+window.selectedBams = {}
 
-window.genomeAssemblyInView = '';
+window.genomeAssemblyInView = ''
 
 /**
  * Upon clicking 'Browse in genome', show selected BAM in igv.js in Genome tab.
  */
 $(document).on('click', '.bam-browse-genome', function(e) {
-  var selectedBam, thisBam, url, i;
+  let thisBam; let url; let i
 
-  selectedBam = $(this).attr('data-filename');
+  const selectedBam = $(this).attr('data-filename')
 
   // bamAndBaiFiles assigned in _genome.html.erb
   for (i = 0; i < bamAndBaiFiles.length; i++) {
-    url = bamAndBaiFiles[i].url;
+    url = bamAndBaiFiles[i].url
     if (typeof url === 'undefined' || url === '?alt=media') {
       // Accounts for "Awaiting remote file"
-      continue;
+      continue
     }
-    thisBam = url.split('\/o/')[1].split('?')[0];
+    thisBam = url.split('/o/')[1].split('?')[0]
     if (thisBam === selectedBam && selectedBam in selectedBams === false) {
-      bamsToViewInIgv.push(bamAndBaiFiles[i]);
+      bamsToViewInIgv.push(bamAndBaiFiles[i])
     }
-    selectedBams[thisBam] = 1;
+    selectedBams[thisBam] = 1
   }
 
-  $('#study-visualize-nav > a').click();
-  $('#genome-tab-nav > a').click();
-});
+  $('#study-visualize-nav > a').click()
+  $('#genome-tab-nav > a').click()
+})
 
-$(document).on('click', '#genome-tab-nav', function (e) {
-  var currentScroll = $(window).scrollTop();
-  window.location.hash = '#genome-tab';
-  window.scrollTo(0, currentScroll);
-});
+$(document).on('click', '#genome-tab-nav', e => {
+  const currentScroll = $(window).scrollTop()
+  window.location.hash = '#genome-tab'
+  window.scrollTo(0, currentScroll)
+})
 
-$(document).on('click', '#plots-tab-nav', function (e) {
-    var currentScroll = $(window).scrollTop();
-    window.location.hash = '#study-visualize';
-    window.scrollTo(0, currentScroll);
-});
+$(document).on('click', '#plots-tab-nav', e => {
+  const currentScroll = $(window).scrollTop()
+  window.location.hash = '#study-visualize'
+  window.scrollTo(0, currentScroll)
+})
 
 /**
  * Get tracks for selected BAM files, to show sequencing reads
  */
 function getBamTracks() {
-  var bam, bamTrack, bamTracks, i, bamFileName;
+  let bam; let bamTrack; let i; let bamFileName
 
-  bamTracks = [];
+  const bamTracks = []
 
   for (i = 0; i < bamsToViewInIgv.length; i++) {
-    bam = bamsToViewInIgv[i];
+    bam = bamsToViewInIgv[i]
 
     // Extracts BAM file name from its GCS API URL
-    bamFileName = bam.url.split('/o/')[1].split('?')[0];
+    bamFileName = bam.url.split('/o/')[1].split('?')[0]
 
     bamTrack = {
       url: bam.url,
       indexURL: bam.indexUrl,
       oauthToken: accessToken,
       label: bamFileName
-    };
-    bamTracks.push(bamTrack);
+    }
+    bamTracks.push(bamTrack)
   }
 
-  return bamTracks;
+  return bamTracks
 }
 
 /**
  * Gets the track of genes and transcripts from the genome's BED file
  */
 function getGenesTrack(genome, genesTrackName) {
-  var gtfFile, genesTrack;
-
   // gtfFiles assigned in _genome.html.erb
-  gtfFile = gtfFiles[genome].genome_annotations;
+  const gtfFile = gtfFiles[genome].genome_annotations
 
-  genesTrack = {
+  const genesTrack = {
     name: genesTrackName,
-    url: gtfFile.url + '?alt=media',
-    indexURL: gtfFile.indexUrl + '?alt=media',
+    url: `${gtfFile.url}?alt=media`,
+    indexURL: `${gtfFile.indexUrl}?alt=media`,
     type: 'annotation',
     format: 'gtf',
     sourceType: 'file',
@@ -98,84 +100,79 @@ function getGenesTrack(genome, genesTrackName) {
     visibilityWindow: 300000000,
     displayMode: 'EXPANDED',
     oauthToken: accessToken // Assigned in _genome.html.erb
-  };
+  }
 
-  return genesTrack;
+  return genesTrack
 }
 
 // Monkey patch getKnownGenome to remove baked-in genes track.
 // We use a different gene annotation source, in a different track order,
 // so removing this default gives our genome browser instance a more
 // polished feel.
-var originalGetKnownGenomes = igv.GenomeUtils.getKnownGenomes;
-igv.GenomeUtils.getKnownGenomes = function () {
-  return originalGetKnownGenomes.apply(this).then(function(reference) {
-    var key,
-        newRef = {};
-    newRef['GRCm38'] = reference['mm10']; // Fix name
+const originalGetKnownGenomes = igv.GenomeUtils.getKnownGenomes
+igv.GenomeUtils.getKnownGenomes = function() {
+  return originalGetKnownGenomes.apply(this).then(reference => {
+    let key
+    const newRef = {}
+    newRef['GRCm38'] = reference['mm10'] // Fix name
     for (key in reference) {
-      delete reference[key].tracks;
-      newRef[key] = reference[key];
+      delete reference[key].tracks
+      newRef[key] = reference[key]
     }
-    return newRef;
+    return newRef
   })
-};
+}
 
 function igvIsDisplayed() {
-  return $('.igv-root-div').length > 0;
+  return $('.igv-root-div').length > 0
 }
 
 /**
  * Instantiates and renders igv.js widget on the page
  */
 function initializeIgv() {
-  var igvContainer, igvOptions, tracks, genome, genesTrack, bamTracks,
-    genesTrackName, genes, locus;
-
   // Bail if already displayed
-  if (igvIsDisplayed()) return;
+  if (igvIsDisplayed()) return
 
-  delete igv.browser;
+  delete igv.browser
 
   if (bamsToViewInIgv.includes(bamAndBaiFiles[0]) === false) {
-    bamsToViewInIgv.push(bamAndBaiFiles[0]);
+    bamsToViewInIgv.push(bamAndBaiFiles[0])
   }
 
-  igvContainer = document.getElementById('igv-container');
+  const igvContainer = document.getElementById('igv-container')
 
-  genes = $('.queried-gene');
-  locus = (genes.length === 0) ? ['myc'] : [genes.first().text()];
+  const genes = $('.queried-gene')
+  const locus = (genes.length === 0) ? ['myc'] : [genes.first().text()]
 
-  genome = bamsToViewInIgv[0].genomeAssembly;
-  genesTrackName = 'Genes | ' + bamsToViewInIgv[0].genomeAnnotation.name;
-  genesTrack = getGenesTrack(genome, genesTrackName);
-  bamTracks = getBamTracks();
-  tracks = [genesTrack].concat(bamTracks);
+  const genome = bamsToViewInIgv[0].genomeAssembly
+  const genesTrackName = `Genes | ${bamsToViewInIgv[0].genomeAnnotation.name}`
+  const genesTrack = getGenesTrack(genome, genesTrackName)
+  const bamTracks = getBamTracks()
+  const tracks = [genesTrack].concat(bamTracks)
 
-  igvOptions = {genome: genome, locus: locus, tracks: tracks};
+  const igvOptions = { genome, locus, tracks }
 
-  igv.createBrowser(igvContainer, igvOptions);
+  igv.createBrowser(igvContainer, igvOptions)
 
   // Log igv.js initialization in Google Analytics
-  ga('send', 'event', 'igv', 'initialize');
+  ga('send', 'event', 'igv', 'initialize')
 }
 
-$(document).on('click', '#genome-tab-nav > a', function(event) {
+$(document).on('click', '#genome-tab-nav > a', event => {
   if (typeof bamAndBaiFiles !== 'undefined') {
-    initializeIgv();
+    initializeIgv()
   }
-});
+})
 
-$(document).ready(function() {
-
+$(document).ready(() => {
   // Bail if on a page without genome visualization support
-  if (typeof accessToken === 'undefined') return;
+  if (typeof accessToken === 'undefined') return
 
   if (window.location.hash === '#genome-tab') {
-    $('#study-visualize-nav > a').click();
+    $('#study-visualize-nav > a').click()
 
     // Reload igv if refreshing
-    $('#genome-tab-nav > a').click();
+    $('#genome-tab-nav > a').click()
   }
-
-});
+})

--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -157,6 +157,7 @@ function initializeIgv() {
 
   // Log igv.js initialization in Google Analytics
   ga('send', 'event', 'igv', 'initialize')
+  log('igv-initialize')
 }
 
 $(document).on('click', '#genome-tab-nav > a', event => {

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -184,10 +184,5 @@ export function log(name, props={}) {
 
   init = Object.assign(init, body)
 
-  // Remove once Bard and Mixpanel are ready for SCP
-  if (
-    'SCP' in window && window.SCP.environment !== 'production'
-  ) {
-    fetch(`${bardDomain}/api/event`, init)
-  }
+  fetch(`${bardDomain}/api/event`, init)
 }

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -16,9 +16,9 @@ const defaultInit = {
 }
 
 const bardDomainsByEnv = {
-  'development': 'https://terra-bard-dev.appspot.com',
-  'staging': 'https://terra-bard-alpha.appspot.com',
-  'production': 'https://terra-bard-prod.appspot.com'
+  development: 'https://terra-bard-dev.appspot.com',
+  staging: 'https://terra-bard-alpha.appspot.com',
+  production: 'https://terra-bard-prod.appspot.com'
 }
 let bardDomain = ''
 let env = ''

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -41,7 +41,8 @@ export function logPageView() {
 
 /** Log click on page.  Delegates to more element-specific loggers. */
 export function logClick(event) {
-  // Don't log programmatically-triggered events
+  // Don't log programmatically-triggered events,
+  // e.g. trigger('click') via jQuery
   if (typeof event.isTrigger !== 'undefined') return
 
   const target = event.target

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -141,6 +141,27 @@ export function logError(text) {
 }
 
 /**
+ * Removes study name from URL, as it might have identifying information.
+ * Terra UI omits workspace name in logs; this follows that precedent.
+ *
+ * For example, for a path like
+ *    /single_cell/study/SCP123/private-study-with-sensitive-name
+ *
+ * This returns:
+ *    /single_cell/study/SCP123
+ *
+ * @param {String} appPath Path name in URL
+ */
+function trimStudyName(appPath) {
+  const studyOverviewMatch = appPath.match(/\/single_cell\/study\/SCP\d+/)
+  if (studyOverviewMatch) {
+    return studyOverviewMatch[0]
+  } else {
+    return appPath
+  }
+}
+
+/**
  * Log metrics to Mixpanel via Bard web service
  *
  * Bard docs:
@@ -150,10 +171,7 @@ export function logError(text) {
  * @param {Object} props
  */
 export function log(name, props={}) {
-  // If/when Mixpanel is extended beyond home page, remove study name from
-  // appPath at least for non-public studies to align with Terra's on
-  // identifiable data we want to omit this logging.
-  const appPath = window.location.pathname
+  const appPath = trimStudyName(window.location.pathname)
 
   props = Object.assign(props, {
     appId: 'single-cell-portal',

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -184,5 +184,7 @@ export function log(name, props={}) {
 
   init = Object.assign(init, body)
 
-  fetch(`${bardDomain}/api/event`, init)
+  if ('SCP' in window) { // Skips fetch during test
+    fetch(`${bardDomain}/api/event`, init)
+  }
 }

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -41,6 +41,9 @@ export function logPageView() {
 
 /** Log click on page.  Delegates to more element-specific loggers. */
 export function logClick(event) {
+  // Don't log programmatically-triggered events
+  if (typeof event.isTrigger !== 'undefined') return
+
   const target = event.target
   const tag = target.localName.toLowerCase() // local tag name
 

--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -84,7 +84,9 @@ export function logSearch(type, searchParams) {
     return
   }
 
-  const terms = searchParams.terms
+  const terms = searchParams.terms.split(' ')
+  console.log('terms')
+  console.log(terms)
   const facets = searchParams.facets
   const page = searchParams.page
 

--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -98,7 +98,8 @@ export function logSearch(type, searchParams) {
 
   const simpleProps = {
     type, terms, page, preset,
-    numTerms, numFacets, numFilters, facetList
+    numTerms, numFacets, numFilters, facetList,
+    context: 'global'
   }
   const props = Object.assign(simpleProps, filterListByFacet)
 

--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -85,8 +85,6 @@ export function logSearch(type, searchParams) {
   }
 
   const terms = searchParams.terms.split(' ')
-  console.log('terms')
-  console.log(terms)
   const facets = searchParams.facets
   const page = searchParams.page
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -35,10 +35,6 @@ import createTracesAndLayout from 'lib/kernel-functions'
 
 document.addEventListener('DOMContentLoaded', () => {
   // Logs only page views for faceted search UI
-  //
-  // If/when Mixpanel is extended beyond home page, remove study name from
-  // appPath in metrics-api.js at least for non-public studies to align with
-  // Terra on identifiable data that we want to omit from this logging.
   logPageView()
 
   $(document).on('click', 'body', event => {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -56,6 +56,8 @@ document.addEventListener('DOMContentLoaded', () => {
 })
 
 // SCP expects these variables to be global.
+//
+// If adding a new variable here, also add it to .eslintrc.js
 window.$ = $
 window.jQuery = $
 window.ClassicEditor = ClassicEditor

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -34,22 +34,21 @@ import { logPageView, logClick } from 'lib/metrics-api'
 import createTracesAndLayout from 'lib/kernel-functions'
 
 document.addEventListener('DOMContentLoaded', () => {
-  if (document.getElementById('home-page-content')) {
-    // Logs only page views for faceted search UI
-    //
-    // If/when Mixpanel is extended beyond home page, remove study name from
-    // appPath in metrics-api.js at least for non-public studies to align with
-    // Terra on identifiable data that we want to omit from this logging.
-    logPageView()
+  // Logs only page views for faceted search UI
+  //
+  // If/when Mixpanel is extended beyond home page, remove study name from
+  // appPath in metrics-api.js at least for non-public studies to align with
+  // Terra on identifiable data that we want to omit from this logging.
+  logPageView()
 
+  $(document).on('click', 'body', event => {
+    logClick(event)
+  })
+
+  if (document.getElementById('home-page-content')) {
     ReactDOM.render(
       <HomePageContent />, document.getElementById('home-page-content')
     )
-
-    // Only logs clicks for home page with faceted search UI
-    $(document).on('click', 'body', event => {
-      logClick(event)
-    })
   }
   if (document.getElementById('covid19-page-content')) {
     logPageView()
@@ -57,11 +56,6 @@ document.addEventListener('DOMContentLoaded', () => {
     ReactDOM.render(
       <Covid19PageContent />, document.getElementById('covid19-page-content')
     )
-
-    // Only logs clicks for home page with faceted search UI
-    $(document).on('click', 'body', event => {
-      logClick(event)
-    })
   }
 })
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -30,7 +30,7 @@ import ClassicEditor from '@ckeditor/ckeditor5-build-classic'
 // Below import resolves to '/app/javascript/components/HomePageContent.js'
 import HomePageContent from 'components/HomePageContent'
 import Covid19PageContent from 'components/covid19/Covid19PageContent'
-import { logPageView, logClick } from 'lib/metrics-api'
+import { logPageView, logClick, log } from 'lib/metrics-api'
 import createTracesAndLayout from 'lib/kernel-functions'
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -68,6 +68,7 @@ window.morpheus = morpheus
 window.igv = igv
 window.Ideogram = Ideogram
 window.createTracesAndLayout = createTracesAndLayout
+window.log = log
 
 /*
  * For down the road, when we use ES6 imports in SCP JS app code

--- a/app/javascript/providers/StudySearchProvider.js
+++ b/app/javascript/providers/StudySearchProvider.js
@@ -42,12 +42,8 @@ export const StudySearchContext = React.createContext(emptySearch)
 /**
  * Count terms, i.e. space-delimited strings, and consider [""] to have 0 terms
  */
-export function getNumberOfTerms(terms) {
+export function getNumberOfTerms(splitTerms) {
   let numTerms = 0
-  if (!terms) {
-    return numTerms
-  }
-  const splitTerms = terms.split(' ')
   if (splitTerms.length > 0 && splitTerms[0] !== '') {
     numTerms = splitTerms.length
   }

--- a/app/views/site/_selection_submit.html.erb
+++ b/app/views/site/_selection_submit.html.erb
@@ -22,6 +22,7 @@
         } else {
             $('#generic-modal-title').html("Saving... Please Wait");
             ga('send', 'event', 'engaged_user_action', 'create_custom_cell_annotation');
+            log('create-custom-cell-annotation');
             launchModalSpinner('#generic-modal-spinner', '#generic-modal', function() {
                 var form = $('#selection-well > form');
                 form.submit();

--- a/app/views/site/genome/_genome.html.erb
+++ b/app/views/site/genome/_genome.html.erb
@@ -13,10 +13,12 @@ See partials referenced below and scp-igv.js for larger bodies of code.
     // Intercept requests to add bearer token, enabling direct load of files from GCS
     var originalFetch = window.fetch;
     window.fetch = function () {
-      var myHeaders = new Headers({
-        'Authorization': 'Bearer ' + accessToken
-      });
-      arguments[1] = {headers: myHeaders};
+      if (arguments[0].includes('https://www.googleapis.com')) {
+        var myHeaders = new Headers({
+          'Authorization': 'Bearer ' + accessToken
+        });
+        arguments[1] = {headers: myHeaders};
+      }
       return originalFetch.apply(this, arguments)
     };
   </script>

--- a/app/views/site/genome/_genome.html.erb
+++ b/app/views/site/genome/_genome.html.erb
@@ -11,6 +11,9 @@ See partials referenced below and scp-igv.js for larger bodies of code.
   <%= render partial: '/site/genome/ideogram' %>
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
     // Intercept requests to add bearer token, enabling direct load of files from GCS
+    // This was needed to load genome visualization data from GCS.
+    //
+    // TODO (SCP-2451): Remove monkey patching of fetch
     var originalFetch = window.fetch;
     window.fetch = function () {
       if (arguments[0].includes('https://www.googleapis.com')) {

--- a/app/views/site/search/_search_genes.html.erb
+++ b/app/views/site/search/_search_genes.html.erb
@@ -59,7 +59,14 @@
             requestUrl += '?genes=' + genes.join('+') + '&num_genes=' + numGenes;
             gaTrack(requestUrl, 'Single Cell Portal | Global Gene Search');
             ga('send', 'event', 'engaged_user_action', 'global_gene_search');
-            log('gene-search:global', {genes: genes, numGenes: numGenes});
+
+
+            log('search', {
+              type: 'gene',
+              context: 'global',
+              terms: genes,
+              numTerms: numGenes
+            });
             return true;
         }
     });

--- a/app/views/site/search/_search_genes.html.erb
+++ b/app/views/site/search/_search_genes.html.erb
@@ -59,6 +59,7 @@
             requestUrl += '?genes=' + genes.join('+') + '&num_genes=' + numGenes;
             gaTrack(requestUrl, 'Single Cell Portal | Global Gene Search');
             ga('send', 'event', 'engaged_user_action', 'global_gene_search');
+            log('gene-search:global', {genes: genes, numGenes: numGenes});
             return true;
         }
     });

--- a/app/views/site/view_gene_expression.js.erb
+++ b/app/views/site/view_gene_expression.js.erb
@@ -9,7 +9,11 @@ closeModalSpinner('#spinner_target', '#loading-modal', function () {
     ga('send', 'event', 'engaged_user_action', 'study_gene_search_single');
 
     var genes = $('#search_genes').val().split(' ');
-    log('gene-search:study', {genes: genes, numGenes: genes.length});
+    log('search', {
+      context: 'study',
+      terms: genes,
+      numTerms: genes.length
+    });
 
     gaTrack(encodedUrl, 'Single Cell Portal');
 });

--- a/app/views/site/view_gene_expression.js.erb
+++ b/app/views/site/view_gene_expression.js.erb
@@ -7,5 +7,9 @@ closeModalSpinner('#spinner_target', '#loading-modal', function () {
     var requestUrl = "<%= request.fullpath %>";
     var encodedUrl = encodeURI(requestUrl);
     ga('send', 'event', 'engaged_user_action', 'study_gene_search_single');
+
+    var genes = $('#search_genes').val().split(' ');
+    log('gene-search:study', {genes: genes, numGenes: genes.length});
+
     gaTrack(encodedUrl, 'Single Cell Portal');
 });

--- a/app/views/site/view_gene_expression_heatmap.js.erb
+++ b/app/views/site/view_gene_expression_heatmap.js.erb
@@ -10,7 +10,12 @@ closeModalSpinner('#spinner_target', '#loading-modal', function () {
     ga('send', 'event', 'engaged_user_action', 'study_gene_search_multiple')
 
     var genes = $('#search_genes').val().split(' ');
-    log('gene-search:study', {genes: genes, numGenes: genes.length});
+    log('search', {
+      type: 'gene',
+      context: 'study',
+      terms: genes,
+      numTerms: genes.length
+    });
 
     gaTrack(encodedUrl, 'Single Cell Portal');
 });

--- a/app/views/site/view_gene_expression_heatmap.js.erb
+++ b/app/views/site/view_gene_expression_heatmap.js.erb
@@ -8,5 +8,9 @@ closeModalSpinner('#spinner_target', '#loading-modal', function () {
     var requestUrl = "<%= request.fullpath %>";
     var encodedUrl = encodeURI(requestUrl);
     ga('send', 'event', 'engaged_user_action', 'study_gene_search_multiple')
+
+    var genes = $('#search_genes').val().split(' ');
+    log('gene-search:study', {genes: genes, numGenes: genes.length});
+
     gaTrack(encodedUrl, 'Single Cell Portal');
 });

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
-    "ideogram": "1.11.0",
+    "ideogram": "1.19.0",
     "igv": "2.1.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.12.1",


### PR DESCRIPTION
This expands the scope of Mixpanel logging in SCP, and adds Mixpanel ports of custom-event logging previously only done in Google Analytics (GA).

Previously, Mixpanel logging was confined to advanced search.  Now, Mixpanel logging is done throughout SCP.  This provides broader and deeper logging of how users interact with the product.  All page views and all clicks on links, buttons, and inputs are now tracked throughout SCP.

Custom events beyond those in advanced search -- e.g. search within Study Overview, initializing visualizations like dot plots, igv.js, and Ideogram -- are now logged in Mixpanel as well.  This ports the handful of custom events logged to GA, and cleans up the logged objects for more consistency across the product.

Various JavaScript files now also conform to our new code style rules.

This satisfies the client-side code requirements of SCP-2326 and SCP-2382.