### PR TITLE
updating to singlecellportal/rails-baseimage:1.0.5 (SCP-2799)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM singlecellportal/rails-baseimage:1.0.4
+FROM singlecellportal/rails-baseimage:1.0.5
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-2.6.5'


### PR DESCRIPTION
Updating to version `1.0.5` of `singlecellportal/rails-baseimage` to incorporate security patches to the `ubuntu` base image.

This PR satisfies SCP-2799.