### PR TITLE
SCP-2859: Increase group annotation visualization threshold to 200

### DIFF
--- a/app/models/cell_metadatum.rb
+++ b/app/models/cell_metadatum.rb
@@ -17,10 +17,10 @@ class CellMetadatum
   BIGQUERY_TABLE = 'alexandria_convention'
 
   # range to determine whether a group annotation is "useful" to visualize
-  # an annotation must have 2-100 different groups.  only 1 label is not informative,
-  # and over 100 is difficult to comprehend and slows down rendering once the group count
+  # an annotation must have 2-200 different groups.  only 1 label is not informative,
+  # and over 200 is difficult to comprehend and slows down rendering once the group count
   # gets over a few hundred (both server- and client-side).
-  GROUP_VIZ_THRESHOLD = (2..100)
+  GROUP_VIZ_THRESHOLD = (2..200)
 
   belongs_to :study
   belongs_to :study_file

--- a/test/models/cell_metadatum_test.rb
+++ b/test/models/cell_metadatum_test.rb
@@ -7,7 +7,7 @@ class CellMetadatumTest < ActiveSupport::TestCase
 
     # setup
     annotation_values = []
-    200.times { annotation_values << SecureRandom.uuid }
+    300.times { annotation_values << SecureRandom.uuid }
     @cell_metadatum = CellMetadatum.new(name: 'Group Count Test', annotation_type: 'group', values: annotation_values)
 
     # assert unique group annotations > 100 cannot visualize

--- a/test/models/cluster_group_test.rb
+++ b/test/models/cluster_group_test.rb
@@ -9,7 +9,7 @@ class ClusterGroupTest < ActiveSupport::TestCase
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
 
     annotation_values = []
-    200.times { annotation_values << SecureRandom.uuid }
+    300.times { annotation_values << SecureRandom.uuid }
     cell_annotation = {name: 'Group Annotation', type: 'group', values: annotation_values}
     cluster = ClusterGroup.new(name: 'Group Count Test', cluster_type: '2d', cell_annotations: [cell_annotation])
     can_visualize = cluster.can_visualize_cell_annotation?(cell_annotation)


### PR DESCRIPTION
Increases the maximum threshold for group-based annotations from 100 to 200, as per user feature request.

This PR satisfies SCP-2859.