### PR TITLE
Hotfix: Remove "starting on" note in deployment banner (SCP-2589)

### DIFF
--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -665,7 +665,6 @@ h6,
   display: inline-block;
 }
 .notification-banner {
-  height: 50px;
   padding: 5px;
   background: $warning-background-color;
   .fa-exclamation-triangle {

--- a/app/views/layouts/_deployment_notification_banner.erb
+++ b/app/views/layouts/_deployment_notification_banner.erb
@@ -3,9 +3,7 @@
     <span aria-hidden="true">&times;</span>
   </button>
   <div class="col-sm-3">
-    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-    <span>Service Alert: Starting on</span></br>
-    <span><%= @deployment_notification.deployment_time.strftime("%a %b %d, %Y %I:%M %p") %> ET</span>
+    <p><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Service Alert</p>
   </div>
   <div >
     <span class="align-middle"><%= @deployment_notification.message %></span>


### PR DESCRIPTION
Per UX recommendation, this removes the "Starting on" clause at left in the deployment banner, to reduce user confusion.

Before:
<img width="1676" alt="Service_alert_SCP_2020-07-15" src="https://user-images.githubusercontent.com/1334561/87599292-7dd01c80-c6c1-11ea-9f55-12ff09cc07e5.png">

After:
<img width="1680" alt="Service_alert_without_deployment_starting_on_time_SCP_2020-07-15" src="https://user-images.githubusercontent.com/1334561/87599789-ad7f2480-c6c1-11ea-834b-74a56e64f6e7.png">

This satisfies SCP-2589.