### PR TITLE
adding validation to ensure one metadata file per study (SCP-2673)

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -528,9 +528,13 @@ class StudiesController < ApplicationController
 
   # update a study_file's upload status to 'uploaded'
   def update_status
-    study_file = StudyFile.where(study_id: params[:id], upload_file_name: params[:file]).first
-    study_file.update!(status: params[:status])
-    head :ok
+    study_file = StudyFile.find_by(study_id: params[:id], upload_file_name: params[:file])
+    if study_file.present?
+      study_file.update!(status: params[:status])
+      head :ok
+    else
+      head :not_found
+    end
   end
 
   # retrieve study file by filename during initializer wizard

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1187,7 +1187,7 @@ class StudyFile
 
   # ensure that a user can only add one metadata file per study
   def ensure_metadata_singleton
-    if StudyFile.where(file_type: 'Metadata', study_id: self.study_id, queued_for_deletion: false).exists?
+    if StudyFile.where(file_type: 'Metadata', study_id: self.study_id, queued_for_deletion: false, :id.ne => self.id).exists?
       errors.add(:file_type, 'You may only add one metadata file per study')
     end
   end

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -518,6 +518,7 @@ class StudyFile
 
   validate :check_taxon, on: :create
   validate :check_assembly, on: :create
+  validate :ensure_metadata_singleton
 
   ###
   #
@@ -1181,6 +1182,13 @@ class StudyFile
   def check_assembly
     if GenomeAssembly.present? && ASSEMBLY_REQUIRED_TYPES.include?(self.file_type) && self.genome_assembly_id.nil?
       errors.add(:genome_assembly_id, 'You must supply a genome assembly for this file type: ' + self.file_type)
+    end
+  end
+
+  # ensure that a user can only add one metadata file per study
+  def ensure_metadata_singleton
+    if StudyFile.where(file_type: 'Metadata', study_id: self.study_id, queued_for_deletion: false).exists?
+      errors.add(:file_type, 'You may only add one metadata file per study')
     end
   end
 end

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -518,7 +518,7 @@ class StudyFile
 
   validate :check_taxon, on: :create
   validate :check_assembly, on: :create
-  validate :ensure_metadata_singleton
+  validate :ensure_metadata_singleton, if: proc {|f| f.file_type == 'Metadata'}
 
   ###
   #

--- a/test/integration/study_validation_test.rb
+++ b/test/integration/study_validation_test.rb
@@ -325,4 +325,16 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
+
+  test 'should ensure one metadata file per study' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    study = Study.find_by(name: "Test Study #{@random_seed}")
+    new_metadata = 'metadata_example2.txt'
+    file_params = {study_file: {file_type: 'Metadata', study_id: study.id.to_s}}
+    perform_study_file_upload(new_metadata, file_params, study.id)
+    assert_response 422, "Did not fail validation for duplicate metadata file; #{@response.code} != 422"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
 end

--- a/test/integration/study_validation_test.rb
+++ b/test/integration/study_validation_test.rb
@@ -27,9 +27,6 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
     assert study.present?, "Study did not successfully save"
 
     example_files = {
-      metadata: {
-        name: 'metadata_bad.txt'
-      },
       metadata_breaking_convention: {
         name: 'metadata_example2.txt'
       },
@@ -43,19 +40,17 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
 
     ## upload files
 
-    # bad metadata file
-    file_params = {study_file: {file_type: 'Metadata', study_id: study.id.to_s}}
-    perform_study_file_upload('metadata_bad.txt', file_params, study.id)
-    assert_response 200, "Metadata upload failed: #{@response.code}"
-    example_files[:metadata][:object] = study.metadata_file
-    assert example_files[:metadata][:object].present?, "Metadata failed to associate, found no file: #{example_files[:metadata][:object].present?}"
-
     # good metadata file, but falsely claiming to use the metadata_convention
     file_params = {study_file: {file_type: 'Metadata', study_id: study.id.to_s, use_metadata_convention: true}}
     perform_study_file_upload('metadata_example2.txt', file_params, study.id)
     assert_response 200, "Metadata upload failed: #{@response.code}"
     example_files[:metadata_breaking_convention][:object] = study.metadata_file
     assert example_files[:metadata_breaking_convention][:object].present?, "Metadata failed to associate, found no file: #{example_files[:metadata_breaking_convention][:object].present?}"
+
+    # metadata file that should fail validation because we already have one
+    file_params = {study_file: {file_type: 'Metadata', study_id: study.id.to_s}}
+    perform_study_file_upload('metadata_bad.txt', file_params, study.id)
+    assert_response 422, "Metadata did not fail validation: #{@response.code}"
 
     # bad cluster
     file_params = {study_file: {name: 'Bad Test Cluster 1', file_type: 'Cluster', study_id: study.id.to_s}}
@@ -322,18 +317,6 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
       uploaded_matrix.reload
     end
     puts "After #{seconds_slept} seconds, #{new_matrix} is #{uploaded_matrix.parse_status}."
-
-    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
-  end
-
-  test 'should ensure one metadata file per study' do
-    puts "#{File.basename(__FILE__)}: #{self.method_name}"
-
-    study = Study.find_by(name: "Test Study #{@random_seed}")
-    new_metadata = 'metadata_example2.txt'
-    file_params = {study_file: {file_type: 'Metadata', study_id: study.id.to_s}}
-    perform_study_file_upload(new_metadata, file_params, study.id)
-    assert_response 422, "Did not fail validation for duplicate metadata file; #{@response.code} != 422"
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end


### PR DESCRIPTION
Since metadata files are treated as singletons per study, this update adds a validation to specifically ensure that to block uploads/syncs of additional metadata files at the model level.  Now any additional metadata file creations will respond `422` with an appropriate message.

This PR satisfies SCP-2673.