### PR TITLE
Fix update of cluster-based annotations menu upon changing cluster (SCP-2936)

### DIFF
--- a/app/javascript/lib/study-overview.js
+++ b/app/javascript/lib/study-overview.js
@@ -300,10 +300,21 @@ function attachEventHandlers() {
   $('#cluster').change(function() {
     $('#cluster-plot').data('rendered', false)
     const newCluster = $(this).val() // eslint-disable-line
+    const subsample = $('#subsample').val()
     // keep track for search purposes
     $('#search_cluster').val(newCluster)
     $('#gene_set_cluster').val(newCluster)
-    drawScatterPlot()
+    const url =
+    `${window.location.pathname}/get_new_annotations` +
+    `?cluster=${encodeURIComponent(newCluster)}&` +
+    `subsample=${encodeURIComponent(subsample)}`
+    $.ajax({
+      url,
+      dataType: 'script',
+      complete(jqXHR, textStatus) {
+        window.renderWithNewCluster(textStatus, drawScatterPlot)
+      }
+    })
   })
 }
 


### PR DESCRIPTION
This backports the hotfix from #824 (via `git cherry-pick ew-fix-annotations-dropdown`).  See there for details.