### PR TITLE
Addressing raw counts UI papercuts (SCP-2963)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -382,4 +382,9 @@ module ApplicationHelper
     end
     page_name
   end
+
+  # helper to add a red * to a form field label
+  def label_with_asterisk(label_name)
+    "#{label_name} <i class='text-danger'>*</i>".html_safe
+  end
 end

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -15,7 +15,7 @@ class ExpressionFileInfo
   validates :units, inclusion: {in: UNITS_VALUES}, allow_blank: true
 
   BIOSAMPLE_INPUT_TYPE_VALUES = ['Whole cell', 'Single nuclei', 'Bulk']
-  validates :biosample_input_type, inclusion: {in: BIOSAMPLE_INPUT_TYPE_VALUES}, allow_blank: true
+  validates :biosample_input_type, inclusion: {in: BIOSAMPLE_INPUT_TYPE_VALUES}
 
   MODALITY_VALUES = [
     'Transcriptomic: unbiased',
@@ -62,7 +62,7 @@ class ExpressionFileInfo
                                 'smFISH',
                                 # single cell ChIP-seq assays
                                 'Drop-ChIP']
-  validates :library_preparation_protocol, inclusion: {in: LIBRARY_PREPARATION_VALUES}, allow_blank: true
+  validates :library_preparation_protocol, inclusion: {in: LIBRARY_PREPARATION_VALUES}
 
   validate :unset_units_unless_raw_counts
   validate :enforce_units_on_raw_counts
@@ -83,5 +83,4 @@ class ExpressionFileInfo
       errors.add(:units, ' must have a value for raw counts matrices')
     end
   end
-
 end

--- a/app/views/studies/_expression_file_info_fields.html.erb
+++ b/app/views/studies/_expression_file_info_fields.html.erb
@@ -1,32 +1,32 @@
 <div class="row expression-file-info-fields">
-  <div class="col-sm-2">
+  <div class="col-lg-2">
     <%= f.label :is_raw_counts, 'Is this a raw counts matrix?' %><br />
     <%= f.radio_button :is_raw_counts, 1, checked: f.object.is_raw_counts, class: 'raw-counts-radio'  %>
     <%= f.label :is_raw_counts, 'Yes', class: 'radio-pad' %>
     <%= f.radio_button :is_raw_counts, 0, checked: !f.object.is_raw_counts, class: 'raw-counts-radio' %>
     <%= f.label :is_raw_counts, 'No', class: 'radio-pad'  %>
   </div>
-  <div class="col-sm-2">
+  <div class="col-lg-2">
     <%= f.label :units %><br />
     <%= f.select :units, options_for_select(ExpressionFileInfo::UNITS_VALUES, f.object.units),
                  {include_blank: true},
                  class: 'form-control raw-counts-select counts-unit-dropdown', disabled: !f.object.is_raw_counts %>
   </div>
-  <div class="col-sm-3">
-    <%= f.label :biosample_input_type, "Biosample Input Type <i class='text-danger'>*</i>".html_safe %><br />
+  <div class="col-lg-2">
+    <%= f.label :biosample_input_type, label_with_asterisk('Biosample Input Type') %><br />
     <%= f.select :biosample_input_type, options_for_select(ExpressionFileInfo::BIOSAMPLE_INPUT_TYPE_VALUES, f.object.biosample_input_type),
-                 {prompt: 'Select one...'}, class: 'form-control' %>
+                 {}, class: 'form-control' %>
 
   </div>
-  <div class="col-sm-3">
-    <%= f.label :library_preparation_protocol, "Library Preparation Protocol <i class='text-danger'>*</i>".html_safe %><br />
+  <div class="col-lg-2">
+    <%= f.label :library_preparation_protocol, label_with_asterisk('Library Preparation Protocol') %><br />
     <%= f.select :library_preparation_protocol,
                  options_for_select(ExpressionFileInfo::LIBRARY_PREPARATION_VALUES, f.object.library_preparation_protocol),
-                 {prompt: 'Select one...'}, class: 'form-control' %>
+                 {}, class: 'form-control' %>
   </div>
-  <div class="col-sm-2">
-    <%= f.label :modality %><br />
-    <%= f.select :modality, options_for_select(ExpressionFileInfo::MODALITY_VALUES, f.object.modality || 'Transcriptomic: unbiased'),
+  <div class="col-lg-4">
+    <%= f.label :modality, label_with_asterisk('Modality') %><br />
+    <%= f.select :modality, options_for_select(ExpressionFileInfo::MODALITY_VALUES, f.object.modality),
                  {}, class: 'form-control' %>
   </div>
 </div>

--- a/app/views/studies/_initialize_expression_form.html.erb
+++ b/app/views/studies/_initialize_expression_form.html.erb
@@ -23,7 +23,7 @@
 	</div>
   <div class="form-group row">
     <div class="col-sm-4">
-      <%= f.label :taxon_id, "Species <i class='text-danger'>*</i>".html_safe %> <%= render partial: 'taxon_help_popover', locals: {id: study_file.id.to_s} %><br />
+      <%= f.label :taxon_id, label_with_asterisk('Species') %> <%= render partial: 'taxon_help_popover', locals: {id: study_file.id.to_s} %><br />
       <%= f.select :taxon_id, options_from_collection_for_select(Taxon.sorted, :id, :display_name, study_file.taxon_id), {prompt: 'Select one...'}, {class: 'form-control'} %>
     </div>
     <div class="col-sm-8">

--- a/app/views/studies/_initialize_study_label.html.erb
+++ b/app/views/studies/_initialize_study_label.html.erb
@@ -2,6 +2,6 @@
 	<% if @study.initialized %>
 		<small class="initialize-label" data-toggle="tooltip" data-placement="right" title="Your study is now initialized and visualizations have been enabled."><span class="label label-success">Visualizations Initialized <span class="fas fa-check" ></span> </span></small>
 	<% else %>
-		<small class="initialize-label" data-toggle="tooltip" data-placement="right" title="You have not uploaded all of the required files to enable visualizations yet."><span class="label label-danger">Visualizations Not Initialized <span class="fas fa-times" ></span> </span></small>
+		<small class="initialize-label" data-toggle="tooltip" data-placement="right" title="Visualizations are not fully enabled until at least one expression matrix, metadata, and cluster file have finished parsing."><span class="label label-danger">Visualizations Not Initialized <span class="fas fa-times" ></span> </span></small>
 	<% end %>
 </span>


### PR DESCRIPTION
This update addresses several small UI and form validation issues associated with the upload wizard:

- Enforces validation of all `expression_file_info` fields, except `units` if matrix is processed
- Adjusts layout of dropdown menus for better utilization of space
- Adds "Required *" asterisks to all required fields for expression files
- Changes content of "initialized" tooltip to reflect what is actually being checked (parsed data, not uploaded files)

This PR satisfies SCP-2963.