### PR TITLE
Correctly loading user-created custom annotations for visualizations (SCP-2459)

### DIFF
--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -28,13 +28,13 @@ class RequestUtils
   def self.populate_annotation_by_class(source:, scope:, type:)
     if source.is_a?(CellMetadatum)
       annotation = {name: source.name, type: source.annotation_type,
-                    scope: 'study', values: source.values.present? ? source.values : [],
+                    scope: 'study', values: source.values.to_a,
                     identifier: "#{source.name}--#{type}--#{scope}"}
     elsif source.is_a?(UserAnnotation)
-      annotation = {name: source.name, type: type, scope: scope, values: source.values.present? ? source.values : [],
-                    identifier: "#{source.name}--#{type}--#{scope}"}
+      annotation = {name: source.name, type: type, scope: scope, values: source.values.to_a,
+                    identifier: "#{source.id}--#{type}--#{scope}", id: source.id}
     elsif source.is_a?(Hash)
-      annotation = {name: source[:name], type: type, scope: scope, values: source[:values].present? ? source[:values] : [],
+      annotation = {name: source[:name], type: type, scope: scope, values: source[:values].to_a,
                     identifier: "#{source[:name]}--#{type}--#{scope}"}
     end
     annotation


### PR DESCRIPTION
This fixes a bug caused by a recent refactoring that broke the loading of user-created custom annotations.  The `id` of the `UserAnnotation` object was not being passed, which is necessary for the Mongo query as multiple users can call their custom annotations the same thing (this is scoped per user account).  Also, this contains a small simplification of how the unique values are loaded into the object - calling `.to_a` on `nil` results in an empty array, so checking for the presence of `values` is not necessary.

This PR satisfies SCP-2459.