### PR TITLE
fixing 'no files available' logic in study download (SCP-3027)

### DIFF
--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -31,7 +31,7 @@
                   </thead>
                 </table>
               <% end %>
-              Then <%= link_to "click here".html_safe, "#{generate_manifest_study_url(@study)}" %> for the manifest.json containing file supplementary information (units, protocols, etc...)
+              Then <%= link_to "click here".html_safe, "#{generate_manifest_study_url(@study)}" %> for the file_supplemental_info.tsv containing file supplementary information (units, protocols, etc...)
             <% elsif @study.public? && !@user_embargoed || current_user.admin? %>
               <p class="lead">To download all files using <code>curl</code>, click the button below to get the download command:</p>
               <p class="lead command-container" id="command-container-all"><%= link_to "<i class='fas fa-download'></i> Get download command for all study data".html_safe, '#/', class: 'btn btn-default get-download-command', id: 'get-download-command_all' %></p>
@@ -53,10 +53,10 @@
                     <% end %>
                   </thead>
                 </table>
-              <% else %>
-                <%# The user is trying to download a public study that is currently embargoed. %>
-                <p class="lead">No downloads are available to you for this study yet</p>
               <% end %>
+            <% else %>
+              <%# The user is trying to download a public study that is currently embargoed. %>
+              <p class="lead">No downloads are available to you for this study yet</p>
             <% end %>
           </div>
           <div class="modal-footer">
@@ -186,7 +186,7 @@
       </tr>
     <% end %>
       <tr>
-        <td>manifest.json <i>(auto-generated)</i></td>
+        <td>file_supplemental_info.tsv <i>(auto-generated)</i></td>
         <td>Listing of all study files, and any supplementary information (units, protocols, etc...)</td>
         <td></td>
         <td></td>


### PR DESCRIPTION
Fixes if/else logic so that 'no downloads are available for you' only shows when appropriate (I suspect the logic got corrupted in a merge conflict resolution).

Adds quote-escaping to manifest download path.

updates filename in page description to match the name of downloaded manifest

TO TEST:
1. Log in as a user that does NOT have direct bucket access to a study (e.g. not the user who created the study)
2. Go to the 'download' tab of a study that user has access to, but not direct bucket access
3. click 'bulk download'
4. Observe that the file list is correct
5. download the files, and confirm success