### PR TITLE
Hotfix: Allowing cluster names with / in API requests (SCP-2920)

### DIFF
--- a/app/controllers/api/v1/concerns/api_caching.rb
+++ b/app/controllers/api/v1/concerns/api_caching.rb
@@ -9,7 +9,7 @@ module Api
         CACHE_PATH_BLACKLIST = %w(controller action format study_id)
 
         # character regex to convert into underscores (_) for cache path setting
-        PATH_REGEX =/(\/|%20|\?|&|=)/
+        PATH_REGEX =/(\/|%2F|%20|\?|&|=|\.)/
 
         # check Rails cache for JSON response based off url/params
         # cache expiration is still handled by CacheRemovalJob
@@ -41,7 +41,7 @@ module Api
           # this simplifies base key into smaller value, e.g. _single_cell_api_v1_studies_SCP123_explore_
           params_key = params.to_unsafe_hash.reject {|name, value| CACHE_PATH_BLACKLIST.include?(name) || value.empty?}.
               map do |parameter_name, parameter_value|
-            "#{parameter_name}_#{parameter_value.split.join('_')}"
+            "#{parameter_name}_#{sanitize_param(parameter_value).split.join('_')}"
           end
           [sanitized_path, params_key].join('_')
         end
@@ -49,6 +49,11 @@ module Api
         # convert url pathname into easily readable fragment
         def sanitize_path
           request.path.gsub(PATH_REGEX, '_')
+        end
+
+        # remove url-encoded characters from parameter values
+        def sanitize_param(parameter)
+          parameter.gsub(PATH_REGEX, '_')
         end
       end
     end

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -159,7 +159,7 @@ export async function fetchCluster(
   // Digest full annotation name to enable easy validation in API
   const [annotName, annotType, annotScope] = annotation.split('--')
   const paramObj = {
-    annotation_name: annotName,
+    annotation_name: encodeURIComponent(annotName),
     annotation_type: annotType,
     annotation_scope: annotScope,
     subsample,
@@ -167,7 +167,7 @@ export async function fetchCluster(
   }
 
   const params = stringifyQuery(paramObj)
-  const apiUrl = `/studies/${studyAccession}/clusters/${cluster}${params}`
+  const apiUrl = `/studies/${studyAccession}/clusters/${encodeURIComponent(cluster)}${params}`
   // don't camelcase the keys since those can be cluster names,
   // so send false for the 4th argument
   const [scatter, perfTime] = await scpApi(apiUrl, defaultInit(), mock, false)

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -159,7 +159,7 @@ export async function fetchCluster(
   // Digest full annotation name to enable easy validation in API
   const [annotName, annotType, annotScope] = annotation.split('--')
   const paramObj = {
-    annotation_name: encodeURIComponent(annotName),
+    annotation_name: annotName,
     annotation_type: annotType,
     annotation_scope: annotScope,
     subsample,

--- a/test/api/visualization/cluster_controller_test.rb
+++ b/test/api/visualization/cluster_controller_test.rb
@@ -39,6 +39,10 @@ class ClusterControllerTest < ActionDispatch::IntegrationTest
   end
 
   teardown do
+    StudyFile.where(study_id: @basic_study.id).destroy_all
+    DataArray.where(study_id: @basic_study.id).destroy_all
+    ClusterGroup.where(study_id: @basic_study.id).destroy_all
+    CellMetadatum.where(study_id: @basic_study.id).destroy_all
     @basic_study.destroy
     @empty_study.destroy
     @user.destroy
@@ -63,6 +67,35 @@ class ClusterControllerTest < ActionDispatch::IntegrationTest
     execute_http_request(:get, api_v1_study_clusters_path(@empty_study))
     assert_equal 404, response.status
     assert_equal({"error"=>"No default cluster exists"}, json)
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  test 'should load clusters with slashes in name' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    @cluster_with_slash = FactoryBot.create(:cluster_file,
+                                            name: 'data/cluster_with_slash.txt',
+                                            study: @basic_study,
+                                            cell_input: {
+                                              x: [1, 2 , 3, 4],
+                                              y: [5, 6, 7, 8],
+                                              cells: %w(A B C D)
+                                            },
+                                            annotation_input: [{name: 'category', type: 'group', values: ['bar', 'bar', 'baz', 'bar']}])
+
+    # slash must be URL encoded with %2F, and URL constructed manually as the path helper cannot resolve cluster_name param
+    # with a slash due to the route constraint of {:cluster_name=>/[^\/]+/}; using route helper api_v1_study_cluster_path()
+    # with the params of cluster_name: 'data/cluster_with_slash.txt' or cluster_name: 'data%2Fcluster_with_slash' does not work
+    basepath = "/single_cell/api/v1/studies/#{@basic_study.accession}/clusters/data%2Fcluster_with_slash.txt"
+    query_string = '?annotation_name=category&annotation_type=group&annotation_scope=cluster'
+    url = basepath + query_string
+    execute_http_request(:get, url)
+    assert_response :success
+    assert_equal 4, json['numPoints']
+    expected_annotations = ["bar (3 points)", "baz (1 points)"]
+    loaded_annotations = json['data'].map {|d| d['name'] }
+    assert_equal expected_annotations, loaded_annotations
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/test/api/visualization/cluster_controller_test.rb
+++ b/test/api/visualization/cluster_controller_test.rb
@@ -87,7 +87,8 @@ class ClusterControllerTest < ActionDispatch::IntegrationTest
     # slash must be URL encoded with %2F, and URL constructed manually as the path helper cannot resolve cluster_name param
     # with a slash due to the route constraint of {:cluster_name=>/[^\/]+/}; using route helper api_v1_study_cluster_path()
     # with the params of cluster_name: 'data/cluster_with_slash.txt' or cluster_name: 'data%2Fcluster_with_slash' does not work
-    basepath = "/single_cell/api/v1/studies/#{@basic_study.accession}/clusters/data%2Fcluster_with_slash.txt"
+    cluster_name = 'data%2Fcluster_with_slash.txt'
+    basepath = "/single_cell/api/v1/studies/#{@basic_study.accession}/clusters/#{cluster_name}"
     query_string = '?annotation_name=category&annotation_type=group&annotation_scope=cluster'
     url = basepath + query_string
     execute_http_request(:get, url)
@@ -96,6 +97,16 @@ class ClusterControllerTest < ActionDispatch::IntegrationTest
     expected_annotations = ["bar (3 points)", "baz (1 points)"]
     loaded_annotations = json['data'].map {|d| d['name'] }
     assert_equal expected_annotations, loaded_annotations
+
+    # assert that non-encoded cluster names do not load correct cluster
+    # using path helper here results in cluster_name not being decoded properly by clusters_controller.rb
+    # and is interpreted literally as data%2Fcluster_with_slash.txt, rather than data/cluster_with_slash.txt
+    execute_http_request(:get, api_v1_study_cluster_path(@basic_study.accession, cluster_name,
+                                                         annotation_name: 'category', annotation_type: 'group',
+                                                         annotation_scope: 'cluster'))
+    assert_response :not_found
+    expected_error = {"error"=>"No cluster named data%2Fcluster_with_slash.txt could be found"}
+    assert_equal expected_error, json
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end


### PR DESCRIPTION
Merge of contents of #821 into `master` ahead of `development` merge.  See #821 for more information.