### PR TITLE
Using single-cell-portal-test Terra billing project (SCP-2744)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_install:
   - sudo unzip vault_1.0.1_linux_amd64.zip
   - sudo mv vault /usr/local/bin
 script:
-  - bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json -s secret/kdux/scp/staging/scp_service_account.json -r secret/kdux/scp/staging/read_only_service_account.json -e test -n single-cell-portal-staging
+  - bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json -s secret/kdux/scp/staging/scp_service_account.json -r secret/kdux/scp/staging/read_only_service_account.json -e test -n single-cell-portal-test

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -117,6 +117,7 @@ else
                     test/models/branding_group_test.rb
                     test/models/synthetic_branding_group_populator_test.rb
                     test/models/admin_configuration_test.rb
+                    test/integration/synthetic_study_populator_test.rb
                     test/integration/lib/search_facet_populator_test.rb
                     test/integration/lib/summary_stats_utils_test.rb
                     test/integration/lib/user_asset_service_test.rb


### PR DESCRIPTION
To avoid concurrency issues with CI, this change moves all Travis CI runs from the Terra billing project `single-cell-portal-staging` to `single-cell-portal-test`.  This will alleviate issues with workspace name collisions caused `test/integration/synthetic_study_populator_test.rb`, which is now re-enabled.

This PR satisfies SCP-2744.