### PR TITLE
enabling gene search within covid-19 space (SCP-2536)

### DIFF
--- a/app/javascript/components/covid19/Covid19PageContent.js
+++ b/app/javascript/components/covid19/Covid19PageContent.js
@@ -1,55 +1,19 @@
 import React, { useContext } from 'react'
 import { Router } from '@reach/router'
 
-import SearchPanel from 'components/search/controls/SearchPanel'
-import ResultsPanel from 'components/search/results/ResultsPanel'
-import StudySearchProvider, { StudySearchContext } from 'providers/StudySearchProvider'
-import SearchFacetProvider from 'providers/SearchFacetProvider'
-import UserProvider from 'providers/UserProvider'
-import ErrorBoundary from 'lib/ErrorBoundary'
-import StudyDetails from 'components/search/results/Study'
-
+import HomePageContent from 'components/HomePageContent'
 
 /**
- * Wrapper component for search and result panels
+ * Render home page search but with covid-19 content and labels
  */
 export default function Covid19PageContent() {
+  let presetEnv = {
+    showCommonButtons: false,
+    keywordPrompt: "Search within COVID-19 studies",
+    geneKeywordPrompt: "Search for genes within COVID-19 studies",
+    preset: "covid19"
+  }
   return (
-    <Router>
-      <CovidPageContainer default/>
-    </Router>
+    <HomePageContent presetEnv={presetEnv}/>
   )
-}
-
-/**
- * The actual rendered content for the covid19 page.
- * Note this needs to be used within a Reach <Router> element or
- * the search component's useLocation hooks will error
- */
-function CovidPageContainer() {
-  return (
-    <ErrorBoundary>
-      <UserProvider>
-        <SearchFacetProvider>
-          <StudySearchProvider preset="covid19" >
-            <CovidPageSearchContent/>
-          </StudySearchProvider>
-        </SearchFacetProvider>
-      </UserProvider>
-    </ErrorBoundary>
-  )
-}
-
-function CovidPageSearchContent() {
-  const studySearchState = useContext(StudySearchContext)
-  return (<>
-    <ErrorBoundary>
-      <SearchPanel showCommonButtons={false}
-        keywordPrompt="Search within COVID-19 studies"
-        searchOnLoad={true}/>
-    </ErrorBoundary>
-    <ErrorBoundary>
-      <ResultsPanel studySearchState={studySearchState} studyComponent={StudyDetails}/>
-    </ErrorBoundary>
-  </>)
 }

--- a/app/javascript/components/search/genes/GeneSearchView.js
+++ b/app/javascript/components/search/genes/GeneSearchView.js
@@ -15,7 +15,7 @@ import { FeatureFlagContext } from 'providers/FeatureFlagProvider'
   * Renders a gene search control panel and the associated results
   * can also show study filter controls if the feature flag gene_study_filter is true
   */
-export default function GeneSearchView() {
+export default function GeneSearchView({keywordPrompt}) {
   const featureFlagState = useContext(FeatureFlagContext)
   const geneSearchState = useContext(GeneSearchContext)
   const studySearchState = useContext(StudySearchContext)
@@ -27,7 +27,7 @@ export default function GeneSearchView() {
                                  !geneSearchState.isLoading &&
                                  !geneSearchState.isError
 
-  let geneSearchPlaceholder = 'Search for genes across all studies'
+  let geneSearchPlaceholder = keywordPrompt ? keywordPrompt : 'Search for genes across all studies'
   if (hasSearchParams(studySearchState.params) && featureFlagState.gene_study_filter) {
     geneSearchPlaceholder = 'Search for genes in the filtered studies'
   }

--- a/app/javascript/providers/GeneSearchProvider.js
+++ b/app/javascript/providers/GeneSearchProvider.js
@@ -69,7 +69,8 @@ export function PropsGeneSearchProvider(props) {
 
     const results = await fetchSearch('study', {
       page: searchParams.page,
-      genes: searchParams.genes
+      genes: searchParams.genes,
+      preset: searchParams.preset
     })
 
     setSearchState({

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,6 +256,7 @@ Rails.application.routes.draw do
     get 'terms_of_service', to: 'site#terms_of_service', as: :terms_of_service
 
     get 'covid19', to: 'site#covid19'
+    get 'covid19/*path', to: 'site#covid19'
 
     get '/', to: 'site#index', as: :site
 


### PR DESCRIPTION
Analytics showed that ~30% of branded space usage is gene search, so that probably means there's demand for Covid-19 gene search, so it was worth turning it on.  This also has the benefit of refactoring the Covid component to no longer duplicate HomePageContent logic