### PR TITLE
fixing view options toggle on mobile (SCP-3148)

### DIFF
--- a/app/javascript/components/explore/ExploreView.js
+++ b/app/javascript/components/explore/ExploreView.js
@@ -100,9 +100,9 @@ function RoutableExploreTab({ studyAccession }) {
 
   // Toggle "View Options" panel
   const viewOptionsIcon = showViewOptionsControls ? faCaretUp : faCaretDown
-  let [mainViewClass, controlPanelClass, optionsLinkClass] = ['col-md-12', 'hidden view-options', 'closed']
+  let [mainViewClass, controlPanelClass, optionsLinkClass] = ['col-md-12', 'hidden view-options']
   if (showViewOptionsControls) {
-    [mainViewClass, controlPanelClass, optionsLinkClass] = ['col-md-10', 'col-md-2 view-options', 'open']
+    [mainViewClass, controlPanelClass, optionsLinkClass] = ['col-md-10', 'col-md-2 view-options']
   }
 
   return (
@@ -119,7 +119,14 @@ function RoutableExploreTab({ studyAccession }) {
             isCellSelecting={isCellSelecting}
             plotPointsSelected={plotPointsSelected}/>
         </div>
+        <div className="col-sm-12 mobile-view-options">
+          <a className={`action view-options-toggle ${optionsLinkClass}`}
+            onClick={handleViewOptionsClick}>
+            View Options <FontAwesomeIcon className="fa-lg" icon={viewOptionsIcon}/>
+          </a>
+        </div>
         <div className={controlPanelClass}>
+
           <div className="cluster-controls">
             <ClusterSelector
               annotationList={annotationList}
@@ -170,10 +177,12 @@ function RoutableExploreTab({ studyAccession }) {
           </button>
         </div>
       </div>
-      <a className={`action view-options-toggle ${optionsLinkClass}`}
-        onClick={handleViewOptionsClick}>
-        View Options <FontAwesomeIcon className="fa-lg" icon={viewOptionsIcon}/>
-      </a>
+      <div className="desktop-view-options">
+        <a className={`action view-options-toggle ${optionsLinkClass}`}
+          onClick={handleViewOptionsClick}>
+          View Options <FontAwesomeIcon className="fa-lg" icon={viewOptionsIcon}/>
+        </a>
+      </div>
     </div>
   )
 }

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -61,7 +61,6 @@
 	}
 }
 
-
 .explore-plot-tab-content {
 	background: #fff;
 }
@@ -70,9 +69,27 @@
 	border: none;
 	background: none;
 	font-weight: bold;
+}
+
+.desktop-view-options {
 	position: absolute;
 	top: 10px;
 	right: 2em;
+}
+
+.mobile-view-options {
+	display: none;
+}
+
+@media (max-width: 991.98px) {
+	.mobile-view-options {
+		display: block;
+		text-align: center;
+		padding-top: 1em;
+	}
+	.desktop-view-options {
+		display: none;
+	}
 }
 
 


### PR DESCRIPTION
To test:
1. Open explore tab, confirm view options toggle works as expected.
2. shrink your browser to tablet width (<998px width)
3. confirm view options toggle migrates below the graphs along with the selection controls