### PR TITLE
Fixing parse launching logic for expression matrices (SCP-3150, SCP-3151)

### DIFF
--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -58,7 +58,7 @@ class FileParseService
                               persist_on_fail: persist_on_fail)
           job.delay.push_remote_and_launch_ingest
         else
-          study.delay.send_to_firecloud(study_file)
+          study.delay.send_to_firecloud(study_file) if study_file.is_local?
           return self.missing_bundled_file(study_file)
         end
       when /10X/

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -145,7 +145,11 @@ class IngestJob
           if !matrix_cells || matrix_genes.empty?
             # return false if matrix hasn't validated, unless the other matrix was uploaded after this file
             # this is to prevent multiple matrix files queueing up and blocking each other from initiating PAPI jobs
-            return false unless matrix_file.created_at > self.study_file.created_at
+            # also, a timeout 24 hours is added to prevent all matrix files from queueing infinitely if one
+            # fails to launch an ingest job for some reason
+            if matrix_file.created_at < self.study_file.created_at && matrix_file.created_at > 24.hours.ago
+              return false
+            end
           end
         end
       end

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -58,6 +58,11 @@ class IngestJobTest < ActiveSupport::TestCase
     refute queued_job.can_launch_ingest?,
            "Should not be able to launch ingest job of queued parse but can_launch_ingest? returned true"
 
+    # show that after 24 hours the job can launch (simulating a failed ingest launch that blocks other parses)
+    @basic_study_exp_file.update_attributes!(created_at: 25.hours.ago)
+    assert queued_job.can_launch_ingest?,
+           "Should be able to launch ingest job of queued parse after 24 hours but can_launch_ingest? returned false"
+
     # simulate new matrix is "older" by backdating created_at by 1 week
     @other_matrix.update_attributes!(created_at: 1.week.ago.in_time_zone)
     backdated_job = IngestJob.new(study: @basic_study, study_file: @other_matrix, action: :ingest_expression)


### PR DESCRIPTION
This update addresses issues related to parsing expression matrix files:

SCP-3150: When attempting to sync an MTX file, `FileParseService` will erroneously attempt to push the MTX file back to the bucket when in fact it is already there.  This update will skip this step unless the file is local to the VM, which does not happen during a sync.  This prevents unnecessary admin error emails from being generated that potentially could cause issues if acted upon, as the parse job does initiate.

SCP-3151: When determining whether an expression matrix (MTX or dense) can launch an ingest job, if an upstream matrix (i.e. created before the one we are currently checking) is still marked as "parsing", it will defer launching the job until that matrix has either validated (by which there are cells & at least one gene present), or has finished parsing altogether.  If that upstream matrix never initiated a parse job due to an uncaught exception, all expression matrix files will queue indefinitely for that study until the blocking matrix is either removed, parsed, or marked as "parsed".  This update adds a maximum queueing period of 24 hours, after which a "stuck parsing" matrix will no longer prevent newer matrices from launching ingest runs.

This PR satisfies SCP-3150 and SCP-3151.