### PR TITLE
Replacing "Issues" link with "Contact Us" modal in Help menu (SCP-2438)

### DIFF
--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -150,3 +150,8 @@
     background-color: transparent;
   }
 }
+
+.scp-help-text {
+  font-size: 18px;
+  font-weight: 300;
+}

--- a/app/views/layouts/_contact_us.html.erb
+++ b/app/views/layouts/_contact_us.html.erb
@@ -1,0 +1,4 @@
+<p class="scp-help-text">If you are experiencing issues using Single Cell Portal, or would like to contact us to ask a question,
+    please send an email to <%= mail_to 'scp-support@broadinstitute.zendesk.com', 'scp-support@broadinstitute.zendesk.com' %>.</p>
+<p class="scp-help-text">You can also visit our <%= link_to 'help wiki', 'https://github.com/broadinstitute/single_cell_portal/wiki', target: :_blank %>
+    to view answers to common questions about using Single Cell Portal.</p>

--- a/app/views/layouts/_contact_us.html.erb
+++ b/app/views/layouts/_contact_us.html.erb
@@ -1,4 +1,4 @@
-<p class="scp-help-text">If you are experiencing issues using Single Cell Portal, or would like to contact us to ask a question,
+<p class="scp-help-text">If you are experiencing issues using Single Cell Portal or would like to ask a question,
     please send an email to <%= mail_to 'scp-support@broadinstitute.zendesk.com', 'scp-support@broadinstitute.zendesk.com' %>.</p>
 <p class="scp-help-text">You can also visit our <%= link_to 'help wiki', 'https://github.com/broadinstitute/single_cell_portal/wiki', target: :_blank %>
-    to view answers to common questions about using Single Cell Portal.</p>
+    to view answers to common questions about Single Cell Portal.</p>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -22,7 +22,7 @@
           <li><%= scp_link_to "<span class='fas fa-fw fa-lock'></span> Privacy Policy".html_safe, privacy_policy_path, class: 'check-upload' %></li>
           <li><%= scp_link_to "<span class='fas fa-fw fa-balance-scale'></span> Terms of Service".html_safe, terms_of_service_path, class: 'check-upload' %></li>
           <li><%= link_to "<span class='fas fa-fw fa-info-circle'></span> Documentation/Wiki".html_safe, 'https://github.com/broadinstitute/single_cell_portal/wiki', target: '_blank' %></li>
-          <li><%= link_to "<span class='fas fa-fw fa-exclamation-circle'></span> Issues".html_safe, 'https://github.com/broadinstitute/single_cell_portal/issues', target: '_blank' %></li>
+          <li><%= link_to "<span class='fas fa-fw fa-question-circle'></span> Contact Us".html_safe, '#', id: 'open-contact-modal' %></li>
           <li><%= link_to "<span class='fab fa-fw fa-github'></span> Portal Source Code".html_safe, 'https://github.com/broadinstitute/single_cell_portal_core', target: '_blank' %></li>
           <li><%= link_to "<span class='fas fa-fw fa-code'></span> REST API Documentation".html_safe, api_swagger_ui_engine_path, target: '_blank' %></li>
 				</ul>
@@ -75,3 +75,12 @@
     <% end %>
   <% end %>
 </nav>
+
+<script type='text/javascript' nonce="<%= content_security_policy_script_nonce %>">
+    $('#open-contact-modal').on('click', function() {
+        $('#generic-update-target').html("<%= escape_javascript(render partial: '/layouts/generic_update_modal') %>");
+        $('#generic-update-modal-title').html("<span class='h2'>Need Help?</span>");
+        $('#generic-update-modal-body').html("<%= escape_javascript(render partial: '/layouts/contact_us') %>");
+        $("#generic-update-modal").modal("show");
+    });
+</script>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -22,7 +22,7 @@
           <li><%= scp_link_to "<span class='fas fa-fw fa-lock'></span> Privacy Policy".html_safe, privacy_policy_path, class: 'check-upload' %></li>
           <li><%= scp_link_to "<span class='fas fa-fw fa-balance-scale'></span> Terms of Service".html_safe, terms_of_service_path, class: 'check-upload' %></li>
           <li><%= link_to "<span class='fas fa-fw fa-info-circle'></span> Documentation/Wiki".html_safe, 'https://github.com/broadinstitute/single_cell_portal/wiki', target: '_blank' %></li>
-          <li><%= link_to "<span class='fas fa-fw fa-question-circle'></span> Contact Us".html_safe, '#', id: 'open-contact-modal' %></li>
+          <li><%= link_to "<span class='fas fa-fw fa-envelope'></span> Contact Us".html_safe, '#', id: 'open-contact-modal' %></li>
           <li><%= link_to "<span class='fab fa-fw fa-github'></span> Portal Source Code".html_safe, 'https://github.com/broadinstitute/single_cell_portal_core', target: '_blank' %></li>
           <li><%= link_to "<span class='fas fa-fw fa-code'></span> REST API Documentation".html_safe, api_swagger_ui_engine_path, target: '_blank' %></li>
 				</ul>


### PR DESCRIPTION
Replacing the outdated "Issues" link to GitHub issues in the single_cell_portal repository to instead show a modal with the new Zendesk email, as well as a link to the help wiki.  This is an MVP that will eventually be superseded by a form that will allow direct submission of Zendesk issues, very similar to the "Contact Us" modal used by Terra.

This PR satisfies SCP-2438.