### PR TITLE
Subsampling in explore tab no longer defaults to 'all cells' (SCP-3144)

### DIFF
--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -203,8 +203,8 @@ module Api
         def self.get_selected_subsample_threshold(param, cluster)
           subsample = nil
           if param.blank?
-            # default to the smallest subsampling threshold
-            subsample = ClusterVizService.subsampling_options(cluster).min
+            # default to largest threshold available that is <10K
+            subsample = ClusterVizService.default_subsampling(cluster)
           elsif param == 'all'
             subsample = nil
           else

--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -121,8 +121,10 @@ module Api
             return nil
           end
 
-          subsample = url_params[:subsample].blank? ? nil : url_params[:subsample].to_i
+          subsample = get_selected_subsample_threshold(url_params[:subsample], cluster)
           consensus = url_params[:consensus].blank? ? nil : url_params[:consensus]
+
+
 
           colorscale = url_params[:colorscale].blank? ? 'Reds' : url_params[:colorscale]
 
@@ -193,8 +195,22 @@ module Api
             "cluster": cluster.name,
             "gene": genes.map {|g| g['name']}.join(', '),
             "annotParams": annotation,
+            "subsample": subsample.nil? ? 'all' : subsample,
             "consensus": consensus
           }
+        end
+
+        def self.get_selected_subsample_threshold(param, cluster)
+          subsample = nil
+          if param.blank?
+            # default to the smallest subsampling threshold
+            subsample = ClusterVizService.subsampling_options(cluster).min
+          elsif param == 'all'
+            subsample = nil
+          else
+            subsample = param.to_i
+          end
+          subsample
         end
       end
     end

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -40,7 +40,7 @@ module Api
                                                                     annot_name: params[:annotation_name],
                                                                     annot_type: params[:annotation_type],
                                                                     annot_scope: params[:annotation_scope])
-          subsample = params[:subsample].blank? ? nil : params[:subsample].to_i
+          subsample = ClustersController.get_selected_subsample_threshold(params[:subsample], cluster)
           genes = RequestUtils.get_genes_from_param(@study, params[:genes])
           if genes.empty?
             render json: {error: 'You must supply at least one gene'}, status: 422

--- a/app/javascript/components/visualization/PlotTitle.js
+++ b/app/javascript/components/visualization/PlotTitle.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 /** Renders a plot title for scatter plots */
-export default function PlotTitle({ cluster, annotation, gene, consensus }) {
+export default function PlotTitle({ cluster, annotation, gene, consensus, subsample }) {
   let contentString = cluster
   let detailString = ''
   if (gene) {
@@ -12,6 +12,9 @@ export default function PlotTitle({ cluster, annotation, gene, consensus }) {
     } else {
       contentString = `${gene} - expression`
     }
+  }
+  if (subsample && subsample !== 'all') {
+    detailString += ` subsample[${subsample}]`
   }
   return <h5 className="plot-title">
     <span className="cluster-title">{contentString} </span>

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -111,6 +111,7 @@ export default function ScatterPlot({
         <PlotTitle
           cluster={clusterData.cluster}
           annotation={clusterData.annotParams.name}
+          subsample={clusterData.subsample}
           gene={clusterData.gene}
           consensus={clusterData.consensus}/>
       }

--- a/app/javascript/components/visualization/controls/SubsampleSelector.js
+++ b/app/javascript/components/visualization/controls/SubsampleSelector.js
@@ -1,12 +1,15 @@
 import React from 'react'
 import Select from 'react-select'
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { Popover, OverlayTrigger } from 'react-bootstrap'
 
 import { clusterSelectStyle } from 'lib/cluster-utils'
 
 
 /** takes the server response and returns subsample options suitable for react-select */
 function getSubsampleOptions(annotationList, clusterName) {
-  let subsampleOptions = [{ label: 'All Cells', value: '' }]
+  let subsampleOptions = []
   if (clusterName && annotationList.subsample_thresholds) {
     let clusterSubsamples = annotationList.subsample_thresholds[clusterName]
     if (!clusterSubsamples) {
@@ -16,6 +19,7 @@ function getSubsampleOptions(annotationList, clusterName) {
       return { label: `${num}`, value: num }
     }))
   }
+  subsampleOptions.push({ label: 'All Cells', value: 'all' })
   return subsampleOptions
 }
 
@@ -41,10 +45,14 @@ export default function SubsampleSelector({
 
   return (
     <div className="form-group">
-      <label>Subsampling</label>
+      <label>
+        <OverlayTrigger trigger="click" rootClose placement="top" overlay={consensusPopover}>
+          <span>Subsampling <FontAwesomeIcon className="action" icon={faInfoCircle}/></span>
+        </OverlayTrigger>
+      </label>
       <Select options={subsampleOptions}
         value={{
-          label: subsample == '' ? 'All Cells' : subsample,
+          label: subsample == 'all' ? 'All Cells' : subsample,
           value: subsample
         }}
         onChange={newSubsample => updateClusterParams({
@@ -54,3 +62,12 @@ export default function SubsampleSelector({
     </div>
   )
 }
+
+const consensusPopover = (
+  <Popover id="explore-subsampling-helptext">
+    Take a representative subsample of the current clusters
+    (<a href='https://github.com/broadinstitute/single_cell_portal/wiki/Subsampling-Cluster-Files'
+      rel="noreferrer" target='_blank'>learn more</a>).
+    Choosing all cells may dramatically increase rendering time for studies with many cells.
+  </Popover>
+)

--- a/app/javascript/components/visualization/controls/SubsampleSelector.js
+++ b/app/javascript/components/visualization/controls/SubsampleSelector.js
@@ -65,7 +65,7 @@ export default function SubsampleSelector({
 
 const consensusPopover = (
   <Popover id="explore-subsampling-helptext">
-    Take a representative subsample of the current clusters
+    Show a representative subsample of the current clusters
     (<a href='https://github.com/broadinstitute/single_cell_portal/wiki/Subsampling-Cluster-Files'
       rel="noreferrer" target='_blank'>learn more</a>).
     <br/>

--- a/app/javascript/components/visualization/controls/SubsampleSelector.js
+++ b/app/javascript/components/visualization/controls/SubsampleSelector.js
@@ -68,6 +68,9 @@ const consensusPopover = (
     Take a representative subsample of the current clusters
     (<a href='https://github.com/broadinstitute/single_cell_portal/wiki/Subsampling-Cluster-Files'
       rel="noreferrer" target='_blank'>learn more</a>).
-    Choosing all cells may dramatically increase rendering time for studies with many cells.
+    <br/>
+    <span className="detail">
+      Choosing &quot;All cells&quot; may dramatically increase rendering time for studies with >100K cells.
+    </span>
   </Popover>
 )

--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -19,7 +19,11 @@ export const emptyDataParams = {
 
 /** takes the server response and returns subsample default subsample for the cluster */
 export function getDefaultSubsampleForCluster(annotationList, clusterName) {
-  return '' // for now, default is always all cells
+  const subsampleOptions = annotationList.subsample_thresholds[clusterName]
+  if (subsampleOptions?.length) {
+    return subsampleOptions[0]
+  }
+  return 'all'
 }
 
 

--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -21,7 +21,10 @@ export const emptyDataParams = {
 export function getDefaultSubsampleForCluster(annotationList, clusterName) {
   const subsampleOptions = annotationList.subsample_thresholds[clusterName]
   if (subsampleOptions?.length) {
-    return subsampleOptions[0]
+    const defaultSubsample = Math.max(subsampleOptions.filter(opt => opt <= 10000))
+    if (defaultSubsample === 10000) {
+      return 10000
+    }
   }
   return 'all'
 }

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -66,10 +66,23 @@ class ClusterVizService
   # only options allowed are 1000, 10000, 20000, and 100000
   # will only provide options if subsampling has completed for a cluster
   def self.subsampling_options(cluster)
+    num_points = cluster.points
     if cluster.is_subsampling?
       []
     else
-      ClusterGroup::SUBSAMPLE_THRESHOLDS.select {|sample| sample < cluster.points}
+      ClusterGroup::SUBSAMPLE_THRESHOLDS.select {|sample| sample < num_points}
+    end
+  end
+
+  # return an array of values to use for subsampling dropdown scaled to number of cells in study
+  # only options allowed are 1000, 10000, 20000, and 100000
+  # will only provide options if subsampling has completed for a cluster
+  def self.default_subsampling(cluster)
+    num_points = cluster.points
+    if num_points < 10000
+      return nil
+    else
+      ClusterGroup::SUBSAMPLE_THRESHOLDS.select{|val| val <= 10000}.max
     end
   end
 


### PR DESCRIPTION
This now defaults to the minimum subsample -- is that right?  Adding @jlchang  to the review to confirm the default and also the tooltip content (shown below)

Also added a tooltip based on our existing one 
![image](https://user-images.githubusercontent.com/2800795/110385615-28b89080-802d-11eb-9ed0-d49c974f7f1b.png)




