### PR TITLE
* SCP-2763 Send user metric ID to ingest pipeline

### DIFF
--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -98,7 +98,7 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
     study = study_file.study
     accession = study.accession
     resources = self.create_resources_object(regions: ['us-central1'])
-    command_line = self.get_command_line(study_file: study_file, action: action,  user_metrics_uuid: user.metrics_uuid)
+    command_line = self.get_command_line(study_file: study_file, action: action, user_metrics_uuid: user.metrics_uuid)
     labels = {
         study_accession: accession,
         user_id: user.id.to_s,

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -98,7 +98,7 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
     study = study_file.study
     accession = study.accession
     resources = self.create_resources_object(regions: ['us-central1'])
-    command_line = self.get_command_line(study_file: study_file, action: action)
+    command_line = self.get_command_line(study_file: study_file, action: action,  user_metrics_uuid: user.metrics_uuid)
     labels = {
         study_accession: accession,
         user_id: user.id.to_s,
@@ -266,10 +266,10 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   #
   # * *raises*
   #   - (ArgumentError) => The requested StudyFile and action do not correspond with each other, or cannot be run yet
-  def get_command_line(study_file:, action:)
+  def get_command_line(study_file:, action:, user_metrics_uuid:)
     validate_action_by_file(action, study_file)
     study = study_file.study
-    command_line = "python ingest_pipeline.py --study-id #{study.id} --study-file-id #{study_file.id} #{action}"
+    command_line = "python ingest_pipeline.py --study-id #{study.id} --study-file-id #{study_file.id} --user-metrics-uuid #{user_metrics_uuid} #{action}"
     case action.to_s
     when 'ingest_expression'
       if study_file.file_type == 'Expression Matrix'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,12 +10,12 @@
 user_access_token = {access_token: 'test-api-token', expires_in: 3600, expires_at: Time.zone.now + 1.hour}
 user_2_access_token = {access_token: 'test-api-token-2', expires_in: 3600, expires_at: Time.zone.now + 1.hour}
 user = User.find_or_initialize_by(email:'testing.user@gmail.com')
-user.update!(password:'password', admin: true, uid: '12345',
+user.update!(password:'password', admin: true, uid: '12345', metrics_uuid: SecureRandom.uuid, 
              api_access_token: user_access_token, access_token: user_access_token, registered_for_firecloud: true,
              authentication_token: Devise.friendly_token(32))
 user_2 = User.find_or_initialize_by(email: 'sharing.user@gmail.com')
 user_2.update!(password: 'password', uid: '67890',
-               api_access_token: user_2_access_token, access_token: user_2_access_token)
+               api_access_token: user_2_access_token, access_token: user_2_access_token, metrics_uuid: SecureRandom.uuid)
 
 TosAcceptance.create(email: user.email)
 TosAcceptance.create(email: user_2.email)
@@ -144,7 +144,7 @@ StudyFileBundle.create!(bundle_type: 'BAM', original_file_list: [{'name' => 'sam
 resource = api_study.external_resources.build(url: 'https://singlecell.broadinstitute.org', title: 'SCP',
                                               description: 'Link to Single Cell Portal')
 resource.save!
-api_user = User.create!(email:'testing.user.2@gmail.com', password:'someotherpassword',
+api_user = User.create!(email:'testing.user.2@gmail.com', password:'someotherpassword', metrics_uuid: SecureRandom.uuid,
              api_access_token: {access_token: 'test-api-token-2', expires_in: 3600, expires_at: Time.zone.now + 1.hour})
 
 # Analysis Configuration seeds

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     end
     email { "test.user.#{random_seed}@test.edu" }
     password { "test_password" }
+    metrics_uuid { SecureRandom.uuid }
     after(:create) do |user, evaluator|
       if evaluator.test_array
         evaluator.test_array.push(user)


### PR DESCRIPTION
This PR passes a user's metric ID to Ingest pipeline so that the user identifier is included in Ingest pipeline's logs. The Papi command now looks like:

```
  - python
  - ingest_pipeline.py
  - "--study-id"
  - 600f3b56fa6429c7942c7152
  - "--study-file-id"
  - 60103546fa6429c7942c715f
  - "--user-metrics-uuid"
  - <user uuid>
  - ingest_cell_metadata
  - "--cell-metadata-file"
  - gs://<bucket location>/metadata_example.txt
  - "--study-accession"
  - SCP78
  - "--ingest-cell-metadata"
  ```

This PR has to be release  [pull #203](https://github.com/broadinstitute/scp-ingest-pipeline/pull/203) in ingest pipeline