### PR TITLE
Fixing parameters for error reporting, data upload directory permissions (SCP-2526, SCP-2529, SCP-2539)

### DIFF
--- a/app/controllers/admin_configurations_controller.rb
+++ b/app/controllers/admin_configurations_controller.rb
@@ -148,7 +148,7 @@ class AdminConfigurationsController < ApplicationController
           redirect_to admin_configuration_path, alert: 'Invalid configuration option; ignored.'
       end
     rescue => e
-      ErrorTracker.report_exception(e, current_user, params)
+      ErrorTracker.report_exception(e, current_user, params.to_unsafe_hash)
       logger.error "#{Time.zone.now}: error in setting download status to #{status}; #{e.message}"
       redirect_to admin_configurations_path, alert: "An error occured while turing #{status} downloads: #{e.message}" and return
     end
@@ -199,7 +199,7 @@ class AdminConfigurationsController < ApplicationController
         end
       end
     rescue => e
-      ErrorTracker.report_exception(e, current_user, params)
+      ErrorTracker.report_exception(e, current_user, params.to_unsafe_hash)
       logger.error "#{Time.zone.now}: unable to retrieve service account FireCloud registration: #{e.message}"
     end
   end
@@ -212,7 +212,7 @@ class AdminConfigurationsController < ApplicationController
       @client.set_profile(profile_params)
       @notice = "The portal service account FireCloud profile has been successfully updated."
     rescue => e
-      ErrorTracker.report_exception(e, current_user, params)
+      ErrorTracker.report_exception(e, current_user, params.to_unsafe_hash)
       logger.error "#{Time.zone.now}: unable to update service account FireCloud registration: #{e.message}"
       @alert = "Unable to update portal service account FireCloud profile: #{e.message}"
     end
@@ -223,7 +223,7 @@ class AdminConfigurationsController < ApplicationController
     begin
       @status = Study.firecloud_client.api_status
     rescue => e
-      ErrorTracker.report_exception(e, current_user, params)
+      ErrorTracker.report_exception(e, current_user, params.to_unsafe_hash)
       logger.error "#{Time.zone.now}: unable to retrieve FireCloud API status due to: #{e.message}"
       @status = {error: "An error occurred while fetching the FireCloud API status: #{e.message}"}
     end
@@ -262,7 +262,7 @@ class AdminConfigurationsController < ApplicationController
         end
         logger.info "#{Time.zone.now}: User group #{@group_name} successfully synchronized"
       rescue => e
-        ErrorTracker.report_exception(e, current_user, params)
+        ErrorTracker.report_exception(e, current_user, params.to_unsafe_hash)
         logger.error "#{Time.zone.now}: Error in synchronizing portal user group #{@group_name}: #{e.message}"
         @alert = "Unable to synchronize user group #{@group_name} due to an error: #{e.message}"
       end
@@ -282,7 +282,7 @@ class AdminConfigurationsController < ApplicationController
       begin
         @success, @alert = AdminConfiguration.set_readonly_service_account_permissions(revoke_access)
       rescue => e
-        ErrorTracker.report_exception(e, current_user, params)
+        ErrorTracker.report_exception(e, current_user, params.to_unsafe_hash)
         @alert = "An error occurred while trying to set the access for the readonly service account: #{e.message}"
       end
     else

--- a/app/controllers/api/v1/directory_listings_controller.rb
+++ b/app/controllers/api/v1/directory_listings_controller.rb
@@ -276,7 +276,7 @@ module Api
           @directory_listing.destroy
           head 204
         rescue => e
-          ErrorTracker.report_exception(e, current_api_user, params)
+          ErrorTracker.report_exception(e, current_api_user, params.to_unsafe_hash)
           render json: {error: e.message}, status: 500
         end
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -93,7 +93,7 @@ class ApplicationController < ActionController::Base
 
   # rescue from an invalid csrf token (if user logged out in another window, or some kind of spoofing attack)
   def invalid_csrf(exception)
-    ErrorTracker.report_exception(exception, current_user, {request_url: request.url, params: params})
+    ErrorTracker.report_exception(exception, current_user, {request_url: request.url, params: params.to_unsafe_hash})
     @alert = "We're sorry, but the change you wanted was rejected by the server."
     respond_to do |format|
       format.html {render template: '/layouts/422', status: 422}

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -33,7 +33,7 @@ class ProfilesController < ApplicationController
           @fire_cloud_profile.email = current_user.email
         end
       rescue => e
-        ErrorTracker.report_exception(e, current_user, params)
+        ErrorTracker.report_exception(e, current_user, params.to_unsafe_hash)
         logger.info "#{Time.zone.now}: unable to retrieve FireCloud profile for #{current_user.email}: #{e.message}"
       end
     end
@@ -88,7 +88,7 @@ class ProfilesController < ApplicationController
         end
       end
     rescue => e
-      ErrorTracker.report_exception(e, current_user, params)
+      ErrorTracker.report_exception(e, current_user, params.to_unsafe_hash)
       logger.info "#{Time.zone.now}: unable to update FireCloud profile for #{current_user.email}: #{e.message}"
       @alert = "An error occurred when trying to update your FireCloud profile: #{e.message}"
     end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -458,8 +458,8 @@ class StudiesController < ApplicationController
         logger.error "#{Time.zone.now} #{study_file.errors.full_messages.join(", ")}"
         existing_file = StudyFile.find(study_file.id)
         if existing_file
-          ErrorTracker.report_exception(e, current_user, params)
-          logger.error("do_upload Failed: Existing file for #{study_file.id} -- type:#{existing_file.type} name:#{existing_file.name}")
+          ErrorTracker.report_exception(e, current_user, params.to_unsafe_hash)
+          logger.error("do_upload Failed: Existing file for #{study_file.id} -- type:#{existing_file.file_type} name:#{existing_file.name}")
         end
         render json: { file: { name: study_file.upload_file_name, errors: study_file.errors.full_messages.join(", ") } }, status: 422 and return
       end

--- a/rails_startup.bash
+++ b/rails_startup.bash
@@ -7,6 +7,17 @@ echo "*** COMPLETED ***"
 echo "*** ROLLING OVER LOGS ***"
 ruby /home/app/webapp/bin/cycle_logs.rb
 echo "*** COMPLETED ***"
+
+# ensure data upload directory exists and has correct permissions
+echo "*** ENSURING DATA UPLOAD DIRECTORY PERMISSIONS ***"
+if [[ ! -d /home/app/webapp/data ]]; then
+    echo "DATA DIRECTORY NOT PRESENT; CREATING"
+    mkdir data
+    echo "DATA DIRECTORY SUCCESSFULLY CREATED"
+fi
+sudo chown -R app:app /home/app/webapp/data
+echo "*** COMPLETED ***"
+
 if [[ $PASSENGER_APP_ENV = "production" ]] || [[ $PASSENGER_APP_ENV = "staging" ]] || [[ $PASSENGER_APP_ENV = "pentest" ]]
 then
     echo "*** PRECOMPILING ASSETS ***"


### PR DESCRIPTION
PR addressing issues with file uploads and error reporting:

* On startup, the portal will now ensure the presence and permissions of the `data` upload directory (where files are stored temporarily while uploading/parsing).  New portal deployments/instances had an issue where the `data` directory was owned by `root`, and not the `app` user, causing a directory permissions error in the filesystem. (SCP-2526).
* Correctly casting all `ActionController::UnfilteredParameters` parameter objects to a `Hash` via the `to_unsafe_hash` method before reporting errors to logging or Sentry.  Previously this would raise a `TypeError: unable to convert unpermitted parameters to hash` (SCP-2529, SCP-2539).