### PR TITLE
improving summary report performance (SCP-2946)

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -109,7 +109,7 @@ class ReportsController < ApplicationController
       else
         studies = @private_studies
       end
-      # build a hash of domain => study count
+      # build a hash of user email domain => study count
       domain_counts = Hash.new(0)
       studies.map {|s| user_domain_hash[s[3]]}.each {|d| domain_counts[d] += 1 }
       user_study_email_dist[study_type] = domain_counts

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -94,7 +94,7 @@
 
     var cellCounts = [{
         x: ['Public', 'Private'],
-        y: [<%= @public_studies.map(&:cell_count).reduce(0, :+) %>, <%= @private_studies.map(&:cell_count).reduce(0, :+) %>],
+        y: [<%= @public_cell_dist.sum %>, <%= @private_cell_dist.sum %>],
         type: 'bar',
         marker: {
             color: [colorBrewerSet[3], colorBrewerSet[4]]
@@ -103,7 +103,7 @@
 
     Plotly.newPlot('plotly-cell-count', cellCounts,
         {
-            title: 'How many cells total are in private or public studies?<br><b>Total number of cells in portal: ' + <%= @all_studies.map(&:cell_count).reduce(0, :+) %> + '</b>',
+            title: 'How many cells total are in private or public studies?<br><b>Total number of cells in portal: ' + <%= @cell_dist.sum %> + '</b>',
             titlefont: plotlyTitleFont,
             font: plotlyLabelFont,
             bargap: 0,


### PR DESCRIPTION
This just improves performance, without doing any refactoring, since we want to make sure this gets out in the upcoming release for Tim to use for his BICCN meeting.  See https://github.com/broadinstitute/single_cell_portal_core/pull/866 for the beginning of a refactoring of reports 

Testing locally, this is ~3x faster, but it's anyone's guess what the production speedup will be.  the main goal was just to eliminate any N+1 queries, as well as avoid hydrating any full study objects into memory.  I also tested this on staging to make sure it would work with a slightly more realistic data set.

(note the test failure seems unrelated)