### PR TITLE
Adding wiki links for cluster subsampling (SCP-2937)

### DIFF
--- a/app/views/site/_view_options.html.erb
+++ b/app/views/site/_view_options.html.erb
@@ -19,7 +19,6 @@
                 <!-- if action_name !~ /heatmap/ -->
                 <div class="form-group col-sm-4">
                   <%= label_tag :subsample, 'Subsampling threshold' %>
-                  &nbsp;
                   <i
                     class='fas fa-question-circle'
                     title="Subsampling"

--- a/app/views/site/_view_options.html.erb
+++ b/app/views/site/_view_options.html.erb
@@ -22,11 +22,14 @@
                   &nbsp;
                   <i
                     class='fas fa-question-circle'
-                    title="Take a representative subsample of the current cluster.
+                    title="Subsampling"
+                    data-content="Take a representative subsample of the current cluster
+                    (<a href='https://github.com/broadinstitute/single_cell_portal/wiki/Subsampling-Cluster-Files' target='_blank'>learn more</a>).
                       <% if /view_gene_(set_)?expression$/.match(action_name) === false %>Choosing all cells may dramatically increase rendering time.  <% end %>
                       <% if @cluster.points < ClusterGroup::MAX_THRESHOLD %>
                       <% else %>Gene search results will be subsampled to <%= ClusterGroup::MAX_THRESHOLD %> cells.<% end %>"
-                    data-toggle="tooltip"></i>
+                    data-toggle="popover" data-html=true data-trigger='hover' data-placement="left" data-container="body">
+                    </i>
                   <br />
                   <% if /view_gene_(set_)?expression$/.match(action_name) %>
                   <%= select_tag :subsample, options_for_select(subsampling_options(@cluster), set_subsample_value(params) ), {include_blank: @cluster.points < ClusterGroup::MAX_THRESHOLD ? 'All Cells' : false, class: 'form-control'} %>

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -134,6 +134,13 @@
               </ul>
             </ul>
           </div>
+          <div class="row">
+            <p class="col-sm-12 text-center">Cluster files with more than 1000 individual points will be subsampled after
+              being successfully ingested. <%= link_to "Learn More <i class='fas fa-question-circle'></i>".html_safe,
+                          'https://github.com/broadinstitute/single_cell_portal/wiki/Subsampling-Cluster-Files', target: :_blank,
+                                                       class: 'btn btn-default'%>
+            </p>
+          </div>
           <% if User.feature_flag_for_instance(current_user, 'spatial_transcriptomics') %>
             <div class="row">
               <p class="col-sm-12"><a href="https://en.wikipedia.org/wiki/Spatial_transcriptomics" target="_blank" rel="noreferrer">Spatial transcriptomics</a> data can also be uploaded with this file format.  The x, y, and z coordinates then represent actual spatial coordinates, as opposed to clustering output.</p>


### PR DESCRIPTION
Adding links in the UI on both the cluster upload form and the "Subsampling Threshold" dropdown in the View Options menu to the wiki page containing information on how/why cluster files are subsampled in SCP.  This was a follow-up item from a recent user liaison interaction with a user who wanted more information on the process.  This update also changes the existing tooltip in View Options for subsampling into a popover in order to contain the HTML link to the wiki page.

Subsampling wiki page: https://github.com/broadinstitute/single_cell_portal/wiki/Subsampling-Cluster-Files

This PR satisfies SCP-2937.