### PR TITLE
Updating to scp-ingest-pipeline:1.6.0, singlecellportal/rails-baseimage:1.0.4 (SCP-2652, SCP-2703)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM singlecellportal/rails-baseimage:1.0.3
+FROM singlecellportal/rails-baseimage:1.0.4
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-2.6.5'

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module SingleCellPortal
     config.middleware.use Rack::Deflater
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.5.7'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.6.0'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Updates to the latest releases of `scp-ingest-pipeline:1.6.0` and `singlecellportal/rails-baseimage:1.0.4`.

This PR finishes up work completed in SCP-2652, SCP-2703.