### PR TITLE
hiding hidden files from sync UI (SCP-2485)

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -26,7 +26,7 @@ class StudiesController < ApplicationController
   before_action :check_firecloud_status, except: [:index, :do_upload, :resume_upload, :update_status,
                                                   :retrieve_wizard_upload, :parse]
   before_action :check_study_detached, only: [:edit, :update, :initialize_study, :sync_study, :sync_submission_outputs]
-
+  helper_method :visible_unsynced_files, :hidden_unsynced_files
   ###
   #
   # STUDY OBJECT METHODS
@@ -1484,4 +1484,15 @@ class StudiesController < ApplicationController
       @unsynced_files << unsynced_output
     end
   end
+
+  # match filenames that start with a . or have a /. in their path
+  HIDDEN_FILE_REGEX = /\/\.|^\./
+  def visible_unsynced_files
+    @unsynced_files.select { |f| HIDDEN_FILE_REGEX.match(f.upload_file_name).nil? }
+  end
+
+  def hidden_unsynced_files
+    @unsynced_files.select { |f| HIDDEN_FILE_REGEX.match(f.upload_file_name).present? }
+  end
+
 end

--- a/app/views/studies/sync_study.html.erb
+++ b/app/views/studies/sync_study.html.erb
@@ -50,8 +50,11 @@
         <div class="panel-body">
           <p class="help-block">These are files that are possibly new and are ready to sync with your study.</p>
           <div id="unsynced-study-files-forms" class="unsynced-content">
-            <% @unsynced_files.each do |study_file| %>
+            <% visible_unsynced_files.each do |study_file| %>
               <%= render partial: 'study_file_form', locals: {study_file: study_file} %>
+            <% end %>
+            <% if hidden_unsynced_files.any?  %>
+               <i><%= hidden_unsynced_files.count %> hidden files not shown (files with a leading '.' are ignored)</i>
             <% end %>
           </div>
         </div>

--- a/test/api/studies_controller_test.rb
+++ b/test/api/studies_controller_test.rb
@@ -130,4 +130,13 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
     assert_response 204, "Did not successfully delete sync study, expected response of 204 but found #{@response.response_code}"
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
+
+  test 'hidden files are identified by regex' do
+    assert StudiesController::HIDDEN_FILE_REGEX.match('.foo').present?
+    assert StudiesController::HIDDEN_FILE_REGEX.match('/whatever/.foo').present?
+    assert StudiesController::HIDDEN_FILE_REGEX.match('/.config/config').present?
+
+    assert StudiesController::HIDDEN_FILE_REGEX.match('/whatever/metadata.txt').nil?
+    assert StudiesController::HIDDEN_FILE_REGEX.match('metadata.txt').nil?
+  end
 end


### PR DESCRIPTION
Excludes files with a leading '.' from the sync UI, with a note displayed

![image](https://user-images.githubusercontent.com/2800795/86420675-5b8fd500-bca5-11ea-828c-7742175fc044.png)
