### PR TITLE
Moving all-user email delivery to background, batched send (SCP-2521)

### DIFF
--- a/app/controllers/admin_configurations_controller.rb
+++ b/app/controllers/admin_configurations_controller.rb
@@ -344,10 +344,11 @@ class AdminConfigurationsController < ApplicationController
   # deliver an email to all portal users
   def deliver_users_email
     begin
-      SingleCellMailer.users_email(users_email_params, current_user).deliver_now
+      # send in background so operation doesn't time out with lots of users
+      SingleCellMailer.delay.users_email(users_email_params, current_user)
       @notice = 'Your email has successfully been delivered.'
     rescue => e
-      ErrorTracker.report_exception(e, current_user, params)
+      ErrorTracker.report_exception(e, current_user, users_email_params.to_unsafe_hash)
       logger.error "#{Time.zone.now}: Error delivering users email: #{e.message}"
       @alert = "Unabled to deliver users email due to the following error: #{e.message}"
     end

--- a/app/mailers/single_cell_mailer.rb
+++ b/app/mailers/single_cell_mailer.rb
@@ -14,8 +14,11 @@ class SingleCellMailer < ApplicationMailer
     @subject = email_params[:subject]
     @from = email_params[:from]
     @message = email_params[:contents]
-    mail(to: @from, bcc: @users, subject: "[Single Cell Portal Message] #{@subject}", from: @from) do |format|
-      format.html {@message.html_safe}
+    # send email in batches to reduce likelihood of errors
+    @users.each_slice(500) do |email_batch|
+      mail(to: @from, bcc: email_batch, subject: "[Single Cell Portal Message] #{@subject}", from: @from) do |format|
+        format.html {@message.html_safe}
+      end
     end
   end
 


### PR DESCRIPTION
Currently, the "email all users" function sends an email from the portal to all users in the portal who have not opted-out of admin emails.  It does so by blind carbon-copying the entire user list (`bcc`) and sending a single email.  For small numbers, this is fine, but as the user list grows, this method runs the risk of two major errors: 1) timing out on the HTTP request, and 2) exceeding quotas for email delivery in Sendgrid (10K users per email).

This update moves the actual email delivery into the background via DelayedJob to avoid the request timing out, and also delivers the emails in batches of 500 users to sidestep any quota issues.  Since it is nearly impossible to test email delivery, this was verified manually in a local instance.

This PR satisfies SCP-2521.