### PR TITLE
Integrating new user- and admin-level error logs into ingest_job.rb (SCP-2703)

### DIFF
--- a/app/mailers/single_cell_mailer.rb
+++ b/app/mailers/single_cell_mailer.rb
@@ -56,12 +56,16 @@ class SingleCellMailer < ApplicationMailer
   def notify_user_parse_fail(email, title, error, study)
     @error = error
     @study = study
+    mail(to: email, subject: '[Single Cell Portal Notifier] ' + title)
+  end
+
+  def notify_admin_parse_fail(user_email, title, contents)
     dev_email_config = AdminConfiguration.find_by(config_type: 'QA Dev Email')
     if dev_email_config.present?
       dev_email = dev_email_config.value
-      mail(to: email, bcc: dev_email, subject: '[Single Cell Portal Notifier] ' + title)
-    else
-      mail(to: email, subject: '[Single Cell Portal Notifier] ' + title)
+      @contents = contents
+      @user_email = user_email
+      mail(to: dev_email, subject: '[Single Cell Portal Admin Notification] ' + title)
     end
   end
 

--- a/app/views/single_cell_mailer/notify_admin_parse_fail.html.erb
+++ b/app/views/single_cell_mailer/notify_admin_parse_fail.html.erb
@@ -1,0 +1,1 @@
+<%= @contents.html_safe %>

--- a/test/integration/study_validation_test.rb
+++ b/test/integration/study_validation_test.rb
@@ -96,11 +96,6 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
     example_files.values.each do |e|
       assert_equal 'failed', e[:object].parse_status, "Incorrect parse_status for #{e[:name]}"
       assert e[:object].queued_for_deletion
-      # check for logfiles in bucket by using IngestJob class
-      job_handler = IngestJob.new(study: study, study_file: e[:object])
-      error_logpath = job_handler.detailed_error_filepath
-      error_contents = job_handler.read_parse_logfile(error_logpath)
-      refute error_contents.blank?, "Did not retrieve content from error log at: #{error_logpath}"
     end
 
     assert_equal 0, study.cell_metadata.size

--- a/test/integration/study_validation_test.rb
+++ b/test/integration/study_validation_test.rb
@@ -96,6 +96,11 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
     example_files.values.each do |e|
       assert_equal 'failed', e[:object].parse_status, "Incorrect parse_status for #{e[:name]}"
       assert e[:object].queued_for_deletion
+      # check for logfiles in bucket by using IngestJob class
+      job_handler = IngestJob.new(study: study, study_file: e[:object])
+      error_logpath = job_handler.detailed_error_filepath
+      error_contents = job_handler.read_parse_logfile(error_logpath)
+      refute error_contents.blank?, "Did not retrieve content from error log at: #{error_logpath}"
     end
 
     assert_equal 0, study.cell_metadata.size


### PR DESCRIPTION
Error logging for failed ingest pipeline jobs is now split into two separate log files, one that is intended for users, and one intended for administrators.  The user-level errors now only contain the actual error message, where as the administrator-level errors include stack traces, PAPI event logs, and debug-level logging messages.  These emails are now sent to both users and administrators separately, allowing for more concise user communication while providing administrators with greater context for parse failures.

For more information regarding the contents of these log files, please refer to the associated [PR](https://github.com/broadinstitute/scp-ingest-pipeline/pull/141) in scp-ingest-pipeline.


This PR satisfies SCP-2703.