### PR TITLE
Fixing bug with non-existent directories causing backup to fail

### DIFF
--- a/app/lib/user_asset_service.rb
+++ b/app/lib/user_asset_service.rb
@@ -72,7 +72,7 @@ class UserAssetService
   # * *returns*
   #   - +Array<String>+ => Array of filenames
   def self.get_directory_entries(pathname = Dir.pwd)
-    Dir.entries(pathname).keep_if {|entry| !entry.start_with?('.')}
+    Dir.exists?(pathname) ? Dir.entries(pathname).keep_if {|entry| !entry.start_with?('.')} : []
   end
   
   # get a list of all local assets; can scope by asset type


### PR DESCRIPTION
Patch to allow `BackupUserAssets` migration to run when a directory is not present (e.g. no one uploaded pictures via CKEditor on an older instance).  This would not have affected production as all asset paths were present - this appears only to be affecting staging or development instances.

This PR is a bugfix for SCP-2374.