### PR TITLE
Fix merge of user identities in Mixpanel via Bard (SCP-2605)

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -17,7 +17,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @user.delay.update_firecloud_status
       sign_in(@user)
       if TosAcceptance.accepted?(@user)
-        MetricsService.merge_identities_in_mixpanel(@user)
+        MetricsService.merge_identities_in_mixpanel(@user, cookies)
         redirect_to request.env['omniauth.origin'] || site_path
       else
         redirect_to accept_tos_path(@user.id)

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -46,13 +46,15 @@ class MetricsService
   # This call links that anonId to the user's bearer token used by DSP's Sam
   # service.  That bearer token is in turn linked to a deidentified
   # "distinct ID" used to track users across auth states in Mixpanel.
-  def self.merge_identities_in_mixpanel(user)
+  def self.merge_identities_in_mixpanel(user, cookies)
 
     Rails.logger.info "#{Time.zone.now}: Merging user identity in Mixpanel via Bard"
 
     headers = get_default_headers(user)
 
-    post_body = {'anonId': user.id}.to_json
+    post_body = {
+      'anonId': cookies['user_id'] # Random UUIDv4 string
+    }.to_json
 
     params = {
       url: BARD_ROOT + '/api/identify',

--- a/test/integration/lib/metrics_service_test.rb
+++ b/test/integration/lib/metrics_service_test.rb
@@ -54,4 +54,39 @@ class MetricsServiceTest < ActiveSupport::TestCase
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
+
+  test 'should post expected data to Mixpanel `identify` endpoint' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # A high-fidelity test double
+    user = User.new(access_token: {
+      access_token: 'foo',
+      expires_at: DateTime.new(3000, 1, 1)
+    })
+
+    cookies = {
+      user_id: '168d8f62-f813-4e45-61d7-b81afe29642a' # Random UUIDv4 string
+    }
+    anon_id = cookies['user_id']
+
+    # As input into RestClient::Request.execute.
+    # These expected arguments are the main thing we are testing.
+    expected_args = {
+      url: "https://terra-bard-dev.appspot.com/api/identify",
+      headers: {Authorization: "Bearer ", "Content-Type": "application/json"},
+      payload: {anonId: anon_id}.to_json,
+      method: "POST"
+    }
+
+    # Mock network traffic to/from Bard, the DSP service proxying Mixpanel
+    mock = Minitest::Mock.new
+    mock.expect :call, mock, [expected_args] # Mock `execute` call (request)
+
+    RestClient::Request.stub :execute, mock do
+      response = MetricsService.merge_identities_in_mixpanel(user, cookies)
+      mock.verify
+    end
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
 end


### PR DESCRIPTION
This fixes a bug in #666 that broke merging of user identities in Mixpanel via Bard.  In brief, the _anonymous_ ID `anonId` should be a [random UUIDv4 string](https://github.com/broadinstitute/single_cell_portal_core/blob/14a9566d30800d5c0a73977021263fe75156b9c2/app/views/layouts/application.html.erb#L45), and _not a signed-in user's_ `user.id` (nor `user.id.to_s`).  See #585 for background.

An automated test verifies the fix.  You can also manually test it like so:

* Go to SCP staging
* Sign in
* Go to [Live View in Terra Analytics Dev in Mixpanel](https://mixpanel.com/report/2085496/view/19055/live)
* Search "identify"
* You should see a recent matching event

Analogous flows can manually verify the fix in development and production environments.

This satisfies SCP-2605.