### PR TITLE
Fix Mixpanel double logging of COVID-19 page views

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -47,8 +47,6 @@ document.addEventListener('DOMContentLoaded', () => {
     )
   }
   if (document.getElementById('covid19-page-content')) {
-    logPageView()
-
     ReactDOM.render(
       <Covid19PageContent />, document.getElementById('covid19-page-content')
     )


### PR DESCRIPTION
While reviewing our recent launch of Mixpanel logging as part of SCP-2450, I noticed that COVID-19 page views are being logged twice for each page load.  This fixes that -- the logging on [line 38 of `.../packs/application.js`](https://github.com/broadinstitute/single_cell_portal_core/blob/4aa8e7ef905351cdb7f8b5d4d6af051e28325d7d/app/javascript/packs/application.js#L38) is enough.