### PR TITLE
fixing bulk download file size for bundles

### DIFF
--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -91,9 +91,9 @@ class BulkDownloadService
     # replace 'Expression' with both dense & sparse matrix file types
     requested_files = get_requested_files(file_types: file_types, study_accessions: study_accessions)
     files_by_type = {}
-    requested_types = requested_files.map(&:bulk_download_type).uniq
+    requested_types = requested_files.map(&:simplified_file_type).uniq
     requested_types.each do |req_type|
-      files = requested_files.select {|file| file.bulk_download_type == req_type}
+      files = requested_files.select {|file| file.simplified_file_type == req_type}
       files_by_type[req_type] = {total_files: files.size, total_bytes: files.map(&:upload_file_size).reduce(:+)}
     end
     files_by_type


### PR DESCRIPTION
Sovles https://broadworkbench.atlassian.net/browse/SCP-2437.  Test build failure seems to be an unrelated (timing?) issue with summary_stats counting studies created

I didn't test this locally because I don't know how to create a bundle.  So I demonstrated the fix in the production console (pasted below).   If one of you has an easy way to do an extra test of this on your local instance, I think it'd be worth it.  Also, I would love a quick run-through of how/why to create a bundle.

(command as-is in production, showing bug)
```
2.5.7 :009 > BulkDownloadService.get_requested_file_sizes_by_type(file_types: ['Expression'], study_accessions: ['SCP264', 'SCP947'])
 => {"Expression/5bf59db2328cee097de76757"=>{:total_files=>1, :total_bytes=>376420560}, "Expression"=>{:total_files=>10, :total_bytes=>16039018497}} 
```

(pasting the fixed method steps into the console to observe output)
```
> file_types = ['Expression']
> study_accessions: ['SCP264', 'SCP947']
> requested_files = BulkDownloadService.get_requested_files(file_types: file_types, study_accessions: study_accessions)
> files_by_type = {}
> requested_types = requested_files.map(&:simplified_file_type).uniq
> requested_types.each do |req_type|
>      files = requested_files.select {|file| file.simplified_file_type == req_type}
>      files_by_type[req_type] = {total_files: files.size, total_bytes: files.map(&:upload_file_size).reduce(:+)}
>    end
>    files_by_type
 => {"Expression"=>{:total_files=>11, :total_bytes=>16415439057}} 
```