### PR TITLE
changing normal keyword search to POST from GET (SCP-2444)

### DIFF
--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -73,7 +73,7 @@ class RequestUtils
   # safely strip unsafe characters and encode search parameters for query/rendering
   # strips out unsafe characters that break rendering notices/modals
   def self.sanitize_search_terms(terms)
-    inputs = terms.is_a?(Array) ? terms.join(',') : terms
+    inputs = terms.is_a?(Array) ? terms.join(',') : terms.to_s
     SANITIZER.sanitize(inputs).encode('ASCII-8BIT', invalid: :replace, undef: :replace)
   end
 end

--- a/app/views/site/search/_search_studies.html.erb
+++ b/app/views/site/search/_search_studies.html.erb
@@ -1,6 +1,6 @@
 <div class="row form-group">
   <div class="col-md-5 col-sm-12 col-xs-12">
-    <%= form_tag(site_path, method: :get, class: 'form') do %>
+    <%= form_tag(site_path, class: 'form') do %>
       <div class="input-group">
         <%= text_field_tag :search_terms, nil, class: 'form-control', placeholder: 'Search Studies...' %>
         <%= hidden_field_tag :order, params[:order].nil? ? "" : params[:order] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -258,6 +258,7 @@ Rails.application.routes.draw do
     get 'covid19', to: 'site#covid19'
 
     get '/', to: 'site#index', as: :site
+    post '/', to: 'site#index'
 
     # let react routing handle app and all subpaths under 'app'
     get 'app', to: 'site#index'


### PR DESCRIPTION
This addresses an issue with serializing query parameters back into the DOM when a user has supplied non-ASCII characters in their search request.  This is only affecting the normal, non-React search front end.  On a `GET` with non-ASCII query string parameters that are used somewhere in the DOM, an `ActionView::Template::Error: incompatible character encodings: ASCII-8BIT and UTF-8` error is thrown.  A `POST` with the same parameters does not throw this error.  

This PR satisfies SCP-2444.