### PR TITLE
Fixing auto-resize of violin plots (SCP-3157)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -403,6 +403,7 @@ export default function ExploreDisplayTabs(
               <StudyViolinPlot
                 studyAccession={studyAccession}
                 updateDistributionPlot={distributionPlot => updateExploreParams({ distributionPlot }, false)}
+                dimensions={getPlotDimensions({})}
                 {...exploreParams}/>
             </div>
           }

--- a/app/javascript/components/visualization/PlotDisplayControls.js
+++ b/app/javascript/components/visualization/PlotDisplayControls.js
@@ -4,7 +4,7 @@ import Select from 'react-select'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCaretRight, faCaretDown } from '@fortawesome/free-solid-svg-icons'
-import { SCATTER_COLOR_OPTIONS } from 'components/visualization/ScatterPlot'
+import { SCATTER_COLOR_OPTIONS, defaultScatterColor } from 'components/visualization/ScatterPlot'
 import { DISTRIBUTION_PLOT_OPTIONS, DISTRIBUTION_POINTS_OPTIONS } from 'components/visualization/StudyViolinPlot'
 import { ROW_CENTERING_OPTIONS, FIT_OPTIONS } from 'components/visualization/Heatmap'
 
@@ -20,7 +20,7 @@ export default function RenderControls({ exploreParams, updateExploreParams }) {
   const [showHeatmap, setShowHeatmap] = useState(false)
   const [showDistribution, setShowDistribution] = useState(false)
 
-  const scatterColorValue = exploreParams.scatterColor ? exploreParams.scatterColor : ''
+  const scatterColorValue = exploreParams.scatterColor ? exploreParams.scatterColor : defaultScatterColor
   let distributionPlotValue = DISTRIBUTION_PLOT_OPTIONS.find(opt => opt.value === exploreParams.distributionPlot)
   if (!distributionPlotValue) {
     distributionPlotValue = DISTRIBUTION_PLOT_OPTIONS[0]

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -6,7 +6,7 @@ import Plotly from 'plotly.js-dist'
 
 import { fetchCluster } from 'lib/scp-api'
 import { labelFont, getColorBrewerColor } from 'lib/plot'
-import { useUpdateLayoutEffect } from 'hooks/useUpdate'
+import { useUpdateEffect } from 'hooks/useUpdate'
 import PlotTitle from './PlotTitle'
 import { log } from 'lib/metrics-api'
 
@@ -72,7 +72,7 @@ export default function ScatterPlot({
   }, [cluster, annotation.name, subsample, consensus, genes.join(',')])
 
   // Handles Plotly `data` updates, e.g. changes in color profile
-  useUpdateLayoutEffect(() => {
+  useUpdateEffect(() => {
     // Don't try to update the color if the graph hasn't loaded yet
     if (clusterData && !isLoading) {
       console.log('updating color scale')
@@ -82,7 +82,7 @@ export default function ScatterPlot({
   }, [scatterColor])
 
   // Handles cell select mode updates
-  useUpdateLayoutEffect(() => {
+  useUpdateEffect(() => {
     // Don't try to update the color if the graph hasn't loaded yet
     if (clusterData && !isLoading) {
       console.log('updating drag mode')
@@ -95,7 +95,7 @@ export default function ScatterPlot({
   }, [isCellSelecting])
 
   // Adjusts width and height of plots upon toggle of "View Options"
-  useUpdateLayoutEffect(() => {
+  useUpdateEffect(() => {
     // Don't update if the graph hasn't loaded yet
     if (clusterData && !isLoading) {
       const { width, height } = dimensions

--- a/app/javascript/components/visualization/StudyViolinPlot.js
+++ b/app/javascript/components/visualization/StudyViolinPlot.js
@@ -7,7 +7,7 @@ import { fetchExpressionViolin } from 'lib/scp-api'
 import { getColorBrewerColor, arrayMin, arrayMax, plotlyDefaultLineColor } from 'lib/plot'
 import Plotly from 'plotly.js-dist'
 
-import { useUpdateEffect } from 'hooks/useUpdate'
+import { useUpdateEffect, useUpdateLayoutEffect } from 'hooks/useUpdate'
 
 
 export const DISTRIBUTION_PLOT_OPTIONS = [
@@ -39,7 +39,7 @@ export const defaultDistributionPoints = DISTRIBUTION_POINTS_OPTIONS[0].value
   */
 export default function StudyViolinPlot({
   studyAccession, genes, cluster, annotation, subsample, consensus, distributionPlot, distributionPoints,
-  updateDistributionPlot, setAnnotationList
+  updateDistributionPlot, setAnnotationList, dimensions
 }) {
   const [isLoading, setIsLoading] = useState(false)
   // array of gene names as they are listed in the study itself
@@ -100,6 +100,16 @@ export default function StudyViolinPlot({
       updateViolinPlot(graphElementId, distributionPlot, distributionPoints)
     }
   }, [distributionPlot, distributionPoints])
+
+  // Adjusts width and height of plots upon toggle of "View Options"
+  useUpdateEffect(() => {
+    // Don't update if the graph hasn't loaded yet
+    if (!isLoading && studyGeneNames.length > 0) {
+      const { width, height } = dimensions
+      const layoutUpdate = { width, height }
+      Plotly.relayout(graphElementId, layoutUpdate)
+    }
+  }, [dimensions.width, dimensions.height])
 
   const isCollapsedView = ['mean', 'median'].indexOf(consensus) >= 0
   return (

--- a/app/javascript/providers/DownloadProvider.js
+++ b/app/javascript/providers/DownloadProvider.js
@@ -32,14 +32,14 @@ export default function DownloadProvider({ children }) {
 
   // Update the size if results are loaded and the accession list has changed
   let currentAccessions = []
-  if (studyContext.results && studyContext.results.matchingAccessions) {
+  if (studyContext?.results?.matchingAccessions) {
     currentAccessions = studyContext.results.matchingAccessions
   }
   useEffect(() => {
     if (!studyContext.isLoading && studyContext.isLoaded && hasSearchParams(studyContext.params)) {
       updateDownloadSize(studyContext.results)
     }
-  }, [currentAccessions])
+  }, [currentAccessions.join(',')])
 
   return (
     <DownloadContext.Provider value={downloadState}>

--- a/app/lib/synthetic_study_populator.rb
+++ b/app/lib/synthetic_study_populator.rb
@@ -1,6 +1,12 @@
 
 # class to populate synthetic studies from files.
 # See db/seed/synthetic_studies for examples of the file formats
+#
+# to use this on the staging server, you must be logged into the console as the app user
+# otherwise files will not be uploaded
+# sudo -E -u app -H bin/rails c -e staging
+#
+
 class SyntheticStudyPopulator
   DEFAULT_SYNTHETIC_STUDY_PATH = Rails.root.join('db', 'seed', 'synthetic_studies')
   # populates all studies defined in db/seed/synthetic_studies


### PR DESCRIPTION
This also switches from useLayoutEffect to useEffect.  useLayoutEffect does not have a pause between when the event occurs and the redraw happens, so the UI is frozen during that time.  useEffect allows for a pause so the page can return to interactivity, at the cost of being a little uglier (there can be a noticeable delay between when the user finishes resizing, and when the graph finishes resizing).  I think this is the right tradeoff for our users -- better to have the page be more responsive at the cost of a delayed resize.

This also contains a trivial improvement to downloadProvider so that it doesn't need to reload the download size unless the results have actually changed.

to test:
0. enable react_explore feature flag
1. Open a study and do a gene search
2. go to the distribution tab and observe the violin plot
3. resize your browser window, and observe the violin plot resizes to match