### PR TITLE
Refactoring feature flags functionality into FeatureFlaggable concern (SCP-2578)

### DIFF
--- a/app/models/branding_group.rb
+++ b/app/models/branding_group.rb
@@ -2,7 +2,7 @@ class BrandingGroup
   include Mongoid::Document
   include Mongoid::Timestamps
   include Mongoid::Paperclip
-  include Featureable
+  include FeatureFlaggable
 
   field :name, type: String
   field :name_as_id, type: String

--- a/app/models/branding_group.rb
+++ b/app/models/branding_group.rb
@@ -2,6 +2,7 @@ class BrandingGroup
   include Mongoid::Document
   include Mongoid::Timestamps
   include Mongoid::Paperclip
+  include Featureable
 
   field :name, type: String
   field :name_as_id, type: String
@@ -9,6 +10,7 @@ class BrandingGroup
   field :background_color, type: String
   field :font_family, type: String, default: 'Helvetica Neue, sans-serif'
   field :font_color, type: String, default: '#333333'
+  field :feature_flags, type: Hash, default: {}
 
   has_many :studies
   belongs_to :user

--- a/app/models/concerns/feature_flaggable.rb
+++ b/app/models/concerns/feature_flaggable.rb
@@ -1,9 +1,9 @@
 ##
-# Featurable: a module to add functionality for supporting "feature_flags" for a given model
-#             used to turn on/off special features in a sandboxed fashion
+# FeatureFlaggable: a module to add functionality for supporting "feature_flags" for a given model
+#                   used to turn on/off special features in a sandboxed fashion
 ##
 
-module Featureable
+module FeatureFlaggable
   extend ActiveSupport::Concern
 
   # merges the user flags with the defaults -- this should  always be used in place of feature_flags

--- a/app/models/concerns/featureable.rb
+++ b/app/models/concerns/featureable.rb
@@ -1,0 +1,33 @@
+##
+# Featurable: a module to add functionality for supporting "feature_flags" for a given model
+#             used to turn on/off special features in a sandboxed fashion
+##
+
+module Featureable
+  extend ActiveSupport::Concern
+
+  # merges the user flags with the defaults -- this should  always be used in place of feature_flags
+  # for determining whether to enable a feature for a given user.
+  def feature_flags_with_defaults
+    FeatureFlag.default_flag_hash.merge(self.feature_flags ? self.feature_flags : {}).with_indifferent_access
+  end
+
+  class_methods do
+    # gets the feature flag value for a given user, and the default value if no user is given
+    def feature_flag_for_instance(instance, flag_key)
+      if instance.present?
+        instance.feature_flags_with_defaults[flag_key]
+      else
+        FeatureFlag.find_by(name: flag_key)&.default_value
+      end
+    end
+
+    # returns feature_flags_with_defaults for the user, or the default flags if no user is given
+    def feature_flags_for_instance(instance)
+      if instance.nil?
+        return FeatureFlag.default_flag_hash
+      end
+      instance.feature_flags_with_defaults
+    end
+  end
+end

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -15,8 +15,8 @@ class FeatureFlag
   # return a hash of name => default for all flags
   def self.default_flag_hash
     FeatureFlag.all.inject({}) do |hash, flag|
-      hash[flag.name] = flag.default_value;
-      hash
+      hash[flag.name] = flag.default_value
+      hash.with_indifferent_access
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User
 
   include Mongoid::Document
   include Mongoid::Timestamps
-  include Featureable
+  include FeatureFlaggable
   extend ErrorTracker
 
   ###

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -325,29 +325,6 @@ class User
     end
   end
 
-  # # merges the user flags with the defaults -- this should  always be used in place of feature_flags
-  # # for determining whether to enable a feature for a given user.
-  # def feature_flags_with_defaults
-  #   FeatureFlag.default_flag_hash.merge(feature_flags ? feature_flags : {})
-  # end
-  #
-  # # gets the feature flag value for a given user, and the default value if no user is given
-  # def self.feature_flag_for_user(user, flag_key)
-  #   if user.present?
-  #     user.feature_flags_with_defaults[flag_key]
-  #   else
-  #     FeatureFlag.find_by(name: flag_key)&.default_value
-  #   end
-  # end
-  #
-  # # returns feature_flags_with_defaults for the user, or the default flags if no user is given
-  # def self.feature_flags_for_user(user)
-  #   if user.nil?
-  #     return FeatureFlag.default_flag_hash
-  #   end
-  #   user.feature_flags_with_defaults
-  # end
-
   # helper method to migrate study ownership & shares from old email to new email
   def self.migrate_studies_and_shares(existing_email, new_email)
     existing_user = self.find_by(email: existing_email)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User
 
   include Mongoid::Document
   include Mongoid::Timestamps
+  include Featureable
   extend ErrorTracker
 
   ###
@@ -100,7 +101,7 @@ class User
   # feature_flags should be a hash of true/false values.  If unspecified for a given flag, the
   # default_value from the FeatureFlag should be used.  Accordingly, the helper method feature_flags_with_defaults
   # is provided
-  field :feature_flags, default: {}
+  field :feature_flags, type: Hash, default: {}
 
   ###
   #
@@ -324,28 +325,28 @@ class User
     end
   end
 
-  # merges the user flags with the defaults -- this should  always be used in place of feature_flags
-  # for determining whether to enable a feature for a given user.
-  def feature_flags_with_defaults
-    FeatureFlag.default_flag_hash.merge(feature_flags ? feature_flags : {})
-  end
-
-  # gets the feature flag value for a given user, and the default value if no user is given
-  def self.feature_flag_for_user(user, flag_key)
-    if user.present?
-      user.feature_flags_with_defaults[flag_key]
-    else
-      FeatureFlag.find_by(name: flag_key)&.default_value
-    end
-  end
-
-  # returns feature_flags_with_defaults for the user, or the default flags if no user is given
-  def self.feature_flags_for_user(user)
-    if user.nil?
-      return FeatureFlag.default_flag_hash
-    end
-    user.feature_flags_with_defaults
-  end
+  # # merges the user flags with the defaults -- this should  always be used in place of feature_flags
+  # # for determining whether to enable a feature for a given user.
+  # def feature_flags_with_defaults
+  #   FeatureFlag.default_flag_hash.merge(feature_flags ? feature_flags : {})
+  # end
+  #
+  # # gets the feature flag value for a given user, and the default value if no user is given
+  # def self.feature_flag_for_user(user, flag_key)
+  #   if user.present?
+  #     user.feature_flags_with_defaults[flag_key]
+  #   else
+  #     FeatureFlag.find_by(name: flag_key)&.default_value
+  #   end
+  # end
+  #
+  # # returns feature_flags_with_defaults for the user, or the default flags if no user is given
+  # def self.feature_flags_for_user(user)
+  #   if user.nil?
+  #     return FeatureFlag.default_flag_hash
+  #   end
+  #   user.feature_flags_with_defaults
+  # end
 
   # helper method to migrate study ownership & shares from old email to new email
   def self.migrate_studies_and_shares(existing_email, new_email)

--- a/app/views/site/covid19.html.erb
+++ b/app/views/site/covid19.html.erb
@@ -60,7 +60,7 @@
     </div>
   </div>
 </div>
-<input type="hidden" id="feature-flags" value='<%= User.feature_flags_for_user(current_user).to_json %>'/>
+<input type="hidden" id="feature-flags" value='<%= User.feature_flags_for_instance(current_user).to_json %>'/>
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
     $(document).ready(function() {
       var main = $('.home-page-fix');

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -2,8 +2,8 @@
 <div class="container-fluid home-page-fix" id="wrap">
   <div class="row section-pad" id="main-body">
     <div class="col-md-12">
-      <% if User.feature_flag_for_user(current_user, "advanced_search") %>
-        <% if User.feature_flag_for_user(current_user, 'covid19_page') && @selected_branding_group.nil? %>
+      <% if User.feature_flag_for_instance(current_user, "advanced_search") %>
+        <% if User.feature_flag_for_instance(current_user, 'covid19_page') && @selected_branding_group.nil? %>
           <div class="home-nav" id="covid19-tab"
               style="float:right;
                      background: url(<%= image_url 'covid19-button.png' %>);
@@ -38,7 +38,7 @@
           <li role="presentation" class="home-nav" id="search-genes-nav">
             <a href="#search-genes" class="home-nav-tab" data-toggle="tab"><span class="fas fa-dna"></span> Search Genes</a>
           </li>
-          <% if User.feature_flag_for_user(current_user, 'covid19_page') && @selected_branding_group.nil? %>
+          <% if User.feature_flag_for_instance(current_user, 'covid19_page') && @selected_branding_group.nil? %>
             <li role="presentation" class="home-nav" id="covid19-tab"
                 style="float:right;
                        background: url(<%= image_url 'covid19-button.png' %>);
@@ -69,7 +69,7 @@
   </div>
 </div>
 <%# render feature flags to html so they can be found by react components #%>
-<input type="hidden" id="feature-flags" value='<%= User.feature_flags_for_user(current_user).to_json %>'/>
+<input type="hidden" id="feature-flags" value='<%= User.feature_flags_for_instance(current_user).to_json %>'/>
 
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
     $(window).scroll(bindScroll);
@@ -81,7 +81,7 @@
     var project = '<%= params[:scpbr] %>';
     var activeTab = 'search-studies';
     window.SCP = window.SCP ? window.SCP : {}
-    window.SCP.featureFlags = <%= User.feature_flags_for_user(current_user).to_json.gsub('"','') %>
+    window.SCP.featureFlags = <%= User.feature_flags_for_instance(current_user).to_json.gsub('"','') %>
     window.SCP.selectedBrandingGroup = '<%= @selected_branding_group %>'
 
     $('.home-nav-tab').on('shown.bs.tab', function(el) {

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -105,6 +105,7 @@ else
                     test/models/search_facet_test.rb
                     test/models/preset_search_test.rb
                     test/models/user_test.rb
+                    test/models/feature_flag_test.rb
                     test/models/admin_configuration_test.rb
                     test/integration/lib/search_facet_populator_test.rb
                     test/integration/lib/summary_stats_utils_test.rb

--- a/test/models/feature_flag_test.rb
+++ b/test/models/feature_flag_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class FeatureFlagTest < ActiveSupport::TestCase
+  def setup
+    @user = User.first
+    @branding_group = BrandingGroup.first
+    @feature_flag = FeatureFlag.find_or_create_by!(name: 'my_feature_flag')
+    @featurable_map = {
+        @user.class.name => @user,
+        @branding_group.class.name => @branding_group
+    }
+  end
+
+  test 'should implement feature flags for included classes' do
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
+
+    # use symbol instead of string to validate indifferent access
+    flag_name = :my_feature_flag
+
+    # test defaults
+    @featurable_map.each do |class_name, instance|
+      refute instance.feature_flags_with_defaults[flag_name],
+             "Did not return false for #{class_name} instance default flag on #{flag_name}"
+      refute class_name.constantize.feature_flag_for_instance(instance, flag_name),
+             "Did not return false for #{class_name} class default flag on #{flag_name}"
+    end
+
+    @feature_flag.update(default_value: true)
+    assert @feature_flag.default_value, "Did not update default value on #{@feature_flag.name} to true"
+
+    # assert changes are global to all included classes & instances
+    @featurable_map.each do |class_name, instance|
+      assert instance.feature_flags_with_defaults[flag_name],
+             "Did not return true for #{class_name} instance default flag on #{flag_name}"
+      assert class_name.constantize.feature_flag_for_instance(instance, flag_name),
+             "Did not return true for #{class_name} class default flag on #{flag_name}"
+    end
+
+    # assert locals override defaults
+    @featurable_map.each do |class_name, instance|
+      instance.feature_flags[flag_name] = false
+      instance.save
+      refute instance.feature_flags_with_defaults[flag_name],
+             "Did not return false for #{class_name} instance override flag on #{flag_name}"
+      refute class_name.constantize.feature_flag_for_instance(instance, flag_name),
+             "Did not return false for #{class_name} class override flag on #{flag_name}"
+    end
+
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
+  end
+end


### PR DESCRIPTION
Functionality relating to feature flags (formerly only associated with the `User` model) is now abstracted into a Rails concern that can be included into any persisted model, which standardizes the interface and reduces potentially duplicated code.  In addition, the `BrandingGroup` model now implements feature flags.

This PR satisfies SCP-2578.