### PR TITLE
Updating paperclip gem for test IO errors (SCP-3039)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     connection_pool (2.2.2)
     crass (1.0.6)
     daemons (1.2.6)
@@ -193,7 +193,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.8.5)
+    i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -225,13 +225,13 @@ GEM
       mimemagic (~> 0.3.2)
     memoist (0.16.0)
     method_source (1.0.0)
-    mime-types (3.2.2)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
+    mime-types-data (3.2020.1104)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
-    minitest (5.14.2)
+    minitest (5.14.3)
     minitest-hooks (1.5.0)
       minitest (> 5.3)
     minitest-rails (3.0.0)
@@ -296,7 +296,7 @@ GEM
       omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
     os (1.0.1)
-    paperclip (6.0.0)
+    paperclip (6.1.0)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
       mime-types
@@ -453,7 +453,7 @@ GEM
     truncate_html (0.9.3)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
-    tzinfo (1.2.7)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uber (0.1.0)
     uglifier (4.1.14)
@@ -549,7 +549,7 @@ DEPENDENCIES
   will_paginate_mongoid
 
 RUBY VERSION
-   ruby 2.6.5p114
+   ruby 2.6.6p146
 
 BUNDLED WITH
-   2.2.1
+   2.2.4


### PR DESCRIPTION
Resolving test IO errors with an update of `paperclip` gem to latest release.  This gem has been deprecated, but the last release from [July 2018](https://github.com/thoughtbot/paperclip/releases/tag/v6.1.0) contains a fix to "Manually close Tempfiles when we are done with them", which could account for the `I/O error: flush error` that was repeatedly triggered during CI runs.  

Because all tests are invoked with a single `bin/rake test` call, the stack is loaded once and all resources are shared across each test suite. This change was introduced in #777 and differered from the previous "manual" invocation of each test suite individually in a specified order, which had a separate overhead/garbage collection for each suite.  This new, streamlined invocation can lead to an overflow if garbage collection does not release all of the temp files created in a timely manner as we simulate file uploads in integration tests.

Eventually, Paperclip will need to be replaced with a more up-to-date library, but this final update will allow us more time to evaluate candidates and perform the migration without constantly having to re-run builds due to spurious errors.

The build associated with this PR was run 5 times in a row without triggering the I/O error.  While not absolute proof, these errors have increased as of late, and were occurring on approximately 1 out of 3 runs, so 5 consecutive green builds is a good indicator this issue is at least resolved for now.

This PR satisfies SCP-3039.