### PR TITLE
fixing click tracking for icons within buttons/links (SCP-2778)

### DIFF
--- a/app/javascript/components/HomePageContent.js
+++ b/app/javascript/components/HomePageContent.js
@@ -29,7 +29,7 @@ const LinkableSearchTabs = function(props) {
   const showGenesTab = location.pathname.startsWith('/single_cell/app/genes')
   return (
     <div>
-      <nav className="nav search-links" data-tablist-name="search" role="tablist">
+      <nav className="nav search-links" data-analytics-name="search" role="tablist">
         <Link to={`/single_cell/app/studies${location.search}`}
           className={showGenesTab ? '' : 'active'}>
           <span className="fas fa-book"></span> Search Studies

--- a/app/views/site/_study_tabs_nav.html.erb
+++ b/app/views/site/_study_tabs_nav.html.erb
@@ -1,4 +1,4 @@
-<ul class="nav nav-tabs"  data-tablist-name="study-overview" role="tablist" id="study-tabs">
+<ul class="nav nav-tabs"  data-analytics-name="study-overview" role="tablist" id="study-tabs">
   <li role="presentation" class="study-nav active" id="study-summary-nav"><a href="#study-summary" data-toggle="tab">Summary <i class="far fa-fw fa-file-alt"></i></a></li>
   <% if @study.can_visualize? %>
     <li role="presentation" class="study-nav" id="study-visualize-nav"><a href="#study-visualize" data-toggle="tab">Explore <i class="fas fa-fw fa-eye"></i></a></li>

--- a/app/views/site/_study_visualize.html.erb
+++ b/app/views/site/_study_visualize.html.erb
@@ -5,7 +5,7 @@
   <div class="col-md-13" id="render-target">
     <div class="row-offcanvas row-offcanvas-right">
       <div id="view-options-nav"><a href="#view-options" id="view-option-link" data-toggle="offcanvas"><i class="fas fa-cog" aria-hidden="true"></i> View Options </a></div>
-      <ul class="nav nav-tabs" role="tablist" id="view-tabs" data-tablist-name="explore-default">
+      <ul class="nav nav-tabs" role="tablist" id="view-tabs" data-analytics-name="explore-default">
         <% if @study.can_visualize_clusters? %>
           <li role="presentation" class="study-nav active" id="plots-tab-nav"><a href="#plots-tab" data-toggle="tab">Clusters </a></li>
         <% end %>

--- a/app/views/site/_view_gene_expression.html.erb
+++ b/app/views/site/_view_gene_expression.html.erb
@@ -13,7 +13,7 @@
   <div class="col-md-13" id="render-target">
     <div class="row-offcanvas row-offcanvas-right">
       <div id="view-options-nav"><a href="#view-options" id="view-option-link" data-toggle="offcanvas"><i class="fas fa-cog" aria-hidden="true"></i> View Options </a></div>
-      <ul class="nav nav-tabs" role="tablist" id="view-tabs" data-tablist-name="explore-single-gene">
+      <ul class="nav nav-tabs" role="tablist" id="view-tabs" data-analytics-name="explore-single-gene">
         <li role="presentation" class="study-nav active" id="box-or-violin-tab-nav"><a href="#box-or-violin-tab" id="distribution-link" data-toggle="tab">Distribution</a></li>
         <li role="presentation" class="study-nav" id="scatter-tab-nav"><a href="#scatter-tab" id="scatter-link" data-toggle="tab">Scatter</a></li>
         <% if !@genes.nil? or @precomputed_heatmap %>

--- a/app/views/site/_view_gene_expression_heatmap.html.erb
+++ b/app/views/site/_view_gene_expression_heatmap.html.erb
@@ -5,7 +5,7 @@
   <div class="col-md-13" id="render-target">
     <div class="row-offcanvas row-offcanvas-right">
       <div id="view-options-nav"><a href="#view-options" id="view-option-link" data-toggle="offcanvas"><i class="fas fa-cog" aria-hidden="true"></i> View Options </a></div>
-      <ul class="nav nav-tabs" role="tablist" id="view-tabs" data-tablist-name="explore-multiple-genes">
+      <ul class="nav nav-tabs" role="tablist" id="view-tabs" data-analytics-name="explore-multiple-genes">
         <li role="presentation" class="study-nav active" id="dot-tab-nav"><a href="#dot-plots-tab" data-toggle="tab">Dot Plot </a></li>
         <li role="presentation" class="study-nav" id="plots-tab-nav"><a href="#plots-tab" data-toggle="tab">Heatmap </a></li>
         <% if @study.has_bam_files? %>


### PR DESCRIPTION
this also standardizes on 'data-analytics-name' as the property we give something that needs an analytics name.

This is needed for tracking clicks on the advanced search opt-in (SCP-2778) but was self-contained enough that I thought it was worth it's own PR