### PR TITLE
Scope job_monitor.rb to only check delayed_job .pid files (SCP-2767)

### DIFF
--- a/bin/job_monitor.rb
+++ b/bin/job_monitor.rb
@@ -20,7 +20,7 @@ end
 
 # get current delayed_job processes & pids from files
 processes = `ps aux | grep delayed_job`.split("\n").map {|l| l.split}.map {|l| [l[1], l.last]}.keep_if {|l| l.last.include?('.')}
-pid_files = Dir.entries(File.join(WEB_DIR, 'tmp','pids')).delete_if {|p| p.start_with?('.')}
+pid_files = Dir.entries(File.join(WEB_DIR, 'tmp','pids')).keep_if {|p| p.start_with?('delayed_job')}
 pids = {}
 pid_files.each do |file|
 	pids[file.chomp('.pid')] = File.open(File.join(WEB_DIR, 'tmp', 'pids', file)).read.strip


### PR DESCRIPTION
A bug in `bin/job_monitor.rb` will cause the cron job to check for `Delayed::Job` process fidelity to continually restart all job workers if another pid file is present in the `tmp` directory that doesn't map to a `Delayed::Job` process (such as `server.pid` mapping to the `puma` application server process).  This update correctly scopes the pid file collector to only keep pid files beginning with "**delayed_job**".  While not a problem for deployed hosts, this was a problem for local development if the developer was switching between the Dockerized and non-Dockerized configurations of SCP.

This PR satisfies SCP-2767.