### PR TITLE
re-enabling synthetic study populator test (SCP-2732)

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -82,6 +82,7 @@ else
                     test/integration/lib/bulk_download_service_test.rb
                     test/integration/study_validation_test.rb
                     test/integration/taxons_controller_test.rb
+                    test/integration/synthetic_study_populator_test.rb
                     test/controllers/analysis_configurations_controller_test.rb
                     test/controllers/site_controller_test.rb
                     test/controllers/preset_searches_controller_test.rb

--- a/test/integration/synthetic_study_populator_test.rb
+++ b/test/integration/synthetic_study_populator_test.rb
@@ -2,23 +2,29 @@ require "integration_test_helper"
 
 class SyntheticStudyPopulatorTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
-  # commented out pending resolution of namespace conflict issue
-  # test 'should be able to populate a study with convention metadata' do
-  #   SYNTH_STUDY_INFO = {
-  #     name: 'HIV in bovine blood',
-  #     folder: 'cow_blood'
-  #   }
 
-  #   if Study.find_by(name: SYNTH_STUDY_INFO[:name])
-  #     Study.find_by(name: SYNTH_STUDY_INFO[:name]).destroy_and_remove_workspace
-  #   end
+  test 'should be able to populate a study with convention metadata' do
+    SYNTH_STUDY_INFO = {
+      name: 'HIV in bovine blood',
+      folder: 'cow_blood'
+    }
 
-  #   assert_nil Study.find_by(name: SYNTH_STUDY_INFO[:name])
+    # SyntheticStudyPopulator does have logic for deleting existing sutdies on populate
+    # but this is for belt-and-suspenders to make sure the delete is successful
+    if Study.find_by(name: SYNTH_STUDY_INFO[:name])
+      Study.find_by(name: SYNTH_STUDY_INFO[:name]).destroy_and_remove_workspace
+    end
 
-  #   SyntheticStudyPopulator.populate(SYNTH_STUDY_INFO[:folder])
-  #   sleep 60
-  #   assert_equal 1, Study.find_by(name: SYNTH_STUDY_INFO[:name])
+    assert_nil Study.find_by(name: SYNTH_STUDY_INFO[:name])
 
-  #   Study.find_by(name: SYNTH_STUDY_INFO[:name]).destroy_and_remove_workspace
-  # end
+    SyntheticStudyPopulator.populate(SYNTH_STUDY_INFO[:folder])
+    populated_study = Study.find_by(name: SYNTH_STUDY_INFO[:name])
+
+    assert_not_nil populated_study
+    assert_equal 1, populated_study.study_files.count
+    assert_equal 'Metadata', populated_study.study_files.first.file_type
+
+    # note that we're not testing the ingest process yet due to timing concerns
+    Study.find_by(name: SYNTH_STUDY_INFO[:name]).destroy_and_remove_workspace
+  end
 end


### PR DESCRIPTION
Now that we have separate firecloud namespaces for each developer, this test can be enabled.  Previously, we weren't running it out of concerns that developers would be conflicting out each other's test studies.  @bistline  right now this test isn't waiting around to see if parsing succeeds -- my sense is that, in order to keep test runs short, this should just focus on testing the structural aspects of the synth population.   And I *think* it makes sense to allocate the few full-parse runs we do during the test suite to the end-to-end tests, since those are testing the actual production parsing cases.  But let me know if you think it would be useful to also test parsing here