### PR TITLE
Direct user to re-authenticate when access tokens are missing (SCP-2729)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -350,14 +350,14 @@ module ApplicationHelper
     if study.public? && Study.read_only_firecloud_client.present?
       Study.read_only_firecloud_client.valid_access_token["access_token"]
     elsif user.present?
-      user.valid_access_token[:access_token]
+      user.valid_access_token.try(:[], :access_token)
     end
   end
 
   # Return the user's access token for bulk download of faceted search results
   def get_user_access_token(user)
     if user.present?
-      user.valid_access_token[:access_token]
+      user.valid_access_token.try(:[], :access_token)
     end
   end
 

--- a/app/javascript/lib/user-auth-tokens.js
+++ b/app/javascript/lib/user-auth-tokens.js
@@ -1,17 +1,17 @@
-export default function checkMissingAuthToken(userToken, userSignedIn) {
-    // error handling for auth errors when getting user access tokens
-    if (userToken === '' && userSignedIn) {
-        var errorTitle = 'Please sign in again';
-        var errorText = '<p class="text-danger">There appears to be an issue with your session - ' +
-                        'please sign out and back in again to continue using Single Cell Portal. </p>';
-        var signOutBtn = "<span class='pull-right'><a class='btn btn-primary' data-method='delete' href='/single_cell/users/sign_out'>" +
-                         "<span class='fas fa-sign-out-alt fa-fw'></span> Sign Out</a></span>";
-        var errorMsg = errorText + signOutBtn;
-        $('#generic-modal-spinner').html(errorMsg + "<p>&nbsp;</p>");
-        $('#generic-modal-spinner').removeClass('spinner-target');
-        $('#generic-modal-title').html(errorTitle);
-        $('#generic-modal-title').removeClass('text-center');
-        $('#generic-modal-footer').remove();
-        $('#generic-modal').modal('show')
-    }
+export default function checkMissingAuthToken() {
+  // error handling for auth errors when getting user access tokens
+  if (window.SCP.userAccessToken === '' && window.SCP.userSignedIn) {
+    var errorTitle = 'Please sign in again';
+    var errorText = '<p class="text-danger">There appears to be an issue with your session - ' +
+      'please sign out and back in again to continue using Single Cell Portal. </p>';
+    var signOutBtn = "<span class='pull-right'><a class='btn btn-primary' data-method='delete' href='/single_cell/users/sign_out'>" +
+      "<span class='fas fa-sign-out-alt fa-fw'></span> Sign Out</a></span>";
+    var errorMsg = errorText + signOutBtn;
+    $('#generic-modal-spinner').html(errorMsg + "<p>&nbsp;</p>");
+    $('#generic-modal-spinner').removeClass('spinner-target');
+    $('#generic-modal-title').html(errorTitle);
+    $('#generic-modal-title').removeClass('text-center');
+    $('#generic-modal-footer').remove();
+    $('#generic-modal').modal('show')
+  }
 }

--- a/app/javascript/lib/user-auth-tokens.js
+++ b/app/javascript/lib/user-auth-tokens.js
@@ -1,0 +1,17 @@
+export default function checkMissingAuthToken(userToken, userSignedIn) {
+    // error handling for auth errors when getting user access tokens
+    if (userToken === '' && userSignedIn) {
+        var errorTitle = 'Please sign in again';
+        var errorText = '<p class="text-danger">There appears to be an issue with your session - ' +
+                        'please sign out and back in again to continue using Single Cell Portal. </p>';
+        var signOutBtn = "<span class='pull-right'><a class='btn btn-primary' data-method='delete' href='/single_cell/users/sign_out'>" +
+                         "<span class='fas fa-sign-out-alt fa-fw'></span> Sign Out</a></span>";
+        var errorMsg = errorText + signOutBtn;
+        $('#generic-modal-spinner').html(errorMsg + "<p>&nbsp;</p>");
+        $('#generic-modal-spinner').removeClass('spinner-target');
+        $('#generic-modal-title').html(errorTitle);
+        $('#generic-modal-title').removeClass('text-center');
+        $('#generic-modal-footer').remove();
+        $('#generic-modal').modal('show')
+    }
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -23,7 +23,7 @@ import 'jquery-ui/ui/effects/effect-highlight'
 import igv from '@single-cell-portal/igv'
 import morpheus from 'morpheus-app'
 import Ideogram from 'ideogram'
-
+import checkMissingAuthToken from 'lib/user-auth-tokens'
 
 // Below import resolves to '/app/javascript/components/HomePageContent.js'
 import HomePageContent from 'components/HomePageContent'
@@ -55,6 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
       <Covid19PageContent />, document.getElementById('covid19-page-content')
     )
   }
+  checkMissingAuthToken(window.SCP.userAccessToken, window.SCP.userSignedIn)
 })
 
 window.SCP = window.SCP ? window.SCP : {}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
       <Covid19PageContent />, document.getElementById('covid19-page-content')
     )
   }
-  checkMissingAuthToken(window.SCP.userAccessToken, window.SCP.userSignedIn)
+  checkMissingAuthToken()
 })
 
 window.SCP = window.SCP ? window.SCP : {}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -168,7 +168,7 @@
       <div class="modal-body">
         <div class="spinner-target" id="generic-modal-spinner"></div>
       </div>
-      <div class="modal-footer">
+      <div class="modal-footer" id="generic-modal-footer">
         <button class="close" data-dismiss="modal">×</button>
       </div>
     </div>
@@ -197,13 +197,18 @@
 
     // error handling for auth errors when getting user access tokens
     if (window.SCP.userAccessToken === '' && <%= user_signed_in? %>) {
-        var errorText = '<p>There was a problem retrieving some credentials associated with your account - ' +
-            'please sign out and back in again to address the issue.</p>'
-        var signOutBtn = "<p><a class='btn btn-primary' data-method='delete' href='/single_cell/users/sign_out'>" +
-            "<span class='fas fa-sign-out-alt fa-fw'></span> Sign Out</a></p>"
-        var errorMsg = errorText + signOutBtn
-        // open modal as an alert type to persist message until user clears or signs out
-        showMessageModal(null, errorMsg)
+        var errorTitle = 'Re-sign in again';
+        var errorText = '<p class="text-danger">There was a problem retrieving some credentials associated with your account - ' +
+            'please sign out and back in again to address the issue.</p>';
+        var signOutBtn = "<span class='pull-right'><a class='btn btn-primary' data-method='delete' href='/single_cell/users/sign_out'>" +
+            "<span class='fas fa-sign-out-alt fa-fw'></span> Sign Out</a></span>";
+        var errorMsg = errorText + signOutBtn; // add empty paragraph for padding
+        $('#generic-modal-spinner').html(errorMsg + "<p>&nbsp;</p>");
+        $('#generic-modal-spinner').removeClass('spinner-target');
+        $('#generic-modal-title').html(errorTitle);
+        $('#generic-modal-title').removeClass('text-center');
+        $('#generic-modal-footer').remove();
+        $('#generic-modal').modal('show');
     }
 
     // variable used mostly for testing

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -197,7 +197,7 @@
 
     // error handling for auth errors when getting user access tokens
     if (window.SCP.userAccessToken === '' && <%= user_signed_in? %>) {
-        var errorText = '<p>There was an issue retrieving the access token associated with your account - ' +
+        var errorText = '<p>There was a problem retrieving some credentials associated with your account - ' +
             'please sign out and back in again to address the issue.</p>'
         var signOutBtn = "<p><a class='btn btn-primary' data-method='delete' href='/single_cell/users/sign_out'>" +
             "<span class='fas fa-sign-out-alt fa-fw'></span> Sign Out</a></p>"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -197,9 +197,9 @@
 
     // error handling for auth errors when getting user access tokens
     if (window.SCP.userAccessToken === '' && <%= user_signed_in? %>) {
-        var errorTitle = 'Re-sign in again';
-        var errorText = '<p class="text-danger">There was a problem retrieving some credentials associated with your account - ' +
-            'please sign out and back in again to address the issue.</p>';
+        var errorTitle = 'Please refresh your login';
+        var errorText = '<p class="text-danger">There appears to be an issue with you session - ' +
+            'please sign out and back in again to continue using Single Cell Portal. </p>';
         var signOutBtn = "<span class='pull-right'><a class='btn btn-primary' data-method='delete' href='/single_cell/users/sign_out'>" +
             "<span class='fas fa-sign-out-alt fa-fw'></span> Sign Out</a></span>";
         var errorMsg = errorText + signOutBtn; // add empty paragraph for padding

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -197,7 +197,7 @@
 
     // error handling for auth errors when getting user access tokens
     if (window.SCP.userAccessToken === '' && <%= user_signed_in? %>) {
-        var errorTitle = 'Please refresh your login';
+        var errorTitle = 'Please sign in again';
         var errorText = '<p class="text-danger">There appears to be an issue with you session - ' +
             'please sign out and back in again to continue using Single Cell Portal. </p>';
         var signOutBtn = "<span class='pull-right'><a class='btn btn-primary' data-method='delete' href='/single_cell/users/sign_out'>" +

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,7 @@
       }
 
       window.SCP.userAccessToken = '<%= get_user_access_token(current_user) %>';
+      window.SCP.userSignedIn = <%= user_signed_in? %>;
       window.SCP.environment = '<%= Rails.env %>';
 
       window.SCP.hasLoggedPageView = false;
@@ -194,22 +195,6 @@
   <% end %>
 </div>
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-
-    // error handling for auth errors when getting user access tokens
-    if (window.SCP.userAccessToken === '' && <%= user_signed_in? %>) {
-        var errorTitle = 'Please sign in again';
-        var errorText = '<p class="text-danger">There appears to be an issue with you session - ' +
-            'please sign out and back in again to continue using Single Cell Portal. </p>';
-        var signOutBtn = "<span class='pull-right'><a class='btn btn-primary' data-method='delete' href='/single_cell/users/sign_out'>" +
-            "<span class='fas fa-sign-out-alt fa-fw'></span> Sign Out</a></span>";
-        var errorMsg = errorText + signOutBtn; // add empty paragraph for padding
-        $('#generic-modal-spinner').html(errorMsg + "<p>&nbsp;</p>");
-        $('#generic-modal-spinner').removeClass('spinner-target');
-        $('#generic-modal-title').html(errorTitle);
-        $('#generic-modal-title').removeClass('text-center');
-        $('#generic-modal-footer').remove();
-        $('#generic-modal').modal('show');
-    }
 
     // variable used mostly for testing
     PAGE_RENDERED = true;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -195,6 +195,17 @@
 </div>
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
 
+    // error handling for auth errors when getting user access tokens
+    if (window.SCP.userAccessToken === '' && <%= user_signed_in? %>) {
+        var errorText = '<p>There was an issue retrieving the access token associated with your account - ' +
+            'please sign out and back in again to address the issue.</p>'
+        var signOutBtn = "<p><a class='btn btn-primary' data-method='delete' href='/single_cell/users/sign_out'>" +
+            "<span class='fas fa-sign-out-alt fa-fw'></span> Sign Out</a></p>"
+        var errorMsg = errorText + signOutBtn
+        // open modal as an alert type to persist message until user clears or signs out
+        showMessageModal(null, errorMsg)
+    }
+
     // variable used mostly for testing
     PAGE_RENDERED = true;
 

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -122,6 +122,7 @@ else
                     test/integration/lib/user_asset_service_test.rb
                     test/models/big_query_client_test.rb
                     test/models/upload_cleanup_job_test.rb
+                    test/helper_tests/application_helper_test.rb
   )
   for test_name in ${tests[*]}; do
       bundle exec ruby -I test $test_name

--- a/test/helper_tests/application_helper_test.rb
+++ b/test/helper_tests/application_helper_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+
+class ApplicationHelperTest < ActionView::TestCase
+
+  test 'should retrieve access token' do
+    user = User.first
+    # store access token to restore later
+    access_token_hash = user.access_token
+    client_access_token = get_user_access_token(user)
+    expected_token = access_token_hash.dig(:access_token)
+    assert_equal expected_token, client_access_token,
+                 "Access tokens do not match; #{expected_token} != #{client_access_token}"
+    refute client_access_token.nil?, "Should have retrieved a value for access token"
+
+    # simulate issue with access token retrieval by clearing values
+    user.update(access_token: nil)
+    user.reload
+    new_token = get_user_access_token(user)
+    assert new_token.nil?, "Access token should be nil, but found #{new_token}"
+
+    # clean up and ensure consistency
+    user.update(access_token: access_token_hash)
+    user.reload
+    assert_equal user.access_token, access_token_hash,
+                 "Restore did not complete successfully; #{user.access_token} != #{access_token_hash}"
+  end
+end

--- a/test/helper_tests/application_helper_test.rb
+++ b/test/helper_tests/application_helper_test.rb
@@ -14,13 +14,13 @@ class ApplicationHelperTest < ActionView::TestCase
     refute client_access_token.nil?, "Should have retrieved a value for access token"
 
     # simulate issue with access token retrieval by clearing values
-    user.update(access_token: nil)
+    user.update!(access_token: nil)
     user.reload
     new_token = get_user_access_token(user)
     assert new_token.nil?, "Access token should be nil, but found #{new_token}"
 
     # clean up and ensure consistency
-    user.update(access_token: access_token_hash)
+    user.update!(access_token: access_token_hash)
     user.reload
     assert_equal user.access_token, access_token_hash,
                  "Restore did not complete successfully; #{user.access_token} != #{access_token_hash}"


### PR DESCRIPTION
SCP stores OAuth access tokens in the `User` model after a user signs in to the portal, which is used in a variety actions.  However, there are corner cases where a user can still be considered "signed in", but the access token has been purged from the database.  This previously would result in an unrecoverable error where the user could not use the portal until their session times out after 30 minutes.  This change now gracefully handles missing access tokens, and will instruct the user to sign out/in to generate new refresh & access tokens.

Preview of the modal dialog shown to users:
![logout_prompt_updated](https://user-images.githubusercontent.com/729968/94287774-b5124380-ff24-11ea-8275-f4920f73814d.png)


This PR satisfies SCP-2729.