### PR TITLE
In igv.js, show BAMs that use accessions instead of chromosome names (SCP-2548)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
     "ideogram": "1.19.0",
-    "@single-cell-portal/igv": "2.5.6-beta.2",
+    "@single-cell-portal/igv": "2.6.4-beta.1",
     "jquery": "3.5.1",
     "jquery-ui": "1.12.1",
     "morpheus-app": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,10 +1574,10 @@
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
   integrity sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==
 
-"@single-cell-portal/igv@2.5.6-beta.2":
-  version "2.5.6-beta.2"
-  resolved "https://registry.yarnpkg.com/@single-cell-portal/igv/-/igv-2.5.6-beta.2.tgz#0e9bf685ff0e7efcb0a708027b0a34021e2defbb"
-  integrity sha512-azNNZeF9ujGfmSEk48IjYRAqkcQH9EN/c7BaGZxJ7TmVfb4rZpQyuHyzTPi/aB1ElzClgbVU1QXnmSEVxuhRRw==
+"@single-cell-portal/igv@2.6.4-beta.1":
+  version "2.6.4-beta.1"
+  resolved "https://registry.yarnpkg.com/@single-cell-portal/igv/-/igv-2.6.4-beta.1.tgz#1e79523b615c79599a8a96eb4f3f7f14e5f84ce7"
+  integrity sha512-BMpHsdLX7XNpt8CD45vEseUSWt4AvrQJSSlgglrqCljqjzfvM2pBt7HlJGjmL5MPQdeFSayAWPmKz0ddLEY0tg==
 
 "@sinonjs/commons@^1.7.0":
   version "1.7.2"


### PR DESCRIPTION
This enhances the igv.js embed in Single Cell Portal (and everywhere else) by supporting more diverse BAMs.  It satisfies SCP collaborator needs to visualize novel BAMs for _Macaca fascicularis_, extending support from #626 and #646.

Previously, igv.js required BAMS to refer to chromosomes the same way as the reference genome's FASTA index does.  In this case the index of the FASTA reference from Ensembl (ftp://ftp.ensembl.org/pub/release-100/fasta/macaca_fascicularis/dna/) uses e.g. "1" for chromosome name, and the collaborator's BAMs use [accession.version](https://www.ncbi.nlm.nih.gov/Sitemap/sequenceIDs.html) identifiers like "[NC_022272.1](https://www.ncbi.nlm.nih.gov/nuccore/540352258)" for the same chromosome on the same Macaca_fascicularis_5.0 reference genome assembly (albeit sourced from NCBI RefSeq, it seems).  So the BAM failed to display.

Now, igv.js maps chromosomes from the BAM to the FASTA index _using chromosome length_, when such name mismatches occur.  Chromosome (formally, top-level sequence) lengths are unique within each genome, and thus provide a fallback identifier.  The fix has been included in Broad's igv.js fork ([diff](https://github.com/broadinstitute/igv.js/commit/3a31c21f518cb85f7cd114f95a31297c11ffaf52)). Desktop IGV uses a similar technique to support this edge case.  The problematic BAMs now display in SCP.

This PR satisfies SCP-2548.