### PR TITLE
Report all ingest jobs to Mixpanel on completion (SCP-2941)

### DIFF
--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -305,6 +305,7 @@ class IngestJob
       SingleCellMailer.notify_user_parse_complete(self.user.email, subject, message, self.study).deliver_now
       self.set_study_state_after_ingest
       self.study_file.invalidate_cache_by_file_type # clear visualization caches for file
+      self.log_to_mixpanel
     elsif self.done? && self.failed?
       Rails.logger.error "IngestJob poller: #{self.pipeline_name} has failed."
       # log errors to application log for inspection
@@ -321,6 +322,7 @@ class IngestJob
       SingleCellMailer.notify_user_parse_fail(self.user.email, subject, user_email_content, self.study).deliver_now
       admin_email_content = self.generate_error_email_body(email_type: :dev)
       SingleCellMailer.notify_admin_parse_fail(self.user.email, subject, admin_email_content).deliver_now
+      self.log_to_mixpanel
     else
       Rails.logger.info "IngestJob poller: #{self.pipeline_name} is not done; queuing check for #{run_at}"
       self.delay(run_at: run_at).poll_for_completion
@@ -511,7 +513,69 @@ class IngestJob
     end
   end
 
-  # generates parse completion email body, and logs analytics to Mixpanel
+  # logs analytics to Mixpanel
+  #
+  # * *yields*
+  #  - MetricsService.log => Hash of job attributes/statistics, which are reported to Mixpanel via
+  def log_to_mixpanel
+    file_type = self.study_file.file_type
+    # Event properties to log to Mixpanel.
+    # Mixpanel uses camelCase for props; snake_case would degrade Mixpanel UX.
+    mixpanel_log_props = {
+      perfTime: self.get_total_runtime_ms, # Latency in milliseconds
+      fileType: file_type,
+      fileSize: self.study_file.upload_file_size,
+      action: self.action,
+      studyAccession: self.study.accession,
+      jobStatus: self.failed? ? 'failed' : 'success'
+    }
+
+    case file_type
+    when /Matrix/
+      # since genes are not ingested for raw counts matrices, report number of cells ingested
+      if self.study_file.is_raw_counts_file?
+        cells = self.study.expression_matrix_cells(self.study_file).count
+        mixpanel_log_props.merge!({:numCells => cells})
+      else
+        genes = Gene.where(study_id: self.study.id, study_file_id: self.study_file.id).count
+        mixpanel_log_props.merge!({:numGenes => genes})
+      end
+    when 'Metadata'
+      use_metadata_convention = self.study_file.use_metadata_convention
+      mixpanel_log_props.merge!({useMetadataConvention: use_metadata_convention})
+      if use_metadata_convention
+        project_name = 'alexandria_convention' # hard-coded is fine for now, consider implications if we get more projects
+        current_schema_version = get_latest_schema_version(project_name)
+        mixpanel_log_props.merge!(
+          {
+            metadataConvention: project_name,
+            schemaVersion: current_schema_version
+          }
+        )
+      end
+    when 'Cluster'
+      cluster = ClusterGroup.find_by(study_id: self.study.id, study_file_id: self.study_file.id)
+      if self.action == :ingest_cluster
+        cluster_type = cluster.cluster_type
+        cluster_points = cluster.points
+        can_subsample = cluster.can_subsample?
+        metadata_file_present = self.study.metadata_file.present?
+        mixpanel_log_props.merge!(
+          {
+            clusterType: cluster_type,
+            numClusterPoints: cluster_points,
+            canSubsample: can_subsample,
+            metadataFilePresent: metadata_file_present
+          }
+        )
+      end
+    end
+
+    # log job properties to Mixpanel
+    MetricsService.log('ingest', mixpanel_log_props, self.user)
+  end
+
+  # generates parse completion email body
   #
   # * *returns*
   #   - (Array) => List of message strings to print in a completion email
@@ -520,43 +584,24 @@ class IngestJob
 
     message = ["Total parse time: #{self.get_total_runtime}"]
 
-    # Event properties to log to Mixpanel.
-    # Mixpanel uses camelCase for props; snake_case would degrade Mixpanel UX.
-    mixpanel_log_props = {
-      perfTime: self.get_total_runtime_ms, # Latency in milliseconds
-      fileType: file_type,
-      fileSize: self.study_file.upload_file_size,
-      action: self.action,
-      studyAccession: self.study.accession
-    }
-
     case file_type
     when /Matrix/
       # since genes are not ingested for raw counts matrices, report number of cells ingested
       if self.study_file.is_raw_counts_file?
         cells = self.study.expression_matrix_cells(self.study_file).count
         message << "Cells ingested: #{cells}"
-        mixpanel_log_props.merge!({:numCells => cells})
       else
         genes = Gene.where(study_id: self.study.id, study_file_id: self.study_file.id).count
         message << "Gene-level entries created: #{genes}"
-        mixpanel_log_props.merge!({:numGenes => genes})
       end
     when 'Metadata'
       use_metadata_convention = self.study_file.use_metadata_convention
-      mixpanel_log_props.merge!({
-        useMetadataConvention: use_metadata_convention,
-      })
       if use_metadata_convention
         project_name = 'alexandria_convention' # hard-coded is fine for now, consider implications if we get more projects
         current_schema_version = get_latest_schema_version(project_name)
         schema_url = 'https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-Convention'
         message << "This metadata file was validated against the latest <a href='#{schema_url}'>Metadata Convention</a>"
         message << "Convention version: <strong>#{project_name}/#{current_schema_version}</strong>"
-        mixpanel_log_props.merge!({
-          metadataConvention: project_name,
-          schemaVersion: current_schema_version
-        })
       end
       cell_metadata = CellMetadatum.where(study_id: self.study.id, study_file_id: self.study_file.id)
       message << "Entries created:"
@@ -588,21 +633,11 @@ class IngestJob
           message << "You will receive an additional email once this has completed."
           message << "While subsamples are being computed, you will not be able to remove this cluster file or your metadata file."
         end
-
-        mixpanel_log_props.merge!({
-          clusterType: cluster_type,
-          numClusterPoints: cluster_points,
-          canSubsample: can_subsample,
-          metadataFilePresent: metadata_file_present
-        })
       else
         message << "Subsampling has completed for #{cluster.name}"
         message << "Subsamples generated: #{cluster.subsample_thresholds_required.join(', ')}"
       end
     end
-
-    MetricsService.log('ingest', mixpanel_log_props, user)
-
     message
   end
 

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -533,8 +533,9 @@ class IngestJob
     case file_type
     when /Matrix/
       # since genes are not ingested for raw counts matrices, report number of cells ingested
-      cells = self.study.expression_matrix_cells(self.study_file).count
-      job_props.merge!({:numCells => cells})
+      cells = self.study.expression_matrix_cells(self.study_file)
+      cell_count = cells.present? ? cells.count : 0
+      job_props.merge!({:numCells => cell_count})
       if !self.study_file.is_raw_counts_file?
         genes = Gene.where(study_id: self.study.id, study_file_id: self.study_file.id).count
         job_props.merge!({:numGenes => genes})

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -22,6 +22,7 @@ class IngestJobTest < ActiveSupport::TestCase
     @basic_study_exp_file.build_expression_file_info(is_raw_counts: false, library_preparation_protocol: 'MARS-seq',
                                                      modality: 'Transcriptomic: unbiased', biosample_input_type: 'Whole cell')
     @basic_study_exp_file.parse_status = 'parsed'
+    @basic_study_exp_file.upload_file_size = 1024
     @basic_study_exp_file.save!
 
     # insert "all cells" array for this expression file
@@ -35,6 +36,7 @@ class IngestJobTest < ActiveSupport::TestCase
                                        study: @basic_study)
     @other_matrix.build_expression_file_info(is_raw_counts: false, library_preparation_protocol: 'MARS-seq',
                                              modality: 'Transcriptomic: unbiased', biosample_input_type: 'Whole cell')
+    @other_matrix.upload_file_size = 2048
     @other_matrix.save!
   end
 
@@ -78,4 +80,63 @@ class IngestJobTest < ActiveSupport::TestCase
 
   end
 
+  test 'should gather job properties to report to mixpanel' do
+    # positive test
+    job = IngestJob.new(study: @basic_study, study_file: @basic_study_exp_file, user: @user, action: :ingest_expression)
+    mock = Minitest::Mock.new
+    now = DateTime.now.in_time_zone
+    mock_metadata = {
+      events: [
+        {timestamp: now.to_s},
+        {timestamp: (now + 1.minute).to_s}
+      ]
+    }.with_indifferent_access
+    mock.expect :metadata, mock_metadata
+    mock.expect :error, nil
+
+    ApplicationController.papi_client.stub :get_pipeline, mock do
+      expected_outputs = {
+        perfTime: 60000,
+        fileType: @basic_study_exp_file.file_type,
+        fileSize: @basic_study_exp_file.upload_file_size,
+        action: :ingest_expression,
+        studyAccession: @basic_study.accession,
+        jobStatus: 'success',
+        numGenes: 1
+      }.with_indifferent_access
+
+      job_analytics = job.get_job_analytics
+      mock.verify
+      assert_equal expected_outputs, job_analytics
+    end
+
+    # negative test
+    job = IngestJob.new(study: @basic_study, study_file: @other_matrix, user: @user, action: :ingest_expression)
+    mock = Minitest::Mock.new
+    now = DateTime.now.in_time_zone
+    mock_metadata = {
+      events: [
+        {timestamp: now.to_s},
+        {timestamp: (now + 2.minutes).to_s}
+      ]
+    }.with_indifferent_access
+    mock.expect :metadata, mock_metadata
+    mock.expect :error, {code: 1, message: 'mock message'} # simulate error
+
+    ApplicationController.papi_client.stub :get_pipeline, mock do
+      expected_outputs = {
+        perfTime: 120000,
+        fileType: @other_matrix.file_type,
+        fileSize: @other_matrix.upload_file_size,
+        action: :ingest_expression,
+        studyAccession: @basic_study.accession,
+        jobStatus: 'failed',
+        numGenes: 0
+      }.with_indifferent_access
+
+      job_analytics = job.get_job_analytics
+      mock.verify
+      assert_equal expected_outputs, job_analytics
+    end
+  end
 end

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -94,6 +94,9 @@ class IngestJobTest < ActiveSupport::TestCase
     mock.expect :metadata, mock_metadata
     mock.expect :error, nil
 
+    cells = @basic_study.expression_matrix_cells(@basic_study_exp_file)
+    num_cells = cells.present? ? cells.count : 0
+
     ApplicationController.papi_client.stub :get_pipeline, mock do
       expected_outputs = {
         perfTime: 60000,
@@ -103,7 +106,7 @@ class IngestJobTest < ActiveSupport::TestCase
         studyAccession: @basic_study.accession,
         jobStatus: 'success',
         numGenes: @basic_study.genes.count,
-        numCells: @basic_study.expression_matrix_cells(@basic_study_exp_file).count
+        numCells: num_cells
       }.with_indifferent_access
 
       job_analytics = job.get_job_analytics

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -102,7 +102,7 @@ class IngestJobTest < ActiveSupport::TestCase
         action: :ingest_expression,
         studyAccession: @basic_study.accession,
         jobStatus: 'success',
-        numGenes: 1
+        numGenes: @basic_study.genes.count
       }.with_indifferent_access
 
       job_analytics = job.get_job_analytics

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -102,7 +102,8 @@ class IngestJobTest < ActiveSupport::TestCase
         action: :ingest_expression,
         studyAccession: @basic_study.accession,
         jobStatus: 'success',
-        numGenes: @basic_study.genes.count
+        numGenes: @basic_study.genes.count,
+        numCells: @basic_study.expression_matrix_cells(@basic_study_exp_file).count
       }.with_indifferent_access
 
       job_analytics = job.get_job_analytics
@@ -131,7 +132,8 @@ class IngestJobTest < ActiveSupport::TestCase
         action: :ingest_expression,
         studyAccession: @basic_study.accession,
         jobStatus: 'failed',
-        numGenes: 0
+        numGenes: 0,
+        numCells: 0
       }.with_indifferent_access
 
       job_analytics = job.get_job_analytics


### PR DESCRIPTION
Previously, only ingest jobs that completed without error were reported to Mixpanel (DSP metrics/analytics tool).  Any job encountering an error that prevented it from completing would be reported to Sentry, and an error email is sent to the user, as well as portal admins.  The only way to gather statistics on failed ingest jobs is by manually collating data from these emails/error reports.  This means that the team lacks detailed real-time analytics into ingest jobs that have failed, which hampers abilities to improve the ingest experience as a whole.

This update now reports all ingest jobs to Mixpanel upon completion, regardless of whether the job has succeeded or failed.  An extra property of `jobStatus` has been added to log the outcome of the job (`success` or `failed`).  All Mixpanel logging code for `IngestJob` has been refactored out into separate methods to aid in reporting and testing.

This PR satisfies SCP-2941.