### PR TITLE
Consolidation of visualization methods to ClusterVizService, ExpressionVizService (SCP-2873)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SINGLE CELL PORTAL README
 
-[![codecov](https://codecov.io/gh/broadinstitute/single_cell_portal_core/branch/development/graph/badge.svg?token=HMWE5BO2a4)](undefined)
+[![codecov](https://codecov.io/gh/broadinstitute/single_cell_portal_core/branch/development/graph/badge.svg?token=HMWE5BO2a4)](https://codecov.io/gh/broadinstitute/single_cell_portal_core)
 [![Build Status](https://travis-ci.com/broadinstitute/single_cell_portal_core.svg?branch=development)](https://travis-ci.com/broadinstitute/single_cell_portal_core)
 
 ## SETUP

--- a/app/controllers/api/v1/visualization/explore_controller.rb
+++ b/app/controllers/api/v1/visualization/explore_controller.rb
@@ -78,8 +78,8 @@ module Api
             taxonNames: @study.expressed_taxon_names,
             inferCNVIdeogramFiles: ideogram_files,
             uniqueGenes: @study.unique_genes,
-            clusterGroupNames: ExpressionVizService.load_cluster_group_options(@study),
-            spatialGroupNames: ExpressionVizService.load_spatial_options(@study),
+            clusterGroupNames: ClusterVizService.load_cluster_group_options(@study),
+            spatialGroupNames: ClusterVizService.load_spatial_options(@study),
             clusterPointAlpha: @study.default_cluster_point_alpha
           }
 

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -34,7 +34,7 @@ module Api
 
         def render_violin
           cluster = ClusterVizService.get_cluster_group(@study, params)
-          annot_params = ExpressionVizService.parse_annotation_legacy_params(@study, cluster, params)
+          annot_params = ExpressionVizService.parse_annotation_legacy_params(@study, params)
           annotation = ExpressionVizService.get_selected_annotation(@study,
                                                                        cluster,
                                                                        annot_params[:name],
@@ -51,7 +51,7 @@ module Api
 
         def render_annotation_values
           cluster = ClusterVizService.get_cluster_group(@study, params)
-          annot_params = ExpressionVizService.parse_annotation_legacy_params(@study, cluster, params)
+          annot_params = ExpressionVizService.parse_annotation_legacy_params(@study, params)
           annotation = ExpressionVizService.get_selected_annotation(@study,
                                                                        cluster,
                                                                        annot_params[:name],

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1336,7 +1336,7 @@ class SiteController < ApplicationController
   end
 
   def set_selected_annotation
-    annot_params = ExpressionVizService.parse_annotation_legacy_params(@study, @cluster, params)
+    annot_params = ExpressionVizService.parse_annotation_legacy_params(@study, params)
     @selected_annotation = ExpressionVizService.get_selected_annotation(@study, @cluster, annot_params[:name], annot_params[:type], annot_params[:scope])
   end
 

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -424,7 +424,7 @@ class SiteController < ApplicationController
       @top_plot_partial = 'expression_annotation_plots_view'
       @top_plot_plotly = 'expression_annotation_plots_plotly'
       @top_plot_layout = 'expression_annotation_scatter_layout'
-      @annotation_scatter_range = ClusterVizService.set_range(@study, @values.values)
+      @annotation_scatter_range = ClusterVizService.set_range(@cluster, @values.values)
     end
     @expression = ExpressionVizService.load_expression_data_array_points(@study, @gene, @cluster, @selected_annotation,
                                                                          subsample, @y_axis_title, params[:colorscale])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -225,7 +225,7 @@ module ApplicationHelper
   # only options allowed are 1000, 10000, 20000, and 100000
   # will only provide options if subsampling has completed for a cluster
   def subsampling_options(cluster)
-    ExpressionVizService.subsampling_options(cluster)
+    ClusterVizService.subsampling_options(cluster)
   end
 
   # get a label for a workflow status code

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -29,6 +29,12 @@ class ClusterVizService
     grouped_options
   end
 
+  # helper method to load spatial coordinate group names
+  def self.load_spatial_options(study)
+    spatial_file_ids = StudyFile.where(study: study, is_spatial: true, file_type: 'Cluster').pluck(:id)
+    ClusterGroup.where(study: study, :study_file_id.in => spatial_file_ids).pluck(:name)
+  end
+
   # Convert cluster group data array points into JSON plot data for Plotly
   def self.transform_coordinates(coordinates, study, cluster_group, selected_annotation)
     plot_data = []

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -11,6 +11,24 @@ class ClusterVizService
     end
   end
 
+  # helper method to load all possible cluster groups for a study
+  def self.load_cluster_group_options(study)
+    study.cluster_groups.map(&:name)
+  end
+
+  # helper method to load all available cluster_group-specific annotations
+  def self.load_cluster_group_annotations(study, cluster, current_user)
+    grouped_options = study.formatted_annotation_select(cluster: cluster)
+    # load available user annotations (if any)
+    if current_user.present?
+      user_annotations = UserAnnotation.viewable_by_cluster(current_user, cluster)
+      unless user_annotations.empty?
+        grouped_options['User Annotations'] = user_annotations.map {|annot| ["#{annot.name}", "#{annot.id}--group--user"] }
+      end
+    end
+    grouped_options
+  end
+
   # Convert cluster group data array points into JSON plot data for Plotly
   def self.transform_coordinates(coordinates, study, cluster_group, selected_annotation)
     plot_data = []

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -35,6 +35,17 @@ class ClusterVizService
     ClusterGroup.where(study: study, :study_file_id.in => spatial_file_ids).pluck(:name)
   end
 
+  # return an array of values to use for subsampling dropdown scaled to number of cells in study
+  # only options allowed are 1000, 10000, 20000, and 100000
+  # will only provide options if subsampling has completed for a cluster
+  def self.subsampling_options(cluster)
+    if cluster.is_subsampling?
+      []
+    else
+      ClusterGroup::SUBSAMPLE_THRESHOLDS.select {|sample| sample < cluster.points}
+    end
+  end
+
   # Convert cluster group data array points into JSON plot data for Plotly
   def self.transform_coordinates(coordinates, study, cluster_group, selected_annotation)
     plot_data = []

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -13,7 +13,8 @@ class ClusterVizService
 
   # helper method to load all possible cluster groups for a study
   def self.load_cluster_group_options(study)
-    study.cluster_groups.map(&:name)
+    non_spatial_file_ids = StudyFile.where(study: study, :is_spatial.ne => true, file_type: 'Cluster').pluck(:id)
+    ClusterGroup.where(study: study, :study_file_id.in => non_spatial_file_ids).pluck(:name)
   end
 
   # helper method to load all available cluster_group-specific annotations

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -16,7 +16,7 @@ class ExpressionVizService
       render_data[:values] = load_annotation_based_data_array_scatter(study, gene, cluster, selected_annotation, subsample, render_data[:y_axis_title])
     end
     render_data[:options] = ClusterVizService.load_cluster_group_options(study)
-    render_data[:sptial_options] = load_spatial_options(study)
+    render_data[:sptial_options] = ClusterVizService.load_spatial_options(study)
     render_data[:cluster_annotations] = ClusterVizService.load_cluster_group_annotations(study, cluster, current_user)
     render_data[:subsampling_options] = subsampling_options(cluster)
 

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -402,7 +402,7 @@ class ExpressionVizService
 
     # helper method for parsing the legacy [name]--[type]--[scope] string format into an object
   # finds the string from either params[:gene_set_annotation] or params[:annotation]
-  def self.parse_annotation_legacy_params(study, cluster, params)
+  def self.parse_annotation_legacy_params(study, params)
     selector = params[:annotation].nil? ? params[:gene_set_annotation] : params[:annotation]
     annot_name, annot_type, annot_scope = selector.nil? ? study.default_annotation.split('--') : selector.split('--')
     {

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -445,5 +445,4 @@ class ExpressionVizService
     values = genes.map {|gene| gene['scores'][cell].to_f}
     Gene.array_median(values)
   end
-
 end

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -15,8 +15,8 @@ class ExpressionVizService
     else
       render_data[:values] = load_annotation_based_data_array_scatter(study, gene, cluster, selected_annotation, subsample, render_data[:y_axis_title])
     end
-    render_data[:options] = load_cluster_group_options(study)
-    render_data[:cluster_annotations] = load_cluster_group_annotations(study, cluster, current_user)
+    render_data[:options] = ClusterVizService.load_cluster_group_options(study)
+    render_data[:cluster_annotations] = ClusterVizService.load_cluster_group_annotations(study, cluster, current_user)
     render_data[:subsampling_options] = subsampling_options(cluster)
 
     render_data[:rendered_cluster] = cluster.name
@@ -48,28 +48,6 @@ class ExpressionVizService
     end
 
     return ideogram_files
-  end
-
-  def self.load_expression_axis_title(study)
-    study.default_expression_label
-  end
-
-   # helper method to load all possible cluster groups for a study
-  def self.load_cluster_group_options(study)
-    study.cluster_groups.map(&:name)
-  end
-
-  # helper method to load all available cluster_group-specific annotations
-  def self.load_cluster_group_annotations(study, cluster, current_user)
-    grouped_options = study.formatted_annotation_select(cluster: cluster)
-    # load available user annotations (if any)
-    if current_user.present?
-      user_annotations = UserAnnotation.viewable_by_cluster(current_user, cluster)
-      unless user_annotations.empty?
-        grouped_options['User Annotations'] = user_annotations.map {|annot| ["#{annot.name}", "#{annot.id}--group--user"] }
-      end
-    end
-    grouped_options
   end
 
   # load box plot scores from gene expression values using data array of cell names for given cluster
@@ -165,6 +143,238 @@ class ExpressionVizService
     values
   end
 
+  # load cluster_group data_array values, but use expression scores to set numerical color array
+  # this is the scatter plot shown in the "scatter" tab next to "distribution" on gene-based views
+  def self.load_expression_data_array_points(study, gene, cluster, annotation, subsample_threshold=nil, y_axis_title)
+    # construct annotation key to load subsample data_arrays if needed, will be identical to params[:annotation]
+    subsample_annotation = "#{annotation[:name]}--#{annotation[:type]}--#{annotation[:scope]}"
+    x_array = cluster.concatenate_data_arrays('x', 'coordinates', subsample_threshold, subsample_annotation)
+    y_array = cluster.concatenate_data_arrays('y', 'coordinates', subsample_threshold, subsample_annotation)
+    z_array = cluster.concatenate_data_arrays('z', 'coordinates', subsample_threshold, subsample_annotation)
+    cells = cluster.concatenate_data_arrays('text', 'cells', subsample_threshold, subsample_annotation)
+    annotation_array = []
+    annotation_hash = {}
+    if annotation[:scope] == 'cluster'
+      annotation_array = cluster.concatenate_data_arrays(annotation[:name], 'annotations', subsample_threshold, subsample_annotation)
+    elsif annotation[:scope] == 'user'
+      # for user annotations, we have to load by id as names may not be unique to clusters
+      user_annotation = UserAnnotation.find(annotation[:id])
+      subsample_annotation = user_annotation.formatted_annotation_identifier
+      annotation_array = user_annotation.concatenate_user_data_arrays(annotation[:name], 'annotations', subsample_threshold, subsample_annotation)
+      x_array = user_annotation.concatenate_user_data_arrays('x', 'coordinates', subsample_threshold, subsample_annotation)
+      y_array = user_annotation.concatenate_user_data_arrays('y', 'coordinates', subsample_threshold, subsample_annotation)
+      z_array = user_annotation.concatenate_user_data_arrays('z', 'coordinates', subsample_threshold, subsample_annotation)
+      cells = user_annotation.concatenate_user_data_arrays('text', 'cells', subsample_threshold, subsample_annotation)
+    else
+      # for study-wide annotations, load from cell_metadata values instead of cluster-specific annotations
+      metadata_obj = study.cell_metadata.by_name_and_type(annotation[:name], annotation[:type])
+      annotation_hash = metadata_obj.cell_annotations
+    end
+    expression = {}
+    expression[:all] = {
+        x: x_array,
+        y: y_array,
+        annotations: [],
+        text: [],
+        cells: cells,
+        marker: {cmax: 0, cmin: 0, color: [], size: study.default_cluster_point_size, showscale: true, colorbar: {title: y_axis_title , titleside: 'right'}}
+    }
+    if cluster.is_3d?
+      expression[:all][:z] = z_array
+    end
+    cells.each_with_index do |cell, index|
+      expression_score = gene['scores'][cell].to_f.round(4)
+      # load correct annotation value based on scope
+      annotation_value = annotation[:scope] == 'cluster' ? annotation_array[index] : annotation_hash[cell]
+      text_value = "#{cell} (#{annotation_value})<br />#{y_axis_title}: #{expression_score}"
+      expression[:all][:annotations] << annotation_value
+      expression[:all][:text] << text_value
+      expression[:all][:marker][:color] << expression_score
+    end
+    expression[:all][:marker][:line] = { color: 'rgb(255,255,255)', width: study.show_cluster_point_borders? ? 0.5 : 0}
+    expression[:all][:marker][:cmin], expression[:all][:marker][:cmax] = RequestUtils.get_minmax(expression[:all][:marker][:color])
+    expression[:all][:marker][:colorscale] = params[:colorscale].blank? ? 'Reds' : params[:colorscale]
+    expression
+  end
+
+  # load boxplot expression scores vs. scores across each gene for all cells
+  # will support a variety of consensus modes (default is mean)
+  def self.load_gene_set_expression_boxplot_scores(study, genes, cluster, annotation, consensus, subsample_threshold=nil)
+    values = initialize_plotly_objects_by_annotation(annotation)
+    # construct annotation key to load subsample data_arrays if needed, will be identical to params[:annotation]
+    subsample_annotation = "#{annotation[:name]}--#{annotation[:type]}--#{annotation[:scope]}"
+    # grab all cells present in the cluster, and use as keys to load expression scores
+    # if a cell is not present for the gene, score gets set as 0.0
+    # will check if there are more than SUBSAMPLE_THRESHOLD cells present in the cluster, and subsample accordingly
+    # values hash will be assembled differently depending on annotation scope (cluster-based is array, study-based is a hash)
+    cells = cluster.concatenate_data_arrays('text', 'cells', subsample_threshold, subsample_annotation)
+    if annotation[:scope] == 'cluster'
+      annotations = cluster.concatenate_data_arrays(annotation[:name], 'annotations', subsample_threshold, subsample_annotation)
+      cells.each_with_index do |cell, index|
+        values[annotations[index]][:annotations] << annotations[index]
+        case consensus
+        when 'mean'
+          values[annotations[index]][:y] << calculate_mean(genes, cell)
+        when 'median'
+          values[annotations[index]][:y] << calculate_median(genes, cell)
+        else
+          values[annotations[index]][:y] << calculate_mean(genes, cell)
+        end
+      end
+    elsif annotation[:scope] == 'user'
+      # for user annotations, we have to load by id as names may not be unique to clusters
+      user_annotation = UserAnnotation.find(annotation[:id])
+      subsample_annotation = user_annotation.formatted_annotation_identifier
+      annotations = user_annotation.concatenate_user_data_arrays(annotation[:name], 'annotations', subsample_threshold, subsample_annotation)
+      cells = user_annotation.concatenate_user_data_arrays('text', 'cells', subsample_threshold, subsample_annotation)
+      cells.each_with_index do |cell, index|
+        values[annotations[index]][:annotations] << annotations[index]
+        case consensus
+        when 'mean'
+          values[annotations[index]][:y] << calculate_mean(genes, cell)
+        when 'median'
+          values[annotations[index]][:y] << calculate_median(genes, cell)
+        else
+          values[annotations[index]][:y] << calculate_mean(genes, cell)
+        end
+      end
+    else
+      # no need to subsample annotation since they are in hash format (lookup done by key)
+      annotations =  study.cell_metadata.by_name_and_type(annotation[:name], annotation[:type]).cell_annotations
+      cells.each do |cell|
+        val = annotations[cell]
+        # must check if key exists
+        if values.has_key?(val)
+          values[annotations[cell]][:cells] << cell
+          case consensus
+          when 'mean'
+            values[annotations[cell]][:y] << calculate_mean(genes, cell)
+          when 'median'
+            values[annotations[cell]][:y] << calculate_median(genes, cell)
+          else
+            values[annotations[cell]][:y] << calculate_mean(genes, cell)
+          end
+        end
+      end
+    end
+    # remove any empty values as annotations may have created keys that don't exist in cluster
+    values.delete_if {|key, data| data[:y].empty?}
+    values
+  end
+
+  # method to load a 2-d scatter of selected numeric annotation vs. gene set expression
+  # will support a variety of consensus modes (default is mean)
+  def self.load_gene_set_annotation_based_scatter(study, genes, cluster, annotation, consensus, subsample_threshold=nil, y_axis_title)
+    # construct annotation key to load subsample data_arrays if needed, will be identical to params[:annotation]
+    subsample_annotation = "#{annotation[:name]}--#{annotation[:type]}--#{annotation[:scope]}"
+    values = {}
+    values[:all] = {
+        x: [], y: [], cells: [], annotations: [], text: [], marker: {
+            size: study.default_cluster_point_size,
+            line: { color: 'rgb(40,40,40)', width: study.show_cluster_point_borders? ? 0.5 : 0}
+        }
+    }
+    cells = cluster.concatenate_data_arrays('text', 'cells', subsample_threshold, subsample_annotation)
+    annotation_array = []
+    annotation_hash = {}
+    if annotation[:scope] == 'cluster'
+      annotation_array = cluster.concatenate_data_arrays(annotation[:name], 'annotations', subsample_threshold, subsample_annotation)
+    elsif annotation[:scope] == 'user'
+      # for user annotations, we have to load by id as names may not be unique to clusters
+      user_annotation = UserAnnotation.find(annotation[:id])
+      subsample_annotation = user_annotation.formatted_annotation_identifier
+      annotation_array = user_annotation.concatenate_user_data_arrays(annotation[:name], 'annotations', subsample_threshold, subsample_annotation)
+      cells = user_annotation.concatenate_user_data_arrays('text', 'cells', subsample_threshold, subsample_annotation)
+    else
+      metadata_obj = study.cell_metadata.by_name_and_type(annotation[:name], annotation[:type])
+      annotation_hash = metadata_obj.cell_annotations
+    end
+    cells.each_with_index do |cell, index|
+      annotation_value = annotation[:scope] == 'cluster' ? annotation_array[index] : annotation_hash[cell]
+      if !annotation_value.nil?
+        case consensus
+        when 'mean'
+          expression_value = calculate_mean(genes, cell)
+        when 'median'
+          expression_value = calculate_median(genes, cell)
+        else
+          expression_value = calculate_mean(genes, cell)
+        end
+        values[:all][:text] << "<b>#{cell}</b><br>#{annotation_value}<br>#{y_axis_title}: #{expression_value}"
+        values[:all][:annotations] << annotation_value
+        values[:all][:x] << annotation_value
+        values[:all][:y] << expression_value
+        values[:all][:cells] << cell
+      end
+    end
+    values
+  end
+
+  # load scatter expression scores with average of scores across each gene for all cells
+  # uses data_array as source for each axis
+  # will support a variety of consensus modes (default is mean)
+  def self.load_gene_set_expression_data_arrays(study, genes, cluster, annotation, consensus, subsample_threshold=nil, y_axis_title)
+    # construct annotation key to load subsample data_arrays if needed, will be identical to params[:annotation]
+    subsample_annotation = "#{annotation[:name]}--#{annotation[:type]}--#{annotation[:scope]}"
+
+    x_array = cluster.concatenate_data_arrays('x', 'coordinates', subsample_threshold, subsample_annotation)
+    y_array = cluster.concatenate_data_arrays('y', 'coordinates', subsample_threshold, subsample_annotation)
+    z_array = cluster.concatenate_data_arrays('z', 'coordinates', subsample_threshold, subsample_annotation)
+    cells = cluster.concatenate_data_arrays('text', 'cells', subsample_threshold, subsample_annotation)
+    annotation_array = []
+    annotation_hash = {}
+    if annotation[:scope] == 'cluster'
+      annotation_array = cluster.concatenate_data_arrays(annotation[:name], 'annotations', subsample_threshold, subsample_annotation)
+    elsif annotation[:scope] == 'user'
+      # for user annotations, we have to load by id as names may not be unique to clusters
+      user_annotation = UserAnnotation.find(annotation[:id])
+      subsample_annotation = user_annotation.formatted_annotation_identifier
+      annotation_array = user_annotation.concatenate_user_data_arrays(annotation[:name], 'annotations', subsample_threshold, subsample_annotation)
+      x_array = user_annotation.concatenate_user_data_arrays('x', 'coordinates', subsample_threshold, subsample_annotation)
+      y_array = user_annotation.concatenate_user_data_arrays('y', 'coordinates', subsample_threshold, subsample_annotation)
+      z_array = user_annotation.concatenate_user_data_arrays('z', 'coordinates', subsample_threshold, subsample_annotation)
+      cells = user_annotation.concatenate_user_data_arrays('text', 'cells', subsample_threshold, subsample_annotation)
+    else
+      # for study-wide annotations, load from cell_metadata values instead of cluster-specific annotations
+      metadata_obj = study.cell_metadata.by_name_and_type(annotation[:name], annotation[:type])
+      annotation_hash = metadata_obj.cell_annotations
+    end
+    expression = {}
+    expression[:all] = {
+        x: x_array,
+        y: y_array,
+        text: [],
+        annotations: [],
+        cells: cells,
+        marker: {cmax: 0, cmin: 0, color: [], size: study.default_cluster_point_size, showscale: true, colorbar: {title: y_axis_title , titleside: 'right'}}
+    }
+    if cluster.is_3d?
+      expression[:all][:z] = z_array
+    end
+    cells.each_with_index do |cell, index|
+      case consensus
+      when 'mean'
+        expression_score = calculate_mean(genes, cell)
+      when 'median'
+        expression_score = calculate_median(genes, cell)
+      else
+        expression_score = calculate_mean(genes, cell)
+      end
+
+      # load correct annotation value based on scope
+      annotation_value = annotation[:scope] == 'cluster' ? annotation_array[index] : annotation_hash[cell]
+      text_value = "#{cell} (#{annotation_value})<br />#{y_axis_title}: #{expression_score}"
+      expression[:all][:annotations] << annotation_value
+      expression[:all][:text] << text_value
+      expression[:all][:marker][:color] << expression_score
+
+    end
+    expression[:all][:marker][:line] = { color: 'rgb(40,40,40)', width: study.show_cluster_point_borders? ? 0.5 : 0}
+    expression[:all][:marker][:cmin], expression[:all][:marker][:cmax] = RequestUtils.get_minmax(expression[:all][:marker][:color])
+    expression[:all][:marker][:colorscale] = params[:colorscale].blank? ? 'Reds' : params[:colorscale]
+    expression
+  end
+
   # method to initialize containers for plotly by annotation values
   def self.initialize_plotly_objects_by_annotation(annotation)
     values = {}
@@ -228,6 +438,18 @@ class ExpressionVizService
                     identifier: "#{source[:name]}--#{type}--#{scope}"}
     end
     annotation
+  end
+
+  # find mean of expression scores for a given cell & list of genes
+  def self.calculate_mean(genes, cell)
+    values = genes.map {|gene| gene['scores'][cell].to_f}
+    values.mean
+  end
+
+  # find median expression score for a given cell & list of genes
+  def self.calculate_median(genes, cell)
+    values = genes.map {|gene| gene['scores'][cell].to_f}
+    Gene.array_median(values)
   end
 
 end

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -50,6 +50,10 @@ class ExpressionVizService
     return ideogram_files
   end
 
+  def self.load_expression_axis_title(study)
+    study.default_expression_label
+  end
+
   # load box plot scores from gene expression values using data array of cell names for given cluster
   def self.load_expression_boxplot_data_array_scores(study, gene, cluster, annotation, subsample_threshold=nil)
     # construct annotation key to load subsample data_arrays if needed, will be identical to params[:annotation]
@@ -145,7 +149,7 @@ class ExpressionVizService
 
   # load cluster_group data_array values, but use expression scores to set numerical color array
   # this is the scatter plot shown in the "scatter" tab next to "distribution" on gene-based views
-  def self.load_expression_data_array_points(study, gene, cluster, annotation, subsample_threshold=nil, y_axis_title)
+  def self.load_expression_data_array_points(study, gene, cluster, annotation, subsample_threshold=nil, y_axis_title, colorscale)
     # construct annotation key to load subsample data_arrays if needed, will be identical to params[:annotation]
     subsample_annotation = "#{annotation[:name]}--#{annotation[:type]}--#{annotation[:scope]}"
     x_array = cluster.concatenate_data_arrays('x', 'coordinates', subsample_threshold, subsample_annotation)
@@ -193,7 +197,7 @@ class ExpressionVizService
     end
     expression[:all][:marker][:line] = { color: 'rgb(255,255,255)', width: study.show_cluster_point_borders? ? 0.5 : 0}
     expression[:all][:marker][:cmin], expression[:all][:marker][:cmax] = RequestUtils.get_minmax(expression[:all][:marker][:color])
-    expression[:all][:marker][:colorscale] = params[:colorscale].blank? ? 'Reds' : params[:colorscale]
+    expression[:all][:marker][:colorscale] = colorscale.blank? ? 'Reds' : colorscale
     expression
   end
 
@@ -313,7 +317,7 @@ class ExpressionVizService
   # load scatter expression scores with average of scores across each gene for all cells
   # uses data_array as source for each axis
   # will support a variety of consensus modes (default is mean)
-  def self.load_gene_set_expression_data_arrays(study, genes, cluster, annotation, consensus, subsample_threshold=nil, y_axis_title)
+  def self.load_gene_set_expression_data_arrays(study, genes, cluster, annotation, consensus, subsample_threshold=nil, y_axis_title, colorscale)
     # construct annotation key to load subsample data_arrays if needed, will be identical to params[:annotation]
     subsample_annotation = "#{annotation[:name]}--#{annotation[:type]}--#{annotation[:scope]}"
 
@@ -371,7 +375,7 @@ class ExpressionVizService
     end
     expression[:all][:marker][:line] = { color: 'rgb(40,40,40)', width: study.show_cluster_point_borders? ? 0.5 : 0}
     expression[:all][:marker][:cmin], expression[:all][:marker][:cmax] = RequestUtils.get_minmax(expression[:all][:marker][:color])
-    expression[:all][:marker][:colorscale] = params[:colorscale].blank? ? 'Reds' : params[:colorscale]
+    expression[:all][:marker][:colorscale] = colorscale.blank? ? 'Reds' : colorscale
     expression
   end
 

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -18,7 +18,7 @@ class ExpressionVizService
     render_data[:options] = ClusterVizService.load_cluster_group_options(study)
     render_data[:sptial_options] = ClusterVizService.load_spatial_options(study)
     render_data[:cluster_annotations] = ClusterVizService.load_cluster_group_annotations(study, cluster, current_user)
-    render_data[:subsampling_options] = subsampling_options(cluster)
+    render_data[:subsampling_options] = ClusterVizService.subsampling_options(cluster)
 
     render_data[:rendered_cluster] = cluster.name
     render_data[:rendered_annotation] = "#{selected_annotation[:name]}--#{selected_annotation[:type]}--#{selected_annotation[:scope]}"
@@ -387,17 +387,6 @@ class ExpressionVizService
       values["#{value}"] = {y: [], cells: [], annotations: [], name: "#{value}" }
     end
     values
-  end
-
-  # return an array of values to use for subsampling dropdown scaled to number of cells in study
-  # only options allowed are 1000, 10000, 20000, and 100000
-  # will only provide options if subsampling has completed for a cluster
-  def self.subsampling_options(cluster)
-    if cluster.is_subsampling?
-      []
-    else
-      ClusterGroup::SUBSAMPLE_THRESHOLDS.select {|sample| sample < cluster.points}
-    end
   end
 
     # helper method for parsing the legacy [name]--[type]--[scope] string format into an object

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1348,7 +1348,7 @@ class Study
                                          cluster_name, annotation_name).first
     {
       'organism': exp_file.species_name,
-      'assembly': exp_file.genome_assembly['name'],
+      'assembly': exp_file.genome_assembly.try(:name),
       'annotationsPath': exp_file.api_url
     }
   end

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,4 @@
 codecov:
   require_ci_to_pass: no
+comment:
+  show_carryforward_flags: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,7 +204,6 @@ Rails.application.routes.draw do
     get 'study/:accession/:study_name', to: 'site#study', as: :view_study
     get 'study/:accession/:study_name/edit_study_description', to: 'site#edit_study_description', as: :edit_study_description
     match 'study/:accession/:study_name/update_settings', to: 'site#update_study_settings', via: [:post, :patch], as: :update_study_settings
-    get 'study/:accession/:study_name/render_cluster', to: 'site#render_cluster', as: :render_cluster
     get 'study/:accession/:study_name/get_new_annotations', to: 'site#get_new_annotations', as: :get_new_annotations
     post 'study/:accession/:study_name/search', to: 'site#search_genes', as: :search_genes
     get 'study/:accession/:study_name/gene_expression/:gene/', to: 'site#view_gene_expression', as: :view_gene_expression,

--- a/test/api/visualization/cluster_controller_test.rb
+++ b/test/api/visualization/cluster_controller_test.rb
@@ -62,7 +62,8 @@ class ClusterControllerTest < ActionDispatch::IntegrationTest
 
     execute_http_request(:get, api_v1_study_clusters_path(@empty_study))
     assert_equal 404, response.status
-    assert_equal {"error"=>"No default cluster exists"}, json
+    expected_error = {"error"=>"No default cluster exists"}
+    assert_equal expected_error, json
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/test/factories/cluster_group.rb
+++ b/test/factories/cluster_group.rb
@@ -25,13 +25,14 @@ FactoryBot.define do
           []
         }
         # range input is min/max values for each domain (e.g. total extent of plot area)
-        # populate raw values in from study_file, and then call compact/delete_if to remove nil values
+        # populate raw values in from study_file, then keep if compacted values have a min & max
+        # this will remove any nil/blank entries and only keep valid input
         range_input {
           {
-              x: [study_file.x_axis_min, study_file.x_axis_max].compact,
-              y: [study_file.y_axis_min, study_file.y_axis_max].compact,
-              z: [study_file.z_axis_min, study_file.z_axis_max].compact
-          }.delete_if {|k, v| v.empty?}
+              x: [study_file.x_axis_min, study_file.x_axis_max],
+              y: [study_file.y_axis_min, study_file.y_axis_max],
+              z: [study_file.z_axis_min, study_file.z_axis_max]
+          }.keep_if {|axis, range| range.compact.size == 2}
         }
       end
       cell_annotations {

--- a/test/factories/cluster_group.rb
+++ b/test/factories/cluster_group.rb
@@ -24,11 +24,20 @@ FactoryBot.define do
         annotation_input {
           []
         }
+        # range input is min/max values for each domain (e.g. total extent of plot area)
+        # populate raw values in from study_file, and then call compact/delete_if to remove nil values
+        range_input {
+          {
+              x: [study_file.x_axis_min, study_file.x_axis_max].compact,
+              y: [study_file.y_axis_min, study_file.y_axis_max].compact,
+              z: [study_file.z_axis_min, study_file.z_axis_max].compact
+          }.delete_if {|k, v| v.empty?}
+        }
       end
       cell_annotations {
         annotation_input.map { |a| { name: a[:name], type: a[:type], values: a[:values].uniq } }
       }
-
+      domain_ranges { range_input if range_input.any? }
       after(:create) do |cluster, evaluator|
         [
           {name: :x, type: 'coordinates', array_name: 'x'},

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -105,5 +105,20 @@ FactoryBot.define do
         end
       end
     end
+    factory :ideogram_output do
+      file_type { 'Analysis Output'}
+      transient do
+        cluster {}
+        annotation {}
+      end
+      options {
+        {
+            analysis_name: 'infercnv',
+            visualization_name: 'ideogram.js',
+            cluster_name: cluster.try(:name),
+            annotation_name: annotation
+        }
+      }
+    end
   end
 end

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -30,6 +30,16 @@ FactoryBot.define do
     end
     factory :cluster_file do
       file_type { 'Cluster' }
+      is_spatial { false }
+      x_axis_label { nil }
+      y_axis_label { nil }
+      z_axis_label { nil }
+      x_axis_min { nil }
+      x_axis_max { nil }
+      y_axis_min { nil }
+      y_axis_max { nil }
+      z_axis_min { nil }
+      z_axis_max { nil }
       transient do
         # cell_input is a hash of three (or 4) arrays: cells, x and y and z
         # {
@@ -40,6 +50,7 @@ FactoryBot.define do
         cell_input {
           {}
         }
+        cluster_type { '2d' }
         # annotation_input is an array of objects specifying name, type, and values for annotations
         # values should be an array in the same length and order as the 'cells' array above
         # e.g. [{ name: 'category', type: 'group', values: ['foo', 'foo', 'bar'] }]
@@ -49,6 +60,7 @@ FactoryBot.define do
         FactoryBot.create(:cluster_group_with_cells,
                           annotation_input: evaluator.annotation_input,
                           cell_input: evaluator.cell_input,
+                          cluster_type: evaluator.cluster_type,
                           study_file: file)
       end
     end
@@ -69,6 +81,27 @@ FactoryBot.define do
           FactoryBot.create(:gene_with_expression,
                             expression_input: expression,
                             study_file: file)
+        end
+      end
+    end
+    factory :coordinate_label_file do
+      file_type { 'Coordinate Labels' }
+      transient do
+        # label input is used for coordinate-based annotations
+        label_input {}
+        # cluster is for setting cluster_group_id on data_arrays
+        cluster {}
+      end
+      after(:create) do |file, evaluator|
+        evaluator.label_input.each do |axis, values|
+          FactoryBot.create(:data_array,
+                            array_type: 'labels',
+                            array_index: 0,
+                            name: axis,
+                            cluster_group: evaluator.cluster,
+                            values: values,
+                            study_file: file
+          )
         end
       end
     end

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -31,15 +31,6 @@ FactoryBot.define do
     factory :cluster_file do
       file_type { 'Cluster' }
       is_spatial { false }
-      x_axis_label { nil }
-      y_axis_label { nil }
-      z_axis_label { nil }
-      x_axis_min { nil }
-      x_axis_max { nil }
-      y_axis_min { nil }
-      y_axis_max { nil }
-      z_axis_min { nil }
-      z_axis_max { nil }
       transient do
         # cell_input is a hash of three (or 4) arrays: cells, x and y and z
         # {

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -14,5 +14,20 @@ FactoryBot.define do
                          }
                        }
     end
+    factory :admin_user do
+      admin { true }
+      access_token {
+        {
+            access_token: "test-admin-token-#{random_seed}",
+            expires_in: 3600, expires_at: Time.zone.now + 1.hour
+        }
+      }
+      api_access_token {
+        {
+            access_token: "test-admin-token-#{random_seed}",
+            expires_in: 3600, expires_at: Time.zone.now + 1.hour
+        }
+      }
+    end
   end
 end

--- a/test/integration/lib/cluster_viz_service_test.rb
+++ b/test/integration/lib/cluster_viz_service_test.rb
@@ -119,6 +119,27 @@ class ClusterVizServiceTest < ActiveSupport::TestCase
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 
+  test 'should load subsampling options' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # create a cluster w/ 2K cells
+    coordinates = 1.upto(2000).to_a
+    cells = coordinates.map {|n| "cell_#{n}"}
+    cluster_name = 'cluster_subsample.txt'
+    FactoryBot.create(:cluster_file,
+                      name: cluster_name, study: @study,
+                      cell_input: {
+                          x: coordinates,
+                          y: coordinates,
+                          cells: cells
+                      })
+    cluster = @study.cluster_groups.by_name(cluster_name)
+    options = ClusterVizService.subsampling_options(cluster)
+    assert_equal [1000], options
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
   test 'should load cluster coordinates' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
 

--- a/test/integration/lib/cluster_viz_service_test.rb
+++ b/test/integration/lib/cluster_viz_service_test.rb
@@ -3,6 +3,245 @@ require 'test_helper'
 class ClusterVizServiceTest < ActiveSupport::TestCase
 
   setup do
+    @user = FactoryBot.create(:admin_user)
+    @study = FactoryBot.create(:detached_study, name: 'Test Cluster Study')
+    @study_cluster_file_1 = FactoryBot.create(:cluster_file,
+                                              name: 'cluster_1.txt', study: @study,
+                                              cell_input: {
+                                                  x: [1, 4 ,6],
+                                                  y: [7, 5, 3],
+                                                  z: [2, 8, 9],
+                                                  cells: ['A', 'B', 'C']
+                                              },
+                                              x_axis_label: 'PCA 1',
+                                              y_axis_label: 'PCA 2',
+                                              z_axis_label: 'PCA 3',
+                                              cluster_type: '3d',
+                                              annotation_input: [
+                                                  {name: 'Category', type: 'group', values: ['bar', 'bar', 'baz']},
+                                                  {name: 'Intensity', type: 'numeric', values: [1.1, 2.2, 3.3]}
+                                              ])
 
+    @study_cluster_file_2 = FactoryBot.create(:cluster_file,
+                                              name: 'cluster_2.txt', study: @study,
+                                              cell_input: {
+                                                  x: [1, 2, 3],
+                                                  y: [4, 5, 6],
+                                                  cells: ['D', 'E', 'F']
+                                              })
+
+    @study_metadata_file = FactoryBot.create(:metadata_file,
+                                             name: 'metadata.txt', study: @study,
+                                             cell_input: ['A', 'B', 'C'],
+                                             annotation_input: [
+                                                 {name: 'species', type: 'group', values: ['dog', 'cat', 'dog']},
+                                                 {name: 'disease', type: 'group', values: ['none', 'none', 'measles']}
+                                             ])
+
+    defaults = {
+        cluster: 'cluster_1.txt',
+        annotation: 'species--group--study'
+    }
+    @study.update(default_options: defaults)
+
+  end
+
+  teardown do
+    @study.destroy
+    @user.destroy
+  end
+
+  test 'should load cluster' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # test default cluster w/ empty params
+    default_cluster = @study.default_cluster
+    loaded_cluster = ClusterVizService.get_cluster_group(@study, {})
+    assert_equal default_cluster, loaded_cluster,
+                 "Did not correctly load default cluster; #{default_cluster.name} != #{loaded_cluster.name}"
+
+    # test loading by params
+    cluster_name = 'cluster_2.txt'
+    params = {cluster: cluster_name}
+    expected_cluster = @study.cluster_groups.by_name(cluster_name)
+    other_cluster = ClusterVizService.get_cluster_group(@study, params)
+    assert_equal expected_cluster, other_cluster,
+                 "Did not correctly load default cluster; #{expected_cluster.name} != #{other_cluster.name}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should load all clusters' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    clusters = %w(cluster_1.txt cluster_2.txt)
+    all_clusters = ClusterVizService.load_cluster_group_options(@study)
+    assert_equal clusters, all_clusters, "Did not load correct clusters; #{clusters} != #{all_clusters}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should load cluster annotation options' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    expected_options = {
+        'Study Wide' => [
+            %w(species species--group--study), %w(disease disease--group--study)
+        ],
+        'Cluster-Based' => [
+            %w(Category Category--group--cluster), %w(Intensity Intensity--numeric--cluster)
+        ]
+    }
+    annotation_opts = ClusterVizService.load_cluster_group_annotations(@study, @study.default_cluster, @user)
+    assert_equal expected_options, annotation_opts
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should load spatial clusters' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    spatial_name = 'spatial.txt'
+    FactoryBot.create(:cluster_file,
+                      name: spatial_name, study: @study,
+                      is_spatial: true,
+                      cell_input: {
+                          x: [1, 2, 3],
+                          y: [4, 5, 6],
+                          cells: ['Q', 'E', 'D']
+                      })
+    loaded_option = ClusterVizService.load_spatial_options(@study)
+    assert_equal [spatial_name], loaded_option
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should load cluster coordinates' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    cluster = @study.default_cluster
+    metadata = @study.cell_metadata.by_name_and_type('species', 'group')
+    annotation = {name: metadata.name, type: metadata.annotation_type, scope: 'study'}
+    coordinates = ClusterVizService.load_cluster_group_data_array_points(@study, cluster, annotation)
+    assert_equal metadata.values.sort, coordinates.keys.sort
+    trace_attributes = [:x, :y, :z, :cells, :annotations, :name]
+    coordinates.each do |name, trace|
+      trace_attributes.each do |attribute|
+        assert trace.try(:[], attribute).present?, "Did not find any values for #{name}:#{attribute}"
+      end
+    end
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should transform cluster coordinates for visualization' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    cluster = @study.default_cluster
+    metadata = @study.cell_metadata.by_name_and_type('disease', 'group')
+    annotation = {name: metadata.name, type: metadata.annotation_type, scope: 'study'}
+    coordinates = ClusterVizService.load_cluster_group_data_array_points(@study, cluster, annotation)
+    transformed_coords = ClusterVizService.transform_coordinates(coordinates, @study, cluster, annotation)
+    assert_equal coordinates.keys.size, transformed_coords.size,
+                 "Did not find correct number of traces; expected #{coordinates.keys.size} but found #{transformed_coords.size}"
+    expected_keys = [:x, :y, :cells, :text, :name, :type, :mode, :marker, :opacity, :annotations, :z, :textposition].sort
+    transformed_coords.each do |trace|
+      keys = trace.keys.sort
+      assert_equal expected_keys, keys
+      assert_equal 'scatter3d', trace[:type]
+      assert_equal 'markers', trace[:mode]
+    end
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should load coordinate labels as annotations' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    cluster = @study.default_cluster
+    FactoryBot.create(:coordinate_label_file,
+                      cluster: cluster, name: 'coordinate_labels.txt', study: @study,
+                      label_input: {
+                          x: [1, 2, 3],
+                          y: [4, 5, 6],
+                          z: [7, 8, 9],
+                          text: ['Group 1', 'Group 2', 'Group 3']
+                      })
+    labels = ClusterVizService.load_cluster_group_coordinate_labels(cluster)
+    assert_equal 3, labels.size, "Did not find correct number of labels; expected 3 but found #{labels.size}"
+    selected_label = labels.first
+    assert_equal 1, selected_label[:x]
+    assert_equal 4, selected_label[:y]
+    assert_equal 7, selected_label[:z]
+    assert_equal 'Group 1', selected_label[:text]
+    assert selected_label[:font].present?
+    font_keys = [:family, :size, :color]
+    assert_equal font_keys, selected_label[:font].keys
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should load axis labels' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    cluster = @study.default_cluster
+    axis_labels = ClusterVizService.load_axis_labels(cluster)
+    axis_labels.values.each_with_index do |label, index|
+      expected_label = "PCA #{index + 1}"
+      assert_equal expected_label, label
+    end
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should compute range for coordinates' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    cluster = @study.default_cluster
+    metadata = @study.cell_metadata.by_name_and_type('species', 'group')
+    annotation = {name: metadata.name, type: metadata.annotation_type, scope: 'study'}
+    coordinates = ClusterVizService.load_cluster_group_data_array_points(@study, cluster, annotation)
+
+    # range of 1 to 9, plus 2% padding of total extent of range. i.e padding =  8 * .02, or .16
+    # therefore domain_range = [1 - padding, 9 + padding]
+    domain_range = [0.84, 9.16]
+    expected_range = {
+        x: domain_range,
+        y: domain_range,
+        z: domain_range
+    }
+    calculated_range = ClusterVizService.set_range(cluster, coordinates.values)
+    assert_equal expected_range, calculated_range
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should compute aspect ratio for predefined range' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    cluser_file_with_range = 'cluster_ranged.txt'
+    FactoryBot.create(:cluster_file,
+                      name: cluser_file_with_range, study: @study,
+                      cluster_type: '3d',
+                      x_axis_min: 0,
+                      x_axis_max: 4,
+                      y_axis_min: 3,
+                      y_axis_max: 7,
+                      z_axis_min: 6,
+                      z_axis_max: 10,
+                      cell_input: {
+                          x: [1, 2, 3],
+                          y: [4, 5, 6],
+                          z: [7, 8, 9],
+                          cells: ['G', 'H', 'I']
+                      })
+    cluster = @study.cluster_groups.by_name(cluser_file_with_range)
+
+    # as absolute extent for each axis is the same (4), this should enforce a cube aspect
+    expected_aspect = {mode: 'cube', x: 1.0, y: 1.0, z: 1.0}
+    computed_aspect = ClusterVizService.compute_aspect_ratios(cluster.domain_ranges)
+    assert_equal expected_aspect, computed_aspect
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 end

--- a/test/integration/lib/cluster_viz_service_test.rb
+++ b/test/integration/lib/cluster_viz_service_test.rb
@@ -47,6 +47,9 @@ class ClusterVizServiceTest < ActiveSupport::TestCase
   end
 
   teardown do
+    StudyFile.where(study_id: @study.id).destroy_all
+    DataArray.where(study_id: @study.id).destroy_all
+    ClusterGroup.where(study_id: @study.id).destroy_all
     @study.destroy
     @user.destroy
   end

--- a/test/integration/lib/cluster_viz_service_test.rb
+++ b/test/integration/lib/cluster_viz_service_test.rb
@@ -69,7 +69,7 @@ class ClusterVizServiceTest < ActiveSupport::TestCase
     expected_cluster = @study.cluster_groups.by_name(cluster_name)
     other_cluster = ClusterVizService.get_cluster_group(@study, params)
     assert_equal expected_cluster, other_cluster,
-                 "Did not correctly load default cluster; #{expected_cluster.name} != #{other_cluster.name}"
+                 "Did not correctly load expected cluster; #{expected_cluster.name} != #{other_cluster.name}"
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/test/integration/lib/cluster_viz_service_test.rb
+++ b/test/integration/lib/cluster_viz_service_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class ClusterVizServiceTest < ActiveSupport::TestCase
+
+  setup do
+
+  end
+end

--- a/test/integration/lib/expression_viz_service_test.rb
+++ b/test/integration/lib/expression_viz_service_test.rb
@@ -5,22 +5,35 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
   setup do
     @user = FactoryBot.create(:user)
     @basic_study = FactoryBot.create(:detached_study, name: 'Basic Viz')
-    @basic_study_cluster_file = FactoryBot.create(:study_file,
-                                                  name: 'cluster1.txt',
-                                                  file_type: 'Cluster',
-                                                  study: @basic_study)
+    @basic_study_cluster_file = FactoryBot.create(:cluster_file,
+                                              name: 'cluster_1.txt', study: @basic_study,
+                                              cell_input: {
+                                                  x: [1, 4 ,6],
+                                                  y: [7, 5, 3],
+                                                  z: [2, 8, 9],
+                                                  cells: ['A', 'B', 'C']
+                                              },
+                                              x_axis_label: 'PCA 1',
+                                              y_axis_label: 'PCA 2',
+                                              z_axis_label: 'PCA 3',
+                                              cluster_type: '3d',
+                                              annotation_input: [
+                                                  {name: 'Category', type: 'group', values: ['bar', 'bar', 'baz']},
+                                                  {name: 'Intensity', type: 'numeric', values: [1.1, 2.2, 3.3]}
+                                              ])
     @basic_study_exp_file = FactoryBot.create(:study_file,
                                                   name: 'dense.txt',
                                                   file_type: 'Expression Matrix',
                                                   study: @basic_study)
-    @cluster_group = FactoryBot.create(:cluster_group_with_cells,
-                                       study_file: @basic_study_cluster_file,
-                                       cell_input: {
-                                         x: [1, 4 ,6],
-                                         y: [7, 5, 3],
-                                         cells: ['A', 'B', 'C']
-                                       },
-                                       annotation_input: [{name: 'foo', type: 'group', values: ['bar', 'bar', 'baz']}])
+
+    @study_metadata_file = FactoryBot.create(:metadata_file,
+                                             name: 'metadata.txt', study: @basic_study,
+                                             cell_input: ['A', 'B', 'C'],
+                                             annotation_input: [
+                                                 {name: 'species', type: 'group', values: ['dog', 'cat', 'dog']},
+                                                 {name: 'disease', type: 'group', values: ['none', 'none', 'measles']}
+                                             ])
+
     @pten_gene = FactoryBot.create(:gene_with_expression,
                                    name: 'PTEN',
                                    study_file: @basic_study_exp_file,
@@ -29,16 +42,312 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
                                      name: 'AGPAT2',
                                      study_file: @basic_study_exp_file,
                                      expression_input: [['A', 0],['B', 0],['C', 8]])
+    defaults = {
+        cluster: 'cluster_1.txt',
+        annotation: 'species--group--study'
+    }
+    @basic_study.update(default_options: defaults)
+
   end
 
   teardown do
-    @basic_study.destroy
+    study_ids = Study.any_of({name: 'Basic Viz'},{name: 'Ideogram Study'}).pluck(:id)
+    StudyFile.where(:study_id.in => study_ids).destroy_all
+    DataArray.where(:study_id.in => study_ids).destroy_all
+    ClusterGroup.where(:study_id.in => study_ids).destroy_all
+    CellMetadatum.where(:study_id.in => study_ids).destroy_all
+    Gene.where(:study_id.in => study_ids).destroy_all
+    Study.where(:id.in => study_ids).each do |study|
+      if study.detached?
+        study.destroy
+      else
+        study.destroy_and_remove_workspace
+      end
+    end
     @user.destroy
   end
 
+  # convenience method to load all gene expression data for a given study like requests to expression_controller
+  def load_all_genes(study)
+    gene_names = %w(PTEN AGPAT2)
+    matrix_ids = study.expression_matrix_files.pluck(:id)
+    gene_names.map {|gene| study.genes.by_name_or_id(gene, matrix_ids)}
+  end
+
   test 'can find annotation for cluster' do
-    annotation = ExpressionVizService.get_selected_annotation(@basic_study, @cluster_group, 'foo', 'group', 'cluster')
-    assert_equal 'foo', annotation[:name]
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    cluster = @basic_study.default_cluster
+    annotation = ExpressionVizService.get_selected_annotation(@basic_study, cluster, 'Category', 'group', 'cluster')
+    assert_equal 'Category', annotation[:name]
     assert_equal ['bar', 'baz'], annotation[:values]
+    metadata = @basic_study.cell_metadata.first
+    study_annotation = ExpressionVizService.get_selected_annotation(@basic_study, cluster, metadata.name, metadata.annotation_type, 'study')
+    assert_equal metadata.name, study_annotation[:name]
+    assert_equal metadata.values, study_annotation[:values]
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should parse legacy annotation params' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    default_annot = @basic_study.default_annotation
+    params = {annotation: default_annot}
+    annot_keys = [:name, :type, :scope]
+    expected_annotation = Hash[annot_keys.zip(default_annot.split('--'))]
+    loaded_annotation = ExpressionVizService.parse_annotation_legacy_params(@basic_study, params)
+    assert_equal expected_annotation, loaded_annotation
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should get global gene search render data' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    cluster = @basic_study.default_cluster
+    default_annot = @basic_study.default_annotation
+    annot_name, annot_type, annot_scope = default_annot.split('--')
+    annotation = ExpressionVizService.get_selected_annotation(@basic_study, cluster, annot_name, annot_type, annot_scope)
+    gene = @basic_study.genes.by_name_or_id('PTEN', @basic_study.expression_matrix_files.pluck(:id))
+    rendered_data = ExpressionVizService.get_global_expression_render_data(@basic_study, nil, gene, cluster,
+                                                                           annotation, 'All', @user)
+    expected_values = %w(dog cat)
+    assert_equal expected_values, rendered_data[:values].keys
+    expected_clusters = @basic_study.cluster_groups.map(&:name).sort
+    loaded_clusters = rendered_data[:options].sort
+    assert_equal expected_clusters, loaded_clusters
+    assert_equal cluster.name, rendered_data[:rendered_cluster]
+    assert_equal default_annot, rendered_data[:rendered_annotation]
+    # expression scores for 'dog'
+    expected_expression = [0, 1.5]
+    expected_cells = %w(A C)
+    assert_equal expected_expression, rendered_data[:values].dig('dog', :y)
+    assert_equal expected_cells, rendered_data[:values].dig('dog', :cells)
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should load ideogram outputs' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    # we need a non-detached study, so create one
+    study = FactoryBot.create(:study, name: 'Ideogram Study')
+    cluster_file = FactoryBot.create(:cluster_file,
+                                     name: 'cluster_1.txt', study: study,
+                                     cell_input: {
+                                         x: [1, 4 ,6],
+                                         y: [7, 5, 3],
+                                         cells: ['A', 'B', 'C']
+                                     },
+                                     x_axis_label: 'PCA 1',
+                                     y_axis_label: 'PCA 2',
+                                     cluster_type: '3d',
+                                     annotation_input: [
+                                         {name: 'Category', type: 'group', values: ['bar', 'bar', 'baz']}
+                                     ])
+    study.update(default_options: {cluster: cluster_file.name, annotation: 'Category--group--cluster'})
+    cluster = study.default_cluster
+    annotation = study.default_annotation
+    filename = 'ideogram_annotations.json'
+    ideogram_file = FactoryBot.create(:ideogram_output,
+                                      study: study,
+                                      name: filename,
+                                      cluster: cluster,
+                                      annotation: annotation)
+
+    ideogram_output = ExpressionVizService.get_infercnv_ideogram_files(study)
+    assert_equal 1, ideogram_output.size
+    ideogram_opts = ideogram_output[ideogram_file.id.to_s]
+    assert_equal ideogram_opts[:cluster], cluster.name
+    assert_equal annotation, ideogram_opts[:annotation]
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should load expression axis label' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    assert_equal 'Expression', ExpressionVizService.load_expression_axis_title(@basic_study)
+    label = 'log(TPM)'
+    @basic_study.default_options = {expression_label: label}
+    assert_equal label, ExpressionVizService.load_expression_axis_title(@basic_study)
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should initialize visualization object from annotation' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    cluster = @basic_study.default_cluster
+    default_annot = @basic_study.default_annotation
+    annot_name, annot_type, annot_scope = default_annot.split('--')
+    annotation = ExpressionVizService.get_selected_annotation(@basic_study, cluster, annot_name, annot_type, annot_scope)
+    plotly_struct = ExpressionVizService.initialize_plotly_objects_by_annotation(annotation)
+    annotation[:values].each do |value|
+      trace = plotly_struct[value]
+      assert trace.present?, "Did not find #{name} in #{plotly_struct.keys}"
+      assert_equal value, trace[:name]
+    end
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  # test group-based violin plot data
+  test 'should load violin plot data' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    gene = @basic_study.genes.by_name_or_id('PTEN', @basic_study.expression_matrix_files.pluck(:id))
+    cluster = @basic_study.default_cluster
+    default_annot = @basic_study.default_annotation
+    annot_name, annot_type, annot_scope = default_annot.split('--')
+    annotation = ExpressionVizService.get_selected_annotation(@basic_study, cluster, annot_name, annot_type, annot_scope)
+    violin_data = ExpressionVizService.load_expression_boxplot_data_array_scores(@basic_study, gene, cluster, annotation)
+    # cells A & C belong to 'dog', and cell B belongs to 'cat' from default metadata annotation
+    expected_output = {
+        dog: {y: [0.0, 1.5], cells: %w(A C), annotations: [], name: 'dog'},
+        cat: {y: [3.0], cells: %w(B), annotations: [], name: 'cat'}
+    }
+    assert_equal expected_output.with_indifferent_access, violin_data.with_indifferent_access
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  # test numeric annotation-based 2d scatter plots, showing expression vs. numeric annotation values
+  test 'should load 2d annotation expression scatter' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    gene = @basic_study.genes.by_name_or_id('PTEN', @basic_study.expression_matrix_files.pluck(:id))
+    cluster = @basic_study.default_cluster
+    annotation = ExpressionVizService.get_selected_annotation(@basic_study, cluster, 'Intensity', 'numeric', 'cluster')
+    scatter_data = ExpressionVizService.load_annotation_based_data_array_scatter(@basic_study, gene, cluster, annotation,
+                                                                                 nil, @basic_study.default_expression_label)
+    expected_x_data = [1.1, 2.2, 3.3]
+    expected_exp_data = [0.0, 3.0, 1.5]
+    expected_cells = %w(A B C)
+    assert_equal expected_x_data, scatter_data[:all][:x]
+    assert_equal expected_exp_data, scatter_data[:all][:y]
+    assert_equal expected_cells, scatter_data[:all][:cells]
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  # test normal scatter plot with expression values overlaid, instead of annotations
+  test 'should load expression based scatter plot' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    gene = @basic_study.genes.by_name_or_id('PTEN', @basic_study.expression_matrix_files.pluck(:id))
+    cluster = @basic_study.default_cluster
+    default_annot = @basic_study.default_annotation
+    annot_name, annot_type, annot_scope = default_annot.split('--')
+    annotation = ExpressionVizService.get_selected_annotation(@basic_study, cluster, annot_name, annot_type, annot_scope)
+    expression_scatter = ExpressionVizService.load_expression_data_array_points(@basic_study, gene, cluster, annotation,
+                                                                                nil, @basic_study.default_expression_label,
+                                                                                'Blues')
+    expected_x_data = cluster.concatenate_data_arrays('x', 'coordinates')
+    expected_y_data = cluster.concatenate_data_arrays('y', 'coordinates')
+    expected_z_data = cluster.concatenate_data_arrays('z', 'coordinates')
+    expected_exp_data = [0.0, 3.0, 1.5]
+    assert_equal expected_x_data, expression_scatter[:all][:x]
+    assert_equal expected_y_data, expression_scatter[:all][:y]
+    assert_equal expected_z_data, expression_scatter[:all][:z]
+    assert_equal expected_exp_data, expression_scatter[:all][:marker][:color]
+    assert_equal @basic_study.default_expression_label, expression_scatter[:all][:marker][:colorbar][:title]
+    assert_equal 'Blues', expression_scatter[:all][:marker][:colorscale]
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should load gene set violin plots' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    genes = load_all_genes(@basic_study)
+    cluster = @basic_study.default_cluster
+    default_annot = @basic_study.default_annotation
+    annot_name, annot_type, annot_scope = default_annot.split('--')
+    annotation = ExpressionVizService.get_selected_annotation(@basic_study, cluster, annot_name, annot_type, annot_scope)
+    gene_set_violin = ExpressionVizService.load_gene_set_expression_boxplot_scores(@basic_study, genes, cluster, annotation,
+                                                                                   'mean')
+    # cells A & C belong to 'dog', and cell B belongs to 'cat' from default metadata annotation
+    # expression values for A: [0,0].mean (0), B: [1.5,8].mean (4.75), C: [0,3].mean (1.5)
+    expected_set_expression = {
+        dog: {y: [0.0, 4.75], cells: %w(A C), annotations:[], name: 'dog'},
+        cat: {y: [1.5], cells: %w(B), annotations:[], name: 'cat'}
+    }
+    assert_equal expected_set_expression.with_indifferent_access, gene_set_violin.with_indifferent_access
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  # test numeric annotation-based 2d scatter plots, showing expression vs. numeric annotation values for multiple genes
+  test 'should load gene set 2d annotation expression scatter' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    genes = load_all_genes(@basic_study)
+    cluster = @basic_study.default_cluster
+    annotation = ExpressionVizService.get_selected_annotation(@basic_study, cluster, 'Intensity', 'numeric', 'cluster')
+    gene_set_annot_scatter = ExpressionVizService.load_gene_set_annotation_based_scatter(
+        @basic_study, genes, cluster, annotation, 'mean', nil, @basic_study.default_expression_label
+    )
+
+    # mean of values for scores across both genes for each cell
+    # A: [0, 0].mean (0), B: [0, 3].mean (1.5), C: [1,8].mean (4.75)
+    expected_exp_data = [0.0, 1.5, 4.75]
+    expected_x_data = [1.1, 2.2, 3.3]
+    expected_cells = %w(A B C)
+    assert_equal expected_x_data, gene_set_annot_scatter[:all][:x]
+    assert_equal expected_exp_data, gene_set_annot_scatter[:all][:y]
+    assert_equal expected_cells, gene_set_annot_scatter[:all][:cells]
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  # test normal scatter plot with gene set expression values overlaid (collapsed by metric), instead of annotations
+  test 'should load gene set expression based scatter plot' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    genes = load_all_genes(@basic_study)
+    cluster = @basic_study.default_cluster
+    default_annot = @basic_study.default_annotation
+    annot_name, annot_type, annot_scope = default_annot.split('--')
+    annotation = ExpressionVizService.get_selected_annotation(@basic_study, cluster, annot_name, annot_type, annot_scope)
+    gene_set_exp_statter = ExpressionVizService.load_gene_set_expression_data_arrays(
+        @basic_study, genes, cluster, annotation, 'mean', nil,
+        @basic_study.default_expression_label, 'Blues'
+    )
+
+    # mean of values for scores across both genes for each cell
+    # A: [0, 0].mean (0), B: [0, 3].mean (1.5), C: [1,8].mean (4.75)
+    expected_exp_data = [0.0, 1.5, 4.75]
+    expected_x_data = cluster.concatenate_data_arrays('x', 'coordinates')
+    expected_y_data = cluster.concatenate_data_arrays('y', 'coordinates')
+    expected_z_data = cluster.concatenate_data_arrays('z', 'coordinates')
+    assert_equal expected_x_data, gene_set_exp_statter[:all][:x]
+    assert_equal expected_y_data, gene_set_exp_statter[:all][:y]
+    assert_equal expected_z_data, gene_set_exp_statter[:all][:z]
+    assert_equal expected_exp_data, gene_set_exp_statter[:all][:marker][:color]
+    assert_equal @basic_study.default_expression_label, gene_set_exp_statter[:all][:marker][:colorbar][:title]
+    assert_equal 'Blues', gene_set_exp_statter[:all][:marker][:colorscale]
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should collapse by mean/median for gene expression values' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    genes = load_all_genes(@basic_study)
+    # since there are only 2 expression values in each set, mean === median
+    cells = %w(A B C)
+    means_medians = [0.0, 1.5, 4.75]
+    expected_outputs = Hash[cells.zip(means_medians)]
+    cells.each do |cell|
+      calculated_mean = ExpressionVizService.calculate_mean(genes, cell)
+      calculated_median = ExpressionVizService.calculate_median(genes, cell)
+      expected_value = expected_outputs[cell]
+      assert_equal expected_value, calculated_mean, "Mean calculation incorrect; #{expected_value} != #{calculated_mean}"
+      assert_equal expected_value, calculated_median, "Median calculation incorrect; #{expected_value} != #{calculated_median}"
+    end
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 end

--- a/test/integration/study_validation_test.rb
+++ b/test/integration/study_validation_test.rb
@@ -111,6 +111,7 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
     study.reload
 
     example_files.values.each do |e|
+      e[:object].reload # address potential race condition between parse_status setting to 'failed' and DeleteQueueJob executing
       assert_equal 'failed', e[:object].parse_status, "Incorrect parse_status for #{e[:name]}"
       assert e[:object].queued_for_deletion
       # check that file is cached in parse_logs/:id folder in the study bucket

--- a/test/integration/study_validation_test.rb
+++ b/test/integration/study_validation_test.rb
@@ -287,10 +287,14 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
       entry['study_accession'] = study.accession
       entry['file_id'] = metadata_file.id.to_s
     end
-    tmp_file = File.new(Rails.root.join('tmp_bq_seeds.json'), 'w+')
+    puts "Data read, writing to newline-delimited JSON"
+    tmp_filename = SecureRandom.uuid + '.json'
+    tmp_file = File.new(Rails.root.join(tmp_filename), 'w+')
     tmp_file.write bq_data.map(&:to_json).join("\n")
+    puts "Data assembled, writing to BigQuery"
     table = ApplicationController.big_query_client.dataset(CellMetadatum::BIGQUERY_DATASET).table(CellMetadatum::BIGQUERY_TABLE)
     job = table.load(tmp_file, write: 'append', format: :json)
+    puts "Write complete, closing/removing files"
     bq_seeds.close
     tmp_file.close
     puts "BigQuery seeding completed: #{job}"


### PR DESCRIPTION
In an effort to reduce duplicated code, and increase test coverage and confidence in visualization-related code, all cluster- and expression-based visualization methods have been migrated to `ClusterVizService` and `ExpressionVizService`, respectively.  This effort follows in spirit recent efforts to consolidate all file parsing code into `FileParseService`, with similar benefits to maintainability and test coverage.

All controllers related to visualization now reference methods in these two classes.  This has reduced the amount of duplicated code by several hundred lines, and increased test coverage substantially.  We now have near total coverage for all visualization methods, with qualitative assertions (i.e. exact value checking) in most cases.  In addition, some methods have been relocated to different classes where they are more appropriately located (e.g. cluster-specific actions in  `ClusterVizService`)

This also includes a small fix to the Codecov badge to correctly point to our [codecov.io](https://codecov.io/gh/broadinstitute/single_cell_portal_core) repository.

This PR satisfies SCP-2873.