### PR TITLE
adding checks & enforcement of SCP-specific User-Agent headers (SCP-2691)

### DIFF
--- a/app/controllers/api/v1/api_base_controller.rb
+++ b/app/controllers/api/v1/api_base_controller.rb
@@ -4,6 +4,7 @@ module Api
       include Concerns::ContentType
       include Concerns::CspHeaderBypass
       include ActionController::MimeResponds
+      include Concerns::IngestAware
       extend ErrorTracker
 
       rescue_from ActionController::ParameterMissing do |exception|

--- a/app/controllers/api/v1/concerns/ingest_aware.rb
+++ b/app/controllers/api/v1/concerns/ingest_aware.rb
@@ -1,0 +1,58 @@
+module Api
+  module V1
+    module Concerns
+      module IngestAware
+        extend ActiveSupport::Concern
+        INGEST_IMAGE_NAME = 'scp-ingest-pipeline'
+        MANAGE_STUDY_NAME = 'single-cell-portal'
+        SCP_PACKAGES = [INGEST_IMAGE_NAME, MANAGE_STUDY_NAME]
+
+        included do
+          before_action :validate_scp_user_agent!
+        end
+
+        # deny connections that declare they are from the single-cell-portal PyPI package and are using a
+        # version of scp-ingest-pipeline that is not the current major release
+        #
+        # Examples:
+        # 'User-Agent': 'single-cell-portal/0.1.3rc1 (manage-study) scp-ingest-pipeline/1.5.6 (ingest_pipeline.py)'
+        # If the configured version of scp-ingest-pipeline is... (the response will be)
+        #  * 0.x = the request is denied with 400: Bad Request
+        #  * 1.x = the request is allowed to proceed
+        #  * 2.x = the request is denied with 400: Bad Request
+        #  * scp-ingest-pipeline-development:ddee8f5 (untagged dev image) = request is denied since tags to not match
+        #
+        # All other requests without UA headers, or non SCP-specific UA headers are allowed
+        def validate_scp_user_agent!
+          scp_package_headers = extract_scp_user_agent_headers(request)
+          if scp_package_headers.any?
+            ingest_image_attributes = AdminConfiguration.get_ingest_docker_image_attributes
+            ingest_pipeline_version = ingest_image_attributes[:tag]
+            request_ingest_version = scp_package_headers[INGEST_IMAGE_NAME]
+            if ingest_pipeline_version.include?('.') && request_ingest_version.include?('.')
+              # both server & client are using a tagged release of scp-ingest-pipeline, so only compare major versions
+              # otherwise fall back to checking entire tag for non-production releases
+              ingest_pipeline_version = ingest_pipeline_version.split('.').first.try(:to_i)
+              request_ingest_version = request_ingest_version.split('.').first.try(:to_i)
+            end
+            render json: {error: "scp-ingest-pipeline: #{scp_package_headers[INGEST_IMAGE_NAME]} incompatible with host, " + \
+                                 "please use #{ingest_image_attributes[:tag]}"},
+                   status: 400 and return if ingest_pipeline_version != request_ingest_version
+          end
+        end
+
+        def extract_scp_user_agent_headers(request)
+          agent = request.headers['User-Agent']
+          scp_ua_headers = {}
+          if agent.present?
+            SCP_PACKAGES.each do |package|
+              package_match = agent.match(/#{package}\/(\w|\.)+/)
+              scp_ua_headers[package] = package_match.to_s.split('/').last if package_match
+            end
+          end
+          scp_ua_headers
+        end
+      end
+    end
+  end
+end

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -85,6 +85,7 @@ else
                     test/controllers/analysis_configurations_controller_test.rb
                     test/controllers/site_controller_test.rb
                     test/controllers/preset_searches_controller_test.rb
+                    test/api/api_base_controller_test.rb
                     test/api/site_controller_test.rb
                     test/api/studies_controller_test.rb
                     test/api/study_files_controller_test.rb

--- a/test/api/api_base_controller_test.rb
+++ b/test/api/api_base_controller_test.rb
@@ -1,0 +1,69 @@
+require 'api_test_helper'
+
+class ApiBaseControllerTest < ActionDispatch::IntegrationTest
+  include Requests::JsonHelpers
+  include Requests::HttpHelpers
+
+  setup do
+    @configured_version = AdminConfiguration.get_ingest_docker_image_attributes[:tag]
+  end
+
+  test 'should allow all requests without user agent header' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    get api_v1_site_studies_path
+    assert_response :success, "Did not get correct response; 200 != #{response.code}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should allow valid scp user agent header values' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    ua_header = {"User-Agent" => "scp-ingest-pipeline/#{@configured_version}"}
+    get api_v1_site_studies_path, headers: ua_header
+    assert_response :success, "Did not get correct response; 200 != #{response.code}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should reject invalid scp user agent header values' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    maj_version = @configured_version[0].to_i
+    version_parts = @configured_version.split('.')
+    version_parts[0] = maj_version - 1
+    bad_version = version_parts.join('.')
+    bad_header = {"User-Agent" => "scp-ingest-pipeline/#{bad_version}"}
+    get api_v1_site_studies_path, headers: bad_header
+    assert_response :bad_request, "Did not respond correctly; 400 != #{response.code}"
+    assert json['error'].include?(@configured_version), "Did not find configured tag of #{@configured_version} in #{json['error']}"
+    assert json['error'].include?(bad_version), "Did not find request version tag of #{bad_version} in #{json['error']}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should match ingest image tags exactly when overridden' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # override image
+    image_name = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline-development:ddee8f5'
+    config = AdminConfiguration.create!(config_type: AdminConfiguration::INGEST_DOCKER_NAME, value_type: 'String',
+                                        value: image_name)
+    current_tag = AdminConfiguration.get_ingest_docker_image_attributes[:tag]
+
+    # validate exact matching of version tags
+    good_header = {"User-Agent" => "scp-ingest-pipeline/#{current_tag}"}
+    get api_v1_site_studies_path, headers: good_header
+    assert_response :success, "Did not get correct response; 200 != #{response.code}"
+
+    bad_header = {"User-Agent" => "scp-ingest-pipeline/this-does-not-match"}
+    get api_v1_site_studies_path, headers: bad_header
+    assert_response :bad_request, "Did not respond correctly; 400 != #{response.code}"
+
+    # clean up
+    config.destroy
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+end

--- a/test/api/api_base_controller_test.rb
+++ b/test/api/api_base_controller_test.rb
@@ -37,7 +37,7 @@ class ApiBaseControllerTest < ActionDispatch::IntegrationTest
     bad_header = {"User-Agent" => "scp-ingest-pipeline/#{bad_version}"}
     get api_v1_site_studies_path, headers: bad_header
     assert_response :bad_request, "Did not respond correctly; 400 != #{response.code}"
-    assert json['error'].include?(@configured_version), "Did not find configured tag of #{@configured_version} in #{json['error']}"
+    assert json['error'].include?('--upgrade'), "Did not find --upgrade message in #{json['error']}"
     assert json['error'].include?(bad_version), "Did not find request version tag of #{bad_version} in #{json['error']}"
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"


### PR DESCRIPTION
The `single-cell-portal` [PyPI package](https://pypi.org/project/single-cell-portal/) will begin reporting installed versions of both itself and `scp-ingest-pipeline` as a `User-Agent` header on all requests to the Single Cell Portal REST API.  This is being done in an effort to catch cases where a user is trying to make requests using an outdated client that may no longer be compatible with a given instance of SCP.

The API will now check for the presence of the `scp-ingest-pipeline` UA header and attempt to compare the version against what is configured for that instance.  If both client & server are declaring that they are using a [tagged release](https://github.com/broadinstitute/scp-ingest-pipeline/releases) of `scp-ingest-pipeline` (i.e. both versions conform with [semantic versioning](https://semver.org/) formats), then the portal will enforce that the _major version_ match.  If one or the other is using a non-tagged release, such as a development build, then the entire version tag must match.

Successful matches will allow the request to proceed, whereas invalid versions will result in a `400 Bad Request` with the following JSON response:

```
{ "error": "scp-ingest-pipeline: [ client request version ] incompatible with host, please use [host configured version]" }
```

This PR satisfies SCP-2691.