### PR TITLE
fixing explore view update on study settings update (SCP-3152)

### DIFF
--- a/app/javascript/components/explore/ExploreView.js
+++ b/app/javascript/components/explore/ExploreView.js
@@ -189,6 +189,7 @@ export default function ExploreTab({ studyAccession }) {
 
 /** convenience function for rendering this in a non-React part of the application */
 export function renderExploreView(target, studyAccession) {
+  ReactDOM.unmountComponentAtNode(target)
   ReactDOM.render(
     <ExploreTab studyAccession={studyAccession}/>,
     target

--- a/app/views/site/update_study_settings.js.erb
+++ b/app/views/site/update_study_settings.js.erb
@@ -8,7 +8,11 @@ closeModalSpinner('#update-study-settings-spinner', '#update-study-settings-moda
         $('#study-summary').html("<%= escape_javascript(render partial: 'study_description_view') %>");
         $('#study-download').html("<%= escape_javascript(render partial: 'study_download_data') %>");
         <% if @study.initialized? %>
-          $('#study-visualize').html("<%= escape_javascript(render partial: 'study_visualize') %>");
+          <% if User.feature_flag_for_instance(current_user, 'react_explore')  %>
+            window.SCP.renderExploreView(document.getElementById('study-visualize'), window.SCP.studyAccession)
+          <% else %>
+            $('#study-visualize').html("<%= escape_javascript(render partial: 'study_visualize') %>");
+          <% end %>
         <% end %>
     <% else %>
         showMessageModal("", "An error occurred while saving: <br /><%= @study.errors.full_messages.join(', ').html_safe %>");


### PR DESCRIPTION
To test:
 0. enable react_explore feature flag
 1. go to a study with explore data
 2. go to the study settings tab, and update a setting
 3. go back to the explore tab, confirm that it has reloaded successfully