### PR TITLE
Update "View required conventional metadata" link (SCP-2775)

### DIFF
--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -93,7 +93,7 @@
             <%= image_tag "metadata-convention-explainer.jpg" %>
           </div>
         </div>
-        <a id="metadata-convention-example-link" href="https://raw.githubusercontent.com/broadinstitute/single_cell_portal/master/demo_data/mc_compliant_metadata_example.tsv" target="_blank" rel="noreferrer">View required conventional metadata</a>
+        <a id="metadata-convention-example-link" href="https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#Required-Conventional-Metadata" target="_blank" rel="noreferrer">View required conventional metadata</a>
       </div>
 
       <div id="container-<%= @metadata_file.id %>">


### PR DESCRIPTION
This refines a link from #803, per Jean, so study owners have a quick way to find links to necessary ontologies.

This relates to SCP-2775.