### PR TITLE
SCP-2863: refactoring set_range to account for missing/na values

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -2024,13 +2024,20 @@ class SiteController < ApplicationController
       range = @cluster.domain_ranges
     else
       # take the minmax of each domain across all groups, then the global minmax
-      @vals = inputs.map {|v| domain_keys.map {|k| RequestUtils.get_minmax(v[k])}}.flatten.minmax
+      raw_values = []
+      inputs.each do |input|
+        domain_keys.each do |domain|
+          domain_range = RequestUtils.get_minmax(input[domain])
+          raw_values << domain_range if domain_range.any?
+        end
+      end
+      aggregate_range = raw_values.flatten.minmax
       # add 2% padding to range
-      scope = (@vals.first - @vals.last) * 0.02
-      raw_range = [@vals.first + scope, @vals.last - scope]
-      range[:x] = raw_range
-      range[:y] = raw_range
-      range[:z] = raw_range
+      scope = (aggregate_range.first - aggregate_range.last) * 0.02
+      absolute_range = [aggregate_range.first + scope, aggregate_range.last - scope]
+      range[:x] = absolute_range
+      range[:y] = absolute_range
+      range[:z] = absolute_range
     end
     range
   end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -2028,13 +2028,15 @@ class SiteController < ApplicationController
       inputs.each do |input|
         domain_keys.each do |domain|
           domain_range = RequestUtils.get_minmax(input[domain])
+          # RequestUtils.get_minmax will discard NaN/nil values that were ingested
+          # only add domain range to list if we have a valid minmax
           raw_values << domain_range if domain_range.any?
         end
       end
       aggregate_range = raw_values.flatten.minmax
       # add 2% padding to range
-      scope = (aggregate_range.first - aggregate_range.last) * 0.02
-      absolute_range = [aggregate_range.first + scope, aggregate_range.last - scope]
+      padding = (aggregate_range.first - aggregate_range.last) * 0.02
+      absolute_range = [aggregate_range.first + padding, aggregate_range.last - padding]
       range[:x] = absolute_range
       range[:y] = absolute_range
       range[:z] = absolute_range

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -66,7 +66,7 @@ class RequestUtils
     begin
       values_array.minmax
     rescue TypeError, ArgumentError
-      values_array.dup.reject!(&:nan?).minmax
+      values_array.dup.reject! {|value| value.nil? || value.nan? }.minmax
     end
   end
 

--- a/app/lib/synthetic_study_populator.rb
+++ b/app/lib/synthetic_study_populator.rb
@@ -52,7 +52,6 @@ class SyntheticStudyPopulator
     study.study_detail = StudyDetail.new(full_description: study_config['study']['description'])
     study.user ||= user
     study.firecloud_project ||= ENV['PORTAL_NAMESPACE']
-    puts "study.firecloud_project: #{study.firecloud_project}"
     puts("Saving Study #{study.name}")
     study.save!
     study

--- a/app/lib/synthetic_study_populator.rb
+++ b/app/lib/synthetic_study_populator.rb
@@ -52,6 +52,7 @@ class SyntheticStudyPopulator
     study.study_detail = StudyDetail.new(full_description: study_config['study']['description'])
     study.user ||= user
     study.firecloud_project ||= ENV['PORTAL_NAMESPACE']
+    puts "study.firecloud_project: #{study.firecloud_project}"
     puts("Saving Study #{study.name}")
     study.save!
     study

--- a/bin/load_env_secrets.sh
+++ b/bin/load_env_secrets.sh
@@ -82,7 +82,7 @@ if [[ -n $VAULT_SECRET_PATH ]] ; then
     echo "setting value for: $key"
     curr_val=$(echo $VALS | jq .data | jq --raw-output .$key)
     # honor PORTAL_NAMESPACE from the environment, if present
-    if [[ "$PORTAL_NAMESPACE" != "" && "$key" = "PORTAL_NAMESPACE"]]; then
+    if [[ "$PORTAL_NAMESPACE" != "" && "$key" = "PORTAL_NAMESPACE" ]] ; then
       echo "honoring current value of PORTAL_NAMESPACE: $PORTAL_NAMESPACE"
       export PORTAL_NAMESPACE=$PORTAL_NAMESPACE
     else

--- a/bin/load_env_secrets.sh
+++ b/bin/load_env_secrets.sh
@@ -81,7 +81,13 @@ if [[ -n $VAULT_SECRET_PATH ]] ; then
   do
     echo "setting value for: $key"
     curr_val=$(echo $VALS | jq .data | jq --raw-output .$key)
-    export $key=$curr_val
+    # honor PORTAL_NAMESPACE from the environment, if present
+    if [[ "$PORTAL_NAMESPACE" != "" && "$key" = "PORTAL_NAMESPACE"]]; then
+      echo "honoring current value of PORTAL_NAMESPACE: $PORTAL_NAMESPACE"
+      export PORTAL_NAMESPACE=$PORTAL_NAMESPACE
+    else
+      export $key=$curr_val
+    fi
   done
 fi
 # now load service account credentials


### PR DESCRIPTION
As discovered in many [bug](https://sentry.io/organizations/broad-institute/issues/1997315121/?project=1424198&query=is%3Aunresolved) reports, issues in parsing or user error in generating data can lead to errors when attempting to compute ranges for scatter plots to enforce square/cube aspect ratios.  This fix now accounts for `NaN` or `nil` values better and rejects them accordingly.  The `SiteController#set_range` method has also been refactored for better readability.

This PR satisfies SCP-2863