### PR TITLE
fixing synth populate for study description

### DIFF
--- a/app/lib/synthetic_study_populator.rb
+++ b/app/lib/synthetic_study_populator.rb
@@ -49,6 +49,7 @@ class SyntheticStudyPopulator
     end
 
     study = Study.new(study_config['study'])
+    study.study_detail = StudyDetail.new(full_description: study_config['study']['description'])
     study.user ||= user
     study.firecloud_project ||= ENV['PORTAL_NAMESPACE']
     puts("Saving Study #{study.name}")


### PR DESCRIPTION
newly-populated Synthetic studies were unviewable due to not having the StudyDetail created.  

I could also see fixing this by adding an on-create trigger to study.rb that auto-creates the StudyDetail object if the description is specified and no StudyDetail already exists.  But given the amount of triggers already in study.rb, I thought it was best to keep it simple and just update the populator.