### PR TITLE
Adding url-safe token for some visualization endpoints (SCP-2928)

### DIFF
--- a/app/controllers/api/v1/concerns/authenticator.rb
+++ b/app/controllers/api/v1/concerns/authenticator.rb
@@ -8,6 +8,10 @@ module Api
           {controller: 'search', action: 'bulk_download'},
           {controller: 'studies', action: 'generate_manifest'}
         ]
+        URL_SAFE_TOKEN_ALLOWED_ACTIONS = [
+          {controller: 'expression', action: 'show'},
+          {controller: 'annotations', action: 'cell_values'}
+        ]
         def authenticate_api_user!
           head 401 unless api_user_signed_in?
         end
@@ -57,6 +61,11 @@ module Api
                 # update last_access_at
                 user.update_last_access_at!
                 return user
+              end
+            else
+              if URL_SAFE_TOKEN_ALLOWED_ACTIONS.include?({controller: controller_name, action: action_name}) && params[:url_safe_token]
+                url_safe_token = params[:url_safe_token]
+                return User.find_by(authentication_token: url_safe_token)
               end
             end
           end

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -21,7 +21,7 @@ module Api
         # to be used other than by the SCP UI, and may change dramatically
         def show
           if (!@study.has_expression_data? || !@study.can_visualize_clusters?)
-            render json: {error: "Study #{@study.accession} does not support expression rendering"}, status: 400
+            render(json: {error: "Study #{@study.accession} does not support expression rendering"}, status: 400) and return
           end
           data_type = params[:data_type]
           if (data_type == 'violin')

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -362,6 +362,7 @@ module ApplicationHelper
   end
 
    # Return a scope-limited access token that can be used in URLs (e.g. in urls passed to Morpheus)
+   # this is different than a totat in that it can be re-used
   def get_url_safe_access_token(user)
     token = ''
     if user.present?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -361,6 +361,15 @@ module ApplicationHelper
     end
   end
 
+   # Return a scope-limited access token that can be used in URLs (e.g. in urls passed to Morpheus)
+  def get_url_safe_access_token(user)
+    token = ''
+    if user.present?
+      token = user.authentication_token
+    end
+    token
+  end
+
   def pluralize_without_count(count, noun, text=nil)
     count.to_i == 1 ? "#{noun}#{text}" : "#{noun.pluralize}#{text}"
   end

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -10,7 +10,7 @@ import camelcaseKeys from 'camelcase-keys'
 import _compact from 'lodash/compact'
 import * as queryString from 'query-string'
 
-import { getAccessToken } from 'providers/UserProvider'
+import { getAccessToken, getURLSafeAccessToken } from 'providers/UserProvider'
 import {
   logSearch, logDownloadAuthorization, mapFiltersForLogging
 } from './scp-api-metrics'
@@ -269,7 +269,8 @@ export function getAnnotationCellValuesURL(studyAccession, clusterName, annotati
   const paramObj = {
     cluster: clusterName,
     annotation_scope: annotationScope,
-    annotation_type: annotationType
+    annotation_type: annotationType,
+    url_safe_token: getURLSafeAccessToken()
   }
   annotationName = annotationName ? annotationName : '_default'
   const apiUrl = `/studies/${studyAccession}/annotations/${encodeURIComponent(annotationName)}/cell_values${stringifyQuery(paramObj)}`
@@ -291,7 +292,8 @@ export function getExpressionHeatmapURL(studyAccession, genes, cluster, annotati
     cluster,
     annotation,
     subsample,
-    genes: genes.join(',')
+    genes: genes.join(','),
+    url_safe_token: getURLSafeAccessToken()
   }
   const path = `/studies/${studyAccession}/expression/heatmap${stringifyQuery(paramObj)}`
   return getFullUrl(path)

--- a/app/javascript/providers/UserProvider.js
+++ b/app/javascript/providers/UserProvider.js
@@ -13,6 +13,15 @@ export function getAccessToken() {
   return ('SCP' in window) ? window.SCP.userAccessToken : 'test'
 }
 
+/**
+  * Returns a scope-limited access token that can be used as a URL param
+  * window.SCP is not available when running via Jest tests,
+  * so default such cases to a string "test"
+  */
+export function getURLSafeAccessToken() {
+  return ('SCP' in window) ? window.SCP.URLSafeAccessToken : 'test'
+}
+
 /** Returns the feature flags with defaults for the current user */
 export function getFeatureFlagsWithDefaults() {
   // for now, read it off the home page.  Eventually, this will want to be an API call

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,7 @@
       }
 
       window.SCP.userAccessToken = '<%= get_user_access_token(current_user) %>';
+      window.SCP.URLSafeAccessToken = '<%= get_url_safe_access_token(current_user) %>'
       window.SCP.userSignedIn = <%= user_signed_in? %>;
       window.SCP.environment = '<%= Rails.env %>';
 

--- a/test/api/visualization/annotations_controller_test.rb
+++ b/test/api/visualization/annotations_controller_test.rb
@@ -47,6 +47,17 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
 
     execute_http_request(:get, cell_values_api_v1_study_annotation_path(@basic_study, 'foo'), user: user2)
     assert_equal 403, response.status
+
+    sign_in_and_update @user
+    execute_http_request(:get, api_v1_study_annotations_path(@basic_study, 'foo'), user: @user)
+    assert_equal 200, response.status
+
+    # test url_safe_token capability
+    get cell_values_api_v1_study_annotation_path(@basic_study, 'foo', params: {url_safe_token: @user.authentication_token})
+    assert_equal 200, response.status
+
+    get cell_values_api_v1_study_annotation_path(@basic_study, 'foo', params: {url_safe_token: 'garbage'})
+    assert_equal 401, response.status
   end
 
   test 'index should return list of annotations' do

--- a/test/api/visualization/expression_controller_test.rb
+++ b/test/api/visualization/expression_controller_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+require 'api_test_helper'
+
+class ExpressionControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+  include Requests::JsonHelpers
+  include Requests::HttpHelpers
+  include Minitest::Hooks
+  include ::SelfCleaningSuite
+  include ::TestInstrumentor
+
+  before(:all) do
+    @user = FactoryBot.create(:api_user, test_array: @@users_to_clean)
+    @basic_study = FactoryBot.create(:detached_study,
+                                     name: 'Basic Expression Study',
+                                     public: false,
+                                     user: @user,
+                                     test_array: @@studies_to_clean)
+  end
+
+  test 'methods should check view permissions' do
+    user2 = FactoryBot.create(:api_user, test_array: @@users_to_clean)
+    sign_in_and_update user2
+
+    execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'heatmap'), user: user2)
+    assert_equal 403, response.status
+
+    sign_in_and_update @user
+    execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'heatmap'), user: @user)
+    assert_equal 400, response.status # response is 400 since study is non-visualizable
+
+    # test url_safe_token capability
+    get api_v1_study_expression_path(@basic_study, 'heatmap', params: {url_safe_token: @user.authentication_token})
+    assert_equal 400, response.status # response is 400 since study is non-visualizable
+
+    get api_v1_study_expression_path(@basic_study, 'heatmap', params: {url_safe_token: 'garbage'})
+    assert_equal 401, response.status
+  end
+end

--- a/test/api_test_helper.rb
+++ b/test/api_test_helper.rb
@@ -34,6 +34,7 @@ module Requests
       })
       sign_in user
       user.update_last_access_at!
+      user.update(authentication_token: Devise.friendly_token(32))
     end
   end
 end

--- a/test/integration/lib/bulk_download_service_test.rb
+++ b/test/integration/lib/bulk_download_service_test.rb
@@ -156,6 +156,7 @@ class BulkDownloadServiceTest < ActiveSupport::TestCase
         units: 'raw counts',
         library_preparation_protocol: 'MARS-seq',
         biosample_input_type: 'Whole cell',
+        modality: 'Transcriptomic: targeted',
         is_raw_counts: true
       )
     )

--- a/test/models/study_file_test.rb
+++ b/test/models/study_file_test.rb
@@ -60,7 +60,7 @@ class StudyFileTest < ActiveSupport::TestCase
       taxon_id: Taxon.new.id,
       expression_file_info: ExpressionFileInfo.new(
         units: 'bad_value',
-        library_preparation_protocol: 'Mars-seq',
+        library_preparation_protocol: 'Mars-seq', # Incorrect case
         is_raw_counts: true
       )
     )
@@ -76,6 +76,7 @@ class StudyFileTest < ActiveSupport::TestCase
         units: 'raw counts',
         library_preparation_protocol: 'MARS-seq',
         biosample_input_type: 'Whole cell',
+        modality: 'Transcriptomic: targeted',
         is_raw_counts: true
       )
     )


### PR DESCRIPTION
This enables generation of links that can be passed to morpheus and still be authenticable like https://localhost:3000/single_cell/api/v1/studies/SCP179/expression/heatmap?genes=agpat2%2Capoe&url_safe_token=CGB12WkrqhGWYsuAbGz5XiSwxaAnTAZ7 , but not unnecessarily exposing risk (since putting tokens in URLs is generally a bad idea).

This PR is based off the raw_counts_ingest branch because it builds off the totat changes from that branch.  But the behavior it fixes is on development now

I would support renaming the User field to url_safe_token too, just to be clearer that that's not the 'real' token.  But I think that's a refactor for later.
