### PR TITLE
refining facet display, sort order (needed for SCP-2556)

### DIFF
--- a/app/javascript/components/search/controls/FiltersBoxSearchable.js
+++ b/app/javascript/components/search/controls/FiltersBoxSearchable.js
@@ -14,7 +14,7 @@ import FiltersSearchBar from './FiltersSearchBar'
  */
 export default function FiltersBoxSearchable({ facet, selection, setSelection, show, setShow, hideControls }) {
   // State that is specific to FiltersBox
-  const [matchingFilters, setMatchingFilters] = useState(facet.filters.slice(0, 15))
+  const [matchingFilters, setMatchingFilters] = useState(facet.filters)
   const [hasFilterSearchResults, setHasFilterSearchResults] = useState(false)
 
   /*
@@ -56,7 +56,7 @@ export default function FiltersBoxSearchable({ facet, selection, setSelection, s
    * Summarize filters, either default or
    */
   function getFiltersSummary() {
-    let filtersSummary = 'Top Filters'
+    let filtersSummary = 'Available Filters'
 
     if (hasFilterSearchResults) {
       const numMatches = matchingFilters.length

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -145,7 +145,7 @@ nav.search-links, #search-panel {
   }
 
   ul.facet-filter-list {
-    max-height: 400px;
+    max-height: 300px;
     overflow-y: auto;
     label {
       display: inline-block;

--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -359,13 +359,13 @@ class SearchFacet
     "SELECT DISTINCT id, name FROM(SELECT id_col AS id, name_col as name " + \
     "FROM #{CellMetadatum::BIGQUERY_TABLE}, UNNEST(#{self.big_query_id_column}) AS id_col WITH OFFSET id_pos, " + \
     "UNNEST(#{self.big_query_name_column}) as name_col WITH OFFSET name_pos WHERE id_pos = name_pos) WHERE id IS NOT NULL " + \
-    "ORDER BY name"
+    "ORDER BY LOWER(name)"
   end
 
   # generate query string to retrieve distinct values for non-array based facets
   def generate_non_array_query
     "SELECT DISTINCT #{self.big_query_id_column} AS id, #{self.big_query_name_column} AS name FROM #{CellMetadatum::BIGQUERY_TABLE} " + \
-    "WHERE #{self.big_query_id_column} IS NOT NULL ORDER BY #{self.big_query_name_column}"
+    "WHERE #{self.big_query_id_column} IS NOT NULL ORDER BY LOWER(#{self.big_query_name_column})"
   end
 
   # generate a minmax query string to set bounds for numeric facets

--- a/test/js/search/facet-control.test.js
+++ b/test/js/search/facet-control.test.js
@@ -114,7 +114,7 @@ describe('Facet control handles facets with many filters', () => {
 
     wrapper.find('#facet-species > a').simulate('click')
     // by default, only show the first 15 filters
-    expect(speciesControl().find('.facet-filter-list li').length).toEqual(15)
+    expect(speciesControl().find('.facet-filter-list li').length).toEqual(22)
 
     speciesControl().find('input#speciesId2').simulate('change', {target: {checked: true}})
     expect(speciesControl().find('button.facet-apply-button').hasClass('active')).toEqual(true)


### PR DESCRIPTION
Shows all facets initially to allow browsing (since max # of filters for a facet in prod is currently 15).  changes label "Top filters" to "Available Filters" since we don't have popular filter tech. yet.  Also reduces the height of the filter display so the apply is easier to find.

![image](https://user-images.githubusercontent.com/2800795/85887630-26bbe380-b7b6-11ea-9832-e4a10131f049.png)
