### PR TITLE
fixing broken wiki link, updating rack re: CVE-2020-8184 (SCP-2542, CVE-2020-8184)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,7 +298,7 @@ GEM
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -52,7 +52,7 @@
           </div>
           </br>
           <div class="row">
-            <p class="col-sm-12">* Before upload, <strong>MM Coordinate Matrix file must be <%= link_to 'sorted', 'https://github.com/broadinstitute/single_cell_portal/wiki/Sorting-Matrix-Market-Coordinate-Matricesx', target: :_blank %></strong>.
+            <p class="col-sm-12">* Before upload, <strong>MM Coordinate Matrix file must be <%= link_to 'sorted', 'https://github.com/broadinstitute/single_cell_portal/wiki/Sorting-Matrix-Market-Coordinate-Matrices', target: :_blank %></strong>.
               Additionally, you will need to upload the <%= link_to 'genes', 'https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices', target: :_blank %> (.csv or .tsv) and
               <%= link_to 'barcodes', 'https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices', target: :_blank %> (.tsv or .csv) files separately.</p>
             <p class="col-sm-12">** <%= link_to 'Gzipped', 'https://www.gnu.org/software/gzip/manual/gzip.html', target: :_blank %>  files of this type (e.g. .txt.gz) are accepted as well</p>


### PR DESCRIPTION
Fixing a broken link for sorting sparse matrices in the upload wizard, and bumping the version of `rack` to `2.2.3` re: [CVE-2020-8184](https://github.com/advisories/GHSA-j6w9-fv6q-3q52).

This PR satisfies SCP-2542 and CVE-2020-8184.