### PR TITLE
Pair DirectoryListing of sequence index files with parent (SCP-3097)

### DIFF
--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -476,8 +476,8 @@ module Api
         @unsynced_directories = @study.directory_listings.unsynced
 
         # split directories into primary data types and 'others'
-        @unsynced_primary_data_dirs = @unsynced_directories.select {|dir| dir.file_type == 'fastq'}
-        @unsynced_other_dirs = @unsynced_directories.select {|dir| dir.file_type != 'fastq'}
+        @unsynced_primary_data_dirs = @unsynced_directories.select {|dir| DirectoryListing::PRIMARY_DATA_TYPES.include?(dir.file_type)}
+        @unsynced_other_dirs = @unsynced_directories.select {|dir| !DirectoryListing::PRIMARY_DATA_TYPES.include?(dir.file_type)}
 
         # now determine if we have study_files that have been 'orphaned' (cannot find a corresponding bucket file)
         @orphaned_study_files = @study_files - @synced_study_files
@@ -611,16 +611,16 @@ module Api
 
         files.each do |file|
           # check first if file type is in file map in a group larger than 10 (or 20 for text files)
-          file_extension = DirectoryListing.file_extension(file.name)
+          file_type = DirectoryListing.file_type_from_extension(file.name)
           directory_name = DirectoryListing.get_folder_name(file.name)
-          max_size = file_extension == 'txt' ? 20 : 10
-          if @file_extension_map.has_key?(directory_name) && !@file_extension_map[directory_name][file_extension].nil? && @file_extension_map[directory_name][file_extension] >= max_size
-            process_directory_listing_file(file, file_extension)
+          if @file_extension_map.has_key?(directory_name) && !@file_extension_map.dig(directory_name, file_type).nil? &&
+            @file_extension_map.dig(directory_name, file_type) >= DirectoryListing::MIN_SIZE
+            process_directory_listing_file(file, file_type)
           else
-            # we are now dealing with singleton files or fastqs, so process accordingly (making sure to ignore directories)
-            if DirectoryListing::PRIMARY_DATA_TYPES.any? {|ext| file_extension.include?(ext)} && !file.name.end_with?('/')
+            # we are now dealing with singleton files or sequence data, so process accordingly (making sure to ignore directories)
+            if DirectoryListing::PRIMARY_DATA_TYPES.any? {|ext| file_type.include?(ext)} && !file.name.end_with?('/')
               # process fastq file into appropriate directory listing
-              process_directory_listing_file(file, 'fastq')
+              process_directory_listing_file(file, file_type)
             else
               # make sure file is not actually a folder by checking its size
               if file.size > 0

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -36,7 +36,7 @@
               <p class="lead">To download all files using <code>curl</code>, click the button below to get the download command:</p>
               <p class="lead command-container" id="command-container-all">
                 <%= link_to "<i class='fas fa-download'></i> Get download command for all study data".html_safe,
-                            '#/', class: 'btn btn-default get-download-command', id: 'get-download-command_all' %></p>
+                            '#/', class: 'btn btn-default get-download-command', id: 'get-download-command__all' %></p>
               <% if @directories.any? %>
                 <p class="lead">To download all data files in a specific folder, use the following commands:</p>
                 <table class="table table-condensed table-striped">
@@ -50,7 +50,7 @@
                         <td><%= directory.name %></td>
                         <td class="command-container" id="command-container-<%= directory.url_safe_name %>">
                           <%= link_to "<i class='fas fa-download'></i> Get download command".html_safe, '#/',
-                                      class: 'btn btn-default get-download-command', id: "get-download-command_#{directory.url_safe_name}",
+                                      class: 'btn btn-default get-download-command', id: "get-download-command__#{directory.url_safe_name}",
                                       data: {filetypes: 'None' } %>
                         </td>
                       </tr>
@@ -86,7 +86,7 @@
 
         $('body').on('click', '.btn-refresh', function(event) {
           var commandContainer = $(this).parentsUntil('.command-container').parent();
-          var downloadObject = commandContainer.attr('id').split('-').slice(-1)[0];
+          var downloadObject = commandContainer.attr('id').split('__').slice(-1)[0];
           var fileTypes = commandContainer.data('filetypes');
           writeDownloadCommand(downloadObject, fileTypes);
         });
@@ -156,7 +156,7 @@
         // Show the download command upon clicking the "Get download command" button
         $('body').on('click', '.get-download-command', function(event) {
           var downloadButton = $(this);
-          var downloadObject = downloadButton.attr('id').split('_')[1];
+          var downloadObject = downloadButton.attr('id').split('__').slice(-1)[0];
           var fileTypes = downloadButton.data('filetypes');
           writeDownloadCommand(downloadObject, fileTypes);
         });

--- a/test/models/directory_listing_test.rb
+++ b/test/models/directory_listing_test.rb
@@ -1,0 +1,118 @@
+require "test_helper"
+
+class DirectoryListingTest < ActiveSupport::TestCase
+  include Minitest::Hooks
+  include TestInstrumentor
+  include SelfCleaningSuite
+
+  before(:all) do
+    @user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    @basic_study = FactoryBot.create(:detached_study,
+                                     name_prefix: 'directory listing test',
+                                     test_array: @@studies_to_clean,
+                                     user: @user)
+
+    @file_list = []
+    1.upto(20).each do |i|
+      @file_list << {
+        name: "sample_#{i}.bam",
+        size: i * 100,
+        generation: SecureRandom.random_number(10000..99999)
+      }.with_indifferent_access
+    end
+    @directory_listing = DirectoryListing.create(study_id: @basic_study.id, file_type: 'bam',
+                                                 name: '/', files: @file_list, sync_status: true)
+  end
+
+  ##
+  # INSTANCE METHODS
+  ##
+
+  test 'should find file' do
+    filename = @file_list.sample[:name]
+    assert @directory_listing.has_file?(filename)
+  end
+
+  test 'should get total bytes' do
+    expected_bytes = (100..2000).step(100).reduce(:+) # 21000, or 100 + 200 + ... + 2000
+    assert_equal expected_bytes, @directory_listing.total_bytes
+  end
+
+  test 'should get bulk download folder name' do
+    file = @file_list.sample
+    expected_output = "root_dir/#{file[:name]}"
+    assert_equal expected_output, @directory_listing.bulk_download_folder(file)
+  end
+
+  test 'should get bulk download pathname' do
+    file = @file_list.sample
+    expected_output = "#{@basic_study.accession}/root_dir/#{file[:name]}"
+    assert_equal expected_output, @directory_listing.bulk_download_pathname(file)
+  end
+
+  ##
+  # CLASS METHODS
+  ##
+
+  test 'should get base filename' do
+    filename = @file_list.sample[:name]
+    expected_basename = filename.split('.').first
+    assert_equal expected_basename, DirectoryListing.file_basename(filename)
+  end
+
+  test 'should get folder name from file' do
+    filepath = 'mouse/sample_1.bam'
+    assert_equal 'mouse', DirectoryListing.get_folder_name(filepath)
+    # test root directory
+    new_path = filepath.split('/').last
+    assert_equal '/', DirectoryListing.get_folder_name(new_path)
+  end
+
+  test 'should get file extension' do
+    filename = @file_list.sample[:name]
+    expected_extension = 'bam'
+    assert_equal expected_extension, DirectoryListing.file_extension(filename)
+    # test gz, tar support
+    gzip_filename = 'sample_1.bam.gz'
+    expected_extension = 'bam.gz'
+    assert_equal expected_extension, DirectoryListing.file_extension(gzip_filename)
+    tar_filename = 'sample_1.bam.tar.gz'
+    expected_extension = 'bam.tar.gz'
+    assert_equal expected_extension, DirectoryListing.file_extension(tar_filename)
+  end
+
+  test 'should get file type from extension' do
+    filename = @file_list.sample[:name]
+    expected_type = 'bam'
+    assert_equal expected_type, DirectoryListing.file_type_from_extension(filename)
+    # test index detection support
+    index_filename = filename + '.bai'
+    assert_equal expected_type, DirectoryListing.file_type_from_extension(index_filename)
+    shortened_filename = 'sample_1.bai'
+    assert_equal expected_type, DirectoryListing.file_type_from_extension(shortened_filename)
+    # test tar, gz support
+    compressed_filename = 'sample_1.bam.tar.gz'
+    assert_equal expected_type, DirectoryListing.file_type_from_extension(compressed_filename)
+    # fallback support
+    archive_name = 'archive.zip'
+    assert_equal 'zip', DirectoryListing.file_type_from_extension(archive_name)
+  end
+
+  # should create map of entries, ignoring txt & sequence file types
+  test 'should create map of file extensions' do
+    expected_map = {csv: {csv: 20}}.with_indifferent_access
+    # create a mock file list to feed into create_extension_map
+    # each entry must respond to the method :name, and be a filepath-like entry
+    # that conforms to {extension}/sample_{num}.{extension}
+    mock_file_list = []
+    %w(csv txt bam bai).each do |ext|
+      1.upto(20).each do |i|
+        mock_file = Minitest::Mock.new
+        mock_file.expect :name, "#{ext}/sample_#{i}.#{ext}"
+        mock_file_list << mock_file
+      end
+    end
+    output_map = DirectoryListing.create_extension_map(mock_file_list)
+    assert_equal expected_map, output_map
+  end
+end


### PR DESCRIPTION
Currently, `DirectoryListing` objects only pair together files of 10 or more with the exact same file extension into a single list.  This is primarily to allow downloads of individual folders of like files.  However, if a user has created a folder of BAM files and their indexes (.bai), SCP will not allow users to pair these together, and will attempt to create two separate `DirectoryListing` objects.  While this will not break when saving, it will cause bulk downloads of those folders to clobber each other, meaning a user downloading "All Data" will only get one of those folders (whichever is downloaded last).

This update now allows BAM and index files to pair together in a single `DirectoryListing` that will set the file type to the parent (BAM).  In addition, new unit tests are added for coverage of relevant methods in the `DirectoryListing` class, as none were present before.

Also, this update fixes a bug with downloading an individual directory that has underscores "`_`" in the name.  Previously, the download modal would not update with the `curl` command to download that directory due to a parsing issue in JS.

This PR satisfies SCP-3097.