### PR TITLE
Allowing export of raw study analytics data (SCP-2946)

### DIFF
--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -8,16 +8,17 @@ module Api
       before_action :authenticate_api_user!
 
       def show
-        if !current_api_user.admin?
+        if !current_api_user.acts_like_reporter?
           head 403 and return
         end
 
         report_name = params[:report_name].to_sym
-        if !ReportsService::REPORTS.keys.include?(report_name)
-          render(json: {error: "unrecognized report"}, status: 422) and return
-        end
         response.headers['Content-Disposition'] = "attachment; filename=#{report_name}_data.tsv"
-        render plain: ReportsService.get_report_data(report_name)
+        begin
+          render plain: ReportsService.get_report_data(report_name)
+        rescue ArgumentError => e
+          render json: {error: e.message}, status: 422
+        end
       end
     end
   end

--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -1,0 +1,24 @@
+module Api
+  module V1
+    # reports endpoint.  No swagger docs since this is admin-user only
+    # This returns tsv files
+    class ReportsController < ApiBaseController
+      include ActionController::RequestForgeryProtection
+
+      before_action :authenticate_api_user!
+
+      def show
+        if !current_api_user.admin?
+          head 403 and return
+        end
+
+        report_name = params[:report_name].to_sym
+        if !ReportsService::REPORTS.keys.include?(report_name)
+          render(json: {error: "unrecognized report"}, status: 422) and return
+        end
+        response.headers['Content-Disposition'] = 'attachment; filename=studies_data.tsv'
+        render plain: ReportsService.get_report_data(report_name)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -16,7 +16,7 @@ module Api
         if !ReportsService::REPORTS.keys.include?(report_name)
           render(json: {error: "unrecognized report"}, status: 422) and return
         end
-        response.headers['Content-Disposition'] = 'attachment; filename=studies_data.tsv'
+        response.headers['Content-Disposition'] = "attachment; filename=#{report_name}_data.tsv"
         render plain: ReportsService.get_report_data(report_name)
       end
     end

--- a/app/lib/reports_service.rb
+++ b/app/lib/reports_service.rb
@@ -10,6 +10,7 @@ class ReportsService
     }
   }
 
+  # fetches the report data for the given report, and returns it as a tsv string
   def self.get_report_data(report_name)
     report_obj = REPORTS[report_name.to_sym]
     if report_obj.nil?
@@ -23,6 +24,8 @@ class ReportsService
     return response_array.concat(study_strings).join("\n")
   end
 
+  # returns an array of hashes representing summary data for each study.
+  # each entry in the array is a study
   def self.study_data
     study_fields = []
     all_studies = Study.where(queued_for_deletion: false)

--- a/app/lib/reports_service.rb
+++ b/app/lib/reports_service.rb
@@ -1,0 +1,86 @@
+class ReportsService
+
+  REPORTS = {
+    studies: {
+      name: 'Study Report',
+      service_method: :study_data,
+      data_columns: %i[accession created_at cell_count user_id public view_count
+                       owner_domain owner_email admin_owned metadata_convention
+                       metadata_file_created has_raw_counts]
+    }
+  }
+
+  def self.get_report_data(report_name)
+    report_obj = REPORTS[report_name.to_sym]
+    if report_obj.nil?
+      raise "Unrecognized report #{report_name}"
+    end
+
+    data = ReportsService.send(report_obj[:service_method])
+
+    response_array = [report_obj[:data_columns].join("\t")]
+    study_strings = study_data.map {|study_hash| study_hash.values_at(*report_obj[:data_columns]).join("\t")}
+    return response_array.concat(study_strings).join("\n")
+  end
+
+  def self.study_data
+    study_fields = []
+    all_studies = Study.where(queued_for_deletion: false)
+                        .pluck(:id, :accession, :created_at, :cell_count, :user_id, :public, :view_count)
+                        .map do |id, accession, created_at, cell_count, user_id, public, view_count|
+                          {
+                            id: id,
+                            accession: accession,
+                            created_at: created_at,
+                            cell_count: cell_count,
+                            user_id: user_id,
+                            view_count: view_count,
+                            public: public
+                          }
+                        end
+    # make a hash of study_id => study object
+    study_hash = {}
+    all_studies.each {|s| study_hash[s[:id]] = s}
+
+    # build a hash of study_id => # of shares
+    share_count_hash = Hash.new(0)
+    StudyShare.pluck(:study_id).each { |id| share_count_hash[id] += 1 }
+    # add share_count column to study_hash
+    share_count_hash.each { |id, count| study_hash[id][:share_count] = count }
+
+    # build a hash of user => domain
+    user_domain_hash = Hash.new(0)
+    User.pluck(:id, :email, :admin).each do |id, email, admin|
+      user_domain_hash[id] = {
+        domain: email.split('@').last,
+        email: email,
+        admin: admin
+      }
+    end
+    # add domain column to study_hash
+    study_hash.each do |id, study|
+      study[:owner_domain] = user_domain_hash[study[:user_id]][:domain]
+      study[:owner_email] = user_domain_hash[study[:user_id]][:email]
+      study[:admin_owned] = user_domain_hash[study[:user_id]][:admin]
+    end
+
+    # build a hash of metadata files to study_id
+    metadata_files = StudyFile.where(file_type: 'Metadata')
+                              .pluck(:study_id, :use_metadata_convention, :created_at)
+    metadata_files.each do |study_id, convention, created_at|
+      study_hash[study_id][:metadata_convention] = convention
+      study_hash[study_id][:metadata_file_created] = created_at
+    end
+
+    # build a hash of metadata files to study_id
+    expression_files = StudyFile.where(file_type: 'Expression Matrix')
+                                .pluck(:study_id, 'expression_file_info.is_raw_counts')
+    expression_files.each do |study_id, is_raw_counts, created_at|
+      # mongoid plucks nested fields as {"is_raw_counts"=>true} objects rather than plain values
+      is_raw_counts_val = is_raw_counts.present? ? is_raw_counts['is_raw_counts'] : false
+      study_hash[study_id][:has_raw_counts] = study_hash[study_id][:has_raw_counts] || is_raw_counts_val
+    end
+
+    study_hash.values
+  end
+end

--- a/app/lib/reports_service.rb
+++ b/app/lib/reports_service.rb
@@ -71,17 +71,21 @@ class ReportsService
     metadata_files = StudyFile.where(file_type: 'Metadata')
                               .pluck(:study_id, :use_metadata_convention, :created_at)
     metadata_files.each do |study_id, convention, created_at|
-      study_hash[study_id][:metadata_convention] = convention
-      study_hash[study_id][:metadata_file_created] = created_at
+      if study_hash[study_id] # check so we don't error for orphaned study files
+        study_hash[study_id][:metadata_convention] = convention
+        study_hash[study_id][:metadata_file_created] = created_at
+      end
     end
 
     # build a hash of metadata files to study_id
     expression_files = StudyFile.where(file_type: 'Expression Matrix')
                                 .pluck(:study_id, 'expression_file_info.is_raw_counts')
     expression_files.each do |study_id, is_raw_counts, created_at|
-      # mongoid plucks nested fields as {"is_raw_counts"=>true} objects rather than plain values
-      is_raw_counts_val = is_raw_counts.present? ? is_raw_counts['is_raw_counts'] : false
-      study_hash[study_id][:has_raw_counts] = study_hash[study_id][:has_raw_counts] || is_raw_counts_val
+      if study_hash[study_id] # check so we don't error for orphaned study files
+        # mongoid plucks nested fields as {"is_raw_counts"=>true} objects rather than plain values
+        is_raw_counts_val = is_raw_counts.present? ? is_raw_counts['is_raw_counts'] : false
+        study_hash[study_id][:has_raw_counts] = study_hash[study_id][:has_raw_counts] || is_raw_counts_val
+      end
     end
 
     study_hash.values

--- a/app/lib/reports_service.rb
+++ b/app/lib/reports_service.rb
@@ -14,7 +14,7 @@ class ReportsService
   def self.get_report_data(report_name)
     report_obj = REPORTS[report_name.to_sym]
     if report_obj.nil?
-      raise "Unrecognized report #{report_name}"
+      raise ArgumentError.new("Unrecognized report: '#{report_name}'")
     end
 
     data = ReportsService.send(report_obj[:service_method])

--- a/app/lib/reports_service.rb
+++ b/app/lib/reports_service.rb
@@ -68,7 +68,7 @@ class ReportsService
     end
 
     # build a hash of metadata files to study_id
-    metadata_files = StudyFile.where(file_type: 'Metadata')
+    metadata_files = StudyFile.where(file_type: 'Metadata', queued_for_deletion: false)
                               .pluck(:study_id, :use_metadata_convention, :created_at)
     metadata_files.each do |study_id, convention, created_at|
       if study_hash[study_id] # check so we don't error for orphaned study files
@@ -78,7 +78,7 @@ class ReportsService
     end
 
     # build a hash of metadata files to study_id
-    expression_files = StudyFile.where(file_type: 'Expression Matrix')
+    expression_files = StudyFile.where(file_type: 'Expression Matrix', queued_for_deletion: false)
                                 .pluck(:study_id, 'expression_file_info.is_raw_counts')
     expression_files.each do |study_id, is_raw_counts, created_at|
       if study_hash[study_id] # check so we don't error for orphaned study files

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -2,7 +2,7 @@
 <h3 class="lead">Updated as of <%= Time.zone.now.strftime("%A, %B %-d %Y %r") %> <%= link_to "<i class='fas fa-toggle-on'></i> Toggle Totals".html_safe, '#/', class: 'btn btn-default pull-right', id: 'toggle-column-annots' %></h3>
 <div class="row">
   <div class="col-md-12">
-    <%= link_to 'Raw study data tsv', api_v1_report_url('studies'), class: 'float-right'%>
+    <%= link_to 'Raw study data tsv', api_v1_report_url('studies') %>
   </div>
 </div>
 <div class="row">

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,6 +1,11 @@
 <h1>Reports <%= link_to "<i class='fas fa-fw fa-chart-bar'></i> Request a new plot".html_safe, report_request_path, class: 'btn btn-primary pull-right', id: 'report-request' %></h1>
 <h3 class="lead">Updated as of <%= Time.zone.now.strftime("%A, %B %-d %Y %r") %> <%= link_to "<i class='fas fa-toggle-on'></i> Toggle Totals".html_safe, '#/', class: 'btn btn-default pull-right', id: 'toggle-column-annots' %></h3>
 <div class="row">
+  <div class="col-md-12">
+    <%= link_to 'Raw study data tsv', api_v1_report_url('studies'), class: 'float-right'%>
+  </div>
+</div>
+<div class="row">
   <div class="col-md-6">
     <div id="plotly-study-count" class="plotly-report"></div>
   </div>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -2,7 +2,7 @@
 <h3 class="lead">Updated as of <%= Time.zone.now.strftime("%A, %B %-d %Y %r") %> <%= link_to "<i class='fas fa-toggle-on'></i> Toggle Totals".html_safe, '#/', class: 'btn btn-default pull-right', id: 'toggle-column-annots' %></h3>
 <div class="row">
   <div class="col-md-12">
-    <%= link_to 'Raw study data tsv', api_v1_report_url('studies') %>
+    <%= link_to 'Raw study data TSV', api_v1_report_url('studies') %>
   </div>
 </div>
 <div class="row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
               constraints: {version: /.*/}
         end
         resources :taxons, only: [:index, :show]
+        resources :reports, only: [:show], param: :report_name
         resources :studies, only: [:index, :show, :create, :update, :destroy] do
           post 'study_files/bundle', to: 'study_files#bundle', as: :study_files_bundle_files
           resources :study_files, only: [:index, :show, :create, :update, :destroy] do

--- a/test/api/reports_controller_test.rb
+++ b/test/api/reports_controller_test.rb
@@ -1,0 +1,39 @@
+require 'api_test_helper'
+require 'test_helper'
+
+class ReportsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+  include Requests::JsonHelpers
+  include Requests::HttpHelpers
+  include Minitest::Hooks
+  include ::SelfCleaningSuite
+  include ::TestInstrumentor
+
+  before(:all) do
+    @user = FactoryBot.create(:api_user, test_array: @@users_to_clean)
+    @admin_user =  FactoryBot.create(:api_user, admin: true, test_array: @@users_to_clean)
+  end
+
+  test 'access control enforced' do
+    sign_in_and_update @user
+    execute_http_request(:get, api_v1_report_path('studies'), user: @user)
+    assert_equal 403, response.status
+
+    sign_in_and_update @admin_user
+    execute_http_request(:get, api_v1_report_path('studies'), user: @admin_user)
+    assert_equal 200, response.status
+  end
+
+  test 'invalid report name rejected' do
+    sign_in_and_update @admin_user
+    execute_http_request(:get, api_v1_report_path('blahblah'), user: @admin_user)
+    assert_equal 422, response.status
+  end
+
+  test 'can fetch study report' do
+    sign_in_and_update @admin_user
+    execute_http_request(:get, api_v1_report_path('studies'), user: @admin_user)
+    assert_equal 200, response.status
+    assert response.body.starts_with?("accession\tcreated_at\tcell_count")
+  end
+end

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -20,12 +20,14 @@ FactoryBot.define do
                             study_file: file)
 
         end
-        FactoryBot.create(:data_array,
-                          array_type: 'cells',
-                          name: 'All Cells',
-                          array_index: 0,
-                          values: evaluator.cell_input,
-                          study_file: file)
+        if !evaluator.cell_input.empty?
+          FactoryBot.create(:data_array,
+                            array_type: 'cells',
+                            name: 'All Cells',
+                            array_index: 0,
+                            values: evaluator.cell_input,
+                            study_file: file)
+        end
       end
     end
     factory :cluster_file do

--- a/test/integration/lib/reports_service_test.rb
+++ b/test/integration/lib/reports_service_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class ReportsServiceTest < ActiveSupport::TestCase
+  include Minitest::Hooks
+  include TestInstrumentor
+  include SelfCleaningSuite
+
+  before(:all) do
+    @user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    @user2 = FactoryBot.create(:user, test_array: @@users_to_clean)
+    @basic_study = FactoryBot.create(:detached_study,
+                                     name_prefix: 'report service test',
+                                     test_array: @@studies_to_clean,
+                                     user: @user)
+    @study_metadata_file = FactoryBot.create(:metadata_file,
+                                             use_metadata_convention: true,
+                                             name: 'metadata.txt',
+                                             study: @basic_study)
+
+    @study_expression_file = FactoryBot.create(:expression_file,
+                                               expression_file_info: {
+                                                 is_raw_counts: true,
+                                                 units: 'raw counts',
+                                                 library_preparation_protocol: 'Drop-seq',
+                                                 biosample_input_type: 'Whole cell',
+                                                 modality: 'Proteomic'
+                                               },
+                                               name: 'expression.txt',
+                                               study: @basic_study)
+  end
+
+  test 'study_data return array of hashes with correct study information' do
+    report_data = ReportsService.study_data
+    assert_equal Study.count, report_data.count
+    basic_study_row = report_data.select {|r| r[:id] == @basic_study.id}.first
+    assert_equal @basic_study.accession, basic_study_row[:accession]
+    assert_equal @user.email, basic_study_row[:owner_email]
+    assert_equal 'test.edu', basic_study_row[:owner_domain]
+    assert_equal true, basic_study_row[:metadata_convention]
+    assert_equal true, basic_study_row[:has_raw_counts]
+  end
+
+  test 'get_report returns tsv' do
+    report_string = ReportsService.get_report_data('studies')
+    assert report_string.starts_with?(ReportsService::REPORTS[:studies][:data_columns].join("\t"))
+    assert report_string.include?(@user.email)
+  end
+end

--- a/test/integration/lib/reports_service_test.rb
+++ b/test/integration/lib/reports_service_test.rb
@@ -31,7 +31,7 @@ class ReportsServiceTest < ActiveSupport::TestCase
 
   test 'study_data return array of hashes with correct study information' do
     report_data = ReportsService.study_data
-    assert_equal Study.count, report_data.count
+    assert_equal Study.where(queued_for_deletion: false).count, report_data.count
     basic_study_row = report_data.select {|r| r[:id] == @basic_study.id}.first
     assert_equal @basic_study.accession, basic_study_row[:accession]
     assert_equal @user.email, basic_study_row[:owner_email]


### PR DESCRIPTION
Goal is to export a plain tsv of useful study info (available only to admins), so that we can can slice and dice the numbers in our tool of choice.  We could also eventually build a nice interactive reports page on the site, but that's a task for another day.  This adds a link on the report page to download a tsv 

![image](https://user-images.githubusercontent.com/2800795/104988130-4bdba200-59e5-11eb-8931-77472fccf32b.png)

Notably, this tries a new pattern for hybrid API/site cookie validation.  This allows a single controller to support both plain links on the site from logged-in users, as well as bearer token auth.  I think this is actually a superior pattern to the URL_SAFE_TOKEN_ALLOWED_ACTIONS pattern we're using to allow embedded morpheus widgets to hit our API.  So if you all approve, after this is merged, I will convert those, and simplify authenticator.rb accordingly.  We should really only have to use totat-like constructs for users who aren't on the site.

To test:
1. log in as admin user
2. go to 'reports'
3. click 'raw study data tsv'
4. observe the downloaded tsv file, and that it matches the studies in the DB