### PR TITLE
supporting ontology browsing urls in search facets  (SCP-2562)

### DIFF
--- a/app/javascript/components/search/controls/FiltersBoxSearchable.js
+++ b/app/javascript/components/search/controls/FiltersBoxSearchable.js
@@ -113,7 +113,7 @@ export default function FiltersBoxSearchable({ facet, selection, setSelection, s
                       return (
                         <a
                           key={`link-${i}`}
-                          href={link.url}
+                          href={link.browser_url ? link.browser_url : link.url}
                           target='_blank'
                           rel='noopener noreferrer'
                         >

--- a/app/lib/search_facet_populator.rb
+++ b/app/lib/search_facet_populator.rb
@@ -5,7 +5,7 @@ class SearchFacetPopulator
   EXCLUDED_BQ_COLUMNS = %w(CellID donor_id biosample_id)
   # loads the alexandria convention schema and populates search facets from it
   def self.populate_from_schema
-    schema_object = fetch_json_from_url(alexandria_convention_config[:url])
+    schema_object = alexandria_convention_config
     required_fields = schema_object['required']
     required_fields.each do |field_name|
       if !EXCLUDED_BQ_COLUMNS.include?(field_name) && !field_name.include?('__ontology_label')
@@ -65,9 +65,8 @@ class SearchFacetPopulator
 
 
   def self.alexandria_convention_config
-    {
-      url: 'https://github.com/broadinstitute/scp-ingest-pipeline/raw/master/schema/alexandria_convention/alexandria_convention_schema.json',
-    }
+    convention_file_location = Rails.root.join('lib', 'assets', 'metadata_schemas', 'alexandria_convention', 'alexandria_convention_schema.json')
+    JSON.parse(File.read(convention_file_location))
   end
 
   # generic fetch of JSON from remote URL, for parsing convention schema or EBI OLS ontology entries

--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -397,8 +397,8 @@ class SearchFacet
     else
       self.ontology_urls.each do |ontology_url|
         # check that entry is a Hash with :name and :url field
-        unless ontology_url.is_a?(Hash) && ontology_url.with_indifferent_access.keys.sort == %w(name url)
-          errors.add(:ontology_urls, "contains a misformed entry: #{ontology_url}. Must be a Hash with a :name and :url field")
+        unless ontology_url.is_a?(Hash) && ontology_url.with_indifferent_access.keys.sort == %w(browser_url name url)
+          errors.add(:ontology_urls, "contains a misformed entry: #{ontology_url}. Must be a Hash with a :name, :url, and :browser_url field")
         end
         santized_url = ontology_url.with_indifferent_access
         unless url_valid?(santized_url[:url])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -126,13 +126,19 @@ AnalysisConfiguration.create(namespace: 'single-cell-portal', name: 'split-clust
 # SearchFacet seeds
 # These facets represent 3 of the main types: String-based (both for array- and non-array columns), and numeric
 SearchFacet.create(name: 'Species', identifier: 'species', filters: [{id: 'NCBITaxon_9606', name: 'Homo sapiens'}],
-                   ontology_urls: [{name: 'NCBI organismal classification', url: 'https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon'}],
+                   ontology_urls: [{name: 'NCBI organismal classification',
+                                    url: 'https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon',
+                                    browser_url: nil}],
                    data_type: 'string', is_ontology_based: true, is_array_based: false, big_query_id_column: 'species',
                    big_query_name_column: 'species__ontology_label', convention_name: 'Alexandria Metadata Convention',
                    convention_version: '1.1.3')
 SearchFacet.create(name: 'Disease', identifier: 'disease', filters: [{id: 'MONDO_0000001', name: 'disease or disorder'}],
-                   ontology_urls: [{name: 'Monarch Disease Ontology', url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo'},
-                                   {name: 'Phenotype And Trait Ontology', url: 'https://www.ebi.ac.uk/ols/ontologies/pato'}],
+                   ontology_urls: [{name: 'Monarch Disease Ontology',
+                                    url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo',
+                                    browser_url: nil},
+                                   {name: 'Phenotype And Trait Ontology',
+                                    url: 'https://www.ebi.ac.uk/ols/ontologies/pato',
+                                    browser_url: nil}],
                    data_type: 'string', is_ontology_based: true, is_array_based: true, big_query_id_column: 'disease',
                    big_query_name_column: 'disease__ontology_label', convention_name: 'Alexandria Metadata Convention',
                    convention_version: '1.1.3')

--- a/test/integration/lib/search_facet_populator_test.rb
+++ b/test/integration/lib/search_facet_populator_test.rb
@@ -6,13 +6,14 @@ class SearchFacetPopulatorTest < ActionDispatch::IntegrationTest
   test 'populate facets from alexandria convention data' do
     SearchFacet.destroy_all
     SearchFacetPopulator.populate_from_schema
-    assert_equal 7, SearchFacet.count
+    assert_equal 6, SearchFacet.count
 
     # spot-check a couple of facets
     disease_facet = SearchFacet.find_by(name: 'disease')
     assert_equal true, disease_facet.is_ontology_based
     assert_equal true, disease_facet.is_array_based
     assert_equal 'https://www.ebi.ac.uk/ols/api/ontologies/mondo', disease_facet.ontology_urls.first['url']
+    assert_equal 'https://www.ebi.ac.uk/ols/ontologies/mondo', disease_facet.ontology_urls.first['browser_url']
     assert_equal 'Mondo Disease Ontology', disease_facet.ontology_urls.first['name']
 
     sex_facet = SearchFacet.find_by(name: 'sex')
@@ -32,9 +33,13 @@ class SearchFacetPopulatorTest < ActionDispatch::IntegrationTest
                         big_query_name_column: 'disease__ontology_label',
                         convention_name: 'Alexandria Metadata Convention',
                         convention_version: '1.1.3',
-                        ontology_urls: [{name: 'MONDO: Monarch Disease Ontology', url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo'}])
+                        ontology_urls: [{
+                          name: 'MONDO: Monarch Disease Ontology',
+                          url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo',
+                          browser_url: nil
+                        }])
     SearchFacetPopulator.populate_from_schema
-    assert_equal 7, SearchFacet.count
+    assert_equal 6, SearchFacet.count
 
     # spot-check a couple of facets
     disease_facet = SearchFacet.find_by(name: 'disease')
@@ -42,5 +47,7 @@ class SearchFacetPopulatorTest < ActionDispatch::IntegrationTest
     assert_equal true, disease_facet.is_array_based
     assert_equal 'https://www.ebi.ac.uk/ols/api/ontologies/mondo', disease_facet.ontology_urls.first['url']
     assert_equal 'Mondo Disease Ontology', disease_facet.ontology_urls.first['name']
+    assert_equal 'https://www.ebi.ac.uk/ols/ontologies/mondo', disease_facet.ontology_urls.first['browser_url']
+    assert_not_equal disease_facet.convention_version, '1.1.3'
   end
 end

--- a/test/models/search_facet_test.rb
+++ b/test/models/search_facet_test.rb
@@ -70,7 +70,7 @@ class SearchFacetTest < ActiveSupport::TestCase
     assert_not @search_facet.valid?, 'Did not correctly find validation errors on invalid facet'
     assert_equal @search_facet.errors.to_hash[:ontology_urls].first,
                  'cannot be empty if SearchFacet is ontology-based'
-    @search_facet.ontology_urls = [{name: 'My Ontology', url: 'not a url'}]
+    @search_facet.ontology_urls = [{name: 'My Ontology', url: 'not a url', browser_url: nil}]
     assert_not @search_facet.valid?, 'Did not correctly find validation errors on invalid facet'
     assert_equal @search_facet.errors.to_hash[:ontology_urls].first,
                  'contains an invalid URL: not a url'


### PR DESCRIPTION
Also updates the facet populator to no longer use the outdated convention version that was stored in our public bucket.