### PR TITLE
Fix input label click handler in cluster file upload (SCP-3008)

### DIFF
--- a/app/views/studies/_initialize_ordinations_form.html.erb
+++ b/app/views/studies/_initialize_ordinations_form.html.erb
@@ -10,13 +10,13 @@
     <div class="form-group row">
       <div class="col-sm-12">
         <%= f.label :is_spatial, 'Coordinate data type: ' %><br/>
-        <%= f.label :is_spatial_false do %>
-          <%= f.radio_button :is_spatial, false %>
+        <%= f.label :is_spatial_false, {for: "is_spatial_false_#{study_file._id}"} do %>
+          <%= f.radio_button :is_spatial, false, {id: "is_spatial_false_#{study_file._id}"} %>
           Clustering
         <% end %>
         &nbsp;
-        <%= f.label :is_spatial_true do %>
-          <%= f.radio_button :is_spatial, true %>
+        <%= f.label :is_spatial_true, {for: "is_spatial_true_#{study_file._id}"} do %>
+          <%= f.radio_button :is_spatial, true, {id: "is_spatial_true_#{study_file._id}"} %>
           Spatial transcriptomics positions
         <% end %>
 


### PR DESCRIPTION
This fixes built-in click handling for the radio input label for the "Coordinate data type" field in cluster file upload.

To test:
1. Go to existing study, or create study
2. Go to "Clusters" tab in Upload Wizard
3. If multiple cluster files exist, go to Step 5, else upload a "Cluster" file
4. Click blue "Add a Cluster File" button
5. Click label text for radio input "Spatial transcriptomics positions"
6. Verify that clicking that label affects only the upload form for the current file, not the other file

See below for demos of the bug and the fix.

https://user-images.githubusercontent.com/1334561/104061156-0f7a9b80-51c6-11eb-9ae1-2fd7f04a780c.mov


https://user-images.githubusercontent.com/1334561/104061172-14d7e600-51c6-11eb-88d8-801494b0012e.mov

This satisfies SCP-3008.