### PR TITLE
Adding inferCNV/Ideogram visualization to React explore tab (SCP-3113)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -440,7 +440,9 @@ export default function ExploreDisplayTabs(
             <InferCNVIdeogram
               studyAccession={studyAccession}
               ideogramFileId={exploreParams?.ideogramFileId}
-              inferCNVIdeogramFiles={exploreInfo.inferCNVIdeogramFiles}/>
+              inferCNVIdeogramFiles={exploreInfo.inferCNVIdeogramFiles}
+              showViewOptionsControls={showViewOptionsControls}
+            />
           </div>
           }
         </div>

--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -458,6 +458,7 @@ export function getEnabledTabs(exploreInfo, exploreParams) {
   const isMultiGene = exploreParams?.genes?.length > 1
   const isGene = exploreParams?.genes?.length > 0
   const isConsensus = !!exploreParams.consensus
+  const hasClusters = exploreInfo && exploreInfo.clusterGroupNames.length > 0
   const hasSpatialGroups = exploreInfo && exploreInfo?.spatialGroups?.length > 0
   const hasGenomeFiles = exploreInfo && exploreInfo?.bamBundleList?.length > 0
   const hasIdeogramOutputs = !!exploreInfo?.inferCNVIdeogramFiles

--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -212,7 +212,7 @@ export default function ExploreDisplayTabs(
             { enabledTabs.map(tabKey => {
               const label = tabList.find(({ key }) => key === tabKey).label
               return (
-                <li key={tabKey} role="presentation" className={`study-nav ${tabKey === shownTab ? 'active' : ''}`}>
+                <li key={tabKey} role="presentation" className={`study-nav ${tabKey === shownTab ? 'active' : ''} ${tabKey}-tab-anchor`}>
                   <a onClick={() => updateExploreParams({ tab: tabKey })}>{label}</a>
                 </li>
               )
@@ -440,9 +440,7 @@ export default function ExploreDisplayTabs(
             <InferCNVIdeogram
               studyAccession={studyAccession}
               ideogramFileId={exploreParams?.ideogramFileId}
-              inferCNVIdeogramFiles={exploreInfo.inferCNVIdeogramFiles}
-              isVisible={shownTab === 'infercnv-genome'}
-              updateExploreParams={updateExploreParams}/>
+              inferCNVIdeogramFiles={exploreInfo.inferCNVIdeogramFiles}/>
           </div>
           }
         </div>
@@ -460,7 +458,7 @@ export function getEnabledTabs(exploreInfo, exploreParams) {
   let hasClusters = exploreInfo && exploreInfo.clusterGroupNames.length > 0
   let hasSpatialGroups = exploreInfo && exploreInfo?.spatialGroups?.length > 0
   let hasGenomeFiles = exploreInfo && exploreInfo?.bamBundleList?.length > 0
-  let hasIdeogramOutputs = exploreInfo && Object.keys(exploreInfo?.inferCNVIdeogramFiles).length > 0
+  let hasIdeogramOutputs = !!exploreInfo?.inferCNVIdeogramFiles
   let enabledTabs = []
   if (isGeneList) {
     enabledTabs = ['heatmap']

--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -445,8 +445,10 @@ export function getEnabledTabs(exploreInfo, exploreParams) {
   let isMultiGene = exploreParams?.genes?.length > 1
   let isGene = exploreParams?.genes?.length > 0
   let isConsensus = !!exploreParams.consensus
+  let hasClusters = exploreInfo && exploreInfo.clusterGroupNames.length > 0
   let hasSpatialGroups = exploreInfo && exploreInfo?.spatialGroups?.length > 0
   let hasGenomeFiles = exploreInfo && exploreInfo?.bamBundleList?.length > 0
+  let hasIdeogramOutputs = exploreInfo && Object.keys(exploreInfo?.inferCNVIdeogramFiles).length > 0
   let enabledTabs = []
   if (isGeneList) {
     enabledTabs = ['heatmap']
@@ -463,11 +465,11 @@ export function getEnabledTabs(exploreInfo, exploreParams) {
       } else {
         enabledTabs = ['scatter', 'distribution']
       }
-    } else {
+    } else if (hasClusters) {
       enabledTabs = ['cluster']
     }
   }
-  if (hasGenomeFiles) {
+  if ( hasGenomeFiles || hasIdeogramOutputs ) {
     enabledTabs.push('genome')
   }
   return {enabledTabs, isGeneList, isGene, isMultiGene}

--- a/app/javascript/components/explore/ExploreTabRouter.js
+++ b/app/javascript/components/explore/ExploreTabRouter.js
@@ -94,6 +94,8 @@ function buildExploreParamsFromQuery(query) {
   exploreParams.tab = queryParams.tab ? queryParams.tab : ''
   exploreParams.heatmapFit = queryParams.heatmapFit ? queryParams.heatmapFit : ''
   exploreParams.bamFileName = queryParams.bamFileName ? queryParams.bamFileName : ''
+  exploreParams.ideogramFileId = queryParams.ideogramFileId ? queryParams.ideogramFileId : ''
+
 
   return exploreParams
 }
@@ -114,7 +116,8 @@ function buildQueryFromParams(exploreParams) {
     distributionPlot: exploreParams.distributionPlot,
     distributionPoints: exploreParams.distributionPoints,
     heatmapFit: exploreParams.heatmapFit,
-    bamFileName: exploreParams.bamFileName
+    bamFileName: exploreParams.bamFileName,
+    ideogramFileId: exploreParams.ideogramFileId
   }
 
   if (querySafeOptions.spatialGroups === '' && exploreParams.userSpecified['spatialGroups']) {
@@ -132,7 +135,7 @@ function buildQueryFromParams(exploreParams) {
 
 /** controls list in which query string params are rendered into URL bar */
 const PARAM_LIST_ORDER = ['geneList', 'genes', 'cluster', 'spatialGroups', 'annotation', 'subsample', 'consensus',
-  'tab', 'scatterColor', 'distributionPlot', 'distributionPoints', 'heatmapFit', 'heatmapRowCentering', 'bamFileName']
+  'tab', 'scatterColor', 'distributionPlot', 'distributionPoints', 'heatmapFit', 'heatmapRowCentering', 'bamFileName', 'ideogramFileId']
 /** sort function for passing to stringify to ensure url params are specified in a user-friendly order */
 function paramSorter(a, b) {
   return PARAM_LIST_ORDER.indexOf(a) - PARAM_LIST_ORDER.indexOf(b)

--- a/app/javascript/components/explore/ExploreView.js
+++ b/app/javascript/components/explore/ExploreView.js
@@ -107,7 +107,7 @@ function RoutableExploreTab({ studyAccession }) {
 
   // handles updating inferCNV/ideogram selection
   function updateInferCNVIdeogramFile(annotationFile) {
-    updateExploreParams( { ideogramFileId: annotationFile })
+    updateExploreParams( { ideogramFileId: annotationFile, tab: 'infercnv-genome' })
   }
 
   useEffect(() => {

--- a/app/javascript/components/explore/ExploreView.js
+++ b/app/javascript/components/explore/ExploreView.js
@@ -18,6 +18,7 @@ import useExploreTabRouter from './ExploreTabRouter'
 import { getDefaultClusterParams, getDefaultSpatialGroupsForCluster } from 'lib/cluster-utils'
 import GeneListSelector from 'components/visualization/controls/GeneListSelector'
 import { log } from 'lib/metrics-api'
+import InferCNVIdeogramSelector from "components/visualization/controls/InferCNVIdeogramSelector";
 
 /**
  * manages view options and basic layout for the explore tab
@@ -91,7 +92,7 @@ function RoutableExploreTab({ studyAccession }) {
     // broken urls in the event of a default cluster/annotation changes
     // also, unset any gene lists as we're about to re-render the explore tab and having gene list selected will show
     // the wrong tabs
-    const updateParams = {geneList: ''}
+    const updateParams = {geneList: '', ideogramFileId: ''}
     const clusterParamNames = ['cluster', 'annotation', 'subsample', 'spatialGroups']
     clusterParamNames.forEach(param => {
       updateParams[param] = param in newParams ? newParams[param] : controlExploreParams[param]
@@ -102,6 +103,11 @@ function RoutableExploreTab({ studyAccession }) {
   /** handles gene list selection */
   function updateGeneList(geneList) {
     updateExploreParams({ geneList: geneList })
+  }
+
+  // handles updating inferCNV/ideogram selection
+  function updateInferCNVIdeogramFile(annotationFile) {
+    updateExploreParams( { ideogramFileId: annotationFile })
   }
 
   useEffect(() => {
@@ -181,6 +187,13 @@ function RoutableExploreTab({ studyAccession }) {
               <ExploreConsensusSelector
                 consensus={controlExploreParams.consensus}
                 updateConsensus={consensus => updateExploreParams({ consensus })}/>
+            }
+            { !!exploreInfo?.inferCNVIdeogramFiles &&
+                <InferCNVIdeogramSelector
+                  inferCNVIdeogramFile={controlExploreParams.ideogramFileId}
+                  studyInferCNVIdeogramFiles={exploreInfo.inferCNVIdeogramFiles}
+                  updateInferCNVIdeogramFile={updateInferCNVIdeogramFile}
+                />
             }
           </div>
           <PlotDisplayControls

--- a/app/javascript/components/explore/ExploreView.js
+++ b/app/javascript/components/explore/ExploreView.js
@@ -42,7 +42,7 @@ function RoutableExploreTab({ studyAccession }) {
   // this is kept separate so that the graphs do not see the change in cluster name from '' to
   // '<<default cluster>>' as a change that requires a re-fetch from the server
   let controlExploreParams = _clone(exploreParams)
-  if (exploreInfo && !exploreParams.cluster) {
+  if (exploreInfo && !exploreParams.cluster && exploreInfo.clusterGroupNames.length > 0) {
     // if the user hasn't specified anything yet, but we have the study defaults, use those
     controlExploreParams = Object.assign(controlExploreParams,
       getDefaultClusterParams(annotationList, exploreInfo.spatialGroups))

--- a/app/javascript/components/visualization/InferCNVIdeogram.js
+++ b/app/javascript/components/visualization/InferCNVIdeogram.js
@@ -4,7 +4,8 @@
  * Show an Ideogram heatmap instance using output from an inferCNV workflow
  */
 
-import React, { useEffect } from 'react'
+import React, {useEffect, useState} from 'react'
+import _uniqueId from 'lodash/uniqueId'
 
 import Ideogram from 'ideogram'
 
@@ -25,6 +26,28 @@ const legend = [{
     { name: 'High', color: '#F00' }
   ]
 }]
+
+export default function InferCNVIdeogram({studyAccession, ideogramFileId, inferCNVIdeogramFiles, isVisible, updateExploreParams }) {
+  const [inferCNVIdeogramFileList, setinferCNVIdeogramFileList] = useState(null)
+  const [ideogramContainerId] = useState(_uniqueId('study-infercnv-ideogram-'))
+
+  const inferCNVIdeogramFile = inferCNVIdeogramFiles[ideogramFileId]
+  useEffect(() => {
+    if ( !!inferCNVIdeogramFile && isVisible ) {
+      let ideogramAnnotsFile = inferCNVIdeogramFile.ideogram_settings.annotationsPath
+      let ideogramOrganism = inferCNVIdeogramFile.ideogram_settings.organism
+      let ideogramAssembly = inferCNVIdeogramFile.ideogram_settings.assembly
+      initializeIdeogram(ideogramAnnotsFile, ideogramOrganism, ideogramAssembly, ideogramContainerId)
+    }
+  }, [ideogramFileId])
+
+  return <div id="ideogram-container">
+    <div id={ideogramContainerId}>
+      <ul id="tracks-to-display">
+      </ul>
+    </div>
+  </div>
+}
 
 /** Get ideogram heatmap tracks selected via checkbox */
 function getSelectedTracks() {
@@ -223,9 +246,9 @@ function warnIdeogramOfNumericCluster() {
 }
 
 /** Initialize ideogram to visualize genomic heatmap from inferCNV  */
-function initializeIdeogram(url) {
-  if (typeof window.ideogram !== 'undefined') {
-    delete window.ideogram
+function initializeIdeogram(url, organism, assembly, domTarget) {
+  if (typeof window.inferCNVIdeogram !== 'undefined') {
+    delete window.inferCNVIdeogram
     $('#tracks-to-display').html('')
     $('#_ideogramOuterWrap').html('')
   }
@@ -233,9 +256,9 @@ function initializeIdeogram(url) {
   $('#ideogramWarning, #ideogramTitle').remove()
 
   ideoConfig = {
-    container: '#ideogram-container',
-    organism: window.ideogramInferCnvSettings.organism.toLowerCase(),
-    assembly: window.ideogramInferCnvSettings.assembly,
+    container: '#' + domTarget,
+    organism: organism.toLowerCase(),
+    assembly: assembly,
     annotationsPath: url,
     annotationsLayout: 'heatmap',
     legend,
@@ -250,9 +273,7 @@ function initializeIdeogram(url) {
   }
 
   inferCNVIdeogram = new Ideogram(ideoConfig)
-
-  // Log Ideogram.js initialization in Google Analytics
-  ga('send', 'event', 'ideogram', 'initialize')
+  window.inferCNVIdeogram = inferCNVIdeogram
 
   window.SCP.log('ideogram:initialize')
 }

--- a/app/javascript/components/visualization/InferCNVIdeogram.js
+++ b/app/javascript/components/visualization/InferCNVIdeogram.js
@@ -1,0 +1,259 @@
+/**
+ * @fileoverview Ideogram for related genes
+ *
+ * Show an Ideogram heatmap instance using output from an inferCNV workflow
+ */
+
+import React, { useEffect } from 'react'
+
+import Ideogram from 'ideogram'
+
+/* eslint-disable no-unused-vars */
+
+let inferCNVIdeogram
+let checkboxes
+let ideoConfig
+let adjustedExpressionThreshold
+let chrMargin
+let expressionThreshold
+
+const legend = [{
+  name: 'Expression level',
+  rows: [
+    { name: 'Low', color: '#00B' },
+    { name: 'Normal', color: '#DDD' },
+    { name: 'High', color: '#F00' }
+  ]
+}]
+
+/** Get ideogram heatmap tracks selected via checkbox */
+function getSelectedTracks() {
+  const selectedTracks = []
+
+  checkboxes.forEach(checkbox => {
+    const trackIndex = parseInt(checkbox.getAttribute('id').split('_')[1])
+    if (checkbox.checked) {
+      selectedTracks.push(trackIndex)
+    }
+  })
+
+  return selectedTracks
+}
+
+/** Set selected tracks as displayed tracks */
+function updateTracks() {
+  const selectedTracks = getSelectedTracks()
+  inferCNVIdeogram.updateDisplayedTracks(selectedTracks)
+}
+
+/** Update space between chromosomes; called upon updating related slider */
+function updateMargin(event) {
+  chrMargin = parseInt(event.target.value)
+  ideoConfig.chrMargin = chrMargin
+  inferCNVIdeogram = new Ideogram(ideoConfig)
+}
+
+/** Create a slider to adjust space between chromosomes */
+function addMarginControl() {
+  chrMargin = (typeof chrMargin === 'undefined' ? 10 : chrMargin)
+  const marginSlider =
+    `<label
+          id="chrMarginContainer"
+          style="float:left; position: relative; top: 50px; left: -130px;">
+        Chromosome margin
+      <input
+        type="range"
+        id="chrMargin"
+        list="chrMarginList" value="${chrMargin}">
+      </label>
+      <datalist id="chrMarginList">
+        <option value="0" label="0%">
+        <option value="10">
+        <option value="20">
+        <option value="30">
+        <option value="40">
+        <option value="50" label="50%">
+        <option value="60">
+        <option value="70">
+        <option value="80">
+        <option value="90">
+        <option value="100" label="100%">
+      </datalist>`
+  d3.select('#_ideogramLegend').node().innerHTML += marginSlider
+}
+
+/** Change expression threshold; called upon updating related slider */
+function updateThreshold(event) {
+  let newThreshold
+
+  expressionThreshold = parseInt(event.target.value)
+
+  adjustedExpressionThreshold = Math.round(expressionThreshold/10 - 4)
+  const thresholds = window.originalHeatmapThresholds
+  const numThresholds = thresholds.length
+  ideoConfig.heatmapThresholds = []
+
+  // If expressionThreshold > 1,
+  //    increase thresholds above middle, decrease below
+  // If expressionThreshold < 1,
+  //    decrease thresholds above middle, increase below
+  for (let i = 0; i < numThresholds; i++) {
+    if (i + 1 > numThresholds/2) {
+      newThreshold = thresholds[i + adjustedExpressionThreshold]
+    } else {
+      newThreshold = thresholds[i - adjustedExpressionThreshold]
+    }
+    ideoConfig.heatmapThresholds.push(newThreshold)
+  }
+  inferCNVIdeogram = new Ideogram(ideoConfig)
+}
+
+/** Create slider to adjust expression threshold for "gain" or "loss" calls */
+function addThresholdControl() {
+  if (typeof expressionThreshold === 'undefined') {
+    expressionThreshold = 50
+    window.originalHeatmapThresholds =
+      inferCNVIdeogram.rawAnnots.metadata.heatmapThresholds
+  }
+
+  const expressionThresholdSlider =
+    `<label id="expressionThresholdContainer" style="float: left">
+      <span
+        class="glossary"
+        title="Denoiser.  Adjusts mapping between inferCNV's output heatmap
+          threshold values and normal vs. loss/gain signal.  Analogous to
+          inferCNV denoise parameters, e.g. --noise_filter."
+        style="cursor: help;">
+      Expression threshold
+      </span>
+      <input
+        type="range"
+        id="expressionThreshold"
+        list="expressionThresholdList"
+        value="${expressionThreshold}"
+      >
+      <datalist id="expressionThresholdList">
+        <option value="0" label="0.">
+        <option value="10">
+        <option value="20">
+        <option value="30">
+        <option value="40">
+        <option value="50" label="1">
+        <option value="60">
+        <option value="70">
+        <option value="80">
+        <option value="90">
+        <option value="100" label="1.5">
+      </datalist>
+      <br/><br/>`
+  d3.select('#_ideogramLegend').node().innerHTML += expressionThresholdSlider
+}
+
+/** Handle updates to slider controls for ideogram display */
+function ideoRangeChangeEventHandler(event) {
+  const id = event.target.id
+  if (id === 'expressionThreshold') updateThreshold(event)
+  if (id === 'chrMargin') updateMargin(event)
+}
+
+/** Add sliders to adjust ideogram display */
+function addIdeoRangeControls() {
+  addThresholdControl()
+  addMarginControl()
+
+  document.removeEventListener('change', ideoRangeChangeEventHandler)
+  document.addEventListener('change', ideoRangeChangeEventHandler)
+}
+
+/** Create interactive filters for ideogram tracks */
+function createTrackFilters() {
+  let i; let listItems; let checked
+
+  addIdeoRangeControls()
+
+  // Only apply this function once
+  if (document.querySelector('#filter_1')) return
+  listItems = ''
+  const trackLabels = inferCNVIdeogram.rawAnnots.keys.slice(6)
+  const displayedTracks = inferCNVIdeogram.config.annotationsDisplayedTracks
+  for (i = 0; i < trackLabels.length; i++) {
+    checked = (displayedTracks.includes(i + 1)) ? 'checked' : ''
+    listItems +=
+      `${'<li>' +
+      '<label for="filter_'}${i + 1}">` +
+      `<input type="checkbox" id="filter_${i + 1}" ${checked}/>${
+        trackLabels[i]
+      }</label>` +
+      `</li>`
+  }
+  const content = `Tracks ${listItems}`
+  document.querySelector('#tracks-to-display').innerHTML = content
+
+
+  $('#filters-container').after(
+    '<div id="ideogramTitle">Copy number variation inference</div>'
+  )
+
+  checkboxes = document.querySelectorAll('input[type=checkbox]')
+  checkboxes.forEach(checkbox => {
+    checkbox.addEventListener('click', () => {
+      updateTracks()
+    })
+  })
+}
+
+/**
+ * Note ideogram is unavailable for this numeric cluster
+ *
+ * Used in render_cluster.js.erb
+ */
+function warnIdeogramOfNumericCluster() {
+  const cluster = $('#cluster option:selected').val()
+  const cellAnnot = $('#annotation option:selected').val()
+
+  const warning =
+    `${'<div id="ideogramWarning" style="height: 400px; margin-left: 20px;">' +
+    'Ideogram not available for selected cluster ("'}${cluster}") and ` +
+    `cell annotation ("${cellAnnot}").` +
+    `</div>`
+
+  $('#tracks-to-display, #_ideogramOuterWrap').html('')
+  $('#ideogramWarning, #ideogramTitle').remove()
+  $('#ideogram-container').append(warning)
+}
+
+/** Initialize ideogram to visualize genomic heatmap from inferCNV  */
+function initializeIdeogram(url) {
+  if (typeof window.ideogram !== 'undefined') {
+    delete window.ideogram
+    $('#tracks-to-display').html('')
+    $('#_ideogramOuterWrap').html('')
+  }
+
+  $('#ideogramWarning, #ideogramTitle').remove()
+
+  ideoConfig = {
+    container: '#ideogram-container',
+    organism: window.ideogramInferCnvSettings.organism.toLowerCase(),
+    assembly: window.ideogramInferCnvSettings.assembly,
+    annotationsPath: url,
+    annotationsLayout: 'heatmap',
+    legend,
+    onDrawAnnots: createTrackFilters,
+    debug: true,
+    rotatable: false,
+    chrMargin: 10,
+    chrHeight: 80,
+    annotationHeight: 20,
+    geometry: 'collinear',
+    orientation: 'horizontal'
+  }
+
+  inferCNVIdeogram = new Ideogram(ideoConfig)
+
+  // Log Ideogram.js initialization in Google Analytics
+  ga('send', 'event', 'ideogram', 'initialize')
+
+  window.SCP.log('ideogram:initialize')
+}
+

--- a/app/javascript/components/visualization/controls/InferCNVIdeogramSelector.js
+++ b/app/javascript/components/visualization/controls/InferCNVIdeogramSelector.js
@@ -22,7 +22,7 @@ function getMatchedIdeogramOption(ideogramFile, studyInferCNVIdeogramFiles) {
     })
     return matchedOption
   }
-  return null
+  return {label: noneSelected, value: ''}
 }
 
 /**

--- a/app/javascript/components/visualization/controls/InferCNVIdeogramSelector.js
+++ b/app/javascript/components/visualization/controls/InferCNVIdeogramSelector.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import Select from 'react-select'
+
+import { clusterSelectStyle } from 'lib/cluster-utils'
+
+// value to render in select menu if user has not selected a gene list
+const noneSelected = "None selected..."
+
+/** takes the server response and returns inferCNV/ideogram options suitable for react-select */
+function getInferCNVIdeogramOptions(studyInferCNVIdeogramFiles) {
+  let inferCNVSelectOpts = []
+  for (const [fileId, ideogramOptions] of Object.entries(studyInferCNVIdeogramFiles)) {
+    inferCNVSelectOpts.push({label: ideogramOptions.display, value: fileId})
+  }
+  return [{label: noneSelected, value: ''}].concat(inferCNVSelectOpts)
+}
+
+function getMatchedIdeogramOption(ideogramFile, studyInferCNVIdeogramFiles) {
+  if (ideogramFile && studyInferCNVIdeogramFiles) {
+    const matchedOption = studyInferCNVIdeogramFiles.find(a => {
+      return a.value === ideogramFile
+    })
+    return matchedOption
+  }
+  return null
+}
+
+/**
+  Renders a gene list selector.
+    @param inferCNVIdeogramFile: requested inferCNV/ideogram annotations file to load.
+    @param studyInferCNVIdeogramFiles: collection of all inferCNV/ideogram annotations for a study
+    @param updateInferCNVIdeogramFile: update function to set the inferCNV/ideogram annotation file
+ */
+export default function InferCNVIdeogramSelector({
+  inferCNVIdeogramFile,
+  studyInferCNVIdeogramFiles,
+  updateInferCNVIdeogramFile
+}) {
+  if (!studyInferCNVIdeogramFiles || studyInferCNVIdeogramFiles.length === 0) {
+    return <></>
+  }
+  const inferCNVIdeogramOptions = getInferCNVIdeogramOptions(studyInferCNVIdeogramFiles)
+  let matchedIdeogramOption = getMatchedIdeogramOption(inferCNVIdeogramFile, inferCNVIdeogramOptions)
+  return (
+    <div className="form-group">
+      <label>Ideogram Files</label>
+      <Select
+        value={matchedIdeogramOption}
+        options={inferCNVIdeogramOptions}
+        styles={clusterSelectStyle}
+        onChange={newInferCNVIdeogramFile => updateInferCNVIdeogramFile(newInferCNVIdeogramFile.value)}
+      />
+    </div>
+  )
+}

--- a/app/javascript/styles/_inferCNVIdeogram.scss
+++ b/app/javascript/styles/_inferCNVIdeogram.scss
@@ -1,0 +1,24 @@
+#tracks-to-display {
+    list-style-type: none;
+    float: left;
+    padding-left: 20px;
+}
+
+#tracks-to-display label {
+    font-weight: normal;
+    position: relative;
+    top: 1px;
+}
+
+#tracks-to-display input {
+    margin-right: 5px;
+}
+
+#_ideogramLegend {
+    position: relative;
+    left: 20px;
+}
+
+#ideogramTitle {
+    margin-left: 110px;
+}

--- a/app/javascript/styles/_inferCNVIdeogram.scss
+++ b/app/javascript/styles/_inferCNVIdeogram.scss
@@ -22,3 +22,7 @@
 #ideogramTitle {
     margin-left: 110px;
 }
+
+#ideogram-container {
+    padding-top: 15px;
+}

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -9,3 +9,4 @@
 @import '/_studyOverview.scss';
 @import './_explore.scss';
 @import '/_relatedGenesIdeogram.scss';
+@import '/_inferCNVIdeogram.scss';

--- a/test/js/explore/explore-display-tabs.test.js
+++ b/test/js/explore/explore-display-tabs.test.js
@@ -11,6 +11,12 @@ jest.mock('components/visualization/RelatedGenesIdeogram', () => {
   }
 })
 
+jest.mock('components/visualization/InferCNVIdeogram', () => {
+  return {
+    Ideogram: jest.fn(() => mockPromise)
+  }
+})
+
 import { getEnabledTabs } from 'components/explore/ExploreDisplayTabs'
 
 describe("explore tabs are activated based on study info and parameters", () => {
@@ -19,7 +25,7 @@ describe("explore tabs are activated based on study info and parameters", () => 
     const exploreInfo = {
       cluster: 'foo',
       taxonNames: ['Homo sapiens'],
-      inferCNVIdeogramFiles: [],
+      inferCNVIdeogramFiles: null,
       bamBundleList: [],
       uniqueGenes: ['Agpat2', 'Apoe', 'Gad1', 'Gad2'],
       geneLists: [],
@@ -42,7 +48,8 @@ describe("explore tabs are activated based on study info and parameters", () => 
       enabledTabs: ['cluster'],
       isGeneList: false,
       isGene: false,
-      isMultiGene: false
+      isMultiGene: false,
+      hasIdeogramOutputs: false
     }
 
     expect(expectedResults).toEqual(getEnabledTabs(exploreInfo, exploreParams))
@@ -53,7 +60,7 @@ describe("explore tabs are activated based on study info and parameters", () => 
     const exploreInfo = {
       cluster: 'foo',
       taxonNames: ['Homo sapiens'],
-      inferCNVIdeogramFiles: [],
+      inferCNVIdeogramFiles: null,
       bamBundleList: [
         {"name": "sample1.bam", "file_type": "BAM"},
         {"name": "sample1.bam.bai", "file_type": "BAM Index"}
@@ -81,7 +88,8 @@ describe("explore tabs are activated based on study info and parameters", () => 
       enabledTabs: ['cluster', 'genome'],
       isGeneList: false,
       isGene: false,
-      isMultiGene: false
+      isMultiGene: false,
+      hasIdeogramOutputs: false
     }
 
     expect(expectedResults).toEqual(getEnabledTabs(exploreInfo, exploreParams))
@@ -92,7 +100,7 @@ describe("explore tabs are activated based on study info and parameters", () => 
     const exploreInfo = {
       cluster: 'foo',
       taxonNames: ['Homo sapiens'],
-      inferCNVIdeogramFiles: [],
+      inferCNVIdeogramFiles: null,
       bamBundleList: [],
       uniqueGenes: ['Agpat2', 'Apoe', 'Gad1', 'Gad2'],
       geneLists: ['Gene List 1', 'Gene List 2'],
@@ -113,7 +121,8 @@ describe("explore tabs are activated based on study info and parameters", () => 
       enabledTabs: ['heatmap'],
       isGeneList: true,
       isGene: false,
-      isMultiGene: false
+      isMultiGene: false,
+      hasIdeogramOutputs: false
     }
 
     expect(expectedResults).toEqual(getEnabledTabs(exploreInfo, exploreParams))
@@ -123,7 +132,7 @@ describe("explore tabs are activated based on study info and parameters", () => 
     const exploreInfo = {
       cluster: 'foo',
       taxonNames: ['Homo sapiens'],
-      inferCNVIdeogramFiles: [],
+      inferCNVIdeogramFiles: null,
       bamBundleList: [],
       uniqueGenes: ['Agpat2', 'Apoe', 'Gad1', 'Gad2'],
       geneLists: [],
@@ -149,7 +158,8 @@ describe("explore tabs are activated based on study info and parameters", () => 
       enabledTabs: ['scatter', 'distribution'],
       isGeneList: false,
       isGene: true,
-      isMultiGene: false
+      isMultiGene: false,
+      hasIdeogramOutputs: false
     }
 
     expect(expectedResults).toEqual(getEnabledTabs(exploreInfo, exploreParams))
@@ -159,7 +169,7 @@ describe("explore tabs are activated based on study info and parameters", () => 
     const exploreInfo = {
       cluster: 'foo',
       taxonNames: ['Homo sapiens'],
-      inferCNVIdeogramFiles: [],
+      inferCNVIdeogramFiles: null,
       bamBundleList: [],
       uniqueGenes: ['Agpat2', 'Apoe', 'Gad1', 'Gad2'],
       geneLists: [],
@@ -185,7 +195,8 @@ describe("explore tabs are activated based on study info and parameters", () => 
       enabledTabs: ['dotplot', 'heatmap'],
       isGeneList: false,
       isGene: true,
-      isMultiGene: true
+      isMultiGene: true,
+      hasIdeogramOutputs: false
     }
 
     expect(expectedResults).toEqual(getEnabledTabs(exploreInfo, exploreParams))
@@ -195,7 +206,7 @@ describe("explore tabs are activated based on study info and parameters", () => 
     const exploreInfo = {
       cluster: 'foo',
       taxonNames: ['Homo sapiens'],
-      inferCNVIdeogramFiles: [],
+      inferCNVIdeogramFiles: null,
       bamBundleList: [],
       uniqueGenes: ['Agpat2', 'Apoe', 'Gad1', 'Gad2'],
       geneLists: [],
@@ -226,7 +237,8 @@ describe("explore tabs are activated based on study info and parameters", () => 
       enabledTabs: ['spatial', 'dotplot', 'heatmap'],
       isGeneList: false,
       isGene: true,
-      isMultiGene: true
+      isMultiGene: true,
+      hasIdeogramOutputs: false
     }
 
     expect(expectedResults).toEqual(getEnabledTabs(exploreInfo, exploreParams))
@@ -236,7 +248,7 @@ describe("explore tabs are activated based on study info and parameters", () => 
     const exploreInfo = {
       cluster: 'foo',
       taxonNames: ['Homo sapiens'],
-      inferCNVIdeogramFiles: [],
+      inferCNVIdeogramFiles: null,
       bamBundleList: [],
       uniqueGenes: ['Agpat2', 'Apoe', 'Gad1', 'Gad2'],
       geneLists: [],
@@ -264,7 +276,52 @@ describe("explore tabs are activated based on study info and parameters", () => 
       enabledTabs: ['scatter', 'distribution', 'dotplot'],
       isGeneList: false,
       isGene: true,
-      isMultiGene: true
+      isMultiGene: true,
+      hasIdeogramOutputs: false
+    }
+
+    expect(expectedResults).toEqual(getEnabledTabs(exploreInfo, exploreParams))
+  })
+
+  it ('should enable infercnv-genome tab when selecting Ideogram annotations', async () => {
+    const ideogramOpts = {
+      "604fc5c4e241391a8ff93271": {
+        "cluster": "foo",
+        "annotation": "bar--group--study",
+        "display": "Observations: foo",
+        "ideogram_settings": {
+          "organism": "human",
+          "assembly": "GRCh38",
+          "annotationsPath": "https://www.googleapis.com/storage/v1/b/my-bucket/o/ideogram_exp_means__Observations--foo--group--study.json?alt=media"
+        }
+      }
+    }
+    const exploreInfo = {
+      taxonNames: ['Homo sapiens'],
+      inferCNVIdeogramFiles: ideogramOpts,
+      bamBundleList: [],
+      uniqueGenes: ['Agpat2', 'Apoe', 'Gad1', 'Gad2'],
+      geneLists: [],
+      annotationList: [],
+      clusterGroupNames: [],
+      spatialGroupNames: [],
+      spatialGroups: [],
+      clusterPointAlpha: 1.0
+    }
+
+    const exploreParams = {
+      ideogramFileId: Object.keys(ideogramOpts)[0],
+      userSpecified: {
+        ideogramFileId: true
+      }
+    }
+
+    const expectedResults = {
+      enabledTabs: ['infercnv-genome'],
+      isGeneList: false,
+      isGene: false,
+      isMultiGene: false,
+      hasIdeogramOutputs: true
     }
 
     expect(expectedResults).toEqual(getEnabledTabs(exploreInfo, exploreParams))

--- a/test/js/explore/explore-tab-router.test.js
+++ b/test/js/explore/explore-tab-router.test.js
@@ -41,6 +41,7 @@ describe('dataParams are appropriately managed on the url', () => {
     const locationMock = jest.spyOn(Reach, 'useLocation')
     let urlString = '?geneList=My%20List&genes=agpat2,apoe&cluster=foo&annotation=bar--group--study&subsample=1000'
     urlString += '&spatialGroups=square,circle&consensus=mean&heatmapRowCentering=z-score&bamFileName=sample1.bam'
+    urlString += '&ideogramFileId=604fc5c4e241391a8ff93271'
     locationMock.mockImplementation(() => ({ search: urlString }))
 
     const { exploreParams, updateExploreParams } = useExploreTabRouter()
@@ -54,6 +55,7 @@ describe('dataParams are appropriately managed on the url', () => {
       spatialGroups: ['square', 'circle'],
       consensus: 'mean',
       heatmapRowCentering: 'z-score',
+      ideogramFileId: '604fc5c4e241391a8ff93271',
       distributionPlot: '',
       distributionPoints: '',
       heatmapFit: '',
@@ -68,13 +70,14 @@ describe('dataParams are appropriately managed on the url', () => {
         geneList: true,
         spatialGroups: true,
         subsample: true,
-        heatmapRowCentering: true
+        heatmapRowCentering: true,
+        ideogramFileId: true
       }
     })
 
     updateExploreParams({ spatialGroups: ['triangle'] })
     let expectedUrlString = '?geneList=My%20List&genes=agpat2%2Capoe&cluster=foo&spatialGroups=triangle&annotation=bar--group--study&subsample=1000'
-    expectedUrlString += '&consensus=mean&heatmapRowCentering=z-score&bamFileName=sample1.bam#study-visualize'
+    expectedUrlString += '&consensus=mean&heatmapRowCentering=z-score&bamFileName=sample1.bam&ideogramFileId=604fc5c4e241391a8ff93271#study-visualize'
     expect(routerNav).toHaveBeenLastCalledWith(expectedUrlString, { replace: true })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -9206,11 +9206,6 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.45.0, "mime-db@>= 1.43.0 < 2":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
-  integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
-
 mime-db@1.46.0, "mime-db@>= 1.43.0 < 2":
   version "1.46.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.46.0.tgz#6267748a7f799594de3cbc8cde91def349661cee"


### PR DESCRIPTION
This updates restores the existing inferCNV/Ideogram visualization to the new React explore tab.  This only applies to studies that have previously run `inferCNV` in their study, and have synced outputs to add the Ideogram Annotations files to their study.  Note: it is possible to upload results to your study bucket and sync the results file by selecting the Ideogram Annotations file type and specifying the correct taxon/assembly.  This visualization can load independent of any clustering/annotations/expression data loaded into a study, and as such does not require any of the other file types to be present to enable this tab (which is now separate from the `genome` tab, which loads IGV only now).

Preview, using sample annotations taken from the [Demo: inferCNV oligodendroglioma](https://singlecell.broadinstitute.org/single_cell/study/SCP384/demo-infercnv-oligodendroglioma#study-visualize) study on production:

![infercnv_ideogram](https://user-images.githubusercontent.com/729968/111349566-9da44f80-8657-11eb-942f-f848130af8ea.png)

To test (once your user account has the `FeatureFlag` for `react_explore` enabled): 
1. Download the `ideogram_exp_means__Observations--Sample--group--cluster.json` file from [Demo: inferCNV oligodendroglioma](https://singlecell.broadinstitute.org/single_cell/study/SCP384/demo-infercnv-oligodendroglioma#study-visualize)
2. Place the file in a bucket for any study connected to your instance of SCP
3. Go to the "Sync Study" page for that study, and specify the following values for `ideogram_exp_means__Observations--Sample--group--cluster.json` and save:
    1. File type: `Ideogram Annotations`
    2. Species: `human`
    3. Assembly: `GRCh37` **!!Important or Ideogram won't render!!**
4. Click "View Study" at the top of the page
5. Click the "Genome (inferCNV)" tab and verify the output looks like the above screenshot

This PR satisfies SCP-3113