### PR TITLE
disabling common edit/update functions

### DIFF
--- a/app/controllers/api/v1/external_resources_controller.rb
+++ b/app/controllers/api/v1/external_resources_controller.rb
@@ -299,7 +299,7 @@ module Api
       end
 
       def check_study_permission
-        head 403 unless @study.can_edit?(current_api_user)
+        head 403 #unless @study.can_edit?(current_api_user)
       end
 
       # study file params whitelist

--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -961,19 +961,19 @@ module Api
       end
 
       def check_study_edit_permission
-        if !api_user_signed_in?
-          head 401
-        else
+        # if !api_user_signed_in?
+        #   head 401
+        # else
           head 403 unless @study.can_edit?(current_api_user)
-        end
+        # end
       end
 
       def check_study_compute_permission
-        if !api_user_signed_in?
-          head 401
-        else
+        # if !api_user_signed_in?
+        #   head 401
+        # else
           head 403 unless @study.can_compute?(current_api_user)
-        end
+        # end
       end
 
       def check_study_detached

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -134,6 +134,7 @@ module Api
 
       # POST /single_cell/api/v1/studies
       def create
+        raise NotImplmentedError
         @study = Study.new(study_params)
         @study.user = current_api_user # automatically set user from credentials
 
@@ -550,7 +551,7 @@ module Api
       end
 
       def check_study_permission
-        head 403 unless @study.can_edit?(current_api_user)
+        head 403 #unless @study.can_edit?(current_api_user)
       end
 
       # study params whitelist

--- a/app/controllers/api/v1/study_file_bundles_controller.rb
+++ b/app/controllers/api/v1/study_file_bundles_controller.rb
@@ -161,7 +161,7 @@ module Api
           extend SwaggerResponses::ValidationFailureResponse
         end
       end
-      
+
 
       # POST /single_cell/api/v1/studies/:study_id/study_file_bundles
       def create
@@ -248,7 +248,7 @@ module Api
       end
 
       def check_study_permission
-        head 403 unless @study.can_edit?(current_api_user)
+        head 403 # unless @study.can_edit?(current_api_user)
       end
 
       # study file params whitelist

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -617,7 +617,7 @@ module Api
       end
 
       def check_study_permission
-        head 403 unless @study.can_edit?(current_api_user)
+        head 403 #unless @study.can_edit?(current_api_user)
       end
 
       # study file params whitelist

--- a/app/controllers/api/v1/study_shares_controller.rb
+++ b/app/controllers/api/v1/study_shares_controller.rb
@@ -315,7 +315,7 @@ module Api
       end
 
       def check_study_permission
-        head 403 unless @study.can_edit?(current_api_user)
+        head 403 #unless @study.can_edit?(current_api_user)
       end
 
       # study file params whitelist

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1340,14 +1340,14 @@ class StudiesController < ApplicationController
   ###
 
   def check_edit_permissions
-    if !user_signed_in? || !@study.can_edit?(current_user)
+    #if !user_signed_in? || !@study.can_edit?(current_user)
       alert = 'You do not have permission to perform that action.'
       respond_to do |format|
         format.js {render js: "alert('#{alert}')" and return}
         format.html {redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
                                  alert: alert and return}
       end
-    end
+    #end
   end
 
   # check on FireCloud API status and respond accordingly

--- a/app/controllers/user_annotations_controller.rb
+++ b/app/controllers/user_annotations_controller.rb
@@ -198,9 +198,9 @@ class UserAnnotationsController < ApplicationController
     if @user_annotation.nil?
       @user_annotation = UserAnnotation.find(params[:id])
     end
-    if !@user_annotation.can_edit?(current_user)
+    # if !@user_annotation.can_edit?(current_user)
       redirect_to merge_default_redirect_params(user_annotations_path, scpbr: params[:scpbr]),
                   alert: "You don't have permission to perform that action"
-    end
+    # end
   end
 end


### PR DESCRIPTION
I've created a new branch 'old-production' that is built to track what is currently on the (soon-to-be) old production server.  This PR will merge in code that disables/hides most common editing operations. Then we can do a release to production from the old-production branch this afternoon immediately before the migration