### PR TITLE
Change "Multimodality" to "Modality", update options (SCP-2924)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM singlecellportal/rails-baseimage:1.0.5
+FROM singlecellportal/rails-baseimage:1.0.6
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-2.6.5'
@@ -7,6 +7,7 @@ RUN bash -lc 'rvm rvmrc warning ignore /home/app/webapp/Gemfile'
 
 # Set up project dir, install gems, set up script to migrate database and precompile static assets on run
 RUN mkdir /home/app/webapp
+RUN sudo chown app:app /home/app/webapp # fix permission issues in local development on MacOSX
 RUN gem update --system
 RUN gem install bundler
 COPY Gemfile /home/app/webapp/Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ group :development, :test do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-  gem 'ruby-debug-ide'
   gem 'debase'
   gem 'test-unit'
   gem 'brakeman', :require => false
@@ -48,6 +47,11 @@ group :development, :test do
   gem 'puma'
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
+end
+
+group :test do
+  gem 'simplecov', require: false
+  gem 'simplecov-lcov', require: false
 end
 
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
       responders
       warden (~> 1.2.3)
     digest-crc (0.4.1)
+    docile (1.3.2)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.9.0)
@@ -370,8 +371,6 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.87.0)
-    ruby-debug-ide (0.6.1)
-      rake (>= 0.8.1)
     ruby-prof (0.17.0)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
@@ -404,6 +403,11 @@ GEM
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
+    simplecov (0.19.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     sprockets (3.7.2)
@@ -469,6 +473,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   actionpack-action_caching
@@ -512,7 +517,6 @@ DEPENDENCIES
   rest-client
   rubocop
   rubocop-rails
-  ruby-debug-ide
   ruby-prof
   ruby_native_statistics
   rubyzip
@@ -521,6 +525,8 @@ DEPENDENCIES
   secure_headers
   selenium-webdriver
   sentry-raven
+  simplecov
+  simplecov-lcov
   spring
   swagger-blocks
   swagger_ui_engine
@@ -539,4 +545,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.4
+   2.2.0

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1011,7 +1011,7 @@ function validateCandidateUpload(formId, filename, classSelector) {
     var form = $(formId)
     var names = [];
     classSelector.each(function(index, name) {
-        
+
         var n = $(name).val().trim();
         if (n !== '') {
             names.push(n);

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1061,7 +1061,7 @@ class StudiesController < ApplicationController
                                                  :matrix_id, :submission_id, :bam_id, :analysis_name, :visualization_name,
                                                  :cluster_name, :annotation_name],
                                        expression_file_info_attributes: [:id, :library_preparation_protocol, :units,
-                                                                         :biosample_input_type, :multimodality, :is_raw_counts])
+                                                                         :biosample_input_type, :modality, :is_raw_counts])
   end
 
   def directory_listing_params

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -266,7 +266,7 @@ class BulkDownloadService
       {library_preparation_protocol: 'expression_file_info.library_preparation_protocol'},
       {units: 'expression_file_info.units'},
       {biosample_input_type: 'expression_file_info.biosample_input_type'},
-      {multimodality: 'expression_file_info.multimodality'}
+      {modality: 'expression_file_info.modality'}
     ]
 
     col_names = col_names_and_paths.map { |np| np.keys[0] }

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -6,7 +6,7 @@ class ExpressionFileInfo
   field :library_preparation_protocol, type: String
   field :units, type: String
   field :biosample_input_type, type: String
-  field :multimodality, type: String
+  field :modality, type: String
   field :is_raw_counts, type: Boolean, default: false
 
   # note that species and reference genome/annotation live at the study_file level, not here
@@ -17,9 +17,18 @@ class ExpressionFileInfo
   BIOSAMPLE_INPUT_TYPE_VALUES = ['Whole cell', 'Single nuclei', 'Bulk']
   validates :biosample_input_type, inclusion: {in: BIOSAMPLE_INPUT_TYPE_VALUES}, allow_blank: true
 
-  MULTIMODALITY_VALUES = ['CITE-seq', 'Patch-seq']
-  validates :multimodality, inclusion: {in: MULTIMODALITY_VALUES}, allow_blank: true
-
+  MODALITY_VALUES = [
+    nil,
+    'Transcriptomic: unbiased',
+    'Transcriptomic: targeted',
+    'Spatial transcriptomics',
+    'Epigenomic: DNA-binding: histone modification',
+    'Epigenomic: DNA-binding: transcriptome factor location',
+    'Epigenomic: DNA chromatin accessibility',
+    'Epigenomic: DNA methylation',
+    'Proteomic'
+  ]
+  validates :modality, inclusion: {in: MODALITY_VALUES}
 
   LIBRARY_PREPARATION_VALUES = ['10x 3\' v1',
                                 '10x 3\' v2',

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -27,7 +27,7 @@ class ExpressionFileInfo
     'Epigenomic: DNA methylation',
     'Proteomic'
   ]
-  validates :modality, inclusion: {in: MODALITY_VALUES}, allow_blank: true
+  validates :modality, inclusion: {in: MODALITY_VALUES}
 
   LIBRARY_PREPARATION_VALUES = ['10x 3\' v1',
                                 '10x 3\' v2',

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -18,7 +18,6 @@ class ExpressionFileInfo
   validates :biosample_input_type, inclusion: {in: BIOSAMPLE_INPUT_TYPE_VALUES}, allow_blank: true
 
   MODALITY_VALUES = [
-    nil,
     'Transcriptomic: unbiased',
     'Transcriptomic: targeted',
     'Spatial transcriptomics',

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -27,7 +27,7 @@ class ExpressionFileInfo
     'Epigenomic: DNA methylation',
     'Proteomic'
   ]
-  validates :modality, inclusion: {in: MODALITY_VALUES}
+  validates :modality, inclusion: {in: MODALITY_VALUES}, allow_blank: true
 
   LIBRARY_PREPARATION_VALUES = ['10x 3\' v1',
                                 '10x 3\' v2',

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -270,10 +270,10 @@ class StudyFile
         key :description, 'Protocol used to generate expression matrix'
         key :enum, ExpressionFileInfo::LIBRARY_PREPARATION_VALUES
       end
-      property :multimodality do
+      property :modality do
         key :type, :string
-        key :description, 'Multimodality type'
-        key :enum, ExpressionFileInfo::MULTIMODALITY_VALUES
+        key :description, 'Modality type'
+        key :enum, ExpressionFileInfo::MODALITY_VALUES
       end
     end
     property :created_at do
@@ -415,10 +415,10 @@ class StudyFile
             key :description, 'Protocol used to generate expression matrix'
             key :enum, ExpressionFileInfo::LIBRARY_PREPARATION_VALUES
           end
-          property :multimodality do
+          property :modality do
             key :type, :string
-            key :description, 'Multimodality type'
-            key :enum, ExpressionFileInfo::MULTIMODALITY_VALUES
+            key :description, 'Modality type'
+            key :enum, ExpressionFileInfo::MODALITY_VALUES
           end
         end
       end
@@ -502,10 +502,10 @@ class StudyFile
             key :description, 'Protocol used to generate expression matrix'
             key :enum, ExpressionFileInfo::LIBRARY_PREPARATION_VALUES
           end
-          property :multimodality do
+          property :modality do
             key :type, :string
-            key :description, 'Multimodality type'
-            key :enum, ExpressionFileInfo::MULTIMODALITY_VALUES
+            key :description, 'Modality type'
+            key :enum, ExpressionFileInfo::MODALITY_VALUES
           end
         end
       end

--- a/app/views/studies/_expression_file_info_fields.html.erb
+++ b/app/views/studies/_expression_file_info_fields.html.erb
@@ -27,7 +27,7 @@
   <div class="col-sm-2">
     <%= f.label :modality %><br />
     <%= f.select :modality, options_for_select(ExpressionFileInfo::MODALITY_VALUES, f.object.modality),
-                 {include_blank: true}, class: 'form-control' %>
+                 {}, class: 'form-control' %>
 
   </div>
 </div>

--- a/app/views/studies/_expression_file_info_fields.html.erb
+++ b/app/views/studies/_expression_file_info_fields.html.erb
@@ -25,8 +25,8 @@
                  {}, class: 'form-control' %>
   </div>
   <div class="col-sm-2">
-    <%= f.label :multimodality %><br />
-    <%= f.select :multimodality, options_for_select(ExpressionFileInfo::MULTIMODALITY_VALUES, f.object.multimodality),
+    <%= f.label :modality %><br />
+    <%= f.select :modality, options_for_select(ExpressionFileInfo::MODALITY_VALUES, f.object.modality),
                  {include_blank: true}, class: 'form-control' %>
 
   </div>

--- a/app/views/studies/_expression_file_info_fields.html.erb
+++ b/app/views/studies/_expression_file_info_fields.html.erb
@@ -26,8 +26,7 @@
   </div>
   <div class="col-sm-2">
     <%= f.label :modality %><br />
-    <%= f.select :modality, options_for_select(ExpressionFileInfo::MODALITY_VALUES, [f.object.modality.blank? ? 'Transcriptomic: unbiased' : f.object.modality]),
-                 {include_blank: true}, class: 'form-control' %>
-
+    <%= f.select :modality, options_for_select(ExpressionFileInfo::MODALITY_VALUES, f.object.modality),
+                 {}, class: 'form-control' %>
   </div>
 </div>

--- a/app/views/studies/_expression_file_info_fields.html.erb
+++ b/app/views/studies/_expression_file_info_fields.html.erb
@@ -22,12 +22,12 @@
     <%= f.label :library_preparation_protocol, "Library Preparation Protocol <i class='text-danger'>*</i>".html_safe %><br />
     <%= f.select :library_preparation_protocol,
                  options_for_select(ExpressionFileInfo::LIBRARY_PREPARATION_VALUES, f.object.library_preparation_protocol),
-                 {}, class: 'form-control' %>
+                 {prompt: 'Select one...'}, class: 'form-control' %>
   </div>
   <div class="col-sm-2">
     <%= f.label :modality %><br />
-    <%= f.select :modality, options_for_select(ExpressionFileInfo::MODALITY_VALUES, f.object.modality),
-                 {}, class: 'form-control' %>
+    <%= f.select :modality, options_for_select(ExpressionFileInfo::MODALITY_VALUES, [f.object.modality.blank? ? 'Transcriptomic: unbiased' : f.object.modality]),
+                 {include_blank: true}, class: 'form-control' %>
 
   </div>
 </div>

--- a/app/views/studies/_initialize_expression_form.html.erb
+++ b/app/views/studies/_initialize_expression_form.html.erb
@@ -24,7 +24,7 @@
   <div class="form-group row">
     <div class="col-sm-4">
       <%= f.label :taxon_id, "Species <i class='text-danger'>*</i>".html_safe %> <%= render partial: 'taxon_help_popover', locals: {id: study_file.id.to_s} %><br />
-      <%= f.select :taxon_id, options_from_collection_for_select(Taxon.sorted, :id, :display_name, study_file.taxon_id), {prompt: 'Please select a species for this file'}, {class: 'form-control'} %>
+      <%= f.select :taxon_id, options_from_collection_for_select(Taxon.sorted, :id, :display_name, study_file.taxon_id), {prompt: 'Select one...'}, {class: 'form-control'} %>
     </div>
     <div class="col-sm-8">
       <%= f.label :y_axis_label, 'Expression Axis Label' %>&nbsp;<span class="fas fa-question-circle expression-label-tooltip" data-toggle="tooltip" data-placement="right" title="This is displayed as the axis label for box & scatter plots showing expression values.  This label is global to all expression values.<%= @study.has_expression_label? ? ' Please use the study default options form to update this value.' : '' %>"></span> <br />

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module SingleCellPortal
     config.middleware.use Rack::Deflater
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.7.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.8.3'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
This changes the label of the "Multimodality" dropdown menu to "Modality", and updates the list of available options.  The particular values, order, and default for the list have been specified (and refinements verified) by Jean.  I've tested it manually locally.

<img width="1680" alt="Expression_file_upload_wizard_form_raw_counts_modality_2020-12-10" src="https://user-images.githubusercontent.com/1334561/101846476-04791080-3b1f-11eb-9193-40af710d561f.png">

After this last PR for `raw-counts-ingest` is merged, I plan to merge `raw-counts-ingest` into `development`.

This supports SCP-2924.