### PR TITLE
HOTFIX: fixing nil error in gene search cluster options (SCP-2967)

### DIFF
--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -69,7 +69,7 @@ class AnnotationVizService
       end
     end
     annotations.concat(cluster_annots)
-    if current_user.present?
+    if current_user.present? && cluster.present?
       user_annotations = UserAnnotation.viewable_by_cluster(current_user, cluster)
       annotations.concat(user_annotations)
     end


### PR DESCRIPTION
This bug was hidden because it only affects users with UserAnnotations, and I'm guessing none of our staging users have user annotations