### PR TITLE
adding logging for non-compliant metadata uploads (SCP-2889)

### DIFF
--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -166,7 +166,7 @@ function logClickInput(target) {
   const domLabels = getLabelsForElement(target)
 
   // User-facing label
-  const label = domLabels.length > 0 ? domLabels[0].innerText : ''
+  const label = domLabels.length > 0 ? getNameForClickTarget(domLabels[0]) : ''
 
   const props = { label }
 

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -268,6 +268,9 @@ export function log(name, props={}) {
     appFullPath: getAppFullPath(),
     env
   }, getDefaultProperties())
+  if (window.SCP.currentStudyAccession) {
+    props['studyAccession'] = window.SCP.currentStudyAccession
+  }
 
   checkForTriggeredPendingEvent(name, props)
 

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -268,7 +268,7 @@ export function log(name, props={}) {
     appFullPath: getAppFullPath(),
     env
   }, getDefaultProperties())
-  if (window.SCP.currentStudyAccession) {
+  if (window.SCP && window.SCP.currentStudyAccession) {
     props['studyAccession'] = window.SCP.currentStudyAccession
   }
 

--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -78,6 +78,13 @@ class FileParseService
       when 'Gene List'
         ParseUtils.delay.initialize_precomputed_scores(study, study_file, user)
       when 'Metadata'
+        # log convention compliance -- see SCP-2890
+        if !study_file.use_metadata_convention
+          MetricsService.log('file-upload:metadata:non-compliant', {
+            studyAccession: study.accession,
+            studyFileName: study_file.name
+        }, user)
+        end
         job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_cell_metadata, reparse: reparse,
                             persist_on_fail: persist_on_fail)
         job.delay.push_remote_and_launch_ingest

--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -80,10 +80,13 @@ class FileParseService
       when 'Metadata'
         # log convention compliance -- see SCP-2890
         if !study_file.use_metadata_convention
+          if User.feature_flag_for_instance(user, 'convention_required')
+            raise 'Metadata files must comply with the SCP metadata convention'
+          end
           MetricsService.log('file-upload:metadata:non-compliant', {
             studyAccession: study.accession,
             studyFileName: study_file.name
-        }, user)
+          }, user)
         end
         job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_cell_metadata, reparse: reparse,
                             persist_on_fail: persist_on_fail)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,7 @@
 
       window.SCP.gaTrackingId = '<%= ENV['GA_TRACKING_ID'] %>';
       window.SCP.analyticsPageName = '<%= get_page_name %>';
+      window.SCP.currentStudyAccession = '<%= @study.try(:accession) ? @study.try(:accession) : "" %>'
 
       // if we had search forms to preserve, recall and resubmit
       if ( localStorage.getItem('previous-search-url') ) {

--- a/app/views/studies/_initialize_metadata_form.html.erb
+++ b/app/views/studies/_initialize_metadata_form.html.erb
@@ -4,7 +4,7 @@
   <%= f.hidden_field :_id, value: study_file._id %>
   <%= hidden_field_tag :selector, '#metadata_form' %>
   <%= hidden_field_tag :partial, 'initialize_metadata_form' %>
-  <% convention_required = true || User.feature_flag_for_instance(current_user, 'convention_required') %>
+  <% convention_required = User.feature_flag_for_instance(current_user, 'convention_required') %>
 	<div class="form-group row">
 		<div class="col-sm-4">
 			<%= f.label :name %><br />

--- a/app/views/studies/_initialize_metadata_form.html.erb
+++ b/app/views/studies/_initialize_metadata_form.html.erb
@@ -4,6 +4,7 @@
   <%= f.hidden_field :_id, value: study_file._id %>
   <%= hidden_field_tag :selector, '#metadata_form' %>
   <%= hidden_field_tag :partial, 'initialize_metadata_form' %>
+  <% convention_required = true || User.feature_flag_for_instance(current_user, 'convention_required') %>
 	<div class="form-group row">
 		<div class="col-sm-4">
 			<%= f.label :name %><br />
@@ -33,9 +34,35 @@
       <% end %>
       &nbsp;
       <%= f.label :use_metadata_convention_false, 'data-analytics-name': 'metadata-convention-optout' do %>
-        <%= f.radio_button :use_metadata_convention, false, checked: false, disabled: !study_file.new_record? %>
-        No
+        <% if convention_required %>
+          <a href="#/" style="color:#999" id="convention-decline-label-<%= f.object.id.to_s %>"
+             data-content="Using the convention is now required.  If this presents a particular issue for your study, please contact us at <a href='mailto:scp-support@broadinstitute.zendesk.com'>scp-support@broadinstitute.zendesk.com</a> so we can help or make any updates to the convention."
+             data-toggle="popover"
+             data-analytics-name="convention-decline-label">
+            <%= f.radio_button :use_metadata_convention, false, checked: false, disabled: true %>
+            No
+          </a>
+
+        <% else %>
+          <%= f.radio_button :use_metadata_convention, false, checked: false, disabled: !study_file.new_record? %>
+          No
+        <% end %>
       <% end %>
+      &nbsp; &nbsp; <a href="#/" id="convention-decline-helplink-<%= f.object.id.to_s %>"
+        data-toggle="popover"
+        data-content="Please contact us at <a href='mailto:scp-support@broadinstitute.zendesk.com'>scp-support@broadinstitute.zendesk.com</a> so we can help or make any needed updates to the convention."
+        data-analytics-name="convention-decline-helplink">
+        Using conventional names is an issue for my study
+      </a>
+      <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+        ['#convention-decline-label-', '#convention-decline-helplink-'].forEach(function(idString) {
+          var popoverTarget = idString + '<%= f.object.id.to_s %>'
+          $(popoverTarget).on('click', function() {
+            window.SCP.log('file-upload:metadata:optout-attempt', {studyAccession: '<%= @study.accession %>'})
+          })
+          enableHoverPopovers(popoverTarget);
+        })
+      </script>
       <div id="use-metadata-convention-message"></div>
     </div>
   </div>
@@ -77,7 +104,14 @@
         var message;
         const advancedUrl = "https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#metadata-powered-advanced-search"
         const advancedLink = `<a href="${advancedUrl}" target="_blank" rel="noreferrer">advanced search</a>`
-        if (useMetadataConvention === true) {
+        const conventionRequired = <%= convention_required == true %>;
+        const helpUrl = 'https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#scp-conventional-file-format'
+        if (conventionRequired) {
+          message =
+            `Learn <a href="${helpUrl}" target="_blank" rel="noreferrer">how to convert your file</a>.<br/>` +
+            `If the file fails metadata convention validation, you will be emailed messages to help correct it.`
+        }
+        else if (useMetadataConvention === true) {
           message =
             `This makes your data discoverable in ${advancedLink}.<br/>` +
             `If the file fails metadata convention validation, you will be emailed messages to help correct it.`
@@ -85,7 +119,6 @@
           const formatUrl = 'https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#scp-conventional-file-format'
           const contactUsLink = '<a href="mailto:scp-support@broadinstitute.zendesk.com">scp-support@broadinstitute.zendesk.com</a>'
           const contactUs = `If you need assistance, please contact us at ${contactUsLink}.`
-
           message =
             `Use the SCP metadata convention ("Yes") to make your data discoverable in ${advancedLink}.<br/>` +
             `Learn <a href="${formatUrl}" target="_blank" rel="noreferrer">how to convert your file</a>.  ${contactUs}`

--- a/app/views/studies/_initialize_metadata_form.html.erb
+++ b/app/views/studies/_initialize_metadata_form.html.erb
@@ -22,13 +22,17 @@
   </div>
   <div class="form-group row">
 		<div class="col-sm-6">
-      <%= f.label :use_metadata_convention, "Do you use SCP conventional names for required metadata column headers?" %> <%= render partial: 'metadata_convention_help_popover', locals: {id: f.object.id.to_s} %><br />
-      <%= f.label :use_metadata_convention_true do %>
+      <%= f.label :use_metadata_convention do %>
+        Do you use SCP conventional names for required metadata column headers?
+        <%= render partial: 'metadata_convention_help_popover', locals: {id: f.object.id.to_s} %>
+      <% end %>
+      <br />
+      <%= f.label :use_metadata_convention_true, 'data-analytics-name': 'metadata-convention-optin' do %>
         <%= f.radio_button :use_metadata_convention, true, checked: true, disabled: !study_file.new_record?%>
         Yes
       <% end %>
       &nbsp;
-      <%= f.label :use_metadata_convention_false do %>
+      <%= f.label :use_metadata_convention_false, 'data-analytics-name': 'metadata-convention-optout' do %>
         <%= f.radio_button :use_metadata_convention, false, checked: false, disabled: !study_file.new_record? %>
         No
       <% end %>
@@ -86,8 +90,6 @@
             `Use the SCP metadata convention ("Yes") to make your data discoverable in ${advancedLink}.<br/>` +
             `Learn <a href="${formatUrl}" target="_blank" rel="noreferrer">how to convert your file</a>.  ${contactUs}`
         }
-        console.log(useMetadataConvention)
-        console.log(message)
         $('#use-metadata-convention-message').html(message + '<br/>')
     }
 

--- a/app/views/studies/_metadata_convention_help_popover.html.erb
+++ b/app/views/studies/_metadata_convention_help_popover.html.erb
@@ -1,7 +1,8 @@
 <a href="#/" title="Why use the metadata convention?" class="badge" id="metadata-convention-popover-<%= id %>"
    data-content="Using the metadata convention will enable your data to be discovered through an upcoming faceted search interface.  Using the convention means extra validation will be applied to ensure your metadata conforms to standard vocabularies.  <a href='https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-Convention' target='_blank'>Learn more</a>."
-   data-toggle="popover">
-  i
+   data-toggle="popover"
+   data-analytics-name="metadata-convention-popover">
+  <span class="fas fa-info"></span>
 </a>
 
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">

--- a/db/migrate/20201118200308_add_convention_feature_flag.rb
+++ b/db/migrate/20201118200308_add_convention_feature_flag.rb
@@ -1,0 +1,20 @@
+class AddConventionFeatureFlag < Mongoid::Migration
+  # mirror of FeatureFlag.rb, so this migration won't error if that class is renamed/altered
+  class FeatureFlagMigrator
+    include Mongoid::Document
+    store_in collection: 'feature_flags'
+    field :name, type: String
+    field :default_value, type: Boolean, default: false
+    field :description, type: String
+  end
+
+  def self.up
+    FeatureFlagMigrator.create!(name: 'convention_required',
+                                default_value: false,
+                                description: 'whether metadata convention compliant files are required')
+  end
+
+  def self.down
+    FeatureFlagMigrator.find_by(name: 'convention_required').destroy
+  end
+end


### PR DESCRIPTION
[major updates to PR following demo today]
This now feature-flags whether the convention is required
If the convention is required, here's the UI the users see 

![image](https://user-images.githubusercontent.com/2800795/100142311-adf2ad80-2e61-11eb-94fa-790c88f75bd6.png)

We now auto-add studyAccession to all frontend events that are from a page with a specific study