### PR TITLE
Prevent users from deleting cluster/metadata files that are subsampling (SCP-2445)

### DIFF
--- a/app/controllers/api/v1/api_base_controller.rb
+++ b/app/controllers/api/v1/api_base_controller.rb
@@ -77,6 +77,11 @@ module Api
           end
         end
       end
+
+      # HTTP 423 - Resource locked (e.g. StudyFile is parsing or being subsampled)
+      def self.resource_locked(resource)
+        "#{resource} is currently locked"
+      end
     end
   end
 end

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -360,11 +360,17 @@ module Api
           response 410 do
             key :description, ApiBaseController.resource_gone
           end
+          response 423 do
+            key :description, ApiBaseController.resource_locked(StudyFile)
+          end
         end
       end
 
       # DELETE /single_cell/api/v1/studies/:study_id/study_files/:id
       def destroy
+        if !@study_file.can_delete_safely?
+          render json: {error: 'Requested file is being used in active parse job'}, status: 423 and return
+        end
         human_data = @study_file.human_data # store this reference for later
         # delete matching caches
         @study_file.invalidate_cache_by_file_type

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -828,7 +828,7 @@ class StudiesController < ApplicationController
     @study_file = StudyFile.find(params[:study_file_id])
     @message = ""
     unless @study_file.nil?
-      if @study_file.parsing?
+      if !@study_file.can_delete_safely?
         render action: 'abort_delete_study_file'
       else
         human_data = @study_file.human_data # store this reference for later
@@ -1122,7 +1122,7 @@ class StudiesController < ApplicationController
     @form = "#study-file-#{@study_file.id}"
     @message = ""
     unless @study_file.nil?
-      if @study_file.parsing?
+      if !@study_file.can_delete_safely?
         render action: 'abort_delete_study_file'
       else
         begin

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -906,7 +906,8 @@ class StudyFile
       when 'Metadata'
         !self.study.cluster_groups.where(is_subsampling: true).any?
       when 'Cluster'
-        !ClusterGroup.where(study_file_id: self.id).is_subsampling?
+        cluster = ClusterGroup.find_by(study_file_id: self.id)
+        cluster.present? && !cluster.is_subsampling?
       else
         true
       end

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -896,6 +896,23 @@ class StudyFile
     Rails.logger.info "Removal of local copy of #{self.upload_file_name} complete"
   end
 
+  # check if this file can be deleted "safely"; e.g. not being used in any running parse jobs
+  # most files just need to check if they are still parsing; cluster/metadata files need to check for subsampling
+  def can_delete_safely?
+    if self.parsing?
+      false
+    else
+      case self.file_type
+      when 'Metadata'
+        !self.study.cluster_groups.where(is_subsampling: true).any?
+      when 'Cluster'
+        !ClusterGroup.where(study_file_id: self.id).is_subsampling?
+      else
+        true
+      end
+    end
+  end
+
   ##
   #
   # MISC METHODS

--- a/app/views/studies/abort_delete_study_file.js.erb
+++ b/app/views/studies/abort_delete_study_file.js.erb
@@ -1,3 +1,6 @@
-alert('You cannot delete a file that is parsing.  Please wait until the parse has completed.')
+alert('This file is currently being used in an active parse job - please wait until that job has completed.  ' +
+      'Cluster & Metadata files must additionally wait until all required subsamples have been computed.')
 
-
+if (OPEN_MODAL !== '') {
+    $('#' + OPEN_MODAL).modal('hide');
+}

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -95,6 +95,7 @@ else
                     test/models/cluster_group_test.rb # deprecated, but needed to set up for user_annotation_test
                     test/models/user_annotation_test.rb
                     test/models/study_test.rb
+                    test/models/study_file_test.rb
                     test/models/cell_metadatum_test.rb
                     test/models/analysis_configuration_test.rb
                     test/models/analysis_parameter_test.rb

--- a/test/models/study_file_test.rb
+++ b/test/models/study_file_test.rb
@@ -1,7 +1,50 @@
 require "test_helper"
 
 class StudyFileTest < ActiveSupport::TestCase
-  def study_file
-    @study_file ||= StudyFile.new
+
+  # load objects and set flags accordingly for test
+  def setup
+    @study = Study.first
+    @expression_matrix = @study.expression_matrix_files.first
+    @expression_matrix.update(parse_status: 'parsed')
+    @metadata_file = @study.metadata_file
+    @metadata_file.update(parse_status: 'parsing')
+    @cluster_file = @study.cluster_ordinations_files.first
+    @cluster_file.update(parse_status: 'parsing')
+    @cluster = @study.cluster_groups.first
+    @cluster.update(is_subsampling: true)
+  end
+
+  test 'should prevent deletion of study files during parsing or subsampling' do
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
+
+    # expression matrix is parsed, so it should be deletable
+    assert @expression_matrix.can_delete_safely?,
+           'Did not correctly return true for a parsed expression matrix'
+
+    # cluster/metadata files should not be deletable yet as they are parsing
+    refute @metadata_file.can_delete_safely?,
+           'Metadata file is still parsing and should not be deletable'
+    refute @cluster_file.can_delete_safely?,
+           'Metadata file is still parsing and should not be deletable'
+
+    # once parsing completes, because the cluster is subsampling, they should still not be deletable
+    @study.study_files.where(:file_type.in => %w(Cluster Metadata)).update_all(parse_status: 'parsed')
+    refute @metadata_file.can_delete_safely?,
+           'Metadata file is still subsampling and should not be deletable'
+    refute @cluster_file.can_delete_safely?,
+           'Metadata file is still subsampling and should not be deletable'
+
+    # once cluster is subsampled, both files should be deletable
+    @cluster.update(subsampled: true, is_subsampling: false)
+    # need to call reload to refresh cached object
+    @metadata_file.reload
+    @cluster_file.reload
+    assert @metadata_file.can_delete_safely?,
+           'Metadata file is no longer parsing/subsampling and should be deletable'
+    assert @cluster_file.can_delete_safely?,
+           'Metadata file is no longer parsing/subsampling and should be deletable'
+
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
 end


### PR DESCRIPTION
Currently a use can delete either a cluster or metadata file that is in the process of being subsampled.  This leads to various unexpected behavior modes, including a scenario where a cluster is "locked" in a mode where it stays labeled as in the process of subsampling, and cannot be unlocked without direct DB manipulation.

This update will block a user from deleting any file that is "locked", i.e being used in an active parse/subsampling job.  API requests to this effect will respond with an error and a status of `423 Locked`.  UI requests will show an alert notifying the user that they cannot delete this file until active jobs are done.  Emails notifying users of cluster file parse completions now also state that the cluster file will be subsampled, and that file (along with the metadata file) cannot be deleted while that job is in process.

This PR satisfies SCP-2445.