### PR TITLE
Log text and label of more interactions to Mixpanel (SCP-2563)

### DIFF
--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -98,7 +98,7 @@ function logClickButton(target) {
  *
  * From https://stackoverflow.com/a/15061155
  */
-function getLabelsForInputElement(element) {
+function getLabelsForElement(element) {
   let labels
   const id = element.id
 
@@ -123,7 +123,7 @@ function getLabelsForInputElement(element) {
  * Log click on input by type, e.g. text, number, checkbox
  */
 function logClickInput(target) {
-  const domLabels = getLabelsForInputElement(target)
+  const domLabels = getLabelsForElement(target)
 
   // User-facing label
   const label = domLabels.length > 0 ? domLabels[0].innerText : ''
@@ -150,6 +150,20 @@ function logClickOther(target) { // eslint-disable-line no-unused-vars
 
   // Google Analytics fallback: remove once Bard and Mixpanel are ready for SCP
   ga('send', 'event', 'click', 'other') // eslint-disable-line no-undef
+}
+
+/** Log text of selected option when dropdown menu (i.e., select) changes */
+export function logMenuChange(event) {
+  // Get user-facing label
+  const domLabels = getLabelsForElement(event.originalEvent.target)
+  const label = domLabels.length > 0 ? domLabels[0].innerText : ''
+
+  // Get newly-selected option
+  const options = event.originalEvent.target.options
+  const text = options[options.selectedIndex].text
+
+  const props = { label, text }
+  log('change:menu', props)
 }
 
 /**

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -129,6 +129,11 @@ function logClickInput(target) {
   const label = domLabels.length > 0 ? domLabels[0].innerText : ''
 
   const props = { label }
+
+  if (target.type === 'submit') {
+    props.text = target.value
+  }
+
   const element = `input-${target.type}`
   log(`click:${element}`, props)
 

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -99,6 +99,8 @@ function logClickButton(target) {
  * From https://stackoverflow.com/a/15061155
  */
 function getLabelsForElement(element) {
+  if (metricsApiMock === true) return [] // Needed for metrics-api.test.js
+
   let labels
   const id = element.id
 
@@ -155,11 +157,11 @@ function logClickOther(target) { // eslint-disable-line no-unused-vars
 /** Log text of selected option when dropdown menu (i.e., select) changes */
 export function logMenuChange(event) {
   // Get user-facing label
-  const domLabels = getLabelsForElement(event.originalEvent.target)
+  const domLabels = getLabelsForElement(event.target)
   const label = domLabels.length > 0 ? domLabels[0].innerText : ''
 
   // Get newly-selected option
-  const options = event.originalEvent.target.options
+  const options = event.target.options
   const text = options[options.selectedIndex].text
 
   const props = { label, text }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -30,7 +30,7 @@ import ClassicEditor from '@ckeditor/ckeditor5-build-classic'
 // Below import resolves to '/app/javascript/components/HomePageContent.js'
 import HomePageContent from 'components/HomePageContent'
 import Covid19PageContent from 'components/covid19/Covid19PageContent'
-import { logPageView, logClick, log } from 'lib/metrics-api'
+import { logPageView, logClick, logMenuChange, log } from 'lib/metrics-api'
 import createTracesAndLayout from 'lib/kernel-functions'
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -39,6 +39,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   $(document).on('click', 'body', event => {
     logClick(event)
+  })
+
+  $(document).on('change', 'select', event => {
+    logMenuChange(event)
   })
 
   if (document.getElementById('home-page-content')) {

--- a/test/js/metrics-api.test.js
+++ b/test/js/metrics-api.test.js
@@ -80,10 +80,6 @@ describe('Library for client-side usage analytics', () => {
         return userContext
       })
 
-  // // Get newly-selected option
-  // const options = event.target.options
-  // const text = options[options.selectedIndex].text
-
     const event = {
       target: {
         options: {

--- a/test/js/metrics-api.test.js
+++ b/test/js/metrics-api.test.js
@@ -3,7 +3,7 @@
 
 const fetch = require('node-fetch')
 
-import {logClick, setMetricsApiMockFlag} from 'lib/metrics-api'
+import {logClick, logMenuChange, setMetricsApiMockFlag} from 'lib/metrics-api'
 import * as UserProvider from 'providers/UserProvider'
 
 describe('Library for client-side usage analytics', () => {
@@ -51,6 +51,55 @@ describe('Library for client-side usage analytics', () => {
       expect.objectContaining({
         body: expect.stringContaining(
           '\"authenticated\":true'
+        )
+      })
+    )
+    process.nextTick(() => {
+      done()
+    })
+  })
+
+  it('logs text of selected option on changing in menu', done => {
+    // Spy on `fetch()` and its contingent methods like `json()`,
+    // because we want to intercept the outgoing request
+    const mockSuccessResponse = {}
+    const mockJsonPromise = Promise.resolve(mockSuccessResponse)
+    const mockFetchPromise = Promise.resolve({
+      json: () => {
+        mockJsonPromise
+      }
+    })
+    jest.spyOn(global, 'fetch').mockImplementation(() => {
+      mockFetchPromise
+    })
+
+    // Mock the user context, to mimic auth'd state
+    const userContext = { accessToken: 'test' }
+    jest.spyOn(UserProvider, 'useContextUser')
+      .mockImplementation(() => {
+        return userContext
+      })
+
+  // // Get newly-selected option
+  // const options = event.target.options
+  // const text = options[options.selectedIndex].text
+
+    const event = {
+      target: {
+        options: {
+          0: {text: 'Yes'},
+          1: {text: 'No'},
+          selectedIndex: 1
+        }
+      }
+    }
+    logMenuChange(event)
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.anything(), // URL
+      expect.objectContaining({
+        body: expect.stringContaining(
+          '\"text\":\"No\"'
         )
       })
     )


### PR DESCRIPTION
This enhances Mixpanel analytics by logging more data on user interactions, specifically:

* Text of element when clicks a submit input -- like "Create Study" in the New Study page (https://singlecell.broadinstitute.org/single_cell/studies/new)
* Text of selected option and the menu label when user changes a menu -- e.g. in the New Study page, when a user changes the menu (`select` element) labeled "Use an existing workspace?" from the default option "Yes" to "No".

It will help answer product usage questions, improving input for UX design and other product and technical decisions.

This satisfies SCP-2563.