### PR TITLE
Fix misplaced "x" clear icon in global study search (SCP-2791)

### DIFF
--- a/app/javascript/styles/_keywordSearch.scss
+++ b/app/javascript/styles/_keywordSearch.scss
@@ -49,7 +49,7 @@
     z-index: 200;
     background: none;
     width: 1.5em;
-    right: 40px;
+    right: 10px;
     svg {
       color: #aaa;
     }


### PR DESCRIPTION
This fixes the placement of the "x" icon in global study search, which appears after users begin typing a keyword.  It was pushed too far away from the search icon -- now it's more conventionally placed.

Bug:
<img width="330" alt="keyword_clear_icon_bug_SCP_2020-10-13" src="https://user-images.githubusercontent.com/1334561/95906814-a02d1100-0d68-11eb-8a27-e6cb7e401345.png">

Fixed:
<img width="341" alt="keyword_clear_icon_fixed_SCP_2020-10-13" src="https://user-images.githubusercontent.com/1334561/95906826-a4f1c500-0d68-11eb-8ec1-102ffbee2c16.png">

This satisfies SCP-2791.
