### PR TITLE
SCP-2398: Changing default workspace owner to SA google group

### DIFF
--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -443,7 +443,7 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   # * *params*
   #   - +workspace_namespace+ (String) => namespace of workspace
   #   - +workspace_name+ (String) => name of workspace
-  #   - +no_workspace_owner+ (Boolean) => T/F to assign workspace owner to user making request (default: false)
+  #   - +no_workspace_owner+ (Boolean) => T/F to skip assigning workspace owner to user making request (default: false)
   #   - +authorization_domains+ (Array<String>) => list of authorization domains to add to workspace
   #
   # * *return*

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -443,16 +443,19 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   # * *params*
   #   - +workspace_namespace+ (String) => namespace of workspace
   #   - +workspace_name+ (String) => name of workspace
+  #   - +no_workspace_owner+ (Boolean) => T/F to assign workspace owner to user making request (default: false)
+  #   - +authorization_domains+ (Array<String>) => list of authorization domains to add to workspace
   #
   # * *return*
   #   - +Hash+ object of workspace instance
-  def create_workspace(workspace_namespace, workspace_name, *authorization_domains)
+  def create_workspace(workspace_namespace, workspace_name, no_workspace_owner=false, *authorization_domains)
     path = self.api_root + '/api/workspaces'
     # construct payload for POST
     payload = {
         namespace: workspace_namespace,
         name: workspace_name,
         attributes: {},
+        noWorkspaceOwner: no_workspace_owner,
         authorizationDomain: []
     }
     # add authorization domains to new workspace

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1652,7 +1652,7 @@ class Study
       begin
         # create workspace
         if self.firecloud_project == FireCloudClient::PORTAL_NAMESPACE
-          workspace = ApplicationController.firecloud_client.create_workspace(self.firecloud_project, self.firecloud_workspace)
+          workspace = ApplicationController.firecloud_client.create_workspace(self.firecloud_project, self.firecloud_workspace, true)
         else
           workspace = client.create_workspace(self.firecloud_project, self.firecloud_workspace)
         end
@@ -1881,25 +1881,25 @@ class Study
     end
   end
 
-  # set permissions on workspaces outside the portal namespace to allow users to use projects they own or are a member of
+  # set permissions on workspaces to workspace owner Google group for service account
+  # this reduces the number of groups the SA is a member of to lower burden on quota (2000 direct memberships)
   def set_service_account_permissions
-    # only perform check if this is not the default portal project
-    if self.firecloud_project != FireCloudClient::PORTAL_NAMESPACE
-      begin
-        sa_owner_group = AdminConfiguration.find_or_create_ws_user_group!
+    begin
+      sa_owner_group = AdminConfiguration.find_or_create_ws_user_group!
+      if self.firecloud_project == FireCloudClient::PORTAL_NAMESPACE
+        client = ApplicationController.firecloud_client
+      else
         client = FireCloudClient.new(self.user, self.firecloud_project)
-        group_email = sa_owner_group['groupEmail']
-        acl = client.create_workspace_acl(group_email, 'OWNER', true, false)
-        client.update_workspace_acl(self.firecloud_project, self.firecloud_workspace, acl)
-        updated = client.get_workspace_acl(self.firecloud_project, self.firecloud_workspace)
-        return updated['acl'][group_email]['accessLevel'] == 'OWNER'
-      rescue RuntimeError => e
-        ErrorTracker.report_exception(e, self.user, {firecloud_project: self.firecloud_workspace})
-        Rails.logger.error "#{Time.zone.now}: unable to add portal service account to #{self.firecloud_workspace}: #{e.message}"
-        false
       end
-    else
-      true
+      group_email = sa_owner_group['groupEmail']
+      acl = client.create_workspace_acl(group_email, 'OWNER', true, false)
+      client.update_workspace_acl(self.firecloud_project, self.firecloud_workspace, acl)
+      updated = client.get_workspace_acl(self.firecloud_project, self.firecloud_workspace)
+      return updated['acl'][group_email]['accessLevel'] == 'OWNER'
+    rescue RuntimeError => e
+      ErrorTracker.report_exception(e, self.user, {firecloud_project: self.firecloud_workspace})
+      Rails.logger.error "#{Time.zone.now}: unable to add portal service account to #{self.firecloud_workspace}: #{e.message}"
+      false
     end
   end
 

--- a/test/integration/study_creation_test.rb
+++ b/test/integration/study_creation_test.rb
@@ -154,7 +154,7 @@ class StudyCreationTest < ActionDispatch::IntegrationTest
     assert study.present?, "Study did not successfully save"
     sa_owner_group = AdminConfiguration.find_or_create_ws_user_group!
     group_email = sa_owner_group['groupEmail']
-    workspace_acl = ApplicationController.firecloud_client.get_worksace_acl(study.firecloud_project, study.firecloud_workspace)
+    workspace_acl = ApplicationController.firecloud_client.get_workspace_acl(study.firecloud_project, study.firecloud_workspace)
     group_acl = workspace_acl['acl'][group_email]
     assert group_acl['accessLevel']  == 'OWNER', "Did not correctly set #{group_email} to 'OWNER'; #{group_acl}"
 

--- a/test/integration/study_creation_test.rb
+++ b/test/integration/study_creation_test.rb
@@ -135,6 +135,33 @@ class StudyCreationTest < ActionDispatch::IntegrationTest
     assert_equal initial_bq_row_count + 30, get_bq_row_count(bq_dataset, study)
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
 
+  # new studies in PORTAL_NAMESPACE should have workspace owners set to SA owner group, not SA directly
+  test 'should assign service account owner group as workspace owner' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    study_name = "Workspace Owner #{@random_seed}"
+    study_params = {
+        study: {
+            name: study_name,
+            user_id: @test_user.id
+        }
+    }
+    post studies_path, params: study_params
+    follow_redirect!
+    study = Study.find_by(name: study_name)
+    assert study.present?, "Study did not successfully save"
+    sa_owner_group = AdminConfiguration.find_or_create_ws_user_group!
+    group_email = sa_owner_group['groupEmail']
+    workspace_acl = ApplicationController.firecloud_client.get_worksace_acl(study.firecloud_project, study.firecloud_workspace)
+    group_acl = workspace_acl['acl'][group_email]
+    assert group_acl['accessLevel']  == 'OWNER', "Did not correctly set #{group_email} to 'OWNER'; #{group_acl}"
+
+    # clean up
+    ApplicationController.firecloud_client.delete_workspace(study.firecloud_project, study.firecloud_workspace)
+    study.destroy
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 end


### PR DESCRIPTION
For studies in the default Terra billing project, workspace ownership will now be set to the service account "owner" Google group, rather than a direct permission for the service account itself.  This is to reduce the number of Google groups the main SA is a member of to ease the burden on the quota (2000 direct memberships, 5000 indirect).

Additional work is required to unset the main portal service account as workspace owner on existing workspaces - this unfortunately cannot be automated as Terra users cannot modify their own permissions at the workspace level.  This is tracked in SCP-2822.

This PR satisfies SCP-2398.