### PR TITLE
Check for presence of redirect route before returning (SCP-2991)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -140,7 +140,8 @@ class ApplicationController < ActionController::Base
 
   # merge in extra parameters on redirects as necessary
   def merge_default_redirect_params(redirect_route, extra_params={})
-    merged_redirect_url = redirect_route.dup
+    # handle case where request.referrer is nil
+    merged_redirect_url = redirect_route.present? ? redirect_route.dup : site_path.dup
     extra_params.each do |key, value|
       if value.present?
         if redirect_route.include?('?')

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -72,7 +72,7 @@ class TaxonsController < ApplicationController
     if annotation_link.present?
       redirect_to annotation_link and return
     else
-      redirect_to request.referrer, alert: "Unable to generate a public link for '#{@taxon.genome_annotation_link}'.  Please try again."
+      redirect_to taxons_path, alert: "Unable to generate a public link for '#{@taxon.genome_annotation_link}'.  Please try again."
     end
   end
 


### PR DESCRIPTION
Several places call `redirect_to merge_default_redirect_params(request.referrer, ...)` to handle errors and redirect the user back to wherever they were while displaying a contextual error message.  However, if I user is copy/pasting a URL into a browser, or clicking a link from some other external resource, `request.referrer` may not be set, which will raise an uncaught exception and display the "Something went wrong" page.

This update checks for the presence of `request.referrer`, and if not set, sets the home page as the redirect target.  Since nearly all instances of `request.referrer` are used in concert with `merge_default_redirect_params`, the error handling is done inside this method.

This PR satisfies SCP-2991.