### PR TITLE
Moving dense expression parsing to ingest pipeline (SCP-2639)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -480,8 +480,7 @@ module Api
               genes.update(parse_status: 'parsing')
               barcodes.update(parse_status: 'parsing')
               @study_file.update(parse_status: 'parsing')
-              job = IngestJob.new(study: @study, study_file: @study_file, user: current_api_user, action: :ingest_expression)
-              job.delay.push_remote_and_launch_ingest
+              ParseUtils.delay.cell_ranger_expression_parse(@study, current_api_user, @study_file, genes, barcodes)
               head 204
             else
               logger.info "#{Time.zone.now}: Parse for #{@study_file.name} as #{@study_file.file_type} in study #{@study.name} aborted; missing required files"

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -479,7 +479,6 @@ module Api
               @study_file.update(parse_status: 'parsing')
               genes.update(parse_status: 'parsing')
               barcodes.update(parse_status: 'parsing')
-              @study_file.update(parse_status: 'parsing')
               ParseUtils.delay.cell_ranger_expression_parse(@study, current_api_user, @study_file, genes, barcodes)
               head 204
             else

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -469,7 +469,8 @@ module Api
             end
           when 'Expression Matrix'
             @study_file.update(parse_status: 'parsing')
-            @study.delay.initialize_gene_expression_data(@study_file, current_api_user)
+            job = IngestJob.new(study: @study, study_file: @study_file, user: current_api_user, action: :ingest_expression)
+            job.delay.push_remote_and_launch_ingest
             head 204
           when 'MM Coordinate Matrix'
             barcodes = @study_file.bundled_files.detect {|f| f.file_type == '10X Barcodes File'}
@@ -478,7 +479,9 @@ module Api
               @study_file.update(parse_status: 'parsing')
               genes.update(parse_status: 'parsing')
               barcodes.update(parse_status: 'parsing')
-              ParseUtils.delay.cell_ranger_expression_parse(@study, current_api_user, @study_file, genes, barcodes)
+              @study_file.update(parse_status: 'parsing')
+              job = IngestJob.new(study: @study, study_file: @study_file, user: current_api_user, action: :ingest_expression)
+              job.delay.push_remote_and_launch_ingest
               head 204
             else
               logger.info "#{Time.zone.now}: Parse for #{@study_file.name} as #{@study_file.file_type} in study #{@study.name} aborted; missing required files"

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -950,8 +950,7 @@ class StudiesController < ApplicationController
             genes.update(parse_status: 'parsing')
             barcodes.update(parse_status: 'parsing')
             @study_file.update(parse_status: 'parsing')
-            job = IngestJob.new(study: @study, study_file: @study_file, user: current_user, action: :ingest_expression)
-            job.delay.push_remote_and_launch_ingest
+            ParseUtils.delay.cell_ranger_expression_parse(study, user, study_file, genes, barcodes)
           end
         when '10X Genes File'
           matrix_id = @study_file.options[:matrix_id]
@@ -964,8 +963,7 @@ class StudiesController < ApplicationController
             @study_file.update(parse_status: 'parsing')
             matrix.update(parse_status: 'parsing')
             barcodes.update(parse_status: 'parsing')
-            job = IngestJob.new(study: @study, study_file: matrix, user: current_user, action: :ingest_expression)
-            job.delay.push_remote_and_launch_ingest
+            ParseUtils.delay.cell_ranger_expression_parse(study, user, matrix, study_file, barcodes)
           end
         when '10X Barcodes File'
           matrix_id = @study_file.options[:matrix_id]
@@ -978,8 +976,7 @@ class StudiesController < ApplicationController
             @study_file.update(parse_status: 'parsing')
             genes.update(parse_status: 'parsing')
             matrix.update(parse_status: 'parsing')
-            job = IngestJob.new(study: @study, study_file: matrix, user: current_user, action: :ingest_expression)
-            job.delay.push_remote_and_launch_ingest
+            ParseUtils.delay.cell_ranger_expression_parse(study, user, matrix, genes, study_file)
           end
         when 'Gene List'
           @study.delay.initialize_precomputed_scores(@study_file, current_user, {local: false})
@@ -1066,8 +1063,7 @@ class StudiesController < ApplicationController
             @study_file.update(parse_status: 'parsing')
             genes.update(parse_status: 'parsing')
             barcodes.update(parse_status: 'parsing')
-            job = IngestJob.new(study: @study, study_file: @study_file, user: current_user, action: :ingest_expression, reparse: true)
-            job.delay.push_remote_and_launch_ingest
+            ParseUtils.delay.cell_ranger_expression_parse(@study, current_user, @study_file, genes, barcodes, {reparse: true, sync: true})
           end
         when '10X Genes File'
           matrix_id = @study_file.options[:matrix_id]
@@ -1079,8 +1075,7 @@ class StudiesController < ApplicationController
             @study_file.update(parse_status: 'parsing')
             matrix.update(parse_status: 'parsing')
             barcodes.update(parse_status: 'parsing')
-            job = IngestJob.new(study: @study, study_file: matrix, user: current_user, action: :ingest_expression, reparse: true)
-            job.delay.push_remote_and_launch_ingest
+            ParseUtils.delay.cell_ranger_expression_parse(@study, current_user, matrix, @study_file, barcodes, {reparse: true, sync: true})
           end
         when '10X Barcodes File'
           matrix_id = @study_file.options[:matrix_id]
@@ -1093,8 +1088,7 @@ class StudiesController < ApplicationController
             @study_file.update(parse_status: 'parsing')
             genes.update(parse_status: 'parsing')
             matrix.update(parse_status: 'parsing')
-            job = IngestJob.new(study: @study, study_file: matrix, user: current_user, action: :ingest_expression, reparse: true)
-            job.delay.push_remote_and_launch_ingest
+            ParseUtils.delay.cell_ranger_expression_parse(@study, current_user, matrix, genes, @study_file, {reparse: true, sync: true})
           end
         when 'Gene List'
           @study.delay.initialize_precomputed_scores(@study_file, current_user, {local: false, reparse: true})

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -936,7 +936,9 @@ class StudiesController < ApplicationController
         when 'Coordinate Labels'
           @study.delay.initialize_coordinate_label_data_arrays(@study_file, current_user, {local: false})
         when 'Expression Matrix'
-          @study.delay.initialize_gene_expression_data(@study_file, current_user, {local: false})
+          @study_file.update(parse_status: 'parsing')
+          job = IngestJob.new(study: @study, study_file: @study_file, user: current_user, action: :ingest_expression)
+          job.delay.push_remote_and_launch_ingest
         when 'MM Coordinate Matrix'
           # we have to cast the study_file ID to a string, otherwise it is a BSON::ObjectID and will not match
           barcodes = @study.study_files.find_by(file_type: '10X Barcodes File', 'options.matrix_id' => @study_file.id.to_s)
@@ -947,7 +949,9 @@ class StudiesController < ApplicationController
             @study_file.update(parse_status: 'parsing')
             genes.update(parse_status: 'parsing')
             barcodes.update(parse_status: 'parsing')
-            ParseUtils.delay.cell_ranger_expression_parse(@study, current_user, @study_file, genes, barcodes, {sync: true})
+            @study_file.update(parse_status: 'parsing')
+            job = IngestJob.new(study: @study, study_file: @study_file, user: current_user, action: :ingest_expression)
+            job.delay.push_remote_and_launch_ingest
           end
         when '10X Genes File'
           matrix_id = @study_file.options[:matrix_id]
@@ -960,7 +964,8 @@ class StudiesController < ApplicationController
             @study_file.update(parse_status: 'parsing')
             matrix.update(parse_status: 'parsing')
             barcodes.update(parse_status: 'parsing')
-            ParseUtils.delay.cell_ranger_expression_parse(@study, current_user, matrix, @study_file, barcodes, {sync: true})
+            job = IngestJob.new(study: @study, study_file: matrix, user: current_user, action: :ingest_expression)
+            job.delay.push_remote_and_launch_ingest
           end
         when '10X Barcodes File'
           matrix_id = @study_file.options[:matrix_id]
@@ -973,7 +978,8 @@ class StudiesController < ApplicationController
             @study_file.update(parse_status: 'parsing')
             genes.update(parse_status: 'parsing')
             matrix.update(parse_status: 'parsing')
-            ParseUtils.delay.cell_ranger_expression_parse(@study, current_user, matrix, genes, @study_file, {sync: true})
+            job = IngestJob.new(study: @study, study_file: matrix, user: current_user, action: :ingest_expression)
+            job.delay.push_remote_and_launch_ingest
           end
         when 'Gene List'
           @study.delay.initialize_precomputed_scores(@study_file, current_user, {local: false})
@@ -1048,7 +1054,8 @@ class StudiesController < ApplicationController
         when 'Coordinate Labels'
           @study.delay.initialize_coordinate_label_data_arrays(@study_file, current_user, {local: false, reparse: true})
         when 'Expression Matrix'
-          @study.delay.initialize_gene_expression_data(@study_file, current_user, {local: false, reparse: true})
+          job = IngestJob.new(study: @study, study_file: @study_file, user: current_user, action: :ingest_expression, reparse: true)
+          job.delay.push_remote_and_launch_ingest
         when 'MM Coordinate Matrix'
           # we have to cast the study_file ID to a string, otherwise it is a BSON::ObjectID and will not match
           barcodes = @study.study_files.find_by(file_type: '10X Barcodes File', 'options.matrix_id' => @study_file.id.to_s)
@@ -1059,7 +1066,8 @@ class StudiesController < ApplicationController
             @study_file.update(parse_status: 'parsing')
             genes.update(parse_status: 'parsing')
             barcodes.update(parse_status: 'parsing')
-            ParseUtils.delay.cell_ranger_expression_parse(@study, current_user, @study_file, genes, barcodes, {reparse: true, sync: true})
+            job = IngestJob.new(study: @study, study_file: @study_file, user: current_user, action: :ingest_expression, reparse: true)
+            job.delay.push_remote_and_launch_ingest
           end
         when '10X Genes File'
           matrix_id = @study_file.options[:matrix_id]
@@ -1071,7 +1079,8 @@ class StudiesController < ApplicationController
             @study_file.update(parse_status: 'parsing')
             matrix.update(parse_status: 'parsing')
             barcodes.update(parse_status: 'parsing')
-            ParseUtils.delay.cell_ranger_expression_parse(@study, current_user, matrix, @study_file, barcodes, {reparse: true, sync: true})
+            job = IngestJob.new(study: @study, study_file: matrix, user: current_user, action: :ingest_expression, reparse: true)
+            job.delay.push_remote_and_launch_ingest
           end
         when '10X Barcodes File'
           matrix_id = @study_file.options[:matrix_id]
@@ -1084,7 +1093,8 @@ class StudiesController < ApplicationController
             @study_file.update(parse_status: 'parsing')
             genes.update(parse_status: 'parsing')
             matrix.update(parse_status: 'parsing')
-            ParseUtils.delay.cell_ranger_expression_parse(@study, current_user, matrix, genes, @study_file, {reparse: true, sync: true})
+            job = IngestJob.new(study: @study, study_file: matrix, user: current_user, action: :ingest_expression, reparse: true)
+            job.delay.push_remote_and_launch_ingest
           end
         when 'Gene List'
           @study.delay.initialize_precomputed_scores(@study_file, current_user, {local: false, reparse: true})

--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -2,22 +2,18 @@
 class FileParseService
   def self.run_parse_job(study_file, study, user)
     logger = Rails.logger
-
     logger.info "#{Time.zone.now}: Parsing #{study_file.name} as #{study_file.file_type} in study #{study.name}"
     case study_file.file_type
     when 'Cluster'
-      study_file.update(parse_status: 'parsing')
       job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_cluster)
       job.delay.push_remote_and_launch_ingest
     when 'Coordinate Labels'
-      study_file.update(parse_status: 'parsing')
       # we need to create the bundle here as it doesn't exist yet
       parent_cluster_file = ClusterGroup.find_by(id: study_file.options[:cluster_group_id]).study_file
       file_list = StudyFileBundle.generate_file_list(parent_cluster_file, study_file)
       StudyFileBundle.create(study_id: study.id, bundle_type: parent_cluster_file.file_type, original_file_list: file_list)
       study.delay.initialize_coordinate_label_data_arrays(study_file, user)
     when 'Expression Matrix'
-      study_file.update(parse_status: 'parsing')
       job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_expression)
       job.delay.push_remote_and_launch_ingest
     when 'MM Coordinate Matrix'
@@ -26,7 +22,6 @@ class FileParseService
       barcodes = study_file.bundled_files.detect {|f| f.file_type == '10X Barcodes File'}
       genes = study_file.bundled_files.detect {|f| f.file_type == '10X Genes File'}
       if barcodes.present? && genes.present? && bundle.completed?
-        study_file.update(parse_status: 'parsing')
         genes.update(parse_status: 'parsing')
         barcodes.update(parse_status: 'parsing')
         ParseUtils.delay.cell_ranger_expression_parse(study, user, study_file, genes, barcodes)
@@ -39,7 +34,6 @@ class FileParseService
       matrix = bundle.parent
       barcodes = bundle.bundled_files.detect {|f| f.file_type == '10X Barcodes File' }
       if barcodes.present? && matrix.present? && bundle.completed?
-        study_file.update(parse_status: 'parsing')
         matrix.update(parse_status: 'parsing')
         barcodes.update(parse_status: 'parsing')
         ParseUtils.delay.cell_ranger_expression_parse(study, user, matrix, study_file, barcodes)
@@ -54,7 +48,6 @@ class FileParseService
       matrix = bundle.parent
       genes = bundle.bundled_files.detect {|f| f.file_type == '10X Genes File' }
       if genes.present? && matrix.present? && bundle.completed?
-        study_file.update(parse_status: 'parsing')
         genes.update(parse_status: 'parsing')
         matrix.update(parse_status: 'parsing')
         ParseUtils.delay.cell_ranger_expression_parse(study, user, matrix, genes, study_file)
@@ -67,11 +60,10 @@ class FileParseService
       study_file.update(parse_status: 'parsing')
       study.delay.initialize_precomputed_scores(study_file, user)
     when 'Metadata'
-      study_file.update(parse_status: 'parsing')
-      study.send_to_firecloud(study_file)
       job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_cell_metadata)
       job.delay.push_remote_and_launch_ingest
     end
+    study_file.update(parse_status: 'parsing')
     changes = ["Study file added: #{study_file.upload_file_name}"]
     if study.study_shares.any?
       SingleCellMailer.share_update_notification(study, changes, user).deliver_now

--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -71,15 +71,6 @@ class FileParseService
       study.send_to_firecloud(study_file)
       job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_cell_metadata)
       job.delay.push_remote_and_launch_ingest
-    when 'Analysis Output'
-      case study_file.options[:analysis_name]
-      when 'infercnv'
-        if study_file.options[:visualization_name] == 'ideogram.js'
-          ParseUtils.delay.extract_analysis_output_files(study, user, study_file, study_file.options[:analysis_name])
-        end
-      else
-        Rails.logger.info "Aborting parse of #{study_file.name} as #{study_file.file_type} in study #{study.name}; not applicable"
-      end
     end
     changes = ["Study file added: #{study_file.upload_file_name}"]
     if study.study_shares.any?

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -316,13 +316,6 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
         taxon = study_file.taxon
         opts += ["--taxon-name", "#{taxon.scientific_name}", "--taxon-common-name", "#{taxon.common_name}",
                  "--ncbi-taxid", "#{taxon.ncbi_taxid}"]
-        if taxon.current_assembly.present?
-          assembly = taxon.current_assembly
-          opts += ["--genome-assembly-accession", "#{assembly.accession}"]
-          if assembly.current_annotation.present?
-            opts += ["--genome-annotation", "#{assembly.current_annotation.name}"]
-          end
-        end
       end
     when 'Cluster'
       # the name of Cluster files is the same as the name of the cluster object itself

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -19,7 +19,7 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   # GCP Compute project to run pipelines in
   COMPUTE_PROJECT = ENV['GOOGLE_CLOUD_PROJECT'].blank? ? '' : ENV['GOOGLE_CLOUD_PROJECT']
   # Docker image in GCP project to pull for running ingest jobs
-  INGEST_DOCKER_IMAGE = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.4.0'
+  INGEST_DOCKER_IMAGE = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.5.0'
   # Network and sub-network names, if needed
   GCP_NETWORK_NAME = ENV['GCP_NETWORK_NAME']
   GCP_SUB_NETWORK_NAME = ENV['GCP_SUB_NETWORK_NAME']

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -19,7 +19,7 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   # GCP Compute project to run pipelines in
   COMPUTE_PROJECT = ENV['GOOGLE_CLOUD_PROJECT'].blank? ? '' : ENV['GOOGLE_CLOUD_PROJECT']
   # Docker image in GCP project to pull for running ingest jobs
-  INGEST_DOCKER_IMAGE = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.5.0'
+  INGEST_DOCKER_IMAGE = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.5.4'
   # Network and sub-network names, if needed
   GCP_NETWORK_NAME = ENV['GCP_NETWORK_NAME']
   GCP_SUB_NETWORK_NAME = ENV['GCP_SUB_NETWORK_NAME']

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1121,7 +1121,7 @@ class Study
 
   # helper method to set the number of unique genes in this study
   def set_gene_count
-    gene_count = self.unique_genes
+    gene_count = self.unique_genes.size
     Rails.logger.info "Setting gene count in #{self.name} to #{gene_count}"
     self.update(gene_count: gene_count)
     Rails.logger.info "Gene count set for #{self.name}"

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -39,7 +39,7 @@
           </div>
           <div class="row code-div">
             <div class="col-sm-3 col-sm-offset-1">
-            <pre class="code-example">GENE&#09;CELL_1&#9;CELL_2&#09;CELL_3&#09;...<br/>It2ma&#09;0&#09;0&#09;0&#09;...<br/>Gergef&#09;0&#09;7.092&#09;0&#09;...<br/>Chil5&#09;0&#09;0&#09;0&#09;...<br/>Fgfr3&#09;0&#9;0&#09;0.978&#09;<br/>...</pre>
+            <pre class="code-example">GENE&#09;CELL_1&#9;CELL_2&#09;CELL_3&#09;...<br/>It2ma&#09;0&#09;0&#09;0&#09;...<br/>Sergef&#09;0&#09;7.092&#09;0&#09;...<br/>Chil5&#09;0&#09;0&#09;0&#09;...<br/>Fgfr3&#09;0&#9;0&#09;0.978&#09;<br/>...</pre>
             </div>
             <div class="col-sm-4 col-sm-offset-2" >
               <pre class="code-example">%%MatrixMarket matrix coordinate real general<br/>%<br>17123 31231 124124<br>1 1241 1.0<br/>1 1552 2.0<br/>...</pre>

--- a/test/integration/study_creation_test.rb
+++ b/test/integration/study_creation_test.rb
@@ -120,12 +120,14 @@ class StudyCreationTest < ActionDispatch::IntegrationTest
     # verify that counts are correct, this will ensure that everything uploaded & parsed correctly
     cluster_count = study.cluster_groups.size
     metadata_count = study.cell_metadata.size
+    gene_count = study.genes.size
     cluster_annot_count = study.cluster_annotation_count
     study_file_count = study.study_files.non_primary_data.size
     share_count = study.study_shares.size
 
     assert_equal 1, cluster_count, "did not find correct number of clusters"
     assert_equal 26, metadata_count, "did not find correct number of metadata objects"
+    assert_equal 19, gene_count, "did not find correct number of gene objects"
     assert_equal 2, cluster_annot_count, "did not find correct number of cluster annotations"
     assert_equal 3, study_file_count, "did not find correct number of study files"
     assert_equal 1, share_count, "did not find correct number of study shares"


### PR DESCRIPTION
Moving parsing of dense expression matrices to `scp-ingest-pipeline`.  Also updating to the latest release: `1.5.4`.  This PR also contains small typo/bugfixes to the upload wizard and setting study gene counts.

This PR satisfies SCP-2639.