### PR TITLE
updating to singlecellportal/rails-baseimage:1.1.0 (SCP-3016)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM singlecellportal/rails-baseimage:1.0.6
+FROM singlecellportal/rails-baseimage:1.1.0
 
 # Set ruby version
-RUN bash -lc 'rvm --default use ruby-2.6.5'
+RUN bash -lc 'rvm --default use ruby-2.6.6'
 RUN bash -lc 'rvm rvmrc warning ignore /home/app/webapp/Gemfile'
 
 # Set up project dir, install gems, set up script to migrate database and precompile static assets on run

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.6.5'
+ruby '2.6.6'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '5.2.4.4'

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -11,7 +11,7 @@ require File.expand_path('ui_test_helper.rb', 'test')
 # Therefore, the following languages/packages must be installed on your host:
 #
 # 1. RVM (or equivalent Ruby language management system)
-# 2. Ruby >= 2.5.1 (currently, 2.5.1 is the version running inside the container)
+# 2. Ruby >= 2.6.6 (currently, 2.6.6 is the version running inside the container)
 # 3. Gems: rubygems, test-unit, selenium-webdriver (see Gemfile.lock for version requirements)
 # 4. Google Chrome
 # 5. Chromedriver (https://sites.google.com/a/chromium.org/chromedriver/); make sure the verison you install works with your version of chrome


### PR DESCRIPTION
Pulling in changes from https://github.com/broadinstitute/scp-rails-baseimage/pull/14 to update to `singlecellportal/rails-baseimage:1.1.0`.  This update includes:

* Ruby 2.6.6
* Phusion Passenger 6.0.7
* Security updates to ubuntu 18.04 operating system

This PR satisfies SCP-3016.