### PR TITLE
Correctly clean up failed ingest artifacts (SCP-3107)

### DIFF
--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -155,7 +155,7 @@ class FileParseService
     Rails.logger.info "Cleaning up all ingest pipeline artifacts older than #{cutoff_date}"
     Study.where(queued_for_deletion: false, detached: false).each do |study|
       Rails.logger.info "Checking #{study.accession}:#{study.bucket_id}"
-      study.delete_ingest_artifacts(cutoff_date)
+      delete_ingest_artifacts(study, cutoff_date)
     end
   end
 

--- a/test/integration/lib/file_parse_service_test.rb
+++ b/test/integration/lib/file_parse_service_test.rb
@@ -87,7 +87,7 @@ class FileParseServiceTest < ActiveSupport::TestCase
     bucket_mock = Minitest::Mock.new
     bucket_mock.expect :execute_gcloud_method, [file_mock], [:get_workspace_files, Integer, String, Hash]
 
-    FireCloudClient.stub :new, bucket_mock do
+    ApplicationController.stub :firecloud_client, bucket_mock do
       FileParseService.delete_ingest_artifacts(study, 30.days.ago)
       bucket_mock.verify
       file_mock.verify


### PR DESCRIPTION
A bug in calling `FileParseService#delete_ingest_artifacts` has caused the regular weekly cleanup of failed ingest runs older than 1 month to not run.  This update fixes the method invocation, and adds an integration test to validate that it works properly (using mocks).

Note: it may not be possible to manually verify this fix due to the nature of the integration requiring a failed upload older than 30 days, but the integration test verifies that the method works as called now.

This PR satisfies SCP-3107.