### PR TITLE
Hotfix: Update cluster-based annotations menu on cluster change (SCP-2936)

### DIFF
--- a/app/javascript/lib/study-overview.js
+++ b/app/javascript/lib/study-overview.js
@@ -300,10 +300,21 @@ function attachEventHandlers() {
   $('#cluster').change(function() {
     $('#cluster-plot').data('rendered', false)
     const newCluster = $(this).val() // eslint-disable-line
+    const subsample = $('#subsample').val()
     // keep track for search purposes
     $('#search_cluster').val(newCluster)
     $('#gene_set_cluster').val(newCluster)
-    drawScatterPlot()
+    const url =
+    `${window.location.pathname}/get_new_annotations` +
+    `?cluster=${encodeURIComponent(newCluster)}&` +
+    `subsample=${encodeURIComponent(subsample)}`
+    $.ajax({
+      url,
+      dataType: 'script',
+      complete(jqXHR, textStatus) {
+        window.renderWithNewCluster(textStatus, drawScatterPlot)
+      }
+    })
   })
 }
 


### PR DESCRIPTION
This fixes a bug in the ongoing refactor of Study Overview for spatial data: in the default view of the Explore tab, the cluster-based annotations menu should update upon selecting another cluster.  

The cause of the bug was that the recent refactor had not accounted for [specific handling for cluster menu changes](https://github.com/broadinstitute/single_cell_portal_core/blob/0.63.0/app/views/site/_study_visualize.html.erb#L138).

I've tested the fix manually on my local SCP instance.  To test this in a basic manner:

1. Find a study that has 2 clusters, each containing different cluster-based annotations
2. Go to its Study Overview page, click "View Options"
3. Click the "Select annotation" menu.  Note the items under "Cluster-Based"
4. Change "Load cluster" menu to a different cluster
5. Click the "Select annotation" menu.  Note the items under "Cluster-Based".  They should differ from those in (3).

This satisfies SCP-2936.