### PR TITLE
Restore consistent colors in violin plot and default categorical scatter plot (SCP-2905)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -701,6 +701,9 @@ var plotlyLabelFont = {
 var plotlyDefaultLineColor = 'rgb(40, 40, 40)';
 
 // default scatter plot colors, a combination of colorbrewer sets 1-3 with tweaks to the yellow members
+//
+// Only use this in legacy ERB templates.  For new JS, use
+// `getColorBrewerColor`a standard convenience method exported from lib/plot.js
 var colorBrewerSet = ["#e41a1c", "#377eb8", "#4daf4a", "#984ea3", "#ff7f00", "#a65628", "#f781bf", "#999999",
     "#66c2a5", "#fc8d62", "#8da0cb", "#e78ac3", "#a6d854", "#ffd92f", "#e5c494", "#b3b3b3", "#8dd3c7",
     "#bebada", "#fb8072", "#80b1d3", "#fdb462", "#b3de69", "#fccde5", "#d9d9d9", "#bc80bd", "#ccebc5", "#ffed6f"];

--- a/app/javascript/lib/kernel-functions.js
+++ b/app/javascript/lib/kernel-functions.js
@@ -1,14 +1,4 @@
-// default scatter plot colors, a combination of colorbrewer sets 1-3 with
-// tweaks to the yellow members
-//
-// To consider: dedup this copy with the one that exists in application.js.
-const colorBrewerSet = [
-  '#e41a1c', '#377eb8', '#4daf4a', '#984ea3', '#ff7f00', '#a65628',
-  '#f781bf', '#999999', '#66c2a5', '#fc8d62', '#8da0cb', '#e78ac3',
-  '#a6d854', '#ffd92f', '#e5c494', '#b3b3b3', '#8dd3c7', '#bebada',
-  '#fb8072', '#80b1d3', '#fdb462', '#b3de69', '#fccde5', '#d9d9d9',
-  '#bc80bd', '#ccebc5', '#ffed6f'
-]
+import { getColorBrewerColor } from 'lib/plot'
 
 // To consider: dedup this copy with the one that exists in application.js.
 const plotlyDefaultLineColor = 'rgb(40, 40, 40)'
@@ -88,7 +78,7 @@ export default function createTracesAndLayout(
           color: '#000000',
           opacity: 0.8
         },
-        'fillcolor': colorBrewerSet[x % 27],
+        'fillcolor': getColorBrewerColor(x),
         'line': {
           color: '#000000',
           width: 1.5
@@ -105,7 +95,7 @@ export default function createTracesAndLayout(
         y: dist,
         boxpoints: jitter,
         marker: {
-          color: colorBrewerSet[x % 27],
+          color: getColorBrewerColor(x),
           size: 2,
           line: {
             color: plotlyDefaultLineColor

--- a/app/javascript/lib/plot.js
+++ b/app/javascript/lib/plot.js
@@ -1,20 +1,37 @@
 import Plotly from 'plotly.js-dist'
 
+// Default plot colors, combining ColorBrewer sets 1-3 with tweaks to yellows.
+const colorBrewerList = [
+  '#e41a1c', '#377eb8', '#4daf4a', '#984ea3', '#ff7f00', '#a65628',
+  '#f781bf', '#999999', '#66c2a5', '#fc8d62', '#8da0cb', '#e78ac3',
+  '#a6d854', '#ffd92f', '#e5c494', '#b3b3b3', '#8dd3c7', '#bebada',
+  '#fb8072', '#80b1d3', '#fdb462', '#b3de69', '#fccde5', '#d9d9d9',
+  '#bc80bd', '#ccebc5', '#ffed6f'
+]
+
+/**
+ * Used in both categorical scatter plots and violin plots, to ensure
+ * they use consistent friendly colors for annotations, etc.
+ */
+export function getColorBrewerColor(index) {
+  return colorBrewerList[index % 27]
+}
+
 // default title font settings for axis titles in plotly
 export const titleFont = {
-    family: 'Helvetica Neue',
-    size: 16,
-    color: '#333'
-};
+  family: 'Helvetica Neue',
+  size: 16,
+  color: '#333'
+}
 
 // default label font settings for colorbar titles in plotly
 export const labelFont = {
-    family: 'Helvetica Neue',
-    size: 12,
-    color: '#333'
-};
+  family: 'Helvetica Neue',
+  size: 12,
+  color: '#333'
+}
 
-export const lineColor = 'rgb(40, 40, 40)';
+export const lineColor = 'rgb(40, 40, 40)'
 
 /**
  * Wrapper for Plotly.newPlot, to enable tests

--- a/app/javascript/lib/study-overview.js
+++ b/app/javascript/lib/study-overview.js
@@ -118,7 +118,7 @@ function resizePlots() {
 }
 
 /** Set colors for group-based annotations */
-function setMarkerColors(data) {
+export function setMarkerColors(data) {
   return data.map((trace, i) => {
     trace.marker.color = getColorBrewerColor(i)
     return trace

--- a/app/javascript/lib/study-overview.js
+++ b/app/javascript/lib/study-overview.js
@@ -12,7 +12,7 @@
  */
 import $ from 'jquery'
 import Plotly from 'plotly.js-dist'
-import { labelFont } from 'lib/plot'
+import { labelFont, getColorBrewerColor } from 'lib/plot'
 import { fetchExplore, fetchCluster } from 'lib/scp-api'
 
 /** Get Plotly layout object for scatter plot */
@@ -117,10 +117,18 @@ function resizePlots() {
   }
 }
 
+/** Set colors for group-based annotations */
+function setMarkerColors(data) {
+  return data.map((trace, i) => {
+    trace.marker.color = getColorBrewerColor(i)
+    return trace
+  })
+}
+
 
 /** Renders Plotly scatter plot for "Clusters" tab */
 function renderScatterPlot(target, rawPlot) {
-  const { data } = rawPlot
+  let { data } = rawPlot
 
   window.SCP.scatterCount += 1
   const scatterCount = window.SCP.scatterCount
@@ -141,6 +149,10 @@ function renderScatterPlot(target, rawPlot) {
     </div>`)
 
   const layout = getScatterPlotLayout(rawPlot)
+
+  if (rawPlot.annotParams.type === 'group') {
+    data = setMarkerColors(data)
+  }
 
   Plotly.newPlot(plotId, data, layout)
 

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -37,11 +37,6 @@ class ClusterVizService
         cluster_props[:textposition] = 'bottom right'
       end
 
-      if selected_annotation[:type] == 'group'
-        # Set color index that will be interpreted by SCP front end
-        cluster_props[:marker][:scpColorIndex] = index
-      end
-
       plot_data.push(cluster_props)
     end
 

--- a/test/js/study-overview.test.js
+++ b/test/js/study-overview.test.js
@@ -1,17 +1,22 @@
 import {
-  getBaseLayout, get3DScatterProps, get2DScatterProps
+  getBaseLayout, setMarkerColors
 } from 'lib/study-overview'
 
 const height = 279
 const width = 1570
 
 describe('Study Overview page', () => {
-
-  it('configures plot layout', async() => {
+  it('configures plot layout', () => {
     // Test base layout
     const layout = getBaseLayout(height, width)
     expect(layout.height).toBe(height)
     expect(layout.width).toBe(width)
   })
 
+  it('sets expected colors in categorical scatter plots', () => {
+    let data = [{ marker: {} }, { marker: {} }, { marker: {} }]
+    data = setMarkerColors(data)
+    expect(data[0].marker.color).toBe('#e41a1c')
+    expect(data[2].marker.color).toBe('#4daf4a')
+  })
 })


### PR DESCRIPTION
This fixes a bug that caused inconsistent colors between A) default categorical scatter plots, and B) violin plots.  A new automated test prevents regression.  

Screenshots below demonstrate the fix.  Note how e.g. CA1 is red and CA2 is blue in both kinds of plots.

Default categorical scatter plot:
<img width="1677" alt="Default_categorical_scatter_plot_SCP-2905_2020-11-17" src="https://user-images.githubusercontent.com/1334561/99449399-c3aa2500-28ed-11eb-9c96-626094a382e4.png">


Violin plot:
<img width="1680" alt="Violin_plot_SCP-2905_2020-11-17" src="https://user-images.githubusercontent.com/1334561/99449839-e76d6b00-28ed-11eb-94c7-c58a497dc17c.png">

This satisfies SCP-2905.