### PR TITLE
Sanitizing and encoding search terms (SCP-2444)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -186,7 +186,7 @@ module Api
         # if search params are present, filter accordingly
         if params[:terms].present?
           sort_type = :keyword
-          @search_terms = sanitize_search_values(params[:terms])
+          @search_terms = RequestUtils.sanitize_search_terms params[:terms]
           # determine if search values contain possible study accessions
           possible_accessions = StudyAccession.sanitize_accessions(@search_terms.split)
           # determine query case based off of search terms (either :keyword or :phrase)

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -2151,12 +2151,7 @@ class SiteController < ApplicationController
 
   # sanitize search values
   def sanitize_search_values(terms)
-    if terms.is_a?(Array)
-      sanitized = terms.map {|t| view_context.sanitize(t)}
-      sanitized.join(',')
-    else
-      view_context.sanitize(terms)
-    end
+    RequestUtils.sanitize_search_terms(terms)
   end
 
   ###

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -1,4 +1,9 @@
 class RequestUtils
+
+  # load same sanitizer as ActionView for stripping html/js from inputs
+  # using FullSanitizer as it is the most strict
+  SANITIZER ||= Rails::Html::FullSanitizer.new
+
   def self.get_selected_annotation(params, study, cluster)
     selector = params[:annotation].nil? ? params[:gene_set_annotation] : params[:annotation]
     annot_name, annot_type, annot_scope = selector.nil? ? study.default_annotation.split('--') : selector.split('--')
@@ -63,5 +68,12 @@ class RequestUtils
     rescue TypeError, ArgumentError
       values_array.dup.reject!(&:nan?).minmax
     end
+  end
+
+  # safely strip unsafe characters and encode search parameters for query/rendering
+  # strips out unsafe characters that break rendering notices/modals
+  def self.sanitize_search_terms(terms)
+    inputs = terms.is_a?(Array) ? terms.join(',') : terms
+    SANITIZER.sanitize(inputs).encode('ASCII-8BIT', invalid: :replace, undef: :replace)
   end
 end

--- a/app/lib/study_search_service.rb
+++ b/app/lib/study_search_service.rb
@@ -37,22 +37,11 @@ class StudySearchService
   def self.sanitize_gene_params(genes)
     delimiter = genes.include?(',') ? ',' : ' '
     raw_genes = genes.split(delimiter)
-    gene_array = sanitize_search_values(raw_genes).split(',').map(&:strip)
+    gene_array = RequestUtils.sanitize_search_terms(raw_genes).split(',').map(&:strip)
     # limit gene search for performance reasons
     if gene_array.size > MAX_GENE_SEARCH
       gene_array = gene_array.take(MAX_GENE_SEARCH)
     end
     gene_array.map(&:strip)
-  end
-
-  # sanitize search values into a comma-delimited string
-  def self.sanitize_search_values(terms)
-    sanitizer = Rails::Html::SafeListSanitizer.new
-    if terms.is_a?(Array)
-      sanitized = terms.map {|t| sanitizer.sanitize(t)}
-      sanitized.join(',')
-    else
-      sanitizer.sanitize(terms)
-    end
   end
 end

--- a/test/integration/lib/request_utils_test.rb
+++ b/test/integration/lib/request_utils_test.rb
@@ -19,4 +19,36 @@ class RequestUtilsTest < ActiveSupport::TestCase
     assert_equal 1.0, min, "Did not get expected min of 1.0: #{min}"
     assert_equal 100.0, min, "Did not get expected max of 100.0: #{max}"
   end
+
+  test 'should sanitize search terms' do
+    # test non-ASCII characters
+    search_terms = 'This is an ASCII-compatible string'
+    sanitized_terms = RequestUtils.sanitize_search_terms search_terms
+    assert_equal search_terms, sanitized_terms,
+                 "Valid search string was changed by sanitizer; #{search_terms} != #{sanitized_terms}"
+    invalid_terms = 'This has încømpåtiblé characters'
+    expected_sanitized = 'This has ?nc?mp?tibl? characters'
+    sanitized_invalid = RequestUtils.sanitize_search_terms invalid_terms
+    assert_equal expected_sanitized, sanitized_invalid,
+                 "Sanitizer did not strip illegal characters from search terms; #{expected_sanitized} != #{sanitized_invalid}"
+
+    # test html tags
+    html_string = "This string has <a href='javascript:alert(\"bad stuff!\")'>html content</a>"
+    expected_output = 'This string has html content'
+    sanitized_html = RequestUtils.sanitize_search_terms html_string
+    assert_equal sanitized_html, expected_output, "Did not correctly remove html tags: #{expected_output} != #{sanitized_html}"
+
+    # test array inputs
+    input_list = %w(Gad1 Gad2 Egfr)
+    expected_output = input_list.join(',')
+    sanitized_genes = RequestUtils.sanitize_search_terms input_list
+    assert_equal sanitized_genes, expected_output,
+                 "Did not correctly return array of genes as comma-delimited list; #{sanitized_genes} != #{expected_output}"
+
+    invalid_list = %w(Gåd1 Gåd2 Égfr)
+    invalid_output = 'G?d1,G?d2,?gfr'
+    sanitized_invalid_list = RequestUtils.sanitize_search_terms invalid_list
+    assert_equal invalid_output, sanitized_invalid_list,
+                 "Did not correctly sanitize characters from list; #{invalid_output} != #{sanitized_invalid_list}"
+  end
 end


### PR DESCRIPTION
This update standardizes how we deal with search terms (either study- or gene-based) in the portal.  All user-provided terms are now run through a `Rails::Html::FullSanitizer` to remove any potentially harmful values, and then encoded as `ASCII-8BIT` to scrub any characters that might cause encoding or rendering issues when displayed.

This PR satisfies SCP-2444.