### PR TITLE
Adding ingest docker image configuration option (SCP-2687)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,9 @@ module SingleCellPortal
 
     config.middleware.use Rack::Deflater
 
+    # Docker image for file parsing via scp-ingest-pipeline
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.5.7'
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/rails_startup.bash
+++ b/rails_startup.bash
@@ -125,6 +125,14 @@ then
   echo "*** COMPLETED ***"
 fi
 
+if [[ $PASSENGER_APP_ENV != "production" ]]
+then
+  echo "*** RESETTING DEFAULT INGEST DOCKER IMAGE ***"
+  sudo -E -u app -H bin/rails runner -e $PASSENGER_APP_ENV "AdminConfiguration.revert_ingest_docker_image"
+  echo "*** COMPLETED ***"
+fi
+
+
 echo "*** ADDING DAILY RESET OF USER DOWNLOAD QUOTAS ***"
 (crontab -u app -l ; echo "@daily . /home/app/.cron_env ; cd /home/app/webapp/; /home/app/webapp/bin/rails runner -e $PASSENGER_APP_ENV \"User.update_all(daily_download_quota: 0)\" >> /home/app/webapp/log/cron_out.log 2>&1") | crontab -u app -
 echo "*** COMPLETED ***"


### PR DESCRIPTION
Adds an `AdminConfiguration` type for specifying a new  [scp-ingest-pipeline](https://github.com/broadinstitute/scp-ingest-pipeline) Docker image to override the configured default (which also moves to application.rb from papi_client.rb).  This feature is for non-production environments only, and will revert on every restart/deployment.  Validations ensure that the specified image exists before saving.  This new configuration option is part of the effort for streamlining non-major releases of scp-ingest-pipeline to allow for faster development/test cycles by removing the need for PRs in single_cell_portal_core to update the Docker image name.  Other efforts include automation in the form of a new Google Cloud Build [trigger](https://console.cloud.google.com/cloud-build/triggers/edit/42f98161-c506-4c53-b206-75df50aa21a3?project=broad-singlecellportal-staging) that runs on all pushes to the [development](https://github.com/broadinstitute/scp-ingest-pipeline/tree/development) branch of scp-ingest-pipeline.  Once builds complete, developers can instantly add the new image name to any non-production instance of SCP and begin testing end-to-end functionality.

This update also removes the "Workflow Name" admin config option as it has been superseded by the `AnalysisConfiguration` model.

This PR satisfies SCP-2687. 