### PR TITLE
Allowing for filenames with spaces in upload wizard (SCP-1953)

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -445,8 +445,9 @@ class StudiesController < ApplicationController
   # method to perform chunked uploading of data
   def do_upload
     upload = get_upload
-    # remove spaces from filename since this converted client-side, but original_filename is unchanged in headers
-    filename = upload.original_filename.gsub(/\s/, '_')
+    # remove spaces and + (encoded whitespace character) from filename since this converted client-side,
+    # but original_filename is unchanged in headers
+    filename = upload.original_filename.gsub(/[\s\+]/, '_')
     study_file = @study.study_files.detect {|sf| sf.upload_file_name == filename}
     # If no file has been uploaded or the uploaded file has a different filename,
     # do a new upload from scratch

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -445,7 +445,8 @@ class StudiesController < ApplicationController
   # method to perform chunked uploading of data
   def do_upload
     upload = get_upload
-    filename = upload.original_filename
+    # remove spaces from filename since this converted client-side, but original_filename is unchanged in headers
+    filename = upload.original_filename.gsub(/\s/, '_')
     study_file = @study.study_files.detect {|sf| sf.upload_file_name == filename}
     # If no file has been uploaded or the uploaded file has a different filename,
     # do a new upload from scratch

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -2,6 +2,19 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path("../../config/environment", __FILE__)
 require "rails/test_help"
 
+# upload a large file (i.e. > 10MB) from the test_data directory to a study
+# simulates chunked upload by streaming file in 10MB chunks and then uploading in series
+def perform_chunked_study_file_upload(filename, study_file_params, study_id)
+  source_file = File.open(Rails.root.join('test', 'test_data', filename))
+  upload_response = nil
+  while chunk = source_file.read(10.megabytes)
+    file_upload = Rack::Test::UploadedFile.new(StringIO.new(chunk), original_filename: filename) # mock original_filename header
+    study_file_params[:study_file].merge!(upload: file_upload)
+    upload_response = patch "/single_cell/studies/#{study_id}/upload", params: study_file_params, headers: {'Content-Type' => 'multipart/form-data'}
+  end
+  upload_response
+end
+
 # upload a file from the test_data directory to a study
 def perform_study_file_upload(filename, study_file_params, study_id)
   file_upload = Rack::Test::UploadedFile.new(Rails.root.join('test', 'test_data', filename))


### PR DESCRIPTION
This bug fix allows for user-uploaded files to have spaces in their names (this is converted to `_` server-side to avoid path issues).  Previously, if a file was larger that 10MB and contained a space in the name, the upload process would incorrectly view each chunk as a new file due to the mismatch in updated and original filenames, which then throws a `422 Unprocessable Entity` error due to "duplicate" filenames.

In addition, this update also adds an integration test for chunked uploading as well as spaces in filenames.

This PR satisfies SCP-1953.