### PR TITLE
Restoring single study bulk download of DirectoryListings (SCP-3096)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -530,7 +530,7 @@ module Api
             key :name, :directory
             key :type, :string
             key :in, :query
-            key :description, 'Name of corresponding to directory folder to download (for single-study bulk download only), can be "all"'
+            key :description, 'Name of directory folder to download (for single-study bulk download only), can be "all"'
             key :required, false
           end
           response 200 do

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -619,7 +619,7 @@ module Api
                                                                            output_pathname_map: pathname_map)
         end_time = Time.zone.now
         runtime = TimeDifference.between(start_time, end_time).humanize
-        logger.info "Curl configs generated for studies #{valid_accessions}, #{files_requested.size} total files"
+        logger.info "Curl configs generated for studies #{valid_accessions}, #{files_requested.size + directory_files.size} total files"
         logger.info "Total time in generating curl configuration: #{runtime}"
         send_data @configuration, type: 'text/plain', filename: 'cfg.txt'
       end

--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -51,6 +51,46 @@ module Api
         @studies = Study.viewable(current_api_user)
       end
 
+      swagger_schema :DirectoryListingDownload do
+        property :name do
+          key :type, :string
+          key :description, 'Name of remote GCS directory containing files'
+        end
+        property :description do
+          key :type, :string
+          key :format, :email
+          key :description, 'Block description for all files contained in DirectoryListing'
+        end
+        property :file_type do
+          key :type, :string
+          key :description, 'File type (i.e. extension) of all files contained in DirectoryListing'
+        end
+        property :download_url do
+          key :type, :string
+          key :description, 'URL to bulk download all files in this directory'
+        end
+        property :files do
+          key :type, :array
+          key :description, 'Array of file objects'
+          items type: :object do
+            key :title, 'GCS File object'
+            key :required, [:name, :size, :generation]
+            property :name do
+              key :type, :string
+              key :description, 'name of File'
+            end
+            property :size do
+              key :type, :integer
+              key :description, 'size of File'
+            end
+            property :generation do
+              key :type, :string
+              key :description, 'GCS generation tag of File'
+            end
+          end
+        end
+      end
+
       swagger_path '/site/studies/{accession}' do
         operation :get do
           key :tags, [

--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -54,7 +54,7 @@ module Api
       swagger_schema :DirectoryListingDownload do
         property :name do
           key :type, :string
-          key :description, 'Name of remote GCS directory containing files'
+          key :description, 'Name of remote Google Cloud Storage (GCS) directory containing files'
         end
         property :description do
           key :type, :string

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -501,6 +501,13 @@ module Api
             key :required, true
             key :type, :string
           end
+          parameter do
+            key :name, :include_dirs
+            key :in, :query
+            key :description, 'Include directory listings in manifest'
+            key :required, false
+            key :type, :string
+          end
           response 200 do
             key :description, 'Manifest file'
             schema do
@@ -530,7 +537,8 @@ module Api
       end
 
       def generate_manifest
-        manifest_obj = BulkDownloadService.generate_study_files_tsv(@study)
+        include_dirs = params[:include_dirs] == 'true'
+        manifest_obj = BulkDownloadService.generate_study_files_tsv(@study, include_dirs)
         response.headers['Content-Disposition'] = 'attachment; filename=file_supplemental_info.tsv'
         render plain: manifest_obj
       end

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -9,6 +9,7 @@ class BulkDownloadService
   #
   # * *params*
   #   - +study_files+ (Array<StudyFile>) => Array of StudyFiles to be downloaded
+  #   - +directory_files+ (Array<Hash>) => Array of file descriptors in a bucket folder (from get_requested_directory_files)
   #   - +user+ (User) => User requesting download
   #   - +study_bucket_map+ => Map of study IDs to bucket names
   #   - +output_pathname_map+ => Map of study file IDs to output pathnames
@@ -16,14 +17,17 @@ class BulkDownloadService
   # * *return*
   #   - (String) => String representation of signed URLs and output filepaths to pass to curl
   def self.generate_curl_configuration(study_files:,
+                                       directory_files: [],
                                        user:,
                                        study_bucket_map:,
                                        output_pathname_map:)
     curl_configs = ['--create-dirs', '--compressed']
-    # Get signed URLs for all files in the requested download objects, and update user quota
-    Parallel.map(study_files, in_threads: 100) do |study_file|
+    # create an array of all objects to be downloaded, including directory files
+    download_objects = study_files.to_a + directory_files
+    # Get signed URLs for all files in the requested download objects
+    Parallel.map(download_objects, in_threads: 100) do |download_object|
       client = FireCloudClient.new
-      curl_configs << self.get_single_curl_command(file: study_file, fc_client: client, user: user,
+      curl_configs << self.get_single_curl_command(file: download_object, fc_client: client, user: user,
                                                    study_bucket_map: study_bucket_map, output_pathname_map: output_pathname_map)
     end
     studies = study_files.map(&:study).uniq
@@ -52,12 +56,15 @@ class BulkDownloadService
   # * *params*
   #   - +user+ (User) => User performing bulk download action
   #   - +files+ (Array<StudyFile>) => Array of files requested
+  #   - +files+ (Array<DirectoryListing>) => Array of files requested in DirectoryListings
   #
   # * *raises*
   #   - (RuntimeError) => User download quota exceeded
-  def self.update_user_download_quota(user:, files:)
+  def self.update_user_download_quota(user:, files:, directories: )
     download_quota = ApplicationController.get_download_quota
-    bytes_requested = files.map(&:upload_file_size).compact.reduce(:+)
+    file_bytes_requested = files.map(&:upload_file_size).compact.reduce(0, :+)
+    dir_bytes_requested = directories.map(&:total_bytes).reduce(0, :+)
+    bytes_requested = file_bytes_requested + dir_bytes_requested
     bytes_allowed = download_quota - user.daily_download_quota
     if bytes_requested > bytes_allowed
       raise RuntimeError.new "Total file size exceeds user download quota: #{bytes_requested} bytes requested, #{bytes_allowed} bytes allowed"
@@ -108,6 +115,8 @@ class BulkDownloadService
   # * *return*
   #   - (Array<StudyFile>) => Array of StudyFiles to pass to #generate_curl_config
   def self.get_requested_files(file_types: [], study_accessions:)
+    # if 'None' is requested type, exit immediately as this is only for a single folder download
+    return [] if file_types == ['None']
     # replace 'Expression' with both dense & sparse matrix file types
     # include bundled 10X files as well to avoid MongoDB timeout issues when trying to load bundles
     if file_types.include?('Expression')
@@ -119,6 +128,27 @@ class BulkDownloadService
     # get requested files, excluding externally stored sequence data
     base_file_selector = StudyFile.where(human_fastq_url: nil, :study_id.in => studies.pluck(:id))
     file_types.present? ? base_file_selector.where(:file_type.in => file_types) : base_file_selector
+  end
+
+  # get all requested files from matching DirectoryListings
+  #
+  # * *params*
+  #   - +directories+ (Mongoid::Critera) => selector mapping to requested DirectoryListings from a study
+  #
+  # * *returns*
+  #   - (Array<Hash>) => {name: name/relative location of file in bucket, study_id: id of study}
+  def self.get_requested_directory_files(directories)
+    dir_files = []
+    directories.each do |directory|
+      directory.files.each do |file|
+        dir_file = {
+          name: file[:name],
+          study_id: directory.study.id.to_s
+        }.with_indifferent_access
+        dir_files << dir_file
+      end
+    end
+    dir_files
   end
 
   # Get a preview of the number of files/total bytes by StudyAccession and file_type
@@ -145,7 +175,7 @@ class BulkDownloadService
   # curl for initiating bulk downloads
   #
   # * *params*
-  #   - +file+ (StudyFile) => StudyFiles to be downloaded
+  #   - +file+ (StudyFile, Hash) => file object to be downloaded
   #   - +fc_client+ (FireCloudClient) => Client to call GCS and generate signed_url
   #   - +user+ (User) => User requesting download
   #   - +study_bucket_map+ => Map of study IDs to bucket names
@@ -156,9 +186,15 @@ class BulkDownloadService
   def self.get_single_curl_command(file:, fc_client:, user:, study_bucket_map:, output_pathname_map:)
     fc_client ||= ApplicationController.firecloud_client
     # if a file is a StudyFile, use bucket_location, otherwise the :name key will contain its location (if DirectoryListing)
-    file_location = file.bucket_location
-    bucket_name = study_bucket_map[file.study_id.to_s]
-    output_path = output_pathname_map[file.id.to_s]
+    if file.is_a?(StudyFile)
+      file_location = file.bucket_location
+      bucket_name = study_bucket_map[file.study_id.to_s]
+      output_path = output_pathname_map[file.id.to_s]
+    elsif file.is_a?(Hash)
+      file_location = file[:name]
+      bucket_name = study_bucket_map[file[:study_id]]
+      output_path = output_pathname_map[file[:name]]
+    end
 
     begin
       signed_url = fc_client.execute_gcloud_method(:generate_signed_url, 0, bucket_name, file_location,
@@ -194,13 +230,19 @@ class BulkDownloadService
   #
   # * *params*
   #   - +study_files+ (Array<StudyFile>) => Array of StudyFiles to be downloaded
+  #   - +directories+ (Array<DirectoryListing>) => Array of DirectoryListings to be downloaded
   #
   # * *returns*
   #   - (Hash<String, String>) => Map of study file IDs to output pathnames
-  def self.generate_output_path_map(study_files)
+  def self.generate_output_path_map(study_files, directories)
     output_map = {}
     study_files.each do |study_file|
       output_map[study_file.id.to_s] = study_file.bulk_download_pathname
+    end
+    directories.each do |directory|
+      directory.files.each do |file|
+        output_map[file[:name]] = directory.bulk_download_pathname(file)
+      end
     end
     output_map
   end

--- a/app/models/directory_listing.rb
+++ b/app/models/directory_listing.rb
@@ -136,16 +136,17 @@ class DirectoryListing
 
 	# output path for bulk download
 	def bulk_download_pathname(file)
-		if self.name == '/'
-			"#{self.study.accession}/root_dir/#{file[:name]}"
-		else
-			"#{self.study.accession}/#{file[:name]}"
-		end
+		"#{self.study.accession}/#{bulk_download_folder(file)}"
 	end
 
 	# helper to get total number of bytes in directory
 	def total_bytes
 		self.files.map {|file| file[:size].to_i}.reduce(:+) # to_i handles any nil file sizes
+	end
+
+	# location of a given file in a bulk download directory
+	def bulk_download_folder(file)
+		self.name == '/' ? "root_dir/#{file[:name]}": file[:name]
 	end
 
 	# helper to render name appropriately for use in download modals
@@ -154,6 +155,15 @@ class DirectoryListing
 			self.name
 		else
 			'/' + self.name + '/'
+		end
+	end
+
+	# helper for setting DOM attributes that are URL-encoded
+	def url_safe_name
+		if self.name == '/'
+			'root-dir'
+		else
+			self.name
 		end
 	end
 

--- a/app/models/directory_listing.rb
+++ b/app/models/directory_listing.rb
@@ -104,7 +104,7 @@ class DirectoryListing
         end
       end
     end
-  end
+	end
 
 	validates_uniqueness_of :name, scope: [:study_id, :file_type]
   validates_presence_of :name, :file_type, :files
@@ -132,6 +132,20 @@ class DirectoryListing
 		else
 			download_private_file_path(accession: self.study.accession, study_name: self.study.url_safe_name, filename: file)
 		end
+	end
+
+	# output path for bulk download
+	def bulk_download_pathname(file)
+		if self.name == '/'
+			"#{self.study.accession}/root_dir/#{file[:name]}"
+		else
+			"#{self.study.accession}/#{file[:name]}"
+		end
+	end
+
+	# helper to get total number of bytes in directory
+	def total_bytes
+		self.files.map {|file| file[:size].to_i}.reduce(:+) # to_i handles any nil file sizes
 	end
 
 	# helper to render name appropriately for use in download modals

--- a/app/models/directory_listing.rb
+++ b/app/models/directory_listing.rb
@@ -1,88 +1,88 @@
 class DirectoryListing
 
-	###
-	#
-	# DirectoryListing: object that holds metadata about groups of files in a specific location in a GCS bucket
-	# Mainly used to supply blanket descriptions for all files at given location
-	#
-	###
+  ###
+  #
+  # DirectoryListing: object that holds metadata about groups of files in a specific location in a GCS bucket
+  # Mainly used to supply blanket descriptions for all files at given location
+  #
+  ###
 
-	include Mongoid::Document
-	include Mongoid::Timestamps
+  include Mongoid::Document
+  include Mongoid::Timestamps
   include Swagger::Blocks
-	include Rails.application.routes.url_helpers # for accessing download_file_path and download_private_file_path
+  include Rails.application.routes.url_helpers # for accessing download_file_path and download_private_file_path
 
-	PRIMARY_DATA_TYPES = %w(fq fastq).freeze
-	READ_PAIR_IDENTIFIERS = %w(_R1 _R2 _I1 _I2).freeze
+  PRIMARY_DATA_TYPES = %w(fq fastq).freeze
+  READ_PAIR_IDENTIFIERS = %w(_R1 _R2 _I1 _I2).freeze
   FILE_ARRAY_ATTRIBUTES = {
       name: 'String',
       size: 'Integer',
       generation: 'String'
   }
   REQUIRED_ATTRIBUTES = %w(study_id name file_type files)
-	TAXON_REQUIRED_REGEX = /(fastq|fq)/
-	IGNORED_EXTENTIONS = %w(txt) # other file extentions to ignore
+  TAXON_REQUIRED_REGEX = /(fastq|fq)/
+  IGNORED_EXTENTIONS = %w(txt) # other file extentions to ignore
   MIN_SIZE = 10 # threshold of like file types required for creating DirectoryListing
 
-	belongs_to :study
+  belongs_to :study
   belongs_to :taxon, optional: true
 
-	field :name, type: String
-	field :description, type: String
-	field :file_type, type: String
-	field :files, type: Array
-	field :sync_status, type: Boolean, default: false
+  field :name, type: String
+  field :description, type: String
+  field :file_type, type: String
+  field :files, type: Array
+  field :sync_status, type: Boolean, default: false
 
-	swagger_schema :DirectoryListing do
-		key :required, [:name, :file_type, :files]
-		key :name, 'DirectoryListing'
-		property :id do
-			key :type, :string
-		end
-		property :study_id do
-			key :type, :string
-			key :description, 'ID of Study this StudyShare belongs to'
-		end
-		property :taxon_id do
-			key :type, :string
-			key :description, 'ID of Taxon (species) this DirectoryListing belongs to'
+  swagger_schema :DirectoryListing do
+    key :required, [:name, :file_type, :files]
+    key :name, 'DirectoryListing'
+    property :id do
+      key :type, :string
+    end
+    property :study_id do
+      key :type, :string
+      key :description, 'ID of Study this StudyShare belongs to'
+    end
+    property :taxon_id do
+      key :type, :string
+      key :description, 'ID of Taxon (species) this DirectoryListing belongs to'
     end
     property :name do
       key :type, :string
       key :description, 'Name of remote GCS directory containing files'
     end
-		property :description do
-			key :type, :string
-			key :format, :email
-			key :description, 'Block description for all files contained in DirectoryListing'
-		end
-		property :file_type do
-			key :type, :string
-			key :description, 'File type (i.e. extension) of all files contained in DirectoryListing'
-		end
-		property :files do
-			key :type, :array
-			key :description, 'Array of file objects'
-			items type: :object do
+    property :description do
+      key :type, :string
+      key :format, :email
+      key :description, 'Block description for all files contained in DirectoryListing'
+    end
+    property :file_type do
+      key :type, :string
+      key :description, 'File type (i.e. extension) of all files contained in DirectoryListing'
+    end
+    property :files do
+      key :type, :array
+      key :description, 'Array of file objects'
+      items type: :object do
         key :title, 'GCS File object'
         key :required, [:name, :size, :generation]
         property :name do
-			    key :type, :string
-					key :description, 'name of File'
-				end
-				property :size do
-					key :type, :integer
-					key :description, 'size of File'
-				end
-				property :generation do
-					key :type, :string
-					key :description, 'GCS generation tag of File'
-				end
-			end
-		end
-		property :sync_status do
-			key :type, :boolean
-			key :description, 'Boolean indication whether this DirectoryListing has been synced (and made available for download)'
+          key :type, :string
+          key :description, 'name of File'
+        end
+        property :size do
+          key :type, :integer
+          key :description, 'size of File'
+        end
+        property :generation do
+          key :type, :string
+          key :description, 'GCS generation tag of File'
+        end
+      end
+    end
+    property :sync_status do
+      key :type, :boolean
+      key :description, 'Boolean indication whether this DirectoryListing has been synced (and made available for download)'
     end
     property :created_at do
       key :type, :string
@@ -104,80 +104,80 @@ class DirectoryListing
         end
       end
     end
-	end
+  end
 
-	validates_uniqueness_of :name, scope: [:study_id, :file_type]
+  validates_uniqueness_of :name, scope: [:study_id, :file_type]
   validates_presence_of :name, :file_type, :files
-	validates_format_of :name, with: ValidationTools::FILENAME_CHARS,
+  validates_format_of :name, with: ValidationTools::FILENAME_CHARS,
                       message: ValidationTools::FILENAME_CHARS_ERROR
   validates_format_of :description, with: ValidationTools::OBJECT_LABELS,
             message: ValidationTools::OBJECT_LABELS_ERROR, allow_blank: true
   validates_format_of :file_type, with: ValidationTools::FILENAME_CHARS,
-											message: ValidationTools::FILENAME_CHARS_ERROR
+                      message: ValidationTools::FILENAME_CHARS_ERROR
 
-	validate :check_taxon, on: :update
-	validate :check_files_array_format
+  validate :check_taxon, on: :update
+  validate :check_files_array_format
 
-	index({ name: 1, study_id: 1, file_type: 1 }, { unique: true, background: true })
+  index({ name: 1, study_id: 1, file_type: 1 }, { unique: true, background: true })
 
-	# check if a directory_listing has a file
-	def has_file?(filename)
-		!self.files.detect(filename).nil?
-	end
+  # check if a directory_listing has a file
+  def has_file?(filename)
+    !self.files.detect(filename).nil?
+  end
 
-	# helper to generate correct urls for downloading fastq files
-	def download_path(file)
-		if self.study.public?
-			download_file_path(accession: self.study.accession, study_name: self.study.url_safe_name, filename: file)
-		else
-			download_private_file_path(accession: self.study.accession, study_name: self.study.url_safe_name, filename: file)
-		end
-	end
+  # helper to generate correct urls for downloading fastq files
+  def download_path(file)
+    if self.study.public?
+      download_file_path(accession: self.study.accession, study_name: self.study.url_safe_name, filename: file)
+    else
+      download_private_file_path(accession: self.study.accession, study_name: self.study.url_safe_name, filename: file)
+    end
+  end
 
-	# output path for bulk download
-	def bulk_download_pathname(file)
-		"#{self.study.accession}/#{bulk_download_folder(file)}"
-	end
+  # output path for bulk download
+  def bulk_download_pathname(file)
+    "#{self.study.accession}/#{bulk_download_folder(file)}"
+  end
 
-	# helper to get total number of bytes in directory
-	def total_bytes
-		self.files.map {|file| file[:size].to_i}.reduce(:+) # to_i handles any nil file sizes
-	end
+  # helper to get total number of bytes in directory
+  def total_bytes
+    self.files.map {|file| file[:size].to_i}.reduce(:+) # to_i handles any nil file sizes
+  end
 
-	# location of a given file in a bulk download directory
-	def bulk_download_folder(file)
-		self.name == '/' ? "root_dir/#{file[:name]}": file[:name]
-	end
+  # location of a given file in a bulk download directory
+  def bulk_download_folder(file)
+    self.name == '/' ? "root_dir/#{file[:name]}": file[:name]
+  end
 
-	# helper to render name appropriately for use in download modals
-	def download_display_name
-		if self.name == '/'
-			self.name
-		else
-			'/' + self.name + '/'
-		end
-	end
+  # helper to render name appropriately for use in download modals
+  def download_display_name
+    if self.name == '/'
+      self.name
+    else
+      '/' + self.name + '/'
+    end
+  end
 
-	# helper for setting DOM attributes that are URL-encoded
-	def url_safe_name
-		if self.name == '/'
-			'root-dir'
-		else
-			self.name
-		end
-	end
+  # helper for setting DOM attributes that are URL-encoded
+  def url_safe_name
+    if self.name == '/'
+      'root-dir'
+    else
+      self.name
+    end
+  end
 
-	# guess at a possible sample name based on filename
-	def possible_sample_name(filename)
-		filename.split('/').last.split('.').first
-	end
+  # guess at a possible sample name based on filename
+  def possible_sample_name(filename)
+    filename.split('/').last.split('.').first
+  end
 
   # generate a gs-url to a file in the files list in the study's GCS bucket
   def gs_url(filename)
-		if self.has_file?(filename)
-			"gs://#{self.study.bucket_id}/#{filename}"
-		end
-	end
+    if self.has_file?(filename)
+      "gs://#{self.study.bucket_id}/#{filename}"
+    end
+  end
 
   # helper method for retrieving species common name
   def species_name
@@ -201,97 +201,97 @@ class DirectoryListing
     else
       nil
     end
-	end
+  end
 
-	# return sample name based on filename (everything to the left of _(R|I)(1|2) string in file basename)
+  # return sample name based on filename (everything to the left of _(R|I)(1|2) string in file basename)
   # will also transform periods into underscores as these are unallowed in FireCloud
-	def self.sample_name(filename)
-		basename = self.file_basename(filename)
-		DirectoryListing::READ_PAIR_IDENTIFIERS.each do |identifier|
-			index = basename.index(identifier)
-			if index
-				return basename[0..index - 1].gsub(/\./, '_')
-			else
-				next
-			end
-		end
-		basename
-	end
+  def self.sample_name(filename)
+    basename = self.file_basename(filename)
+    DirectoryListing::READ_PAIR_IDENTIFIERS.each do |identifier|
+      index = basename.index(identifier)
+      if index
+        return basename[0..index - 1].gsub(/\./, '_')
+      else
+        next
+      end
+    end
+    basename
+  end
 
-	def self.read_position(filename)
-		DirectoryListing::READ_PAIR_IDENTIFIERS.each do |identifier|
-			if filename.match(/#{identifier}/)
-				return DirectoryListing::READ_PAIR_IDENTIFIERS.index(identifier)
-			end
-		end
-		0 # in case no pairing info is found, return 0 for first position
-	end
+  def self.read_position(filename)
+    DirectoryListing::READ_PAIR_IDENTIFIERS.each do |identifier|
+      if filename.match(/#{identifier}/)
+        return DirectoryListing::READ_PAIR_IDENTIFIERS.index(identifier)
+      end
+    end
+    0 # in case no pairing info is found, return 0 for first position
+  end
 
-	# method to return a mapping of samples and paired reads based on contents of a file list
-	def self.sample_read_pairings(files)
-		map = {}
-		files.each do |file|
-			sample = DirectoryListing.sample_name(file[:name])
-			map[sample] ||= []
-			# determine 'position' of read, i.e. 0-3 based on presence of read identifier in filename
-			position = DirectoryListing.read_position(file[:name])
-			map[sample][position] = file[:gs_url]
-		end
-		map
-	end
+  # method to return a mapping of samples and paired reads based on contents of a file list
+  def self.sample_read_pairings(files)
+    map = {}
+    files.each do |file|
+      sample = DirectoryListing.sample_name(file[:name])
+      map[sample] ||= []
+      # determine 'position' of read, i.e. 0-3 based on presence of read identifier in filename
+      position = DirectoryListing.read_position(file[:name])
+      map[sample][position] = file[:gs_url]
+    end
+    map
+  end
 
-	# create a mapping of file extensions and counts based on a list of input files from a google bucket
-	# keys to map are the path at which groups of files are found, and values are key/value pairs of file
-	# extensions and counts
-	def self.create_extension_map(files, map={})
-		files.map(&:name).each do |name|
-			# don't use directories in extension map
-			unless name.end_with?('/')
-				path = self.get_folder_name(name)
-				ext = self.file_extension(name)
-				# don't store primary data filetypes in map as these are handled separately
+  # create a mapping of file extensions and counts based on a list of input files from a google bucket
+  # keys to map are the path at which groups of files are found, and values are key/value pairs of file
+  # extensions and counts
+  def self.create_extension_map(files, map={})
+    files.map(&:name).each do |name|
+      # don't use directories in extension map
+      unless name.end_with?('/')
+        path = self.get_folder_name(name)
+        ext = self.file_extension(name)
+        # don't store primary data filetypes in map as these are handled separately
         # also ignore any file types in IGNORED_EXTENTIONS
-				unless DirectoryListing::PRIMARY_DATA_TYPES.any? {|e| ext.include?(e)} ||
+        unless DirectoryListing::PRIMARY_DATA_TYPES.any? {|e| ext.include?(e)} ||
             DirectoryListing::IGNORED_EXTENTIONS.include?(ext)
-					if map[path].nil?
-						map[path] = {"#{ext}" => 1}
-					elsif map[path][ext].nil?
-						map[path][ext] = 1
-					else
-						map[path][ext] += 1
-					end
-				end
-			end
-		end
-		map
-	end
+          if map[path].nil?
+            map[path] = {"#{ext}" => 1}
+          elsif map[path][ext].nil?
+            map[path][ext] = 1
+          else
+            map[path][ext] += 1
+          end
+        end
+      end
+    end
+    map
+  end
 
-	# helper to return file extension for a given filename
-	def self.file_extension(filename)
-		parts = filename.split('.')
-		size = parts.size
-		if parts[size - 2] == 'tar' && parts.last == 'gz'
-			# handle tar.gz files first, returning '[ext].tar.gz'
-			parts[(size - 3)..(size - 1)].join('.')
-		elsif parts.last == 'gz'
-			# if the file is a gzip archive, return '[ext].gz'
-			parts[(size - 2)..(size - 1)].join('.')
-		else
-			parts.last
-		end
-	end
+  # helper to return file extension for a given filename
+  def self.file_extension(filename)
+    parts = filename.split('.')
+    size = parts.size
+    if parts[size - 2] == 'tar' && parts.last == 'gz'
+      # handle tar.gz files first, returning '[ext].tar.gz'
+      parts[(size - 3)..(size - 1)].join('.')
+    elsif parts.last == 'gz'
+      # if the file is a gzip archive, return '[ext].gz'
+      parts[(size - 2)..(size - 1)].join('.')
+    else
+      parts.last
+    end
+  end
 
-	# get basename of file (everything in front of extension)
-	def self.file_basename(filename)
-		# in case the file is in a directory in the bucket, trim off the directory name(s)
-		actual_filename = filename.split('/').last
-		actual_filename.chomp(".#{self.file_extension(actual_filename)}")
-	end
+  # get basename of file (everything in front of extension)
+  def self.file_basename(filename)
+    # in case the file is in a directory in the bucket, trim off the directory name(s)
+    actual_filename = filename.split('/').last
+    actual_filename.chomp(".#{self.file_extension(actual_filename)}")
+  end
 
-	# get the 'folder' of a file in a bucket based on its pathname
-	def self.get_folder_name(filepath)
-		filepath.include?('/') ? filepath.split('/').first : '/'
-	end
+  # get the 'folder' of a file in a bucket based on its pathname
+  def self.get_folder_name(filepath)
+    filepath.include?('/') ? filepath.split('/').first : '/'
+  end
 
   private
 
@@ -302,20 +302,20 @@ class DirectoryListing
         errors.add(:taxon_id, 'You must supply a species for this file type: ' + self.file_type)
       end
     end
-	end
+  end
 
-	# make sure that the files array is in the correct format
-	def check_files_array_format
-		error_msg = 'has invalid entries.  Each entry must be a hash with the keys of name (String), size (Integer), and '\
- 								'generation (String).  The following entries are invalid: '
-		has_error = false
-		self.files.each do |file|
-			unless file.keys.map(&:to_s).sort == %w(generation name size)
-				error_msg += "#{file}"
-			end
-		end
-		if has_error
-			errors.add(:files, error_msg)
-		end
-	end
+  # make sure that the files array is in the correct format
+  def check_files_array_format
+    error_msg = 'has invalid entries.  Each entry must be a hash with the keys of name (String), size (Integer), and '\
+                'generation (String).  The following entries are invalid: '
+    has_error = false
+    self.files.each do |file|
+      unless file.keys.map(&:to_s).sort == %w(generation name size)
+        error_msg += "#{file}"
+      end
+    end
+    if has_error
+      errors.add(:files, error_msg)
+    end
+  end
 end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -537,6 +537,14 @@ class Study
         key '$ref', 'SiteStudyFile'
       end
     end
+    property :directory_listings do
+      key :type, :array
+      key :description, 'Available Directories of files for bulk download'
+      items do
+        key :title, 'DirectoryListing'
+        key '$ref', 'DirectoryListingDownload'
+      end
+    end
     property :external_resources do
       key :type, :array
       key :description, 'Available external resource links'

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -33,8 +33,11 @@ class StudyFile
   ASSEMBLY_REQUIRED_TYPES = ['BAM', 'Ideogram Annotations']
   GZIP_MAGIC_NUMBER = "\x1f\x8b".force_encoding(Encoding::ASCII_8BIT)
   REQUIRED_ATTRIBUTES = %w(file_type name)
+  # allowed bulk download file types
+  # 'Expression' covers dense & sparse matrix files
+  # 'None' is used when only bulk downloading a single directory_listing folder
   BULK_DOWNLOAD_TYPES = ['Expression', 'Metadata', 'Cluster', 'Coordinate Labels', 'Fastq', 'BAM', 'Documentation',
-                         'Other', 'Analysis Output', 'Ideogram Annotations']
+                         'Other', 'Analysis Output', 'Ideogram Annotations', 'None']
 
   # Constants for scoping values for AnalysisParameter inputs/outputs
   ASSOCIATED_MODEL_METHOD = %w(gs_url name upload_file_name bucket_location)

--- a/app/views/api/v1/site/_directory_listing.json.jbuilder
+++ b/app/views/api/v1/site/_directory_listing.json.jbuilder
@@ -1,0 +1,6 @@
+json.set! :name, directory_listing.name
+json.set! :description, directory_listing.description
+json.set! :file_type, directory_listing.file_type
+json.set! :download_url, api_v1_search_bulk_download_url(accessions: directory_listing.study.accession,
+                                                         directory: directory_listing.name)
+json.set! :files, directory_listing.files

--- a/app/views/api/v1/site/_study.json.jbuilder
+++ b/app/views/api/v1/site/_study.json.jbuilder
@@ -10,6 +10,7 @@ if study.detached
   json.set! :study_files, 'Unavailable (cannot load study workspace or bucket)'
 else
   json.study_files study.study_files.downloadable, partial: 'api/v1/site/study_file', as: :study_file, locals: {study: study}
+  json.directory_listings study.directory_listings.are_synced, partial: 'api/v1/site/directory_listing', as: :directory_listing, locals: {study: study}
 end
 json.external_resources do
   json.array! study.external_resources do |external_resource|

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -34,7 +34,9 @@
               Then <%= link_to "click here".html_safe, "#{generate_manifest_study_url(@study)}" %> for the file_supplemental_info.tsv containing file supplementary information (units, protocols, etc...)
             <% elsif @study.public? && !@user_embargoed || current_user.admin? %>
               <p class="lead">To download all files using <code>curl</code>, click the button below to get the download command:</p>
-              <p class="lead command-container" id="command-container-all"><%= link_to "<i class='fas fa-download'></i> Get download command for all study data".html_safe, '#/', class: 'btn btn-default get-download-command', id: 'get-download-command_all' %></p>
+              <p class="lead command-container" id="command-container-all">
+                <%= link_to "<i class='fas fa-download'></i> Get download command for all study data".html_safe,
+                            '#/', class: 'btn btn-default get-download-command', id: 'get-download-command_all' %></p>
               <% if @directories.any? %>
                 <p class="lead">To download all data files in a specific folder, use the following commands:</p>
                 <table class="table table-condensed table-striped">
@@ -46,8 +48,10 @@
                     <% @directories.each do |directory| %>
                       <tr>
                         <td><%= directory.name %></td>
-                        <td class="command-container" id="command-container-<%= directory.name %>">
-                          <%= link_to "<i class='fas fa-download'></i> Get download command".html_safe, '#/', class: 'btn btn-default get-download-command', id: "get-download-command_#{directory.name}" %>
+                        <td class="command-container" id="command-container-<%= directory.url_safe_name %>">
+                          <%= link_to "<i class='fas fa-download'></i> Get download command".html_safe, '#/',
+                                      class: 'btn btn-default get-download-command', id: "get-download-command_#{directory.url_safe_name}",
+                                      data: {filetypes: 'None' } %>
                         </td>
                       </tr>
                     <% end %>
@@ -83,7 +87,8 @@
         $('body').on('click', '.btn-refresh', function(event) {
           var commandContainer = $(this).parentsUntil('.command-container').parent();
           var downloadObject = commandContainer.attr('id').split('-').slice(-1)[0];
-          writeDownloadCommand(downloadObject);
+          var fileTypes = commandContainer.data('filetypes');
+          writeDownloadCommand(downloadObject, fileTypes);
         });
 
         /**
@@ -91,7 +96,7 @@
          *
          * @param downloadObject {String} 'all' or a particular directory listing, e.g. 'csvs'
          */
-        function writeDownloadCommand(downloadObject) {
+        function writeDownloadCommand(downloadObject, fileTypes) {
 
           $('.tooltip').remove();
 
@@ -104,14 +109,22 @@
               var expiresMinutes = timeInterval / 60;
               const accession = "<%= @study.accession %>"
               const curlSecureFlag = "<%= Rails.env.development? ? '-k' : '' %>"
+              const downloadObjectName = downloadObject == 'root-dir' ? '%2F' : downloadObject
               // Gets a curl configuration ("cfg.txt") containing signed
               // URLs and output names for all files in the download object.
               var url = (
                 window.location.origin +
                 '/single_cell/api/v1/search/bulk_download?' +
                 `accessions=${accession}` +
-                `&auth_code=${authCode}`
+                `&auth_code=${authCode}` +
+                `&directory=${downloadObjectName}`
               );
+
+              // if this is a single-directory download, append 'file_types=None' to exclude all other files from
+              // bulk download request
+              if ( typeof fileTypes !== 'undefined' ) {
+                  url += `&file_types=${fileTypes}`
+              }
 
               // This is what the user will run in their terminal to download the data.
               var downloadCommand = (
@@ -144,7 +157,8 @@
         $('body').on('click', '.get-download-command', function(event) {
           var downloadButton = $(this);
           var downloadObject = downloadButton.attr('id').split('_')[1];
-          writeDownloadCommand(downloadObject);
+          var fileTypes = downloadButton.data('filetypes');
+          writeDownloadCommand(downloadObject, fileTypes);
         });
     </script>
     <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -125,6 +125,14 @@ gene2_vals.save!
 gene2_cells = gene_2.data_arrays.build(name: gene_2.cell_key, array_type: 'cells', cluster_name: expression_file.name,
                                        array_index: 1, study_id: study.id, study_file_id: expression_file.id, values: all_cell_array)
 gene2_cells.save!
+DirectoryListing.create!(name: 'fastq', file_type: 'fastq',
+                         files: [
+                           {name: '1_L1_001.fastq', size: 100, generation: '12345'},
+                           {name: '1_R1_001.fastq', size: 100, generation: '12345'},
+                           {name: '2_L1_001.fastq', size: 100, generation: '12345'},
+                           {name: '2_R1_001.fastq', size: 100, generation: '12345'},
+                         ], sync_status: true, study_id: study.id)
+
 
 # API TEST SEEDS
 api_study = Study.create!(name: "API Test Study #{@random_seed}", data_dir: 'api_test_study', user_id: user.id,

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -245,8 +245,9 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     auth_code = json['auth_code']
 
     files = study.study_files.by_type(['Expression Matrix', 'Metadata'])
+    directory = study.directory_listings.first
     execute_http_request(:get, api_v1_search_bulk_download_path(
-        auth_code: auth_code, accessions: study.accession, file_types: file_types)
+        auth_code: auth_code, accessions: study.accession, file_types: file_types, directory: directory.name)
     )
     assert_response :success
 
@@ -256,6 +257,13 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       assert config_file.include?(filename), "Did not find URL for filename: #{filename}"
       output_path = file.bulk_download_pathname
       assert config_file.include?(output_path), "Did not correctly set output path for #{filename} to #{output_path}"
+    end
+
+    directory.files.each do |file|
+      filename = file[:name]
+      assert config_file.include?(filename), "Did not find URL for directory filename: #{filename}"
+      output_path = directory.bulk_download_pathname(file)
+      assert config_file.include?(output_path), "Did not correctly set output path for directory file #{filename} to #{output_path}"
     end
 
     # ensure bad/missing auth_token return 401

--- a/test/bulk_download_helper.rb
+++ b/test/bulk_download_helper.rb
@@ -15,3 +15,7 @@ end
 def get_file_count_from_response(response)
   response.values.map {|entry| entry[:total_files]}.reduce(&:+)
 end
+
+def get_file_size_from_response(response)
+  response.values.map {|entry| entry[:total_bytes]}.reduce(&:+)
+end


### PR DESCRIPTION
Previously, when doing a single-study bulk download request (not via advanced search), the `curl` command would also include any extra directories of data in the study that were registered via `DirectoryListing` objects.  These are only created via sync, and represent entire folders of files that are all of the same type (such as fastq, BAM, or text files) and have at least 10 entries.  Since the refactoring of bulk download into `BulkDownloadService`, this functionality has been lost, and only `StudyFiles` can be downloaded.

This update restores the ability to download _all_ data from a single study via the bulk download modal, or individual folders of files, if present.  Bulk downloads via advanced search will not include these directories, as the potential for exceeding the user's download quota would be quite high, and would fail the entire request before downloading.  In addition, this also adds `DirectoryListing` objects to the `file_supplemental_info.tsv` manifest, as `DirectoryListing` objects can have an associated `Taxon` if the folder contains sequence data.

This PR satisfies SCP-3096.

