### PR TITLE
SCP-2865: updating to rails-baseimage:1.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM singlecellportal/rails-baseimage:1.0.5
+FROM singlecellportal/rails-baseimage:1.0.6
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-2.6.5'

--- a/test/integration/cache_management_test.rb
+++ b/test/integration/cache_management_test.rb
@@ -13,7 +13,7 @@ class CacheManagementTest < ActionDispatch::IntegrationTest
     cluster = ClusterGroup.first
     cluster_file = study.cluster_ordinations_files.first
     expression_file = study.expression_matrix_file('expression_matrix.txt')
-    genes = study.genes.map(&:name)
+    genes = Gene.all.map(&:name)
     gene = genes.sample
     genes_hash = Digest::SHA256.hexdigest genes.sort.join
     cluster.cell_annotations.each do |cell_annotation|

--- a/test/integration/cache_management_test.rb
+++ b/test/integration/cache_management_test.rb
@@ -13,7 +13,7 @@ class CacheManagementTest < ActionDispatch::IntegrationTest
     cluster = ClusterGroup.first
     cluster_file = study.cluster_ordinations_files.first
     expression_file = study.expression_matrix_file('expression_matrix.txt')
-    genes = Gene.all.map(&:name)
+    genes = study.genes.map(&:name)
     gene = genes.sample
     genes_hash = Digest::SHA256.hexdigest genes.sort.join
     cluster.cell_annotations.each do |cell_annotation|


### PR DESCRIPTION
Pulling in regular security package updates to the `ubuntu` base image.

This PR satisfies SCP-2865.