### PR TITLE
Back merge hotfix for "Load cluster" menu in single-gene view in Study Overview (SCP-2969)

### DIFF
--- a/app/javascript/lib/violin-plot.js
+++ b/app/javascript/lib/violin-plot.js
@@ -242,7 +242,7 @@ export async function violinPlot(plotId, study, gene) {
   const plotDom = document.getElementById(plotId)
   const spinner = new Spinner(window.opts).spin(plotDom)
 
-  const { cluster, subsample } = getMainViewOptions()
+  const { cluster, subsample } = getMainViewOptions(0)
 
   const { name, type, scope } = getAnnotParams()
 


### PR DESCRIPTION
This back merges #844, which was deployed in [0.66.2](https://github.com/broadinstitute/single_cell_portal_core/releases/tag/0.66.2).