### PR TITLE
Log branding group to Mixpanel (SCP-2568)

### DIFF
--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -6,6 +6,7 @@
  */
 
 import { accessToken } from 'providers/UserProvider'
+import { getBrandingGroup } from 'lib/scp-api'
 
 let metricsApiMock = false
 
@@ -198,6 +199,10 @@ export function log(name, props={}) {
   if ('SCP' in window && 'featuredSpace' in window.SCP) {
     // For e.g. COVID-19 featured space
     props['featuredSpace'] = window.SCP.featuredSpace
+  }
+
+  if ('SCP' in window && window.location.search.includes('scpbr=')) {
+    props['brand'] = getBrandingGroup()
   }
 
   let init = Object.assign({}, defaultInit)

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -203,6 +203,8 @@ export function log(name, props={}) {
 
   if ('SCP' in window && window.location.search.includes('scpbr=')) {
     props['brand'] = getBrandingGroup()
+  } else {
+    props['brand'] = ''
   }
 
   let init = Object.assign({}, defaultInit)

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -201,11 +201,8 @@ export function log(name, props={}) {
     props['featuredSpace'] = window.SCP.featuredSpace
   }
 
-  if ('SCP' in window && window.location.search.includes('scpbr=')) {
-    props['brand'] = getBrandingGroup()
-  } else {
-    props['brand'] = ''
-  }
+  const brandingGroup = getBrandingGroup()
+  props['brand'] = brandingGroup ? brandingGroup : ''
 
   let init = Object.assign({}, defaultInit)
 

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -333,7 +333,7 @@ export function buildFacetsFromQueryString(facetsParamString) {
 }
 
 /** returns the current branding group as specified by the url  */
-function getBrandingGroup(path) {
+export function getBrandingGroup() {
   const queryParams = queryString.parse(window.location.search)
   return queryParams.scpbr
 }


### PR DESCRIPTION
This logs the SCP branding group for all events to Mixpanel, by introducing the `brand` event property.  It will enable analysts to compare user behavior between default SCP and branded spaces / branding groups, like the Alexandria Project.

This satisfies SCP-2568.