### PR TITLE
Download Agreements hotfix (SCP-2788)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_install:
   - sudo unzip vault_1.0.1_linux_amd64.zip
   - sudo mv vault /usr/local/bin
 script:
-  - bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json -s secret/kdux/scp/staging/scp_service_account.json -r secret/kdux/scp/staging/read_only_service_account.json -e test -n single-cell-portal-test
+  - bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json -s secret/kdux/scp/staging/scp_service_account.json -r secret/kdux/scp/staging/read_only_service_account.json -e test -n single-cell-portal-staging

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1144,3 +1144,29 @@ function appendOptionsToDropdown(options, selectElement) {
     });
     selectElement.append(optionsArray);
 }
+
+// dynamically disable click events on DOM elements using jQuery selector
+// will not allow pointer events on mouse, and will grey out element (50% opacity)
+function disableElements(selector) {
+    var disabledCss = {
+        'pointer-events' : 'none',
+        'opacity': '0.5'
+    };
+    var cursorCss = {
+        'cursor' : 'not-allowed'
+    };
+    selector.css(disabledCss).parent().css(cursorCss);
+}
+
+// dynamically re-enable click events on DOM elements using jQuery selector
+// restores pointer events and resets opacity to 100%
+function enableElements(selector) {
+    var enalbedCss = {
+        'pointer-events': 'auto',
+        'opacity': '1.0'
+    }
+    var cursorCss = {
+        'cursor' : 'auto'
+    };
+    selector.css(enalbedCss).parent().css(cursorCss);
+}

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1146,31 +1146,16 @@ function appendOptionsToDropdown(options, selectElement) {
 }
 
 /**
- * dynamically disable click events on DOM elements using jQuery selector
+ * dynamically enable/disable click events on DOM elements using jQuery selector
  * will not allow pointer events on mouse, and will grey out element (50% opacity)
  */
-function disableElements(selector) {
-    var disabledCss = {
-        'pointer-events': 'none',
-        'opacity': '0.5'
+function setElementsEnabled(selector, enabled= true) {
+    var elementCss = {
+        'pointer-events': enabled ? 'auto' : 'none',
+        'opacity': enabled ? '1.0' : '0.5'
     };
-    var cursorCss = {
-        'cursor': 'not-allowed'
+    var parentCss = {
+        'cursor': enabled ? 'auto' : 'not-allowed'
     };
-    selector.css(disabledCss).parent().css(cursorCss);
-}
-
-/**
- * dynamically re-enable click events on DOM elements using jQuery selector
- * restores pointer events and resets opacity to 100%
- */
-function enableElements(selector) {
-    var enalbedCss = {
-        'pointer-events': 'auto',
-        'opacity': '1.0'
-    }
-    var cursorCss = {
-        'cursor': 'auto'
-    };
-    selector.css(enalbedCss).parent().css(cursorCss);
+    selector.css(elementCss).parent().css(parentCss);
 }

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1145,28 +1145,32 @@ function appendOptionsToDropdown(options, selectElement) {
     selectElement.append(optionsArray);
 }
 
-// dynamically disable click events on DOM elements using jQuery selector
-// will not allow pointer events on mouse, and will grey out element (50% opacity)
+/**
+ * dynamically disable click events on DOM elements using jQuery selector
+ * will not allow pointer events on mouse, and will grey out element (50% opacity)
+ */
 function disableElements(selector) {
     var disabledCss = {
-        'pointer-events' : 'none',
+        'pointer-events': 'none',
         'opacity': '0.5'
     };
     var cursorCss = {
-        'cursor' : 'not-allowed'
+        'cursor': 'not-allowed'
     };
     selector.css(disabledCss).parent().css(cursorCss);
 }
 
-// dynamically re-enable click events on DOM elements using jQuery selector
-// restores pointer events and resets opacity to 100%
+/**
+ * dynamically re-enable click events on DOM elements using jQuery selector
+ * restores pointer events and resets opacity to 100%
+ */
 function enableElements(selector) {
     var enalbedCss = {
         'pointer-events': 'auto',
         'opacity': '1.0'
     }
     var cursorCss = {
-        'cursor' : 'auto'
+        'cursor': 'auto'
     };
     selector.css(enalbedCss).parent().css(cursorCss);
 }

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -570,11 +570,8 @@ module Api
         # load the user from the auth token
         requested_user = valid_totat
 
-        # final auth check - ensure user has permission to download from requested studies
-        # rather than fail entire request, allow subset if user can view some but not others
-        viewable_accessions = Study.viewable(requested_user).pluck(:accession)
-        permitted_accessions = valid_accessions & viewable_accessions
-
+        permitted_accessions = ::BulkDownloadService.get_permitted_accessions(study_accessions: valid_accessions,
+                                                                             user: current_api_user)
         if permitted_accessions.empty?
           render json: {error: "Forbidden: cannot access requested accessions"},
                  status: 403 and return

--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -19,6 +19,7 @@ module Api
                            :get_study_submission, :sync_submission_outputs]
       before_action :check_study_edit_permission, only: [:sync_submission_outputs]
       before_action :set_study_file, only: [:download_data, :stream_data]
+      before_action :check_download_agreement, only: [:download_data, :stream_data]
       before_action :get_download_quota, only: [:download_data, :stream_data]
 
       swagger_path '/site/studies' do
@@ -979,6 +980,12 @@ module Api
       def check_study_detached
         if @study.detached?
           head 410 and return
+        end
+      end
+
+      def check_download_agreement
+        if @study.has_download_agreement? && !@study.download_agreement.user_accepted?(current_api_user)
+          head 403 and return
         end
       end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -176,9 +176,11 @@ class ApplicationController < ActionController::Base
     elsif study.embargoed?(current_user)
       redirect_parameters[:url] = view_study_path(accession: study.accession, study_name: study.url_safe_name)
       redirect_parameters[:message_key] = :embargoed
-    elsif !study.can_download?(current_user) || (study.has_download_agreement? && !study.download_agreement.user_accepted?(current_user))
+    elsif !study.can_download?(current_user)
       redirect_parameters[:url] = view_study_path(accession: study.accession, study_name: study.url_safe_name)
       redirect_parameters[:message_key] = :invalid_permission
+    elsif study.has_download_agreement? && !study.download_agreement.user_accepted?(current_user)
+      head 403 and return
     end
 
     if redirect_parameters.any?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -147,6 +147,93 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # helper method to check all conditions before allowing a user to download file
+  # verifies user permissions, study availability, and download agreements, as well as external services
+  def verify_file_download_permissions(study)
+    # default alert messages for redirect
+    redirect_messages = {
+        invalid_permission: 'You do not have permission to perform that action.',
+        not_authenticated: 'You must be signed in to download data.',
+        study_not_found: 'The study you requested was not found.',
+        detached: 'We were unable to complete your request as the study is question is detached from the workspace (maybe the workspace was deleted?)',
+        embargoed: "You may not download any data from this study until #{study.embargo.try(:to_s, :long)}."
+    }
+    # store redirect_url and message for later
+    redirect_parameters = {}
+
+    if study.nil?
+      redirect_parameters[:url] = site_path
+      redirect_parameters[:message_key] = :study_not_found
+    elsif !user_signed_in?
+      redirect_parameters[:url] = site_path
+      redirect_parameters[:message_key] = :not_authenticated
+    elsif !study.public? && !study.can_view?(current_user)
+      redirect_parameters[:url] = site_path
+      redirect_parameters[:message_key] = :invalid_permission
+    elsif study.detached?
+      redirect_parameters[:url] = site_path
+      redirect_parameters[:message_key] = :detached
+    elsif study.embargoed?(current_user)
+      redirect_parameters[:url] = view_study_path(accession: study.accession, study_name: study.url_safe_name)
+      redirect_parameters[:message_key] = :embargoed
+    elsif !study.can_download?(current_user) || (study.has_download_agreement? && !study.download_agreement.user_accepted?(current_user))
+      redirect_parameters[:url] = view_study_path(accession: study.accession, study_name: study.url_safe_name)
+      redirect_parameters[:message_key] = :invalid_permission
+    end
+
+    if redirect_parameters.any?
+      redirect_to merge_default_redirect_params(redirect_parameters[:url], scpbr: params[:scpbr]),
+                  alert: redirect_messages.dig(redirect_parameters[:message_key]) and return
+    end
+
+    # next check if downloads have been disabled by administrator, this will abort the download
+    # download links shouldn't be rendered in any case, this just catches someone doing a straight GET on a file
+    # also check if workspace google buckets are available
+    if !AdminConfiguration.firecloud_access_enabled? || !Study.firecloud_client.services_available?(FireCloudClient::BUCKETS_SERVICE)
+      head 503 and return
+    end
+  end
+
+  # generate a signed URL for a file and redirect to object in GCS
+  # will account for @download_quota and redirect as necessary
+  def execute_file_download(study)
+    begin
+      # get filesize and make sure the user is under their quota
+      requested_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, study.bucket_id, params[:filename])
+      if requested_file.present?
+        filesize = requested_file.size
+        user_quota = current_user.daily_download_quota + filesize
+        # check against download quota that is loaded in ApplicationController.get_download_quota
+        if user_quota <= @download_quota
+          @signed_url = Study.firecloud_client.execute_gcloud_method(:generate_signed_url, 0, study.bucket_id, params[:filename], expires: 15)
+          current_user.update(daily_download_quota: user_quota)
+        else
+          redirect_to merge_default_redirect_params(view_study_path(accession: study.accession, study_name: study.url_safe_name), scpbr: params[:scpbr]),
+                      alert: 'You have exceeded your current daily download quota.  You must wait until tomorrow to download this file.' and return
+        end
+        # redirect directly to file to trigger download
+        # validate that the signed_url is in fact the correct URL - it must be a GCS lin
+        if is_valid_signed_url?(@signed_url)
+          redirect_to @signed_url
+        else
+          redirect_to merge_default_redirect_params(view_study_path(accession: study.accession, study_name: study.url_safe_name), scpbr: params[:scpbr]),
+                      alert: 'We are unable to process your download.  Please try again later.' and return
+        end
+      else
+        # send notification to the study owner that file is missing (if notifications turned on)
+        SingleCellMailer.user_download_fail_notification(study, params[:filename]).deliver_now
+        redirect_to merge_default_redirect_params(view_study_path(accession: study.accession, study_name: study.url_safe_name), scpbr: params[:scpbr]),
+                    alert: 'The file you requested is currently not available.  Please contact the study owner if you require access to this file.' and return
+      end
+    rescue => e
+      error_context = ErrorTracker.format_extra_context(@study, {params: params})
+      ErrorTracker.report_exception(e, current_user, error_context)
+      logger.error "#{Time.zone.now}: error generating signed url for #{params[:filename]}; #{e.message}"
+      redirect_to merge_default_redirect_params(request.referrer, scpbr: params[:scpbr]),
+                  alert: "We were unable to download the file #{params[:filename]} do to an error: #{view_context.simple_format(e.message)}" and return
+    end
+  end
+
   protected
 
   # patch to supply CSRF token on all ajax requests if it is not present

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -815,6 +815,11 @@ class SiteController < ApplicationController
       return
     end
 
+    if @study.has_download_agreement? && !@study.download_agreement.user_accepted?(current_user)
+      render plain: "Forbidden: Download agreement not accepted for #{@study.accession}" , status: 403
+      return
+    end
+
     # 'all' or the name of a directory, e.g. 'csvs'
     download_object = params[:download_object]
 

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -588,67 +588,12 @@ class StudiesController < ApplicationController
   # method to download files if study is private, will create temporary signed_url after checking user quota
   def download_private_file
     @study = Study.find_by(accession: params[:accession])
-    # make study exists, then ensure user is signed in
-    if @study.nil?
-      redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
-                  alert: 'The study you requested was not found.' and return
-    elsif !user_signed_in? || !@study.can_view?(current_user)
-      redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
-                  alert: 'You do not have permission to perform that action.' and return
-    elsif @study.detached?
-      redirect_to merge_default_redirect_params(request.referrer, scpbr: params[:scpbr]),
-                  alert: "We were unable to complete your request as the study is question is detached from the workspace (maybe the workspace was deleted?)" and return
-    elsif @study.embargoed?(current_user)
-      redirect_to merge_default_redirect_params(view_study_path(accession: @study.accession, study_name: @study.url_safe_name), scpbr: params[:scpbr]),
-                  alert: "You may not download any data from this study until #{@study.embargo.to_s(:long)}." and return
-    elsif !@study.can_download?(current_user)
-      redirect_to merge_default_redirect_params(view_study_path(accession: @study.accession, study_name: @study.url_safe_name), scpbr: params[:scpbr]),
-                  alert: 'You do not have permission to perform that action.' and return
-    elsif @study.has_download_agreement? && !@study.download_agreement.user_accepted?(current_user)
-      head 403 and return
-    end
 
-    # next check if downloads have been disabled by administrator, this will abort the download
-    # download links shouldn't be rendered in any case, this just catches someone doing a straight GET on a file
-    # also check if workspace google buckets are available
-    if !AdminConfiguration.firecloud_access_enabled? || !Study.firecloud_client.services_available?(FireCloudClient::BUCKETS_SERVICE)
-      head 503 and return
-    end
-    begin
-      # get filesize and make sure the user is under their quota
-      requested_file = Study.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, @study.bucket_id, params[:filename])
-      if requested_file.present?
-        filesize = requested_file.size
-        user_quota = current_user.daily_download_quota + filesize
-        # check against download quota that is loaded in ApplicationController.get_download_quota
-        if user_quota <= @download_quota
-          @signed_url = Study.firecloud_client.execute_gcloud_method(:generate_signed_url, 0, @study.bucket_id, params[:filename], expires: 15)
-          current_user.update(daily_download_quota: user_quota)
-        else
-          redirect_to merge_default_redirect_params(view_study_path(accession: @study.accession, study_name: @study.url_safe_name), scpbr: params[:scpbr]),
-                      alert: 'You have exceeded your current daily download quota.  You must wait until tomorrow to download this file.' and return
-        end
-        # redirect directly to file to trigger download
-        # validate that the signed_url is in fact the correct URL - it must be a GCS lin
-        if is_valid_signed_url?(@signed_url)
-          redirect_to @signed_url
-        else
-          redirect_to merge_default_redirect_params(view_study_path(accession: @study.accession, study_name: @study.url_safe_name), scpbr: params[:scpbr]),
-                      alert: 'We are unable to process your download.  Please try again later.' and return
-        end
-      else
-        # send notification to the study owner that file is missing (if notifications turned on)
-        SingleCellMailer.user_download_fail_notification(@study, params[:filename]).deliver_now
-        redirect_to merge_default_redirect_params(view_study_path(accession: @study.accession, study_name: @study.url_safe_name), scpbr: params[:scpbr]),
-                    alert: 'The file you requested is currently not available.  Please contact the study owner if you require access to this file.' and return
-      end
-    rescue => e
-      error_context = ErrorTracker.format_extra_context(@study, {params: params})
-      ErrorTracker.report_exception(e, current_user, error_context)
-      logger.error "#{Time.zone.now}: error generating signed url for #{params[:filename]}; #{e.message}"
-      redirect_to merge_default_redirect_params(request.referrer, scpbr: params[:scpbr]),
-                  alert: "We were unable to download the file #{params[:filename]} do to an error: #{view_context.simple_format(e.message)}" and return
-    end
+    # verify user can download file
+    verify_file_download_permissions(@study); return if performed?
+    # initiate file download action
+    execute_file_download(@study); return if performed?
+
   end
 
   # for files that don't need parsing, send directly to firecloud on upload completion

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -588,12 +588,10 @@ class StudiesController < ApplicationController
   # method to download files if study is private, will create temporary signed_url after checking user quota
   def download_private_file
     @study = Study.find_by(accession: params[:accession])
-
     # verify user can download file
     verify_file_download_permissions(@study); return if performed?
     # initiate file download action
     execute_file_download(@study); return if performed?
-
   end
 
   # for files that don't need parsing, send directly to firecloud on upload completion

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -604,6 +604,8 @@ class StudiesController < ApplicationController
     elsif !@study.can_download?(current_user)
       redirect_to merge_default_redirect_params(view_study_path(accession: @study.accession, study_name: @study.url_safe_name), scpbr: params[:scpbr]),
                   alert: 'You do not have permission to perform that action.' and return
+    elsif @study.has_download_agreement? && !@study.download_agreement.user_accepted?(current_user)
+      head 403 and return
     end
 
     # next check if downloads have been disabled by administrator, this will abort the download

--- a/app/models/download_acceptance.rb
+++ b/app/models/download_acceptance.rb
@@ -1,0 +1,17 @@
+class DownloadAcceptance
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  belongs_to :download_agreement
+  field :email, type: String
+
+  validates_presence_of :email
+
+  def user
+    User.find_by(email: self.email)
+  end
+
+  def study
+    self.download_agreement.study
+  end
+end

--- a/app/models/download_acceptance.rb
+++ b/app/models/download_acceptance.rb
@@ -4,8 +4,11 @@ class DownloadAcceptance
 
   belongs_to :download_agreement
   field :email, type: String
+  field :study_accession, type: String
 
-  validates_presence_of :email
+  before_validation :set_study_accession, on: :create
+
+  validates_presence_of :email, :study_accession
 
   def user
     User.find_by(email: self.email)
@@ -13,5 +16,13 @@ class DownloadAcceptance
 
   def study
     self.download_agreement.study
+  end
+
+  private
+
+  # set the study_accession for this download_acceptance
+  # useful for provenance in case parent study/agreement is destroyed
+  def set_study_accession
+    self.study_accession = self.study.accession
   end
 end

--- a/app/models/download_acceptance.rb
+++ b/app/models/download_acceptance.rb
@@ -1,3 +1,7 @@
+##
+# DownloadAcceptance: tracks acceptance of DownloadAgreement for individual user & study.
+# records the email & study_accession directly rather than relying on :belongs_to in case associated record is deleted
+##
 class DownloadAcceptance
   include Mongoid::Document
   include Mongoid::Timestamps

--- a/app/models/download_agreement.rb
+++ b/app/models/download_agreement.rb
@@ -13,7 +13,7 @@ class DownloadAgreement
 
   # Check if an agreement has expired.  If no expiration date is present, agreement is still enforced
   def expired?
-    self.expires_at.present? ? self.expires_at < Date.today : true
+    self.expires_at.present? ? self.expires_at < Date.today : false
   end
 
   def user_emails

--- a/app/models/download_agreement.rb
+++ b/app/models/download_agreement.rb
@@ -1,0 +1,26 @@
+class DownloadAgreement
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  belongs_to :study
+  has_many :download_acceptances
+
+  field :content, type: String
+  field :expires_at, type: Date
+
+  validates_presence_of :content
+  validates_uniqueness_of :study_id
+
+  # Check if an agreement has expired.  If no expiration date is present, agreement is still enforced
+  def expired?
+    self.expires_at.present? ? self.expires_at < Date.today : true
+  end
+
+  def user_emails
+    self.download_acceptances.pluck(:email)
+  end
+
+  def user_accepted?(user)
+    user.present? ? self.user_emails.include?(user.email) : false
+  end
+end

--- a/app/models/download_agreement.rb
+++ b/app/models/download_agreement.rb
@@ -23,4 +23,12 @@ class DownloadAgreement
   def user_accepted?(user)
     user.present? ? self.user_emails.include?(user.email) : false
   end
+
+  def expiration_date
+    self.expires_at || "N/A"
+  end
+
+  def accepted_count
+    self.download_acceptances.count
+  end
 end

--- a/app/models/download_agreement.rb
+++ b/app/models/download_agreement.rb
@@ -1,3 +1,7 @@
+##
+# DownloadAgreement: study-scope policy terms that users must accept in order to gain access to download data
+# individual records of users accepting policies are tracked in DownloadAcceptance
+##
 class DownloadAgreement
   include Mongoid::Document
   include Mongoid::Timestamps

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -883,6 +883,14 @@ class Study
     self.embargo.nil? || self.embargo.blank? ? false : Date.today <= self.embargo
   end
 
+  def download_agreement
+    DownloadAgreement.find_by(study_id: self.id)
+  end
+
+  def has_download_agreement?
+    self.download_agreement.present? ? self.download_agreement.expired? : false
+  end
+
   # label for study visibility
   def visibility
     self.public? ? "<span class='sc-badge bg-success text-success'>Public</span>".html_safe : "<span class='sc-badge bg-danger text-danger'>Private</span>".html_safe

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -218,6 +218,9 @@ class Study
   # Study Detail (full html description)
   has_one :study_detail, dependent: :delete
 
+  # DownloadAgreement (extra user terms for downloading data)
+  has_one :download_agreement, dependent: :delete
+
   # field definitions
   field :name, type: String
   field :embargo, type: Date
@@ -243,6 +246,7 @@ class Study
   accepts_nested_attributes_for :study_shares, allow_destroy: true, reject_if: proc { |attributes| attributes['email'].blank? }
   accepts_nested_attributes_for :external_resources, allow_destroy: true
   accepts_nested_attributes_for :study_detail, allow_destroy: true
+  accepts_nested_attributes_for :download_agreement, allow_destroy: true
 
   ##
   #
@@ -883,12 +887,8 @@ class Study
     self.embargo.nil? || self.embargo.blank? ? false : Date.today <= self.embargo
   end
 
-  def download_agreement
-    DownloadAgreement.find_by(study_id: self.id)
-  end
-
   def has_download_agreement?
-    self.download_agreement.present? ? self.download_agreement.expired? : false
+    self.download_agreement.present? ? !self.download_agreement.expired? : false
   end
 
   # label for study visibility

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -776,7 +776,7 @@ class Study
       elsif self.can_edit?(user)
         return true
       else
-        self.user_in_group_share?(user, 'View', 'Reviewer')
+        return self.user_in_group_share?(user, 'View', 'Reviewer')
       end
     end
     false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -313,7 +313,6 @@ class User
         end
       end
     end
-    Rails.logger.info "projects: #{projects}"
     projects
   end
 

--- a/app/views/site/_study_download_agreement.html.erb
+++ b/app/views/site/_study_download_agreement.html.erb
@@ -1,0 +1,19 @@
+<div class="row" id="study-download-agreement">
+  <div class="col-xs-12">
+    <%= form_for :download_acceptance,
+                 url: record_download_acceptance_path(accession: @study.accession),
+                 html: {class: 'form', id: 'record-download-agreement', data: {remote: true}} do |f| %>
+
+      <%= f.hidden_field :email, value: current_user.email %>
+      <%= f.hidden_field :download_agreement_id, value: @download_agreement.id %>
+
+      <h2>Before Downloading Data...</h2>
+      <%= @study.download_agreement.content.html_safe %>
+      <div class="form-group text-center">
+        <%= f.submit "I Accept", class: 'btn btn-lg btn-success', id: 'download-agreement-submit' %>
+      </div>
+
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/site/_study_download_agreement.html.erb
+++ b/app/views/site/_study_download_agreement.html.erb
@@ -1,5 +1,5 @@
 <div class="row" id="study-download-agreement">
-  <div class="col-xs-12">
+  <div class="col-xs-offset-2 col-xs-8">
     <%= form_for :download_acceptance,
                  url: record_download_acceptance_path(accession: @study.accession),
                  html: {class: 'form', id: 'record-download-agreement', data: {remote: true}} do |f| %>
@@ -10,9 +10,12 @@
       <h2>Before Downloading Data...</h2>
       <%= @study.download_agreement.content.html_safe %>
       <div class="form-group text-center">
-        <%= f.submit "I Accept", class: 'btn btn-lg btn-success', id: 'download-agreement-submit' %>
+        <% if !@download_agreement.user_accepted?(current_user) %>
+          <%= f.submit "I Accept", class: 'btn btn-lg btn-success', id: 'download-agreement-submit' %>
+        <% else %>
+          <%= button_tag "Accepted", type: 'button', class: 'btn btn-lg btn-default', disabled: true  %>
+        <% end %>
       </div>
-
 
     <% end %>
   </div>

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -1,6 +1,4 @@
-<% if @download_agreement && !@user_accepted_agreement  %>
-  <%= render partial: 'study_download_agreement' %>
-<% end %>
+<%= render partial: 'study_download_agreement' if @download_agreement.present? %>
 
 <div class="row">
   <div class="col-xs-12">

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'study_download_agreement' if @download_agreement.present? %>
+<%= render partial: 'study_download_agreement' if @study.has_download_agreement? %>
 
 <div class="row">
   <div class="col-xs-12">
@@ -286,8 +286,8 @@
     var hasAgreement = <%= @study.has_download_agreement? %>;
     var userHasAccepted = <%= @user_accepted_agreement %>;
     if (hasAgreement && !userHasAccepted) {
-        disableElements($('.dl-link'))
-        disableElements($('#download-help'))
+        setElementsEnabled($('.dl-link'), false)
+        setElementsEnabled($('#download-help'), false)
     }
 
     $('#fastq-table').dataTable({

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -1,3 +1,7 @@
+<% if @download_agreement && !@user_accepted_agreement  %>
+  <%= render partial: 'study_download_agreement' %>
+<% end %>
+
 <div class="row">
   <div class="col-xs-12">
     <h2>Study Files <span class="badge"><%= @study_files.count %></span>  <%= link_to "<i class='fas fa-question-circle'></i> Bulk Download".html_safe, '#/', class: "btn btn-default pull-right #{!@allow_downloads ? 'disabled' : nil}", id: 'download-help' %></h2>
@@ -281,6 +285,12 @@
 
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
 
+    var hasAgreement = <%= @study.has_download_agreement? %>;
+    var userHasAccepted = <%= @user_accepted_agreement %>;
+    if (hasAgreement && !userHasAccepted) {
+        disableElements($('.dl-link'))
+        disableElements($('#download-help'))
+    }
 
     $('#fastq-table').dataTable({
         pagingType: 'full',

--- a/app/views/site/record_download_acceptance.js.erb
+++ b/app/views/site/record_download_acceptance.js.erb
@@ -1,0 +1,3 @@
+enableElements($('.dl-link'));
+enableElements($('#download-help'));
+$('#study-download-agreement').remove();

--- a/app/views/site/record_download_acceptance.js.erb
+++ b/app/views/site/record_download_acceptance.js.erb
@@ -1,3 +1,5 @@
 enableElements($('.dl-link'));
 enableElements($('#download-help'));
-$('#study-download-agreement').remove();
+// $('#study-download-agreement').remove();
+$('#download-agreement-submit').replaceWith("<%= j(button_tag "Accepted", type: 'button', class: 'btn btn-lg btn-default', disabled: true) %>")
+showMessageModal("Thank you for accepting - you may now download data from this study.")

--- a/app/views/site/record_download_acceptance.js.erb
+++ b/app/views/site/record_download_acceptance.js.erb
@@ -1,5 +1,4 @@
 enableElements($('.dl-link'));
 enableElements($('#download-help'));
-// $('#study-download-agreement').remove();
 $('#download-agreement-submit').replaceWith("<%= j(button_tag "Accepted", type: 'button', class: 'btn btn-lg btn-default', disabled: true) %>")
 showMessageModal("Thank you for accepting - you may now download data from this study.")

--- a/app/views/site/record_download_acceptance.js.erb
+++ b/app/views/site/record_download_acceptance.js.erb
@@ -1,4 +1,4 @@
-enableElements($('.dl-link'));
-enableElements($('#download-help'));
+setElementsEnabled($('.dl-link'));
+setElementsEnabled($('#download-help'));
 $('#download-agreement-submit').replaceWith("<%= j(button_tag "Accepted", type: 'button', class: 'btn btn-lg btn-default', disabled: true) %>")
 showMessageModal("Thank you for accepting - you may now download data from this study.")

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -117,7 +117,6 @@ else
                     test/models/branding_group_test.rb
                     test/models/synthetic_branding_group_populator_test.rb
                     test/models/admin_configuration_test.rb
-                    test/integration/synthetic_study_populator_test.rb
                     test/integration/lib/search_facet_populator_test.rb
                     test/integration/lib/summary_stats_utils_test.rb
                     test/integration/lib/user_asset_service_test.rb

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -122,6 +122,7 @@ else
                     test/integration/lib/summary_stats_utils_test.rb
                     test/integration/lib/user_asset_service_test.rb
                     test/integration/lib/file_parse_service_test.rb
+                    test/integration/download_agreement_test.rb
                     test/models/big_query_client_test.rb
                     test/models/upload_cleanup_job_test.rb
                     test/helper_tests/application_helper_test.rb

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -247,6 +247,9 @@ Rails.application.routes.draw do
     get 'genome_assemblies', to: 'site#get_taxon_assemblies', as: :get_taxon_assemblies
     get 'taxon', to: 'site#get_taxon', as: :get_taxon
 
+    # download agreement actions
+    post 'study/:accession/:study_name/download_acceptance', to: 'site#record_download_acceptance', as: :record_download_acceptance
+
     # base actions
     get 'search', to: 'site#search', as: :search
     post 'get_viewable_studies', to: 'site#get_viewable_studies', as: :get_viewable_studies

--- a/test/integration/download_agreement_test.rb
+++ b/test/integration/download_agreement_test.rb
@@ -1,0 +1,49 @@
+require "integration_test_helper"
+
+class DownloadAgreementTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @random_seed = File.open(Rails.root.join('.random_seed')).read.strip
+    @study = Study.find_by(name: "Test Study #{@random_seed}")
+    @test_user = User.find_by(email: 'testing.user@gmail.com')
+    auth_as_user(@test_user)
+    sign_in @test_user
+  end
+
+  test 'should enforce download agreement' do
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
+
+    # ensure normal download works
+    file = @study.study_files.sample
+    get download_file_path(accession: @study.accession, study_name: @study.url_safe_name, filename: file.upload_file_name)
+    # since this is an external redirect, we cannot call follow_redirect! but instead have to get the location header
+    assert_response 302, "Did not initiate file download as expected; response code: #{response.code}"
+    signed_url = response.headers['Location']
+    assert signed_url.include?(file.upload_file_name), "Redirect url does not point at requested file"
+
+    # enable download agreement, assert 403
+    download_agreement = DownloadAgreement.new(study_id: @study.id, content: 'This is the agreement content')
+    download_agreement.save!
+
+    file = @study.study_files.sample
+    get download_file_path(accession: @study.accession, study_name: @study.url_safe_name, filename: file.upload_file_name)
+    assert_response :forbidden, "Did not correctly respond 403 when download agreement is in place: #{response.code}"
+
+    # accept agreement and validate downloads resume
+    download_acceptance = DownloadAcceptance.new(email: @test_user.email, download_agreement: download_agreement)
+    download_acceptance.save!
+
+    get download_file_path(accession: @study.accession, study_name: @study.url_safe_name, filename: file.upload_file_name)
+    assert_response 302, "Did not re-enable file download as expected; response code: #{response.code}"
+    signed_url = response.headers['Location']
+    assert signed_url.include?(file.upload_file_name), "Redirect url does not point at requested file"
+
+    # clean up
+    download_agreement.destroy
+    download_acceptance.destroy
+
+    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
+  end
+
+end

--- a/test/integration/download_agreement_test.rb
+++ b/test/integration/download_agreement_test.rb
@@ -24,7 +24,7 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
 
     # test bulk download
     get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
-                                 download_object: 'all', totat: @user.create_totat)
+                                 download_object: 'all', totat: @test_user.create_totat)
     assert_response :success, "Did not get curl config for bulk download"
 
     # enable download agreement, assert 403
@@ -35,7 +35,7 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     get download_file_path(accession: @study.accession, study_name: @study.url_safe_name, filename: file.upload_file_name)
     assert_response :forbidden, "Did not correctly respond 403 when download agreement is in place: #{response.code}"
     get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
-                                 download_object: 'all', totat: @user.create_totat)
+                                 download_object: 'all', totat: @test_user.create_totat)
     assert_response :forbidden, "Did not correctly respond 403 for bulk download: #{response.code}"
     assert response.body.include?('Download agreement'), "Error response did not reference download agreement: #{response.body}"
 
@@ -48,7 +48,7 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     signed_url = response.headers['Location']
     assert signed_url.include?(file.upload_file_name), "Redirect url does not point at requested file"
     get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
-                                 download_object: 'all', totat: @user.create_totat)
+                                 download_object: 'all', totat: @test_user.create_totat)
     assert_response :success, "Did not get curl config for bulk download after accepting download agreement"
 
     # clean up

--- a/test/integration/download_agreement_test.rb
+++ b/test/integration/download_agreement_test.rb
@@ -22,6 +22,11 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     signed_url = response.headers['Location']
     assert signed_url.include?(file.upload_file_name), "Redirect url does not point at requested file"
 
+    # test bulk download
+    get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
+                                 download_object: 'all', totat: @user.create_totat)
+    assert_response :success, "Did not get curl config for bulk download"
+
     # enable download agreement, assert 403
     download_agreement = DownloadAgreement.new(study_id: @study.id, content: 'This is the agreement content')
     download_agreement.save!
@@ -29,6 +34,10 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     file = @study.study_files.sample
     get download_file_path(accession: @study.accession, study_name: @study.url_safe_name, filename: file.upload_file_name)
     assert_response :forbidden, "Did not correctly respond 403 when download agreement is in place: #{response.code}"
+    get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
+                                 download_object: 'all', totat: @user.create_totat)
+    assert_response :forbidden, "Did not correctly respond 403 for bulk download: #{response.code}"
+    assert response.body.include?('Download agreement'), "Error response did not reference download agreement: #{response.body}"
 
     # accept agreement and validate downloads resume
     download_acceptance = DownloadAcceptance.new(email: @test_user.email, download_agreement: download_agreement)
@@ -38,6 +47,9 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     assert_response 302, "Did not re-enable file download as expected; response code: #{response.code}"
     signed_url = response.headers['Location']
     assert signed_url.include?(file.upload_file_name), "Redirect url does not point at requested file"
+    get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
+                                 download_object: 'all', totat: @user.create_totat)
+    assert_response :success, "Did not get curl config for bulk download after accepting download agreement"
 
     # clean up
     download_agreement.destroy

--- a/test/integration/download_agreement_test.rb
+++ b/test/integration/download_agreement_test.rb
@@ -25,7 +25,7 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     # test bulk download, first by generating and saving user totat.
     totat = @test_user.create_totat
     get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
-                                 download_object: 'all', totat: totat['totat'])
+                                 download_object: 'all', totat: totat[:totat])
     assert_response :success, "Did not get curl config for bulk download"
 
     # enable download agreement, assert 403
@@ -36,7 +36,7 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     assert_response :forbidden, "Did not correctly respond 403 when download agreement is in place: #{response.code}"
     totat = @test_user.create_totat
     get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
-                                 download_object: 'all', totat: totat['totat'])
+                                 download_object: 'all', totat: totat[:totat])
     assert_response :forbidden, "Did not correctly respond 403 for bulk download: #{response.code}"
     assert response.body.include?('Download agreement'), "Error response did not reference download agreement: #{response.body}"
 
@@ -50,7 +50,7 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     assert signed_url.include?(file.upload_file_name), "Redirect url does not point at requested file"
     totat = @test_user.create_totat
     get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
-                                 download_object: 'all', totat: totat['totat'])
+                                 download_object: 'all', totat: totat[:totat])
     assert_response :success, "Did not get curl config for bulk download after accepting download agreement"
 
     # clean up

--- a/test/integration/download_agreement_test.rb
+++ b/test/integration/download_agreement_test.rb
@@ -15,7 +15,7 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
 
     # ensure normal download works
-    file = @study.study_files.sample
+    file = @study.expression_matrix_files.first
     get download_file_path(accession: @study.accession, study_name: @study.url_safe_name, filename: file.upload_file_name)
     # since this is an external redirect, we cannot call follow_redirect! but instead have to get the location header
     assert_response 302, "Did not initiate file download as expected; response code: #{response.code}"

--- a/test/integration/lib/bulk_download_service_test.rb
+++ b/test/integration/lib/bulk_download_service_test.rb
@@ -116,4 +116,32 @@ class BulkDownloadServiceTest < ActiveSupport::TestCase
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 
+  test 'should get list of permitted accessions' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+    accessions = Study.pluck(:accession)
+    permitted = BulkDownloadService.get_permitted_accessions(study_accessions: accessions, user: @user)
+    assert_equal accessions.sort, permitted.sort,
+                 "Did not return expected list of accessions; #{permitted} != #{accessions}"
+
+    # add download agreement to remove study from list
+    download_agreement = DownloadAgreement.new(study_id: @study.id, content: 'This is the agreement content')
+    download_agreement.save!
+    with_agreement = BulkDownloadService.get_permitted_accessions(study_accessions: accessions, user: @user)
+    refute with_agreement.include?(@study.accession),
+           "Should not have found #{@study.accession} in updated list: #{with_agreement}"
+
+    # accept terms to restore access
+    download_acceptance = DownloadAcceptance.new(email: @user.email, download_agreement: download_agreement)
+    download_acceptance.save!
+
+    final_accessions = BulkDownloadService.get_permitted_accessions(study_accessions: accessions, user: @user)
+    assert_equal accessions.sort, final_accessions.sort,
+                 "Did not return expected list of accessions; #{final_accessions} != #{accessions}"
+
+    # clean up
+    download_acceptance.destroy
+    download_agreement.destroy
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
 end


### PR DESCRIPTION
Implementing `DownloadAgreement` and `DownloadAcceptance`, an interface for creating and tracking user acceptance of any additional study owner-provided terms before downloading data from a study.  An example would be a researcher that wants to distribute their data in advance of publication, but would like to ensure that other users do not take the data and publish any results ahead of the original publication.  This new functionality would block downloads both client- and server-side until the user has accepted the terms, at which time downloads are re-enabled for that user account.

This PR is a "hotfix" to merge the requested functionality into `master` for deployment ahead of the next regularly scheduled release on 2020.10.15 (see #745 for the `development` merge).

This PR satisfies SCP-2788.