### PR TITLE
Setting default empty values for non-existent tokens (SCP-3127)

### DIFF
--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -110,7 +110,9 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
       self.project = project
       # user.token_for_api_call will retrieve valid access token to use, if present
       self.access_token = user.token_for_api_call
-      self.expires_at = self.access_token['expires_at']
+      # set a default timeout if no token was retrieved; this prevents errors when attempting requests, although
+      # the request will most likely fail with a 401, which is expected
+      self.expires_at = self.access_token['expires_at'].present? ? self.access_token['expires_at'] : Time.now.in_time_zone + 1.hour
 
       # use user-defined project instead of portal default
       # if no keyfile is present, use environment variables

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -158,7 +158,7 @@ class User
       end
     else
       Rails.logger.error "#{Time.zone.now}: Unable to generate access token for user #{self.email} due to missing refresh token"
-      nil
+      {} # default empty value to prevent NoMethodError for nil object when using empty token
     end
   end
 


### PR DESCRIPTION
This update adds a default token response (empty hash: `{}`) to `User#valid_access_token` to prevent `NoMethodError` exceptions when trying to generate an OAuth token for a user.  This can happen if a user is signed into the portal, and either their session times out, or a deployment happens while they still have a valid session open.  Both cases result in their cached tokens being deleted, which can cause issues if a request is attempted before they re-authenticate.

This update also refactors `test/models/user_test.rb` to use `FactoryBot` for test maintainability.

This PR satisfies SCP-3127.