### PR TITLE
Check billing-project ownership when attempting to sync study (SCP-2507)

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -3229,8 +3229,11 @@ class Study
           end
           # check permissions
           if acl['acl'][study_owner].nil? || acl['acl'][study_owner]['accessLevel'] == 'READER'
-            errors.add(:firecloud_workspace, ': You do not have write permission for the workspace you provided.  Please use another workspace.')
-            return false
+            # check if user has project-level permission as an 'Owner' before failing validation
+            unless self.user.is_billing_project_owner?(self.firecloud_project)
+              errors.add(:firecloud_workspace, ': You do not have write permission for the workspace you provided.  Please use another workspace.')
+              return false
+            end
           end
           # check compute permissions
           if acl['acl'][study_owner]['canCompute'] != can_compute

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -794,10 +794,7 @@ class Study
           workspace_acl = Study.firecloud_client.get_workspace_acl(self.firecloud_project, self.firecloud_workspace)
           if workspace_acl['acl'][user.email].nil?
             # check if user has project-level permissions
-            user_client = FireCloudClient.new(user, self.firecloud_project)
-            projects = user_client.get_billing_projects
-            # billing project users can only create workspaces, so unless user is an owner, user cannot compute
-            projects.detect {|project| project['projectName'] == self.firecloud_project && project['role'] == 'Owner'}.present?
+            user.is_billing_project_owner?(self.firecloud_project)
           else
             workspace_acl['acl'][user.email]['canCompute']
           end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -305,6 +305,7 @@ class User
         end
       end
     end
+    Rails.logger.info "projects: #{projects}"
     projects
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -293,6 +293,26 @@ class User
     end
   end
 
+  # retrieve billing projects for a given user (if registered for firecloud)
+  def get_billing_projects
+    projects = {User: [], Owner: []}
+    if self.registered_for_firecloud
+      client = FireCloudClient.new(self, FireCloudClient::PORTAL_NAMESPACE)
+      user_projects = client.get_billing_projects
+      user_projects.each do |project|
+        if project['creationStatus'] == 'Ready'
+          projects[project['role'].to_sym] << project['projectName']
+        end
+      end
+    end
+    projects
+  end
+
+  # return true/false if user is an owner of a given billing project
+  def is_billing_project_owner?(billing_project)
+    self.get_billing_projects[:Owner].include?(billing_project)
+  end
+
   def add_to_portal_user_group
     user_group_config = AdminConfiguration.find_by(config_type: 'Portal FireCloud User Group')
     if user_group_config.present?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,6 +3,12 @@ require "test_helper"
 class UserTest < ActiveSupport::TestCase
   def setup
     @user = User.first
+
+    @billing_projects = [
+        {'creationStatus'=>'Ready', 'projectName'=>'lab-billing-project', 'role'=>'User'},
+        {'creationStatus'=>'Ready', 'projectName'=>'my-billing-project', 'role'=>'Owner'},
+        {'creationStatus'=>'Ready', 'projectName'=>'my-other-billing-project', 'role'=>'Owner'}
+    ]
   end
 
   test 'should time out token after inactivity' do
@@ -22,6 +28,34 @@ class UserTest < ActiveSupport::TestCase
            "API access token should have timed out, #{invalid_access} is outside #{User.timeout_in} seconds of #{now}"
     # clean up
     @user.update_last_access_at!
+
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
+  end
+
+  test 'should check billing project ownership' do
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
+
+    # assert user is 'Owner', using mock as we have no actual user in Terra or OAuth token to make API call
+    mock = Minitest::Mock.new
+    mock.expect :get_billing_projects, @billing_projects
+
+    FireCloudClient.stub :new, mock do
+      project = 'my-billing-project'
+      is_owner = @user.is_billing_project_owner?(project)
+      mock.verify
+      assert is_owner, "Did not correctly return true for ownership of #{project}: #{@billing_projects}"
+    end
+
+    # refute user is 'Owner'
+    negative_mock = Minitest::Mock.new
+    negative_mock.expect :get_billing_projects, @billing_projects
+
+    FireCloudClient.stub :new, negative_mock do
+      project = 'lab-billing-project'
+      is_owner = @user.is_billing_project_owner?(project)
+      negative_mock.verify
+      refute is_owner, "Did not correctly return false for ownership of #{project}: #{@billing_projects}"
+    end
 
     puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end


### PR DESCRIPTION
A user trying to create a study using an existing workspace in a Terra billing project that they own currently where they do not have a direct workspace-level ACL encounters an error saying that they do not have permission to access the requested workspace, when in fact they do.  This is because project-level permissions no longer appear in the workspace ACL object.  This update now adds a fallback to check project level ownership for the requesting user.  It it worth noting that the portal has been doing this check for compute permissions since the change was made in the orchestration API, but missed the corner case in study creation.  This update now enforces that permission check uniformly.

This PR satisfies SCP-2507.