### PR TITLE
Fix expression threshold slider in inferCNV ideogram (SCP-2745)

### DIFF
--- a/app/assets/javascripts/scp-infercnv-ideogram.js
+++ b/app/assets/javascripts/scp-infercnv-ideogram.js
@@ -75,7 +75,7 @@ function addMarginControl() {
 function updateThreshold(event) {
   let newThreshold
 
-  const expressionThreshold = parseInt(event.target.value)
+  window.expressionThreshold = parseInt(event.target.value)
 
   adjustedExpressionThreshold = Math.round(expressionThreshold/10 - 4)
   const thresholds = window.originalHeatmapThresholds
@@ -99,7 +99,7 @@ function updateThreshold(event) {
 
 /** Create slider to adjust expression threshold for "gain" or "loss" calls */
 function addThresholdControl() {
-  if (typeof(expressionThreshold) === 'undefined') {
+  if (typeof window.expressionThreshold === 'undefined') {
     window.expressionThreshold = 50
     window.originalHeatmapThresholds =
       ideogram.rawAnnots.metadata.heatmapThresholds

--- a/app/assets/javascripts/scp-infercnv-ideogram.js
+++ b/app/assets/javascripts/scp-infercnv-ideogram.js
@@ -5,6 +5,7 @@ let checkboxes
 let ideoConfig
 let adjustedExpressionThreshold
 let chrMargin
+let expressionThreshold
 
 const legend = [{
   name: 'Expression level',
@@ -75,7 +76,7 @@ function addMarginControl() {
 function updateThreshold(event) {
   let newThreshold
 
-  window.expressionThreshold = parseInt(event.target.value)
+  expressionThreshold = parseInt(event.target.value)
 
   adjustedExpressionThreshold = Math.round(expressionThreshold/10 - 4)
   const thresholds = window.originalHeatmapThresholds
@@ -99,8 +100,8 @@ function updateThreshold(event) {
 
 /** Create slider to adjust expression threshold for "gain" or "loss" calls */
 function addThresholdControl() {
-  if (typeof window.expressionThreshold === 'undefined') {
-    window.expressionThreshold = 50
+  if (typeof expressionThreshold === 'undefined') {
+    expressionThreshold = 50
     window.originalHeatmapThresholds =
       ideogram.rawAnnots.metadata.heatmapThresholds
   }
@@ -119,7 +120,7 @@ function addThresholdControl() {
         type="range"
         id="expressionThreshold"
         list="expressionThresholdList"
-        value="${window.expressionThreshold}"
+        value="${expressionThreshold}"
       >
       <datalist id="expressionThresholdList">
         <option value="0" label="0.">


### PR DESCRIPTION
This fixes a bug -- seemingly caused by auto-formatting -- in which adjusting the "Expression threshold" slider in inferCNV ideograms would change the visualization as expected, but not be reflected in the slider widget itself.

This satisfies SCP-2745.