### PR TITLE
Update to Ingest Pipeline 1.6.2

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module SingleCellPortal
     config.middleware.use Rack::Deflater
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.6.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.6.1'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module SingleCellPortal
     config.middleware.use Rack::Deflater
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.6.1'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.6.2'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
This updates SCP to [Ingest Pipeline 1.6.2](https://github.com/broadinstitute/scp-ingest-pipeline/releases/tag/1.6.2).