### PR TITLE
Fixing Codecov integration on PRs (SCP-2927)

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -104,11 +104,6 @@ else
     first_test_to_fail=${first_test_to_fail-"yarn ui-test"}
     ((FAILED_COUNT++))
   fi
-
-  if [[ "$CODECOV_TOKEN" != "" ]] && [[ "$CI" == "true" ]]; then
-    echo "uploading JS coverage to codecov"
-    bash <(curl -s https://codecov.io/bash) -cF javascript -t $CODECOV_TOKEN
-  fi
   RAILS_ENV=test bundle exec bin/rake test
   code=$?
   if [[ $code -ne 0 ]]; then
@@ -117,8 +112,8 @@ else
     ((FAILED_COUNT++))
   fi
   if [[ "$CODECOV_TOKEN" != "" ]] && [[ "$CI" == "true" ]]; then
-    echo "uploading ruby coverage to codecov"
-    bash <(curl -s https://codecov.io/bash) -cF ruby -t $CODECOV_TOKEN
+    echo "uploading all coverage data to codecov"
+    bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
   fi
 fi
 clean_up

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,2 @@
 codecov:
   require_ci_to_pass: no
-comment:
-  show_carryforward_flags: true


### PR DESCRIPTION
Merges `codecov` bash upload invocations into single call to merge all coverage data into a single report, rather than using multiple reports separated by flags (`-F`).  This will prevent `codecov` from clobbering existing reports and "losing" coverage data of either the Ruby or Javascript test suites.

Note: the flags still appear in this PR due to multiple reports appearing on the default branch, but should disappear after merge.

This PR satisfies SCP-2927.