### PR TITLE
Adding permission enforcement tests (SCP-3075)

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -6,7 +6,7 @@ Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', "delayed_job.#{
 Delayed::Worker.default_queue_name = :default
 
 if Rails.env.test? || Rails.env.development? # save a little time in testing/dev
-  Delayed::Worker.sleep_delay = 5
+  Delayed::Worker.sleep_delay = 5 # seconds
 end
 
 # Fixing class loader issues with delayed_job, for Rails 5

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -6,7 +6,7 @@ Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', "delayed_job.#{
 Delayed::Worker.default_queue_name = :default
 
 if Rails.env.test? || Rails.env.development? # save a little time in testing/dev
-  Delayed::Worker.sleep_delay = 10
+  Delayed::Worker.sleep_delay = 5
 end
 
 # Fixing class loader issues with delayed_job, for Rails 5

--- a/test/api/api_site_controller_test.rb
+++ b/test/api/api_site_controller_test.rb
@@ -1,7 +1,7 @@
 require 'api_test_helper'
 require 'user_tokens_helper'
 
-class SiteControllerTest < ActionDispatch::IntegrationTest
+class ApiSiteControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
   include Requests::JsonHelpers
   include Requests::HttpHelpers

--- a/test/api/studies_controller_test.rb
+++ b/test/api/studies_controller_test.rb
@@ -40,6 +40,11 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
         assert json[attribute] == value, "Attribute mismatch: #{attribute} is incorrect, expected #{value} but found #{json[attribute.to_s]}"
       end
     end
+
+    # ensure other users cannot access study
+    sign_in_and_update(@user_2)
+    execute_http_request(:get, api_v1_study_path(@study), user: @user_2)
+    assert_response 403
   end
 
   # create, update & delete tested together to use new object rather than main testing study
@@ -158,7 +163,6 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
 
   test 'should enforce edit access restrictions on studies' do
     # auth as other user
-    sign_out @user
     sign_in_and_update(@user_2)
     update_attributes = {
       study: {
@@ -167,6 +171,5 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
     }
     execute_http_request(:patch, api_v1_study_path(id: @study.id.to_s), request_payload: update_attributes, user: @user_2)
     assert_response 403
-    sign_in_and_update(@user)
   end
 end

--- a/test/api/study_files_controller_test.rb
+++ b/test/api/study_files_controller_test.rb
@@ -108,4 +108,25 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
     assert_response 204
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
+
+  test 'should enforce edit access restrictions on study files' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}!"
+
+    sign_out @user
+    other_user = User.find_by(email: 'sharing.user@gmail.com')
+    sign_in_and_update other_user
+    description = "This is the updated description with random seed #{@random_seed}"
+    update_attributes = {
+      study_file: {
+        description: description
+      }
+    }
+    execute_http_request(:patch, api_v1_study_study_file_path(study_id: @study.id, id: @study_file.id.to_s),
+                         request_payload: update_attributes, user: other_user)
+    assert_response 403
+    @study_file.reload
+    refute @study_file.description == description
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name}! succcessful!"
+  end
 end

--- a/test/api/study_files_controller_test.rb
+++ b/test/api/study_files_controller_test.rb
@@ -46,6 +46,13 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
         assert json[attribute] == value, "Attribute mismatch: #{attribute} is incorrect, expected #{value} but found #{json[attribute.to_s]}"
       end
     end
+
+    # ensure other users cannot access study_file
+    other_user = User.find_by(email: 'sharing.user@gmail.com')
+    sign_in_and_update other_user
+    execute_http_request(:get, api_v1_study_study_file_path(study_id: @study.id, id: @study_file.id), user: other_user)
+    assert_response 403
+
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 
@@ -112,7 +119,6 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
   test 'should enforce edit access restrictions on study files' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}!"
 
-    sign_out @user
     other_user = User.find_by(email: 'sharing.user@gmail.com')
     sign_in_and_update other_user
     description = "This is the updated description with random seed #{@random_seed}"

--- a/test/integration/study_validation_test.rb
+++ b/test/integration/study_validation_test.rb
@@ -18,6 +18,7 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
     reset_user_tokens
     # remove all validation studies
     Study.where(name: /Validation/).destroy_all
+    Study.find_by(name: "Testing Study #{@random_seed}").update(public: true)
   end
 
   # check that file header/format checks still function properly
@@ -388,6 +389,39 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
       uploaded_matrix.reload
     end
     puts "After #{seconds_slept} seconds, #{new_matrix} is #{uploaded_matrix.parse_status}."
+
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
+
+  # ensure unauthorized users cannot edit other studies
+  test 'should enforce edit access restrictions on studies' do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+
+    study = Study.find_by(name: "Testing Study #{@random_seed}")
+    patch study_path(study), params: {study: { public: false }}
+    follow_redirect!
+    assert_response :success
+    study.reload
+    refute study.public
+
+    auth_as_user(@sharing_user)
+    sign_in @sharing_user
+    patch study_path(study), params: {study: { public: true }}
+    follow_redirect!
+    assert_equal studies_path, path, "Did not redirect to My Studies page"
+    study.reload
+    refute study.public
+
+    sign_out @sharing_user
+    get site_path
+    patch study_path(study), params: {study: { public: true }}
+    assert_response 302 # redirect to "My Studies" page when :check_edit_permissions fires
+    follow_redirect!
+    assert_response 302 # redirect to sign in page when :authenticate_user! fires
+    follow_redirect!
+    assert_equal new_user_session_path, path # redirects have finished and path is updated
+    study.reload
+    refute study.public
 
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end

--- a/test/integration/study_validation_test.rb
+++ b/test/integration/study_validation_test.rb
@@ -114,7 +114,6 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
     example_files.values.each do |e|
       e[:object].reload # address potential race condition between parse_status setting to 'failed' and DeleteQueueJob executing
       assert_equal 'failed', e[:object].parse_status, "Incorrect parse_status for #{e[:name]}"
-      assert e[:object].queued_for_deletion
       # check that file is cached in parse_logs/:id folder in the study bucket
       cached_file = ApplicationController.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, study.bucket_id, e[:cache_location])
       assert cached_file.present?, "Did not find cached file at #{e[:cache_location]} in #{study.bucket_id}"
@@ -404,6 +403,7 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
     study.reload
     refute study.public
 
+    sign_out @test_user
     auth_as_user(@sharing_user)
     sign_in @sharing_user
     patch study_path(study), params: {study: { public: true }}


### PR DESCRIPTION
This update adds explicit tests to ensure study/file permissions are honored in both traditional and API Rails controllers.  While positive tests for normal access are in place, negative tests ensuring that unauthorized users cannot perform edit actions on resources they do not have access to were missing.  This covers accessing & editing both studies and files at the integration level.

This update also deals an issue where `delayed_job` was not processing some background jobs quickly enough in tests that caused false negative results.  The `sleep_delay` has been lowered, and some unnecessary assertions were removed.  Also, `test/api/site_controller_test.rb` has been renamed to `test/api/api_site_controller_test.rb` as it shared a class name with `test/controllers/site_controller_test.rb` that caused both test suites to run concurrently and caused additional false negative results.

This PR satisfies SCP-3075.