### PR TITLE
Fixing reference for bundled coordinate label files (SCP-2990)

### DIFF
--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -813,8 +813,8 @@ class StudyFile
       when 'BAM'
         selector += '.bam_id'
       when 'Cluster'
-        selector += '.cluster_group_id'
-        query_id = self.cluster_groups.first.id.to_s
+        selector += '.cluster_file_id'
+        query_id = self.id.to_s
       end
       StudyFile.where(selector => query_id) # return Mongoid::Criteria to lazy-load, better performance
     end
@@ -832,7 +832,7 @@ class StudyFile
       when 'BAM Index'
         selector = :bam_id
       when 'Coordinate Labels'
-        selector = :cluster_group_id
+        selector = :cluster_file_id
       end
       # call find_by(id: ) to avoid Mongoid::Errors::InvalidFind
       StudyFile.find_by(id: self.options[selector])


### PR DESCRIPTION
Previously, there was a value in a coordinate label file's `options` hash called `cluster_group_id`, that pointed to the actual `ClusterGroup` this coordinate label file refers to, and was part of the behavior for creating `StudyFileBundle` objects for these files as a part of normal form-based file upload. 

This was changed in #734 to point instead to the parent `StudyFile` rather than the `ClusterGroup`, which brings it in line with all other `StudyFileBundle` objects.  The option key was changed to `cluster_file_id`, but that change was not applied in `StudyFile#bundled_files` and `StudyFile#bundle_parent` for legacy files.  This causes potential issues when trying to access bundled files, and also exposes a potential [failure point](https://sentry.io/organizations/broad-institute/issues/1995713253/?project=1424198&query=is%3Aunresolved&statsPeriod=14d) when trying to update file state if a cluster file fails to ingest.  This update fixes those references.

As there is test coverage already for parsing coordinate label files in `SyntheticStudyPopulatorTest`, and negative cluster parsing tests in `StudyValidationTest`, no additional tests were added.  This PR satisfies SCP-2990.