### PR TITLE
fixing menu resize bug (SCP-3015)

### DIFF
--- a/app/javascript/lib/study-overview/explore-single.js
+++ b/app/javascript/lib/study-overview/explore-single.js
@@ -59,7 +59,10 @@ async function renderSingleGenePlots(study, gene) {
 
   const geneList = window.SCP.formatTerms(gene)
   if (geneList.length > 1) {
+    // draw the dotPlot for comparison if this is a multi-gene collapsed by mean
     window.drawHeatmap()
+    // reattach the event handlers, since that call removes them
+    attachEventHandlers(study, gene)
   } else if (geneList.length === 1) {
     // only show ideogram for single gene queries
     window.showRelatedGenesIdeogram()
@@ -73,7 +76,8 @@ function attachEventHandlers(study, gene) {
   $(window).off('resizeEnd') // Clear any existing handler
   $(window).on('resizeEnd', () => {
     resizeScatterPlots()
-    if (getAnnotParams().type === 'group') { resizeViolinPlot() }
+    // calling this method is safe even if there is no violin plot currently
+    resizeViolinPlot()
   })
 
   handleMenuChange(renderSingleGenePlots, [study, gene])


### PR DESCRIPTION
Fixes bug where opening the 'view options' tab after doing a 'collapse my mean' would not resize the graph.  

To test:
1. Go to explore tab
2. do a search for 2+ genes
3. select "collapse by" -> "mean"
4. after graph renders, select "view options".  Observe that the graphs resize to make room for the menu