### PR TITLE
Also disable Burp in before_install (SCP-2878)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
       [[ "${TRAVIS_PULL_REQUEST}"   = "false" ]] ;
       echo $?
     )
+    export BURP_ENABLE=-1
     if [ "${BURP_ENABLE}" = "0" ]; then
       bin/burp_start.sh "${BURP_DOCKER_IMAGE}" "${BURP_SA_KEY}"
       export BURP_PROXY="http://$(hostname):8080"


### PR DESCRIPTION
Burp was temporarily disabled in #793, but two recent build failures (e.g. [here](https://travis-ci.com/github/broadinstitute/single_cell_portal_core/jobs/436310341#L1407)) indicate that was insufficient.  This disables Burp in `before_install` as well -- which, reading AppSec's suggested code change more closely, is likely what they intended in their recommendation.

This relates to SCP-2878.