### PR TITLE
Enhance related genes analytics for load times, tooltips (SCP-2850)

### DIFF
--- a/app/assets/javascripts/scp-related-genes-ideogram.js
+++ b/app/assets/javascripts/scp-related-genes-ideogram.js
@@ -76,18 +76,39 @@ function showRelatedGenesIdeogram() { // eslint-disable-line
   ideoContainer.classList = 'show-related-genes-ideogram'
 }
 
-/**
- * Get summary of related-genes ideogram that was just loaded or clicked
- */
-function getRelatedGenesAnalytics(ideogram) {
-  const props = Object.assign({}, ideogram.relatedGenesAnalytics)
-
+/** Refine analytics to use DSP-conventional names */
+function conformAnalytics(props, ideogram) {
   // Use DSP-conventional name
-  props['perfTime'] = props.time
-  delete props['time']
+  props['perfTime'] = props.timeTotal
+  delete props.timeTotal
 
-  props['species'] = ideogram.getScientificName(ideogram.config.taxid)
+  props['species'] = ideogram.organismScientificName
 
+  return props
+}
+
+/** Log hover over related genes ideogram tooltip */
+function onWillShowAnnotTooltip(annot) {
+  // Ideogram object; used to inspect ideogram state
+  const ideogram = this // eslint-disable-line
+  let props = ideogram.getTooltipAnalytics(annot)
+
+  // `props` is null if it is merely analytics noise.
+  // Accounts for quick moves from label to annot, or away then immediately
+  // back to same annot.  Such action flicker tooltip and represents a
+  // technical artifact that is not worth analyzing.
+  if (props) {
+    props = conformAnalytics(props, ideogram)
+    window.SCP.log('ideogram:related-genes:tooltip', props)
+  }
+
+  return annot
+}
+
+/** Get summary of related-genes ideogram that was just loaded or clicked */
+function getRelatedGenesAnalytics(ideogram) {
+  let props = Object.assign({}, ideogram.relatedGenesAnalytics)
+  props = conformAnalytics(props, ideogram)
   return props
 }
 
@@ -134,8 +155,10 @@ function createRelatedGenesIdeogram(taxon) { // eslint-disable-line
     chrHeight: 100,
     chrLabelSize: 12,
     annotationHeight: 7,
+    showAnnotLabels: false,
     onClickAnnot,
     onPlotRelatedGenes,
+    onWillShowAnnotTooltip,
     onLoad() {
       // Handles edge case: when organism lacks chromosome-level assembly
       if (!genomeHasChromosomes()) return

--- a/app/assets/javascripts/scp-related-genes-ideogram.js
+++ b/app/assets/javascripts/scp-related-genes-ideogram.js
@@ -95,7 +95,7 @@ function onWillShowAnnotTooltip(annot) {
 
   // `props` is null if it is merely analytics noise.
   // Accounts for quick moves from label to annot, or away then immediately
-  // back to same annot.  Such action flicker tooltip and represents a
+  // back to same annot.  Such action flickers tooltip and represents a
   // technical artifact that is not worth analyzing.
   if (props) {
     props = conformAnalytics(props, ideogram)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
-    "ideogram": "1.26.0",
+    "ideogram": "1.28.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.12.1",
     "morpheus-app": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6878,10 +6878,10 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ideogram@1.26.0:
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.26.0.tgz#8680566e7a872eb6b7dbe01fbf191258c7aac9ea"
-  integrity sha512-7tE2wzMk/dszuYhudMg6YIWRbEswmbQG74wCqigbyWV/MXDwBcXsh+SVddm/v8JyVYe9nh90Kvs5osx4jKJxBg==
+ideogram@1.28.0:
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.28.0.tgz#dc98811c774e9a0ec9f26c04108f8010e7e658a2"
+  integrity sha512-xUvQX6ozPIEx5gHdKU+gWGPKkl2gFK0OK3bnm1FM2X7+qf8bestilnJea8dC9unhLMacd9l48s1DvF+InJW++w==
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"


### PR DESCRIPTION
This improves Mixpanel logging instrumentation for the related genes ideogram.  It gives more insight on load times and tooltips.

For example, we'll be able to measure time of first plot of related genes, and between first and last plot of related genes.  This will help assess impact of occasionally slow or down upstream services (mostly Ensembl).  That will inform improvements around how we display the ideogram (or not) when there are no related genes.  

This satisfies SCP-2850.