### PR TITLE
Resize heatmap upon "View Options" click, modularize JS (SCP-2968)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,6 +33,7 @@
 //= require scp-infercnv-ideogram
 //= require scp-related-genes-ideogram
 //= require scp-dot-plot
+//= require scp-heatmap
 //= require ckeditor
 
 var fileUploading = false;
@@ -729,70 +730,6 @@ $(window).resize(function() {
         $(this).trigger('resizeEnd');
     }, 100);
 });
-
-// generic function to render Morpheus heatmap
-function renderMorpheus(dataPath, annotPath, selectedAnnot, selectedAnnotType, target, annotations, fitType, heatmapHeight, colorScaleMode) {
-    console.log('render status of ' + target + ' at start: ' + $(target).data('rendered'));
-    $(target).empty();
-    console.log("scaling mode: " + colorScaleMode);
-    var config = {name: 'Heatmap', dataset: dataPath, el: $(target), menu: null, colorScheme: {scalingMode: colorScaleMode}};
-
-    // set height if specified, otherwise use default setting of 500 px
-    if (heatmapHeight !== undefined) {
-        config.height = heatmapHeight;
-    } else {
-        config.height = 500;
-    }
-
-    // fit rows, columns, or both to screen
-    if (fitType === 'cols') {
-        config.columnSize = 'fit';
-    } else if (fitType === 'rows') {
-        config.rowSize = 'fit';
-    } else if (fitType === 'both') {
-        config.columnSize = 'fit';
-        config.rowSize = 'fit';
-    } else {
-        config.columnSize = null;
-        config.rowSize = null;
-    }
-
-    // load annotations if specified
-    if (annotPath !== '') {
-        config.columnAnnotations = [{
-            file : annotPath,
-            datasetField : 'id',
-            fileField : 'NAME',
-            include: [selectedAnnot]}
-        ];
-        config.columnSortBy = [
-            {field: selectedAnnot, order:0}
-        ];
-        config.columns = [
-            {field:'id', display:'text'},
-            {field: selectedAnnot, display: selectedAnnotType === 'group' ? 'color' : 'bar'}
-        ];
-        // create mapping of selected annotations to colorBrewer colors
-        var annotColorModel = {};
-        annotColorModel[selectedAnnot] = {};
-        var sortedAnnots = annotations['values'].sort();
-
-        // calling % 27 will always return to the beginning of colorBrewerSet once we use all 27 values
-        $(sortedAnnots).each(function(index, annot) {
-            annotColorModel[selectedAnnot][annot] = colorBrewerSet[index % 27];
-        });
-        config.columnColorModel = annotColorModel;
-    }
-
-    // instantiate heatmap and embed in DOM element
-    var heatmap = new morpheus.HeatMap(config);
-
-    // set render variable to true for tests
-    $(target).data('morpheus', heatmap);
-    $(target).data('rendered', true);
-    console.log('render status of ' + target + ' at end: ' + $(target).data('rendered'));
-
-}
 
 // toggles visibility and disabled status of file upload and fastq url fields
 function toggleFastqFields(target, state) {

--- a/app/assets/javascripts/scp-dot-plot.js
+++ b/app/assets/javascripts/scp-dot-plot.js
@@ -114,7 +114,7 @@ function renderDotPlotLegend(dotPlotTarget, legendTarget) {
 }
 
 /** Render Morpheus dot plot */
-function renderMorpheusDotPlot(
+function renderDotPlot(
   dataPath, annotPath, selectedAnnot, selectedAnnotType,
   target, annotations, fitType, dotHeight, legendTarget
 ) {
@@ -245,9 +245,9 @@ function renderMorpheusDotPlot(
 
 /** High-level function called from _expression_plots_view.html.erb */
 function drawDotplot(dataPath,
-                     requestToken,
-                     annotPathBase,
-                     annotValuesPath) {
+  requestToken,
+  annotPathBase,
+  annotValuesPath) {
   $(window).off('resizeEnd')
 
   // Clear out previous stored dotplot object
@@ -277,7 +277,7 @@ function drawDotplot(dataPath,
     url: `${annotValuesPath}?${renderUrlParams}`,
     dataType: 'JSON',
     success(annotations) {
-      renderMorpheusDotPlot(
+      renderDotPlot(
         dataPath, newAnnotPath, annotName, annotType, '#dot-plot',
         annotations, fit, height
       )

--- a/app/assets/javascripts/scp-heatmap.js
+++ b/app/assets/javascripts/scp-heatmap.js
@@ -1,0 +1,75 @@
+/**
+ * Render Morpheus heatmap
+ */
+function renderMorpheus(
+  dataPath, annotPath, selectedAnnot, selectedAnnotType, target, annotations,
+  fitType, heatmapHeight, colorScaleMode
+) {
+  console.log(
+    `render status of ${target} at start: ${$(target).data('rendered')}`
+  )
+  $(target).empty()
+  console.log(`scaling mode: ${colorScaleMode}`)
+  const config = {
+    name: 'Heatmap',
+    dataset: dataPath,
+    el: $(target),
+    menu: null,
+    colorScheme: { scalingMode: colorScaleMode }
+  }
+
+  // set height if specified, otherwise use default setting of 500 px
+  if (heatmapHeight !== undefined) {
+    config.height = heatmapHeight
+  } else {
+    config.height = 500
+  }
+
+  // fit rows, columns, or both to screen
+  if (fitType === 'cols') {
+    config.columnSize = 'fit'
+  } else if (fitType === 'rows') {
+    config.rowSize = 'fit'
+  } else if (fitType === 'both') {
+    config.columnSize = 'fit'
+    config.rowSize = 'fit'
+  } else {
+    config.columnSize = null
+    config.rowSize = null
+  }
+
+  // load annotations if specified
+  if (annotPath !== '') {
+    config.columnAnnotations = [{
+      file: annotPath,
+      datasetField: 'id',
+      fileField: 'NAME',
+      include: [selectedAnnot]
+    }]
+    config.columnSortBy = [
+      { field: selectedAnnot, order: 0 }
+    ]
+    config.columns = [
+      { field: 'id', display: 'text' },
+      { field: selectedAnnot, display: selectedAnnotType === 'group' ? 'color' : 'bar' }
+    ]
+    // create mapping of selected annotations to colorBrewer colors
+    const annotColorModel = {}
+    annotColorModel[selectedAnnot] = {}
+    const sortedAnnots = annotations['values'].sort()
+
+    // calling % 27 will always return to the beginning of colorBrewerSet once we use all 27 values
+    $(sortedAnnots).each((index, annot) => {
+      annotColorModel[selectedAnnot][annot] = colorBrewerSet[index % 27]
+    })
+    config.columnColorModel = annotColorModel
+  }
+
+  // instantiate heatmap and embed in DOM element
+  const heatmap = new morpheus.HeatMap(config)
+
+  // set render variable to true for tests
+  $(target).data('morpheus', heatmap)
+  $(target).data('rendered', true)
+  console.log(`render status of ${target} at end: ${$(target).data('rendered')}`)
+}

--- a/app/assets/javascripts/scp-heatmap.js
+++ b/app/assets/javascripts/scp-heatmap.js
@@ -1,7 +1,7 @@
 /**
  * Render Morpheus heatmap
  */
-function renderMorpheus(
+function renderHeatmap(
   dataPath, annotPath, selectedAnnot, selectedAnnotType, target, annotations,
   fitType, heatmapHeight, colorScaleMode
 ) {

--- a/app/views/site/_view_gene_expression_heatmap.html.erb
+++ b/app/views/site/_view_gene_expression_heatmap.html.erb
@@ -106,8 +106,8 @@
             url: '<%= annotation_values_path(accession: @study.accession, study_name: @study.url_safe_name) %>?' + renderUrlParams,
             dataType: 'JSON',
             success: function(annotations) {
-                renderMorpheus(dataPath, newAnnotPath, annotName, annotType, '#heatmap-plot', annotations, fit, height, colorScalingMode);
-                renderMorpheusDotPlot(dataPath, newAnnotPath, annotName, annotType, '#dot-plot', annotations, fit, height);
+                renderHeatmap(dataPath, newAnnotPath, annotName, annotType, '#heatmap-plot', annotations, fit, height, colorScalingMode);
+                renderDotPlot(dataPath, newAnnotPath, annotName, annotType, '#dot-plot', annotations, fit, height);
             }
         });
     }

--- a/app/views/site/_view_gene_expression_heatmap.html.erb
+++ b/app/views/site/_view_gene_expression_heatmap.html.erb
@@ -60,6 +60,9 @@
     $('#dot-plot').data('rendered', false);
     function drawHeatmap(height) {
         $(window).off('resizeEnd');
+
+        $(window).on('resizeEnd', () => { $(window).trigger('resize.morpheus')})
+
         // clear out previous stored heatmap object
         $('#heatmap-plot').data('heatmap', null);
         $('#dot-plot').data('heatmap', null);

--- a/app/views/site/_view_precomputed_gene_expression_heatmap.html.erb
+++ b/app/views/site/_view_precomputed_gene_expression_heatmap.html.erb
@@ -52,7 +52,7 @@
 
             // reset status on render call
             $('#heatmap-plot').data('rendered', false);
-            renderMorpheus(newDataPath, '', '', '', '#heatmap-plot', {}, 'both', null, colorScalingMode);
+            renderHeatmap(newDataPath, '', '', '', '#heatmap-plot', {}, 'both', null, colorScalingMode);
         }
     });
 
@@ -68,7 +68,7 @@
             colorScalingMode = 'fixed';
         }
 
-        renderMorpheus(dataPath, '', '', '', '#heatmap-plot', {}, 'both', null, colorScalingMode);
+        renderHeatmap(dataPath, '', '', '', '#heatmap-plot', {}, 'both', null, colorScalingMode);
     });
 
 </script>


### PR DESCRIPTION
This fixes a UI layout bug in our use of the Morpheus.js heatmap widget.  Previously, upon clicking "View Options", the heatmap would not resize, and overflow into "View Options".  Now, it resizes like other widgets.

Also, heatmap JavaScript has been modularized, like dot plots and other widgets in the Explore tab.

To test:
* Go to a study with visualizations fully initialized, e.g. [here on production](https://singlecell.broadinstitute.org/single_cell/study/SCP1) or [here on staging](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP197).
* In "Explore" tab, search two genes, e.g. "Sergef Setd6"
* Click "Heatmap" tab
* Click "View Options"
* Verify that heatmap resizes

See below for demos of the bug and the fix.

https://user-images.githubusercontent.com/1334561/104224175-99b73f80-5412-11eb-8121-2074967035e6.mov


https://user-images.githubusercontent.com/1334561/104224198-a340a780-5412-11eb-8ae0-e679e8f2d4dd.mov

This satisfies SCP-2968.