### PR TITLE
Raw counts information download via manifest (SCP-2811, SCP-2817)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   gem 'debase'
   gem 'test-unit'
   gem 'brakeman', :require => false
+  gem 'factory_bot_rails'
   gem 'listen'
   gem 'byebug'
   gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,11 @@ GEM
     ethon (0.11.0)
       ffi (>= 1.3.0)
     execjs (2.7.0)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
@@ -478,6 +483,7 @@ DEPENDENCIES
   delayed_job
   delayed_job_mongoid
   devise
+  factory_bot_rails
   font-awesome-sass!
   gibberish
   google-cloud-bigquery

--- a/app/controllers/api/v1/concerns/authenticator.rb
+++ b/app/controllers/api/v1/concerns/authenticator.rb
@@ -20,8 +20,12 @@ module Api
           current_api_user.present?
         end
 
-        # method to authenticate a user via Authorization Bearer tokens
         def current_api_user
+          @current_api_user ||= get_current_api_user
+        end
+
+        # method to authenticate a user via Authorization Bearer tokens or Totat
+        def get_current_api_user
           user = nil
           api_access_token = extract_bearer_token(request)
           if api_access_token.present?
@@ -49,7 +53,7 @@ module Api
               return nil
             end
             Rails.logger.info "Authenticating user via auth_token: #{params[:auth_code]}"
-            user = User.find_by(totat: params[:auth_code])
+            user = User.verify_totat(params[:auth_code], request.path)
             user.try(:update_last_access_at!)
             return user
           end

--- a/app/controllers/api/v1/concerns/authenticator.rb
+++ b/app/controllers/api/v1/concerns/authenticator.rb
@@ -38,6 +38,7 @@ module Api
             user.try(:update_last_access_at!)
             return user
           else
+            api_access_token = extract_bearer_token(request)
             if api_access_token.present?
               user = User.find_by('api_access_token.access_token' => api_access_token)
               if user.nil?

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -414,8 +414,8 @@ module Api
 
       def create_auth_code
         half_hour = 1800 # seconds
-        otac_and_ti = current_api_user.create_totat(half_hour)
-        auth_code_response = {auth_code: otac_and_ti[:totat], time_interval: otac_and_ti[:time_interval]}
+        totat = current_api_user.create_totat(half_hour, ["bulk_download"])
+        auth_code_response = {auth_code: totat[:totat], time_interval: totat[:totat_info][:valid_seconds]}
         render json: auth_code_response
       end
 
@@ -554,7 +554,7 @@ module Api
 
       def bulk_download
         totat = params[:auth_code]
-        valid_totat = User.verify_totat(totat)
+        valid_totat = User.verify_totat(totat, "bulk_download")
 
         # sanitize study accessions and file types
         valid_accessions = self.class.find_matching_accessions(params[:accessions])
@@ -601,7 +601,7 @@ module Api
                                                                            user: requested_user,
                                                                            study_bucket_map: bucket_map,
                                                                            output_pathname_map: pathname_map,
-                                                                           root_url: root_url)
+                                                                           host: "#{request.protocol}#{request.host_with_port}")
         end_time = Time.zone.now
         runtime = TimeDifference.between(start_time, end_time).humanize
         logger.info "Curl configs generated for studies #{valid_accessions}, #{files_requested.size} total files"

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -568,7 +568,7 @@ module Api
             error_msg += "You do not have permission to view #{accessions_by_permission[:forbidden].join(', ')}"
           end
           if accessions_by_permission[:lacks_acceptance].any?
-            error_msg += "#{accessions_by_permission[:lacks_acceptance].join(', ')} require accepting a download agreement that can be found by viewing that study and going to the 'download' tab"
+            error_msg += "#{accessions_by_permission[:lacks_acceptance].join(', ')} require accepting a download agreement that can be found by viewing that study and going to the 'Download' tab"
           end
           render json: {error: error_msg},
                  status: 403 and return

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -601,7 +601,7 @@ module Api
                                                                            user: requested_user,
                                                                            study_bucket_map: bucket_map,
                                                                            output_pathname_map: pathname_map,
-                                                                           host: "#{request.protocol}#{request.host_with_port}")
+                                                                           hostname: "#{request.protocol}#{request.host_with_port}")
         end_time = Time.zone.now
         runtime = TimeDifference.between(start_time, end_time).humanize
         logger.info "Curl configs generated for studies #{valid_accessions}, #{files_requested.size} total files"

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -598,8 +598,7 @@ module Api
         @configuration = ::BulkDownloadService.generate_curl_configuration(study_files: files_requested,
                                                                            user: current_api_user,
                                                                            study_bucket_map: bucket_map,
-                                                                           output_pathname_map: pathname_map,
-                                                                           hostname: "#{request.protocol}#{request.host_with_port}")
+                                                                           output_pathname_map: pathname_map)
         end_time = Time.zone.now
         runtime = TimeDifference.between(start_time, end_time).humanize
         logger.info "Curl configs generated for studies #{valid_accessions}, #{files_requested.size} total files"

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -600,7 +600,8 @@ module Api
         @configuration = ::BulkDownloadService.generate_curl_configuration(study_files: files_requested,
                                                                            user: requested_user,
                                                                            study_bucket_map: bucket_map,
-                                                                           output_pathname_map: pathname_map)
+                                                                           output_pathname_map: pathname_map,
+                                                                           root_url: root_url)
         end_time = Time.zone.now
         runtime = TimeDifference.between(start_time, end_time).humanize
         logger.info "Curl configs generated for studies #{valid_accessions}, #{files_requested.size} total files"

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -592,6 +592,7 @@ module Api
       def generate_manifest
         manifest_obj = BulkDownloadService.generate_study_manifest(@study)
         # prettify the string so it's more human-readable after download
+        response.headers['Content-Disposition'] = 'attachment; filename=manifest.json'
         render json: JSON.pretty_generate(manifest_obj)
       end
 

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -611,8 +611,18 @@ module Api
         head 403 unless @study.can_edit?(current_api_user)
       end
 
+      # checks the view permissions, either for the current_api_user or a totat, if given
       def check_study_view_permission
-        head 403 unless (@study.public || @study.can_view?(current_api_user))
+        user = current_api_user
+        totat = params[:auth_code]
+        if totat
+          user = User.verify_totat(totat, "#{@study.accession}-view")
+          # if a bad totat is given, fail the request even if there is a valid API user
+          if !user
+            head 403
+          end
+        end
+        head 403 unless (@study.public || @study.can_view?(user))
       end
 
       # study params whitelist

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -554,13 +554,6 @@ module Api
             key :required, true
             key :type, :string
           end
-          parameter do
-            key :name, :file_types
-            key :in, :query
-            key :description, 'File types to include in the manifest (default is all)'
-            key :required, false
-            key :type, :array
-          end
           response 200 do
             key :description, 'Manifest file'
             schema do
@@ -572,7 +565,7 @@ module Api
             key :description, ApiBaseController.unauthorized
           end
           response 403 do
-            key :description, ApiBaseController.forbidden('edit Study')
+            key :description, ApiBaseController.forbidden('View Study')
           end
           response 404 do
             key :description, ApiBaseController.not_found(Study)

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -583,10 +583,9 @@ module Api
       end
 
       def generate_manifest
-        manifest_obj = BulkDownloadService.generate_study_manifest(@study, "#{request.protocol}#{request.host_with_port}")
-        # prettify the string so it's more human-readable after download
-        response.headers['Content-Disposition'] = 'attachment; filename=manifest.json'
-        render json: JSON.pretty_generate(manifest_obj)
+        manifest_obj = BulkDownloadService.generate_study_files_tsv(@study, "#{request.protocol}#{request.host_with_port}")
+        response.headers['Content-Disposition'] = 'attachment; filename=file_supplemental_info.tsv'
+        render plain: manifest_obj
       end
 
       private

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -6,7 +6,7 @@ module Api
       include Concerns::FireCloudStatus
       include Swagger::Blocks
 
-      before_action :authenticate_api_user!, except: [:generate_manifest]
+      before_action :authenticate_api_user!
       before_action :set_study, except: [:index, :create]
       before_action :check_study_permission, except: [:index, :create, :generate_manifest]
       before_action :check_study_view_permission, only: [:generate_manifest]
@@ -606,16 +606,7 @@ module Api
 
       # checks the view permissions, either for the current_api_user or a totat, if given
       def check_study_view_permission
-        user = current_api_user
-        totat = params[:auth_code]
-        if totat
-          user = User.verify_totat(totat, "#{@study.accession}-view")
-          # if a bad totat is given, fail the request even if there is a valid API user
-          if !user
-            head 403
-          end
-        end
-        head 403 unless (@study.public || @study.can_view?(user))
+        head 403 unless (@study.public || @study.can_view?(current_api_user))
       end
 
       # study params whitelist

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -590,7 +590,7 @@ module Api
       end
 
       def generate_manifest
-        manifest_obj = BulkDownloadService.generate_study_manifest(@study)
+        manifest_obj = BulkDownloadService.generate_study_manifest(@study, "#{request.protocol}#{request.host_with_port}")
         # prettify the string so it's more human-readable after download
         response.headers['Content-Disposition'] = 'attachment; filename=manifest.json'
         render json: JSON.pretty_generate(manifest_obj)

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -583,7 +583,7 @@ module Api
       end
 
       def generate_manifest
-        manifest_obj = BulkDownloadService.generate_study_files_tsv(@study, "#{request.protocol}#{request.host_with_port}")
+        manifest_obj = BulkDownloadService.generate_study_files_tsv(@study)
         response.headers['Content-Disposition'] = 'attachment; filename=file_supplemental_info.tsv'
         render plain: manifest_obj
       end

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -544,20 +544,20 @@ module Api
           key :tags, [
               'Studies'
           ]
-          key :summary, 'Get a Study Manifest file'
+          key :summary, 'Get a study manifest file'
           key :description, 'Return a file summarizing the study and each of the files within it'
           key :operationId, 'generate_manifest'
           parameter do
             key :name, :id
             key :in, :path
-            key :description, 'ID of Study to generate manifest'
+            key :description, 'ID of study to generate manifest'
             key :required, true
             key :type, :string
           end
           response 200 do
             key :description, 'Manifest file'
             schema do
-              key :title, 'JSON object of Study and study file'
+              key :title, 'JSON object of study and study file'
               # Once file format is finalized, complete this documentation
             end
           end
@@ -697,4 +697,3 @@ module Api
     end
   end
 end
-

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -35,7 +35,7 @@ class SiteController < ApplicationController
                                                    :delete_workspace_samples, :get_workspace_submissions, :create_workspace_submission,
                                                    :get_submission_workflow, :abort_submission_workflow, :get_submission_errors,
                                                    :get_submission_outputs, :delete_submission_files, :get_submission_metadata]
-  before_action :check_study_detached, only: [:download_file, :update_study_settings, :download_bulk_files,
+  before_action :check_study_detached, only: [:download_file, :update_study_settings,
                                               :get_fastq_files, :get_workspace_samples, :update_workspace_samples,
                                               :delete_workspace_samples, :get_workspace_submissions, :create_workspace_submission,
                                               :get_submission_workflow, :abort_submission_workflow, :get_submission_errors,
@@ -752,96 +752,6 @@ class SiteController < ApplicationController
     execute_file_download(@study); return if performed?
   end
 
-  # Returns text file listing signed URLs, etc. of files for download via curl.
-  # That is, this return 'cfg.txt' used as config (K) argument in 'curl -K cfg.txt'
-  def download_bulk_files
-
-    # Ensure study is public
-    if !@study.public?
-      message = 'Only public studies can be downloaded via curl.'
-      render plain: "Forbidden: " + message, status: 403
-      return
-    end
-
-    if @study.has_download_agreement? && !@study.download_agreement.user_accepted?(current_user)
-      render plain: "Forbidden: Download agreement not accepted for #{@study.accession}" , status: 403
-      return
-    end
-
-    # 'all' or the name of a directory, e.g. 'csvs'
-    download_object = params[:download_object]
-
-    totat = params[:totat]
-
-    # Time-based one-time access token (totat) is used to track user's download quota
-    valid_totat = User.verify_totat(totat, 'bulk_download')
-
-    if valid_totat.nil?
-      render plain: "Forbidden: Invalid access token " + totat, status: 403
-      return
-    else
-      user = valid_totat
-    end
-
-    user_quota = user.daily_download_quota
-
-    # Only check quota at beginning of download, not per file.
-    # Studies might be massive, and we want user to be able to download at least
-    # one requested download object per day.
-    if user_quota >= @download_quota
-      message = 'You have exceeded your current daily download quota.  You must wait until tomorrow to download this object.'
-      render plain: "Forbidden: " + message, status: 403
-      return
-    end
-
-    curl_configs = ['--create-dirs', '--compressed']
-
-    curl_files = []
-
-    # Gather all study files, if we're downloading whole study ('all')
-    if download_object == 'all'
-      files = @study.study_files.valid
-      files.each do |study_file|
-        unless study_file.human_data?
-          curl_files.push(study_file)
-        end
-      end
-    end
-
-    # Gather all files in requested directory listings
-    synced_dirs = @study.directory_listings.are_synced
-    synced_dirs.each do |synced_dir|
-      if download_object != 'all' and synced_dir[:name] != download_object
-        next
-      end
-      synced_dir.files.each do |file|
-        curl_files.push(file)
-      end
-    end
-
-    start_time = Time.zone.now
-
-    # Get signed URLs for all files in the requested download objects, and update user quota
-    Parallel.map(curl_files, in_threads: 100) do |file|
-      fc_client = FireCloudClient.new
-      curl_config, file_size = get_curl_config(file, fc_client)
-      curl_configs.push(curl_config)
-      user_quota += file_size
-    end
-
-    end_time = Time.zone.now
-    time = (end_time - start_time).divmod 60.0
-    @log_message = ["#{@study.url_safe_name} curl configs generated!"]
-    @log_message << "Signed URLs generated: #{curl_configs.size}"
-    @log_message << "Total time in get_curl_config: #{time.first} minutes, #{time.last} seconds"
-    logger.info @log_message.join("\n")
-
-    curl_configs = curl_configs.join("\n\n")
-
-    user.update(daily_download_quota: user_quota)
-
-    send_data curl_configs, type: 'text/plain', filename: 'cfg.txt'
-  end
 
   ###
   #
@@ -2207,41 +2117,6 @@ class SiteController < ApplicationController
       analysis_submission.update(status: workflow_status)
       analysis_submission.delay.set_completed_on # run in background to avoid UI blocking
     end
-  end
-
-  # Helper method for download_bulk_files.  Returns file's curl config, size.
-  def get_curl_config(file, fc_client=nil)
-
-    # Is this a study file, or a file from a directory listing?
-    is_study_file = file.is_a? StudyFile
-
-    if fc_client == nil
-      fc_client = ApplicationController.firecloud_client
-    end
-
-    filename = (is_study_file ? file.upload_file_name : file[:name])
-
-    begin
-      signed_url = fc_client.execute_gcloud_method(:generate_signed_url, 0, @study.bucket_id, filename,
-                                                   expires: 1.day.to_i) # 1 day in seconds, 86400
-      curl_config = [
-          'url="' + signed_url + '"',
-          'output="' + filename + '"'
-      ]
-    rescue => e
-      error_context = ErrorTracker.format_extra_context(@study)
-      ErrorTracker.report_exception(e, current_user, error_context)
-      logger.error "Error generating signed url for #{filename}; #{e.message}"
-      curl_config = [
-          '# Error downloading ' + filename + '.  ' +
-          'Did you delete the file in the bucket and not sync it in Single Cell Portal?'
-      ]
-    end
-
-    curl_config = curl_config.join("\n")
-    file_size = (is_study_file ? file.upload_file_size : file[:size])
-
-    return curl_config, file_size
   end
 
   protected

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -802,7 +802,7 @@ class StudiesController < ApplicationController
   end
 
   def generate_manifest
-    manifest_obj = BulkDownloadService.generate_study_files_tsv(@study, "#{request.protocol}#{request.host_with_port}")
+    manifest_obj = BulkDownloadService.generate_study_files_tsv(@study)
     response.headers['Content-Disposition'] = 'attachment; filename=file_supplemental_info.tsv'
     render plain: manifest_obj
   end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -803,7 +803,6 @@ class StudiesController < ApplicationController
 
   def generate_manifest
     manifest_obj = BulkDownloadService.generate_study_files_tsv(@study)
-    response.headers['Content-Disposition'] = 'attachment; filename=file_supplemental_info.tsv'
     render plain: manifest_obj
   end
 

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -17,7 +17,7 @@ class StudiesController < ApplicationController
   before_action :set_study, except: [:index, :new, :create, :download_private_file]
   before_action :set_file_types, only: [:sync_study, :sync_submission_outputs, :sync_study_file, :sync_orphaned_study_file,
                                         :update_study_file_from_sync]
-  before_action :check_edit_permissions, except: [:index, :new, :create, :download_private_file]
+  before_action :check_edit_permissions, except: [:index, :new, :create, :download_private_file, :generate_manifest]
   before_action do
     authenticate_user!
     check_access_settings
@@ -799,6 +799,13 @@ class StudiesController < ApplicationController
     else
       @reset_status = false
     end
+  end
+
+  def generate_manifest
+    manifest_obj = BulkDownloadService.generate_study_manifest(@study, "#{request.protocol}#{request.host_with_port}")
+    # prettify the string so it's more human-readable after download
+    response.headers['Content-Disposition'] = 'attachment; filename=manifest.json'
+    render json: JSON.pretty_generate(manifest_obj)
   end
 
   # adding new study_file entries based on remote files in GCP

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -802,10 +802,9 @@ class StudiesController < ApplicationController
   end
 
   def generate_manifest
-    manifest_obj = BulkDownloadService.generate_study_manifest(@study, "#{request.protocol}#{request.host_with_port}")
-    # prettify the string so it's more human-readable after download
-    response.headers['Content-Disposition'] = 'attachment; filename=manifest.json'
-    render json: JSON.pretty_generate(manifest_obj)
+    manifest_obj = BulkDownloadService.generate_study_files_tsv(@study, "#{request.protocol}#{request.host_with_port}")
+    response.headers['Content-Disposition'] = 'attachment; filename=file_supplemental_info.tsv'
+    render plain: manifest_obj
   end
 
   # adding new study_file entries based on remote files in GCP

--- a/app/javascript/components/search/controls/DownloadButton.js
+++ b/app/javascript/components/search/controls/DownloadButton.js
@@ -41,7 +41,7 @@ async function generateDownloadConfig(matchingAccessions) {
   // instead of the hostname
   const downloadCommand = (
     `curl "${url}" -${curlSecureFlag}o cfg.txt; ` +
-    `curl -K cfg.txt; rm cfg.txt`
+    `curl -K cfg.txt && rm cfg.txt`
   )
 
   return {

--- a/app/javascript/components/search/controls/DownloadButton.js
+++ b/app/javascript/components/search/controls/DownloadButton.js
@@ -41,7 +41,7 @@ async function generateDownloadConfig(matchingAccessions) {
   // instead of the hostname
   const downloadCommand = (
     `curl "${url}" -${curlSecureFlag}o cfg.txt; ` +
-    `curl -K cfg.txt && rm cfg.txt`
+    `curl -K cfg.txt && rm cfg.txt` // Removes only if curl succeeds
   )
 
   return {

--- a/app/javascript/components/search/controls/DownloadButton.js
+++ b/app/javascript/components/search/controls/DownloadButton.js
@@ -32,7 +32,7 @@ async function generateDownloadConfig(matchingAccessions) {
 
   // "-k" === "--insecure"
   let curlSecureFlag = ''
-  if (('SCP' in window) && window.location.host === 'localhost') {
+  if (('SCP' in window) && window.location.hostname === 'localhost') {
     curlSecureFlag = 'k'
   }
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -32,6 +32,7 @@ import { logPageView, logClick, logMenuChange, startPendingEvent, log } from 'li
 import { getLogPlotProps } from 'lib/scp-api-metrics'
 import { formatTerms } from 'providers/StudySearchProvider'
 import createTracesAndLayout from 'lib/kernel-functions'
+import * as ScpApi from 'lib/scp-api'
 
 document.addEventListener('DOMContentLoaded', () => {
   // Logs only page views for faceted search UI
@@ -73,6 +74,7 @@ window.SCP.log = log
 window.SCP.startPendingEvent = startPendingEvent
 window.SCP.getLogPlotProps = getLogPlotProps
 window.SCP.formatTerms = formatTerms
+window.SCP.ScpApi = ScpApi
 
 /*
  * For down the road, when we use ES6 imports in SCP JS app code

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -74,7 +74,7 @@ window.SCP.log = log
 window.SCP.startPendingEvent = startPendingEvent
 window.SCP.getLogPlotProps = getLogPlotProps
 window.SCP.formatTerms = formatTerms
-window.SCP.ScpApi = ScpApi
+window.SCP.API = ScpApi
 
 /*
  * For down the road, when we use ES6 imports in SCP JS app code

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -209,7 +209,7 @@ class BulkDownloadService
     output_map
   end
 
-  # generate a study_info.json object from an existing study
+  # generate a study_info object from an existing study
   def self.generate_study_manifest(study, hostname)
     info = HashWithIndifferentAccess.new
     info[:study] = {

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -205,17 +205,17 @@ class BulkDownloadService
 
   # generate a study_info.json object from an existing study
   def self.generate_study_manifest(study, hostname)
-    info = {}
-    info['study'] = {
+    info = HashWithIndifferentAccess.new
+    info[:study] = {
       name: study.name,
-      description: study.description.truncate(150),
+      description: study.description.try(:truncate, 150),
       accession: study.accession,
       cell_count: study.cell_count,
       link: hostname + Rails.application.routes.url_helpers.view_study_path(accession: study.accession, study_name: study.name)
     }
-    info['files'] = study.study_files
-                         .where(queued_for_deletion: false)
-                         .map{|f| generate_study_file_manifest(f)}
+    info[:files] = study.study_files
+                        .select{|sf| !sf.queued_for_deletion }
+                        .map{|f| generate_study_file_manifest(f)}
     info
   end
 

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -215,7 +215,7 @@ class BulkDownloadService
       accession: study.accession,
       cell_count: study.cell_count,
       gene_count: study.gene_count,
-      link: RequestUtils.get_base_url + view_study_path(accession: study.accession, study_name: study.name)
+      link: RequestUtils.get_base_url + Rails.application.routes.url_helpers.view_study_path(accession: study.accession, study_name: study.name)
     }
     info[:files] = study.study_files
                         .where(queued_for_deletion: false)

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -3,7 +3,6 @@
 # keyword and faceted search
 
 class BulkDownloadService
-  include Rails.application.routes.url_helpers
   extend ErrorTracker
 
   # Generate a String representation of a configuration file containing URLs and output paths to pass to
@@ -40,7 +39,7 @@ class BulkDownloadService
         # if we're in development, allow not checking the cert
         manifest_config += "-k\n"
       end
-      manifest_path = RequestUtils.get_base_url + manifest_api_v1_study_path(study)
+      manifest_path = RequestUtils.get_base_url + Rails.application.routes.url_helpers.manifest_api_v1_study_path(study)
       manifest_config += "url=#{manifest_path}?auth_code=#{totat[:totat]}\n"
       manifest_config += "output=#{study.accession}/file_supplemental_info.tsv"
       curl_configs << manifest_config

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -214,7 +214,7 @@ class BulkDownloadService
       link: hostname + Rails.application.routes.url_helpers.view_study_path(accession: study.accession, study_name: study.name)
     }
     info[:files] = study.study_files
-                        .select{|sf| !sf.queued_for_deletion }
+                        .where(queued_for_deletion: false)
                         .map{|f| generate_study_file_manifest(f)}
     info
   end

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -34,7 +34,8 @@ class BulkDownloadService
     study_manifest_paths = studies.map do |study|
       "#{Rails.application.routes.url_helpers.manifest_api_v1_study_path(study)}"
     end
-    totat = user.create_totat(1800, study_manifest_paths)
+    half_hour = 1800
+    totat = user.create_totat(half_hour, study_manifest_paths)
     studies.map do |study|
       manifest_config = ""
       if Rails.env.development?
@@ -216,6 +217,7 @@ class BulkDownloadService
       description: study.description.try(:truncate, 150),
       accession: study.accession,
       cell_count: study.cell_count,
+      gene_count: study.gene_count,
       link: hostname + Rails.application.routes.url_helpers.view_study_path(accession: study.accession, study_name: study.name)
     }
     info[:files] = study.study_files
@@ -246,6 +248,7 @@ class BulkDownloadService
       output[:species_scientific_name] = study_file.taxon.scientific_name
     end
     if study_file.genome_assembly
+      output[:genome_assembly_name] = study_file.genome_assembly.name
       output[:genome_assembly_accession] = study_file.genome_assembly.accession
     end
     if study_file.genome_annotation

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -31,7 +31,10 @@ class BulkDownloadService
                                                    study_bucket_map: study_bucket_map, output_pathname_map: output_pathname_map)
     end
     studies = study_files.map(&:study).uniq
-    totat = user.create_totat(1800, studies.map{|s| "#{s.accession}-view"})
+    study_manifest_paths = studies.map do |study|
+      "#{Rails.application.routes.url_helpers.api_v1_study_path(study)}/manifest"
+    end
+    totat = user.create_totat(1800, study_manifest_paths)
     studies.map do |study|
       manifest_config = ""
       if Rails.env.development?

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -82,7 +82,7 @@ class RequestUtils
   # helper method for getting the base url with protocol, hostname, and port
   # e.g. "https://localhost"
   def self.get_base_url
-    url_opts =  Rails.application.config.action_controller.default_url_options
+    url_opts = ApplicationController.default_url_options
     base_url = "#{url_opts[:protocol]}://#{url_opts[:host]}"
     port = Rails::Server::Options.new.parse!(ARGV)[:Port]
     if port

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -1,3 +1,5 @@
+require 'rails/commands/server/server_command'
+
 class RequestUtils
 
   # load same sanitizer as ActionView for stripping html/js from inputs
@@ -75,5 +77,17 @@ class RequestUtils
   def self.sanitize_search_terms(terms)
     inputs = terms.is_a?(Array) ? terms.join(',') : terms.to_s
     SANITIZER.sanitize(inputs).encode('ASCII-8BIT', invalid: :replace, undef: :replace)
+  end
+
+  # helper method for getting the base url with protocol, hostname, and port
+  # e.g. "https://localhost"
+  def self.get_base_url
+    url_opts =  Rails.application.config.action_controller.default_url_options
+    base_url = "#{url_opts[:protocol]}://#{url_opts[:host]}"
+    port = Rails::Server::Options.new.parse!(ARGV)[:Port]
+    if port
+      base_url += ":#{port.to_s}"
+    end
+    base_url
   end
 end

--- a/app/lib/synthetic_study_populator.rb
+++ b/app/lib/synthetic_study_populator.rb
@@ -124,13 +124,4 @@ class SyntheticStudyPopulator
     params
   end
 
-  # utility method to generate a study_info.json file string from an existing study
-  # useful for, e.g., downloading all the files from a production study to your local machine,
-  # and then using SyntheticStudyPopulator to ingest it
-  def self.generate_study_info_json(study)
-    info = {}
-    info['study'] = {name: study.name, description: study.description, data_dir: 'test'}
-    info['files'] = study.study_files.map{|f| { filename: f.name, type: f.file_type}}
-    puts JSON.pretty_generate(info)
-  end
 end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -629,7 +629,7 @@ class Study
   ###
 
   # custom validator since we need everything to pass in a specific order (otherwise we get orphaned FireCloud workspaces)
-  validate :initialize_with_new_workspace, on: :create, if: Proc.new {|study| !study.use_existing_workspace}
+  validate :initialize_with_new_workspace, on: :create, if: Proc.new {|study| !study.use_existing_workspace && !study.detached}
   validate :initialize_with_existing_workspace, on: :create, if: Proc.new {|study| study.use_existing_workspace}
 
   # populate specific errors for study shares since they share the same form

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -81,6 +81,8 @@ class StudyFile
   field :remote_location, type: String, default: ''
   field :options, type: Hash, default: {}
 
+  accepts_nested_attributes_for :expression_file_info
+
   Paperclip.interpolates :data_dir do |attachment, style|
     attachment.instance.data_dir
   end

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -192,6 +192,14 @@
         </td>
       </tr>
     <% end %>
+      <tr>
+        <td>Manifest</td>
+        <td>Listing of all study files, and any supplementary information (units, protocols, etc...)</td>
+        <td></td>
+        <td></td>
+        <td><%= link_to "<span class='fas fa-download'></span> 1 KB".html_safe, "#{api_v1_study_path(@study)}/manifest", class: "btn btn-primary dl-link" %>
+        </td>
+      </tr>
     </tbody>
   </table>
   <% if @primary_study_files.any? || @primary_data.any? %>

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -31,6 +31,7 @@
                   </thead>
                 </table>
               <% end %>
+              Then <%= link_to "click here".html_safe, "#{api_v1_study_path(@study)}/manifest" %> for the manifest.json containing file supplementary information (units, protocols, etc...)
             <% elsif @study.public? && !@user_embargoed || current_user.admin? %>
               <p class="lead">To download all files using <code>curl</code>, click the button below to get the download command:</p>
               <p class="lead command-container" id="command-container-all"><%= link_to "<i class='fas fa-download'></i> Get download command for all study data".html_safe, '#/', class: 'btn btn-default get-download-command', id: 'get-download-command_all' %></p>
@@ -97,7 +98,7 @@
           // Get a time-based one time authentication token (totat),
           // then show the download command
           $.ajax({
-              url: '/single_cell/totat',
+              url: '/single_cell/api/v1/search/auth_code',
               type: 'post',
               dataType: 'json',
               success: function (response) {
@@ -105,24 +106,20 @@
                   var timeInterval = response.time_interval; // token expires after this many seconds
 
                   var expiresMinutes = timeInterval / 60;
-
+                  const accession = <%= @study.accession %>
+                  const curlSecureFlag = "<%= Rails.env.development? ? '-k' : '' %>"
                   // Gets a curl configuration ("cfg.txt") containing signed
                   // URLs and output names for all files in the download object.
                   var url = (
-                      window.location.origin +
-                      '/single_cell/bulk_data' +
-                      '/<%= @study.accession %>' +
-                      '/<%= @study.url_safe_name %>' +
-                      '/' + downloadObject +
-                      '/' + totat
+                    window.location.origin +
+                    '/single_cell/api/v1/search/bulk_download?' +
+                    `accessions=${accession}` +
+                    `&auth_code=${totat}`
                   );
 
-                  var curlSecureFlag = (window.location.host === 'localhost') ? 'k' : ''; // "-k" === "--insecure"
-
                   // This is what the user will run in their terminal to download the data.
-                  // TODO: Consider checking the node environment (either at compile or runtime) instead of the hostname
                   var downloadCommand = (
-                      'curl &quot;' + url + '&quot; -' + curlSecureFlag + 'o cfg.txt; ' +
+                      'curl &quot;' + url + '&quot; ' + curlSecureFlag + ' -o cfg.txt; ' +
                       'curl -K cfg.txt; rm cfg.txt'
                   );
 
@@ -193,7 +190,7 @@
       </tr>
     <% end %>
       <tr>
-        <td>Manifest</td>
+        <td>manifest.json</td>
         <td>Listing of all study files, and any supplementary information (units, protocols, etc...)</td>
         <td></td>
         <td></td>

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -31,7 +31,7 @@
                   </thead>
                 </table>
               <% end %>
-              Then <%= link_to "click here".html_safe, "#{api_v1_study_path(@study)}/manifest" %> for the manifest.json containing file supplementary information (units, protocols, etc...)
+              Then <%= link_to "click here".html_safe, "#{generate_manifest_study_url(@study)}" %> for the manifest.json containing file supplementary information (units, protocols, etc...)
             <% elsif @study.public? && !@user_embargoed || current_user.admin? %>
               <p class="lead">To download all files using <code>curl</code>, click the button below to get the download command:</p>
               <p class="lead command-container" id="command-container-all"><%= link_to "<i class='fas fa-download'></i> Get download command for all study data".html_safe, '#/', class: 'btn btn-default get-download-command', id: 'get-download-command_all' %></p>
@@ -117,7 +117,7 @@
               // This is what the user will run in their terminal to download the data.
               var downloadCommand = (
                   'curl &quot;' + url + '&quot; ' + curlSecureFlag + ' -o cfg.txt; ' +
-                  'curl -K cfg.txt; rm cfg.txt'
+                  'curl -K cfg.txt && rm cfg.txt'
               );
 
               var commandID = 'command-' + authCode;
@@ -191,7 +191,7 @@
         <td>Listing of all study files, and any supplementary information (units, protocols, etc...)</td>
         <td></td>
         <td></td>
-        <td><%= link_to "<span class='fas fa-download'></span> 1 KB".html_safe, "#{study_path(@study)}/manifest", class: "btn btn-primary dl-link" %>
+        <td><%= link_to "<span class='fas fa-download'></span> 1 KB".html_safe, "#{generate_manifest_study_url(@study)}", class: "btn btn-primary dl-link" %>
         </td>
       </tr>
     </tbody>

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -191,7 +191,7 @@
         <td>Listing of all study files, and any supplementary information (units, protocols, etc...)</td>
         <td></td>
         <td></td>
-        <td><%= link_to "<span class='fas fa-download'></span> 1 KB".html_safe, "#{api_v1_study_path(@study)}/manifest", class: "btn btn-primary dl-link" %>
+        <td><%= link_to "<span class='fas fa-download'></span> 1 KB".html_safe, "#{study_path(@study)}/manifest", class: "btn btn-primary dl-link" %>
         </td>
       </tr>
     </tbody>

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -97,51 +97,48 @@
 
           // Get a time-based one time authentication token (totat),
           // then show the download command
-          $.ajax({
-              url: '/single_cell/api/v1/search/auth_code',
-              type: 'post',
-              dataType: 'json',
-              success: function (response) {
-                  var totat = response.totat;
-                  var timeInterval = response.time_interval; // token expires after this many seconds
+          window.SCP.ScpApi.fetchAuthCode().then(
+            function (response) {
+              var authCode = response.authCode;
+              var timeInterval = response.timeInterval; // token expires after this many seconds
+              debugger;
+              var expiresMinutes = timeInterval / 60;
+              const accession = "<%= @study.accession %>"
+              const curlSecureFlag = "<%= Rails.env.development? ? '-k' : '' %>"
+              // Gets a curl configuration ("cfg.txt") containing signed
+              // URLs and output names for all files in the download object.
+              var url = (
+                window.location.origin +
+                '/single_cell/api/v1/search/bulk_download?' +
+                `accessions=${accession}` +
+                `&auth_code=${authCode}`
+              );
 
-                  var expiresMinutes = timeInterval / 60;
-                  const accession = <%= @study.accession %>
-                  const curlSecureFlag = "<%= Rails.env.development? ? '-k' : '' %>"
-                  // Gets a curl configuration ("cfg.txt") containing signed
-                  // URLs and output names for all files in the download object.
-                  var url = (
-                    window.location.origin +
-                    '/single_cell/api/v1/search/bulk_download?' +
-                    `accessions=${accession}` +
-                    `&auth_code=${totat}`
-                  );
+              // This is what the user will run in their terminal to download the data.
+              var downloadCommand = (
+                  'curl &quot;' + url + '&quot; ' + curlSecureFlag + ' -o cfg.txt; ' +
+                  'curl -K cfg.txt; rm cfg.txt'
+              );
 
-                  // This is what the user will run in their terminal to download the data.
-                  var downloadCommand = (
-                      'curl &quot;' + url + '&quot; ' + curlSecureFlag + ' -o cfg.txt; ' +
-                      'curl -K cfg.txt; rm cfg.txt'
-                  );
+              var commandID = 'command-' + authCode;
+              var commandContainer = $('#command-container-' + downloadObject);
+              var countdownValue = '<span class="countdown" id="countdown-' + authCode + '">' + expiresMinutes + '</span>';
 
-                  var commandID = 'command-' + totat;
-                  var commandContainer = $('#command-container-' + downloadObject);
-                  var countdownValue = '<span class="countdown" id="countdown-' + totat + '">' + expiresMinutes + '</span>';
-
-                  commandContainer.html(
-                      '<div class="input-group">' +
-                      '<input id="' + commandID + '" class="form-control curl-download-command" value="' + downloadCommand + '" readonly/>' +
-                      '<span class="input-group-btn">' +
-                      '<button id="copy-button-' + totat + '" class="btn btn-default btn-copy" data-clipboard-target="#' + commandID + '" data-toggle="tooltip" title="Copy to clipboard">' +
-                      '<i class="far fa-copy"></i>' +
-                      '</button>' +
-                      '<button id="refresh-button-' + totat + '" class="btn btn-default btn-refresh glyphicon glyphicon-refresh" data-toggle="tooltip" style="top: -0.5px;" title="Refresh download command">' +
-                      '</button>' +
-                      '</span>' +
-                      '</div>' +
-                      '<div style="font-size: 12px">Valid for one use within ' + countdownValue + ' minutes.  Paste into Mac/Linux/Unix terminal and execute to download.</div>'
-                  );
-              }
-          });
+              commandContainer.html(
+                  '<div class="input-group">' +
+                  '<input id="' + commandID + '" class="form-control curl-download-command" value="' + downloadCommand + '" readonly/>' +
+                  '<span class="input-group-btn">' +
+                  '<button id="copy-button-' + authCode + '" class="btn btn-default btn-copy" data-clipboard-target="#' + commandID + '" data-toggle="tooltip" title="Copy to clipboard">' +
+                  '<i class="far fa-copy"></i>' +
+                  '</button>' +
+                  '<button id="refresh-button-' + authCode + '" class="btn btn-default btn-refresh glyphicon glyphicon-refresh" data-toggle="tooltip" style="top: -0.5px;" title="Refresh download command">' +
+                  '</button>' +
+                  '</span>' +
+                  '</div>' +
+                  '<div style="font-size: 12px">Valid for one use within ' + countdownValue + ' minutes.  Paste into Mac/Linux/Unix terminal and execute to download.</div>'
+              );
+            }
+          );
         }
 
         // Show the download command upon clicking the "Get download command" button
@@ -190,7 +187,7 @@
       </tr>
     <% end %>
       <tr>
-        <td>manifest.json</td>
+        <td>manifest.json <i>(auto-generated)</i></td>
         <td>Listing of all study files, and any supplementary information (units, protocols, etc...)</td>
         <td></td>
         <td></td>

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -97,7 +97,7 @@
 
           // Get a time-based one time authentication token (totat),
           // then show the download command
-          window.SCP.ScpApi.fetchAuthCode().then(
+          window.SCP.API.fetchAuthCode().then(
             function (response) {
               var authCode = response.authCode;
               var timeInterval = response.timeInterval; // token expires after this many seconds

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,6 +169,7 @@ Rails.application.routes.draw do
         post 'initialize_bundled_file', to: 'studies#initialize_bundled_file', as: 'initialize_bundled_file'
         get 'load_annotation_options', to: 'studies#load_annotation_options', as: :load_annotation_options
         post 'update_default_options', to: 'studies#update_default_options', as: :update_default_options
+        get 'manifest', to: 'studies#generate_manifest', as: :generate_manifest
       end
     end
 
@@ -180,9 +181,6 @@ Rails.application.routes.draw do
     # public/private file download links (redirect to signed_urls from Google)
     get 'data/public/:accession/:study_name', to: 'site#download_file', as: :download_file
     get 'data/private/:accession/:study_name', to: 'studies#download_private_file', as: :download_private_file
-
-    get 'bulk_data/:accession/:study_name/:download_object/:totat', to: 'site#download_bulk_files', as: :download_bulk_files,
-        constraints: {filename: /.*/}
 
     # user account actions
     get 'profile/:id', to: 'profiles#show', as: :view_profile

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,7 +181,6 @@ Rails.application.routes.draw do
     get 'data/public/:accession/:study_name', to: 'site#download_file', as: :download_file
     get 'data/private/:accession/:study_name', to: 'studies#download_private_file', as: :download_private_file
 
-    post 'totat', to: 'site#create_totat', as: :create_totat
     get 'bulk_data/:accession/:study_name/:download_object/:totat', to: 'site#download_bulk_files', as: :download_bulk_files,
         constraints: {filename: /.*/}
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,9 @@ Rails.application.routes.draw do
           member do
             post 'sync', to: 'studies#sync_study'
           end
+          member do
+            get 'manifest', to: 'studies#generate_manifest'
+          end
           resources :expression_data, only: [:show], param: :data_type
         end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,8 +36,6 @@ Rails.application.routes.draw do
           resources :external_resources, only: [:index, :show, :create, :update, :destroy]
           member do
             post 'sync', to: 'studies#sync_study'
-          end
-          member do
             get 'manifest', to: 'studies#generate_manifest'
           end
           resources :expression_data, only: [:show], param: :data_type

--- a/db/migrate/20201021141827_clear_old_totats.rb
+++ b/db/migrate/20201021141827_clear_old_totats.rb
@@ -1,0 +1,10 @@
+class ClearOldTotats < Mongoid::Migration
+  def self.up
+    User.where(:totat.exists => true).each do |user|
+      user.update(totat: nil, totat_t_ti: nil)
+    end
+  end
+
+  def self.down
+  end
+end

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -253,8 +253,8 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
 
     execute_http_request(:get, api_v1_search_bulk_download_path(accessions: study.accession, file_types: file_types))
-    # response should be successful with no auth_code, since bearer token is valid
-    assert_response :success
+    # response should fail with no auth_code, since auth code is required
+    assert_response :unauthorized
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -252,11 +252,9 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     )
     assert_response :unauthorized
 
-    execute_http_request(:get, api_v1_search_bulk_download_path(
-        auth_code: ' ', accessions: study.accession, file_types: file_types)
-    )
-
-    assert_response :unauthorized
+    execute_http_request(:get, api_v1_search_bulk_download_path(accessions: study.accession, file_types: file_types))
+    # response should be successful with no auth_code, since bearer token is valid
+    assert_response :success
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/test/api/studies_controller_test.rb
+++ b/test/api/studies_controller_test.rb
@@ -76,10 +76,22 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
   # get the study manifest for a study
   test 'should get study manifest' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
-
-    execute_http_request(:get, "#{api_v1_studies_path(id: @study.id)}/manifest")
+    totat = @user.create_totat(30, manifest_api_v1_study_path(@study))
+    get manifest_api_v1_study_path(@study), params: { auth_code: totat[:totat] }
     assert_response :success
-    assert json['study']['name'] == @study.name
+    assert_equal @study.name, json['study']['name']
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+
+    # should fail with bad totat
+    totat = @user.create_totat(30, manifest_api_v1_study_path(@study))
+    get manifest_api_v1_study_path(@study), params: { auth_code: 'haxxor' }
+    assert_response 401
+
+    # should fail if totat for a different purpose
+    totat = @user.create_totat(30, "/api/v1/some/other/thing")
+    get manifest_api_v1_study_path(@study), params: { auth_code: totat[:totat] }
+    assert_response 401
+
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 

--- a/test/api/studies_controller_test.rb
+++ b/test/api/studies_controller_test.rb
@@ -79,8 +79,6 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
     totat = @user.create_totat(30, manifest_api_v1_study_path(@study))
     get manifest_api_v1_study_path(@study), params: { auth_code: totat[:totat] }
     assert_response :success
-    assert_equal @study.name, json['study']['name']
-    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
 
     # should fail with bad totat
     totat = @user.create_totat(30, manifest_api_v1_study_path(@study))

--- a/test/api/studies_controller_test.rb
+++ b/test/api/studies_controller_test.rb
@@ -79,7 +79,7 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
 
     execute_http_request(:get, "#{api_v1_studies_path(id: @study.id)}/manifest")
     assert_response :success
-    assert_json['study']['name'] == @study.name
+    assert json['study']['name'] == @study.name
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 

--- a/test/api/studies_controller_test.rb
+++ b/test/api/studies_controller_test.rb
@@ -73,6 +73,16 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 
+  # get the study manifest for a study
+  test 'should get study manifest' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    execute_http_request(:get, "#{api_v1_studies_path(id: @study.id)}/manifest")
+    assert_response :success
+    assert_json['study']['name'] == @study.name
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
   # test sync function by manually creating a new study using FireCloudClient methods, adding shares and files to the bucket,
   # then call sync_study API method
   test 'should create and then sync study' do

--- a/test/factories/study.rb
+++ b/test/factories/study.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
   # in the description of the study, to aid in test DB uniqueness and cleanup efforts
   factory :study do
     transient do
-      test_name { 'test' }
       auto_suffixes { true }
     end
     data_dir { '/tmp' }

--- a/test/factories/study.rb
+++ b/test/factories/study.rb
@@ -1,0 +1,27 @@
+FactoryBot.define do
+  # gets a study object, defaulting to the first user found.  Auto-appends a unique number to the name, and a note
+  # in the description of the study, to aid in test DB uniqueness and cleanup efforts
+  factory :study do
+    transient do
+      test_name { 'test' }
+      auto_suffixes { true }
+    end
+    data_dir { '/tmp' }
+    user { User.first }
+    after(:create) do |study, evaluator|
+      if evaluator.auto_suffixes
+        study.name << " #{SecureRandom.hex(8)} [FactoryBot]"
+        calling_test =  caller.find { |s| /_test.rb/ =~ s }
+        description_suffix = " Test study created by FactoryBot at #{Time.current}. #{calling_test}"
+        if study.description.nil?
+          study.description = ""
+        end
+        study.description << description_suffix
+      end
+    end
+    # create a study but mark as detached, so a Terra workspace is not created
+    factory :detached_study do
+      detached { true }
+    end
+  end
+end

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -1,0 +1,5 @@
+# factory for study_file test objects.
+FactoryBot.define do
+  factory :study_file do
+  end
+end

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -1,5 +1,6 @@
 # factory for study_file test objects.
 FactoryBot.define do
   factory :study_file do
+    upload_file_name { name }
   end
 end

--- a/test/integration/download_agreement_test.rb
+++ b/test/integration/download_agreement_test.rb
@@ -23,9 +23,8 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     assert signed_url.include?(file.upload_file_name), "Redirect url does not point at requested file"
 
     # test bulk download, first by generating and saving user totat.
-    totat = @test_user.create_totat(30, ['bulk_download'])
-    get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
-                                 download_object: 'all', totat: totat[:totat])
+    totat = @test_user.create_totat(30, api_v1_search_bulk_download_path)
+    get api_v1_search_bulk_download_path, params: {accessions: [@study.accession], auth_code: totat[:totat]}
     assert_response :success, "Did not get curl config for bulk download"
 
     # enable download agreement, assert 403
@@ -34,11 +33,10 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
 
     get download_file_path(accession: @study.accession, study_name: @study.url_safe_name, filename: file.upload_file_name)
     assert_response :forbidden, "Did not correctly respond 403 when download agreement is in place: #{response.code}"
-    totat = @test_user.create_totat(30, ['bulk_download'])
-    get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
-                                 download_object: 'all', totat: totat[:totat])
+    totat = @test_user.create_totat(30, api_v1_search_bulk_download_path)
+    get api_v1_search_bulk_download_path, params: {accessions: [@study.accession], auth_code: totat[:totat]}
     assert_response :forbidden, "Did not correctly respond 403 for bulk download: #{response.code}"
-    assert response.body.include?('Download agreement'), "Error response did not reference download agreement: #{response.body}"
+    assert response.body.include?('download agreement'), "Error response did not reference download agreement: #{response.body}"
 
     # accept agreement and validate downloads resume
     download_acceptance = DownloadAcceptance.new(email: @test_user.email, download_agreement: download_agreement)
@@ -48,10 +46,9 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     assert_response 302, "Did not re-enable file download as expected; response code: #{response.code}"
     signed_url = response.headers['Location']
     assert signed_url.include?(file.upload_file_name), "Redirect url does not point at requested file"
-    totat = @test_user.create_totat(30, ['bulk_download'])
-    get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
-                                 download_object: 'all', totat: totat[:totat])
-    assert_response :success, "Did not get curl config for bulk download after accepting download agreement"
+    totat = @test_user.create_totat(30, api_v1_search_bulk_download_path)
+    get api_v1_search_bulk_download_path, params: {accessions: [@study.accession], auth_code: totat[:totat]}
+    assert_response :success, "Did get curl config for bulk download after accepting download agreement"
 
     # clean up
     download_agreement.destroy

--- a/test/integration/download_agreement_test.rb
+++ b/test/integration/download_agreement_test.rb
@@ -23,7 +23,7 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     assert signed_url.include?(file.upload_file_name), "Redirect url does not point at requested file"
 
     # test bulk download, first by generating and saving user totat.
-    totat = @test_user.create_totat
+    totat = @test_user.create_totat(30, ['bulk_download'])
     get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
                                  download_object: 'all', totat: totat[:totat])
     assert_response :success, "Did not get curl config for bulk download"
@@ -34,7 +34,7 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
 
     get download_file_path(accession: @study.accession, study_name: @study.url_safe_name, filename: file.upload_file_name)
     assert_response :forbidden, "Did not correctly respond 403 when download agreement is in place: #{response.code}"
-    totat = @test_user.create_totat
+    totat = @test_user.create_totat(30, ['bulk_download'])
     get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
                                  download_object: 'all', totat: totat[:totat])
     assert_response :forbidden, "Did not correctly respond 403 for bulk download: #{response.code}"
@@ -48,7 +48,7 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     assert_response 302, "Did not re-enable file download as expected; response code: #{response.code}"
     signed_url = response.headers['Location']
     assert signed_url.include?(file.upload_file_name), "Redirect url does not point at requested file"
-    totat = @test_user.create_totat
+    totat = @test_user.create_totat(30, ['bulk_download'])
     get download_bulk_files_path(accession: @study.accession, study_name: @study.url_safe_name,
                                  download_object: 'all', totat: totat[:totat])
     assert_response :success, "Did not get curl config for bulk download after accepting download agreement"

--- a/test/integration/lib/bulk_download_service_test.rb
+++ b/test/integration/lib/bulk_download_service_test.rb
@@ -71,8 +71,7 @@ class BulkDownloadServiceTest < ActiveSupport::TestCase
     path_map = BulkDownloadService.generate_output_path_map([study_file])
     signed_url = "https://storage.googleapis.com/#{@study.bucket_id}/#{study_file.upload_file_name}"
     output_path = study_file.bulk_download_pathname
-    fake_hostname = "https://localhost"
-    manifest_path = "#{fake_hostname}/single_cell/api/v1/studies/#{@study.id}/manifest"
+    manifest_path = "#{RequestUtils.get_base_url}/single_cell/api/v1/studies/#{@study.id}/manifest"
 
     # mock call to GCS
     mock = Minitest::Mock.new
@@ -80,8 +79,7 @@ class BulkDownloadServiceTest < ActiveSupport::TestCase
     FireCloudClient.stub :new, mock do
       configuration = BulkDownloadService.generate_curl_configuration(study_files: [study_file], user: @user,
                                                                       study_bucket_map: bucket_map,
-                                                                      output_pathname_map: path_map,
-                                                                      hostname: fake_hostname)
+                                                                      output_pathname_map: path_map)
       mock.verify
       assert configuration.include?(signed_url), "Configuration does not include expected signed URL (#{signed_url}): #{configuration}"
       assert configuration.include?(output_path), "Configuration does not include expected output path (#{output_path}): #{configuration}"
@@ -171,7 +169,7 @@ class BulkDownloadServiceTest < ActiveSupport::TestCase
       name: 'metadata2.tsv'
     )
 
-    manifest_obj = BulkDownloadService.generate_study_manifest(study, 'localhost')
+    manifest_obj = BulkDownloadService.generate_study_manifest(study)
     # just test basic properties for now, we can add more once the format is finalized
     assert_equal study.name, manifest_obj[:study][:name]
     assert_equal 2, manifest_obj[:files].count

--- a/test/integration/lib/bulk_download_service_test.rb
+++ b/test/integration/lib/bulk_download_service_test.rb
@@ -76,13 +76,11 @@ class BulkDownloadServiceTest < ActiveSupport::TestCase
     # mock call to GCS
     mock = Minitest::Mock.new
     mock.expect :execute_gcloud_method, signed_url, [:generate_signed_url, Integer, String, String, Hash]
-    byebug
     FireCloudClient.stub :new, mock do
       configuration = BulkDownloadService.generate_curl_configuration(study_files: [study_file], user: @user,
                                                                       study_bucket_map: bucket_map,
                                                                       output_pathname_map: path_map,
                                                                       hostname: fake_hostname)
-      byebug
       mock.verify
       assert configuration.include?(signed_url), "Configuration does not include expected signed URL (#{signed_url}): #{configuration}"
       assert configuration.include?(output_path), "Configuration does not include expected output path (#{output_path}): #{configuration}"
@@ -151,10 +149,8 @@ class BulkDownloadServiceTest < ActiveSupport::TestCase
 
   test 'should generate study manifest file' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
-
-    study = Study.new(name: 'test manifest', description: 'stuff')
-    study.assign_accession # need an accession for study link to be generated
-    raw_counts_file = StudyFile.new(
+    study = FactoryBot.create(:detached_study, name: "#{self.method_name}")
+    raw_counts_file =  FactoryBot.create(:study_file,
       study: study,
       file_type: 'Expression Matrix',
       name: 'test_exp_validate',
@@ -170,9 +166,10 @@ class BulkDownloadServiceTest < ActiveSupport::TestCase
     # just test basic properties for now, we can add more once the format is finalized
     assert_equal study.name, manifest_obj[:study][:name]
     assert_equal 1, manifest_obj[:files].count
-    byebug
     assert_equal raw_counts_file.expression_file_info.units,
                  manifest_obj[:files][0][:units]
+
+    study.destroy!
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 end

--- a/test/integration/lib/bulk_download_service_test.rb
+++ b/test/integration/lib/bulk_download_service_test.rb
@@ -176,7 +176,7 @@ class BulkDownloadServiceTest < ActiveSupport::TestCase
     assert_equal study.name, manifest_obj[:study][:name]
     assert_equal 2, manifest_obj[:files].count
 
-    tsv_string = BulkDownloadService.generate_study_files_tsv(study, 'localhost')
+    tsv_string = BulkDownloadService.generate_study_files_tsv(study)
     tsv = ::CSV.new(tsv_string, col_sep: "\t", headers: true)
     rows = tsv.read
     assert_equal 2, rows.count

--- a/test/js/search/facet-control.test.js
+++ b/test/js/search/facet-control.test.js
@@ -34,6 +34,7 @@ describe('Facet control handles selections appropriately', () => {
     }
     const wrapper = mount((
       <PropsStudySearchProvider searchParams={{terms: '', facets:{}, page: 1}}>
+
         <FacetControl facet={speciesFacet}/>
       </PropsStudySearchProvider>
     ))


### PR DESCRIPTION
This enables download of a manifest file via bulk download, as shown in demo.  As discussed, the file/display format will likely be subject to change over the coming month as we get more feedback, but I think it makes sense to merge this code now into the raw counts branch, so that it's easier to iterate, and since this has a number of infrastructure improvements.

1.  Totats -- in order to support getting the manifest files, I had to significantly improve the robustness of the totat generator and checks.  Totats are now scoped to a specific path, and are 8-char alphanumeric so the search space is much larger.  Also, I've consolidated the totat operations between study download and bulk download -- both now use the API endpoint, and totat authentication is contained within the authenticator concern.

2. I've added window.SCP.ScpApi as an entry to scp-api.js.  This gives our rails templates and other javascript code easy access to the v1/api via the same javascript infrastructure we have for advanced search.  I think this will really let us simplify our JS as we start adding more API endpoints that may be shared across rails templates and react components.

3.  I've added FactoryBot (https://github.com/thoughtbot/factory_bot) for easier construction of single-use studies and other objects in tests.  The syntax for building a factory takes some getting used to, but using them makes tests much cleaner.  The tests only need to specify the attributes they care about, rather than a bunch of extra stuff just so the object passes validation, and we can auto-add uniqueness to names and descriptions for easier cleanup/debug.  

4.  Bulk download now gives error messages on being forbidden to download one of the accessions.  The errors are put in the cfg.txt file, which is not deleted if the curl execution of it fails, so the user can read the message.  Eventually, we'll want the authorization check to also be done when the auth_code is requested, so the user can be alerted in the UI, but this should be good enough for now.


