### PR TITLE
Ensure deletion of study files regardless of state (SCP-2992)

### DIFF
--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -90,6 +90,10 @@ class DeleteQueueJob < Struct.new(:object)
         nil
       end
 
+      # remove any embedded documents from study_file before queueing for deletion as validation errors can occur
+      unset_embedded_documents(object)
+      object.reload
+
       # if this is a parent bundled file, delete all other associated files and bundle
       if object.is_bundle_parent?
         object.bundled_files.each do |file|
@@ -165,6 +169,17 @@ class DeleteQueueJob < Struct.new(:object)
     if metadata_file.use_metadata_convention
       bq_dataset.query "DELETE FROM #{CellMetadatum::BIGQUERY_TABLE} WHERE study_accession = '#{study.accession}' AND file_id = '#{metadata_file.id}'"
       SearchFacet.delay.update_all_facet_filters
+    end
+  end
+
+  # remove any embedded documents before deleting study_file to prevent validation issues when queueing for deletion
+  def unset_embedded_documents(study_file)
+    study_file.embedded_relations.each do |name, relation|
+      embedded_document = study_file.send(relation.name)
+      if embedded_document.present?
+        study_file.send("#{name}=", nil)
+        study_file.save!
+      end
     end
   end
 end

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -73,7 +73,7 @@ class ExpressionFileInfo
   # this has to be invoked as a validation as callbacks only fire on parent document (StudyFile)
   def unset_units_unless_raw_counts
     unless self.is_raw_counts
-      self.units = nil
+      self.units = nil unless self.frozen? # document will be frozen if it is being unset, so don't attempt update
     end
   end
 

--- a/app/views/studies/_expression_file_info_fields.html.erb
+++ b/app/views/studies/_expression_file_info_fields.html.erb
@@ -1,9 +1,11 @@
 <div class="row expression-file-info-fields">
   <div class="col-lg-2">
     <%= f.label :is_raw_counts, 'Is this a raw counts matrix?' %><br />
-    <%= f.radio_button :is_raw_counts, 1, checked: f.object.is_raw_counts, class: 'raw-counts-radio'  %>
+    <%= f.radio_button :is_raw_counts, 1,
+                       checked: f.object.is_raw_counts, class: 'raw-counts-radio'  %>
     <%= f.label :is_raw_counts, 'Yes', class: 'radio-pad' %>
-    <%= f.radio_button :is_raw_counts, 0, checked: !f.object.is_raw_counts, class: 'raw-counts-radio' %>
+    <%= f.radio_button :is_raw_counts, 0,
+                       checked: !f.object.is_raw_counts, class: 'raw-counts-radio' %>
     <%= f.label :is_raw_counts, 'No', class: 'radio-pad'  %>
   </div>
   <div class="col-lg-2">

--- a/test/models/delete_queue_job_test.rb
+++ b/test/models/delete_queue_job_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class DeleteQueueJobTest < ActiveSupport::TestCase
+
+  include Minitest::Hooks
+  include SelfCleaningSuite
+  include TestInstrumentor
+
+  before(:all) do
+    @user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    @basic_study = FactoryBot.create(:detached_study, name_prefix: 'DeleteQueue Test', test_array: @@studies_to_clean)
+
+    @basic_study_exp_file = FactoryBot.create(:study_file,
+                                              name: 'dense.txt',
+                                              file_type: 'Expression Matrix',
+                                              study: @basic_study)
+
+
+    @pten_gene = FactoryBot.create(:gene_with_expression,
+                                   name: 'PTEN',
+                                   study_file: @basic_study_exp_file,
+                                   expression_input: [['A', 0],['B', 3],['C', 1.5]])
+    @basic_study_exp_file.build_expression_file_info(is_raw_counts: false, library_preparation_protocol: 'MARS-seq',
+                                                     modality: 'Transcriptomic: unbiased', biosample_input_type: 'Whole cell')
+    @basic_study_exp_file.save!
+  end
+
+  # test to ensure expression matrix files with "invalid" expression_file_info documents can still be deleted
+  # this happens when attributes on nested documents have new constraints placed after creation, like additional
+  # validations or fields
+  test 'should allow deletion of legacy expression matrices' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    assert @basic_study_exp_file.valid?,
+           "Expression file should be valid but is not: #{@basic_study_exp_file.errors.full_messages}"
+    assert @basic_study.genes.count == 1,
+           "Did not find correct number of genes, expected 1 but found #{@basic_study.genes.count}"
+
+    # manually unset an attribute for expression_file_info to simulate "legacy" data
+    @basic_study_exp_file.expression_file_info.modality = nil
+    @basic_study_exp_file.save(validate: false)
+    @basic_study_exp_file.reload
+    assert_nil @basic_study_exp_file.expression_file_info.modality,
+               "Did not unset value for modality: #{@basic_study_exp_file.expression_file_info.modality}"
+
+    # run DeleteQueueJob and ensure proper deletion
+    DeleteQueueJob.new(@basic_study_exp_file).perform
+    @basic_study_exp_file.reload
+    @basic_study.reload
+
+    assert @basic_study_exp_file.queued_for_deletion,
+           "Did not successfully queue exp matrix for deletion: #{@basic_study_exp_file.queued_for_deletion}"
+
+    assert_equal @basic_study.genes.count, 0, "Should not have found any genes but found #{@basic_study.genes.count}"
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+end


### PR DESCRIPTION
A recent update to the codebase changed validations for `ExpressionFileInfo` documents, which are embedded in `StudyFile` documents for expression matrix files.  This caused an unintended issue with `DeleteQueueJob` which ended up preventing the deletion of expression matrices that had been added before the validation change was made, as the embedded documents were now invalid, which prevented saving the parent document.  This then broke the normal garbage collection process in the portal for these newly invalid documents, which resulted in the UX of files simply not deleting, without any error being presented to the user.

This update now unsets all embedded documents before attempting to queue a file for deletion.  Furthermore, it has been written in a manner that will be forward-compatible: any new embedded document types that are added in the future will not need to have new cleanup code written.  Each embedded document will now be unset prior to deleting the parent document, which sidesteps the validation issue entirely.

This PR satisfies SCP-2992.