### PR TITLE
Adding resource links to single-study API endpoint (SCP-3038)

### DIFF
--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -57,7 +57,7 @@ module Api
               'Site'
           ]
           key :summary, 'View a Study & available StudyFiles'
-          key :description, 'View a single Study, and any StudyFiles available for download/streaming'
+          key :description, 'View a single Study, and any StudyFiles available for download/streaming, plus ExternalResource links'
           key :operationId, 'site_study_view_path'
           parameter do
             key :name, :accession
@@ -67,7 +67,7 @@ module Api
             key :type, :string
           end
           response 200 do
-            key :description, 'Study, Array of StudyFiles'
+            key :description, 'Study, Array of StudyFiles, ExternalResources'
             schema do
               key :title, 'Study, StudyFiles'
               key :'$ref', :SiteStudyWithFiles

--- a/app/models/analysis_configuration.rb
+++ b/app/models/analysis_configuration.rb
@@ -4,7 +4,7 @@ class AnalysisConfiguration
   extend ValidationTools
 
   belongs_to :user
-  has_many :external_resources, as: :resource_links
+  has_many :external_resources, as: :resource_links, dependent: :destroy
   accepts_nested_attributes_for :external_resources, allow_destroy: true
 
   swagger_schema :AnalysisConfigurationList do

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -60,6 +60,11 @@ class Study
     def valid
       where(queued_for_deletion: false, :generation.ne => nil).to_a
     end
+
+    # includes links to external data which do not reside in the workspace bucket
+    def downloadable
+      where(queued_for_deletion: false).any_of({:generation.ne => nil}, {:human_fastq_url.ne => nil})
+    end
   end
 
   has_many :study_file_bundles, dependent: :destroy do

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -188,7 +188,7 @@ class Study
   has_one :study_accession
 
   # External Resource links
-  has_many :external_resources, as: :resource_links, dependent: :delete
+  has_many :external_resources, as: :resource_links, dependent: :destroy
 
   # Study Detail (full html description)
   has_one :study_detail, dependent: :delete
@@ -530,6 +530,14 @@ class Study
       items do
         key :title, 'StudyFile'
         key '$ref', 'SiteStudyFile'
+      end
+    end
+    property :external_resources do
+      key :type, :array
+      key :description, 'Available external resource links'
+      items do
+        key :title, 'ExternalResource'
+        key '$ref', :ExternalResourceInput
       end
     end
   end

--- a/app/views/api/v1/site/_study.json.jbuilder
+++ b/app/views/api/v1/site/_study.json.jbuilder
@@ -9,7 +9,7 @@ json.set! :gene_count, study.gene_count
 if study.detached
   json.set! :study_files, 'Unavailable (cannot load study workspace or bucket)'
 else
-  json.study_files study.study_files.valid, partial: 'api/v1/site/study_file', as: :study_file, locals: {study: study}
+  json.study_files study.study_files.downloadable, partial: 'api/v1/site/study_file', as: :study_file, locals: {study: study}
 end
 json.external_resources do
   json.array! study.external_resources do |external_resource|

--- a/app/views/api/v1/site/_study.json.jbuilder
+++ b/app/views/api/v1/site/_study.json.jbuilder
@@ -9,7 +9,7 @@ json.set! :gene_count, study.gene_count
 if study.detached
   json.set! :study_files, 'Unavailable (cannot load study workspace or bucket)'
 else
-  json.study_files study.study_files, partial: 'api/v1/site/study_file', as: :study_file, locals: {study: study}
+  json.study_files study.study_files.valid, partial: 'api/v1/site/study_file', as: :study_file, locals: {study: study}
 end
 json.external_resources do
   json.array! study.external_resources do |external_resource|

--- a/app/views/api/v1/site/_study.json.jbuilder
+++ b/app/views/api/v1/site/_study.json.jbuilder
@@ -11,3 +11,11 @@ if study.detached
 else
   json.study_files study.study_files, partial: 'api/v1/site/study_file', as: :study_file, locals: {study: study}
 end
+json.external_resources do
+  json.array! study.external_resources do |external_resource|
+    json.set! :title, external_resource.title
+    json.set! :description, external_resource.description
+    json.set! :url, external_resource.url
+    json.set! :publication_url, external_resource.publication_url
+  end
+end

--- a/db/migrate/20210125191551_clean_up_orphaned_external_resources.rb
+++ b/db/migrate/20210125191551_clean_up_orphaned_external_resources.rb
@@ -1,0 +1,15 @@
+class CleanUpOrphanedExternalResources < Mongoid::Migration
+  def self.up
+    ids_to_delete = []
+    ExternalResource.all.each do |external_resource|
+      # external_resource.resource_links will call back to the parent object, be it a study or analysis_configuration
+      # due to a mis-configuration on both associations, external_resource objects have not been destroyed when their
+      # parent object is destroyed, leading to many orphaned records
+      ids_to_delete << external_resource.id if external_resource.resource_links.nil?
+    end
+    ExternalResource.where(:id.in => ids_to_delete).delete_all
+  end
+
+  def self.down
+  end
+end

--- a/test/api/site_controller_test.rb
+++ b/test/api/site_controller_test.rb
@@ -37,7 +37,7 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
 
     @study = Study.find_by(name: "API Test Study #{@random_seed}")
-    expected_files = @study.study_files.count
+    expected_files = @study.study_files.downloadable.count
     expected_resources = @study.external_resources.count
     execute_http_request(:get, api_v1_site_study_view_path(accession: @study.accession))
     assert_response :success

--- a/test/api/site_controller_test.rb
+++ b/test/api/site_controller_test.rb
@@ -38,9 +38,13 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
 
     @study = Study.find_by(name: "API Test Study #{@random_seed}")
     expected_files = @study.study_files.count
+    expected_resources = @study.external_resources.count
     execute_http_request(:get, api_v1_site_study_view_path(accession: @study.accession))
     assert_response :success
-    assert json['study_files'].size == expected_files, "Did not find correct number of files, expected #{expected_files} but found #{json['study_files'].size}"
+    assert json['study_files'].size == expected_files,
+           "Did not find correct number of files, expected #{expected_files} but found #{json['study_files'].size}"
+    assert json['external_resources'].size == expected_resources,
+           "Did not find correct number of resource links, expected #{expected_resources} but found #{json['external_resources'].size}"
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end


### PR DESCRIPTION
The single-study API endpoint (analogous to the "Study Overview" page) shows basic statistics about a study, such as the number of genes/cells, and links to any files for downloading/streaming.  However, there is additional information - such as `ExternalResource` links - that are not present in the API endpoint, but are present in the analogous page in the portal.  This update adds `ExternalResource` links to the `api/v1/site/studies/{accession}` endpoint to maintain feature parity.

In addition, this update fixes two small problems: 

1. Ensuring `ExternalResource` documents are deleted when the parent `Study` or `AnalysisConfiguration` is deleted, as well as a migration to clean up orphaned records
2. The `api/v1/site/studies/{accession}` endpoint now only shows study files that are available for download/streaming via `study.study_files.valid`.  This removes files that are either not completely uploaded or are queued for deletion from this view.