### PR TITLE
DRYing references to parsing code into FileParseService (SCP-2659)

### DIFF
--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -569,7 +569,9 @@ module Api
         files_to_remove = []
         files.each do |file|
           # first, check if file is in a submission directory, and if so mark it for removal from list of files to sync
-          if @submission_ids.include?(file.name.split('/').first) || file.name.end_with?('/')
+          # also ignore any files in the parse_logs folder
+          base_dir = file.name.split('/').first
+          if @submission_ids.include?(base_dir) || base_dir == 'parse_logs' || file.name.end_with?('/')
             files_to_remove << file.generation
           else
             directory_name = DirectoryListing.get_folder_name(file.name)

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -448,58 +448,11 @@ module Api
 
       # POST /single_cell/api/v1/studies/:study_id/study_files/:id/parse
       def parse
-        logger.info "#{Time.zone.now}: Parsing #{@study_file.name} as #{@study_file.file_type} in study #{@study.name}"
-        unless @study_file.parsing?
-          case @study_file.file_type
-          when 'Cluster'
-            @study_file.update(parse_status: 'parsing')
-            job = IngestJob.new(study: @study, study_file: @study_file, user: current_api_user, action: :ingest_cluster)
-            job.delay.push_remote_and_launch_ingest
-            head 204
-          when 'Coordinate Labels'
-            if @study_file.bundle_parent.present?
-              @study_file.update(parse_status: 'parsing')
-              @study.delay.initialize_coordinate_label_data_arrays(@study_file, current_api_user)
-              head 204
-            else
-              logger.info "#{Time.zone.now}: Parse for #{@study_file.name} as #{@study_file.file_type} in study #{@study.name} aborted; missing required files"
-              respond_to do |format|
-                format.json {render 'missing_file_bundle', status: 412}
-              end
-            end
-          when 'Expression Matrix'
-            @study_file.update(parse_status: 'parsing')
-            job = IngestJob.new(study: @study, study_file: @study_file, user: current_api_user, action: :ingest_expression)
-            job.delay.push_remote_and_launch_ingest
-            head 204
-          when 'MM Coordinate Matrix'
-            barcodes = @study_file.bundled_files.detect {|f| f.file_type == '10X Barcodes File'}
-            genes = @study_file.bundled_files.detect {|f| f.file_type == '10X Genes File'}
-            if barcodes.present? && genes.present?
-              @study_file.update(parse_status: 'parsing')
-              genes.update(parse_status: 'parsing')
-              barcodes.update(parse_status: 'parsing')
-              ParseUtils.delay.cell_ranger_expression_parse(@study, current_api_user, @study_file, genes, barcodes)
-              head 204
-            else
-              logger.info "#{Time.zone.now}: Parse for #{@study_file.name} as #{@study_file.file_type} in study #{@study.name} aborted; missing required files"
-              respond_to do |format|
-                format.json {render 'missing_file_bundle', status: 412}
-              end
-            end
-          when 'Gene List'
-            @study_file.update(parse_status: 'parsing')
-            @study.delay.initialize_precomputed_scores(@study_file, current_api_user)
-          when 'Metadata'
-            @study_file.update(parse_status: 'parsing')
-            job = IngestJob.new(study: @study, study_file: @study_file, user: current_api_user, action: :ingest_cell_metadata)
-            job.delay.push_remote_and_launch_ingest
-          else
-            # study file is not parseable
-            render json: {error: "Files of type #{@study_file.file_type} are not parseable"}, status: :unprocessable_entity
-          end
+        parse_response = FileParseService.run_parse_job(@study_file, @study, current_api_user)
+        if parse_response[:status_code] == 204
+          head 204
         else
-          render json: {error: "File is already parsing"}, status: 405
+          render json: parse_response, status: parse_response[:status_code]
         end
       end
 

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1214,7 +1214,9 @@ class StudiesController < ApplicationController
     files_to_remove = []
     files.each do |file|
       # first, check if file is in a submission directory, and if so mark it for removal from list of files to sync
-      if @submission_ids.include?(file.name.split('/').first) || file.name.end_with?('/')
+      # also ignore any files in the parse_logs folder
+      base_dir = file.name.split('/').first
+      if @submission_ids.include?(base_dir) || base_dir == 'parse_logs' || file.name.end_with?('/')
         files_to_remove << file.generation
       else
         directory_name = DirectoryListing.get_folder_name(file.name)

--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -1,72 +1,120 @@
 # collection of methods involved in parsing files
+# also includes option return status object when being called from Api::V1::StudyFilesController
 class FileParseService
-  def self.run_parse_job(study_file, study, user)
+  # * *params*
+  #   - +study_file+      (StudyFile) => File being parsed
+  #   - +study+           (Study) => Study to which StudyFile belongs
+  #   - +user+            (User) => User initiating parse action (for email delivery)
+  #   - +reparse+         (Boolean) => Control for deleting existing data when initiating parse (default: false)
+  #   - +persist_on_fail+ (Boolean) => Control for persisting files from GCS buckets on parse fail (default: false)
+  #
+  # * *returns*
+  #   - (Hash) => Status object with http status_code and optional error message
+  def self.run_parse_job(study_file, study, user, reparse: false, persist_on_fail: false)
     logger = Rails.logger
     logger.info "#{Time.zone.now}: Parsing #{study_file.name} as #{study_file.file_type} in study #{study.name}"
-    case study_file.file_type
-    when 'Cluster'
-      job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_cluster)
-      job.delay.push_remote_and_launch_ingest
-    when 'Coordinate Labels'
-      # we need to create the bundle here as it doesn't exist yet
-      parent_cluster_file = ClusterGroup.find_by(id: study_file.options[:cluster_group_id]).study_file
-      file_list = StudyFileBundle.generate_file_list(parent_cluster_file, study_file)
-      StudyFileBundle.create(study_id: study.id, bundle_type: parent_cluster_file.file_type, original_file_list: file_list)
-      study.delay.initialize_coordinate_label_data_arrays(study_file, user)
-    when 'Expression Matrix'
-      job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_expression)
-      job.delay.push_remote_and_launch_ingest
-    when 'MM Coordinate Matrix'
-      study.send_to_firecloud(study_file)
-      bundle = study_file.study_file_bundle
-      barcodes = study_file.bundled_files.detect {|f| f.file_type == '10X Barcodes File'}
-      genes = study_file.bundled_files.detect {|f| f.file_type == '10X Genes File'}
-      if barcodes.present? && genes.present? && bundle.completed?
-        genes.update(parse_status: 'parsing')
-        barcodes.update(parse_status: 'parsing')
-        ParseUtils.delay.cell_ranger_expression_parse(study, user, study_file, genes, barcodes)
-      else
-        logger.info "#{Time.zone.now}: Parse for #{study_file.name} as #{study_file.file_type} in study #{study.name} aborted; missing required files"
+    if !study_file.parseable?
+      return {
+          status_code: 422,
+          error: "Files of type #{study_file.file_type} are not parseable"
+      }
+    elsif study_file.parsing?
+      return {
+          status_code: 405,
+          error: "File: #{study_file.upload_file_name} is already parsing"
+      }
+    else
+      case study_file.file_type
+      when 'Cluster'
+        job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_cluster, reparse: reparse,
+                            persist_on_fail: persist_on_fail)
+        job.delay.push_remote_and_launch_ingest
+      when 'Coordinate Labels'
+        # we need to create the bundle here as it doesn't exist yet
+        parent_cluster = ClusterGroup.find_by(id: study_file.options[:cluster_group_id])
+        if parent_cluster.present?
+          parent_cluster_file = parent_cluster.study_file
+          file_list = StudyFileBundle.generate_file_list(parent_cluster_file, study_file)
+          StudyFileBundle.find_or_create_by(study_id: study.id, bundle_type: parent_cluster_file.file_type,
+                                            original_file_list: file_list)
+          study.delay.initialize_coordinate_label_data_arrays(study_file, user, {reparse: reparse})
+        else
+          return self.missing_bundled_file(study_file)
+        end
+      when 'Expression Matrix'
+        job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_expression, reparse: reparse,
+                            persist_on_fail: persist_on_fail)
+        job.delay.push_remote_and_launch_ingest
+      when 'MM Coordinate Matrix'
+        bundle = study_file.study_file_bundle
+        barcodes = study_file.bundled_files.detect {|f| f.file_type == '10X Barcodes File'}
+        genes = study_file.bundled_files.detect {|f| f.file_type == '10X Genes File'}
+        if barcodes.present? && genes.present? && bundle.completed?
+          genes.update(parse_status: 'parsing')
+          barcodes.update(parse_status: 'parsing')
+          ParseUtils.delay.cell_ranger_expression_parse(study, user, study_file, genes, barcodes, {reparse: reparse})
+        else
+          logger.info "#{Time.zone.now}: Parse for #{study_file.name} as #{study_file.file_type} in study #{study.name} aborted; missing required files"
+          study.delay.send_to_firecloud(study_file)
+          return self.missing_bundled_file(study_file)
+        end
+      when '10X Genes File'
+        bundle = study_file.study_file_bundle
+        matrix = bundle.parent
+        barcodes = bundle.bundled_files.detect {|f| f.file_type == '10X Barcodes File' }
+        if barcodes.present? && matrix.present? && bundle.completed?
+          matrix.update(parse_status: 'parsing')
+          barcodes.update(parse_status: 'parsing')
+          ParseUtils.delay.cell_ranger_expression_parse(study, user, matrix, study_file, barcodes, {reparse: reparse})
+        else
+          study.delay.send_to_firecloud(study_file)
+          return self.missing_bundled_file(study_file)
+        end
+      when '10X Barcodes File'
+        bundle = study_file.study_file_bundle
+        matrix = bundle.parent
+        genes = bundle.bundled_files.detect {|f| f.file_type == '10X Genes File' }
+        if genes.present? && matrix.present? && bundle.completed?
+          genes.update(parse_status: 'parsing')
+          matrix.update(parse_status: 'parsing')
+          ParseUtils.delay.cell_ranger_expression_parse(study, user, matrix, genes, study_file, {reparse: reparse})
+        else
+          study.delay.send_to_firecloud(study_file)
+          return self.missing_bundled_file(study_file)
+        end
+      when 'Gene List'
+        study.delay.initialize_precomputed_scores(study_file, user)
+      when 'Metadata'
+        job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_cell_metadata, reparse: reparse,
+                            persist_on_fail: persist_on_fail)
+        job.delay.push_remote_and_launch_ingest
+      when 'Analysis Output'
+        case @study_file.options[:analysis_name]
+        when 'infercnv'
+          if @study_file.options[:visualization_name] == 'ideogram.js'
+            ParseUtils.delay.extract_analysis_output_files(@study, current_user, @study_file, @study_file.options[:analysis_name])
+          end
+        else
+          Rails.logger.info "Aborting parse of #{@study_file.name} as #{@study_file.file_type} in study #{@study.name}; not applicable"
+        end
       end
-    when '10X Genes File'
-      study.send_to_firecloud(study_file)
-      bundle = study_file.study_file_bundle
-      matrix = bundle.parent
-      barcodes = bundle.bundled_files.detect {|f| f.file_type == '10X Barcodes File' }
-      if barcodes.present? && matrix.present? && bundle.completed?
-        matrix.update(parse_status: 'parsing')
-        barcodes.update(parse_status: 'parsing')
-        ParseUtils.delay.cell_ranger_expression_parse(study, user, matrix, study_file, barcodes)
-      else
-        # we can only get here if we have a matrix and no barcodes, which means the barcodes form is already rendered
-        logger.info "#{Time.zone.now}: Parse for #{study_file.name} as #{study_file.file_type} in study #{study.name} aborted; missing required files"
-        study.delay.send_to_firecloud(study_file)
-      end
-    when '10X Barcodes File'
-      study.send_to_firecloud(study_file)
-      bundle = study_file.study_file_bundle
-      matrix = bundle.parent
-      genes = bundle.bundled_files.detect {|f| f.file_type == '10X Genes File' }
-      if genes.present? && matrix.present? && bundle.completed?
-        genes.update(parse_status: 'parsing')
-        matrix.update(parse_status: 'parsing')
-        ParseUtils.delay.cell_ranger_expression_parse(study, user, matrix, genes, study_file)
-      else
-        # we can only get here if we have a matrix and no genes, which means the genes form is already rendered
-        logger.info "#{Time.zone.now}: Parse for #{study_file.name} as #{study_file.file_type} in study #{study.name} aborted; missing required files"
-        study.delay.send_to_firecloud(study_file)
-      end
-    when 'Gene List'
       study_file.update(parse_status: 'parsing')
-      study.delay.initialize_precomputed_scores(study_file, user)
-    when 'Metadata'
-      job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_cell_metadata)
-      job.delay.push_remote_and_launch_ingest
+      changes = ["Study file added: #{study_file.upload_file_name}"]
+      if study.study_shares.any?
+        SingleCellMailer.share_update_notification(study, changes, user).deliver_now
+      end
+      return {
+          status_code: 204,
+      }
     end
-    study_file.update(parse_status: 'parsing')
-    changes = ["Study file added: #{study_file.upload_file_name}"]
-    if study.study_shares.any?
-      SingleCellMailer.share_update_notification(study, changes, user).deliver_now
-    end
+  end
+
+  # Helper for rendering error when a bundled file is missing requirements for parsing
+  def self.missing_bundled_file(study_file)
+    Rails.logger.info "#{Time.zone.now}: Parse for #{study_file.name} as #{study_file.file_type} in study #{study_file.study.name} aborted; missing required files"
+    {
+        status_code: 412,
+        error: "File is not parseable; missing required files for parsing #{study_file.file_type} file type: #{StudyFileBundle::PARSEABLE_BUNDLE_REQUIREMENTS.to_json}"
+    }
   end
 end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -234,7 +234,7 @@ class IngestJob
       self.log_error_messages
       self.study_file.update(parse_status: 'failed')
       DeleteQueueJob.new(self.study_file).delay.perform
-      Study.firecloud_client.delete_workspace_file(self.study.bucket_id, self.study_file.bucket_location) unless self.persist_on_fail?
+      Study.firecloud_client.delete_workspace_file(self.study.bucket_id, self.study_file.bucket_location) unless self.persist_on_fail
       subject = "Error: #{self.study_file.file_type} file: '#{self.study_file.upload_file_name}' parse has failed"
       email_content = self.generate_error_email_body
       SingleCellMailer.notify_user_parse_fail(self.user.email, subject, email_content, self.study).deliver_now
@@ -247,8 +247,7 @@ class IngestJob
   # Set study state depending on what kind of file was just ingested
   # Does not return anything, but will set state and launch other jobs as needed
   #
-  # * *yields
-  # *
+  # * *yields*
   #   - Study#set_cell_count, :set_study_default_options, Study#set_gene_count, and :set_study_initialized
   def set_study_state_after_ingest
     case self.study_file.file_type


### PR DESCRIPTION
Consolidating all parsing code calls into `FileParseService` for maintainability.  This update also adds support for common parameters such as `reparse` (deletes existing data), and the ability to persist files in buckets on failure, which is feature parity with the `sync` function.  This also adds a response to `FileParseService#run_parse_job` to make it compatible with the API.

This PR satisfies SCP-2659.