### PR TITLE
Fixing gene list parsing, adding Mixpanel logging, code cleanup (SCP-2966)

### DIFF
--- a/app/models/parse_utils.rb
+++ b/app/models/parse_utils.rb
@@ -1,222 +1,6 @@
 require 'rubygems/package' # for tar reader
 class ParseUtils
 
-  # parse a 10X gene-barcode matrix file triplet (input matrix must be sorted by gene indices)
-  def self.cell_ranger_expression_parse(study, user, matrix_study_file, genes_study_file, barcodes_study_file, opts={})
-    begin
-      start_time = Time.zone.now
-      # localize files
-      Rails.logger.info "Parsing gene-barcode matrix source data files for #{study.name} with the following options: #{opts}"
-      study.make_data_dir
-      Rails.logger.info "Localizing output files & creating study file entries from 10X CellRanger source data for #{study.name}"
-
-      # localize files if necessary, otherwise open newly uploaded files. check to make sure a local copy doesn't already exists
-      # as we may be uploading files piecemeal from upload wizard
-      matrix_file = localize_study_file(matrix_study_file, study)
-      genes_file = localize_study_file(genes_study_file, study)
-      barcodes_file = localize_study_file(barcodes_study_file, study)
-
-      # next, check if this is a re-parse job, in which case we need to remove all existing entries first
-      if opts[:reparse]
-        Gene.where(study_id: study.id, study_file_id: matrix_study_file.id).delete_all
-        DataArray.where(study_id: study.id, study_file_id: matrix_study_file.id).delete_all
-        DataArray.where(name: "#{matrix_file.name} Cells", array_type: 'cells', linear_data_type: 'Study',
-                        linear_data_id: study.id).delete_all
-        matrix_study_file.invalidate_cache_by_file_type
-      end
-
-      # process the genes file to concatenate gene names and IDs together (for differentiating entries with duplicate names)
-      raw_genes = genes_file.readlines.map(&:strip)
-      @genes = []
-      raw_genes.each do |row|
-        vals = row.split(/[\t,\s]/) # split on tabs, commas, or whitespace
-        if vals.size == 1
-          @genes << vals.first.strip
-        else
-          gene_id, gene_name = vals.map(&:strip)
-          @genes << [gene_name, gene_id]
-        end
-      end
-
-      # read barcodes file
-      @barcodes = barcodes_file.readlines.map(&:strip)
-
-      # close files
-      genes_file.close
-      barcodes_file.close
-
-      # validate that barcodes list does not have any repeated values
-      existing_cells = study.all_expression_matrix_cells
-      uniques = @barcodes - existing_cells
-
-      unless uniques.size == @barcodes.size
-        repeats = @barcodes - uniques
-        raise StandardError, "You have re-used the following cell names that were found in another expression matrix in your study (cell names must be unique across all expression matrices): #{repeats.join(', ')}"
-      end
-
-      # open matrix file and read contents
-      Rails.logger.info "Reading gene/barcode/matrix file contents for #{study.name}"
-      m_header_1 = matrix_file.readline.split.map(&:strip)
-      valid_headers = %w(%%MatrixMarket matrix coordinate)
-      unless m_header_1.first == valid_headers.first && m_header_1[1] == valid_headers[1] && m_header_1[2] == valid_headers[2]
-        raise StandardError, "Your input matrix is not a Matrix Market Coordinate Matrix (header validation failed).  The first line should read: #{valid_headers.join(' ')}, but found #{m_header_1}"
-      end
-
-      scores_header = matrix_file.readline.strip
-      while scores_header.start_with?('%')
-        # discard empty comment lines
-        scores_header = matrix_file.readline.strip
-      end
-
-      # containers for holding data yet to be saved to database
-      @gene_documents = []
-      @data_arrays = []
-      @count = 0
-      @child_count = 0
-
-      # read first line manually and initialize containers for storing temporary data yet to be added to documents
-      Rails.logger.info "Initializing data structures from 10X CellRanger source data for #{study.name}"
-      line = matrix_file.readline.strip
-      gene_index, barcode_index, expression_score = parse_line(line)
-      @last_gene_index, @current_gene = initialize_new_gene(study, gene_index, matrix_study_file)
-      @current_barcodes = [@barcodes[barcode_index]]
-      @current_expression = [expression_score]
-      Rails.logger.info "Creating new gene & data_array records from 10X CellRanger source data for #{study.name}"
-
-      # now process all lines
-      process_matrix_data(study, matrix_file, matrix_study_file)
-
-      # create last batch of arrays
-      create_data_arrays(@current_barcodes, matrix_study_file, 'cells', @current_gene, @data_arrays)
-      create_data_arrays(@current_expression, matrix_study_file, 'expression', @current_gene, @data_arrays)
-
-      # close file and clean up
-      matrix_file.close
-
-      # write last records to database
-      Gene.create(@gene_documents)
-      @count += @gene_documents.size
-      Rails.logger.info "Processed #{@count} expressed genes from 10X CellRanger source data for #{study.name}"
-      DataArray.create(@data_arrays)
-      @child_count += @data_arrays.size
-      Rails.logger.info "Processed #{@child_count} child data arrays from 10X CellRanger source data for #{study.name}"
-      # create array of known cells for this expression matrix
-      @barcodes.each_slice(DataArray::MAX_ENTRIES).with_index do |slice, index|
-        Rails.logger.info "Create known cells array ##{index + 1} for #{matrix_study_file.name}:#{matrix_study_file.id} in #{study.name}"
-        known_cells = DataArray.new(study_id: study.id, name: "#{matrix_study_file.name} Cells", cluster_name: matrix_study_file.name,
-                                    array_type: 'cells', array_index: index + 1, values: slice, study_file_id: matrix_study_file.id,
-                                    linear_data_type: 'Study', linear_data_id: study.id)
-        known_cells.save
-      end
-
-      # now we have to create empty gene records for all the non-significant genes
-      # reset the count as we'll get an accurate total count from the length of the genes list
-      @count = 0
-      other_genes = []
-      other_genes_count = 0
-      @genes.each do |gene|
-        if gene.is_a?(Array)
-          gene_name, gene_id = gene
-        else
-          gene_name = gene
-          gene_id = nil
-        end
-        other_genes << Gene.new(study_id: study.id, name: gene_name, searchable_name: gene_name.downcase, gene_id: gene_id, study_file_id: matrix_study_file.id).attributes
-        other_genes_count += 1
-        if other_genes.size % 1000 == 0
-          Rails.logger.info "Creating #{other_genes_count} non-expressed gene records in #{study.name}"
-          Gene.create(other_genes)
-          @count += other_genes.size
-          other_genes = []
-        end
-      end
-      # process last batch
-      Rails.logger.info "Creating #{other_genes_count} non-expressed gene records in #{study.name}"
-      Gene.create(other_genes)
-      @count += other_genes.size
-
-      # finish up
-      matrix_study_file.update(parse_status: 'parsed')
-      genes_study_file.update(parse_status: 'parsed')
-      barcodes_study_file.update(parse_status: 'parsed')
-
-      # set gene count
-      study.delay.set_gene_count
-
-      # set the default expression label if the user supplied one
-      if !study.has_expression_label? && !matrix_study_file.y_axis_label.blank?
-        Rails.logger.info "Setting default expression label in #{study.name} to '#{matrix_study_file.y_axis_label}'"
-        study_opts = study.default_options
-        study.update!(default_options: study_opts.merge(expression_label: matrix_study_file.y_axis_label))
-      end
-
-      # set initialized to true if possible
-      if study.cluster_groups.any? && study.cell_metadata.any? && !study.initialized?
-        Rails.logger.info "initializing #{study.name}"
-        study.update!(initialized: true)
-        Rails.logger.info "#{study.name} successfully initialized"
-      end
-
-      end_time = Time.zone.now
-      time = (end_time - start_time).divmod 60.0
-      @message = []
-      @message << "#{Time.zone.now}: #{study.name} 10X CellRanger expression data parse completed!"
-      @message << "Gene-level entries created: #{@count}"
-      @message << "Total Time: #{time.first} minutes, #{time.last} seconds"
-      Rails.logger.info @message.join("\n")
-      begin
-        SingleCellMailer.notify_user_parse_complete(user.email, "Gene-barcode matrix expression data has completed parsing", @message, study).deliver_now
-      rescue => e
-        ErrorTracker.report_exception(e, user, {message: @message})
-        Rails.logger.error "Unable to deliver email: #{e.message}"
-      end
-
-      # determine what to do with local files
-      begin
-        unless opts[:skip_upload] == true
-          upload_or_remove_study_file(matrix_study_file, study)
-          upload_or_remove_study_file(genes_study_file, study)
-          upload_or_remove_study_file(barcodes_study_file, study)
-        end
-      rescue => e
-        ErrorTracker.report_exception(e, user, {matrix_study_file: matrix_study_file.attributes.to_h,
-                                                genes_study_file: genes_study_file.attributes.to_h,
-                                                barcodes_study_file: barcodes_study_file.attributes.to_h,
-                                                study: study.attributes.to_h})
-        Rails.logger.error "Error in uploading files from sparse matrix parse to #{study.firecloud_project}/#{study.firecloud_workspace}#{study.bucket_id}: #{e.message}"
-      end
-
-      # finished, so return true
-      true
-    rescue => e
-      ErrorTracker.report_exception(e, user, {matrix_study_file: matrix_study_file.attributes.to_h,
-                                              genes_study_file: genes_study_file.attributes.to_h,
-                                              barcodes_study_file: barcodes_study_file.attributes.to_h,
-                                              study: study.attributes.to_h})
-      error_message = e.message
-      Rails.logger.error "#{e.class.name}:#{error_message}, #{@last_line}"
-      # error has occurred, so clean up records and remove file
-      Gene.where(study_id: study.id, study_file_id: matrix_study_file.id).delete_all
-      DataArray.where(study_id: study.id, study_file_id: matrix_study_file.id).delete_all
-      # clean up files
-      matrix_study_file.remove_local_copy
-      genes_study_file.remove_local_copy
-      barcodes_study_file.remove_local_copy
-      unless opts[:sync] == true # if parse was initiated via sync, don't remove files
-        delete_remote_file_on_fail(matrix_study_file, study)
-        delete_remote_file_on_fail(genes_study_file, study)
-        delete_remote_file_on_fail(barcodes_study_file, study)
-      end
-      bundle = matrix_study_file.study_file_bundle
-      bundle.destroy
-      matrix_study_file.destroy
-      genes_study_file.destroy
-      barcodes_study_file.destroy
-      SingleCellMailer.notify_user_parse_fail(user.email, "Gene-barcode matrix expression data in #{study.name} parse has failed", error_message, study).deliver_now
-      false
-    end
-  end
-
   # extract analysis output files based on a type of analysis output
   def self.extract_analysis_output_files(study, user, archive_file, analysis_method)
     begin
@@ -341,7 +125,7 @@ class ParseUtils
 
       # validate headers of coordinate file
       @validation_error = false
-      start_time = Time.zone.now
+      @start_time = Time.zone.now
       headers = c_file.readline.split(/[\t,]/).map(&:strip)
       @last_line = "#{coordinate_file.name}, line 1"
       # must have at least NAME, X and Y fields
@@ -485,8 +269,9 @@ class ParseUtils
       end
       coordinate_data.close
       coordinate_file.update(parse_status: 'parsed')
-      end_time = Time.zone.now
-      time = (end_time - start_time).divmod 60.0
+      @end_time = Time.zone.now
+      self.log_to_mixpanel(study, coordinate_file, user, @start_time, @end_time, 'success')
+      time = (@end_time - @start_time).divmod 60.0
       # assemble email message parts
       @message << "#{coordinate_file.upload_file_name} parse completed!"
       @message << "Labels created (#{@labels_created.size}: #{@labels_created.join(', ')}"
@@ -537,7 +322,9 @@ class ParseUtils
         end
       end
     rescue => e
+      @end_time = Time.now
       ErrorTracker.report_exception(e, user, error_context)
+      self.log_to_mixpanel(study, coordinate_file, user, @start_time, @end_time, 'failed')
       # error has occurred, so clean up records and remove file
       DataArray.where(study_file_id: coordinate_file.id).delete_all
       filename = coordinate_file.upload_file_name
@@ -546,7 +333,6 @@ class ParseUtils
       error_message = "#{@last_line} ERROR: #{e.message}"
       Rails.logger.info error_message
       SingleCellMailer.notify_user_parse_fail(user.email, "Error: Coordinate Labels file: '#{filename}' parse has failed", error_message, study).deliver_now
-
     end
   end
 
@@ -574,7 +360,7 @@ class ParseUtils
 
       @count = 0
       @message = []
-      start_time = Time.zone.now
+      @start_time = Time.zone.now
       @last_line = ""
       @validation_error = false
 
@@ -671,11 +457,11 @@ class ParseUtils
       precomputed_score.gene_scores = rows
       precomputed_score.save
       marker_file.update(parse_status: 'parsed')
-      marker_scores.close
 
       # assemble message
-      end_time = Time.zone.now
-      time = (end_time - start_time).divmod 60.0
+      @end_time = Time.zone.now
+      self.log_to_mixpanel(study, marker_file, user, @start_time, @end_time, 'success')
+      time = (@end_time - @start_time).divmod 60.0
       @message << "#{Time.zone.now}: #{marker_file.name} parse completed!"
       @message << "Total gene list entries created: #{@count}"
       @message << "Total Time: #{time.first} minutes, #{time.last} seconds"
@@ -723,7 +509,9 @@ class ParseUtils
         end
       end
     rescue => e
+      @end_time = Time.zone.now
       ErrorTracker.report_exception(e, user, error_context)
+      self.log_to_mixpanel(study, marker_file, user, @start_time, @end_time, 'failed')
       # parse has failed, so clean up records and remove file
       PrecomputedScore.where(study_file_id: marker_file.id).delete_all
       filename = marker_file.upload_file_name
@@ -736,6 +524,21 @@ class ParseUtils
     true
   end
 
+  # log parse job status to Mixpanel
+  def self.log_to_mixpanel(study, study_file, user, start_time, end_time, status)
+    total_runtime = (TimeDifference.between(start_time, end_time).in_seconds * 1000).to_i
+    parser = caller_locations.first.base_label # will get the method name of caller, which will be the parse method
+    job_props = {
+      perfTime: total_runtime, # Latency in milliseconds
+      fileType: study_file.file_type,
+      fileSize: study_file.upload_file_size,
+      action: parser,
+      studyAccession: study.accession,
+      jobStatus: status
+    }
+    MetricsService.log('rails-parse', job_props, user)
+  end
+
   private
 
   # helper method to sanitize arrays of data for use as keys or names (removes quotes, can transform . into _)
@@ -746,136 +549,6 @@ class ParseUtils
       output << (replace_periods ? value.gsub(/\./, '_') : value)
     end
     output
-  end
-
-  # read a single line of a coordinate matrix and return parsed indices and expression value
-  def self.parse_line(line)
-    raw_gene_idx, raw_barcode_idx, raw_expression_score = line.split.map(&:strip)
-    gene_idx = raw_gene_idx.to_i - 1 # since arrays are zero based, we need to offset by 1
-    barcode_idx = raw_barcode_idx.to_i - 1 # since arrays are zero based, we need to offset by 1
-    expression_score = raw_expression_score.to_f.round(3) # only keep 3 significant digits
-    [gene_idx, barcode_idx, expression_score]
-  end
-
-  # process a single line from a coordinate matrix and initialize a new gene object to use for associations
-  # stores new values for barcodes and expression scores in containers to be converted into data_arrays later
-  # returns current gene index and new gene object
-  def self.initialize_new_gene(study, gene_idx, matrix_file)
-    reference_gene = @genes[gene_idx]
-    if reference_gene.is_a?(Array)
-      gene_name, gene_id = reference_gene
-    else
-      gene_name = reference_gene
-      gene_id = nil
-    end
-    new_gene = Gene.new(study_id: study.id, name: gene_name, searchable_name: gene_name.downcase, gene_id: gene_id, study_file_id: matrix_file.id)
-    @gene_documents << new_gene.attributes
-    [gene_idx, new_gene]
-  end
-
-  # main parser method, will iterate through lines and create documents as necessary
-  def self.process_matrix_data(study, matrix_data, matrix_file)
-    while !matrix_data.eof?
-      line = matrix_data.readline.strip
-      if line.strip.blank?
-        break # would be the end of the file (hopefully)
-      else
-        gene_idx, barcode_idx, expression_score = parse_line(line)
-        if @last_gene_index == gene_idx
-          @current_barcodes << @barcodes[barcode_idx]
-          @current_expression << expression_score
-        else
-          # we need to validate that the file is sorted correctly.  if our gene index has gone down from what it was before,
-          # then we must abort and throw an error as the parse will not complete properly.  we will have all the genes,
-          # but not all of the expression data
-          if gene_idx < @last_gene_index
-            Rails.logger.error "Error in parsing #{matrix_file.bucket_location} in #{study.name}: incorrect sort order; #{gene_idx + 1} is less than #{@last_gene_index + 1} at line #{matrix_data.lineno}"
-            error_message = "Your input matrix is not sorted in the correct order.  The data must be sorted by gene index first, then barcode index: #{gene_idx + 1} is less than #{@last_gene_index + 1} at #{matrix_data.lineno}"
-            raise StandardError, error_message
-          end
-          # create data_arrays and move to the next gene
-          create_data_arrays(@current_barcodes, matrix_file, 'cells', @current_gene, @data_arrays)
-          create_data_arrays(@current_expression, matrix_file, 'expression', @current_gene, @data_arrays)
-          @last_gene_index, @current_gene = initialize_new_gene(study, gene_idx, matrix_file)
-          @current_barcodes = [@barcodes[barcode_idx]]
-          @current_expression = [expression_score]
-
-          # batch insert records in groups of 1000
-          if @data_arrays.size >= 1000
-            Gene.create(@gene_documents) # genes must be saved first, otherwise the linear data polymorphic association is invalid and will cause a parse fail
-            @count += @gene_documents.size
-            Rails.logger.info "Processed #{@count} expressed genes from 10X CellRanger source data for #{study.name}"
-            @gene_documents = []
-            DataArray.create(@data_arrays)
-            @child_count += @data_arrays.size
-            Rails.logger.info "Processed #{@child_count} child data arrays from 10X CellRanger source data for #{study.name}"
-            @data_arrays = []
-          end
-        end
-      end
-    end
-  end
-
-  # slice up arrays of barcodes and expression scores and create data arrays, storing them in a container for saving later
-  def self.create_data_arrays(source_data, study_file, data_array_type, parent_gene, data_arrays_container)
-    data_array_name = data_array_type == 'cells' ? parent_gene.cell_key : parent_gene.score_key
-    source_data.each_slice(DataArray::MAX_ENTRIES).with_index do |slice, index|
-      array = DataArray.new(name: data_array_name, cluster_name: study_file.name, array_type: data_array_type,
-                                 array_index: index + 1, study_file_id: study_file.id, values: slice,
-                                 linear_data_type: 'Gene', linear_data_id: parent_gene.id, study_id: parent_gene.study_id)
-      data_arrays_container << array.attributes
-    end
-  end
-
-  # localize a file for parsing and return opened file handler
-  def self.localize_study_file(study_file, study)
-    Rails.logger.info "Attempting to localize #{study_file.upload_file_name}"
-    if File.exists?(study_file.upload.path)
-      local_path = study_file.upload.path
-    elsif File.exists?(Rails.root.join(study.data_dir, study_file.download_location))
-      local_path = File.join(study.data_store_path, study_file.download_location)
-    else
-      Rails.logger.info "Downloading #{study_file.upload_file_name} from remote"
-      ApplicationController.firecloud_client.execute_gcloud_method(:download_workspace_file, 0, study.bucket_id, study_file.bucket_location,
-                                                   study.data_store_path, verify: :none)
-      Rails.logger.info "Successful localization of #{study_file.upload_file_name}"
-      local_path = File.join(study.data_store_path, study_file.bucket_location)
-    end
-    content_type = study_file.determine_content_type
-    if content_type == 'application/gzip'
-      Rails.logger.info "Parsing #{study_file.name}:#{study_file.id} as application/gzip"
-      local_file = Zlib::GzipReader.open(local_path)
-    else
-      Rails.logger.info "Parsing #{study_file.name}:#{study_file.id} as text/plain"
-      local_file = File.open(local_path, 'rb')
-    end
-    local_file
-  end
-
-  # determine if local files need to be pushed to GCS bucket, or if they can be removed safely
-  def self.upload_or_remove_study_file(study_file, study)
-    Rails.logger.info "Determining upload status of #{study_file.file_type}: #{study_file.bucket_location}:#{study_file.id}"
-    # now that parsing is complete, we can move file into storage bucket and delete local (unless we downloaded from FireCloud to begin with)
-    # rather than relying on opts[:local], actually check if the file is already in the GCS bucket
-    begin
-      remote = ApplicationController.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, study.bucket_id, study_file.bucket_location)
-      if remote.nil?
-        Rails.logger.info "Preparing to upload expression file: #{study_file.bucket_location}:#{study_file.id} to FireCloud"
-        study.send_to_firecloud(study_file)
-      else
-        Rails.logger.info "Found remote version of #{study_file.bucket_location}: #{remote.name} (#{remote.generation})"
-        run_at = 2.minutes.from_now
-        Delayed::Job.enqueue(UploadCleanupJob.new(study, study_file, 0), run_at: run_at)
-        Rails.logger.info "Cleanup job for #{study_file.bucket_location}:#{study_file.id} scheduled for #{run_at}"
-      end
-    rescue => e
-      error_context = ErrorTracker.format_extra_context(study, study_file)
-      ErrorTracker.report_exception(e, nil, error_context)
-      Rails.logger.error "Error in pushing #{study_file.bucket_location}:#{study_file.id} to #{study.firecloud_project}/#{study.firecloud_workspace}:#{study.bucket_id}: #{e.message}"
-      run_at = 2.minutes.from_now
-      Delayed::Job.enqueue(UploadCleanupJob.new(study, study_file, 0), run_at: run_at)
-      Rails.logger.info "UploadCleanupJob scheduled for #{run_at} for #{study_file.bucket_location}:#{study_file.id}"
-    end
   end
 
   # delete a file from the bucket on fail

--- a/test/integration/lib/file_parse_service_test.rb
+++ b/test/integration/lib/file_parse_service_test.rb
@@ -119,6 +119,31 @@ class FileParseServiceTest < ActiveSupport::TestCase
     assert_nil @coordinate_file.study_file_bundle
   end
 
+  test 'should parse gene list file' do
+    gene_list_name = 'Test Gene List'
+    gene_list_file = File.open(Rails.root.join('test', 'test_data', 'marker_1_gene_list.txt'))
+    gene_list = StudyFile.create(study_id: @basic_study.id, upload: gene_list_file, file_type: 'Gene List',
+                                 name: gene_list_name)
+    job_status = FileParseService.run_parse_job(gene_list, @basic_study, @user)
+    assert_equal 204, job_status[:status_code]
+    gene_list_file.close
+
+    # wait until parse is done and assert precomputed_score entry was inserted
+    max_wait = 60
+    current_wait = 0
+    interval = 10
+    precomputed_score = @basic_study.precomputed_scores.by_name(gene_list_name)
+    while precomputed_score.nil?
+      sleep interval
+      current_wait += interval
+      precomputed_score = @basic_study.precomputed_scores.by_name(gene_list_name)
+      if current_wait >= max_wait
+        break
+      end
+    end
+    assert precomputed_score.present?
+  end
+
   # TODO: once SCP-2765 is completed, test that all genes/values are parsed from mtx bundle
   # this will replace the deprecated 'should parse valid mtx bundle' from study_validation_test.rb
   test 'should store all genes and expression values from mtx parse' do

--- a/test/integration/lib/file_parse_service_test.rb
+++ b/test/integration/lib/file_parse_service_test.rb
@@ -133,11 +133,11 @@ class FileParseServiceTest < ActiveSupport::TestCase
     current_wait = 0
     interval = 10
     sleep interval
-    while !gene_list_file.parsed?
-      puts "After #{current_wait} seconds, #{gene_list_file.name} is #{gene_list_file.parse_status}"
+    while !gene_list.parsed?
+      puts "After #{current_wait} seconds, #{gene_list.name} is #{gene_list.parse_status}"
       sleep interval
       current_wait += interval
-      gene_list_file.reload
+      gene_list.reload
       if current_wait >= max_wait
         break
       end

--- a/test/integration/lib/file_parse_service_test.rb
+++ b/test/integration/lib/file_parse_service_test.rb
@@ -132,15 +132,17 @@ class FileParseServiceTest < ActiveSupport::TestCase
     max_wait = 60
     current_wait = 0
     interval = 10
-    precomputed_score = @basic_study.precomputed_scores.by_name(gene_list_name)
-    while precomputed_score.nil?
+    sleep interval
+    while !gene_list_file.parsed?
+      puts "After #{current_wait} seconds, #{gene_list_file.name} is #{gene_list_file.parse_status}"
       sleep interval
       current_wait += interval
-      precomputed_score = @basic_study.precomputed_scores.by_name(gene_list_name)
+      gene_list_file.reload
       if current_wait >= max_wait
         break
       end
     end
+    precomputed_score = @basic_study.precomputed_scores.by_name(gene_list_name)
     assert precomputed_score.present?
   end
 


### PR DESCRIPTION
Gene list file parsing has been broken since #743 due to a broken reference to an object when the parse methods were refactored out of the `Study` model and into `ParseUtils`.  This update fixes the issue, and also adds reporting to Mixpanel for the two remaining file parse jobs that still run on the server: Coordinate Labels and Gene Lists.  These will show up in Mixpanel now under the `rails-parse` event, since these are not ingest pipeline jobs.

A preview of what the `rails-parse` event looks like in Mixpanel:

![gene_list_job](https://user-images.githubusercontent.com/729968/109171991-4e51ba00-7750-11eb-867e-fce2a7242aac.png)


In addition, this update removes all deprecated parsers/methods from `ParseUtils` that have been superseded by scp-ingest-pipeline.

This PR satisfies SCP-2966.