### PR TITLE
SCP-2823: fixing SyntaxError due to @user_accepted_agreement not being initialized

### DIFF
--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -284,7 +284,7 @@
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
 
     var hasAgreement = <%= @study.has_download_agreement? %>;
-    var userHasAccepted = <%= @user_accepted_agreement %>;
+    var userHasAccepted = <%= @study.has_download_agreement? ? @user_accepted_agreement : false %>;
     if (hasAgreement && !userHasAccepted) {
         setElementsEnabled($('.dl-link'), false)
         setElementsEnabled($('#download-help'), false)


### PR DESCRIPTION
If a study does not have a `DownloadAgreement` object configured, there is a bug in the Javascript that renders in the downloads tab that will throw a `SyntaxError` due to a Ruby variable not being initialized, and thus interpolated into the page as nothing.  This update adds a ternary operator to check for presence first, and falls back to a default value of `false`.

This PR satisfies SCP-2823. 