### PR TITLE
Ingest pipeline 1.5.6 (SCP-2674)

### DIFF
--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -19,7 +19,7 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   # GCP Compute project to run pipelines in
   COMPUTE_PROJECT = ENV['GOOGLE_CLOUD_PROJECT'].blank? ? '' : ENV['GOOGLE_CLOUD_PROJECT']
   # Docker image in GCP project to pull for running ingest jobs
-  INGEST_DOCKER_IMAGE = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.5.5'
+  INGEST_DOCKER_IMAGE = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.5.6'
   # Network and sub-network names, if needed
   GCP_NETWORK_NAME = ENV['GCP_NETWORK_NAME']
   GCP_SUB_NETWORK_NAME = ENV['GCP_SUB_NETWORK_NAME']

--- a/test/integration/study_validation_test.rb
+++ b/test/integration/study_validation_test.rb
@@ -290,7 +290,7 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
   end
 
   # validates that additional expression matrices with unique cells can be ingested to a study that already has a
-  # metadata file and at least one other expresison matrix
+  # metadata file and at least one other expression matrix
   test 'should validate unique cells for expression matrices' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
 
@@ -326,4 +326,3 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 end
-


### PR DESCRIPTION
Updating to the latest version of `scp-ingest-pipeline` : `1.5.6`.  This also adds an integration test to validate that Ingest Pipeline can correctly check that a new expression matrix in a study has a unique list of cell names.

This PR supports SCP-2674