### PR TITLE
Avoid scroll upon clicking tabs in Study Overview (SCP-2804)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -479,12 +479,9 @@ function enableDefaultActions() {
 
     // when clicking the main study view page tabs, update the current URL so that when you refresh the tab stays open
     $('#study-tabs').on('shown.bs.tab', function(event) {
-        var anchor = $(event.target).attr('href');
-        var currentScroll = $(window).scrollTop();
-        window.location.hash = anchor;
+        var href = $(event.target).attr('href');
         // use HTML5 history API to update the url without reloading the DOM
-        history.pushState('', document.title, window.location.href);
-        window.scrollTo(0, currentScroll);
+        history.pushState('', document.title, href);
     });
 
   // Remove styling set in scpPlotsDidRender


### PR DESCRIPTION
This removes a jarring automatic scroll upon clicking the top tabs -- Summary, Explore, Download, etc. -- in Study Overview.

The culprit was updating `window.location.href`.  Simply using `pushState` does the same, so removing the unnecessary code fixed the bug.

This satisfies SCP-2804.