### PR TITLE
Fixing parameter encoding & user for API errors (SCP-2436)

### DIFF
--- a/app/controllers/api/v1/api_base_controller.rb
+++ b/app/controllers/api/v1/api_base_controller.rb
@@ -17,7 +17,7 @@ module Api
       # this is needed to get stack traces of view errors on the console in development
       # otherwise, e.g. errors in study_search_results_objects.rb would just be swallowed and returned as 500
       rescue_from StandardError do |exception|
-        ErrorTracker.report_exception(exception, current_user, params)
+        ErrorTracker.report_exception(exception, current_api_user, params.to_unsafe_hash)
         logger.error ([exception.message] + exception.backtrace).join($/)
         if Rails.env.production?
           render json: {error: "An unexpected error has occurred"}, status: 500


### PR DESCRIPTION
Converting the `ActionController::UnfilteredParameters` parameters object into a `Hash` for logging uncaught API errors.  Also, correctly setting the `current_api_user` for logging request identifiers.

This PR satisfies SCP-2436.