### PR TITLE
fixing broken assignment, re-enabling unit tests for sparse matrices (SCP-2488)

### DIFF
--- a/app/models/parse_utils.rb
+++ b/app/models/parse_utils.rb
@@ -209,7 +209,6 @@ class ParseUtils
         delete_remote_file_on_fail(barcodes_study_file, study)
       end
       bundle = matrix_study_file.study_file_bundle
-      puts "bundle: #{bundle}"
       bundle.destroy
       matrix_study_file.destroy
       genes_study_file.destroy

--- a/app/models/parse_utils.rb
+++ b/app/models/parse_utils.rb
@@ -104,7 +104,7 @@ class ParseUtils
       # create array of known cells for this expression matrix
       @barcodes.each_slice(DataArray::MAX_ENTRIES).with_index do |slice, index|
         Rails.logger.info "#{Time.zone.now}: Create known cells array ##{index + 1} for #{matrix_study_file.name}:#{matrix_study_file.id} in #{study.name}"
-        known_cells = DataArray.new(study_id: self.id, name: "#{matrix_study_file.name} Cells", cluster_name: matrix_study_file.name,
+        known_cells = DataArray.new(study_id: study.id, name: "#{matrix_study_file.name} Cells", cluster_name: matrix_study_file.name,
                                     array_type: 'cells', array_index: index + 1, values: slice, study_file_id: matrix_study_file.id,
                                     linear_data_type: 'Study', linear_data_id: study.id)
         known_cells.save
@@ -209,6 +209,7 @@ class ParseUtils
         delete_remote_file_on_fail(barcodes_study_file, study)
       end
       bundle = matrix_study_file.study_file_bundle
+      puts "bundle: #{bundle}"
       bundle.destroy
       matrix_study_file.destroy
       genes_study_file.destroy

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -96,6 +96,7 @@ else
                     test/models/user_annotation_test.rb
                     test/models/study_test.rb
                     test/models/study_file_test.rb
+                    test/models/parse_utils_test.rb
                     test/models/cell_metadatum_test.rb
                     test/models/analysis_configuration_test.rb
                     test/models/analysis_parameter_test.rb

--- a/test/models/parse_utils_test.rb
+++ b/test/models/parse_utils_test.rb
@@ -13,7 +13,7 @@ class ParseUtilsTest < ActiveSupport::TestCase
     # load study files
     matrix = @study.study_files.by_type('MM Coordinate Matrix').first
     genes = @study.study_files.by_type('10X Genes File').first
-    barcodes = @study.study_files.by_type('10X Barcodes File').first
+    barcodes_file = @study.study_files.by_type('10X Barcodes File').first
 
     # control values
     @expected_genes = File.open(genes.upload.path).readlines.map {|line| line.split.map(&:strip)}
@@ -27,7 +27,7 @@ class ParseUtilsTest < ActiveSupport::TestCase
 
     user = User.first
     puts 'Parsing 10X GRCh38 output...'
-    ParseUtils.cell_ranger_expression_parse(@study, user, matrix, genes, barcodes, {skip_upload: true})
+    ParseUtils.cell_ranger_expression_parse(@study, user, matrix, genes, barcodes_file, {skip_upload: true})
     puts 'Parse of 10X GRCh38 complete'
     # validate that the expected significant values have been created
     @expected_genes.each do |entry|
@@ -59,7 +59,7 @@ class ParseUtilsTest < ActiveSupport::TestCase
                                       file_type: 'MM Coordinate Matrix', study_id: study.id)
     genes_file = StudyFile.create!(name: 'GRCh38/test_genes.tsv', upload: File.open(Rails.root.join('test', 'test_data', 'GRCh38', 'test_genes.tsv')),
                                    file_type: '10X Genes File', study_id: study.id, options: {matrix_id: mm_coord_file.id.to_s})
-    barcodes = StudyFile.create!(name: 'GRCh38/barcodes.tsv', upload: File.open(Rails.root.join('test', 'test_data', 'GRCh38', 'barcodes.tsv')),
+    barcodes_file = StudyFile.create!(name: 'GRCh38/barcodes.tsv', upload: File.open(Rails.root.join('test', 'test_data', 'GRCh38', 'barcodes.tsv')),
                                  file_type: '10X Barcodes File', study_id: study.id, options: {matrix_id: mm_coord_file.id.to_s})
 
     study_file_bundle = study.study_file_bundles.build(bundle_type: mm_coord_file.file_type)
@@ -72,11 +72,11 @@ class ParseUtilsTest < ActiveSupport::TestCase
 
     begin
       puts 'Parsing 10X incorrectly sorted matrix...'
-      ParseUtils.cell_ranger_expression_parse(study, user, mm_coord_file, genes_file, barcodes, {skip_upload: true, sync: true})
+      ParseUtils.cell_ranger_expression_parse(study, user, mm_coord_file, genes_file, barcodes_file, {skip_upload: true, sync: true})
     rescue => e
       assert e.is_a?(StandardError), "Did not raise the correct error, expected StandardError but found #{e.class}"
       assert e.message.starts_with?('Your input matrix is not sorted in the correct order.'), "Error message did not specify incorrect sort order: #{e.message}"
-      assert study.genes.count == 0, "Should not have saved any genes, found #{@study.genes.count}"
+      assert study.genes.count == 0, "Should not have saved any genes, found #{study.genes.count}"
     end
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"

--- a/test/models/parse_utils_test.rb
+++ b/test/models/parse_utils_test.rb
@@ -50,19 +50,33 @@ class ParseUtilsTest < ActiveSupport::TestCase
   # test that sparse matrix parsing validates coordinate matrix sort order correctly
   def test_sparse_matrix_sort_check
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
-    @study = Study.find_by(name: 'Negative Testing Study')
+
+    # create a test study and add matrix files and bundle
     user = User.first
-    matrix = @study.study_files.by_type('MM Coordinate Matrix').first
-    genes = @study.study_files.by_type('10X Genes File').first
-    barcodes = @study.study_files.by_type('10X Barcodes File').first
+    study = Study.create(name: 'Negative Testing Study', firecloud_project: ENV['PORTAL_NAMESPACE'], user_id: user.id)
+    user = User.first
+    mm_coord_file = StudyFile.create!(name: 'GRCh38/test_bad_matrix.mtx', upload: File.open(Rails.root.join('test', 'test_data', 'GRCh38', 'test_bad_matrix.mtx')),
+                                      file_type: 'MM Coordinate Matrix', study_id: study.id)
+    genes_file = StudyFile.create!(name: 'GRCh38/test_genes.tsv', upload: File.open(Rails.root.join('test', 'test_data', 'GRCh38', 'test_genes.tsv')),
+                                   file_type: '10X Genes File', study_id: study.id, options: {matrix_id: mm_coord_file.id.to_s})
+    barcodes = StudyFile.create!(name: 'GRCh38/barcodes.tsv', upload: File.open(Rails.root.join('test', 'test_data', 'GRCh38', 'barcodes.tsv')),
+                                 file_type: '10X Barcodes File', study_id: study.id, options: {matrix_id: mm_coord_file.id.to_s})
+
+    study_file_bundle = study.study_file_bundles.build(bundle_type: mm_coord_file.file_type)
+    bundle_payload = StudyFileBundle.generate_file_list(mm_coord_file)
+    study_file_bundle.original_file_list = bundle_payload
+    study_file_bundle.save!
+
+    # gotcha for refreshing matrix file after creating bundle to pick up association
+    mm_coord_file.reload
 
     begin
       puts 'Parsing 10X incorrectly sorted matrix...'
-      ParseUtils.cell_ranger_expression_parse(@study, user, matrix, genes, barcodes, {skip_upload: true, sync: true})
+      ParseUtils.cell_ranger_expression_parse(study, user, mm_coord_file, genes_file, barcodes, {skip_upload: true, sync: true})
     rescue => e
       assert e.is_a?(StandardError), "Did not raise the correct error, expected StandardError but found #{e.class}"
       assert e.message.starts_with?('Your input matrix is not sorted in the correct order.'), "Error message did not specify incorrect sort order: #{e.message}"
-      assert @study.genes.count == 0, "Should not have saved any genes, found #{@study.genes.count}"
+      assert study.genes.count == 0, "Should not have saved any genes, found #{@study.genes.count}"
     end
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"

--- a/test/models/parse_utils_test.rb
+++ b/test/models/parse_utils_test.rb
@@ -17,7 +17,7 @@ class ParseUtilsTest < ActiveSupport::TestCase
 
     # control values
     @expected_genes = File.open(genes.upload.path).readlines.map {|line| line.split.map(&:strip)}
-    @expected_cells = File.open(barcodes.upload.path).readlines.map(&:strip)
+    @expected_cells = File.open(barcodes_file.upload.path).readlines.map(&:strip)
     matrix_file = File.open(matrix.upload.path).readlines
     matrix_file.shift(3) # discard header lines
     expressed_gene_idx = matrix_file.map {|line| line.split.first.strip.to_i}


### PR DESCRIPTION
Fixing a regression introduced in PR #600 where a copy/paste error led to an incorrect reference to `self`, instead of `study`.  Also re-enables unit tests for sparse matrix parsing that were removed from CI runs.

This PR satisfies SCP-2488