### PR TITLE
Temporarily disable Burp (SCP-2878)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
   - bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json -s secret/kdux/scp/staging/scp_service_account.json -r secret/kdux/scp/staging/read_only_service_account.json -e test -n single-cell-portal-test
 after_success:
   - |
+    export BURP_ENABLE=-1
     if [ "${BURP_ENABLE}" = "0" ]; then
       bin/burp_scan.sh "${BURP_DOCKER_IMAGE}" "${BURP_SA_KEY}" "${BURP_BUCKET}" "${TRAVIS_REPO_SLUG}"
     fi


### PR DESCRIPTION
This temporarily disables Burp.  Merging #733 broke the build due to an expired license.  I'm working with AppSec to enact a proper solution; this patch from AppSec patches the problem for now.

This relates to SCP-2878.