### PR TITLE
Adding SyntheticBrandingGroupPopulator (SCP-2576)

### DIFF
--- a/app/lib/synthetic_branding_group_populator.rb
+++ b/app/lib/synthetic_branding_group_populator.rb
@@ -14,7 +14,7 @@ class SyntheticBrandingGroupPopulator
     SyntheticStudyPopulator.populate_all if create_studies
     configurations = self.load_all_config_files
     configurations.each do |configuration|
-      self.populate(configuration, user: user, study_list: study_list)
+      self.populate(configuration, user: user)
     end
   end
 

--- a/app/lib/synthetic_branding_group_populator.rb
+++ b/app/lib/synthetic_branding_group_populator.rb
@@ -8,33 +8,24 @@ class SyntheticBrandingGroupPopulator
   # populate all branding groups using synthetic studies
   #
   # @param user (User)                 => User account to own the branding groups
-  # @param overwrite_groups (Boolean)  => T/F for destroying/recreating any existing groups
-  # @param overwrite_studies (Boolean) => T/F for destroying/recreating any existing studies
-  def self.populate_all(user: User.first, overwrite_groups: true, overwrite_studies: false)
-    # populate all studies first to ensure they exist
-    SyntheticStudyPopulator.populate_all(overwrite: overwrite_studies)
-    synthetic_studies_ids = self.collect_synthetic_studies.pluck(:id)
-    # divide into two groups, one for human data, another for mouse
-    human_studies = Study.where(name: /human/i, :id.in => synthetic_studies_ids)
-    mouse_studies = Study.where(name: /(mouse|murine)/i, :id.in => synthetic_studies_ids)
-    if human_studies.empty? || mouse_studies.empty?
-      raise ArgumentError.new("Required synthetic studies not present, please manually run SyntheticStudyPopulator.populate_all")
-    end
-    group_dirs = Dir.glob(BASE_BRANDING_GROUPS_CONFIG_PATH.join('*')).select {|f| File.directory? f}
-    group_dirs.each do |group_dir|
-      # detect if this is the human or mouse group
-      group_type = group_dir.split('/').last.split('_').first
-      study_list = group_type == 'human' ? human_studies : mouse_studies
-      self.populate(group_dir, user: user, study_list: study_list, overwrite: overwrite_groups)
+  # @param create_studies (Boolean)    => Set to true to run SytheticStudyPopulator to create/overwrite studies
+  def self.populate_all(user: User.first, create_studies: false)
+    # populate all studies first to ensure they exist, if specified
+    SyntheticStudyPopulator.populate_all if create_studies
+    synthetic_studies_ids = SyntheticStudyPopulator.collect_synthetic_studies.pluck(:id)
+    configurations = self.load_all_config_files
+    configurations.each do |configuration|
+      study_regex = /#{configuration.dig('study_title_regex')}/i
+      study_list = Study.where(name: study_regex, :id.in => synthetic_studies_ids)
+      self.populate(configuration, user: user, study_list: study_list)
     end
   end
 
   # remove all synthetic branding groups, leaving studies in place
   def self.remove_all
-    config_dirs = Dir.glob(BASE_BRANDING_GROUPS_CONFIG_PATH.join('*')).select {|f| File.directory? f}
-    config_dirs.each do |config_dir|
-      branding_group_config = self.parse_configuration_file(config_dir)
-      group_name = branding_group_config['branding_group']['name']
+    configurations = self.load_all_config_files
+    configurations.each do |configuration|
+      group_name = configuration.dig('branding_group', 'name')
       group = BrandingGroup.find_by(name: group_name)
       if group.present?
         puts "Removing branding group #{group_name}"
@@ -45,63 +36,51 @@ class SyntheticBrandingGroupPopulator
 
   # create a single branding group and associate designated studies
   #
-  # @param config_dir (Pathname, String)  => Directory pathname containing configuration JSON for branding group
+  # @param branding_group_config (Hash)   => Configuration JSON for branding group
   # @param user (User)                    => User account to own branding group
   # @param study_list (Mongoid::Criteria) => List of studies to associate with new branding group
-  # @param overwrite (Boolean)            => T/F for destroying/recreating an existing group
-  def self.populate(config_dir, user: User.first, study_list:, overwrite: true)
-    branding_group_config = self.parse_configuration_file(config_dir)
-
-    puts("Populating synthetic branding group from #{config_dir}")
-    branding_group = create_branding_group(branding_group_config, user, overwrite: overwrite)
+  def self.populate(branding_group_config, user: User.first, study_list:)
+    puts("Populating synthetic branding group for #{branding_group_config.dig('branding_group', 'name')}")
+    branding_group = self.create_branding_group(branding_group_config, user)
     # assign new branding group to all studies
-    study_list.update_all(branding_group_id: branding_group.id)
-  end
-
-  # find all matching instances of synthetic studies
-  def self.collect_synthetic_studies
-    study_names = []
-    synthetic_base_path = SyntheticStudyPopulator::DEFAULT_SYNTHETIC_STUDY_PATH
-    study_dirs = Dir.glob(synthetic_base_path.join('*')).select {|f| File.directory? f}
-    study_dirs.each do |study_dir|
-      synthetic_study_folder = synthetic_base_path.join(study_dir).to_s
-      study_info_file = File.read(synthetic_study_folder + '/study_info.json')
-      study_config = JSON.parse(study_info_file)
-      study_names << study_config.dig('study', 'name')
-    end
-    Study.where(:name.in => study_names)
+    study_list.update_all(branding_group_id: branding_group.id) if study_list.any?
   end
 
   private
 
-  def self.create_branding_group(branding_group_info, user, overwrite: true)
-    existing_group = BrandingGroup.find_by(name: branding_group_info['branding_group']['name'])
-    if existing_group && overwrite
+  def self.create_branding_group(branding_group_config, user)
+    existing_group = BrandingGroup.find_by(name: branding_group_config.dig('branding_group', 'name'))
+    if existing_group
       puts "Destroying exiting branding group #{existing_group.name}"
       existing_group.destroy
     end
 
-    if existing_group.nil?
-      branding_group = BrandingGroup.new(branding_group_info['branding_group'])
-      branding_group.user ||= user
-      image_info = branding_group_info['images']
-      # dynamically assign image files
-      image_info.each do |attribute_name, filename|
-        image_file = File.open(Rails.root.join('test', 'test_data', 'branding_groups', filename))
-        branding_group.send("#{attribute_name}=", image_file)
-      end
-      puts "Saving branding group #{branding_group.name}"
-      branding_group.save!
-      branding_group
-    else
-      puts "Preserving existing branding group #{existing_group.name}"
-      existing_group
+    branding_group = BrandingGroup.new(branding_group_config.dig('branding_group'))
+    branding_group.user ||= user
+    image_info = branding_group_config.dig('images')
+    # dynamically assign image files
+    image_info.each do |attribute_name, filename|
+      image_file = File.open(Rails.root.join('test', 'test_data', 'branding_groups', filename))
+      branding_group.send("#{attribute_name}=", image_file)
     end
+    puts "Saving branding group #{branding_group.name}"
+    branding_group.save!
+    branding_group
   end
 
   def self.parse_configuration_file(config_dir)
     synthetic_group_folder = BASE_BRANDING_GROUPS_CONFIG_PATH.join(config_dir.chomp('/')).to_s
     group_info_file = File.read(File.join(synthetic_group_folder, 'branding_group_info.json'))
     JSON.parse(group_info_file)
+  end
+
+  def self.load_all_config_files
+    configs_by_group = []
+    group_dirs = Dir.glob(BASE_BRANDING_GROUPS_CONFIG_PATH.join('*')).select {|f| File.directory? f}
+    group_dirs.each do |directory_path|
+      group_config = self.parse_configuration_file(directory_path)
+      configs_by_group << group_config
+    end
+    configs_by_group
   end
 end

--- a/app/lib/synthetic_branding_group_populator.rb
+++ b/app/lib/synthetic_branding_group_populator.rb
@@ -1,0 +1,89 @@
+##
+# SyntheticBrandingGroupPopulator: class to populate branding groups using the output of SyntheticStudyPopulator
+##
+
+class SyntheticBrandingGroupPopulator
+  BASE_BRANDING_GROUPS_CONFIG_PATH = Rails.root.join('db', 'seed', 'synthetic_branding_groups')
+
+  # populate all branding groups using synthetic studies
+  #
+  # @param user (User)                 => User account to own the branding groups
+  # @param overwrite_groups (Boolean)  => T/F for destroying/recreating any existing groups
+  # @param overwrite_studies (Boolean) => T/F for destroying/recreating any existing studies
+  def self.populate_all(user: User.first, overwrite_groups: true, overwrite_studies: false)
+    # populate all studies first to ensure they exist
+    SyntheticStudyPopulator.populate_all(overwrite: overwrite_studies)
+    synthetic_studies_ids = self.collect_synthetic_studies.pluck(:id)
+    # divide into two groups, one for human data, another for mouse
+    human_studies = Study.where(name: /human/i, :id.in => synthetic_studies_ids)
+    mouse_studies = Study.where(name: /(mouse|murine)/i, :id.in => synthetic_studies_ids)
+    if human_studies.empty? || mouse_studies.empty?
+      raise ArgumentError.new("Required synthetic studies not present, please manually run SyntheticStudyPopulator.populate_all")
+    end
+    group_dirs = Dir.glob(BASE_BRANDING_GROUPS_CONFIG_PATH.join('*')).select {|f| File.directory? f}
+    group_dirs.each do |group_dir|
+      # detect if this is the human or mouse group
+      group_type = group_dir.split('/').last.split('_').first
+      study_list = group_type == 'human' ? human_studies : mouse_studies
+      self.populate(group_dir, user: user, study_list: study_list, overwrite: overwrite_groups)
+    end
+  end
+
+  # create a single branding group and associate designated studies
+  #
+  # @param config_dir (Pathname, String)  => Directory pathname containing configuration JSON for branding group
+  # @param user (User)                    => User account to own branding group
+  # @param study_list (Mongoid::Criteria) => List of studies to associate with new branding group
+  # @param overwrite (Boolean)            => T/F for destroying/recreating an existing group
+  def self.populate(config_dir, user: User.first, study_list:, overwrite: true)
+    synthetic_group_folder = BASE_BRANDING_GROUPS_CONFIG_PATH.join(config_dir.chomp('/')).to_s
+    group_info_file = File.read(File.join(synthetic_group_folder, 'branding_group_info.json'))
+    branding_group_config = JSON.parse(group_info_file)
+
+    puts("Populating synthetic branding group from #{synthetic_group_folder}")
+    branding_group = create_branding_group(branding_group_config, user, overwrite: overwrite)
+    # assign new branding group to all studies
+    study_list.update_all(branding_group_id: branding_group.id)
+  end
+
+  # find all matching instances of synthetic studies
+  def self.collect_synthetic_studies
+    study_names = []
+    synthetic_base_path = SyntheticStudyPopulator::DEFAULT_SYNTHETIC_STUDY_PATH
+    study_dirs = Dir.glob(synthetic_base_path.join('*')).select {|f| File.directory? f}
+    study_dirs.each do |study_dir|
+      synthetic_study_folder = synthetic_base_path.join(study_dir).to_s
+      study_info_file = File.read(synthetic_study_folder + '/study_info.json')
+      study_config = JSON.parse(study_info_file)
+      study_names << study_config.dig('study', 'name')
+    end
+    Study.where(:name.in => study_names)
+  end
+
+  private
+
+  def self.create_branding_group(branding_group_info, user, overwrite: true)
+    existing_group = BrandingGroup.find_by(name: branding_group_info['branding_group']['name'])
+    if existing_group && overwrite
+      puts "Destroying exiting branding group #{existing_group.name}"
+      existing_group.destroy
+    end
+
+    if existing_group.nil?
+      branding_group = BrandingGroup.new(branding_group_info['branding_group'])
+      branding_group.user ||= user
+      image_info = branding_group_info['images']
+      # dynamically assign image files
+      image_info.each do |attribute_name, filename|
+        image_file = File.open(Rails.root.join('test', 'test_data', 'branding_groups', filename))
+        branding_group.send("#{attribute_name}=", image_file)
+      end
+      puts "Saving branding group #{branding_group.name}"
+      branding_group.save!
+      branding_group
+    else
+      puts "Preserving existing branding group #{existing_group.name}"
+      existing_group
+    end
+  end
+end

--- a/app/lib/synthetic_study_populator.rb
+++ b/app/lib/synthetic_study_populator.rb
@@ -22,9 +22,12 @@ class SyntheticStudyPopulator
     study_info_file = File.read(synthetic_study_folder + '/study_info.json')
     study_config = JSON.parse(study_info_file)
 
-    puts("Populating synthetic study from #{synthetic_study_folder}")
-    study = create_study(study_config, user, overwrite: overwrite)
-    add_files(study, study_config, synthetic_study_folder, user)
+    existing_study = Study.find_by(name: study_config['study']['name'])
+    if overwrite || existing_study.nil?
+      puts("Populating synthetic study from #{synthetic_study_folder}")
+      study = create_study(study_config, user, overwrite: overwrite)
+      add_files(study, study_config, synthetic_study_folder, user)
+    end
   end
 
   private

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -107,6 +107,7 @@ else
                     test/models/user_test.rb
                     test/models/feature_flag_test.rb
                     test/models/branding_group_test.rb
+                    test/models/synthetic_branding_group_populator_test.rb
                     test/models/admin_configuration_test.rb
                     test/integration/lib/search_facet_populator_test.rb
                     test/integration/lib/summary_stats_utils_test.rb

--- a/db/migrate/20200720175116_create_synthetic_branding_groups.rb
+++ b/db/migrate/20200720175116_create_synthetic_branding_groups.rb
@@ -1,9 +1,13 @@
 class CreateSyntheticBrandingGroups < Mongoid::Migration
   def self.up
-    SyntheticBrandingGroupPopulator.populate_all
+    unless Rails.env == 'production'
+      SyntheticBrandingGroupPopulator.populate_all
+    end
   end
 
   def self.down
-    SyntheticBrandingGroupPopulator.remove_all
+    unless Rails.env == 'production'
+      SyntheticBrandingGroupPopulator.remove_all
+    end
   end
 end

--- a/db/migrate/20200720175116_create_synthetic_branding_groups.rb
+++ b/db/migrate/20200720175116_create_synthetic_branding_groups.rb
@@ -1,0 +1,9 @@
+class CreateSyntheticBrandingGroups < Mongoid::Migration
+  def self.up
+    SyntheticBrandingGroupPopulator.populate_all
+  end
+
+  def self.down
+    SyntheticBrandingGroupPopulator.remove_all
+  end
+end

--- a/db/seed/synthetic_branding_groups/human_group/branding_group_info.json
+++ b/db/seed/synthetic_branding_groups/human_group/branding_group_info.json
@@ -2,9 +2,11 @@
   "branding_group": {
     "name" : "Human Research Group",
     "tag_line": "Synthetic branding group containing only human synthetic studies",
-    "background_color": "lightgray"
+    "background_color": "lightgray",
+    "facet_list": ["organ", "disease"]
   },
   "images": {
     "splash_image": "SCP-logo-invert.png"
-  }
+  },
+  "study_title_regex": "human"
 }

--- a/db/seed/synthetic_branding_groups/human_group/branding_group_info.json
+++ b/db/seed/synthetic_branding_groups/human_group/branding_group_info.json
@@ -1,0 +1,10 @@
+{
+  "branding_group": {
+    "name" : "Human Research Group",
+    "tag_line": "Synthetic branding group containing only human synthetic studies",
+    "background_color": "lightgray"
+  },
+  "images": {
+    "splash_image": "SCP-logo-invert.png"
+  }
+}

--- a/db/seed/synthetic_branding_groups/mouse_group/branding_group_info.json
+++ b/db/seed/synthetic_branding_groups/mouse_group/branding_group_info.json
@@ -2,9 +2,11 @@
   "branding_group": {
     "name" : "Mouse Research Group",
     "tag_line": "Synthetic branding group containing only mouse synthetic studies",
-    "background_color": "lightblue"
+    "background_color": "lightblue",
+    "facet_list": ["species", "sex"]
   },
   "images": {
     "splash_image": "SCP-logo-invert.png"
-  }
+  },
+  "study_title_regex": "(mouse|murine)"
 }

--- a/db/seed/synthetic_branding_groups/mouse_group/branding_group_info.json
+++ b/db/seed/synthetic_branding_groups/mouse_group/branding_group_info.json
@@ -1,0 +1,10 @@
+{
+  "branding_group": {
+    "name" : "Mouse Research Group",
+    "tag_line": "Synthetic branding group containing only mouse synthetic studies",
+    "background_color": "lightblue"
+  },
+  "images": {
+    "banner_image": "SCP-Header-resize-invert.png"
+  }
+}

--- a/db/seed/synthetic_branding_groups/mouse_group/branding_group_info.json
+++ b/db/seed/synthetic_branding_groups/mouse_group/branding_group_info.json
@@ -5,6 +5,6 @@
     "background_color": "lightblue"
   },
   "images": {
-    "banner_image": "SCP-Header-resize-invert.png"
+    "splash_image": "SCP-logo-invert.png"
   }
 }

--- a/test/models/synthetic_branding_group_populator_test.rb
+++ b/test/models/synthetic_branding_group_populator_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class SyntheticBrandingGroupPopulatorTest < ActiveSupport::TestCase
+
+  test 'should populate synthetic branding groups' do
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
+
+    branding_group_count = BrandingGroup.count
+
+    # populate all synthetic groups
+    SyntheticBrandingGroupPopulator.populate_all
+    updated_count = BrandingGroup.count
+    expected_count = branding_group_count + 2
+    assert_equal expected_count, updated_count,
+                 "Did not create correct number of groups; expected #{expected_count} but found #{updated_count}"
+
+    configurations = SyntheticBrandingGroupPopulator.load_all_config_files
+    configurations.each do |configuration|
+      group_name = configuration.dig('branding_group', 'name')
+      group = BrandingGroup.find_by(name: group_name)
+      assert group.present?, "Could not find branding group called #{group_name}"
+      configuration['branding_group'].each do |name, value|
+        loaded_value = group.send(name)
+        assert_equal value, loaded_value,
+                     "Value for #{name} is incorrect; expected #{value} but found #{loaded_value}"
+      end
+    end
+
+    # delete all synthetic groups
+    SyntheticBrandingGroupPopulator.remove_all
+    final_count = BrandingGroup.count
+    assert_equal branding_group_count, final_count,
+                 "Did not remove synthetic branding groups; expected #{branding_group_count} but found #{final_count}"
+
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
+  end
+end


### PR DESCRIPTION
The `SyntheticBrandingGroupPopulator` class will create synthetic branding group instances using the synthetic studies created via `SyntheticStudyPopulator`.  This can be used to test various behaviors/features of branding groups in a non-production setting.  The associated database migration will trigger in all non-production environments.

Note: tests are not included for this functionality, which is in keeping with the `SyntheticStudyPopulator`, as this is not user-facing functionality, and is only intended for development purposes.

This PR satisfies SCP-2576.