### PR TITLE
Adding RuboCop for local Ruby linting (SCP-2128)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+require: rubocop-rails
+
+AllCops:
+  Exclude:
+    - 'node_modules/**/*'
+    - 'vendor/**/*'
+    - Gemfile.lock
+    - yarn.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,48 @@
+# .rubocop.yml
 require: rubocop-rails
 
 AllCops:
+  TargetRubyVersion: 2.6.5
+  TargetRailsVersion: 5.2.4.3
+  DefaultFormatter: progress
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+
   Exclude:
+    - 'bin/*'
+    - 'db/**/*'
     - 'node_modules/**/*'
-    - 'vendor/**/*'
-    - Gemfile.lock
-    - yarn.lock
+    - 'vendor/bundle/**/*'
+    - '*.lock'
+    - '.rubocop.yml'
+    - 'test/ui_test_suite.rb'
+
+Metrics/LineLength:
+  Max: 120
+
+Metrics/MethodLength:
+  Max: 15
+
+Metrics/ClassLength:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'test/**/*'
+
+Metrics/AbcSize:
+  Max: 19
+
+Style/Documentation:
+  Exclude:
+    - 'test/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem 'byebug'
   gem 'puma'
   gem 'rubocop', require: false
+  gem 'rubocop-rails', require: false
 end
 
 gem 'devise'

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development, :test do
   gem 'listen'
   gem 'byebug'
   gem 'puma'
+  gem 'rubocop', require: false
 end
 
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     ansi (1.5.0)
     arel (9.0.0)
+    ast (2.4.1)
     autoprefixer-rails (8.6.5)
       execjs
     backports (3.11.4)
@@ -291,6 +292,8 @@ GEM
       mimemagic (~> 0.3.0)
       terrapin (~> 0.6.0)
     parallel (1.12.1)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
     power_assert (1.1.3)
     public_suffix (3.1.1)
     puma (4.3.5)
@@ -327,11 +330,13 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    rainbow (3.0.0)
     rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rdoc (6.2.1)
+    regexp_parser (1.7.1)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -344,6 +349,18 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
+    rexml (3.2.4)
+    rubocop (0.90.0)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.3.0, < 1.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.4.0)
+      parser (>= 2.7.1.4)
     ruby-debug-ide (0.6.1)
       rake (>= 0.8.1)
     ruby-prof (0.17.0)
@@ -425,6 +442,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
+    unicode-display_width (1.7.0)
     warden (1.2.8)
       rack (>= 2.0.6)
     webpacker (4.2.2)
@@ -482,6 +500,7 @@ DEPENDENCIES
   puma
   rails (= 5.2.4.3)
   rest-client
+  rubocop
   ruby-debug-ide
   ruby-prof
   ruby_native_statistics

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,6 +361,10 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.4.0)
       parser (>= 2.7.1.4)
+    rubocop-rails (2.8.0)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.87.0)
     ruby-debug-ide (0.6.1)
       rake (>= 0.8.1)
     ruby-prof (0.17.0)
@@ -501,6 +505,7 @@ DEPENDENCIES
   rails (= 5.2.4.3)
   rest-client
   rubocop
+  rubocop-rails
   ruby-debug-ide
   ruby-prof
   ruby_native_statistics

--- a/README.md
+++ b/README.md
@@ -603,3 +603,26 @@ dispruption when doing updates during that window (or hot fixes any other time) 
 that will return a 503 and redirect all incoming traffic to a static maintenance HTML page.
 
 To use this feature, run the `bin/enable_maintenance.sh [on/off]` script accordingly.
+
+### RUBOCOP
+
+This project is configured to use [RuboCop](https://docs.rubocop.org/rubocop/index.html) for static code analysis.  There 
+is a [shell script](.bin/run_rubocop.sh) that allows for running RuboCop only on files that have been edited since the last 
+commit to Git.  Configuration for RuboCop can be found [here](.rubocop.yml), or referenced from RuboCop's 
+[default configuration](https://github.com/rubocop-hq/rubocop/blob/master/config/default.yml).
+
+#### USAGE
+
+To run RuboCop normally on all your local changes:
+
+    bin/run_rubocop.sh
+    
+Run in "lint-only" mode (does not enforce style checks):
+
+    bin/run_rubocop.sh -l
+    
+Run in "safe auto-correct" mode (will automatically correct any issues, where possible):
+
+    bin/run_rubocop.sh -a
+
+The `-a` and `-l` flags can be used together.  Usage text for the script can be printed with `-h`.

--- a/bin/run_rubocop.sh
+++ b/bin/run_rubocop.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# run_rubocop.sh - Bash one-liner to run RuboCop on all local changes not yet staged for commit to Git
+# refer to https://docs.rubocop.org/rubocop/index.html for more information on RuboCop usage
+
+usage=$(
+cat <<EOF
+USAGE:
+   $(basename $0) [<options>]
+
+### Bash one-liner to run RuboCop on all local changes not yet staged for commit to Git ###
+
+[OPTIONS]
+-l  Run RuboCop in "lint-only" mode (does not run style checks)
+-a  Use RuboCop "safe auto-correct" mode
+-h  Print this text
+EOF
+)
+
+RUBOCOP_ARGS=""
+
+while getopts "alh" OPTION; do
+case $OPTION in
+  a)
+    RUBOCOP_ARGS="$RUBOCOP_ARGS -a"
+    ;;
+  l)
+    RUBOCOP_ARGS="$RUBOCOP_ARGS -l"
+    ;;
+  h)
+    echo "$usage"
+    exit 0
+    ;;
+  esac
+done
+
+echo "Running rubocop with flags: $RUBOCOP_ARGS"
+
+git status -s | cut -f 3 -d" " | xargs rubocop $RUBOCOP_ARGS


### PR DESCRIPTION
Adds the `rubocop` and `rubocop-rails` gems for local Ruby linting, as well as `bin/run_rubocop.sh` for easily running RuboCop on all local changes that have not been staged for commit yet.  This could be leveraged as a pre-commit hook in future work.  This PR does not apply any changes, but provides functionality to do that in the future.

This PR satisfies SCP-2128.