### PR TITLE
fixing populator test to handle bam/bai files

### DIFF
--- a/app/controllers/api/v1/visualization/explore_controller.rb
+++ b/app/controllers/api/v1/visualization/explore_controller.rb
@@ -102,7 +102,7 @@ module Api
             ]
             key :summary, 'Basic study visualization information'
             key :description, 'Returns overview of visualization properties for the given study'
-            key :operationId, 'api_v1_studies_explore_cluster_options_path'
+            key :operationId, 'cluster_options_api_v1_studies_explore_path'
             parameter do
               key :name, :study_id
               key :in, :path

--- a/test/api/visualization/clusters_controller_test.rb
+++ b/test/api/visualization/clusters_controller_test.rb
@@ -42,14 +42,14 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
     execute_http_request(:get, api_v1_study_clusters_path(@basic_study), user: user2)
     assert_equal 403, response.status
 
-    execute_http_request(:get, api_v1_study_explore_cluster_options_path(@basic_study), user: user2)
+    execute_http_request(:get, cluster_options_api_v1_study_explore_path(@basic_study), user: user2)
     assert_equal 403, response.status
 
     sign_in_and_update @user
     execute_http_request(:get, api_v1_study_clusters_path(@basic_study))
     assert_equal 200, response.status
 
-    execute_http_request(:get, api_v1_study_explore_cluster_options_path(@basic_study))
+    execute_http_request(:get, cluster_options_api_v1_study_explore_path(@basic_study))
     assert_equal 200, response.status
   end
 

--- a/test/api/visualization/explore_controller_test.rb
+++ b/test/api/visualization/explore_controller_test.rb
@@ -39,14 +39,14 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
     execute_http_request(:get, api_v1_study_explore_path(@basic_study), user: user2)
     assert_equal 403, response.status
 
-    execute_http_request(:get, api_v1_study_explore_cluster_options_path(@basic_study), user: user2)
+    execute_http_request(:get, cluster_options_api_v1_study_explore_path(@basic_study), user: user2)
     assert_equal 403, response.status
 
     sign_in_and_update @user
     execute_http_request(:get, api_v1_study_explore_path(@basic_study))
     assert_equal 200, response.status
 
-    execute_http_request(:get, api_v1_study_explore_cluster_options_path(@basic_study))
+    execute_http_request(:get, cluster_options_api_v1_study_explore_path(@basic_study))
     assert_equal 200, response.status
   end
 
@@ -64,7 +64,7 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
 
   test 'should get annotation listings' do
     sign_in_and_update @user
-    execute_http_request(:get, api_v1_study_explore_cluster_options_path(@basic_study))
+    execute_http_request(:get, cluster_options_api_v1_study_explore_path(@basic_study))
     assert_response :success
 
     assert_equal 'clusterA.txt', json['default_cluster']
@@ -72,14 +72,14 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_annotations, json['annotations']
     assert_equal({"clusterA.txt"=>[], "spatialA.txt"=>[]}, json['subsample_thresholds'])
 
-    execute_http_request(:get, api_v1_study_explore_cluster_options_path(@empty_study))
+    execute_http_request(:get, cluster_options_api_v1_study_explore_path(@empty_study))
     assert_equal [], json['annotations']
   end
 
 
   test 'should handle invalid study id' do
     sign_in_and_update @user
-    execute_http_request(:get, api_v1_study_explore_cluster_options_path('SCP1234567'))
+    execute_http_request(:get, cluster_options_api_v1_study_explore_path('SCP1234567'))
     assert_equal 404, response.status
   end
 end


### PR DESCRIPTION
Updating the study files in the mouse_brain study broke the synth populator test, and I also realized the logic needed to be updated to take into account non-parsed files

Also, unbeknownst to me, my cleanup of the rails routes in the earlier PR didn't change the actual URL path, but it did change the rails helper method path