### PR TITLE
fixing mean/median consensus view for multi-gene search (SCP-3015, SCP-2988)

### DIFF
--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -42,18 +42,21 @@ module Api
                                                                     params[:annotation_scope])
           subsample = params[:subsample].blank? ? nil : params[:subsample].to_i
           genes = RequestUtils.get_genes_from_param(@study, params[:genes])
-
-          render_data = ExpressionVizService.get_global_expression_render_data(
-            study: @study,
-            subsample: subsample,
-            genes: genes,
-            cluster: cluster,
-            selected_annotation: annotation,
-            boxpoints: params[:boxpoints],
-            consensus: params[:consensus],
-            current_user: current_api_user
-          )
-          render json: render_data, status: 200
+          if genes.empty?
+            render json: {error: 'You must supply at least one gene'}, status: 422
+          else
+            render_data = ExpressionVizService.get_global_expression_render_data(
+              study: @study,
+              subsample: subsample,
+              genes: genes,
+              cluster: cluster,
+              selected_annotation: annotation,
+              boxpoints: params[:boxpoints],
+              consensus: params[:consensus],
+              current_user: current_api_user
+            )
+            render json: render_data, status: 200
+          end
         end
 
         # this is intended to provide morpheus compatibility, so it returns plain text, instead of json

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -41,7 +41,7 @@ module Api
                                                                     params[:annotation_type],
                                                                     params[:annotation_scope])
           subsample = params[:subsample].blank? ? nil : params[:subsample].to_i
-          genes = self.class.get_genes_from_param(@study, params[:genes])
+          genes = RequestUtils.get_genes_from_param(@study, params[:genes])
 
           render_data = ExpressionVizService.get_global_expression_render_data(
             study: @study,
@@ -61,7 +61,7 @@ module Api
           cluster = ClusterVizService.get_cluster_group(@study, params)
 
           collapse_by = params[:row_centered]
-          genes = self.class.get_genes_from_param(@study, params[:genes])
+          genes = RequestUtils.get_genes_from_param(@study, params[:genes])
 
           expression_data = ExpressionVizService.get_morpheus_text_data(
               genes: genes, cluster: cluster, collapse_by: collapse_by, file_type: :gct
@@ -70,18 +70,7 @@ module Api
           render plain: expression_data, status: 200
         end
 
-        def self.get_genes_from_param(study, gene_param)
-          terms = RequestUtils.sanitize_search_terms(gene_param).split(',')
-          matrix_ids = study.expression_matrix_files.map(&:id)
-          genes = []
-          terms.each do |term|
-            matches = study.genes.by_name_or_id(term, matrix_ids)
-            unless matches.empty?
-              genes << matches
-            end
-          end
-          genes
-        end
+
       end
     end
   end

--- a/app/javascript/lib/study-overview/explore-single.js
+++ b/app/javascript/lib/study-overview/explore-single.js
@@ -29,19 +29,22 @@ import {
   addSpatialDropdown, getMainViewOptions, getAnnotParams, handleMenuChange
 } from 'lib/study-overview/view-options'
 
-/** Render violin and scatter plots for the Explore tab's single-gene view */
+/** Render violin and scatter plots for the Explore tab's single-gene view
+ * this also handles multi-gene plots where the genes are collapsed by mean/median
+ */
 async function renderSingleGenePlots(study, gene) {
   clearPlots()
 
   $('#box-plot').html('')
   $('#scatter-plots .panel-body').html('')
+  const consensus = $('#search_consensus').val()
 
   // Draw violin (or box) plot if showing group annotation, or
   // draw scatter plot if showing numeric annotation
   const annotType = getAnnotParams().type
   if (annotType === 'group') {
     $('#distribution-link').html('Distribution')
-    violinPlot('box-plot', study, gene)
+    violinPlot('box-plot', study, gene, consensus)
   } else {
     $('#distribution-link').html('Annotated Scatter')
     const accession = study.accession
@@ -54,7 +57,14 @@ async function renderSingleGenePlots(study, gene) {
 
   exploreScatterPlots(study, gene, true)
 
-  window.showRelatedGenesIdeogram()
+  const geneList = window.SCP.formatTerms(gene)
+  if (geneList.length > 1) {
+    window.drawHeatmap()
+  } else if (geneList.length === 1) {
+    // only show ideogram for single gene queries
+    window.showRelatedGenesIdeogram()
+  }
+
 }
 
 /** Listen for events, and update view accordingly */
@@ -73,7 +83,12 @@ function attachEventHandlers(study, gene) {
 export default async function exploreSingle() {
   // As set in exploreDefault
   const study = window.SCP.study
-  const gene = window.SCP.gene
+  let gene = window.SCP.gene
+  if (!gene || !gene.length) {
+    // if window.SCP.gene is not defined, read it from the search bar
+    // this happens when, e.g. 'view as' -> 'violin - mean' is selected
+    gene = window.SCP.formatTerms($('#search_genes').val()).join(',')
+  }
 
   attachEventHandlers(study, gene)
 

--- a/app/javascript/lib/violin-plot.js
+++ b/app/javascript/lib/violin-plot.js
@@ -194,6 +194,9 @@ export function renderViolinPlot(target, results) {
 /** Resize Plotly violin -- e.g. upon resizing window or plot container  */
 export function resizeViolinPlot() {
   const rawPlot = violinPlots[0]
+  if (!rawPlot) {
+    return;  // this can happen if resize is called as the graph is being redrawn
+  }
   const title = rawPlot.rendered_cluster
   const expressionLabel = rawPlot.y_axis_title
   const layout = getViolinLayout(title, expressionLabel)
@@ -238,7 +241,7 @@ export function updateDataPoints(mode) {
 }
 
 /** Load expression data and draw violin (or box) plot */
-export async function violinPlot(plotId, study, gene) {
+export async function violinPlot(plotId, study, gene, consensus) {
   const plotDom = document.getElementById(plotId)
   const spinner = new Spinner(window.opts).spin(plotDom)
 
@@ -247,7 +250,7 @@ export async function violinPlot(plotId, study, gene) {
   const { name, type, scope } = getAnnotParams()
 
   const rawPlot = await fetchExpressionViolin(
-    study.accession, gene, cluster, name, type, scope, subsample
+    study.accession, gene, cluster, name, type, scope, subsample, consensus
   )
   rawPlot.plotId = plotId
   rawPlot.plotType = $('#plot_type').val()

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -9,6 +9,7 @@ class ExpressionVizService
                                              current_user:)
     render_data = {}
     render_data[:y_axis_title] = load_expression_axis_title(study)
+
     if selected_annotation[:type] == 'group'
       if genes.count == 1
         render_data[:values] = load_expression_boxplot_data_array_scores(study, genes[0], cluster, selected_annotation, subsample)

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -44,4 +44,18 @@ class RequestUtils
     end
     base_url
   end
+
+  # extracts an array of genes from a comma-delimited string list of gene names
+  def self.get_genes_from_param(study, gene_param)
+    terms = RequestUtils.sanitize_search_terms(gene_param).split(',')
+    matrix_ids = study.expression_matrix_files.map(&:id)
+    genes = []
+    terms.each do |term|
+      matches = study.genes.by_name_or_id(term, matrix_ids)
+      unless matches.empty?
+        genes << matches
+      end
+    end
+    genes
+  end
 end

--- a/app/views/site/_search_options.html.erb
+++ b/app/views/site/_search_options.html.erb
@@ -44,8 +44,8 @@
               <%= f.file_field :upload, class: 'form-control', accept: '.txt,text/plain' %>
             </div>
             <div class="form-group">
-              <%= f.label :consensus, "Collapse genes by <i class='fas fa-question-circle'></i>".html_safe, title: "Multiple genes only: Collapse expression scores of multiple genes for each cell using this metric.  Selecting 'None' will view genes individually as a heatmap.", data: {toggle: 'tooltip', placement: 'right'} %><br/>
-              <%= f.select :consensus, options_for_select([['Mean', 'mean'],['Median', 'median']], params[:consensus]), {include_blank: 'None'}, {class: 'form-control'} %>
+              <%= f.label :consensus, "View as <i class='fas fa-question-circle'></i>".html_safe, title: "Multiple genes only: Selecting one of the 'violin' options will combine expression scores of multiple genes for each cell using the selected metric.", data: {toggle: 'tooltip', placement: 'right'} %><br/>
+              <%= f.select :consensus, options_for_select([['Violin - mean', 'mean'],['Violin - median', 'median']], params[:consensus]), {include_blank: 'Dot plot'}, {class: 'form-control'} %>
             </div>
             <%= link_to "<span class='fas fa-chevron-left'></span> Back".html_safe, "javascript:", class: "btn pull-right #{action_name == 'study' ? 'btn-default disabled' : 'btn-warning'}", id: 'clear-gene-search', title: 'Clear gene search and return to cluster scatter plots', data: {toggle: 'tooltip'} %>
             <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">

--- a/app/views/site/_search_options.html.erb
+++ b/app/views/site/_search_options.html.erb
@@ -44,8 +44,8 @@
               <%= f.file_field :upload, class: 'form-control', accept: '.txt,text/plain' %>
             </div>
             <div class="form-group">
-              <%= f.label :consensus, "View as <i class='fas fa-question-circle'></i>".html_safe, title: "Multiple genes only: Selecting one of the 'violin' options will combine expression scores of multiple genes for each cell using the selected metric.", data: {toggle: 'tooltip', placement: 'right'} %><br/>
-              <%= f.select :consensus, options_for_select([['Violin - mean', 'mean'],['Violin - median', 'median']], params[:consensus]), {include_blank: 'Dot plot'}, {class: 'form-control'} %>
+              <%= f.label :consensus, "Collapse genes by <i class='fas fa-question-circle'></i>".html_safe, title: "Multiple genes only: Collapse expression scores of multiple genes for each cell using this metric.  Selecting 'None' will view genes individually as a heatmap.", data: {toggle: 'tooltip', placement: 'right'} %><br/>
+              <%= f.select :consensus, options_for_select([['Mean', 'mean'],['Median', 'median']], params[:consensus]), {include_blank: 'None'}, {class: 'form-control'} %>
             </div>
             <%= link_to "<span class='fas fa-chevron-left'></span> Back".html_safe, "javascript:", class: "btn pull-right #{action_name == 'study' ? 'btn-default disabled' : 'btn-warning'}", id: 'clear-gene-search', title: 'Clear gene search and return to cluster scatter plots', data: {toggle: 'tooltip'} %>
             <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">


### PR DESCRIPTION
 In addition to fixing the bug, I did *not* update the dropdown to match the language we agreed on for the global gene search collapse control -- the new labels don't make as much sense in a control that's being shown alongside both single and multi-gene search.  And implementing show/hide for that control is outside the scope of this fix

![image](https://user-images.githubusercontent.com/2800795/104648351-00da2b80-5681-11eb-8406-6627d8189ced.png)


To test:
1. open study explore for a study
2. search for two or more genes
3. then use the hamburger menu to the left of the gene search box to select 'violin-mean' or 'violin-median'
4. Observe that a consensus violin plot appears
5. Select 'dot plot' and observe the display reverts to the previous, uncollapsed view 
