### PR TITLE
adding annotation to study file and updating synth populate script (SCP-2824)

### DIFF
--- a/app/lib/synthetic_study_populator.rb
+++ b/app/lib/synthetic_study_populator.rb
@@ -71,7 +71,7 @@ class SyntheticStudyPopulator
         study: study
       }
 
-      study_file_params = study_file_params.merge(process_genomic_file_params(finfo))
+      study_file_params.merge!(process_genomic_file_params(finfo))
 
       if study_file_params[:file_type] == 'Expression Matrix'
         exp_finfo_params = finfo['expression_file_info']
@@ -79,7 +79,7 @@ class SyntheticStudyPopulator
           exp_file_info = ExpressionFileInfo.new(
             is_raw_counts: exp_finfo_params['is_raw_counts'] ? true : false,
             units: exp_finfo_params['units'],
-            library_construction_protocol: exp_finfo_params['library_construction_protocol'],
+            library_construction_protocol: exp_finfo_params['library_construction_protocol']
           )
           study_file_params['expression_file_info'] = exp_file_info
         end

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -53,6 +53,7 @@ class StudyFile
   has_many :cell_metadata, dependent: :destroy
   belongs_to :taxon, optional: true
   belongs_to :genome_assembly, optional: true
+  belongs_to :genome_annotation, optional: true
   belongs_to :study_file_bundle, optional: true
   embeds_one :expression_file_info
 

--- a/db/seed/synthetic_studies/mouse_brain/study_info.json
+++ b/db/seed/synthetic_studies/mouse_brain/study_info.json
@@ -19,6 +19,8 @@
       "type": "Expression Matrix",
       "filename": "raw_counts.tsv",
       "species_scientific_name": "Mus musculus",
+      "genome_assembly_name": "GRCm38",
+      "genome_annotation_name": "Ensembl 94",
       "expression_file_info": {
         "is_raw_counts": true,
         "units": "raw counts",

--- a/test/integration/synthetic_study_populator_test.rb
+++ b/test/integration/synthetic_study_populator_test.rb
@@ -5,8 +5,8 @@ class SyntheticStudyPopulatorTest < ActionDispatch::IntegrationTest
 
   test 'should be able to populate a study with convention metadata' do
     SYNTH_STUDY_INFO = {
-      name: 'HIV in bovine blood',
-      folder: 'cow_blood'
+      name: 'Male Mouse brain',
+      folder: 'mouse_brain'
     }
 
     # SyntheticStudyPopulator does have logic for deleting existing sutdies on populate
@@ -24,6 +24,13 @@ class SyntheticStudyPopulatorTest < ActionDispatch::IntegrationTest
     assert_equal 1, populated_study.study_files.count
     assert_equal 'Metadata', populated_study.study_files.first.file_type
     assert_not_nil populated_study.study_detail.full_description
+
+    # check supplementary study file information
+    raw_counts_files = StudyFile.where(study: populated_study, 'expression_file_info.is_raw_counts': true)
+    assert_equal 1, raw_counts_files.count
+    raw_counts_file = raw_counts_files.first
+    assert_equal raw_counts_file.genome_assembly.name = 'GRCm38'
+    assert_equal raw_counts_file.genome_annotation.name = 'Ensembl 94'
 
     # note that we're not testing the ingest process yet due to timing concerns
     Study.find_by(name: SYNTH_STUDY_INFO[:name]).destroy_and_remove_workspace

--- a/test/integration/synthetic_study_populator_test.rb
+++ b/test/integration/synthetic_study_populator_test.rb
@@ -3,6 +3,29 @@ require "integration_test_helper"
 class SyntheticStudyPopulatorTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
+  setup do
+    @taxon = Taxon.create!(common_name: 'mouse',
+                           scientific_name: 'Mus musculus',
+                           user: User.first,
+                           ncbi_taxid: 10090,
+                           notes: 'fake mouse taxon for testing')
+    @genome_assembly = GenomeAssembly.create!(name: "GRCm38",
+                                              alias: nil,
+                                              release_date: '2012-01-09',
+                                              accession: "GCA_000001635.2",
+                                              taxon: @taxon)
+    @genome_annotation = GenomeAnnotation.create!(name: 'Ensembl 94',
+                                                  link: 'http://google.com/search?q=mouse',
+                                                  index_link: 'http://google.com/search?q=mouse_index',
+                                                  release_date: '2020-10-19',
+                                                  genome_assembly: @genome_assembly)
+  end
+
+  teardown do
+    # this will also destroy the dependent annotation and assembly
+    @taxon.destroy!
+  end
+
   test 'should be able to populate a study with convention metadata' do
     SYNTH_STUDY_INFO = {
       name: 'Male Mouse brain',
@@ -21,7 +44,7 @@ class SyntheticStudyPopulatorTest < ActionDispatch::IntegrationTest
     populated_study = Study.find_by(name: SYNTH_STUDY_INFO[:name])
 
     assert_not_nil populated_study
-    assert_equal 1, populated_study.study_files.count
+    assert_equal 4, populated_study.study_files.count
     assert_equal 'Metadata', populated_study.study_files.first.file_type
     assert_not_nil populated_study.study_detail.full_description
 
@@ -29,8 +52,8 @@ class SyntheticStudyPopulatorTest < ActionDispatch::IntegrationTest
     raw_counts_files = StudyFile.where(study: populated_study, 'expression_file_info.is_raw_counts': true)
     assert_equal 1, raw_counts_files.count
     raw_counts_file = raw_counts_files.first
-    assert_equal raw_counts_file.genome_assembly.name = 'GRCm38'
-    assert_equal raw_counts_file.genome_annotation.name = 'Ensembl 94'
+    assert_equal 'GRCm38', raw_counts_file.genome_assembly.name
+    assert_equal 'Ensembl 94', raw_counts_file.genome_annotation.name
 
     # note that we're not testing the ingest process yet due to timing concerns
     Study.find_by(name: SYNTH_STUDY_INFO[:name]).destroy_and_remove_workspace


### PR DESCRIPTION
@bistline  This likely still needs work to make sure the test passes -- I'm not sure if the needed genome/annotations are populated.  But it works in development, so I thought I'd put it up so you can grab the model/populator changes.

Also, since this doesn't impact UI/UX, it might as well go on development, and then we can merge development into raw_counts_ingest