### PR TITLE
Fix double search and render in Study Overview (SCP-2728)

### DIFF
--- a/app/views/site/_search_options.html.erb
+++ b/app/views/site/_search_options.html.erb
@@ -51,7 +51,6 @@
             <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
 
                 initializeAutocomplete('#search_genes');
-
                 $('#clear-gene-search').click(function(){
                     clearForm('search_genes');
                     $(this).tooltip('hide');
@@ -127,6 +126,7 @@
                 // handler to catch ENTER keypress and open modal
                 $('#search-genes-form').on('submit', function(submitEvent) {
                     submitGeneSearch(submitEvent);
+                    return false;
                 });
             </script>
           </div>

--- a/app/views/site/_search_options.html.erb
+++ b/app/views/site/_search_options.html.erb
@@ -126,7 +126,7 @@
                 // handler to catch ENTER keypress and open modal
                 $('#search-genes-form').on('submit', function(submitEvent) {
                     submitGeneSearch(submitEvent);
-                    return false;
+                    return false; // Prevents double search-and-render
                 });
             </script>
           </div>


### PR DESCRIPTION
This fixes double search and render requests in Study Overview, when search is triggered by pressing the "Enter" key.

To verify fix:
* Go to a Study Overview page that has visualizations initialized
* Open Chrome DevTools, go to Network tab
* Enter name of gene present in study
* Press "Enter" to search
* One "search" request and one "render_gene_expression_plots" request should be sent.  (Before, two of each were sent.)

This satisfies SCP-2728.