### PR TITLE
Fixing scatter color and distribution control options

### DIFF
--- a/app/javascript/components/visualization/PlotDisplayControls.js
+++ b/app/javascript/components/visualization/PlotDisplayControls.js
@@ -4,7 +4,7 @@ import Select from 'react-select'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCaretRight, faCaretDown } from '@fortawesome/free-solid-svg-icons'
-import { SCATTER_COLOR_OPTIONS } from 'components/visualization/ScatterPlot'
+import { SCATTER_COLOR_OPTIONS, defaultScatterColor } from 'components/visualization/ScatterPlot'
 import { DISTRIBUTION_PLOT_OPTIONS, DISTRIBUTION_POINTS_OPTIONS } from 'components/visualization/StudyViolinPlot'
 import { ROW_CENTERING_OPTIONS, FIT_OPTIONS } from 'components/visualization/Heatmap'
 
@@ -20,7 +20,7 @@ export default function RenderControls({ exploreParams, updateExploreParams }) {
   const [showHeatmap, setShowHeatmap] = useState(false)
   const [showDistribution, setShowDistribution] = useState(false)
 
-  const scatterColorValue = exploreParams.scatterColor ? exploreParams.scatterColor : ''
+  const scatterColorValue = exploreParams.scatterColor ? exploreParams.scatterColor : defaultScatterColor
   let distributionPlotValue = DISTRIBUTION_PLOT_OPTIONS.find(opt => opt.value === exploreParams.distributionPlot)
   if (!distributionPlotValue) {
     distributionPlotValue = DISTRIBUTION_PLOT_OPTIONS[0]

--- a/app/lib/synthetic_study_populator.rb
+++ b/app/lib/synthetic_study_populator.rb
@@ -1,6 +1,12 @@
 
 # class to populate synthetic studies from files.
 # See db/seed/synthetic_studies for examples of the file formats
+#
+# to use this on the staging server, you must be logged into the console as the app user
+# otherwise files will not be uploaded
+# sudo -E -u app -H bin/rails c -e staging
+#
+
 class SyntheticStudyPopulator
   DEFAULT_SYNTHETIC_STUDY_PATH = Rails.root.join('db', 'seed', 'synthetic_studies')
   # populates all studies defined in db/seed/synthetic_studies


### PR DESCRIPTION
To test:

 0. Load a study, go to the explore tab
 1. Do a gene search
 2. Confirm 'reds' is selected by default in the 'Scatter' dropdown
 3. Go to the 'distribution' tab
 4. Use the 'Distribution' control to toggle box/violin and all/none points, and confirm display updates appropriately (note that showing 'all' points on violin can take a looooong time)