### PR TITLE
Proof of concept: Refactor default view for Explore tab in Study Overview (SCP-2815)

### DIFF
--- a/app/assets/javascripts/scp-related-genes-ideogram.js
+++ b/app/assets/javascripts/scp-related-genes-ideogram.js
@@ -104,6 +104,31 @@ function onPlotRelatedGenes() {
 }
 
 /**
+ * Set inner visibility of ideogram
+ *
+ * @param found Boolean Whether related genes have been found
+ */
+function setFoundRelatedGenes(found) {
+  if (found) {
+    const ideoContainer =
+      document.querySelector('#related-genes-ideogram-container')
+
+    // Make Ideogram visible
+    ideoContainer.classList = 'show-related-genes-ideogram'
+  }
+}
+
+/**
+ * Show ideogram upon finding any interacting gene or paralog
+ *
+ * This enables ideogram to only be shown when related genes are found (while
+ * also allowing incremental rendering).
+ */
+function onFindRelatedGenes() {
+  setFoundRelatedGenes(true)
+}
+
+/**
  * Initiates Ideogram for related genes
  *
  * This is only done in the context of single-gene search in Study Overview
@@ -136,6 +161,7 @@ function createRelatedGenesIdeogram(taxon) { // eslint-disable-line
     annotationHeight: 7,
     onClickAnnot,
     onPlotRelatedGenes,
+    onFindRelatedGenes,
     onLoad() {
       // Handles edge case: when organism lacks chromosome-level assembly
       if (!genomeHasChromosomes()) return

--- a/app/assets/javascripts/scp-related-genes-ideogram.js
+++ b/app/assets/javascripts/scp-related-genes-ideogram.js
@@ -104,31 +104,6 @@ function onPlotRelatedGenes() {
 }
 
 /**
- * Set inner visibility of ideogram
- *
- * @param found Boolean Whether related genes have been found
- */
-function setFoundRelatedGenes(found) {
-  if (found) {
-    const ideoContainer =
-      document.querySelector('#related-genes-ideogram-container')
-
-    // Make Ideogram visible
-    ideoContainer.classList = 'show-related-genes-ideogram'
-  }
-}
-
-/**
- * Show ideogram upon finding any interacting gene or paralog
- *
- * This enables ideogram to only be shown when related genes are found (while
- * also allowing incremental rendering).
- */
-function onFindRelatedGenes() {
-  setFoundRelatedGenes(true)
-}
-
-/**
  * Initiates Ideogram for related genes
  *
  * This is only done in the context of single-gene search in Study Overview
@@ -161,7 +136,6 @@ function createRelatedGenesIdeogram(taxon) { // eslint-disable-line
     annotationHeight: 7,
     onClickAnnot,
     onPlotRelatedGenes,
-    onFindRelatedGenes,
     onLoad() {
       // Handles edge case: when organism lacks chromosome-level assembly
       if (!genomeHasChromosomes()) return

--- a/app/assets/javascripts/study-overview.js
+++ b/app/assets/javascripts/study-overview.js
@@ -6,15 +6,12 @@
 
 const study = window.SCP.study
 
-if (typeof window.SCP.pushedPendingPageViewEvent === 'undefined') {
-  window.SCP.startPendingEvent('user-action:page:view:site-study',
-    { speciesList: window.SCP.taxons },
-    'plot:',
-    true)
 
-  // Flag to ensure we only log this pending event once per page view
-  window.SCP.pushedPendingPageViewEvent = true
-}
+window.SCP.startPendingEvent('user-action:page:view:site-study',
+  { speciesList: window.SCP.taxons },
+  'plot:',
+  true)
+
 
 /** Draws the scatter plot for the default Explore tab view */
 function renderScatter() {

--- a/app/assets/javascripts/study-overview.js
+++ b/app/assets/javascripts/study-overview.js
@@ -1,0 +1,130 @@
+/**
+* @fileoverview Default view of Explore tab in Study Overview
+*
+* Shows "Clusters" and sometimes "Genomes", etc.
+*/
+
+if (typeof window.SCP.pushedPendingPageViewEvent === 'undefined') {
+  window.SCP.startPendingEvent('user-action:page:view:site-study',
+    { speciesList: window.SCP.taxons },
+    'plot:',
+    true)
+
+  // Flag to ensure we only log this pending event once per page view
+  window.SCP.pushedPendingPageViewEvent = true
+}
+
+/** Draws the scatter plot for the default Explore tab view */
+function renderScatter() {
+  // detach listener as it will be re-attached in response;
+  // this helps reduce spurious errors
+  $(window).off('resizeEnd')
+
+  const target = $('#cluster-plot')[0]
+  const spinner = new Spinner(window.opts).spin(target)
+  $('#cluster-plot').data('spinner', spinner)
+
+  const urlParams = window.getRenderUrlParams()
+  const url = `${window.SCP.renderClusterPath}?${urlParams}`
+
+  $.ajax({
+    url,
+    method: 'GET',
+    dataType: 'script'
+  })
+}
+
+// For inferCNV ideogram
+$('#ideogram_annotation').on('change', function() {
+  const ideogramFiles = window.SCP.ideogramFiles
+  const fileId = $(this).val() // eslint-disable-line
+  if (fileId !== '') {
+    const ideogramAnnot = ideogramFiles[fileId]
+    window.ideogramInferCnvSettings = ideogramAnnot.ideogram_settings
+    window.initializeIdeogram(ideogramAnnot.ideogram_settings.annotationsPath)
+  } else {
+    $('#tracks-to-display, #_ideogramOuterWrap').html('')
+    $('#ideogramTitle').remove()
+  }
+})
+
+if (window.SCP.canVisualizeClusters) {
+  $('#cluster-plot').data('rendered', false)
+
+  const baseCamera = {
+    'up': { 'x': 0, 'y': 0, 'z': 1 },
+    'center': { 'x': 0, 'y': 0, 'z': 0 },
+    'eye': { 'x': 1.25, 'y': 1.25, 'z': 1.25 }
+  }
+
+  $(document).ready(() => {
+    // if tab position was specified in url, show the current tab
+    if (window.location.href.split('#')[1] !== '') {
+      const tab = window.location.href.split('#')[1]
+      $(`#study-tabs a[href="#${tab}"]`).tab('show')
+    }
+    $('#cluster-plot').data('camera', baseCamera)
+    // set default subsample option of 10K (if subsampled) or all cells
+    if (window.SCP.clusterNumPoints > 10000 && window.SCP.clusterIsSampled) {
+      $('#subsample').val(10000)
+      $('#search_subsample').val(10000)
+    }
+
+    renderScatter()
+  })
+
+  // listener for cluster nav, specific to study page
+  $('#annotation').change(function() {
+    $('#cluster-plot').data('rendered', false)
+    const an = $(this).val() // eslint-disable-line
+    // keep track for search purposes
+    $('#search_annotation').val(an)
+    $('#gene_set_annotation').val(an)
+    renderScatter()
+  })
+
+  $('#subsample').change(function() {
+    $('#cluster-plot').data('rendered', false)
+    const sample = $(this).val() // eslint-disable-line
+    $('#search_subsample').val(sample)
+    $('#gene_set_subsample').val(sample)
+    renderScatter()
+  })
+
+  $('#cluster').change(function() {
+    $('#cluster-plot').data('rendered', false)
+    const newCluster = $(this).val() // eslint-disable-line
+    // keep track for search purposes
+    $('#search_cluster').val(newCluster)
+    $('#gene_set_cluster').val(newCluster)
+    // grab currently selected annotation
+    const currSubsample = $('#subsample').val()
+
+    const params = [
+      'cluster=', encodeURIComponent(newCluster),
+      '&subsample=', encodeURIComponent(currSubsample)
+    ].join('')
+    const url = `${window.SCP.getNewAnnotationsPath}?${params}`
+
+    // get new annotation options and re-render
+    $.ajax({
+      url,
+      method: 'GET',
+      dataType: 'script',
+      complete(jqXHR, textStatus) {
+        window.renderWithNewCluster(textStatus, renderScatter)
+      }
+    })
+  })
+
+  if (window.SCP.hasIdeogramInferCnvFiles) {
+    // user has no clusters, but does have ideogram annotations
+    $(document).ready(() => {
+      const ideogramSelect = $('#ideogram_annotation')
+      const firstIdeogram = $('#ideogram_annotation option')[1].value
+
+      // manually trigger change to cause ideogram to render
+      ideogramSelect.val(firstIdeogram).trigger('change')
+    })
+  }
+}

--- a/app/assets/javascripts/study-overview.js
+++ b/app/assets/javascripts/study-overview.js
@@ -4,6 +4,8 @@
 * Shows "Clusters" and sometimes "Genomes", etc.
 */
 
+const study = window.SCP.study
+
 if (typeof window.SCP.pushedPendingPageViewEvent === 'undefined') {
   window.SCP.startPendingEvent('user-action:page:view:site-study',
     { speciesList: window.SCP.taxons },
@@ -25,7 +27,7 @@ function renderScatter() {
   $('#cluster-plot').data('spinner', spinner)
 
   const urlParams = window.getRenderUrlParams()
-  const url = `${window.SCP.renderClusterPath}?${urlParams}`
+  const url = `${study.renderClusterPath}?${urlParams}`
 
   $.ajax({
     url,
@@ -36,7 +38,7 @@ function renderScatter() {
 
 // For inferCNV ideogram
 $('#ideogram_annotation').on('change', function() {
-  const ideogramFiles = window.SCP.ideogramFiles
+  const ideogramFiles = study.ideogramFiles
   const fileId = $(this).val() // eslint-disable-line
   if (fileId !== '') {
     const ideogramAnnot = ideogramFiles[fileId]
@@ -48,7 +50,7 @@ $('#ideogram_annotation').on('change', function() {
   }
 })
 
-if (window.SCP.canVisualizeClusters) {
+if (study.canVisualizeClusters) {
   $('#cluster-plot').data('rendered', false)
 
   const baseCamera = {
@@ -65,7 +67,7 @@ if (window.SCP.canVisualizeClusters) {
     }
     $('#cluster-plot').data('camera', baseCamera)
     // set default subsample option of 10K (if subsampled) or all cells
-    if (window.SCP.clusterNumPoints > 10000 && window.SCP.clusterIsSampled) {
+    if (window.SCP.numPointsCluster > 10000 && window.SCP.clusterIsSampled) {
       $('#subsample').val(10000)
       $('#search_subsample').val(10000)
     }

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -298,7 +298,7 @@ export function log(name, props={}) {
  Initializes an event to log later (usually on completion of an async process)
  Handles measuring duration of the event.
  @param {String} name: the name of the event
- @param {} props: the props to pass along with the event.  This function
+ @param {Object} props: the props to pass along with the event.  This function
   automatically handles computing and adding 'perfTime' properties to the
   event props
  @param {String} completionTriggerPrefix: The prefix of an event on whose

--- a/app/views/site/_study_visualize.html.erb
+++ b/app/views/site/_study_visualize.html.erb
@@ -55,118 +55,22 @@
   </div>
 </div>
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-  <% if @study.can_visualize_clusters? %>
-    if (typeof window.SCP.pushedPendingPageViewEvent === 'undefined') {
-      window.SCP.startPendingEvent('user-action:page:view:site-study',
-                                 {},
-                                 'plot:',
-                                 true);
+  window.SCP.canVisualizeClusters = <%= @study.can_visualize_clusters? %>;
+  window.SCP.ideogramFiles = <%= raw @ideogram_files.to_json %>;
 
-      // Flag to ensure we only log this pending event once per page view
-      window.SCP.pushedPendingPageViewEvent = true;
-    }
+  // Used for Ideogram for related genes
+  window.SCP.taxons = <%= raw @taxons.to_json %>;
 
-    $('#cluster-plot').data('rendered', false);
+  window.SCP.clusterNumPoints = <%= @cluster.points %>
+  window.SCP.clusterIsSubsampled = <%= @cluster.subsampled %>
+  window.SCP.hasIdeogramInferCnvFiles = <%= @ideogram_files.present? %>
 
-    var baseCamera = {
-        "up":{"x":0,"y":0,"z":1},
-        "center":{"x":0,"y":0,"z":0},
-        "eye":{"x":1.25,"y":1.25,"z":1.25}
-    };
+  window.SCP.renderClusterPath =
+    '<%= render_cluster_path(accession: @study.accession, study_name: @study.url_safe_name) %>'
 
-    function renderScatter() {
-        // detach listener as it will be re-attached in response; this helps reduce spurious errors
-        $(window).off('resizeEnd');
-        var url = '<%= render_cluster_path(accession: @study.accession, study_name: @study.url_safe_name) %>';
-        var target = $('#cluster-plot')[0];
-        var spinner = new Spinner(opts).spin(target);
-        $('#cluster-plot').data('spinner', spinner);
+  window.SCP.getNewAnnotationsPath =
+    '<%= get_new_annotations_path(accession: @study.accession, study_name: @study.url_safe_name)%>'
 
-        var urlParams = getRenderUrlParams();
-        url += '?' + urlParams;
-
-        $.ajax({
-            url: url,
-            method: 'GET',
-            dataType: 'script'
-        });
-    }
-
-    $(document).ready(function() {
-      //if tab position was specified in url, show the current tab
-      if (window.location.href.split('#')[1] !== '') {
-          var tab = window.location.href.split('#')[1];
-          $('#study-tabs a[href="#' + tab + '"]').tab('show');
-      }
-      $('#cluster-plot').data('camera', baseCamera);
-      // set default subsample option of 10K (if subsampled) or all cells
-      if (<%= @cluster.points > 10000 && @cluster.subsampled? %>) {
-          $('#subsample').val(10000);
-          $('#search_subsample').val(10000);
-      }
-
-      renderScatter();
-    });
-
-    // listener for cluster nav, specific to study page
-    $("#annotation").change(function() {
-        $('#cluster-plot').data('rendered', false);
-        var an = $(this).val();
-        // keep track for search purposes
-        $('#search_annotation').val(an);
-        $('#gene_set_annotation').val(an);
-        renderScatter();
-    });
-
-    $('#subsample').change(function() {
-        $('#cluster-plot').data('rendered', false);
-        var sample = $(this).val();
-        $('#search_subsample').val(sample);
-        $('#gene_set_subsample').val(sample);
-        renderScatter();
-    });
-
-    $("#cluster").change(function() {
-        $('#cluster-plot').data('rendered', false);
-        var newCluster = $(this).val();
-        // keep track for search purposes
-        $('#search_cluster').val(newCluster);
-        $('#gene_set_cluster').val(newCluster);
-        // grab currently selected annotation
-        var currSubsample = $('#subsample').val();
-        // get new annotation options and re-render
-        $.ajax({
-            url: "<%= get_new_annotations_path(accession: @study.accession, study_name: @study.url_safe_name)%>?cluster=" + encodeURIComponent(newCluster) + '&subsample=' + encodeURIComponent(currSubsample),
-            method: 'GET',
-            dataType: 'script',
-            complete: function (jqXHR, textStatus) {
-                renderWithNewCluster(textStatus, renderScatter);
-            }
-        });
-    });
-
-    // Used for Ideogram for related genes
-    window.SCP.taxons = <%= raw @taxons.to_json %>;
-  <% end %>
-    $('#ideogram_annotation').on('change', function() {
-        var ideogramFiles = <%= raw @ideogram_files.to_json %>;
-        var fileId = $(this).val();
-        if (fileId !== '') {
-            var ideogramAnnot = ideogramFiles[fileId];
-            window.ideogramInferCnvSettings = ideogramAnnot.ideogram_settings;
-            initializeIdeogram(ideogramAnnot.ideogram_settings.annotationsPath);
-        } else {
-            $('#tracks-to-display, #_ideogramOuterWrap').html('');
-            $('#ideogramTitle').remove();
-        }
-
-    });
-  <% if !@study.can_visualize_clusters? && @ideogram_files.present? %>
-    // user has no clusters, but does have ideogram annotations
-    $(document).ready(function () {
-      var ideogramSelect = $('#ideogram_annotation');
-      var firstIdeogram = $('#ideogram_annotation option')[1].value;
-      ideogramSelect.val(firstIdeogram).trigger('change'); // manually trigger change to cause ideogram to render
-    });
-  <% end %>
 </script>
+
+<%= nonced_javascript_include_tag 'study-overview' %>

--- a/app/views/site/_study_visualize.html.erb
+++ b/app/views/site/_study_visualize.html.erb
@@ -55,22 +55,18 @@
   </div>
 </div>
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-  window.SCP.canVisualizeClusters = <%= @study.can_visualize_clusters? %>;
-  window.SCP.ideogramFiles = <%= raw @ideogram_files.to_json %>;
+  window.SCP.study = {
+    canVisualizeClusters: <%= @study.can_visualize_clusters? %>,
+    taxons: <%= raw @taxons.to_json %>,
+    numPointsCluster: <%= @cluster.points %>,
+    isClusterSubsampled: <%= @cluster.subsampled %>,
+    ideogramInferCnvFiles: <%= raw @ideogram_files.to_json %>,
+    hasIdeogramInferCnvFiles: <%= @ideogram_files.present? %>,
+    renderClusterPath: '<%= render_cluster_path(accession: @study.accession, study_name: @study.url_safe_name) %>',
+    getNewAnnotationsPath:'<%= get_new_annotations_path(accession: @study.accession, study_name: @study.url_safe_name)%>'
+  }
 
-  // Used for Ideogram for related genes
-  window.SCP.taxons = <%= raw @taxons.to_json %>;
-
-  window.SCP.clusterNumPoints = <%= @cluster.points %>
-  window.SCP.clusterIsSubsampled = <%= @cluster.subsampled %>
-  window.SCP.hasIdeogramInferCnvFiles = <%= @ideogram_files.present? %>
-
-  window.SCP.renderClusterPath =
-    '<%= render_cluster_path(accession: @study.accession, study_name: @study.url_safe_name) %>'
-
-  window.SCP.getNewAnnotationsPath =
-    '<%= get_new_annotations_path(accession: @study.accession, study_name: @study.url_safe_name)%>'
-
+  window.SCP.taxons = window.SCP.study.taxons;
 </script>
 
 <%= nonced_javascript_include_tag 'study-overview' %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,8 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
+  config.assets.check_precompiled_asset = false
+
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 


### PR DESCRIPTION
This decouples JavaScript and Rails in the top-level template for the "Explore" tab in Study Overview.  General idea:

* Extract Rails variables interpolated in JavaScript.  Move them to top of `.js.erb`, create new `.js` file for plain JavaScript.

This improves testability.  It progresses towards fast, reliable tests of Study Overview that can run with mock data.  This will help ensure upcoming spatial UI features are robust.

The code is a proof-of-concept.  In a subsequent PR, I'd like to refine use of `nonced_javascript_include_tag` and `config.assets.check_precompiled_asset = false`, e.g. to perhaps `embed` plain `.js` files -- unless reviewers know a solution off-hand.  I didn't find anything suitable after searching for some time.

The code merges into a long-lived branch, `spatial-transcriptomics`, to land spatial code not stable enough for mainline.

More context is available in the [Study Overview refactor for spatial UI](https://docs.google.com/document/d/1nnr1NNeejP5I1XApeK9BcKxZLCRbQeNJItGYyeilqm8/edit#) design doc.  This code is a first step in that.

This relates to SCP-2815.