### PR TITLE
Adding visible to SearchFacet, facet_list to BrandingGroup (SCP-2575)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -10,7 +10,7 @@ module Api
       before_action :set_search_facet, only: :facet_filters
       before_action :set_search_facets_and_filters, only: :index
       before_action :set_preset_search, only: :index
-      before_action :set_branding_group, only: :index
+      before_action :set_branding_group, only: [:index, :facets]
 
       swagger_path '/search' do
         operation :get do
@@ -305,6 +305,13 @@ module Api
           key :summary, 'Get all available facets'
           key :description, 'Returns a list of all available search facets, including filter values'
           key :operationId, 'search_facets_path'
+          parameter do
+            key :name, :scpbr
+            key :in, :query
+            key :description, 'Requested branding group (to filter facets on)'
+            key :reqired, false
+            key :type, :string
+          end
           response 200 do
             key :description, 'Array of SearchFacets'
             schema do
@@ -323,7 +330,11 @@ module Api
       end
 
       def facets
-        @search_facets = SearchFacet.all
+        if @selected_branding_group.present?
+          @search_facets = @selected_branding_group.facets
+        else
+          @search_facets = SearchFacet.visible
+        end
       end
 
       swagger_path '/search/facet_filters' do

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -77,7 +77,13 @@ export async function fetchAuthCode(mock=false) {
  * @returns {Promise} Promise object containing camel-cased data from API
  */
 export async function fetchFacets(mock=false) {
-  const facets = await scpApi('/search/facets', defaultInit(), mock)
+  let path = '/search/facets'
+  const brandingGroup = getBrandingGroup()
+  if (brandingGroup) {
+    path = `${path}?scpbr=${brandingGroup}`
+  }
+
+  const facets = await scpApi(path, defaultInit(), mock)
 
   mapFiltersForLogging(facets, true)
 

--- a/app/models/branding_group.rb
+++ b/app/models/branding_group.rb
@@ -12,6 +12,9 @@ class BrandingGroup
   field :font_color, type: String, default: '#333333'
   field :feature_flags, type: Hash, default: {}
 
+  # list of facets to show for this branding group (will restrict to only provided identifiers, if present)
+  field :facet_list, type: Array, default: []
+
   has_many :studies
   belongs_to :user
 
@@ -54,6 +57,11 @@ class BrandingGroup
 
   before_validation :set_name_as_id
   before_destroy :remove_branding_association
+
+  # helper to return list of associated search facets
+  def facets
+    self.facet_list.any? ? SearchFacet.where(:identifier.in => self.facet_list) : SearchFacet.visible
+  end
 
   private
 

--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -25,6 +25,7 @@ class SearchFacet
   field :unit, type: String # unit represented by values in number-based facets
   field :min, type: Float # minimum allowed value for number-based facets
   field :max, type: Float # maximum allowed value for number-based facets
+  field :visible, type: Boolean, default: true # default visibility (false will not show in UI but can be queried via API)
 
   DATA_TYPES = %w(string number boolean)
   BQ_DATA_TYPES = %w(STRING FLOAT64 BOOL)
@@ -276,6 +277,11 @@ class SearchFacet
         Rails.logger.error "Update to #{facet.name} failed"
       end
     end
+  end
+
+  # return all "visible" facets
+  def self.visible
+    self.where(visible: true)
   end
 
   # helper to know if column is numeric

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -106,6 +106,7 @@ else
                     test/models/preset_search_test.rb
                     test/models/user_test.rb
                     test/models/feature_flag_test.rb
+                    test/models/branding_group_test.rb
                     test/models/admin_configuration_test.rb
                     test/integration/lib/search_facet_populator_test.rb
                     test/integration/lib/summary_stats_utils_test.rb

--- a/db/migrate/20200716191055_set_visible_on_search_facets.rb
+++ b/db/migrate/20200716191055_set_visible_on_search_facets.rb
@@ -1,0 +1,8 @@
+class SetVisibleOnSearchFacets < Mongoid::Migration
+  def self.up
+    SearchFacet.update_all(visible: true)
+  end
+
+  def self.down
+  end
+end

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -20,10 +20,41 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   test 'should get all search facets' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
 
-    facet_count = SearchFacet.count
+    facet_count = SearchFacet.visible.count
     execute_http_request(:get, api_v1_search_facets_path)
     assert_response :success
     assert json.size == facet_count, "Did not find correct number of search facets, expected #{facet_count} but found #{json.size}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should get visible search facets' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # make one random facet not visible
+    invisible_facet = SearchFacet.all.sample
+    invisible_facet.update(visible: false)
+    visible_count = SearchFacet.visible.count
+    execute_http_request(:get, api_v1_search_facets_path)
+    assert_response :success
+    assert json.size == visible_count, "Did not find correct number of visible search facets, expected #{visible_count} but found #{json.size}"
+    invisible_facet.update(visible: true)
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should get search facets for branding group' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    branding_group = BrandingGroup.first
+    facet_list = SearchFacet.pluck(:identifier).take(2).sort
+    branding_group.update(facet_list: facet_list)
+    execute_http_request(:get, api_v1_search_facets_path(scpbr: branding_group.name_as_id))
+    assert_response :success
+    response_facets = json.map {|entry| entry['id']}.sort
+    assert response_facets == facet_list,
+           "Did not find correct facets for #{branding_group.name_as_id}, expected #{facet_list} but found #{response_facets}"
+    branding_group.update(facet_list: [])
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -33,12 +33,15 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
     # make one random facet not visible
     invisible_facet = SearchFacet.all.sample
-    invisible_facet.update(visible: false)
+    invisible_facet.update!(visible: false)
     visible_count = SearchFacet.visible.count
     execute_http_request(:get, api_v1_search_facets_path)
     assert_response :success
-    assert json.size == visible_count, "Did not find correct number of visible search facets, expected #{visible_count} but found #{json.size}"
-    invisible_facet.update(visible: true)
+    assert json.size == visible_count,
+           "Did not find correct number of visible search facets, expected #{visible_count} but found #{json.size}"
+    assert visible_count == SearchFacet.count - 1,
+           "Did not return correct direct count of visible facets; #{visible_count} != #{SearchFacet.count - 1}"
+    invisible_facet.update!(visible: true)
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
@@ -48,13 +51,13 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
     branding_group = BrandingGroup.first
     facet_list = SearchFacet.pluck(:identifier).take(2).sort
-    branding_group.update(facet_list: facet_list)
+    branding_group.update!(facet_list: facet_list)
     execute_http_request(:get, api_v1_search_facets_path(scpbr: branding_group.name_as_id))
     assert_response :success
     response_facets = json.map {|entry| entry['id']}.sort
     assert response_facets == facet_list,
            "Did not find correct facets for #{branding_group.name_as_id}, expected #{facet_list} but found #{response_facets}"
-    branding_group.update(facet_list: [])
+    branding_group.update!(facet_list: [])
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/test/models/branding_group_test.rb
+++ b/test/models/branding_group_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class BrandingGroupTest < ActiveSupport::TestCase
+
+  def setup
+    @branding_group = BrandingGroup.first
+  end
+
+  test 'should return list of approved facets for branding groups' do
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
+
+    # test that default returns all visible facets
+    visible_facets = SearchFacet.visible.pluck(:identifier).sort
+    branding_group_facets = @branding_group.facets.pluck(:identifier).sort
+    assert_equal visible_facets, branding_group_facets,
+                 "Did not return all visible facets w/o facet list; #{visible_facets} != #{branding_group_facets}"
+
+    # test that facet_list returns correct facets
+    facet_list = visible_facets.take(2)
+    @branding_group.update(facet_list: facet_list)
+    branding_facet_list = @branding_group.facets.pluck(:identifier).sort
+    assert_equal facet_list, branding_facet_list,
+                 "Did not return filtered lists of facets; #{facet_list} != #{branding_facet_list}"
+
+    # clean up
+    @branding_group.update(facet_list: [])
+
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
+  end
+end


### PR DESCRIPTION
 Search facets now have a `visible` attribute that will govern their default visibility.  Facets with `visibility: false` can still be used for queries, but do not show up in the UI, or in API calls for available facets.  In addition, branding groups now have an attribute called `facet_list`, which is a whitelist of search facet identifiers that will control which facets are shown when viewing a branding group on the homepage.  The default behavior is now all "visible" facets will show if no `facet_list` has been configured.

This PR satisfies SCP-2575.