### PR TITLE
Update cluster / spatial tab label (SCP-2825)

### DIFF
--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -16,7 +16,7 @@
     <li role="presentation" class="wizard-nav" id="initialize_expression_form_nav"><a href="#expression" data-toggle="tab">1. Expression Matrix <span id="initialize_expression_form_nav_completed"></span></a></li>
     <li role="presentation" class="wizard-nav" id="initialize_metadata_form_nav"><a href="#metadata" data-toggle="tab">2. Metadata <span id="initialize_metadata_form_nav_completed"></span></a></li>
     <% if User.feature_flag_for_instance(current_user, 'spatial_transcriptomics') %>
-      <li role="presentation" class="wizard-nav" id="initialize_ordinations_form_nav"><a href="#ordinations" data-toggle="tab">3. Clusters & Spatial <span id="initialize_ordinations_form_nav_completed"></span></a></li>
+      <li role="presentation" class="wizard-nav" id="initialize_ordinations_form_nav"><a href="#ordinations" data-toggle="tab">3. Clusters / Spatial <span id="initialize_ordinations_form_nav_completed"></span></a></li>
     <% else %>
       <li role="presentation" class="wizard-nav" id="initialize_ordinations_form_nav"><a href="#ordinations" data-toggle="tab">3. Clusters <span id="initialize_ordinations_form_nav_completed"></span></a></li>
     <% end %>
@@ -125,7 +125,7 @@
         <div class="well well-sm upload-wizard">
           <div class="row">
           <% if User.feature_flag_for_instance(current_user, 'spatial_transcriptomics') %>
-            <h2 class="col-sm-12">Step 3. Upload Cluster & Spatial Files <small class="initialize-label" id="initialize_ordinations_form_completed"></small></h2>
+            <h2 class="col-sm-12">Step 3. Upload Cluster / Spatial Files <small class="initialize-label" id="initialize_ordinations_form_completed"></small></h2>
           <% else %>
             <h2 class="col-sm-12">Step 3. Upload ClusterFiles <small class="initialize-label" id="initialize_ordinations_form_completed"></small></h2>
           <% end %>


### PR DESCRIPTION
This covers the obvious improvement of switching the ampersand to a slash.  Later, more involved PRs can handle communicating the idea that spatial data requires at least one corresponding cluster file for the visualization to work.