### PR TITLE
Updating to scp-ingest-pipeline:1.9.0

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module SingleCellPortal
     config.middleware.use Rack::Deflater
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.8.6'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.9.0'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Updating to the latest version of [scp-ingest-pipeline](https://github.com/broadinstitute/scp-ingest-pipeline).  Refer to this [PR](https://github.com/broadinstitute/scp-ingest-pipeline/pull/199) for more information regarding the updates.

This PR supports SCP-2975 and SCP-2911.