### PR TITLE
Enable live control over action/view caching in local development (SCP-2923)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,29 @@ in package.json), The following snippet can be used to update dependencies not c
 
 https://gist.github.com/pftg/fa8fe4ca2bb4638fbd19324376487f42
 
+## CACHING IN LOCAL DEVELOPMENT
+Single Cell Portal employs action caching for all data visualization requests, such as viewing cluster, violin, or dot 
+plots.  As such, making code changes during local development may not always reflect the most recent changes as a particular 
+request may have already been cached by the server.
+
+In order to turn caching on/off dynamically without having to restart the server, developers can run the following command 
+from the terminal:
+
+    bin/rails dev:cache
+
+This will add/remove a file in the `tmp` directory called `caching-dev.txt` that will govern whether or not action caching 
+is enabled.  NOTE: if you are developing inside Docker, you must run this command inside the running container.
+
+If you want to clear the entire cache for the portal while running, you can enter the Rails console and run the `Rails.cache.clear` 
+command which will clear the entire Rails cache (actions and assets, such as CSS and JS assets):
+
+    root@localhost:/home/app/webapp# bin/rails c
+    Loading development environment (Rails 5.2.4.4)
+    2.6.5 :001 > Rails.cache.clear
+   
+This will then return a list of cache paths that have been deleted.  If you encounter a `Directory not empty` error when 
+running this command, simply retry until it succeeds, as it usually only takes one or two attempts.
+
 ## TESTS
 
 ### UI REGRESSION SUITE

--- a/app/controllers/api/v1/concerns/api_caching.rb
+++ b/app/controllers/api/v1/concerns/api_caching.rb
@@ -15,7 +15,7 @@ module Api
         # cache expiration is still handled by CacheRemovalJob
         def check_api_cache!
           cache_path = get_cache_key
-          if Rails.cache.exist?(cache_path)
+          if check_caching_config && Rails.cache.exist?(cache_path)
             Rails.logger.info "Reading from API cache: #{cache_path}"
             json_response = Rails.cache.fetch(cache_path)
             render json: json_response
@@ -25,7 +25,7 @@ module Api
         # write to the cache after a successful response
         def write_api_cache!
           cache_path = get_cache_key
-          unless Rails.cache.exist?(cache_path)
+          if check_caching_config && !Rails.cache.exist?(cache_path)
             Rails.logger.info "Writing to API cache: #{cache_path}"
             Rails.cache.write(cache_path, response.body)
           end
@@ -49,6 +49,16 @@ module Api
         # convert url pathname into easily readable fragment
         def sanitize_path
           request.path.gsub(PATH_REGEX, '_')
+        end
+
+        # check if caching is enabled/disabled in development environment
+        # will always return true in all other environments
+        def check_caching_config
+          if Rails.env == 'development'
+            Rails.root.join('tmp/caching-dev.txt').exist?
+          else
+            true
+          end
         end
       end
     end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,6 +16,14 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
+
+  if Rails.root.join('tmp/caching-dev.txt').exist?
+    config.action_controller.perform_caching = true
+  else
+    config.action_controller.perform_caching = false
+    config.cache_store = :null_store
+  end
+
   config.action_controller.perform_caching = true
 
   config.public_file_server.headers = {


### PR DESCRIPTION
Because SCP employs caching for "visualization" endpoints, making changes to code in local development will not always show updated results due to previous requests being already cached.  This requires developers to constantly run `Rails.cache.clear` in the Rails console in order to remove exiting caches.  This is both tedious and error-prone, and drastically slows down productivity.  Other options are even more disruptive that require commenting out methods, or changing configuration values and restarting the server, which can take minutes to complete.

This update now allows developers to turn on/off caching dynamically by running the `bin/rails dev:cache` command locally in the terminal (_not_ the Rails console).  This will only affect the `development` environment, and will not be used in deployed environments.  This command will place/remove a file in the `tmp` directory called `caching-dev.txt`.  The presence or absence of this file will control caching behavior, and does not require any restarts or reloads.

This PR satisfies SCP-2923.