### PR TITLE
Log performance and other Ingest Pipeline metrics from Rails to Mixpanel (SCP-2433, SCP-2553)

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -17,7 +17,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @user.delay.update_firecloud_status
       sign_in(@user)
       if TosAcceptance.accepted?(@user)
-        MetricsService.identify(@user)
+        MetricsService.merge_identities(@user)
         redirect_to request.env['omniauth.origin'] || site_path
       else
         redirect_to accept_tos_path(@user.id)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -6,55 +6,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   #
   ###
 
-
-
-  # Merges unauth’d and auth’d user identities in Mixpanel via Bard
-  #
-  # Bard is a DSP service that mediates writes to Mixpanel. To enable tracking
-  # users when they are signed in and not, Bard provides an endpoint
-  # `/api/identify` to merge identities.  In SCP's case, the anonynmous ID
-  # (`anonId`) is a random UUIDv4 string set as a cookie for all users --
-  # auth'd or not -- upon visiting SCP.
-
-  # This call links that anonId to the user's bearer token used by DSP's Sam
-  # service.  That bearer token is in turn linked to a deidentified
-  # "distinct ID" used to track users across auth states in Mixpanel.
-  def self.merge_identities(user, cookies)
-
-    # Skip merge_identities on production until Mixpanel is ready
-    if Rails.env == 'production'
-      return nil
-    end
-
-    Rails.logger.info "Merging user identity in Mixpanel via Bard"
-
-    bard_host_url = Rails.application.config.bard_host_url
-
-    bard_path = bard_host_url + '/api/identify'
-    headers = {
-      'Authorization' => "Bearer #{user.access_token['access_token']}",
-      'Content-Type': 'application/json'
-    }
-
-    post_body = {'anonId': cookies['user_id']}.to_json
-
-    params = {
-      method: 'POST',
-      url: bard_path,
-      headers: headers,
-      payload: post_body
-    }
-
-    begin
-      response = RestClient::Request.execute(params)
-    rescue RestClient::ExceptionWithResponse => e
-      Rails.logger.error "Bard error in call to #{bard_path}: #{e.message}"
-      # Rails.logger.error e.to_yaml
-      ErrorTracker.report_exception(e, user, params)
-    end
-
-  end
-
   def google_oauth2
     # You need to implement the method below in your model (e.g. app/models/user.rb)
     @user = User.from_omniauth(request.env["omniauth.auth"])
@@ -66,7 +17,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @user.delay.update_firecloud_status
       sign_in(@user)
       if TosAcceptance.accepted?(@user)
-        self.class.merge_identities(@user, cookies)
+        MetricsService.identify(@user, cookies)
         redirect_to request.env['omniauth.origin'] || site_path
       else
         redirect_to accept_tos_path(@user.id)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -17,7 +17,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @user.delay.update_firecloud_status
       sign_in(@user)
       if TosAcceptance.accepted?(@user)
-        MetricsService.identify(@user, cookies)
+        MetricsService.identify(@user)
         redirect_to request.env['omniauth.origin'] || site_path
       else
         redirect_to accept_tos_path(@user.id)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -17,7 +17,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @user.delay.update_firecloud_status
       sign_in(@user)
       if TosAcceptance.accepted?(@user)
-        MetricsService.merge_identities(@user)
+        MetricsService.merge_identities_in_mixpanel(@user)
         redirect_to request.env['omniauth.origin'] || site_path
       else
         redirect_to accept_tos_path(@user.id)

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -212,7 +212,6 @@ export function log(name, props={}) {
 
   props = Object.assign(props, {
     appId: 'single-cell-portal',
-    timestamp: Date.now(),
     appPath,
     env
   })

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -77,13 +77,10 @@ class MetricsService
       env: Rails.env
     })
 
-    puts 'user'
-    puts user
-
-    access_token = user.access_token['access_token'] || ''
-    user_id = user.id
-
     headers = get_default_headers(user)
+
+    access_token = user.access_token['access_token']
+    user_id = user.id
 
     if access_token === ''
       # User is unauthenticated / unregistered / anonynmous

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -22,7 +22,7 @@ class MetricsService
       # Uncomment line below to get known-good test data
       # puts "Posting to Mixpanel.  Params: #{params}"
       RestClient::Request.execute(params)
-    rescue RestClient::ExceptionWithResponse => e
+    rescue RestClient::Exception => e
       Rails.logger.error "#{Time.zone.now}: Bard error in call to #{params[:url]}: #{e.message}"
       # Rails.logger.error e.to_yaml
       ErrorTracker.report_exception(e, user, params)
@@ -30,8 +30,8 @@ class MetricsService
   end
 
   def self.get_default_headers(user)
-    return {
-      'Authorization': "Bearer #{user.access_token['access_token']}",
+    {
+      'Authorization': "Bearer #{user.valid_access_token['access_token']}",
       'Content-Type': 'application/json'
     }
   end
@@ -82,7 +82,7 @@ class MetricsService
 
     headers = get_default_headers(user)
 
-    access_token = user.access_token['access_token']
+    access_token = user.valid_access_token['access_token']
     user_id = user.id
 
     if access_token === ''

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -71,6 +71,7 @@ class MetricsService
   #
   # @param {String} name Name of the event
   # @param {Hash} props Properties associated with the event
+  # @param {User} user User model object
   def self.log(name, props={}, user)
     Rails.logger.info "Logging analytics to Mixpanel for event name: #{name}"
 

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -13,8 +13,6 @@ class MetricsService
 
   BARD_ROOT = Rails.application.config.bard_host_url
 
-  EVENT_PATH = BARD_ROOT + '/api/event'
-
   def self.post_to_bard(params, user)
     params.merge!({
       method: 'POST'

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -72,9 +72,9 @@ class MetricsService
   # @param {Hash} props Properties associated with the event
   def log(name, props = {}, user, cookies)
     props.merge!({
-      appId: 'single-cell-portal',
-      timestamp: Time.now.in_milliseconds,
-      env: Rails.env
+      :appId => 'single-cell-portal',
+      :timestamp => Time.now.in_milliseconds,
+      :env => Rails.env
     })
 
     access_token = user.access_token['access_token']
@@ -82,14 +82,14 @@ class MetricsService
 
     headers = get_default_headers(user)
 
-    if (access_token === '') {
+    if access_token === ''
       # User is unauthenticated / unregistered / anonynmous
       props['distinct_id'] = userId
       headers.delete('Authorization')
       props['authenticated'] = false
-    } else {
+    else
       props['authenticated'] = true
-    }
+    end
 
     post_body = {'event': name, 'props': props}.to_json
 

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -46,7 +46,7 @@ class MetricsService
   # This call links that anonId to the user's bearer token used by DSP's Sam
   # service.  That bearer token is in turn linked to a deidentified
   # "distinct ID" used to track users across auth states in Mixpanel.
-  def self.identify(user)
+  def self.merge_identities(user)
 
     Rails.logger.info "#{Time.zone.now}: Merging user identity in Mixpanel via Bard"
 

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -19,7 +19,9 @@ class MetricsService
     })
     begin
       Rails.logger.info "Posting to Mixpanel.  Params: #{params}"
-      return RestClient::Request.execute(params)
+      # Uncomment line below to get known-good test data
+      # puts "Posting to Mixpanel.  Params: #{params}"
+      RestClient::Request.execute(params)
     rescue RestClient::ExceptionWithResponse => e
       Rails.logger.error "Bard error in call to #{params[:url]}: #{e.message}"
       # Rails.logger.error e.to_yaml

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -1,0 +1,74 @@
+# Service to record events to Mixpanel via Bard
+#
+# Mixpanel is a business analytics service for tracking user interactions.
+# Bard is a DSP service that mediates writes to Mixpanel.
+#
+# Most logging to Mixpanel is done in JavaScript (see metrics-api.js and
+# scp-api-metrics.js in /app/javascript/lib/).  But some logging is done
+# in Rails to make it easy to analyze metrics around long-running events
+# triggered by user interactions -- like upload and ingest -- or events
+# arround auth.
+
+class MetricsService
+
+  BARD_ROOT = Rails.application.config.bard_host_url
+
+  IDENTIFY_PATH = BARD_ROOT + '/api/identify'
+  EVENT_PATH = BARD_ROOT + '/api/event'
+
+  # Merges unauth’d and auth’d user identities in Mixpanel via Bard
+  #
+  # To enable tracking users when they are signed in and not, Bard provides an
+  # endpoint `/api/identify` to merge identities.  In SCP's case, the
+  # anonynmous ID (`anonId`) is a random UUIDv4 string set as a cookie for all
+  # users -- auth'd or not -- upon visiting SCP.
+
+  # This call links that anonId to the user's bearer token used by DSP's Sam
+  # service.  That bearer token is in turn linked to a deidentified
+  # "distinct ID" used to track users across auth states in Mixpanel.
+  def self.identify(user, cookies)
+
+    Rails.logger.info "Merging user identity in Mixpanel via Bard"
+
+    headers = {
+      'Authorization' => "Bearer #{user.access_token['access_token']}",
+      'Content-Type': 'application/json'
+    }
+
+    post_body = {'anonId': cookies['user_id']}.to_json
+
+    params = {
+      method: 'POST',
+      url: IDENTIFY_PATH,
+      headers: headers,
+      payload: post_body
+    }
+
+    begin
+      response = RestClient::Request.execute(params)
+    rescue RestClient::ExceptionWithResponse => e
+      Rails.logger.error "Bard error in call to #{bard_path}: #{e.message}"
+      # Rails.logger.error e.to_yaml
+      ErrorTracker.report_exception(e, user, params)
+    end
+
+  end
+
+  # Log metrics to Mixpanel via Bard web service
+  #
+  # Bard docs:
+  # https://terra-bard-prod.appspot.com/docs/
+  #
+  # @param {String} name Name of the event
+  # @param {Hash} props Properties associated with the event
+  def log(name, props = {})
+    props.merge!({
+      appId: 'single-cell-portal',
+      timestamp: Time.now.in_milliseconds,
+      env: Rails.env
+    })
+
+    post_body = {'anonId': cookies['user_id']}.to_json
+
+  end
+end

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -17,7 +17,7 @@ class MetricsService
 
   def self.post_to_bard(params, user)
     params.merge!({
-      :method => 'POST'
+      method: 'POST'
     })
     begin
       Rails.logger.info "Posting to Mixpanel.  Params: #{params}"
@@ -31,7 +31,7 @@ class MetricsService
 
   def self.get_default_headers(user)
     return {
-      'Authorization' => "Bearer #{user.access_token['access_token']}",
+      'Authorization': "Bearer #{user.access_token['access_token']}",
       'Content-Type': 'application/json'
     }
   end
@@ -75,9 +75,9 @@ class MetricsService
     Rails.logger.info "Logging analytics to Mixpanel for event name: #{name}"
 
     props.merge!({
-      :appId => 'single-cell-portal',
-      :timestamp => (Time.now.to_f * 1000).to_i, # Epoch time in milliseconds
-      :env => Rails.env
+      appId: 'single-cell-portal',
+      timestamp: (Time.now.to_f * 1000).to_i, # Epoch time in milliseconds
+      env: Rails.env
     })
 
     access_token = user.access_token['access_token']

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -19,7 +19,7 @@ class MetricsService
     })
     begin
       Rails.logger.info "Posting to Mixpanel.  Params: #{params}"
-      response = RestClient::Request.execute(params)
+      return RestClient::Request.execute(params)
     rescue RestClient::ExceptionWithResponse => e
       Rails.logger.error "Bard error in call to #{params[:url]}: #{e.message}"
       # Rails.logger.error e.to_yaml
@@ -69,7 +69,7 @@ class MetricsService
   #
   # @param {String} name Name of the event
   # @param {Hash} props Properties associated with the event
-  def self.log(name, props = {}, user)
+  def self.log(name, props={}, user)
     Rails.logger.info "Logging analytics to Mixpanel for event name: #{name}"
 
     props.merge!({
@@ -77,7 +77,10 @@ class MetricsService
       env: Rails.env
     })
 
-    access_token = user.access_token['access_token']
+    puts 'user'
+    puts user
+
+    access_token = user.access_token['access_token'] || ''
     user_id = user.id
 
     headers = get_default_headers(user)

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -46,7 +46,7 @@ class MetricsService
   # This call links that anonId to the user's bearer token used by DSP's Sam
   # service.  That bearer token is in turn linked to a deidentified
   # "distinct ID" used to track users across auth states in Mixpanel.
-  def self.merge_identities(user)
+  def self.merge_identities_in_mixpanel(user)
 
     Rails.logger.info "#{Time.zone.now}: Merging user identity in Mixpanel via Bard"
 

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -18,12 +18,12 @@ class MetricsService
       method: 'POST'
     })
     begin
-      Rails.logger.info "Posting to Mixpanel.  Params: #{params}"
+      Rails.logger.info "#{Time.zone.now}: Posting to Mixpanel.  Params: #{params}"
       # Uncomment line below to get known-good test data
       # puts "Posting to Mixpanel.  Params: #{params}"
       RestClient::Request.execute(params)
     rescue RestClient::ExceptionWithResponse => e
-      Rails.logger.error "Bard error in call to #{params[:url]}: #{e.message}"
+      Rails.logger.error "#{Time.zone.now}: Bard error in call to #{params[:url]}: #{e.message}"
       # Rails.logger.error e.to_yaml
       ErrorTracker.report_exception(e, user, params)
     end
@@ -48,7 +48,7 @@ class MetricsService
   # "distinct ID" used to track users across auth states in Mixpanel.
   def self.identify(user)
 
-    Rails.logger.info "Merging user identity in Mixpanel via Bard"
+    Rails.logger.info "#{Time.zone.now}: Merging user identity in Mixpanel via Bard"
 
     headers = get_default_headers(user)
 
@@ -73,7 +73,7 @@ class MetricsService
   # @param {Hash} props Properties associated with the event
   # @param {User} user User model object
   def self.log(name, props={}, user)
-    Rails.logger.info "Logging analytics to Mixpanel for event name: #{name}"
+    Rails.logger.info "#{Time.zone.now}: Logging analytics to Mixpanel for event name: #{name}"
 
     props.merge!({
       appId: 'single-cell-portal',

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -76,7 +76,6 @@ class MetricsService
 
     props.merge!({
       appId: 'single-cell-portal',
-      timestamp: (Time.now.to_f * 1000).to_i, # Epoch time in milliseconds
       env: Rails.env
     })
 

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -403,7 +403,8 @@ class IngestJob
 
     message = ["Total parse time: #{self.get_total_runtime}"]
 
-    # Event properties to log to Mixpanel.  Mixpanel uses camelCase for props.
+    # Event properties to log to Mixpanel.
+    # Mixpanel uses camelCase for props; snake_case would degrade Mixpanel UX.
     mixpanel_log_props = {
       perfTime: self.get_total_runtime_ms, # Latency in milliseconds
       fileType: file_type,

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -401,7 +401,7 @@ class IngestJob
       :action => self.action
     }
 
-     case file_type
+    case file_type
     when /Matrix/
       genes = Gene.where(study_id: self.study.id, study_file_id: self.study_file.id).count
       message << "Gene-level entries created: #{genes}"

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -405,10 +405,11 @@ class IngestJob
 
     # Event properties to log to Mixpanel.  Mixpanel uses camelCase for props.
     mixpanel_log_props = {
-      :latency => self.get_total_runtime_ms, # Tracks performance
-      :fileType => file_type,
-      :fileSize => self.study_file.upload_file_size,
-      :action => self.action
+      perfTime: self.get_total_runtime_ms, # Latency in milliseconds
+      fileType: file_type,
+      fileSize: self.study_file.upload_file_size,
+      action: self.action,
+      studyAccession: self.study.accession
     }
 
     case file_type
@@ -419,7 +420,7 @@ class IngestJob
     when 'Metadata'
       use_metadata_convention = self.study_file.use_metadata_convention
       mixpanel_log_props.merge!({
-        :useMetadataConvention => use_metadata_convention,
+        useMetadataConvention: use_metadata_convention,
       })
       if use_metadata_convention
         project_name = 'alexandria_convention' # hard-coded is fine for now, consider implications if we get more projects
@@ -428,8 +429,8 @@ class IngestJob
         message << "This metadata file was validated against the latest <a href='#{schema_url}'>Metadata Convention</a>"
         message << "Convention version: <strong>#{project_name}/#{current_schema_version}</strong>"
         mixpanel_log_props.merge!({
-          :metadataConvention => project_name,
-          :schemaVersion => current_schema_version
+          metadataConvention: project_name,
+          schemaVersion: current_schema_version
         })
       end
       cell_metadata = CellMetadatum.where(study_id: self.study.id, study_file_id: self.study_file.id)
@@ -464,10 +465,10 @@ class IngestJob
         end
 
         mixpanel_log_props.merge!({
-          :clusterType => cluster_type,
-          :numClusterPoints => cluster_points,
-          :canSubsample => can_subsample,
-          :metadataFilePresent => metadata_file_present
+          clusterType: cluster_type,
+          numClusterPoints: cluster_points,
+          canSubsample: can_subsample,
+          metadataFilePresent: metadata_file_present
         })
       else
         message << "Subsampling has completed for #{cluster.name}"

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -220,7 +220,7 @@ class IngestJob
       self.study.reload # refresh cached instance of study
       self.study_file.reload # refresh cached instance of study_file
       subject = "#{self.study_file.file_type} file: '#{self.study_file.upload_file_name}' has completed parsing"
-      message = self.get_email_and_log_to_mixpanel
+      message = self.generate_success_email_array
       SingleCellMailer.notify_user_parse_complete(self.user.email, subject, message, self.study).deliver_now
       self.set_study_state_after_ingest
       self.study_file.invalidate_cache_by_file_type # clear visualization caches for file
@@ -398,7 +398,7 @@ class IngestJob
   #
   # * *returns*
   #   - (Array) => List of message strings to print in a completion email
-  def get_email_and_log_to_mixpanel
+  def generate_success_email_array
     file_type = self.study_file.file_type
 
     message = ["Total parse time: #{self.get_total_runtime}"]

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -62,4 +62,6 @@ Rails.application.configure do
 
   # set MongoDB logging level
   Mongoid.logger.level = Logger::INFO
+
+  config.bard_host_url = 'https://terra-bard-dev.appspot.com'
 end

--- a/test/integration/lib/metrics_service_test.rb
+++ b/test/integration/lib/metrics_service_test.rb
@@ -2,12 +2,6 @@ require "test_helper"
 
 class MetricsServiceTest < ActiveSupport::TestCase
 
-  def setup
-    @user = User.find_by(email: 'testing.user.2@gmail.com')
-    @random_seed = File.open(Rails.root.join('.random_seed')).read.strip
-    @study = Study.find_by(name: "Test Study #{@random_seed}")
-  end
-
   test 'should log to Mixpanel via Bard' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
 
@@ -28,78 +22,18 @@ class MetricsServiceTest < ActiveSupport::TestCase
       authenticated: true
     }
 
-    puts ('user in test')
-    puts (@user)
+    user = User.new(access_token: {access_token: 'foo'})
 
-    log_return = MetricsService.log(event, props, @user)
+     # Mock response from Bard, the DSP service mediating access to Mixpanel
+     mock = Minitest::Mock.new
+     mock.expect :code, 200
 
-    puts "Log return: #{log_return}"
-
-    # current_quota = @user.daily_download_quota
-    # assert current_quota > starting_quota, "User download quota did not increase"
-    # assert_equal current_quota, (starting_quota + bytes_requested),
-    #              "User download quota did not increase by correct amount: #{current_quota} != #{starting_quota + bytes_requested}"
+     RestClient::Request.stub :execute, mock do
+      response = MetricsService.log(event, props, user)
+      assert response.code, 200
+      mock.verify
+     end
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
-
-  # test 'should load requested files' do
-  #   puts "#{File.basename(__FILE__)}: #{self.method_name}"
-
-  #   requested_file_types = %w(Metadata Expression)
-  #   files = BulkDownloadService.get_requested_files(file_types: requested_file_types, study_accessions: [@study.accession])
-  #   assert_equal 2, files.size, "Did not find correct number of files, expected 2 but found #{files.size}"
-  #   expected_files = @study.study_files.by_type(['Metadata', 'Expression Matrix']).map(&:name).sort
-  #   found_files = files.map(&:name).sort
-  #   assert_equal expected_files, found_files, "Did not find the correct files, expected: #{expected_files} but found #{found_files}"
-
-  #   puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
-  # end
-
-  # test 'should get requested file sizes by query' do
-  #   puts "#{File.basename(__FILE__)}: #{self.method_name}"
-
-  #   requested_file_types = %w(Metadata Expression)
-  #   files_by_size = BulkDownloadService.get_requested_file_sizes_by_type(file_types: requested_file_types, study_accessions: [@study.accession])
-  #   assert_equal 2, files_by_size.keys.size,
-  #                "Did not find correct number of file classes, expected 2 but found #{files_by_size.keys.size}"
-  #   expected_response = {
-  #       Metadata: {
-  #           total_files: 1,
-  #           total_bytes: @study.metadata_file.upload_file_size
-  #       },
-  #       Expression: {
-  #           total_files: 1,
-  #           total_bytes: @study.expression_matrix_files.first.upload_file_size
-  #       }
-  #   }.with_indifferent_access
-  #   assert_equal expected_response, files_by_size.with_indifferent_access,
-  #                "Did not return correct response, expected: #{expected_response} but found #{files_by_size}"
-
-  #   puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
-  # end
-
-  # # should return curl configuration file contents
-  # # mock call to GCS as this is covered in API/SearchControllerTest
-  # test 'should generate curl configuration' do
-  #   puts "#{File.basename(__FILE__)}: #{self.method_name}"
-
-  #   study_file = @study.metadata_file
-  #   signed_url = "https://storage.googleapis.com/#{@study.bucket_id}/#{study_file.upload_file_name}"
-  #   output_path = study_file.bulk_download_pathname
-
-  #   # mock call to GCS
-  #   mock = Minitest::Mock.new
-  #   mock.expect :execute_gcloud_method, signed_url, [:generate_signed_url, Integer, String, String, Hash]
-
-  #   FireCloudClient.stub :new, mock do
-  #     configuration = BulkDownloadService.generate_curl_configuration(study_files: [study_file], user: @user)
-  #     mock.verify
-  #     assert configuration.include?(signed_url), "Configuration does not include expected signed URL (#{signed_url}): #{configuration}"
-  #     assert configuration.include?(output_path), "Configuration does not include expected output path (#{output_path}): #{configuration}"
-  #   end
-
-  #   puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
-  # end
-
 end

--- a/test/integration/lib/metrics_service_test.rb
+++ b/test/integration/lib/metrics_service_test.rb
@@ -37,19 +37,17 @@ class MetricsServiceTest < ActiveSupport::TestCase
       :method=>"POST"
     }
 
-    # A sort of high-fidelity mock
+    # A high-fidelity test double
     user = User.new(access_token: {access_token: 'foo'})
 
-    # Mock response from Bard, the DSP service mediating access to Mixpanel
+    # Mock network traffic to/from Bard, the DSP service proxying Mixpanel
     mock = Minitest::Mock.new
-    mock.expect :code, 200
-    mock.expect :call, mock, [expected_args]
+    mock.expect :call, mock, [expected_args] # Mock request
+    mock.expect :code, 200 # Mock response
 
      RestClient::Request.stub :execute, mock do
       response = MetricsService.log(event, input_props, user)
-
       assert response.code, 200
-
       mock.verify
      end
 

--- a/test/integration/lib/metrics_service_test.rb
+++ b/test/integration/lib/metrics_service_test.rb
@@ -38,18 +38,21 @@ class MetricsServiceTest < ActiveSupport::TestCase
     }
 
     # A high-fidelity test double
-    user = User.new(access_token: {access_token: 'foo'})
+    user = User.new(access_token: {
+      access_token: 'foo',
+      expires_at: DateTime.new(3000, 1, 1)
+    })
 
     # Mock network traffic to/from Bard, the DSP service proxying Mixpanel
     mock = Minitest::Mock.new
-    mock.expect :call, mock, [expected_args] # Mock request
+    mock.expect :call, mock, [expected_args] # Mock `execute` call (request)
     mock.expect :code, 200 # Mock response
 
-     RestClient::Request.stub :execute, mock do
+    RestClient::Request.stub :execute, mock do
       response = MetricsService.log(event, input_props, user)
       assert response.code, 200
       mock.verify
-     end
+    end
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/test/integration/lib/metrics_service_test.rb
+++ b/test/integration/lib/metrics_service_test.rb
@@ -46,11 +46,9 @@ class MetricsServiceTest < ActiveSupport::TestCase
     # Mock network traffic to/from Bard, the DSP service proxying Mixpanel
     mock = Minitest::Mock.new
     mock.expect :call, mock, [expected_args] # Mock `execute` call (request)
-    mock.expect :code, 200 # Mock response
 
     RestClient::Request.stub :execute, mock do
       response = MetricsService.log(event, input_props, user)
-      assert response.code, 200
       mock.verify
     end
 

--- a/test/integration/lib/metrics_service_test.rb
+++ b/test/integration/lib/metrics_service_test.rb
@@ -31,10 +31,10 @@ class MetricsServiceTest < ActiveSupport::TestCase
     # As input into RestClient::Request.execute.
     # These expected arguments are the main thing we are testing.
     expected_args = {
-      :url=>"https://terra-bard-dev.appspot.com/api/event",
-      :headers=>{:Authorization=>"Bearer ", :"Content-Type"=>"application/json"},
-      :payload=>{event: event, properties: expected_output_props}.to_json,
-      :method=>"POST"
+      url: "https://terra-bard-dev.appspot.com/api/event",
+      headers: {:Authorization=>"Bearer ", :"Content-Type"=>"application/json"},
+      payload: {event: event, properties: expected_output_props}.to_json,
+      method: "POST"
     }
 
     # A high-fidelity test double

--- a/test/integration/lib/metrics_service_test.rb
+++ b/test/integration/lib/metrics_service_test.rb
@@ -1,0 +1,105 @@
+require "test_helper"
+
+class MetricsServiceTest < ActiveSupport::TestCase
+
+  def setup
+    @user = User.find_by(email: 'testing.user.2@gmail.com')
+    @random_seed = File.open(Rails.root.join('.random_seed')).read.strip
+    @study = Study.find_by(name: "Test Study #{@random_seed}")
+  end
+
+  test 'should log to Mixpanel via Bard' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    event = "ingest"
+    props = {
+      perfTime: 276322,
+      fileType: "Cluster",
+      fileSize: 680,
+      action: "ingest_cluster",
+      studyAccession: "SCP3",
+      clusterType: "3d",
+      numClusterPoints: 15,
+      canSubsample: false,
+      metadataFilePresent: false,
+      appId: "single-cell-portal",
+      timestamp: 1594820819674,
+      env: "test",
+      authenticated: true
+    }
+
+    puts ('user in test')
+    puts (@user)
+
+    log_return = MetricsService.log(event, props, @user)
+
+    puts "Log return: #{log_return}"
+
+    # current_quota = @user.daily_download_quota
+    # assert current_quota > starting_quota, "User download quota did not increase"
+    # assert_equal current_quota, (starting_quota + bytes_requested),
+    #              "User download quota did not increase by correct amount: #{current_quota} != #{starting_quota + bytes_requested}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  # test 'should load requested files' do
+  #   puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+  #   requested_file_types = %w(Metadata Expression)
+  #   files = BulkDownloadService.get_requested_files(file_types: requested_file_types, study_accessions: [@study.accession])
+  #   assert_equal 2, files.size, "Did not find correct number of files, expected 2 but found #{files.size}"
+  #   expected_files = @study.study_files.by_type(['Metadata', 'Expression Matrix']).map(&:name).sort
+  #   found_files = files.map(&:name).sort
+  #   assert_equal expected_files, found_files, "Did not find the correct files, expected: #{expected_files} but found #{found_files}"
+
+  #   puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  # end
+
+  # test 'should get requested file sizes by query' do
+  #   puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+  #   requested_file_types = %w(Metadata Expression)
+  #   files_by_size = BulkDownloadService.get_requested_file_sizes_by_type(file_types: requested_file_types, study_accessions: [@study.accession])
+  #   assert_equal 2, files_by_size.keys.size,
+  #                "Did not find correct number of file classes, expected 2 but found #{files_by_size.keys.size}"
+  #   expected_response = {
+  #       Metadata: {
+  #           total_files: 1,
+  #           total_bytes: @study.metadata_file.upload_file_size
+  #       },
+  #       Expression: {
+  #           total_files: 1,
+  #           total_bytes: @study.expression_matrix_files.first.upload_file_size
+  #       }
+  #   }.with_indifferent_access
+  #   assert_equal expected_response, files_by_size.with_indifferent_access,
+  #                "Did not return correct response, expected: #{expected_response} but found #{files_by_size}"
+
+  #   puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  # end
+
+  # # should return curl configuration file contents
+  # # mock call to GCS as this is covered in API/SearchControllerTest
+  # test 'should generate curl configuration' do
+  #   puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+  #   study_file = @study.metadata_file
+  #   signed_url = "https://storage.googleapis.com/#{@study.bucket_id}/#{study_file.upload_file_name}"
+  #   output_path = study_file.bulk_download_pathname
+
+  #   # mock call to GCS
+  #   mock = Minitest::Mock.new
+  #   mock.expect :execute_gcloud_method, signed_url, [:generate_signed_url, Integer, String, String, Hash]
+
+  #   FireCloudClient.stub :new, mock do
+  #     configuration = BulkDownloadService.generate_curl_configuration(study_files: [study_file], user: @user)
+  #     mock.verify
+  #     assert configuration.include?(signed_url), "Configuration does not include expected signed URL (#{signed_url}): #{configuration}"
+  #     assert configuration.include?(output_path), "Configuration does not include expected output path (#{output_path}): #{configuration}"
+  #   end
+
+  #   puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  # end
+
+end


### PR DESCRIPTION
This logs Ingest Pipeline metrics like latency (i.e. duration or time taken, as `perfTime`), file type, and file size to Mixpanel.  This lets us analyze how ingest performance correlates with file size, file type, and user interactions in SCP.

The newly-tracked event is named "ingest" in Mixpanel.  See the ["Live View" in Mixpanel development](https://mixpanel.com/report/2085496/view/19055/live#chosen_columns:!('$browser','$city',mp_country_code,distinct_id,'$referring_domain'),column_widths:!(200,100,219,149,218,250,180),search:ingest).  Click on an event there to see the various properties logged for it.

The Ruby library `metrics_service.rb` essentially ports the JavaScript library [`metrics-api.js`](https://github.com/broadinstitute/single_cell_portal_core/blob/3c133bab4b11a3ef224b8645dee0f3b63198813f/app/javascript/lib/metrics-api.js).  Both write logs to Mixpanel via [Bard](https://terra-bard-prod.appspot.com/docs/), the DSP service that mediates writes to Mixpanel.

This satisfies SCP-2433 and SCP-2553.