### PR TITLE
Caching API visualization endpoints (SCP-2899)

### DIFF
--- a/app/controllers/api/v1/concerns/api_caching.rb
+++ b/app/controllers/api/v1/concerns/api_caching.rb
@@ -11,11 +11,6 @@ module Api
         # character regex to convert into underscores (_) for cache path setting
         PATH_REGEX =/(\/|%20|\?|&|=)/
 
-        included do
-          before_action :check_api_cache!
-          after_action :write_api_cache!
-        end
-
         # check Rails cache for JSON response based off url/params
         # cache expiration is still handled by CacheRemovalJob
         def check_api_cache!

--- a/app/controllers/api/v1/concerns/api_caching.rb
+++ b/app/controllers/api/v1/concerns/api_caching.rb
@@ -46,7 +46,7 @@ module Api
           # this simplifies base key into smaller value, e.g. _single_cell_api_v1_studies_SCP123_explore_
           params_key = params.to_unsafe_hash.reject {|name, value| CACHE_PATH_BLACKLIST.include?(name) || value.empty?}.
               map do |parameter_name, parameter_value|
-            "#{parameter_name}_#{parameter_value.split.join('-')}"
+            "#{parameter_name}_#{parameter_value.split.join('_')}"
           end
           [sanitized_path, params_key].join('_')
         end

--- a/app/controllers/api/v1/concerns/api_caching.rb
+++ b/app/controllers/api/v1/concerns/api_caching.rb
@@ -1,0 +1,53 @@
+module Api
+  module V1
+    module Concerns
+      module ApiCaching
+        extend ActiveSupport::Concern
+
+        # list of parameters to reject from :get_cache_key as they will be represented by request.fullpath
+        # format is always :json and therefore unnecessary
+        CACHE_PATH_BLACKLIST = %w(controller action format study_id)
+
+        included do
+          before_action :check_api_cache!
+          after_action :write_api_cache!
+        end
+
+        # check Rails cache for JSON response based off url/params
+        # cache expiration is still handled by CacheRemovalJob
+        def check_api_cache!
+          cache_path = get_cache_key
+          if Rails.cache.exist?(cache_path)
+            Rails.logger.info "Reading from API cache: #{cache_path}"
+            json_response = Rails.cache.fetch(cache_path)
+            render json: json_response and return
+          end
+        end
+
+        # write to the cache after a successful response
+        def write_api_cache!
+          cache_path = get_cache_key
+          unless Rails.cache.exist?(cache_path)
+            Rails.logger.info "Writing to API cache: #{cache_path}"
+            Rails.cache.write(cache_path, response.body)
+          end
+        end
+
+        private
+
+        # construct cache_key for accessing Rails cache
+        def get_cache_key
+          # transform / into _ to avoid encoding as %2f
+          sanitized_path = request.fullpath.gsub(/\//, '_')
+          # remove unwanted parameters from cache_key, as well as empty values
+          # this simplifies base key into smaller value, e.g. _single_cell_api_v1_studies_SCP123_explore_
+          params_key = params.to_unsafe_hash.reject {|name, value| CACHE_PATH_BLACKLIST.include?(name) || value.empty?}.
+              map do |parameter_name, parameter_value|
+            "#{parameter_name}_#{parameter_value.split.join('-')}"
+          end
+          [sanitized_path, params_key].join('_')
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -6,6 +6,7 @@ module Api
       class ClustersController < ApiBaseController
         include Concerns::Authenticator
         include Concerns::StudyAware
+        include Concerns::ApiCaching
         include Swagger::Blocks
 
         VALID_SCOPE_VALUES = ['study', 'cluster']

--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -16,6 +16,8 @@ module Api
         before_action :set_current_api_user!
         before_action :set_study
         before_action :check_study_view_permission
+        before_action :check_api_cache!
+        after_action :write_api_cache!
 
         # shared
         cluster_param_docs = [{

--- a/app/controllers/api/v1/visualization/explore_controller.rb
+++ b/app/controllers/api/v1/visualization/explore_controller.rb
@@ -5,6 +5,7 @@ module Api
       class ExploreController < ApiBaseController
         include Concerns::Authenticator
         include Concerns::StudyAware
+        include Concerns::ApiCaching
         include Swagger::Blocks
 
         before_action :set_current_api_user!

--- a/app/controllers/api/v1/visualization/explore_controller.rb
+++ b/app/controllers/api/v1/visualization/explore_controller.rb
@@ -5,7 +5,6 @@ module Api
       class ExploreController < ApiBaseController
         include Concerns::Authenticator
         include Concerns::StudyAware
-        include Concerns::ApiCaching
         include Swagger::Blocks
 
         before_action :set_current_api_user!

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -6,6 +6,7 @@ module Api
       class ExpressionController < ApiBaseController
         include Concerns::Authenticator
         include Concerns::StudyAware
+        include Concerns::ApiCaching
         include Swagger::Blocks
 
         before_action :set_current_api_user!

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -12,7 +12,8 @@ module Api
         before_action :set_current_api_user!
         before_action :set_study
         before_action :check_study_view_permission
-
+        before_action :check_api_cache!
+        after_action :write_api_cache!
 
         # Returns the specified expression data for the gene within the given study, optimized for rendering
         # by the SCP UI.

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -845,8 +845,9 @@ class StudyFile
   def invalidate_cache_by_file_type
     cache_key = self.cache_removal_key
     unless cache_key.nil?
-      # clear matching caches in background
+      # clear matching caches in background, including API responses
       CacheRemovalJob.new(cache_key).delay(queue: :cache).perform
+      CacheRemovalJob.new(self.api_cache_removal_key).delay(queue: :cache).perform
     end
   end
 
@@ -876,6 +877,12 @@ class StudyFile
         @cache_key = nil
     end
     @cache_key
+  end
+
+  # cache key for API responses (Api::V1::ClustersController, etc.)
+  # for safety, all API caches are invalidated on delete
+  def api_cache_removal_key
+    "api_v1_studies_#{self.study.accession}"
   end
 
   ###

--- a/test/integration/cache_management_test.rb
+++ b/test/integration/cache_management_test.rb
@@ -12,7 +12,8 @@ class CacheManagementTest < ActionDispatch::IntegrationTest
 
     study = Study.find_by(name: "Testing Study #{@random_seed}")
     cluster = study.cluster_groups.first
-    cluster_file = study.cluster_ordinations_files.first
+    cluster_name = cluster.name.split.join('-')
+    cluster_underscore = cluster.name.split.join('_') # for API cache paths
     expression_file = study.expression_matrix_file('expression_matrix_example.txt')
     genes = study.genes.map(&:name)
     gene = genes.sample
@@ -28,14 +29,22 @@ class CacheManagementTest < ActionDispatch::IntegrationTest
       get render_gene_set_expression_plots_path(accession: study.accession, study_name: study.url_safe_name, cluster: cluster.name, annotation: annotation, search: {genes: genes.join(' ')}, plot_type: 'box','boxpoints':'all'), xhr: true
       get expression_query_path(accession: study.accession, study_name: study.url_safe_name, cluster: cluster.name, annotation: annotation, search: {genes: genes.join(' ')} ), xhr: true
       get annotation_query_path(accession: study.accession, study_name: study.url_safe_name, annotation: annotation, cluster: cluster.name), xhr: true
+      get api_v1_study_explore_path(study_id: study.accession), as: :json
+      get api_v1_study_clusters_path(study_id: study.accession), as: :json
+      get api_v1_study_cluster_path(study_id: study.accession, annotation_name: cell_annotation[:name],
+                                    annotation_type: cell_annotation[:type], annotation_scope: 'cluster',
+                                    cluster_name: cluster.name), as: :json
 
       # construct various cache keys for direct lookup (cannot lookup via regex)
-      v_expression_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/render_gene_expression_plots/#{gene}_#{cluster.name.split.join('-')}_#{annotation}_violin.js"
-      v_set_expression_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/render_gene_set_expression_plots_#{cluster.name.split.join('-')}_#{annotation}_#{genes_hash}_violin_all.js"
-      b_expression_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/render_gene_expression_plots/#{gene}_#{cluster.name.split.join('-')}_#{annotation}_box.js"
-      b_set_expression_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/render_gene_set_expression_plots_#{cluster.name.split.join('-')}_#{annotation}_#{genes_hash}_box_all.js"
-      exp_query_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/expression_query_#{cluster.name.split.join('-')}_#{annotation}__#{genes_hash}.js"
-      annot_query_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/annotation_query_#{cluster.name.split.join('-')}_#{annotation}.js"
+      v_expression_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/render_gene_expression_plots/#{gene}_#{cluster_name}_#{annotation}_violin.js"
+      v_set_expression_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/render_gene_set_expression_plots_#{cluster_name}_#{annotation}_#{genes_hash}_violin_all.js"
+      b_expression_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/render_gene_expression_plots/#{gene}_#{cluster_name}_#{annotation}_box.js"
+      b_set_expression_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/render_gene_set_expression_plots_#{cluster_name}_#{annotation}_#{genes_hash}_box_all.js"
+      exp_query_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/expression_query_#{cluster_name}_#{annotation}__#{genes_hash}.js"
+      annot_query_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/annotation_query_#{cluster_name}_#{annotation}.js"
+      study_explore_key = "_single_cell_api_v1_studies_#{study.accession}_explore_"
+      study_clusters_key = "_single_cell_api_v1_studies_#{study.accession}_clusters_"
+      study_cluster_key = "#{study_clusters_key}#{cluster_underscore}_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_cluster_name_#{cluster_underscore}"
 
       assert Rails.cache.exist?(v_expression_cache_key), "Did not find matching gene expression cache entry at #{v_expression_cache_key}"
       assert Rails.cache.exist?(v_set_expression_cache_key), "Did not find matching gene set expression cache entry at #{v_set_expression_cache_key}"
@@ -43,19 +52,27 @@ class CacheManagementTest < ActionDispatch::IntegrationTest
       assert Rails.cache.exist?(b_set_expression_cache_key), "Did not find matching gene set expression cache entry at #{b_set_expression_cache_key}"
       assert Rails.cache.exist?(exp_query_cache_key), "Did not find matching expression query cache entry at #{exp_query_cache_key}"
       assert Rails.cache.exist?(annot_query_cache_key), "Did not find matching annotation query cache entry at #{annot_query_cache_key}"
+      assert Rails.cache.exist?(study_explore_key), "Did not find matching API explore cache entry at #{study_explore_key}"
+      assert Rails.cache.exist?(study_clusters_key), "Did not find matching API clusters cache entry at #{study_clusters_key}"
+      assert Rails.cache.exist?(study_cluster_key), "Did not find matching API single cluster cache entry at #{study_cluster_key}"
 
       # load removal keys via associated study files
       expression_file_cache_key = expression_file.cache_removal_key
+      api_removal_key = "_single_cell_api_v1_studies_#{study.accession}"
 
       # clear caches individually and assert removals
       CacheRemovalJob.new(expression_file_cache_key).perform
-      assert_not Rails.cache.exist?(v_expression_cache_key), "Did not delete matching gene expression cache entry at #{v_expression_cache_key}"
-      assert_not Rails.cache.exist?(v_set_expression_cache_key), "Did not delete matching gene set expression cache entry at #{v_set_expression_cache_key}"
-      assert_not Rails.cache.exist?(b_expression_cache_key), "Did not delete matching gene expression cache entry at #{b_expression_cache_key}"
-      assert_not Rails.cache.exist?(b_set_expression_cache_key), "Did not delete matching gene set expression cache entry at #{b_set_expression_cache_key}"
-      assert_not Rails.cache.exist?(exp_query_cache_key), "Did not delete matching expression query cache entry at #{exp_query_cache_key}"
+      refute Rails.cache.exist?(v_expression_cache_key), "Did not delete matching gene expression cache entry at #{v_expression_cache_key}"
+      refute Rails.cache.exist?(v_set_expression_cache_key), "Did not delete matching gene set expression cache entry at #{v_set_expression_cache_key}"
+      refute Rails.cache.exist?(b_expression_cache_key), "Did not delete matching gene expression cache entry at #{b_expression_cache_key}"
+      refute Rails.cache.exist?(b_set_expression_cache_key), "Did not delete matching gene set expression cache entry at #{b_set_expression_cache_key}"
+      refute Rails.cache.exist?(exp_query_cache_key), "Did not delete matching expression query cache entry at #{exp_query_cache_key}"
+      CacheRemovalJob.new(api_removal_key).perform
+      refute Rails.cache.exist?(study_explore_key), "Did not delete matching API explore cache entry at #{study_explore_key}"
+      refute Rails.cache.exist?(study_clusters_key), "Did not delete matching API clusters cache entry at #{study_clusters_key}"
+      refute Rails.cache.exist?(study_cluster_key), "Did not delete matching API single cluster cache entry at #{study_cluster_key}"
       CacheRemovalJob.new(study.url_safe_name).perform
-      assert_not Rails.cache.exist?(annot_query_cache_key), "Did not delete matching annotation query cache entry at #{annot_query_cache_key}"
+      refute Rails.cache.exist?(annot_query_cache_key), "Did not delete matching annotation query cache entry at #{annot_query_cache_key}"
       puts "#{annotation} tests pass!"
     end
 

--- a/test/integration/cache_management_test.rb
+++ b/test/integration/cache_management_test.rb
@@ -42,7 +42,6 @@ class CacheManagementTest < ActionDispatch::IntegrationTest
       b_set_expression_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/render_gene_set_expression_plots_#{cluster_name}_#{annotation}_#{genes_hash}_box_all.js"
       exp_query_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/expression_query_#{cluster_name}_#{annotation}__#{genes_hash}.js"
       annot_query_cache_key = "views/localhost/single_cell/study/#{study.accession}/#{study.url_safe_name}/annotation_query_#{cluster_name}_#{annotation}.js"
-      study_explore_key = "_single_cell_api_v1_studies_#{study.accession}_explore_"
       study_clusters_key = "_single_cell_api_v1_studies_#{study.accession}_clusters_"
       study_cluster_key = "#{study_clusters_key}#{cluster_underscore}_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_cluster_name_#{cluster_underscore}"
 
@@ -52,7 +51,6 @@ class CacheManagementTest < ActionDispatch::IntegrationTest
       assert Rails.cache.exist?(b_set_expression_cache_key), "Did not find matching gene set expression cache entry at #{b_set_expression_cache_key}"
       assert Rails.cache.exist?(exp_query_cache_key), "Did not find matching expression query cache entry at #{exp_query_cache_key}"
       assert Rails.cache.exist?(annot_query_cache_key), "Did not find matching annotation query cache entry at #{annot_query_cache_key}"
-      assert Rails.cache.exist?(study_explore_key), "Did not find matching API explore cache entry at #{study_explore_key}"
       assert Rails.cache.exist?(study_clusters_key), "Did not find matching API clusters cache entry at #{study_clusters_key}"
       assert Rails.cache.exist?(study_cluster_key), "Did not find matching API single cluster cache entry at #{study_cluster_key}"
 
@@ -68,7 +66,6 @@ class CacheManagementTest < ActionDispatch::IntegrationTest
       refute Rails.cache.exist?(b_set_expression_cache_key), "Did not delete matching gene set expression cache entry at #{b_set_expression_cache_key}"
       refute Rails.cache.exist?(exp_query_cache_key), "Did not delete matching expression query cache entry at #{exp_query_cache_key}"
       CacheRemovalJob.new(api_removal_key).perform
-      refute Rails.cache.exist?(study_explore_key), "Did not delete matching API explore cache entry at #{study_explore_key}"
       refute Rails.cache.exist?(study_clusters_key), "Did not delete matching API clusters cache entry at #{study_clusters_key}"
       refute Rails.cache.exist?(study_cluster_key), "Did not delete matching API single cluster cache entry at #{study_cluster_key}"
       CacheRemovalJob.new(study.url_safe_name).perform


### PR DESCRIPTION
As the JSON API in SCP is subclassed from `ActionController::API`, and not `ActionController::Base`, we cannot use the current caching mechanism of "action caching" employed in the rest of the portal.  This update implements caching for API visualization endpoints by manually writing/reading from the standard `Rails.cache` instance, mimicking the functionality provided by the `caches_action` method from `ActionPack::ActionCaching`.  Cache clearing is still controlled via `CacheRemovalJob`, which removes entries from the file-based cache depending on a provided key.

This new API caching is implemented as a concern, which can be included into any API controller to allow caching for responses via the `:check_api_cache!` and `:write_api_cache!` methods (they must be declared in the included controller to execute).  However, since cache clearing is dependent on functionality from the `StudyFile` class, it should only be used in controllers/endpoints that relate to files (such as cluster & expression rendering).

This PR satisfies SCP-2899.