### PR TITLE
fixing default annotation logic (SCP-3059)

### DIFF
--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -52,7 +52,7 @@ module Api
 
         #
         def index
-          render json: AnnotationVizService.available_annotations(@study, nil, current_api_user)
+          render json: AnnotationVizService.available_annotations(@study, cluster: nil, current_user: current_api_user)
         end
 
         swagger_path '/studies/{accession}/annotations/{annotation_name}' do
@@ -170,10 +170,10 @@ module Api
             cluster = study.cluster_groups.by_name(params[:cluster])
           end
           AnnotationVizService.get_selected_annotation(study,
-                                                       cluster,
-                                                       annot_params[:name],
-                                                       annot_params[:type],
-                                                       annot_params[:scope])
+                                                       cluster: cluster,
+                                                       annot_name: annot_params[:name],
+                                                       annot_type: annot_params[:type],
+                                                       annot_scope: annot_params[:scope])
         end
 
 

--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -113,10 +113,10 @@ module Api
         def self.get_cluster_viz_data(study, cluster, url_params)
           annot_params = AnnotationsController.get_annotation_params(url_params)
           annotation = AnnotationVizService.get_selected_annotation(study,
-                                                       cluster,
-                                                       annot_params[:name],
-                                                       annot_params[:type],
-                                                       annot_params[:scope])
+                                                       cluster: cluster,
+                                                       annot_name: annot_params[:name],
+                                                       annot_type: annot_params[:type],
+                                                       annot_scope: annot_params[:scope])
           if !annotation
             return nil
           end

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -36,10 +36,10 @@ module Api
         def render_violin
           cluster = ClusterVizService.get_cluster_group(@study, params)
           annotation = AnnotationVizService.get_selected_annotation(@study,
-                                                                    cluster,
-                                                                    params[:annotation_name],
-                                                                    params[:annotation_type],
-                                                                    params[:annotation_scope])
+                                                                    cluster: cluster,
+                                                                    annot_name: params[:annotation_name],
+                                                                    annot_type: params[:annotation_type],
+                                                                    annot_scope: params[:annotation_scope])
           subsample = params[:subsample].blank? ? nil : params[:subsample].to_i
           genes = RequestUtils.get_genes_from_param(@study, params[:genes])
           if genes.empty?

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1239,7 +1239,13 @@ class SiteController < ApplicationController
 
   def set_selected_annotation
     annot_params = ExpressionVizService.parse_annotation_legacy_params(@study, params)
-    @selected_annotation = AnnotationVizService.get_selected_annotation(@study, @cluster, annot_params[:name], annot_params[:type], annot_params[:scope])
+    @selected_annotation = AnnotationVizService.get_selected_annotation(
+      @study,
+      cluster: @cluster,
+      annot_name: annot_params[:name],
+      annot_type: annot_params[:type],
+      annot_scope: annot_params[:scope]
+    )
   end
 
   def set_workspace_samples

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -93,7 +93,7 @@ class AnnotationVizService
   end
 
   # returns a flat array of annotation objects, with name, scope, annotation_type, and values for each
-  def self.available_annotations(study, cluster, current_user, annotation_type=nil)
+  def self.available_annotations(study, cluster=nil, current_user=nil, annotation_type=nil)
     annotations = []
     viewable = study.viewable_metadata
     metadata = annotation_type.nil? ? viewable : viewable.select {|m| m.annotation_type == annotation_type}

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -2,7 +2,7 @@ class AnnotationVizService
   # set of utility methods used for interacting with annotation data
 
   # Retrieves an object representing the selected annotation. If nil is passed for the last four
-  # arguments, it will get the study annotation instead
+  # arguments, it will get the study's default annotation instead
   # Params:
   # - study: the Study object
   # - cluster: ClusterGroup object (or nil for study-wide annotations)
@@ -11,7 +11,7 @@ class AnnotationVizService
   # - annot_scope: string scope (study, cluster, or user)
   # Returns:
   # - See populate_annotation_by_class for the object structure
-  def self.get_selected_annotation(study, cluster=nil, annot_name=nil, annot_type=nil, annot_scope=nil)
+  def self.get_selected_annotation(study, cluster: nil, annot_name: nil, annot_type: nil, annot_scope: nil)
     # construct object based on name, type & scope
     if annot_name.blank?
       # get the default annotation
@@ -34,6 +34,7 @@ class AnnotationVizService
         end
       end
     end
+
     case annot_scope
     when 'cluster'
       annotation_source = cluster.cell_annotations.find {|ca| ca[:name] == annot_name && ca[:type] == annot_type}
@@ -85,15 +86,15 @@ class AnnotationVizService
     ]
     {
       default_cluster: study.default_cluster&.name,
-      default_annotation: AnnotationVizService.get_selected_annotation(study, nil, nil, nil, nil),
-      annotations: AnnotationVizService.available_annotations(study, nil, user),
+      default_annotation: AnnotationVizService.get_selected_annotation(study),
+      annotations: AnnotationVizService.available_annotations(study, cluster: nil, current_user: user),
       clusters: study.cluster_groups.pluck(:name),
       subsample_thresholds: subsample_thresholds
     }
   end
 
   # returns a flat array of annotation objects, with name, scope, annotation_type, and values for each
-  def self.available_annotations(study, cluster=nil, current_user=nil, annotation_type=nil)
+  def self.available_annotations(study, cluster: nil, current_user: nil, annotation_type: nil)
     annotations = []
     viewable = study.viewable_metadata
     metadata = annotation_type.nil? ? viewable : viewable.select {|m| m.annotation_type == annotation_type}

--- a/test/api/visualization/clusters_controller_test.rb
+++ b/test/api/visualization/clusters_controller_test.rb
@@ -69,10 +69,10 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
     sign_in_and_update @user
     execute_http_request(:get, api_v1_study_cluster_path(@basic_study, 'clusterA.txt'))
     assert_equal 3, json['numPoints']
-    assert_equal ["cat (1 points)", "dog (2 points)"], json['data'].map{|d| d['name']}
+    assert_equal ["bar (2 points)", "baz (1 points)"], json['data'].map{|d| d['name']}
     assert_equal false, json['is3D']
-    dog_data = json['data'].find{|d| d['name'] == 'dog (2 points)'}
-    assert_equal [1, 6], dog_data['x']
+    bar_data = json['data'].find{|d| d['name'] == 'bar (2 points)'}
+    assert_equal [1, 4], bar_data['x']
   end
 
   test 'should load clusters with slashes in name' do

--- a/test/integration/lib/annotation_viz_service_test.rb
+++ b/test/integration/lib/annotation_viz_service_test.rb
@@ -76,4 +76,15 @@ class AnnotationVizServiceTest < ActiveSupport::TestCase
     annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, 'foobar', 'group', 'cluster')
     assert_equal 'Category', annotation[:name]
   end
+
+  test 'available annotations returns the available annotations' do
+    annots = AnnotationVizService.available_annotations(@basic_study)
+    assert_equal ["species", "disease", "Category", "Intensity", "Fizziness", "Buzziness"], annots.map { |a| a[:name] }
+    assert_equal [nil, nil, "cluster_1.txt", "cluster_1.txt", "cluster_2.txt", "cluster_2.txt"], annots.map { |a| a[:cluster_name] }
+
+    # if a cluster is specified, returns the study wide and annotations specific to that cluster
+    cluster = @basic_study.cluster_groups.find_by(name: 'cluster_1.txt')
+    annots = AnnotationVizService.available_annotations(@basic_study, cluster)
+    assert_equal ["species", "disease", "Category", "Intensity"], annots.map { |a| a[:name] }
+  end
 end

--- a/test/integration/lib/annotation_viz_service_test.rb
+++ b/test/integration/lib/annotation_viz_service_test.rb
@@ -36,16 +36,16 @@ class AnnotationVizServiceTest < ActiveSupport::TestCase
 
 
   test 'gets the default annotation when no annotation name is specified' do
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, nil, nil, nil, nil)
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study)
     assert_equal 'Category', annotation[:name]
     assert_equal  ['bar', 'baz'], annotation[:values]
 
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, nil, nil, nil, 'study')
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, annot_scope: 'study')
     assert_equal 'species', annotation[:name]
     assert_equal  ['dog', 'cat'], annotation[:values]
 
     fizz_cluster = @basic_study.cluster_groups.find_by(name: 'cluster_2.txt')
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, fizz_cluster, nil, nil, nil)
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: fizz_cluster)
     assert_equal 'Fizziness', annotation[:name]
     assert_equal  ['high', 'low', 'medium'], annotation[:values]
 
@@ -53,27 +53,27 @@ class AnnotationVizServiceTest < ActiveSupport::TestCase
         cluster: 'cluster_1.txt',
         annotation: 'species--group--study'
     })
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, nil, nil, nil, nil)
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study)
     assert_equal 'species', annotation[:name]
     assert_equal ['dog', 'cat'], annotation[:values]
   end
 
   test 'can get annotations by name and scope' do
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, nil, 'disease', 'group', 'study')
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, annot_name: 'disease', annot_type: 'group', annot_scope: 'study')
     assert_equal 'disease', annotation[:name]
     assert_equal  ['none', 'measles'], annotation[:values]
 
     cluster = @basic_study.cluster_groups.first
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, 'Intensity', 'numeric', 'cluster')
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: 'Intensity', annot_type: 'numeric', annot_scope: 'cluster')
     assert_equal 'Intensity', annotation[:name]
     assert_equal  [1.1, 2.2, 3.3], annotation[:values]
   end
 
   test 'returns first study/cluster annotation if no matching annotation is found' do
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, nil, 'foobar', 'group', 'study')
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, annot_name: 'foobar', annot_scope: 'group', annot_type: 'study')
     assert_equal 'species', annotation[:name]
     cluster = @basic_study.cluster_groups.first
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, 'foobar', 'group', 'cluster')
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: 'foobar', annot_type: 'group', annot_scope: 'cluster')
     assert_equal 'Category', annotation[:name]
   end
 
@@ -84,7 +84,7 @@ class AnnotationVizServiceTest < ActiveSupport::TestCase
 
     # if a cluster is specified, returns the study wide and annotations specific to that cluster
     cluster = @basic_study.cluster_groups.find_by(name: 'cluster_1.txt')
-    annots = AnnotationVizService.available_annotations(@basic_study, cluster)
+    annots = AnnotationVizService.available_annotations(@basic_study, cluster: cluster)
     assert_equal ["species", "disease", "Category", "Intensity"], annots.map { |a| a[:name] }
   end
 end

--- a/test/integration/lib/annotation_viz_service_test.rb
+++ b/test/integration/lib/annotation_viz_service_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+class AnnotationVizServiceTest < ActiveSupport::TestCase
+  include Minitest::Hooks
+  include SelfCleaningSuite
+  include TestInstrumentor
+
+  before(:all) do
+    @user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    @basic_study = FactoryBot.create(:detached_study, name_prefix: 'Basic Viz', test_array: @@studies_to_clean)
+    @basic_study_cluster_file = FactoryBot.create(:cluster_file,
+                                              name: 'cluster_1.txt', study: @basic_study,
+                                              annotation_input: [
+                                                  {name: 'Category', type: 'group', values: ['bar', 'bar', 'baz']},
+                                                  {name: 'Intensity', type: 'numeric', values: [1.1, 2.2, 3.3]}
+                                              ])
+    @basic_study_cluster_file2 = FactoryBot.create(:cluster_file,
+                                              name: 'cluster_2.txt', study: @basic_study,
+                                              annotation_input: [
+                                                  {name: 'Fizziness', type: 'group', values: ['high', 'low', 'medium']},
+                                                  {name: 'Buzziness', type: 'group', values: ['large', 'medium', 'small']}
+                                              ])
+    @basic_study_exp_file = FactoryBot.create(:study_file,
+                                                  name: 'dense.txt',
+                                                  file_type: 'Expression Matrix',
+                                                  study: @basic_study)
+
+    @study_metadata_file = FactoryBot.create(:metadata_file,
+                                             name: 'metadata.txt', study: @basic_study,
+                                             annotation_input: [
+                                                 {name: 'species', type: 'group', values: ['dog', 'cat', 'dog']},
+                                                 {name: 'disease', type: 'group', values: ['none', 'none', 'measles']}
+                                             ])
+
+  end
+
+
+  test 'gets the default annotation when no annotation name is specified' do
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, nil, nil, nil, nil)
+    assert_equal 'Category', annotation[:name]
+    assert_equal  ['bar', 'baz'], annotation[:values]
+
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, nil, nil, nil, 'study')
+    assert_equal 'species', annotation[:name]
+    assert_equal  ['dog', 'cat'], annotation[:values]
+
+    fizz_cluster = @basic_study.cluster_groups.find_by(name: 'cluster_2.txt')
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, fizz_cluster, nil, nil, nil)
+    assert_equal 'Fizziness', annotation[:name]
+    assert_equal  ['high', 'low', 'medium'], annotation[:values]
+
+    @basic_study.update!(default_options: {
+        cluster: 'cluster_1.txt',
+        annotation: 'species--group--study'
+    })
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, nil, nil, nil, nil)
+    assert_equal 'species', annotation[:name]
+    assert_equal ['dog', 'cat'], annotation[:values]
+  end
+
+  test 'can get annotations by name and scope' do
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, nil, 'disease', 'group', 'study')
+    assert_equal 'disease', annotation[:name]
+    assert_equal  ['none', 'measles'], annotation[:values]
+
+    cluster = @basic_study.cluster_groups.first
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, 'Intensity', 'numeric', 'cluster')
+    assert_equal 'Intensity', annotation[:name]
+    assert_equal  [1.1, 2.2, 3.3], annotation[:values]
+  end
+
+  test 'returns first study/cluster annotation if no matching annotation is found' do
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, nil, 'foobar', 'group', 'study')
+    assert_equal 'species', annotation[:name]
+    cluster = @basic_study.cluster_groups.first
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, 'foobar', 'group', 'cluster')
+    assert_equal 'Category', annotation[:name]
+  end
+end

--- a/test/integration/lib/expression_viz_service_test.rb
+++ b/test/integration/lib/expression_viz_service_test.rb
@@ -61,11 +61,11 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
 
   test 'can find annotation for cluster' do
     cluster = @basic_study.default_cluster
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, 'Category', 'group', 'cluster')
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: 'Category', annot_type: 'group', annot_scope: 'cluster')
     assert_equal 'Category', annotation[:name]
     assert_equal ['bar', 'baz'], annotation[:values]
     metadata = @basic_study.cell_metadata.first
-    study_annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, metadata.name, metadata.annotation_type, 'study')
+    study_annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: metadata.name, annot_type: metadata.annotation_type, annot_scope: 'study')
     assert_equal metadata.name, study_annotation[:name]
     assert_equal metadata.values, study_annotation[:values]
   end
@@ -83,7 +83,7 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
     cluster = @basic_study.default_cluster
     default_annot = @basic_study.default_annotation
     annot_name, annot_type, annot_scope = default_annot.split('--')
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, annot_name, annot_type, annot_scope)
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: annot_name, annot_type: annot_type, annot_scope: annot_scope)
     gene = @basic_study.genes.by_name_or_id('PTEN', @basic_study.expression_matrix_files.pluck(:id))
     rendered_data = ExpressionVizService.get_global_expression_render_data(
       study: @basic_study,
@@ -124,7 +124,7 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
 
     # confirm it works for numeric annotations
     annot_name, annot_type, annot_scope = ['Intensity', 'numeric', 'cluster']
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, annot_name, annot_type, annot_scope)
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: annot_name, annot_type: annot_type, annot_scope: annot_scope)
     rendered_data = ExpressionVizService.get_global_expression_render_data(
       study: @basic_study,
       subsample: nil,
@@ -184,7 +184,7 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
     cluster = @basic_study.default_cluster
     default_annot = @basic_study.default_annotation
     annot_name, annot_type, annot_scope = default_annot.split('--')
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, annot_name, annot_type, annot_scope)
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: annot_name, annot_type: annot_type, annot_scope: annot_scope)
     plotly_struct = ExpressionVizService.initialize_plotly_objects_by_annotation(annotation)
     annotation[:values].each do |value|
       trace = plotly_struct[value]
@@ -199,7 +199,7 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
     cluster = @basic_study.default_cluster
     default_annot = @basic_study.default_annotation
     annot_name, annot_type, annot_scope = default_annot.split('--')
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, annot_name, annot_type, annot_scope)
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: annot_name, annot_type: annot_type, annot_scope: annot_scope)
     violin_data = ExpressionVizService.load_expression_boxplot_data_array_scores(@basic_study, gene, cluster, annotation)
     # cells A & C belong to 'dog', and cell B belongs to 'cat' from default metadata annotation
     expected_output = {
@@ -213,7 +213,7 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
   test 'should load 2d annotation expression scatter' do
     gene = @basic_study.genes.by_name_or_id('PTEN', @basic_study.expression_matrix_files.pluck(:id))
     cluster = @basic_study.default_cluster
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, 'Intensity', 'numeric', 'cluster')
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: 'Intensity', annot_type: 'numeric', annot_scope: 'cluster')
     scatter_data = ExpressionVizService.load_annotation_based_data_array_scatter(@basic_study, gene, cluster, annotation,
                                                                                  nil, @basic_study.default_expression_label)
     expected_x_data = [1.1, 2.2, 3.3]
@@ -230,7 +230,7 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
     cluster = @basic_study.default_cluster
     default_annot = @basic_study.default_annotation
     annot_name, annot_type, annot_scope = default_annot.split('--')
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, annot_name, annot_type, annot_scope)
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: annot_name, annot_type: annot_type, annot_scope: annot_scope)
     expression_scatter = ExpressionVizService.load_expression_data_array_points(@basic_study, gene, cluster, annotation,
                                                                                 nil, @basic_study.default_expression_label,
                                                                                 'Blues')
@@ -251,7 +251,7 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
     cluster = @basic_study.default_cluster
     default_annot = @basic_study.default_annotation
     annot_name, annot_type, annot_scope = default_annot.split('--')
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, annot_name, annot_type, annot_scope)
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: annot_name, annot_type: annot_type, annot_scope: annot_scope)
     gene_set_violin = ExpressionVizService.load_gene_set_expression_boxplot_scores(@basic_study, genes, cluster, annotation,
                                                                                    'mean')
     # cells A & C belong to 'dog', and cell B belongs to 'cat' from default metadata annotation
@@ -267,7 +267,7 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
   test 'should load gene set 2d annotation expression scatter' do
     genes = load_all_genes(@basic_study)
     cluster = @basic_study.default_cluster
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, 'Intensity', 'numeric', 'cluster')
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: 'Intensity', annot_type: 'numeric', annot_scope: 'cluster')
     gene_set_annot_scatter = ExpressionVizService.load_gene_set_annotation_based_scatter(
         @basic_study, genes, cluster, annotation, 'mean', nil, @basic_study.default_expression_label
     )
@@ -288,7 +288,7 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
     cluster = @basic_study.default_cluster
     default_annot = @basic_study.default_annotation
     annot_name, annot_type, annot_scope = default_annot.split('--')
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster, annot_name, annot_type, annot_scope)
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: annot_name, annot_type: annot_type, annot_scope: annot_scope)
     gene_set_exp_statter = ExpressionVizService.load_gene_set_expression_data_arrays(
         @basic_study, genes, cluster, annotation, 'mean', nil,
         @basic_study.default_expression_label, 'Blues'


### PR DESCRIPTION
There was a big gap in the automated tests for the annotation service, which was definitely my oversight in rushing to get them out before the end of the year.

@bistline  I'd really appreciate your careful eyes on this to make sure I'm passing through the behavior of study.default_annotation correctly.  

To test:
1. Set a default annotation for a study.  
2. Do a global gene search for that study
3. confirm the default annotation is what renders first