### PR TITLE
Fix Mixpanel logging for users who are signed-in, but unregistered in Terra (SCP-2734)

### DIFF
--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -260,15 +260,12 @@ export function log(name, props={}) {
 
   props['timeSincePageLoad'] = Math.round(performance.now())
 
-  // Only report 'authenticated' users if signed in and registered for Terra
-  // reporting non-Terra users to Bard results in 503 errors
-  if (accessToken === '') {
-    // User is unauthenticated, anonymous, or not registered for Terra
-    props['authenticated'] = false
-    if (!registeredForTerra) {
-      props['distinct_id'] = userId
-      delete init['headers']['Authorization']
-    }
+  if (accessToken === '' || !registeredForTerra) {
+    // User is unauthenticated, unregistered, anonymous,
+    // or authenticated in SCP but not registered for Terra
+    props['authenticated'] = (accessToken !== '')
+    props['distinct_id'] = userId
+    delete init['headers']['Authorization']
   } else {
     props['authenticated'] = true
   }


### PR DESCRIPTION
This fixes Mixpanel logging for users who are signed-in, but unregistered in Terra.  Such accounts threw `503` in all client-side requests to Bard, i.e. basically all logs for those accounts.

I've tested locally with the four possible account combinations:
1. Signed in and registered in SCP and Terra: `authenticated: true, registeredInTerra: true`
2. Signed in and registered in SCP but not Terra: `authenticated: true, registeredInTerra: false`
3. Signed in but not registered in SCP but not Terra: `authenticated: true, registeredInTerra: false`
4. Not signed in: `authenticated: false, registeredInTerra: false`

The problem was in Case 2, which represents most SCP accounts.  This fix also handles the rare Case 3.

This fixes an issue in #714 and relates to SCP-2734.