### PR TITLE
updating to scp-ingest-pipeline:1.10.0

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module SingleCellPortal
     config.middleware.use Rack::Deflater
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.9.1'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.10.0'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Updating to the latest version of [scp-ingest-pipeline](https://github.com/broadinstitute/scp-ingest-pipeline). Refer to the [Release Notes](https://github.com/broadinstitute/scp-ingest-pipeline/releases/tag/1.10.0) for more information regarding the update.