### PR TITLE
UI refinements from demo, and making advanced search linkable (SCP-2821)

### DIFF
--- a/app/javascript/components/HomePageContent.js
+++ b/app/javascript/components/HomePageContent.js
@@ -11,12 +11,13 @@ import StudySearchProvider, { StudySearchContext } from 'providers/StudySearchPr
 import SearchFacetProvider from 'providers/SearchFacetProvider'
 import UserProvider from 'providers/UserProvider'
 import ErrorBoundary from 'lib/ErrorBoundary'
+import * as queryString from 'query-string'
 
 /** include search controls and results */
-export function StudySearchView() {
+export function StudySearchView({advancedSearchDefault}) {
   const studySearchState = useContext(StudySearchContext)
   return <>
-    <SearchPanel searchOnLoad={true}/>
+    <SearchPanel advancedSearchDefault={advancedSearchDefault} searchOnLoad={true}/>
     <ResultsPanel studySearchState={studySearchState} studyComponent={StudyDetails} />
   </>
 }
@@ -26,6 +27,9 @@ const LinkableSearchTabs = function(props) {
   // since the Reach router doesn't own the home path
   const location = useLocation()
   const showGenesTab = location.pathname.startsWith('/single_cell/app/genes')
+  const queryParams = queryString.parse(location.search)
+  // the queryParams object does not support the more typical hasOwnProperty test
+  const advancedSearchDefault = ('advancedSearch' in queryParams)
   return (
     <div>
       <nav className="nav search-links" data-analytics-name="search" role="tablist">
@@ -41,7 +45,7 @@ const LinkableSearchTabs = function(props) {
       <div className="tab-content top-pad">
         <Router basepath="/single_cell">
           <GeneSearchView path="app/genes"/>
-          <StudySearchView default/>
+          <StudySearchView advancedSearchDefault={advancedSearchDefault} default/>
         </Router>
       </div>
     </div>

--- a/app/javascript/components/search/controls/SearchPanel.js
+++ b/app/javascript/components/search/controls/SearchPanel.js
@@ -50,6 +50,7 @@ const helpModalContent = (<div>
  */
 export default function SearchPanel({
   showCommonButtons,
+  advancedSearchDefault,
   keywordPrompt,
   searchOnLoad
 }) {
@@ -65,7 +66,8 @@ export default function SearchPanel({
       featureFlagState.faceted_search = true
     }
   }
-  const [showAdvancedSearch, setShowAdvancedSearch] = useState(featureFlagState.faceted_search)
+
+  const [showAdvancedSearch, setShowAdvancedSearch] = useState(advancedSearchDefault || featureFlagState.faceted_search)
   const [showSearchHelpModal, setShowSearchHelpModal] = useState(false)
   const [showSearchOptInModal, setShowSearchOptInModal] = useState(false)
   const [isNewToUser, setIsNewToUser] = useState(true)
@@ -86,7 +88,7 @@ export default function SearchPanel({
   }
 
   let advancedOptsLink = <a className="action advanced-opts" onClick={handleMoreFiltersClick}>
-    Advanced search<sup className="new-feature">BETA</sup>
+    Advanced Search <sup className="new-feature">BETA</sup>
   </a>
   if (showAdvancedSearch) {
     searchButtons = <FacetsPanel/>

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -325,7 +325,8 @@ nav.search-links, #search-panel {
 .advanced-opts {
   vertical-align: top;
   display: inline-block;
-  padding-top: 0.65em;
+  padding: 0.65em 0.25em;
+  border-radius: 1em;
 }
 
 .new-feature {


### PR DESCRIPTION
Now you can default advanced search to on (even overriding a user feature flag), by including `advancedSearch` in the query params.  e.g. `https://singlecell.broadinstitute.org/single_cell?advancedSearch`    This will enable reliable linking to the feature from wikis, etc...