### PR TITLE
Fix a UI flow for gene search in Study Overview (SCP-2772)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -261,9 +261,6 @@ function initializeAutocomplete(selector) {
         if (event.keyCode === $.ui.keyCode.TAB && $(this).autocomplete("instance").menu.active) {
             // allow user to select terms with TAB key
             event.preventDefault();
-        } else if (event.keyCode === $.ui.keyCode.ENTER && keydownIsFromAutocomplete === false) {
-            // only perform search if user has selected items and is pressing ENTER on focused search box
-            $('#perform-gene-search').click();
         }
     }).autocomplete(
         {

--- a/app/views/site/_search_options.html.erb
+++ b/app/views/site/_search_options.html.erb
@@ -113,7 +113,8 @@
                               type: 'gene',
                               context: 'study',
                               genes,
-                              numGenes: genes.length
+                              numGenes: genes.length,
+                              trigger: event.type // "submit" or "click"
                             }
 
                             var searchEvent = window.SCP.startPendingEvent('search', searchLogProps);

--- a/app/views/site/_search_options.html.erb
+++ b/app/views/site/_search_options.html.erb
@@ -106,41 +106,37 @@
                         setErrorOnBlank($('.search-genes-input'));
                     } else {
                         $(window).off('resizeEnd');
-                        if (event.type == 'click') {
-                            launchModalSpinner('#spinner_target', '#loading-modal', function() {
-                                var genes = window.SCP.formatTerms($('#search_genes').val())
-                                var searchLogProps = {
-                                  type: 'gene',
-                                  context: 'study',
-                                  genes,
-                                  numGenes: genes.length,
-                                }
 
-                                var searchEvent = window.SCP.startPendingEvent('search', searchLogProps);
-                                // also start measuring the end-to-end user experience event
-                                // this will complete when the plot is rendered
-                                window.SCP.startPendingEvent(
-                                  'user-action:search:site-study', searchLogProps, 'plot:'
-                                );
-                                var form = $('#search-genes-form');
-                                $.ajax({
-                                    type: 'POST',
-                                    url: form.attr('action'),
-                                    data: form.serialize(),
-                                    dataType: 'script',
-                                    complete: searchEvent.complete
-                                });
+                        launchModalSpinner('#spinner_target', '#loading-modal', function() {
+                            var genes = window.SCP.formatTerms($('#search_genes').val())
+                            var searchLogProps = {
+                              type: 'gene',
+                              context: 'study',
+                              genes,
+                              numGenes: genes.length
+                            }
+
+                            var searchEvent = window.SCP.startPendingEvent('search', searchLogProps);
+                            // also start measuring the end-to-end user experience event
+                            // this will complete when the plot is rendered
+                            window.SCP.startPendingEvent(
+                              'user-action:search:site-study', searchLogProps, 'plot:'
+                            );
+                            var form = $('#search-genes-form');
+                            $.ajax({
+                                type: 'POST',
+                                url: form.attr('action'),
+                                data: form.serialize(),
+                                dataType: 'script',
+                                complete: searchEvent.complete
                             });
-                        } else if (event.type == 'submit') {
-                            launchModalSpinner('#spinner_target', '#loading-modal', function() {
-                                return true; // just return as submit event has fired
-                            });
-                        }
+                        });
+
                     }
                 }
                 // handler to catch ENTER keypress and open modal
-                $('#search-genes-form').on('submit', function(submitEvent) {
-                    submitGeneSearch(submitEvent);
+                $('#search-genes-form').on('submit', function(event) {
+                    submitGeneSearch(event);
                     return false; // Prevents double search-and-render
                 });
             </script>


### PR DESCRIPTION
This fixes a bug in gene search within studies.  For context, users can search a gene in Study Overview via one of four flows:

1. Type gene name, press Enter
2. Type gene name, click button
3. Type part of gene name, pick from autocomplete, press Enter
4. Type part of gene name, pick from autocomplete, click button

Flow 1 was broken and is now fixed.  

The bug was caused by #710, which fixed a minor server-load bug triggered by flows 1 and 3, but was only tested in flow 3 (which I've grown so accustomed to I conflated with flow 1).  These changes preserve the server-load fix while also, more importantly, ensuring flow 1 works.

The user interaction that triggered search is now also logged.  This will be extended to help facilitate analytics for Ideogram for related genes (SCP-2720).

I manually tested the four flows above.  I'll also be talking with folks about automated test strategy for this complex legacy UI.

This satisfies SCP-2772.