### PR TITLE
fixing coordinate labels bug. (SCP-2942)

### DIFF
--- a/app/lib/synthetic_study_populator.rb
+++ b/app/lib/synthetic_study_populator.rb
@@ -23,6 +23,7 @@ class SyntheticStudyPopulator
     puts("Populating synthetic study from #{synthetic_study_folder}")
     study = create_study(study_config, user, detached)
     add_files(study, study_config, synthetic_study_folder, user)
+    study
   end
 
   # find all matching instances of synthetic studies

--- a/app/lib/synthetic_study_populator.rb
+++ b/app/lib/synthetic_study_populator.rb
@@ -93,7 +93,22 @@ class SyntheticStudyPopulator
         end
       end
 
+      if study_file_params[:file_type] == 'Coordinate Labels'
+        if !finfo['cluster_file_name']
+          throw 'Coordinate label files must specify a cluster_file_name'
+        end
+        matching_cluster_file = StudyFile.find_by(name: finfo['cluster_file_name'], study: study)
+        if matching_cluster_file.nil?
+          throw "No cluster file with name #{finfo['cluster_file_name']} to match coordinate labels"
+        end
+        study_file_params[:options] = {'cluster_file_id' => matching_cluster_file.id.to_s}
+      end
+
       study_file = StudyFile.create!(study_file_params)
+      # the status has to be 'uploading' when created so the file gets pulled into the workspace
+      # after creation, we want it to be uploaded so that, e.g. bundles can create
+      study_file.update(status: 'uploaded')
+
       if !study.detached
         FileParseService.run_parse_job(study_file, study, user)
       end

--- a/app/models/parse_utils.rb
+++ b/app/models/parse_utils.rb
@@ -410,7 +410,7 @@ class ParseUtils
       end
 
       raw_header_data = coordinate_data.readline.encode('UTF-8', invalid: :replace, undef: :replace, replace: '').split(/[\t,]/).map(&:strip)
-      header_data = study.sanitize_input_array(raw_header_data)
+      header_data = self.sanitize_input_array(raw_header_data)
 
       # determine if 3d coordinates have been provided
       is_3d = header_data.include?('Z')

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1051,7 +1051,7 @@ class StudyFile
             file = File.open(file_location, 'rb')
           end
           raw_cells = file.readline.rstrip.split(/[\t,]/).map(&:strip)
-          cells = self.study.sanitize_input_array(raw_cells)
+          cells = ParseUtils.sanitize_input_array(raw_cells)
           if shift_headers
             cells.shift
           end

--- a/db/seed/synthetic_studies/mouse_brain/coordinate_labels.tsv
+++ b/db/seed/synthetic_studies/mouse_brain/coordinate_labels.tsv
@@ -1,0 +1,5 @@
+X	Y	LABELS
+20	20	Lower left
+140	140	Upper right
+30	130	Upper left
+120	33	Lower right

--- a/db/seed/synthetic_studies/mouse_brain/study_info.json
+++ b/db/seed/synthetic_studies/mouse_brain/study_info.json
@@ -30,6 +30,11 @@
     {
       "type": "Cluster",
       "filename": "cluster.tsv"
+    },
+    {
+      "type": "Coordinate Labels",
+      "filename": "coordinate_labels.tsv",
+      "cluster_file_name": "cluster.tsv"
     }
   ]
 }

--- a/test/integration/synthetic_study_populator_test.rb
+++ b/test/integration/synthetic_study_populator_test.rb
@@ -24,7 +24,7 @@ class SyntheticStudyPopulatorTest < ActionDispatch::IntegrationTest
   teardown do
     # this will also destroy the dependent annotation and assembly
     @taxon.destroy!
-    if study.present?
+    if @study.present?
       Study.find_by(name: SYNTH_STUDY_INFO[:name]).destroy_and_remove_workspace
     end
   end
@@ -42,7 +42,7 @@ class SyntheticStudyPopulatorTest < ActionDispatch::IntegrationTest
     end
 
     assert_nil Study.find_by(name: SYNTH_STUDY_INFO[:name])
-    SyntheticStudyPopulator.populate(SYNTH_STUDY_INFO[:folder])
+    @study = SyntheticStudyPopulator.populate(SYNTH_STUDY_INFO[:folder])
     populated_study = Study.find_by(name: SYNTH_STUDY_INFO[:name])
 
     assert_not_nil populated_study

--- a/test/integration/synthetic_study_populator_test.rb
+++ b/test/integration/synthetic_study_populator_test.rb
@@ -24,6 +24,9 @@ class SyntheticStudyPopulatorTest < ActionDispatch::IntegrationTest
   teardown do
     # this will also destroy the dependent annotation and assembly
     @taxon.destroy!
+    if study.present?
+      Study.find_by(name: SYNTH_STUDY_INFO[:name]).destroy_and_remove_workspace
+    end
   end
 
   test 'should be able to populate a study with convention metadata' do
@@ -43,7 +46,7 @@ class SyntheticStudyPopulatorTest < ActionDispatch::IntegrationTest
     populated_study = Study.find_by(name: SYNTH_STUDY_INFO[:name])
 
     assert_not_nil populated_study
-    assert_equal 4, populated_study.study_files.count
+    assert_equal 5, populated_study.study_files.count
     assert_equal 'Metadata', populated_study.study_files.first.file_type
     assert_not_nil populated_study.study_detail.full_description
 
@@ -55,6 +58,5 @@ class SyntheticStudyPopulatorTest < ActionDispatch::IntegrationTest
     assert_equal 'Ensembl 94', raw_counts_file.genome_annotation.name
 
     # note that we're not testing the ingest process yet due to timing concerns
-    Study.find_by(name: SYNTH_STUDY_INFO[:name]).destroy_and_remove_workspace
   end
 end


### PR DESCRIPTION
This fixes the support issue 69589  from Chris.  It also updates the synthetic populator to be able to handle coordinate label files for easier testing.