### PR TITLE
Updates to subsampling help text (SCP-2937)

### DIFF
--- a/app/views/site/_view_options.html.erb
+++ b/app/views/site/_view_options.html.erb
@@ -22,7 +22,7 @@
                   <i
                     class='fas fa-question-circle'
                     title="Subsampling"
-                    data-content="Take a representative subsample of the current cluster
+                    data-content="Take a representative subsample of the current clusters
                     (<a href='https://github.com/broadinstitute/single_cell_portal/wiki/Subsampling-Cluster-Files' target='_blank'>learn more</a>).
                       <% if /view_gene_(set_)?expression$/.match(action_name) === false %>Choosing all cells may dramatically increase rendering time.  <% end %>
                       <% if @cluster.points < ClusterGroup::MAX_THRESHOLD %>

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -135,8 +135,8 @@
             </ul>
           </div>
           <div class="row">
-            <p class="col-sm-12 text-center">Cluster files with more than 1000 individual points will be subsampled after
-              being successfully ingested. <%= link_to "Learn More <i class='fas fa-question-circle'></i>".html_safe,
+            <p class="col-sm-12 text-center">Once your cluster file has been successfully ingested, additional representative
+              subsamples of the full resolution data will be stored as well. <%= link_to "Learn More <i class='fas fa-question-circle'></i>".html_safe,
                           'https://github.com/broadinstitute/single_cell_portal/wiki/Subsampling-Cluster-Files', target: :_blank,
                                                        class: 'btn btn-default'%>
             </p>


### PR DESCRIPTION
This is a patch to #826 that refines the language surrounding subsampling of cluster files.

This PR supports SCP-2937.