### PR TITLE
Support Macaca fascicularis genome in igv.js (SCP-2448)

### DIFF
--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -6,8 +6,6 @@
  * Provides a way to view nucleotide sequencing reads in genomic context.
  */
 
-console.log('start scp-igv.js')
-
 // Persists 'Genome' tab and IGV embed across view states.
 // Ensures that IGV doesn't disappear when user clicks 'Browse in genome' in
 // default view, then searches a gene.
@@ -130,8 +128,6 @@ function igvIsDisplayed() {
  * Instantiates and renders igv.js widget on the page
  */
 function initializeIgv() {
-  console.log('start initializeIgv')
-
   // Bail if already displayed
   if (igvIsDisplayed()) return
 
@@ -147,11 +143,20 @@ function initializeIgv() {
   const locus = (genes.length === 0) ? ['chr1:1-2'] : [genes.first().text()]
 
   const genomeId = bamsToViewInIgv[0].genomeAssembly
-  const reference = {
-    id: genomeId,
-    cytobandURL: 'https://www.googleapis.com/storage/v1/b/broad-singlecellportal-public/o/cytobands%2Fmacaca-fascicularis-cytobands.txt?alt=media',
-    fastaURL: 'https://www.googleapis.com/storage/v1/b/broad-singlecellportal-public/o/genomes%2FMacaca_fascicularis.Macaca_fascicularis_5.0.dna.toplevel.fa.gz?alt=media',
-    indexURL: 'https://www.googleapis.com/storage/v1/b/broad-singlecellportal-public/o/genomes%2FMacaca_fascicularis.Macaca_fascicularis_5.0.dna.toplevel.fa.gz.fai?alt=media'
+
+  let reference
+  if (genomeId === 'Macaca_fascicularis_5.0') {
+    // To consider:
+    //  - Move these to reference data bucket
+    //  - Update genomes pipeline to make such files automatically reproducible
+    reference = {
+      id: genomeId,
+      cytobandURL: 'https://www.googleapis.com/storage/v1/b/broad-singlecellportal-public/o/cytobands%2Fmacaca-fascicularis-cytobands.txt?alt=media',
+      fastaURL: 'https://www.googleapis.com/storage/v1/b/broad-singlecellportal-public/o/genomes%2FMacaca_fascicularis.Macaca_fascicularis_5.0.dna.toplevel.fa?alt=media',
+      indexURL: 'https://www.googleapis.com/storage/v1/b/broad-singlecellportal-public/o/genomes%2FMacaca_fascicularis.Macaca_fascicularis_5.0.dna.toplevel.fa.fai?alt=media'
+    }
+  } else {
+    reference = genomeId
   }
   const genesTrackName = `Genes | ${bamsToViewInIgv[0].genomeAnnotation.name}`
   const genesTrack = getGenesTrack(genomeId, genesTrackName)
@@ -168,16 +173,12 @@ function initializeIgv() {
 }
 
 $(document).on('click', '#genome-tab-nav > a', event => {
-  console.log('in #genome-tab-nav click handler, bamAndBaiFiles:')
-  console.log(bamAndBaiFiles)
   if (typeof bamAndBaiFiles !== 'undefined') {
     initializeIgv()
   }
 })
 
 $(document).ready(() => {
-  console.log('in scp-igv.js, $(document).ready(), accessToken:')
-  console.log(accessToken)
   // Bail if on a page without genome visualization support
   if (typeof accessToken === 'undefined') return
 

--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -144,7 +144,7 @@ function initializeIgv() {
   const igvContainer = document.getElementById('igv-container')
 
   const genes = $('.queried-gene')
-  const locus = (genes.length === 0) ? ['myc'] : [genes.first().text()]
+  const locus = (genes.length === 0) ? ['chr1:1-2'] : [genes.first().text()]
 
   const genomeId = bamsToViewInIgv[0].genomeAssembly
   const reference = {

--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -147,13 +147,18 @@ function initializeIgv() {
   let reference
   if (genomeId === 'Macaca_fascicularis_5.0') {
     // To consider:
-    //  - Move these to reference data bucket
     //  - Update genomes pipeline to make such files automatically reproducible
+    const genomeAnnotationObj = bamsToViewInIgv[0].genomeAnnotation
+    const genomePath = `${genomeAnnotationObj.link.split('/').slice(0, -2).join('%2F')}%2F`
+    const bucket = genomeAnnotationObj.bucket_id
+    const gcsBase = 'https://www.googleapis.com/storage/v1/b/'
+    const macacaFascicularisBase = `${gcsBase + bucket}/o/${genomePath}`
+
     reference = {
       id: genomeId,
-      cytobandURL: 'https://www.googleapis.com/storage/v1/b/broad-singlecellportal-public/o/cytobands%2Fmacaca-fascicularis-cytobands.txt?alt=media',
-      fastaURL: 'https://www.googleapis.com/storage/v1/b/broad-singlecellportal-public/o/genomes%2FMacaca_fascicularis.Macaca_fascicularis_5.0.dna.toplevel.fa?alt=media',
-      indexURL: 'https://www.googleapis.com/storage/v1/b/broad-singlecellportal-public/o/genomes%2FMacaca_fascicularis.Macaca_fascicularis_5.0.dna.toplevel.fa.fai?alt=media'
+      cytobandURL: `${macacaFascicularisBase}macaca-fascicularis-cytobands.txt?alt=media`,
+      fastaURL: `${macacaFascicularisBase}Macaca_fascicularis.Macaca_fascicularis_5.0.dna.toplevel.fa?alt=media`,
+      indexURL: `${macacaFascicularisBase}Macaca_fascicularis.Macaca_fascicularis_5.0.dna.toplevel.fa.fai?alt=media`
     }
   } else {
     reference = genomeId

--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -140,12 +140,14 @@ function initializeIgv() {
   const igvContainer = document.getElementById('igv-container')
 
   const genes = $('.queried-gene')
-  const locus = (genes.length === 0) ? ['chr1:1-2'] : [genes.first().text()]
 
   const genomeId = bamsToViewInIgv[0].genomeAssembly
 
   let reference
+  let locus
   if (genomeId === 'Macaca_fascicularis_5.0') {
+    locus = ['chr1:1-2']
+
     // To consider:
     //  - Update genomes pipeline to make such files automatically reproducible
     const genomeAnnotationObj = bamsToViewInIgv[0].genomeAnnotation
@@ -161,6 +163,7 @@ function initializeIgv() {
       indexURL: `${macacaFascicularisBase}Macaca_fascicularis.Macaca_fascicularis_5.0.dna.toplevel.fa.fai?alt=media`
     }
   } else {
+    locus = (genes.length === 0) ? ['myc'] : [genes.first().text()]
     reference = genomeId
   }
   const genesTrackName = `Genes | ${bamsToViewInIgv[0].genomeAnnotation.name}`

--- a/app/assets/javascripts/scp-igv.js
+++ b/app/assets/javascripts/scp-igv.js
@@ -6,6 +6,8 @@
  * Provides a way to view nucleotide sequencing reads in genomic context.
  */
 
+console.log('start scp-igv.js')
+
 // Persists 'Genome' tab and IGV embed across view states.
 // Ensures that IGV doesn't disappear when user clicks 'Browse in genome' in
 // default view, then searches a gene.
@@ -83,7 +85,7 @@ function getBamTracks() {
  */
 function getGenesTrack(genome, genesTrackName) {
   // gtfFiles assigned in _genome.html.erb
-  const gtfFile = gtfFiles[genome].genome_annotations
+  const gtfFile = window.gtfFiles[genome].genome_annotations
 
   const genesTrack = {
     name: genesTrackName,
@@ -128,6 +130,8 @@ function igvIsDisplayed() {
  * Instantiates and renders igv.js widget on the page
  */
 function initializeIgv() {
+  console.log('start initializeIgv')
+
   // Bail if already displayed
   if (igvIsDisplayed()) return
 
@@ -142,13 +146,19 @@ function initializeIgv() {
   const genes = $('.queried-gene')
   const locus = (genes.length === 0) ? ['myc'] : [genes.first().text()]
 
-  const genome = bamsToViewInIgv[0].genomeAssembly
+  const genomeId = bamsToViewInIgv[0].genomeAssembly
+  const reference = {
+    id: genomeId,
+    cytobandURL: 'https://www.googleapis.com/storage/v1/b/broad-singlecellportal-public/o/cytobands%2Fmacaca-fascicularis-cytobands.txt?alt=media',
+    fastaURL: 'https://www.googleapis.com/storage/v1/b/broad-singlecellportal-public/o/genomes%2FMacaca_fascicularis.Macaca_fascicularis_5.0.dna.toplevel.fa.gz?alt=media',
+    indexURL: 'https://www.googleapis.com/storage/v1/b/broad-singlecellportal-public/o/genomes%2FMacaca_fascicularis.Macaca_fascicularis_5.0.dna.toplevel.fa.gz.fai?alt=media'
+  }
   const genesTrackName = `Genes | ${bamsToViewInIgv[0].genomeAnnotation.name}`
-  const genesTrack = getGenesTrack(genome, genesTrackName)
+  const genesTrack = getGenesTrack(genomeId, genesTrackName)
   const bamTracks = getBamTracks()
   const tracks = [genesTrack].concat(bamTracks)
 
-  const igvOptions = { genome, locus, tracks }
+  const igvOptions = { reference, locus, tracks }
 
   igv.createBrowser(igvContainer, igvOptions)
 
@@ -158,12 +168,16 @@ function initializeIgv() {
 }
 
 $(document).on('click', '#genome-tab-nav > a', event => {
+  console.log('in #genome-tab-nav click handler, bamAndBaiFiles:')
+  console.log(bamAndBaiFiles)
   if (typeof bamAndBaiFiles !== 'undefined') {
     initializeIgv()
   }
 })
 
 $(document).ready(() => {
+  console.log('in scp-igv.js, $(document).ready(), accessToken:')
+  console.log(accessToken)
   // Bail if on a page without genome visualization support
   if (typeof accessToken === 'undefined') return
 

--- a/app/views/site/genome/_genome.html.erb
+++ b/app/views/site/genome/_genome.html.erb
@@ -31,6 +31,8 @@ See partials referenced below and scp-igv.js for larger bodies of code.
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
   if (typeof bamAndBaiFiles === 'undefined') {
     window.bamAndBaiFiles = <%= raw @study.get_bam_files.to_json %>;
+    console.log('window.bamAndBaiFiles')
+    console.log(window.bamAndBaiFiles)
     window.gtfFiles = <%= raw @study.get_genome_annotations_by_assembly.to_json %>;
   }
   </script>

--- a/app/views/site/genome/_genome.html.erb
+++ b/app/views/site/genome/_genome.html.erb
@@ -31,8 +31,6 @@ See partials referenced below and scp-igv.js for larger bodies of code.
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
   if (typeof bamAndBaiFiles === 'undefined') {
     window.bamAndBaiFiles = <%= raw @study.get_bam_files.to_json %>;
-    console.log('window.bamAndBaiFiles')
-    console.log(window.bamAndBaiFiles)
     window.gtfFiles = <%= raw @study.get_genome_annotations_by_assembly.to_json %>;
   }
   </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,6 +1549,11 @@
     webpack-cli "^3.3.10"
     webpack-sources "^1.4.3"
 
+"@ranfdev/deepobj@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@ranfdev/deepobj/-/deepobj-1.0.2.tgz#9dba923578fa24aed3d3961975037b6423a03771"
+  integrity sha512-FM3y6kfJaj5MCoAjdv24EDCTDbuFz+4+pgAunbjYfugwIE4O/xx8mPNji1n/ouG8pHCntSnBr1xwTOensF23Gg==
+
 "@reach/router@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.3.tgz#58162860dce6c9449d49be86b0561b5ef46d80db"
@@ -4209,10 +4214,12 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crossfilter@1.3.12:
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/crossfilter/-/crossfilter-1.3.12.tgz#147d7236a98c45c69f78bdc3a99d6fb00f70930c"
-  integrity sha1-FH1yNqmMRcafeL3DqZ1vsA9wkww=
+crossfilter2@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/crossfilter2/-/crossfilter2-1.5.1.tgz#d83715ec4bad916415994230be203d63ad7b28a2"
+  integrity sha512-dx9s8FbnUuaG8GvrdxkEa8i9vk61RDQFUir3X/Cdd7htpYG65vXOWRXtTLLnCbm/0RzZKqgXfk5aPrftqHLEBQ==
+  dependencies:
+    "@ranfdev/deepobj" "1.0.2"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -4580,7 +4587,7 @@ d3-fetch@^1.1.2:
   dependencies:
     d3-dsv "1"
 
-d3-format@1:
+d3-format@1, d3-format@^1.4.2:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.4.tgz#356925f28d0fd7c7983bfad593726fce46844030"
   integrity sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw==
@@ -7014,16 +7021,17 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ideogram@1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.11.0.tgz#13fefd6d81f85f2d3f54684f0a13f4046cb837b1"
-  integrity sha512-0C3Jl3lKg6ZVAcLWXlNKhDEi8m2F8XUh/mhZDQa5vw/fzf8K1Ld/gX2fM8x/liHGm5lAzaFQL91Q/+UwQGVddg==
+ideogram@1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.19.0.tgz#472066ccee7bec7db9b1eabb04a86c2a0b45bc8f"
+  integrity sha512-N6XUvXT6hP2+GJ0seANAtA5mlFdHkMhQ3N4wjYeEoZ0ZqL4QwQkdbtOUN4T23UiUIhMHGmJXkUecOsoqE9aJeA==
   dependencies:
-    crossfilter "1.3.12"
+    crossfilter2 "1.5.1"
     d3-array "^1.2.4"
     d3-brush "^1.0.6"
     d3-dispatch "^1.0.5"
     d3-fetch "^1.1.2"
+    d3-format "^1.4.2"
     d3-scale "^1.0.6"
     d3-selection "^1.3.2"
     d3-transition "^1.2.0"
@@ -12355,7 +12363,7 @@ react-scripts@^3.4.0:
   optionalDependencies:
     fsevents "2.1.2"
 
-react-table@7.1.0:
+react-table@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.1.0.tgz#c975cd67e917c54190b6c9df29f085285b0c3f4e"
   integrity sha512-AZpgW0Xpo6Z7jxXZIBovzCGoYVkuBwATsJh7X4+JXwq9JtDaorOmxWC9gKx5Hui4d+n+I99enyyJS+LRtKydxA==


### PR DESCRIPTION
This adds a special case of rudimentary support for _Macaca fascicularis_ (crab-eating macaque) in the igv.js genome browser embedded in Single Cell Portal.  It enables viewing BAMs for the genome assembly Macaca_fascicularis_5.0.

I generated the files referenced here manually.  A more generic and reproducible approach is under development to generate these files.  That is needed for other current SCP organisms that do not have built-in support in igv.js, and to address tech debt in this quick and dirty solution.  But this fixes a known user issue for now.

This satisfies SCP-2448.