### PR TITLE
Remove ruby-debug-ide from Gemfile (SCP-2948)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN bash -lc 'rvm rvmrc warning ignore /home/app/webapp/Gemfile'
 
 # Set up project dir, install gems, set up script to migrate database and precompile static assets on run
 RUN mkdir /home/app/webapp
+RUN sudo chown app:app /home/app/webapp # fix permission issues in local development on MacOSX
 RUN gem update --system
 RUN gem install bundler
 COPY Gemfile /home/app/webapp/Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ group :development, :test do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-  gem 'ruby-debug-ide'
   gem 'debase'
   gem 'test-unit'
   gem 'brakeman', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,8 +371,6 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.87.0)
-    ruby-debug-ide (0.6.1)
-      rake (>= 0.8.1)
     ruby-prof (0.17.0)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
@@ -475,6 +473,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   actionpack-action_caching
@@ -518,7 +517,6 @@ DEPENDENCIES
   rest-client
   rubocop
   rubocop-rails
-  ruby-debug-ide
   ruby-prof
   ruby_native_statistics
   rubyzip
@@ -547,4 +545,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.4
+   2.2.0


### PR DESCRIPTION
The gem `ruby-debug-ide` does not build/install in the latest version of Rubygems (3.2).  This causes build failures in Travis, and will eventually prevent all deployments as containers will not be able to build anywhere.  As this gem is unused - developers are debugging with `byebug` instead - this is being removed from the Gemfile.

This update also addresses an issue with local development in Docker with the latest version of Docker CE and Catalina.  File ownership was being interpreted as `root` rather than `app` which prevented live reloading of changes in the container.  This now sets the project root ownership to `app` in the Dockerfile.  Deployed hosts are unaffected as they are `ubuntu` hosts, and the ownership is correctly interpreted as `app` inside the container.

This PR satisfies SCP-2948.