### PR TITLE
Only show ideogram if related genes are found (SCP-2816)

### DIFF
--- a/app/assets/javascripts/scp-related-genes-ideogram.js
+++ b/app/assets/javascripts/scp-related-genes-ideogram.js
@@ -17,6 +17,8 @@ function onClickAnnot(annot) {
   const ideogram = this // eslint-disable-line
   document.querySelector('#search_genes').value = annot.name
 
+  setFoundRelatedGenes(false)
+
   // Enable merge of related-genes log props into search log props
   // This helps profile the numerator of click-through-rate
   const event = {}
@@ -71,9 +73,6 @@ function showRelatedGenesIdeogram() { // eslint-disable-line
   }
 
   putIdeogramInPlotTabs(ideoContainer)
-
-  // Make Ideogram visible
-  ideoContainer.classList = 'show-related-genes-ideogram'
 }
 
 /**
@@ -101,6 +100,35 @@ function onPlotRelatedGenes() {
   const props = getRelatedGenesAnalytics(ideogram)
 
   window.SCP.log('ideogram:related-genes', props)
+}
+
+/**
+ * Set inner visibility of ideogram
+ *
+ * @param found Boolean Whether related genes have been found
+ */
+function setFoundRelatedGenes(found) {
+  const innerFoundClass = (found) ? 'found-related-genes' : ''
+  const innerSelect = '#related-genes-ideogram-container #_ideogramInnerWrap'
+  document.querySelector(innerSelect).classList = innerFoundClass
+
+  if (found) {
+    const ideoContainer =
+      document.querySelector('#related-genes-ideogram-container')
+
+    // Make Ideogram visible
+    ideoContainer.classList = 'show-related-genes-ideogram'
+  }
+}
+
+/**
+ * Show ideogram upon finding any interacting gene or paralog
+ *
+ * This enables ideogram to only be shown when related genes are found (while
+ * also allowing incremental rendering).
+ */
+function onFindRelatedGenes() {
+  setFoundRelatedGenes(true)
 }
 
 /**
@@ -136,6 +164,7 @@ function createRelatedGenesIdeogram(taxon) { // eslint-disable-line
     annotationHeight: 7,
     onClickAnnot,
     onPlotRelatedGenes,
+    onFindRelatedGenes,
     onLoad() {
       // Handles edge case: when organism lacks chromosome-level assembly
       if (!genomeHasChromosomes()) return

--- a/app/assets/javascripts/scp-related-genes-ideogram.js
+++ b/app/assets/javascripts/scp-related-genes-ideogram.js
@@ -67,7 +67,7 @@ function showRelatedGenesIdeogram() { // eslint-disable-line
     document.querySelector('#related-genes-ideogram-container')
 
   if (!genomeHasChromosomes()) {
-    ideoContainer.classList = 'hidden-related-genes-ideogram'
+    ideoContainer.classList = 'hidden'
     ideoContainer.innerHTML = ''
     return
   }
@@ -152,7 +152,7 @@ function createRelatedGenesIdeogram(taxon) { // eslint-disable-line
 
   // Create scaffolding for Ideogram for related genes
   const ideoContainer =
-    '<div id="related-genes-ideogram-container" class="hidden-related-genes-ideogram"></div>' // eslint-disable-line
+    '<div id="related-genes-ideogram-container" class="hidden"></div>' // eslint-disable-line
   document.querySelector('body').insertAdjacentHTML('beforeEnd', ideoContainer)
 
   const ideoConfig = {

--- a/app/javascript/styles/_relatedGenesIdeogram.scss
+++ b/app/javascript/styles/_relatedGenesIdeogram.scss
@@ -2,6 +2,14 @@
   z-index: 1000;
   background: #FFF;
 
+  #_ideogramInnerWrap {
+    visibility: hidden;
+
+    &.found-related-genes {
+      visibility: visible;
+    }
+  }
+
   &.hidden-related-genes-ideogram {
     visibility: hidden;
 

--- a/app/javascript/styles/_relatedGenesIdeogram.scss
+++ b/app/javascript/styles/_relatedGenesIdeogram.scss
@@ -10,8 +10,7 @@
     }
   }
 
-  &.hidden-related-genes-ideogram {
-    visibility: hidden;
+  &.hidden {
 
     #_ideogramMiddleWrap {
       height: 0 !important;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
-    "ideogram": "1.26.0",
+    "ideogram": "1.27.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.12.1",
     "morpheus-app": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6878,10 +6878,10 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ideogram@1.26.0:
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.26.0.tgz#8680566e7a872eb6b7dbe01fbf191258c7aac9ea"
-  integrity sha512-7tE2wzMk/dszuYhudMg6YIWRbEswmbQG74wCqigbyWV/MXDwBcXsh+SVddm/v8JyVYe9nh90Kvs5osx4jKJxBg==
+ideogram@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.27.0.tgz#e5e9d6ac8e7ef0b894f767c35b8cbc20bd38164b"
+  integrity sha512-meIg6C9lrrg5wT173got4jRIvdVY7352AEstvCdgflXy0N2dcRArmm8qguQ4GYRz8+iOdDFTGZWoMT1TmwAiFg==
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"


### PR DESCRIPTION
This refines handling of Ensembl REST API outages by only showing the new related genes ideogram if results are found.  This resiliency enhancement preserves incremental rendering -- a significant performance optimization.

This satisfies SCP-2816.