### PR TITLE
Speed up and refine UI in related genes ideogram (SCP-2363)

### DIFF
--- a/app/assets/javascripts/scp-related-genes-ideogram.js
+++ b/app/assets/javascripts/scp-related-genes-ideogram.js
@@ -74,7 +74,8 @@ function createRelatedGenesIdeogram(taxon) { // eslint-disable-line
   // Clear any prior ideogram
   if (typeof window.ideogram !== 'undefined') {
     delete window.ideogram
-    document.querySelector('#related-genes-ideogram-container').remove()
+    const ideoContainer = document.querySelector('#related-genes-ideogram-container')
+    if (ideoContainer) ideoContainer.remove()
   }
 
   const gene = document.querySelector('#search_genes').value.trim()

--- a/app/assets/javascripts/scp-related-genes-ideogram.js
+++ b/app/assets/javascripts/scp-related-genes-ideogram.js
@@ -46,8 +46,7 @@ function putIdeogramInPlotTabs(ideoContainer) {
  */
 function showRelatedGenesIdeogram() { // eslint-disable-line
 
-  // Enables handling for old SCP studies, where matrices lack taxons
-  if (window.SCP.taxons.length === 0) return
+  if (!window.ideogram) return
 
   const ideoContainer =
     document.querySelector('#related-genes-ideogram-container')
@@ -70,6 +69,8 @@ function showRelatedGenesIdeogram() { // eslint-disable-line
  * This is only done in the context of single-gene search in Study Overview
  */
 function createRelatedGenesIdeogram(taxon) { // eslint-disable-line
+
+  if (taxon === null) return
 
   // Clear any prior ideogram
   if (typeof window.ideogram !== 'undefined') {

--- a/app/assets/javascripts/scp-related-genes-ideogram.js
+++ b/app/assets/javascripts/scp-related-genes-ideogram.js
@@ -74,7 +74,8 @@ function createRelatedGenesIdeogram(taxon) { // eslint-disable-line
   // Clear any prior ideogram
   if (typeof window.ideogram !== 'undefined') {
     delete window.ideogram
-    const ideoContainer = document.querySelector('#related-genes-ideogram-container')
+    const ideoContainer =
+      document.querySelector('#related-genes-ideogram-container')
     if (ideoContainer) ideoContainer.remove()
   }
 

--- a/app/assets/javascripts/scp-related-genes-ideogram.js
+++ b/app/assets/javascripts/scp-related-genes-ideogram.js
@@ -84,8 +84,15 @@ function createRelatedGenesIdeogram() { // eslint-disable-line
   // Clear any prior ideogram
   if (typeof window.ideogram !== 'undefined') {
     delete window.ideogram
-    document.querySelector('#related-genes-ideogram-container').innerHTML = ''
+    document.querySelector('#related-genes-ideogram-container').remove()
   }
+
+  const gene = document.querySelector('#search_genes').value.trim()
+
+  // Create scaffolding for Ideogram for related genes
+  const ideoContainer =
+    '<div id="related-genes-ideogram-container" class="hidden-related-genes-ideogram"></div>' // eslint-disable-line
+  $('body').append(ideoContainer)
 
   const ideoConfig = {
     container: '#related-genes-ideogram-container',
@@ -94,16 +101,12 @@ function createRelatedGenesIdeogram() { // eslint-disable-line
     chrHeight: 100,
     chrLabelSize: 12,
     annotationHeight: 7,
-    showTools: true,
     onClickAnnot,
     onLoad() {
       // Handles edge case: when organism lacks chromosome-level assembly
       if (!genomeHasChromosomes()) return
 
-      const searchInput = document.querySelector('#search_genes').value.trim()
-      const geneSymbol = searchInput.split(/[, ]/).filter(d => d !== '')[0]
-
-      this.plotRelatedGenes(geneSymbol)
+      this.plotRelatedGenes(gene)
     }
   }
 

--- a/app/assets/javascripts/scp-related-genes-ideogram.js
+++ b/app/assets/javascripts/scp-related-genes-ideogram.js
@@ -92,7 +92,7 @@ function createRelatedGenesIdeogram() { // eslint-disable-line
   // Create scaffolding for Ideogram for related genes
   const ideoContainer =
     '<div id="related-genes-ideogram-container" class="hidden-related-genes-ideogram"></div>' // eslint-disable-line
-  $('body').append(ideoContainer)
+  document.querySelector('body').insertAdjacentHTML('beforeEnd', ideoContainer)
 
   const ideoConfig = {
     container: '#related-genes-ideogram-container',

--- a/app/assets/javascripts/scp-related-genes-ideogram.js
+++ b/app/assets/javascripts/scp-related-genes-ideogram.js
@@ -18,15 +18,6 @@ function onClickAnnot(annot) {
 }
 
 /**
- * Reports if current gene has associated taxon (aka species, organism)
- *
- * Enables handling for old SCP studies, where matrices lack taxons
- */
-function geneHasTaxon() {
-  return window.SCP.taxon !== ''
-}
-
-/**
  * Reports if current genome assembly has chromosome length data
  *
  * Enables handling for taxons that cannot be visualized in an ideogram.
@@ -55,7 +46,8 @@ function putIdeogramInPlotTabs(ideoContainer) {
  */
 function showRelatedGenesIdeogram() { // eslint-disable-line
 
-  if (!geneHasTaxon()) return
+  // Enables handling for old SCP studies, where matrices lack taxons
+  if (window.SCP.taxons.length === 0) return
 
   const ideoContainer =
     document.querySelector('#related-genes-ideogram-container')
@@ -77,9 +69,7 @@ function showRelatedGenesIdeogram() { // eslint-disable-line
  *
  * This is only done in the context of single-gene search in Study Overview
  */
-function createRelatedGenesIdeogram() { // eslint-disable-line
-
-  if (!geneHasTaxon()) return
+function createRelatedGenesIdeogram(taxon) { // eslint-disable-line
 
   // Clear any prior ideogram
   if (typeof window.ideogram !== 'undefined') {
@@ -96,7 +86,7 @@ function createRelatedGenesIdeogram() { // eslint-disable-line
 
   const ideoConfig = {
     container: '#related-genes-ideogram-container',
-    organism: window.SCP.taxon,
+    organism: taxon,
     chrWidth: 9,
     chrHeight: 100,
     chrLabelSize: 12,

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -311,6 +311,7 @@ class SiteController < ApplicationController
     @primary_data = @study.directory_listings.primary_data
     @other_data = @study.directory_listings.non_primary_data
     @unique_genes = @study.unique_genes
+    @taxons = @study.expressed_taxon_names
 
     # double check on download availability: first, check if administrator has disabled downloads
     # then check individual statuses to see what to enable/disable
@@ -416,14 +417,18 @@ class SiteController < ApplicationController
 
   ## GENE-BASED
 
-  # render box and scatter plots for parent clusters or a particular sub cluster
+  # render violin and scatter plots for parent clusters or a particular sub cluster
   def view_gene_expression
     @options = load_cluster_group_options
     @cluster_annotations = load_cluster_group_annotations
     @top_plot_partial = @selected_annotation[:type] == 'group' ? 'expression_plots_view' : 'expression_annotation_plots_view'
     @y_axis_title = load_expression_axis_title
 
-    @taxons = @study.infer_taxons(params[:gene])
+    if @study.expressed_taxon_names.length > 1
+      @gene_taxons = @study.infer_taxons(params[:gene])
+    else
+      @gene_taxons = @study.expressed_taxon_names
+    end
 
     if request.format == 'text/html'
       # only set this check on full page loads (happens if user was not signed in but then clicked the 'genome' tab)

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -418,9 +418,12 @@ label {
   z-index: 500;
 }
 
-/* Ensures autocomplete is never hidden behind other elements */
+/*
+* Ensures autocomplete is never hidden behind other elements,
+* except loading model (z-index 1050, per Bootstrap default)
+*/
 .ui-autocomplete.ui-front {
-  z-index: 1100;
+  z-index: 1040;
 }
 
 .gene-panel {

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1116,6 +1116,13 @@ class Study
     Gene.where(study_id: self.id, :study_file_id.in => self.expression_matrix_files.map(&:id)).pluck(:name).uniq
   end
 
+  # List unique scientific names of species for all expression matrices in study
+  def expressed_taxon_names
+    self.expression_matrix_files
+      .map {|f| f.taxon.try(:scientific_name) }
+      .uniq
+  end
+
   # For a gene name in this study, get scientific name of species / organism
   # For example: "PTEN" -> ["Homo sapiens"].
   #
@@ -1262,7 +1269,7 @@ class Study
     self.study_files.by_type(['Expression Matrix', 'MM Coordinate Matrix'])
   end
 
-  # helper method to directly access expression matrix file file by name
+  # helper method to directly access expression matrix file by name
   def expression_matrix_file(name)
     self.study_files.find_by(:file_type.in => ['Expression Matrix', 'MM Coordinate Matrix'], name: name)
   end

--- a/app/views/site/_search_options.html.erb
+++ b/app/views/site/_search_options.html.erb
@@ -109,11 +109,12 @@
 
                         launchModalSpinner('#spinner_target', '#loading-modal', function() {
                             var genes = window.SCP.formatTerms($('#search_genes').val())
+                            var numGenes = genes.length
                             var searchLogProps = {
                               type: 'gene',
                               context: 'study',
                               genes,
-                              numGenes: genes.length,
+                              numGenes,
                               trigger: event.type // "submit" or "click"
                             }
 
@@ -125,7 +126,7 @@
                             );
                             var form = $('#search-genes-form');
 
-                            if (window.SCP.taxons.length === 1) {
+                            if (window.SCP.taxons.length === 1 && numGenes === 1) {
                               window.SCP.taxon = window.SCP.taxons[0];
                               createRelatedGenesIdeogram();
                             }

--- a/app/views/site/_search_options.html.erb
+++ b/app/views/site/_search_options.html.erb
@@ -127,8 +127,8 @@
                             var form = $('#search-genes-form');
 
                             if (window.SCP.taxons.length === 1 && numGenes === 1) {
-                              window.SCP.taxon = window.SCP.taxons[0];
-                              createRelatedGenesIdeogram();
+                              const currentTaxon = window.SCP.taxons[0]
+                              createRelatedGenesIdeogram(currentTaxon);
                             }
 
                             $.ajax({

--- a/app/views/site/_search_options.html.erb
+++ b/app/views/site/_search_options.html.erb
@@ -124,6 +124,12 @@
                               'user-action:search:site-study', searchLogProps, 'plot:'
                             );
                             var form = $('#search-genes-form');
+
+                            if (window.SCP.taxons.length === 1) {
+                              window.SCP.taxon = window.SCP.taxons[0];
+                              createRelatedGenesIdeogram();
+                            }
+
                             $.ajax({
                                 type: 'POST',
                                 url: form.attr('action'),

--- a/app/views/site/_study_visualize.html.erb
+++ b/app/views/site/_study_visualize.html.erb
@@ -144,6 +144,9 @@
             }
         });
     });
+
+    // Used for Ideogram for related genes
+    window.SCP.taxons = <%= raw @taxons.to_json %>;
   <% end %>
     $('#ideogram_annotation').on('change', function() {
         var ideogramFiles = <%= raw @ideogram_files.to_json %>;

--- a/app/views/site/_view_gene_expression_title_bar.html.erb
+++ b/app/views/site/_view_gene_expression_title_bar.html.erb
@@ -8,14 +8,13 @@
 </div>
 
 <script>
-  // Initializes Ideogram for related genes
 
-  document.querySelector('.study-lead').parentElement.innerHTML +=
-    '<div id="related-genes-ideogram-container" class="hidden-related-genes-ideogram"></div>';
-
-  // TODO (SCP-2769): Handle when a searched gene maps to multiple species
-  window.SCP.taxon = '<%= @taxons.first %>';
-
-  createRelatedGenesIdeogram();
+  // Initializes Ideogram for related genes, if it hasn't already been
+  // started for the current searched gene.
+  if (window.SCP.taxons.length > 1) {
+    // TODO (SCP-2769): Handle when a searched gene maps to multiple species
+    window.SCP.taxon = '<%= @gene_taxons.first %>';
+    createRelatedGenesIdeogram();
+  }
 
 </script>

--- a/app/views/site/_view_gene_expression_title_bar.html.erb
+++ b/app/views/site/_view_gene_expression_title_bar.html.erb
@@ -13,8 +13,8 @@
   // started for the current searched gene.
   if (window.SCP.taxons.length > 1) {
     // TODO (SCP-2769): Handle when a searched gene maps to multiple species
-    window.SCP.taxon = '<%= @gene_taxons.first %>';
-    createRelatedGenesIdeogram();
+    const currentTaxon = '<%= @gene_taxons.first %>';
+    createRelatedGenesIdeogram(currentTaxon);
   }
 
 </script>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
-    "ideogram": "git+https://github.com/eweitz/ideogram.git#011351bff9dbc82d3febf56598ef637cadbfe800",
+    "ideogram": "1.26.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.12.1",
     "morpheus-app": "1.0.18",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
-    "ideogram": "git+https://github.com/eweitz/ideogram.git#0e02554acf530b8740c452b85b4c4092c045878d",
+    "ideogram": "git+https://github.com/eweitz/ideogram.git#011351bff9dbc82d3febf56598ef637cadbfe800",
     "jquery": "3.5.1",
     "jquery-ui": "1.12.1",
     "morpheus-app": "1.0.18",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
-    "ideogram": "1.25.0",
+    "ideogram": "git+https://github.com/eweitz/ideogram.git#0e02554acf530b8740c452b85b4c4092c045878d",
     "jquery": "3.5.1",
     "jquery-ui": "1.12.1",
     "morpheus-app": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6878,10 +6878,9 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ideogram@1.25.0:
+"ideogram@git+https://github.com/eweitz/ideogram.git#0e02554acf530b8740c452b85b4c4092c045878d":
   version "1.25.0"
-  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.25.0.tgz#a6423902487bdd2c5857194952830d2f279c7e55"
-  integrity sha512-lBPVgh/3I0/q2UzPoN8sIINUDt7Zi2Tm+/ux5PmkfRnrQ97gZ6/lzDkeUZne8s66cAGRynpRwdHS/ZtEuoFl9g==
+  resolved "git+https://github.com/eweitz/ideogram.git#0e02554acf530b8740c452b85b4c4092c045878d"
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6878,9 +6878,9 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-"ideogram@git+https://github.com/eweitz/ideogram.git#0e02554acf530b8740c452b85b4c4092c045878d":
+"ideogram@git+https://github.com/eweitz/ideogram.git#011351bff9dbc82d3febf56598ef637cadbfe800":
   version "1.25.0"
-  resolved "git+https://github.com/eweitz/ideogram.git#0e02554acf530b8740c452b85b4c4092c045878d"
+  resolved "git+https://github.com/eweitz/ideogram.git#011351bff9dbc82d3febf56598ef637cadbfe800"
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6878,9 +6878,10 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-"ideogram@git+https://github.com/eweitz/ideogram.git#011351bff9dbc82d3febf56598ef637cadbfe800":
-  version "1.25.0"
-  resolved "git+https://github.com/eweitz/ideogram.git#011351bff9dbc82d3febf56598ef637cadbfe800"
+ideogram@1.26.0:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.26.0.tgz#8680566e7a872eb6b7dbe01fbf191258c7aac9ea"
+  integrity sha512-7tE2wzMk/dszuYhudMg6YIWRbEswmbQG74wCqigbyWV/MXDwBcXsh+SVddm/v8JyVYe9nh90Kvs5osx4jKJxBg==
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"


### PR DESCRIPTION
This improves performance and includes several suggested UI refinements in the new related genes ideogram.  Compared to #735, the feature is over 2x faster and more polished.

Speed optimizations include:
* [Parallelizing requests for paralogs and interacting genes](https://github.com/eweitz/ideogram/pull/243)
* [Making fewer requests and using faster APIs](https://github.com/eweitz/ideogram/pull/244)
* Starting genomics API calls sooner

The last one is SCP-specific and accounts for most of the code changes seen here.  In brief: if the expression matrices for the current study are all for the same taxon, then we can 1) avoid search-time, gene-specific taxon lookups and thus 2) start related genes API calls sooner.  See diagram below.

![Optimizing_related_genes_ideogram_SCP_2020-10-13](https://user-images.githubusercontent.com/1334561/95904526-a53c9100-0d65-11eb-9e50-1cf1d7596aef.png)

User interface improvements include:
* Softer color for chromosome labels and borders
* No more extraneous scrolling for cursor-placement edge cases
* Legend icon rotation matches chromosome annotations
* Z-index fixes for autocomplete in gene search UI [flow 1](#750), and ideogram tooltips relative to loading modal

Case sensitivity in related genes search has also been relaxed.  So now in single-species studies, like we do elsewhere, searching for "gad1" will return results even if the gene name is technically "GAD1".

A look at the latest:
<img width="1680" alt="ideogram_for_related_genes_SCP_2020-10-13" src="https://user-images.githubusercontent.com/1334561/95891639-5dad0980-0d53-11eb-95c2-ad3ead993994.png">

This relates to SCP-2363.