### PR TITLE
Changing SingleCellMailer.users_email behavior (SCP-2586)

### DIFF
--- a/app/controllers/admin_configurations_controller.rb
+++ b/app/controllers/admin_configurations_controller.rb
@@ -345,8 +345,8 @@ class AdminConfigurationsController < ApplicationController
   def deliver_users_email
     begin
       # send in background so operation doesn't time out with lots of users
-      SingleCellMailer.delay.users_email(users_email_params, current_user)
-      @notice = 'Your email has successfully been delivered.'
+      SingleCellMailer.delay.batch_users_email(users_email_params, current_user)
+      @notice = 'Your email has successfully been queued for delivery and should arrive shortly.'
     rescue => e
       ErrorTracker.report_exception(e, current_user, users_email_params.to_unsafe_hash)
       logger.error "#{Time.zone.now}: Error delivering users email: #{e.message}"


### PR DESCRIPTION
The "All Users" email for admins was recently changed to deliver emails in batches of 500.  It was then discovered that blocks in ActionMailer methods that call `mail` only perform deliveries for the last entry in the block.  This update changes that behavior to iterate over a block in a separate method called `batch_users_email` that then calls the `users_email` method to deliver an email to a batch of 500 users.

This was tested manually in a local instance using a batch size of `2`, and it was confirmed that each email address in the total list of users received the test email.

This PR satisfies SCP-2586.