### PR TITLE
Better error handling re: uploading Coordinate Labels files (SCP-3101)

### DIFF
--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -130,8 +130,8 @@ class FileParseService
         elsif bundled_types.include?(study_file.file_type)
           parent_file_id = study_file.options.with_indifferent_access[options_key]
           parent_file = StudyFile.find_by(id: parent_file_id)
-          # parent file may or may not be present, so check first
-          if parent_file.present?
+          # parent file may or may not be present, or queued for deletion, so check first
+          if parent_file.present? && !parent_file.queued_for_deletion
             study_file_bundle = StudyFileBundle.initialize_from_parent(study, parent_file)
             study_file_bundle.add_files(study_file)
           end

--- a/app/models/study_file_bundle.rb
+++ b/app/models/study_file_bundle.rb
@@ -10,6 +10,8 @@ class StudyFileBundle
 
   # allowed bundle types
   BUNDLE_TYPES = ['MM Coordinate Matrix', 'BAM', 'Cluster']
+  # file types that must be bundled to be valid
+  REQUIRE_BUNDLE = ['MM Coordinate Matrix', 'BAM', 'BAM Index', 'Coordinate Labels', '10X Genes File', '10X Barcodes File']
   # required keys for file list
   FILE_LIST_KEYS = %w(name file_type)
   # child file type requirements by bundle type
@@ -17,6 +19,13 @@ class StudyFileBundle
       'MM Coordinate Matrix' => ['10X Genes File', '10X Barcodes File'],
       'BAM' => ['BAM Index'],
       'Cluster' => ['Coordinate Labels']
+  }
+  # parent file type requirements by child file type
+  CHILD_REQUIREMENTS = {
+    '10X Genes File' => 'MM Coordinate Matrix',
+    '10X Barcodes File' => 'MM Coordinate Matrix',
+    'BAM Index' => 'BAM',
+    'Coordinate Labels' => 'Cluster'
   }
   PARSEABLE_BUNDLE_REQUIREMENTS = BUNDLE_REQUIREMENTS.dup.keep_if {|k,v| k != 'BAM'}
   FILE_ARRAY_ATTRIBUTES = {

--- a/app/models/study_file_bundle.rb
+++ b/app/models/study_file_bundle.rb
@@ -20,7 +20,9 @@ class StudyFileBundle
       'BAM' => ['BAM Index'],
       'Cluster' => ['Coordinate Labels']
   }
-  # parent file type requirements by child file type
+  # inverse of BUNDLE_REQUIREMENTS - this shows the required parent file type for each "bundled" file type
+  # this is used in the upload wizard for error handling when a user uploads a bundled file, but the parent
+  # has been deleted while the upload was in progress
   CHILD_REQUIREMENTS = {
     '10X Genes File' => 'MM Coordinate Matrix',
     '10X Barcodes File' => 'MM Coordinate Matrix',

--- a/app/views/studies/_deleted_bundle_message.html.erb
+++ b/app/views/studies/_deleted_bundle_message.html.erb
@@ -1,0 +1,6 @@
+<p class="lead">
+  The file <strong>'<%= file_name %>' (<%= file_type %>)</strong> is missing the required pairing to a
+  <strong><%= missing_file_type %></strong> file.  This may have happened due to the associated file failing to ingest
+  properly and subsequently being automatically deleted while this upload was in process.  Please re-upload the
+  <strong><%= missing_file_type %></strong> file, and once that file has ingested properly, you may re-upload this file.
+</p>

--- a/app/views/studies/_initialize_labels_form.html.erb
+++ b/app/views/studies/_initialize_labels_form.html.erb
@@ -19,7 +19,7 @@
     <%= f.fields_for :options do |opts| %>
       <div class="col-sm-4">
         <%= opts.label :cluster_file_id, 'Select the cluster to apply labels to' %><br />
-        <%= opts.select :cluster_file_id, options_for_select(@study.cluster_ordinations_files.map {|cluster_file| [cluster_file.name, cluster_file.id]}, f.object.new_record? ? nil : f.object.bundle_parent.id), {}, class: 'form-control' %>
+        <%= opts.select :cluster_file_id, options_for_select(@study.cluster_ordinations_files.map {|cluster_file| [cluster_file.name, cluster_file.id]}, f.object.new_record? ? nil : f.object.bundle_parent.try(:id)), {include_blank: true}, class: 'form-control' %>
       </div>
       <div class="col-sm-3">
         <%= opts.label :font_family, 'Display font for labels' %><br />

--- a/app/views/studies/deleted_bundle.js.erb
+++ b/app/views/studies/deleted_bundle.js.erb
@@ -2,6 +2,6 @@ $('<%= params[:modal_target]%>').modal('hide');
 $('<%= params[:selector] %>').remove();
 
 $('#generic-update-target').html("<%= j(render partial: '/layouts/generic_update_modal') %>");
-$('#generic-update-modal-title').html("<span class='text-danger'>Upload of <%= @file_name %> has been cancelled</span>");
+$('#generic-update-modal-title').html("<span class='text-danger'>Upload of <%= @file_name %> cancelled</span>");
 $('#generic-update-modal-body').html("<%= j(render partial: 'deleted_bundle_message', locals: {file_name: @file_name, file_type: @file_type, missing_file_type: @missing_file_type})%>");
 $("#generic-update-modal").modal("show");

--- a/app/views/studies/deleted_bundle.js.erb
+++ b/app/views/studies/deleted_bundle.js.erb
@@ -1,0 +1,7 @@
+$('<%= params[:modal_target]%>').modal('hide');
+$('<%= params[:selector] %>').remove();
+
+$('#generic-update-target').html("<%= j(render partial: '/layouts/generic_update_modal') %>");
+$('#generic-update-modal-title').html("<span class='text-danger'>Upload of <%= @file_name %> has been cancelled</span>");
+$('#generic-update-modal-body').html("<%= j(render partial: 'deleted_bundle_message', locals: {file_name: @file_name, file_type: @file_type, missing_file_type: @missing_file_type})%>");
+$("#generic-update-modal").modal("show");

--- a/test/factories/study.rb
+++ b/test/factories/study.rb
@@ -25,6 +25,7 @@ FactoryBot.define do
     # create a study but mark as detached, so a Terra workspace is not created
     factory :detached_study do
       detached { true }
+      bucket_id { SecureRandom.alphanumeric(16) }
     end
   end
 end

--- a/test/factories/study.rb
+++ b/test/factories/study.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
     # create a study but mark as detached, so a Terra workspace is not created
     factory :detached_study do
       detached { true }
-      bucket_id { SecureRandom.alphanumeric(16) }
+      bucket_id { SecureRandom.alphanumeric(16) } # needed to prevent test errors when mocking/stubbing GCS calls
     end
   end
 end

--- a/test/integration/lib/file_parse_service_test.rb
+++ b/test/integration/lib/file_parse_service_test.rb
@@ -106,7 +106,7 @@ class FileParseServiceTest < ActiveSupport::TestCase
 
     # don't use factory bot as we want to test parsing logic
     @coordinate_file = StudyFile.create(file_type: 'Coordinate Labels', name: 'coordinate_labels_2.txt', study_id: @basic_study.id,
-                                    upload: File.open(Rails.root.join('test', 'test_data', 'coordinate_labels_1.txt')),
+                                    upload: File.open(Rails.root.join('test', 'test_data', 'coordinate_labels_2.txt')),
                                     options: {cluster_file_id: @cluster_file.id.to_s})
 
     # simulate "failed" upload by queuing cluster file for deletion

--- a/test/integration/lib/file_parse_service_test.rb
+++ b/test/integration/lib/file_parse_service_test.rb
@@ -2,11 +2,20 @@ require "test_helper"
 
 class FileParseServiceTest < ActiveSupport::TestCase
 
+  include Minitest::Hooks
+  include SelfCleaningSuite
+  include TestInstrumentor
+
+  before(:all) do
+    @user = FactoryBot.create(:api_user, test_array: @@users_to_clean)
+    @basic_study = FactoryBot.create(:detached_study,
+                                     name_prefix: 'File Parse Service Test',
+                                     user: @user,
+                                     test_array: @@studies_to_clean)
+  end
+
   # test detection & automatic creating of study_file_bundle objects based off of study_file.options params
   test 'should create study file bundle from parent' do
-    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
-    study = Study.first
-
     # test MTX bundling from parent
     test_data_basepath = Rails.root.join('test', 'test_data', 'GRCh38')
     matrix_filename = 'test_matrix.mtx'
@@ -16,16 +25,16 @@ class FileParseServiceTest < ActiveSupport::TestCase
     genes_file = File.open(File.join(test_data_basepath, genes_filename))
     barcodes_file = File.open(File.join(test_data_basepath, barcodes_filename))
     # status: 'uploaded' is required for study_file_bundle to be marked as 'completed'
-    matrix = study.study_files.build(file_type: 'MM Coordinate Matrix', upload: matrix_file, name: matrix_filename,
+    matrix = @basic_study.study_files.build(file_type: 'MM Coordinate Matrix', upload: matrix_file, name: matrix_filename,
                                      status: 'uploaded')
     matrix.save!
-    genes = study.study_files.build(file_type: '10X Genes File', upload: genes_file, name: genes_filename,
+    genes = @basic_study.study_files.build(file_type: '10X Genes File', upload: genes_file, name: genes_filename,
                                     options: {matrix_id: matrix.id.to_s}, status: 'uploaded')
-    barcodes = study.study_files.build(file_type: '10X Barcodes File', upload: barcodes_file, name: barcodes_filename,
+    barcodes = @basic_study.study_files.build(file_type: '10X Barcodes File', upload: barcodes_file, name: barcodes_filename,
                                        options: {matrix_id: matrix.id.to_s}, status: 'uploaded')
     genes.save!
     barcodes.save!
-    FileParseService.create_bundle_from_file_options(matrix, study)
+    FileParseService.create_bundle_from_file_options(matrix, @basic_study)
     matrix_file.close
     genes_file.close
     barcodes_file.close
@@ -42,42 +51,32 @@ class FileParseServiceTest < ActiveSupport::TestCase
       assert bundle_file.study_file_bundle == parent_bundle,
              "Did not associate correct study file bundle object for #{filename}"
     end
-
-    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
 
   test 'should create study file bundle from child' do
     # test cluster/labels bundling from child/bundled file
-    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
-    study = Study.first
-
     test_data_basepath = Rails.root.join('test', 'test_data')
     cluster_filename = 'cluster_2_example_2.txt'
     cluster_file = File.open(File.join(test_data_basepath, cluster_filename))
-    cluster = study.study_files.build(file_type: 'Cluster', upload: cluster_file, name: cluster_filename,
+    cluster = @basic_study.study_files.build(file_type: 'Cluster', upload: cluster_file, name: cluster_filename,
                                       status: 'uploaded')
     cluster.save!
     coordinate_filename = 'coordinate_labels_1.txt'
     coordinate_file = File.open(File.join(test_data_basepath, coordinate_filename))
-    coordinate_labels = study.study_files.build(file_type: 'Coordinate Labels', upload: coordinate_file,
+    coordinate_labels = @basic_study.study_files.build(file_type: 'Coordinate Labels', upload: coordinate_file,
                                                 name: coordinate_filename, status: 'uploaded',
                                                 options: {cluster_file_id: cluster.id.to_s})
     coordinate_labels.save!
-    FileParseService.create_bundle_from_file_options(coordinate_labels, study)
+    FileParseService.create_bundle_from_file_options(coordinate_labels, @basic_study)
     cluster.reload
     coordinate_labels.reload
     cluster_bundle = cluster.study_file_bundle
     assert cluster_bundle.present?, "Did not create study file bundle for cluster file w/ coordinate labels present"
     assert cluster_bundle.completed?, "Did not mark cluster bundle completed"
     assert cluster_bundle.bundled_files.first == coordinate_labels, "Did not correctly return labels file from bundle"
-
-    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
 
   test 'should clean up ingest artifacts after one month' do
-    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
-
-    study = Study.first
     file_mock = Minitest::Mock.new
     two_months_ago = DateTime.now - 2.months
     file_mock.expect :size, 1024
@@ -88,12 +87,36 @@ class FileParseServiceTest < ActiveSupport::TestCase
     bucket_mock.expect :execute_gcloud_method, [file_mock], [:get_workspace_files, Integer, String, Hash]
 
     ApplicationController.stub :firecloud_client, bucket_mock do
-      FileParseService.delete_ingest_artifacts(study, 30.days.ago)
+      FileParseService.delete_ingest_artifacts(@basic_study, 30.days.ago)
       bucket_mock.verify
       file_mock.verify
     end
+  end
 
-    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
+  test 'should prevent parsing coordinate label file after cluster deletes' do
+    @cluster_file = FactoryBot.create(:cluster_file,
+                                                  name: 'clusterA.txt',
+                                                  study: @basic_study,
+                                                  cell_input: {
+                                                    x: [1, 4 ,6],
+                                                    y: [7, 5, 3],
+                                                    cells: ['A', 'B', 'C']
+                                                  },
+                                                  annotation_input: [{name: 'foo', type: 'group', values: ['bar', 'bar', 'baz']}])
+
+    # don't use factory bot as we want to test parsing logic
+    @coordinate_file = StudyFile.create(file_type: 'Coordinate Labels', name: 'coordinate_labels_2.txt', study_id: @basic_study.id,
+                                    upload: File.open(Rails.root.join('test', 'test_data', 'coordinate_labels_1.txt')),
+                                    options: {cluster_file_id: @cluster_file.id.to_s})
+
+    # simulate "failed" upload by queuing cluster file for deletion
+    DeleteQueueJob.new(@cluster_file).perform
+
+    # attempt to parse coordinate file and assert 412 response and that no study_file_bundle is created
+    response = FileParseService.run_parse_job(@coordinate_file, @basic_study, @user)
+    @coordinate_file.reload
+    assert_equal 412, response[:status_code]
+    assert_nil @coordinate_file.study_file_bundle
   end
 
   # TODO: once SCP-2765 is completed, test that all genes/values are parsed from mtx bundle

--- a/yarn.lock
+++ b/yarn.lock
@@ -6539,9 +6539,9 @@ globule@^1.0.0:
     minimatch "~3.0.2"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
-  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
+  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -7225,7 +7225,7 @@ is-color-stop@^1.0.0:
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
 
-is-core-module@^2.1.0:
+is-core-module@^2.1.0, is-core-module@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
   integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
@@ -9211,17 +9211,17 @@ mime-db@1.44.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
-"mime-db@>= 1.43.0 < 2":
+mime-db@1.45.0, "mime-db@>= 1.43.0 < 2":
   version "1.45.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
   integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
 
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
-  version "2.1.27"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
-  integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
+  version "2.1.28"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.28.tgz#1160c4757eab2c5363888e005273ecf79d2a0ecd"
+  integrity sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==
   dependencies:
-    mime-db "1.44.0"
+    mime-db "1.45.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -12331,11 +12331,11 @@ resolve@1.15.0:
     path-parse "^1.0.6"
 
 resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.8.1:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
-  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
   dependencies:
-    is-core-module "^2.1.0"
+    is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
 restore-cursor@^3.1.0:
@@ -13895,9 +13895,9 @@ upath@^1.1.1:
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
 uri-js@^4.2.2:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.0.tgz#aa714261de793e8a82347a7bcc9ce74e86f28602"
-  integrity sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
 
@@ -14692,9 +14692,9 @@ xtend@^4.0.0, xtend@~4.0.1:
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
+  integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
Coordinate Labels files are files that add text annotations to Cluster files inside the plot area, usually to annotate a specific population inside a scatter plot.  These files cannot be uploaded until the user has added at least one cluster file, and the association is managed through the `StudyFileBundle` class.  However, there is a corner case where the user can add the cluster file, which will then begin an ingest run, and then add the coordinate labels file.  If that cluster file fails its ingest run before the coordinate labels file has finished uploading, it will fail to launch a parse job and become orphaned, as the "parent" of the `StudyFileBundle` that was created was removed.  This then causes two errors: first, the upload wizard or sync page cannot be rendered due to the missing association (trying to reference `id` on a `nil` object), and the coordinate labels file cannot be parsed or deleted, and requires manual intervention at the database level to resolve.

This update fixes the error that prevents forms from rendering, and adds better error handling to detect and rescue from this corner case.  The update flow will now catch this potential error and remove the coordinate labels file, and then show the following modal to the user to notify them of the issue:

![automatic_bundle_delete](https://user-images.githubusercontent.com/729968/108423329-ba3e9a80-7205-11eb-89a0-4afb3b5e2243.png)

Also, the `FileParseServiceTest` suite was updated to test this new integration, and was generally refactored for better maintainability by using `FactoryBot`.

This PR satisfies SCP-3101