### PR TITLE
Basic drop-down menu for "Spatial group" view option (SCP-2829)

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -2132,7 +2132,7 @@ class SiteController < ApplicationController
 
   # helper method to load all possible cluster groups for a study
   def load_cluster_group_options
-    @study.cluster_groups.map(&:name)
+    ExpressionVizService.load_cluster_group_options(@study)
   end
 
   # helper method to load all available cluster_group-specific annotations

--- a/app/javascript/lib/study-overview.js
+++ b/app/javascript/lib/study-overview.js
@@ -8,7 +8,7 @@
 */
 
 /**
- * TODO (SCP-2884): Move code specific to default Explore view into separate module
+ * TODO (SCP-2884): Move code for default Explore view into separate module
  */
 import $ from 'jquery'
 import Plotly from 'plotly.js-dist'
@@ -295,6 +295,29 @@ function attachEventHandlers() {
   })
 }
 
+/** Get HTML for dropdown menu for spatial files */
+function getSpatialDropdown(study) {
+  const options = study.spatialGroupNames.map(name => {
+    return `<option value="${name}">${name}</option>`
+  })
+  const domId = 'spatial-clusters'
+  const select =
+    `<select name="${domId}" id="${domId}" class="form-control">${
+      options
+    }</select>`
+  return (
+    `<div class="form-group col-sm-4">` +
+    `<label for=${domId}>Spatial groups</label><br/>${select}` +
+    `</div>`
+  )
+}
+
+/** Add dropdown menu for spatial files */
+function addSpatialDropdown(study) {
+  const dropdown = getSpatialDropdown(study)
+  $('#view-options #precomputed-panel #precomputed .row').append(dropdown)
+}
+
 /** Initialize the "Explore" tab in Study Overview */
 export default async function initializeExplore() {
   window.SCP.study = {}
@@ -326,9 +349,9 @@ export default async function initializeExplore() {
 
   const accession = window.SCP.studyAccession
   const study = await fetchExplore(accession)
+
   window.SCP.study = study
   window.SCP.study.accession = accession
-
   window.SCP.taxons = window.SCP.study.taxonNames
 
   if (study.cluster) {
@@ -337,6 +360,10 @@ export default async function initializeExplore() {
       $('#subsample').val(10000)
       $('#search_subsample').val(10000)
     }
+
+    console.log('in study.cluster')
+
+    addSpatialDropdown(study)
 
     drawScatterPlot()
   }

--- a/app/javascript/lib/study-overview.js
+++ b/app/javascript/lib/study-overview.js
@@ -314,8 +314,10 @@ function getSpatialDropdown(study) {
 
 /** Add dropdown menu for spatial files */
 function addSpatialDropdown(study) {
-  const dropdown = getSpatialDropdown(study)
-  $('#view-options #precomputed-panel #precomputed .row').append(dropdown)
+  if (study.spatialGroupNames.length > 0) {
+    const dropdown = getSpatialDropdown(study)
+    $('#view-options #precomputed-panel #precomputed .row').append(dropdown)
+  }
 }
 
 /** Initialize the "Explore" tab in Study Overview */

--- a/app/javascript/lib/study-overview.js
+++ b/app/javascript/lib/study-overview.js
@@ -300,14 +300,14 @@ function getSpatialDropdown(study) {
   const options = study.spatialGroupNames.map(name => {
     return `<option value="${name}">${name}</option>`
   })
-  const domId = 'spatial-clusters'
+  const domId = 'spatial-groups'
   const select =
     `<select name="${domId}" id="${domId}" class="form-control">${
       options
     }</select>`
   return (
     `<div class="form-group col-sm-4">` +
-    `<label for=${domId}>Spatial groups</label><br/>${select}` +
+    `<label for=${domId}>Spatial group</label><br/>${select}` +
     `</div>`
   )
 }

--- a/app/javascript/lib/study-overview.js
+++ b/app/javascript/lib/study-overview.js
@@ -361,8 +361,6 @@ export default async function initializeExplore() {
       $('#search_subsample').val(10000)
     }
 
-    console.log('in study.cluster')
-
     addSpatialDropdown(study)
 
     drawScatterPlot()


### PR DESCRIPTION
This implements a simple drop-down menu for spatial transcriptomics files.  A more sophisticated widget is envisioned for later, but this supports the MVP scoped for this quarter.

<img width="497" alt="Spatial_group_drop-down_menu_SCP_2020-11-29" src="https://user-images.githubusercontent.com/1334561/99705077-42769d80-2a67-11eb-9066-e3eb2394eb0d.png">

This satisfies SCP-2829.