### PR TITLE
Updating messaging, fixing modal close timing

### DIFF
--- a/app/views/layouts/_contact_us.html.erb
+++ b/app/views/layouts/_contact_us.html.erb
@@ -1,4 +1,4 @@
 <p class="scp-help-text">If you are experiencing issues using Single Cell Portal or would like to ask a question,
     please send an email to <%= mail_to 'scp-support@broadinstitute.zendesk.com', 'scp-support@broadinstitute.zendesk.com' %>.</p>
 <p class="scp-help-text">You can also visit our <%= link_to 'help wiki', 'https://github.com/broadinstitute/single_cell_portal/wiki', target: :_blank %>
-    to view answers to common questions about Single Cell Portal.</p>
+    to view common topics about using Single Cell Portal.</p>

--- a/app/views/studies/abort_delete_study_file.js.erb
+++ b/app/views/studies/abort_delete_study_file.js.erb
@@ -6,7 +6,7 @@ function closeOpenModal() {
 // delete modal may open before or after alert message, so check both times
 closeOpenModal();
 
-alert('This file is still being processed and cannot be deleted yet.  You will receive an email when all parsing and/or ' +
+alert('This file is still being processed and cannot be deleted yet.  You will receive an email when all parsing and ' +
     'optional subsampling has completed.'
 )
 

--- a/app/views/studies/abort_delete_study_file.js.erb
+++ b/app/views/studies/abort_delete_study_file.js.erb
@@ -1,6 +1,13 @@
-alert('This file is currently being used in an active parse job - please wait until that job has completed.  ' +
-      'Cluster & Metadata files must additionally wait until all required subsamples have been computed.')
-
-if (OPEN_MODAL !== '') {
-    $('#' + OPEN_MODAL).modal('hide');
+function closeOpenModal() {
+    if (OPEN_MODAL !== '') {
+        $('#' + OPEN_MODAL).modal('hide');
+    }
 }
+// delete modal may open before or after alert message, so check both times
+closeOpenModal();
+
+alert('This file is still being processed and cannot be deleted yet.  You will receive an email when all parsing and/or ' +
+    'optional subsampling has completed.'
+)
+
+closeOpenModal();


### PR DESCRIPTION
Rephrasing messages shown to users when viewing the "Contact Us" modal, or when trying to delete a file that is still parsing or subsampling.  This also fixes a timing issue with closing the delete modal once the alert shows.