### PR TITLE
Track authentication state for users (SCP-2502)

### DIFF
--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -192,6 +192,9 @@ export function log(name, props={}) {
     // User is unauthenticated / unregistered / anonynmous
     props['distinct_id'] = userId
     delete init['headers']['Authorization']
+    props['authenticated'] = false
+  } else {
+    props['authenticated'] = true
   }
 
   const body = {

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -7,6 +7,8 @@
 
 import { accessToken } from 'providers/UserProvider'
 
+let metricsApiMock = false
+
 const defaultInit = {
   method: 'POST',
   headers: {
@@ -30,6 +32,18 @@ if ('SCP' in window) {
   bardDomain = bardDomainsByEnv[env]
   // To consider: Replace SCP-specific userId with DSP-wide userId
   userId = window.SCP.userId
+}
+
+/**
+ * Sets flag on whether to use mock data for Metrics API responses.
+ *
+ * This method is useful for tests and certain development scenarios,
+ * e.g. when evolving a new API or to work around occasional API blockers.
+ *
+ * @param {Boolean} flag Whether to use mock data for all API responses
+ */
+export function setMetricsApiMockFlag(flag) {
+  metricsApiMock = flag
 }
 
 /**
@@ -206,7 +220,8 @@ export function log(name, props={}) {
 
   init = Object.assign(init, body)
 
-  if ('SCP' in window) { // Skips fetch during test
+  if ('SCP' in window || metricsApiMock) {
+    // Skips fetch during test, unless explicitly testing Metrics API
     fetch(`${bardDomain}/api/event`, init)
   }
 }

--- a/test/js/metrics-api.test.js
+++ b/test/js/metrics-api.test.js
@@ -1,0 +1,104 @@
+// Without disabling eslint code, Promises are auto inserted
+/* eslint-disable*/
+
+const fetch = require('node-fetch')
+
+import {logClick, setMetricsApiMockFlag} from 'lib/metrics-api'
+import * as UserProvider from 'providers/UserProvider'
+
+describe('Library for client-side usage analytics', () => {
+  beforeAll(() => {
+    global.fetch = fetch
+    setMetricsApiMockFlag(true)
+  })
+  // Note: tests that mock global.fetch must be cleared after every test
+  afterEach(() => {
+    // Restores all mocks back to their original value
+    jest.restoreAllMocks()
+  })
+
+  it('includes `authenticated: true` when signed in', done => {
+    // Spy on `fetch()` and its contingent methods like `json()`,
+    // because we want to intercept the outgoing request
+    const mockSuccessResponse = {}
+    const mockJsonPromise = Promise.resolve(mockSuccessResponse)
+    const mockFetchPromise = Promise.resolve({
+      json: () => {
+        mockJsonPromise
+      }
+    })
+    jest.spyOn(global, 'fetch').mockImplementation(() => {
+      mockFetchPromise
+    })
+
+    // Mock the user context, to mimic auth'd state
+    const userContext = { accessToken: 'test' }
+    jest.spyOn(UserProvider, 'useContextUser')
+      .mockImplementation(() => {
+        return userContext
+      })
+
+    const event = {
+      target: {
+        localName: 'a',
+        text: 'Text that is linked'
+      }
+    }
+    logClick(event)
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.anything(), // URL
+      expect.objectContaining({
+        body: expect.stringContaining(
+          '\"authenticated\":true'
+        )
+      })
+    )
+    process.nextTick(() => {
+      done()
+    })
+  })
+
+  it('includes `authenticated: false` when not signed in', done => {
+    // Spy on `fetch()` and its contingent methods like `json()`,
+    // because we want to intercept the outgoing request
+    const mockSuccessResponse = {}
+    const mockJsonPromise = Promise.resolve(mockSuccessResponse)
+    const mockFetchPromise = Promise.resolve({
+      json: () => {
+        mockJsonPromise
+      }
+    })
+    jest.spyOn(global, 'fetch').mockImplementation(() => {
+      mockFetchPromise
+    })
+
+    // Mock the user context, to mimic unauth'd state
+    const userContext = { accessToken: '' }
+    jest.spyOn(UserProvider, 'useContextUser')
+      .mockImplementation(() => {
+        return userContext
+      })
+
+    const event = {
+      target: {
+        localName: 'a',
+        text: 'Text that is linked'
+      }
+    }
+    logClick(event)
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.anything(), // URL
+      expect.objectContaining({
+        body: expect.stringContaining(
+          '\"authenticated\":true'
+        )
+      })
+    )
+    process.nextTick(() => {
+      done()
+    })
+  })
+
+})

--- a/test/js/metrics-api.test.js
+++ b/test/js/metrics-api.test.js
@@ -58,47 +58,4 @@ describe('Library for client-side usage analytics', () => {
       done()
     })
   })
-
-  it('includes `authenticated: false` when not signed in', done => {
-    // Spy on `fetch()` and its contingent methods like `json()`,
-    // because we want to intercept the outgoing request
-    const mockSuccessResponse = {}
-    const mockJsonPromise = Promise.resolve(mockSuccessResponse)
-    const mockFetchPromise = Promise.resolve({
-      json: () => {
-        mockJsonPromise
-      }
-    })
-    jest.spyOn(global, 'fetch').mockImplementation(() => {
-      mockFetchPromise
-    })
-
-    // Mock the user context, to mimic unauth'd state
-    const userContext = { accessToken: '' }
-    jest.spyOn(UserProvider, 'useContextUser')
-      .mockImplementation(() => {
-        return userContext
-      })
-
-    const event = {
-      target: {
-        localName: 'a',
-        text: 'Text that is linked'
-      }
-    }
-    logClick(event)
-
-    expect(global.fetch).toHaveBeenCalledWith(
-      expect.anything(), // URL
-      expect.objectContaining({
-        body: expect.stringContaining(
-          '\"authenticated\":true'
-        )
-      })
-    )
-    process.nextTick(() => {
-      done()
-    })
-  })
-
 })


### PR DESCRIPTION
This adding a Mixpanel property to track whether the user has signed in or not.  It also introduces automated tests for the SCP's Metrics API library.

Now we can answer questions like "How many of the users who visited COVID-19 featured studies are authenticated?"

This satisfies SCP-2502.  See there for screenshots and a link answering the above question.