### PR TITLE
Fixing heatmap layout/fit options (SCP-3145, SCP-3146)

### DIFF
--- a/app/javascript/components/visualization/DotPlot.js
+++ b/app/javascript/components/visualization/DotPlot.js
@@ -157,7 +157,7 @@ export function morpheusTabManager($target) {
     setTabTitle: () => {},
     setActiveTab: () => {},
     getWidth: () => $target.actual('width'),
-    getHeight: () => $target.height(),
+    getHeight: () => $target.actual('height'),
     getTabCount: () => 1
   }
 }

--- a/app/javascript/components/visualization/DotPlot.js
+++ b/app/javascript/components/visualization/DotPlot.js
@@ -27,7 +27,7 @@ export const dotPlotColorScheme = {
   */
 export default function DotPlot({
   studyAccession, genes=[], cluster, annotation={},
-  subsample, annotationValues, dimensions
+  subsample, annotationValues
 }) {
   const [graphId] = useState(_uniqueId('dotplot-'))
   const expressionValuesURL = getExpressionHeatmapURL({ studyAccession, genes, cluster })

--- a/app/javascript/components/visualization/DotPlot.js
+++ b/app/javascript/components/visualization/DotPlot.js
@@ -38,11 +38,6 @@ export default function DotPlot({
     annotation.type,
     subsample)
 
-  let dimensionsFn = null
-  if (dimensions?.width) {
-    dimensionsFn = () => dimensions.width
-  }
-
   useEffect(() => {
     if (annotation.name) {
       const plotEvent = startPendingEvent('plot:dot', window.SCP.getLogPlotProps())
@@ -52,8 +47,7 @@ export default function DotPlot({
         expressionValuesURL,
         annotationCellValuesURL,
         annotationName: annotation.name,
-        annotationValues,
-        dimensionsFn
+        annotationValues
       })
       plotEvent.complete()
     }
@@ -78,7 +72,7 @@ export default function DotPlot({
 
 /** Render Morpheus dot plot */
 function renderDotPlot(
-  { target, expressionValuesURL, annotationCellValuesURL, annotationName, annotationValues, dimensionsFn }
+  { target, expressionValuesURL, annotationCellValuesURL, annotationName, annotationValues }
 ) {
   const $target = $(target)
   $target.empty()
@@ -107,7 +101,7 @@ function renderDotPlot(
       scalingMode: 'relative'
     },
     focus: null,
-    tabManager: morpheusTabManager($target, dimensionsFn),
+    tabManager: morpheusTabManager($target),
     tools
   }
 
@@ -153,10 +147,7 @@ function renderDotPlot(
  * (after 2+ hours of digging) to prevent morpheus auto-scrolling
  * to a heatmap once it's rendered
  */
-export function morpheusTabManager($target, dimensionsFn) {
-  if (!dimensionsFn) {
-    dimensionsFn = () => $target.width()
-  }
+export function morpheusTabManager($target) {
   return {
     add: options => {
       $target.empty()
@@ -165,7 +156,7 @@ export function morpheusTabManager($target, dimensionsFn) {
     },
     setTabTitle: () => {},
     setActiveTab: () => {},
-    getWidth: () => {return dimensionsFn().width},
+    getWidth: () => $target.actual('width'),
     getHeight: () => $target.height(),
     getTabCount: () => 1
   }

--- a/app/javascript/components/visualization/Heatmap.js
+++ b/app/javascript/components/visualization/Heatmap.js
@@ -31,7 +31,7 @@ export const DEFAULT_FIT = ''
   * @param subsample {string} a string for the subsampel to be retrieved.
 */
 export default function Heatmap({
-  studyAccession, genes=[], cluster, annotation={}, subsample, heatmapFit, heatmapRowCentering, dimensions
+  studyAccession, genes=[], cluster, annotation={}, subsample, heatmapFit, heatmapRowCentering
 }) {
   const [graphId] = useState(_uniqueId('heatmap-'))
   const morpheusHeatmap = useRef(null)
@@ -48,11 +48,6 @@ export default function Heatmap({
     annotation.type,
     subsample)
 
-  let dimensionsFn = null
-  if (dimensions.width) {
-    dimensionsFn = () => dimensions.width
-  }
-
   useEffect(() => {
     // we can't render until we know what the cluster is, since morpheus requires the annotation name
     if (cluster) {
@@ -63,7 +58,6 @@ export default function Heatmap({
         expressionValuesURL,
         annotationCellValuesURL,
         annotationName: annotation.name,
-        dimensionsFn,
         fit: heatmapFit,
         rowCentering: heatmapRowCentering
       })
@@ -81,11 +75,15 @@ export default function Heatmap({
   useUpdateEffect(() => {
     if (morpheusHeatmap.current && morpheusHeatmap.current.fitToWindow) {
       const fit = heatmapFit
-      morpheusHeatmap.current.fitToWindow({
-        fitRows: fit === 'rows' || fit === 'both',
-        fitColumns: fit === 'cols' || fit === 'both',
-        repaint: true
-      })
+      if (fit === '') {
+        morpheusHeatmap.current.resetZoom()
+      } else {
+        morpheusHeatmap.current.fitToWindow({
+          fitRows: fit === 'rows' || fit === 'both',
+          fitColumns: fit === 'cols' || fit === 'both',
+          repaint: true
+        })
+      }
     }
   }, [heatmapFit])
 
@@ -101,7 +99,7 @@ export default function Heatmap({
 /** Render Morpheus heatmap */
 function renderHeatmap({
   target, expressionValuesURL, annotationCellValuesURL, annotationName,
-  dimensionsFn, fit, rowCentering
+  fit, rowCentering
 }) {
   const $target = $(target)
   $target.empty()
@@ -128,6 +126,9 @@ function renderHeatmap({
   } else if (fit === 'both') {
     config.columnSize = 'fit'
     config.rowSize = 'fit'
+  } else if (fit === 'none') {
+    config.columnSize = null
+    config.rowSize = null
   } else {
     config.columnSize = null
     config.rowSize = null

--- a/app/javascript/components/visualization/Heatmap.js
+++ b/app/javascript/components/visualization/Heatmap.js
@@ -117,7 +117,7 @@ function renderHeatmap({
     // We implement our own trivial tab manager as it seems to be the only way
     // (after 2+ hours of digging) to prevent morpheus auto-scrolling
     // to the heatmap once it's rendered
-    tabManager: morpheusTabManager($target, dimensionsFn)
+    tabManager: morpheusTabManager($target)
   }
 
   // Fit rows, columns, or both to screen
@@ -145,6 +145,7 @@ function renderHeatmap({
       { field: annotationName, order: 0 }
     ]
     config.columns = [
+      { field: 'id', display: 'text'},
       { field: annotationName, display: 'text' }
     ]
     config.rows = [

--- a/app/javascript/components/visualization/Heatmap.js
+++ b/app/javascript/components/visualization/Heatmap.js
@@ -146,7 +146,7 @@ function renderHeatmap({
     ]
     config.columns = [
       { field: 'id', display: 'text'},
-      { field: annotationName, display: 'text' }
+      { field: annotationName, display: 'color' }
     ]
     config.rows = [
       { field: 'id', display: 'text' }


### PR DESCRIPTION
This update fixes both the general layout of the Morpheus heatmap visualization (now fits inside bounds of parent div), and restores the functionality of the heatmap "Fit options" select menu.  This update only applies to the React-based Explore tab.

To test (must have `react_explore` FeatureFlag set to `true` for your account):
1. Perform multi-gene search in a study
2. Click 'Heatmap' tab
3. Use the "Fit options" dropdown to change heatmap layout (selecting "None" will reset the zoom to defaults)

Examples:

Default zoom:
![heatmap_default](https://user-images.githubusercontent.com/729968/110828030-a1edf880-8264-11eb-9153-a2819446eb74.png)

Column fit (condenses all columns into viewport):
![heatmap_col_fit](https://user-images.githubusercontent.com/729968/110828075-b03c1480-8264-11eb-8943-6bba836329ca.png)

This PR satisfies SCP-3145 & SCP-3146.