### PR TITLE
Cache copy of study file in parse_logs folder on ingest failure (SCP-2731)

### DIFF
--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -656,6 +656,11 @@ class StudyFile
     end
   end
 
+  # possible bucket location of file after an ingest failure (will only persist for 30 days after failure)
+  def parse_fail_bucket_location
+    "parse_logs/#{self.id}/#{self.upload_file_name}"
+  end
+
   # generate a download path to use with bulk_download
   # takes the form of :study_accession/:output_directory_name/:filename
   def bulk_download_pathname

--- a/rails_startup.bash
+++ b/rails_startup.bash
@@ -115,6 +115,8 @@ else
 	(crontab -u app -l ; echo "0 1 * * * . /home/app/.cron_env ; cd /home/app/webapp/; /home/app/webapp/bin/rails runner -e $PASSENGER_APP_ENV \"Study.delete_queued_studies\" >> /home/app/webapp/log/cron_out.log 2>&1") | crontab -u app -
 	(crontab -u app -l ; echo "0 1 * * * . /home/app/.cron_env ; cd /home/app/webapp/; /home/app/webapp/bin/rails runner -e $PASSENGER_APP_ENV \"StudyFile.delete_queued_files\" >> /home/app/webapp/log/cron_out.log 2>&1") | crontab -u app -
 	(crontab -u app -l ; echo "0 1 * * * . /home/app/.cron_env ; cd /home/app/webapp/; /home/app/webapp/bin/rails runner -e $PASSENGER_APP_ENV \"UserAnnotation.delete_queued_annotations\" >> /home/app/webapp/log/cron_out.log 2>&1") | crontab -u app -
+	# clean up cached failed ingest runs weekly
+  (crontab -u app -l ; echo "@weekly . /home/app/.cron_env ; cd /home/app/webapp/; /home/app/webapp/bin/rails runner -e $PASSENGER_APP_ENV \"Study.clean_up_ingest_artifacts\" >> /home/app/webapp/log/cron_out.log 2>&1") | crontab -u app -
 fi
 echo "*** COMPLETED ***"
 


### PR DESCRIPTION
Adds functionality to store a copy of a study file in the `parse_logs/:study_file_id` folder in a workspace bucket if the associated ingest pipeline run fails.  This will greatly reduce overhead/latency for QA purposes.  Files/logs older than 30 days will be cleaned up on a weekly basis to reduce storage costs.  A link to the file in question will be included in all admin-facing parse failure emails to further speed up QA/user liaison interactions.

This PR satisfies SCP-2731.