### PR TITLE
Logging manage-study usage in Mixpanel, identify updates (SCP-2691, SCP-2734)

### DIFF
--- a/app/controllers/api/v1/concerns/ingest_aware.rb
+++ b/app/controllers/api/v1/concerns/ingest_aware.rb
@@ -32,7 +32,7 @@ module Api
                 appFullPath: request.fullpath
             }
             if api_user_signed_in?
-              MetricsService.merge_identities_in_mixpanel(current_api_user) if @user.registered_for_firecloud
+              MetricsService.merge_identities_in_mixpanel(current_api_user)
               MetricsService.log('manage-study', mixpanel_log_props, current_api_user)
             end
             ingest_image_attributes = AdminConfiguration.get_ingest_docker_image_attributes

--- a/app/controllers/api/v1/concerns/ingest_aware.rb
+++ b/app/controllers/api/v1/concerns/ingest_aware.rb
@@ -32,7 +32,7 @@ module Api
                 appFullPath: request.fullpath
             }
             if api_user_signed_in?
-              MetricsService.merge_identities_in_mixpanel(current_api_user) if !@user.registered_for_firecloud
+              MetricsService.merge_identities_in_mixpanel(current_api_user) if @user.registered_for_firecloud
               MetricsService.log('manage-study', mixpanel_log_props, current_api_user)
             end
             ingest_image_attributes = AdminConfiguration.get_ingest_docker_image_attributes

--- a/app/controllers/api/v1/concerns/ingest_aware.rb
+++ b/app/controllers/api/v1/concerns/ingest_aware.rb
@@ -26,6 +26,12 @@ module Api
         def validate_scp_user_agent!
           scp_package_headers = extract_scp_user_agent_headers(request)
           if scp_package_headers.any?
+            # log usage to Mixpanel
+            mixpanel_log_props = {
+                user_agent: request.headers['User-Agent'],
+                appFullPath: request.fullpath
+            }
+            MetricsService.log('manage-study', mixpanel_log_props, current_api_user) if api_user_signed_in?
             ingest_image_attributes = AdminConfiguration.get_ingest_docker_image_attributes
             ingest_pipeline_version = ingest_image_attributes[:tag]
             request_ingest_version = scp_package_headers[INGEST_IMAGE_NAME]

--- a/app/controllers/api/v1/concerns/ingest_aware.rb
+++ b/app/controllers/api/v1/concerns/ingest_aware.rb
@@ -31,7 +31,10 @@ module Api
                 user_agent: request.headers['User-Agent'],
                 appFullPath: request.fullpath
             }
-            MetricsService.log('manage-study', mixpanel_log_props, current_api_user) if api_user_signed_in?
+            if api_user_signed_in?
+              MetricsService.merge_identities_in_mixpanel(current_api_user) if !@user.registered_for_firecloud
+              MetricsService.log('manage-study', mixpanel_log_props, current_api_user)
+            end
             ingest_image_attributes = AdminConfiguration.get_ingest_docker_image_attributes
             ingest_pipeline_version = ingest_image_attributes[:tag]
             request_ingest_version = scp_package_headers[INGEST_IMAGE_NAME]

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -18,6 +18,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in(@user)
       if TosAcceptance.accepted?(@user)
         MetricsService.merge_identities_in_mixpanel(@user, cookies) if !@user.registered_for_firecloud
+        if cookies.key?('user_id')
+          # unify browser-based cookie with model-based UUID unless already assigned
+          @user.update(metrics_uuid: cookies['user_id']) if @user.metrics_uuid.nil?
+        end
         redirect_to request.env['omniauth.origin'] || site_path
       else
         redirect_to accept_tos_path(@user.id)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -17,7 +17,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @user.delay.update_firecloud_status
       sign_in(@user)
       if TosAcceptance.accepted?(@user)
-        MetricsService.merge_identities_in_mixpanel(@user, cookies)
+        MetricsService.merge_identities_in_mixpanel(@user, cookies) if !@user.registered_for_firecloud
         redirect_to request.env['omniauth.origin'] || site_path
       else
         redirect_to accept_tos_path(@user.id)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -17,7 +17,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @user.delay.update_firecloud_status
       sign_in(@user)
       if TosAcceptance.accepted?(@user)
-        MetricsService.merge_identities_in_mixpanel(@user, cookies) if !@user.registered_for_firecloud
+        MetricsService.merge_identities_in_mixpanel(@user, cookies) if @user.registered_for_firecloud
         if cookies.key?('user_id')
           # unify browser-based cookie with model-based UUID unless already assigned
           @user.update(metrics_uuid: cookies['user_id']) if @user.metrics_uuid.nil?

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -17,11 +17,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @user.delay.update_firecloud_status
       sign_in(@user)
       if TosAcceptance.accepted?(@user)
-        MetricsService.merge_identities_in_mixpanel(@user, cookies) if @user.registered_for_firecloud
-        if cookies.key?('user_id')
-          # unify browser-based cookie with model-based UUID unless already assigned
-          @user.update(metrics_uuid: cookies['user_id']) if @user.metrics_uuid.nil?
-        end
+        MetricsService.merge_identities_in_mixpanel(@user, cookies)
         redirect_to request.env['omniauth.origin'] || site_path
       else
         redirect_to accept_tos_path(@user.id)

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -248,11 +248,13 @@ export function log(name, props={}) {
 
   // only report 'authenticated' users if signed in and also registered for Terra
   // reporting non-Terra users to Bard results in 503 errors
-  if (accessToken === '' || !registeredForTerra) {
-    // User is unauthenticated / unregistered / anonynmous / not registered for Terra
-    props['distinct_id'] = userId
-    delete init['headers']['Authorization']
+  if (accessToken === '') {
+    // User is unauthenticated / unregistered / anonymous / not registered for Terra
     props['authenticated'] = false
+    if (registeredForTerra) {
+      props['distinct_id'] = userId
+      delete init['headers']['Authorization']
+    }
   } else {
     props['authenticated'] = true
   }

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -28,12 +28,14 @@ const bardDomainsByEnv = {
 let bardDomain = ''
 const env = getSCPContext().environment
 let userId = ''
+let registeredForTerra = false
 
 // TODO (SCP-2237): Use Node environment to get React execution context
 if (env != 'test') {
   bardDomain = bardDomainsByEnv[env]
   // To consider: Replace SCP-specific userId with DSP-wide userId
   userId = window.SCP.userId
+  registeredForTerra = window.SCP.registeredForTerra
 }
 
 /**
@@ -243,11 +245,14 @@ export function log(name, props={}) {
 
   let init = Object.assign({}, defaultInit)
 
-  if (accessToken === '') {
-    // User is unauthenticated / unregistered / anonynmous
+  // only report 'authenticated' users if signed in and also registered for Terra
+  // reporting non-Terra users to Bard results in 503 errors
+  if (accessToken === '' || !registeredForTerra) {
+    // User is unauthenticated / unregistered / anonynmous / not registered for Terra
     props['distinct_id'] = userId
     delete init['headers']['Authorization']
     props['authenticated'] = false
+    props['registeredForTerra'] = registeredForTerra
   } else {
     props['authenticated'] = true
   }

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -242,6 +242,7 @@ export function log(name, props={}) {
 
   const brandingGroup = getBrandingGroup()
   props['brand'] = brandingGroup ? brandingGroup : ''
+  props['registeredForTerra'] = registeredForTerra
 
   let init = Object.assign({}, defaultInit)
 
@@ -252,7 +253,6 @@ export function log(name, props={}) {
     props['distinct_id'] = userId
     delete init['headers']['Authorization']
     props['authenticated'] = false
-    props['registeredForTerra'] = registeredForTerra
   } else {
     props['authenticated'] = true
   }

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -50,14 +50,26 @@ class MetricsService
   # This call links that anonId to the user's bearer token used by DSP's Sam
   # service.  That bearer token is in turn linked to a deidentified
   # "distinct ID" used to track users across auth states in Mixpanel.
-  def self.merge_identities_in_mixpanel(user, cookies)
+  def self.merge_identities_in_mixpanel(user, cookies={})
 
     Rails.logger.info "#{Time.zone.now}: Merging user identity in Mixpanel via Bard"
 
     headers = get_default_headers(user)
 
+    # store random UUIDv4 string from client in user model to allow tracking API calls
+    if cookies.dig('user_id')
+      user_id = cookies['user_id']
+    else
+      user_id = user.get_metrics_uuid
+    end
+
+    # update metrics UUID if it has changed
+    # this unifies browser cookie value with metrics_uuid to avoid double-counting users
+    user.update(metrics_uuid: user_id) if user_id != user.metrics_uuid
+
     post_body = {
-      'anonId': cookies['user_id'] # Random UUIDv4 string
+      'anonId': user_id,
+      'registeredForTerra': false # mark that user is not registered for Terra
     }.to_json
 
     params = {
@@ -89,13 +101,14 @@ class MetricsService
     headers = get_default_headers(user)
 
     access_token = user.token_for_api_call
-    user_id = user.id
+    user_id = user.get_metrics_uuid
 
-    if access_token.nil?
+    if access_token.nil? || !user.registered_for_firecloud
       # User is unauthenticated / unregistered / anonynmous
       props['distinct_id'] = user_id
       headers.delete('Authorization')
       props['authenticated'] = false
+      props['registeredForTerra'] = false
     else
       props['authenticated'] = true
     end

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -57,7 +57,7 @@ class MetricsService
     headers = get_default_headers(user)
 
     # store random UUIDv4 string from client in user model to allow tracking API calls
-    if cookies.dig('user_id')
+    if cookies.key?('user_id')
       user_id = cookies['user_id']
     else
       user_id = user.get_metrics_uuid

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -57,7 +57,7 @@ class MetricsService
     headers = get_default_headers(user)
 
     # store random UUIDv4 string from client in user model to allow tracking API calls
-    if cookies.key?('user_id')
+    if cookies.dig('user_id')
       user_id = cookies['user_id']
     else
       user_id = user.get_metrics_uuid
@@ -69,8 +69,13 @@ class MetricsService
 
     post_body = {
       'anonId': user_id,
-      'registeredForTerra': false # mark that user is not registered for Terra
+      'registeredForTerra': user.registered_for_firecloud
     }.to_json
+
+    if !user.registered_for_firecloud
+      headers.delete('Authorization')
+      post_body['authenticated'] = false
+    end
 
     params = {
       url: BARD_ROOT + '/api/identify',
@@ -104,7 +109,7 @@ class MetricsService
     user_id = user.get_metrics_uuid
 
     if access_token.nil? || !user.registered_for_firecloud
-      # User is unauthenticated / unregistered / anonynmous
+      # User is unauthenticated / unregistered / anonymous
       props['distinct_id'] = user_id
       headers.delete('Authorization')
       props['authenticated'] = false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -97,6 +97,7 @@ class User
   #   last_access_at: DateTime last usage of token
   # }
   field :api_access_token, type: Hash
+  field :metrics_uuid, type: String
 
   # feature_flags should be a hash of true/false values.  If unspecified for a given flag, the
   # default_value from the FeatureFlag should be used.  Accordingly, the helper method feature_flags_with_defaults
@@ -112,8 +113,7 @@ class User
   def self.from_omniauth(access_token)
     data = access_token.info
     provider = access_token.provider
-    uid =
-     access_token.uid
+    uid = access_token.uid
     # create bogus password, Devise will never use it to authenticate
     password = Devise.friendly_token[0,20]
     user = User.find_by(email: data['email'])
@@ -257,6 +257,13 @@ class User
     else
       return false
     end
+  end
+
+  def get_metrics_uuid
+    if self.metrics_uuid.nil?
+      self.update(metrics_uuid: SecureRandom.uuid)
+    end
+    self.metrics_uuid
   end
 
   ###

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,9 +43,13 @@
       // Set the unique cookie for tracking user IDs in GA.  Also used in Mixpanel.
       // This is not personally identifiable, lasts for 1 year or until cleared.
       if ( typeof Cookies.get('user_id') === 'undefined' ) {
-        Cookies.set('user_id', '<%= SecureRandom.uuid %>', {expires: 365})
+        Cookies.set('user_id', '<%= user_signed_in? ? current_user.get_metrics_uuid : SecureRandom.uuid %>', {expires: 365})
       }
       window.SCP.userId = Cookies.get('user_id');
+
+      // track whether this user (if present) is registered for Terra
+      // this is needed for reporting upstream to Bard
+      window.SCP.registeredForTerra = <%= user_signed_in? ? current_user.registered_for_firecloud : false %>
 
       // set userId in Google Analytics
       // Where else is `userId` used?  Consider removing this raw global.

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -59,4 +59,17 @@ class UserTest < ActiveSupport::TestCase
 
     puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
+
+  test 'should assign and use metrics_uuid' do
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
+
+    uuid = @user.get_metrics_uuid
+    @user.reload # gotcha for refreshing in-memory user object
+    assert_equal uuid, @user.metrics_uuid, "Metrics UUID was not assigned correctly; #{uuid} != #{@user.metrics_uuid}"
+    assigned_uuid = @user.get_metrics_uuid
+    @user.reload
+    assert_equal assigned_uuid, @user.metrics_uuid, "Metrics UUID has changed; #{assigned_uuid} != #{@user.metrics_uuid}"
+
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
+  end
 end


### PR DESCRIPTION
Tracking usage of `single-cell-portal` PyPI package (i.e. manage-study) via `User-Agent` headers in Mixpanel.  This change also fixes an issue with `503` errors from Bard when logging usage.  The issue identified was authenticated SCP users who have not registered for Terra do no show up in SAM, and result in a `503` from Bard when it queries upstream as it receives an error.  Now, only authenticated SCP users who have also registered for Terra are identified via their Bearer token.  All other instances fall back to either the browser-based UUID cookie, or the new User model-based `metrics_uuid`.  These values will be unified where possible to avoid double-counting.

This PR satisfies SCP-2691 and SCP-2734.