### PR TITLE
SCP-2789: Adding accessioned study link to share emails

### DIFF
--- a/app/views/single_cell_mailer/share_notification.html.erb
+++ b/app/views/single_cell_mailer/share_notification.html.erb
@@ -1,6 +1,8 @@
-<p>The following study on the <%= link_to 'Single Cell Portal', studies_url %> has been shared:</p>
+<p>
+  The study '<%= @study.name %>'
+  (<%= link_to @study.accession, view_study_url(accession: @study.accession, study_name: @study.url_safe_name) %>)
+  has been shared:</p>
 <hr />
-<p><strong>Name: </strong><%= @study.name %></p>
-<p><strong>Owner: </strong><%= @user.email %></p>
+
 <p><strong>Shared With: </strong><%= @share.email %></p>
 <p><strong>Granted Permission: </strong><%= @share.permission %></p>

--- a/app/views/single_cell_mailer/share_update_notification.html.erb
+++ b/app/views/single_cell_mailer/share_update_notification.html.erb
@@ -1,5 +1,7 @@
-<p>The following study on the <%= link_to 'Single Cell Portal', studies_url %> has been updated:</p>
+<p>
+  The study '<%= @study.name %>'
+  (<%= link_to @study.accession, view_study_url(accession: @study.accession, study_name: @study.url_safe_name) %>)
+  has had the following attributes updated.</p>
 <hr />
-<p><strong>Name: </strong><%= @study.name %></p>
-<p>The following attributes were updated:</strong> <strong><%= @changes.join(', ') %></strong></p>
-<p>Please <%= link_to 'log in', studies_url %> to view the resulting changes.</p>
+<p><strong><%= @changes.join(', ') %></strong></p>
+<p>Please <%= link_to 'log in', study_url(@study) %> to view the resulting changes.</p>


### PR DESCRIPTION
When users are notified of shares/changes to studies via email, those emails lacked a direct link to the study itself in the portal.  This update adds the accessioned study link to both emails.

This PR satisfies SCP-2789.