### PR TITLE
improving error handling for explore tab graphs (SCP-3160)

### DIFF
--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -160,6 +160,7 @@ module Api
           if cell_cluster.nil?
             cell_cluster = @study.default_cluster
           end
+
           render plain: AnnotationVizService.annotation_cell_values_tsv(@study, cell_cluster, annotation)
         end
 

--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -105,7 +105,7 @@ module Api
           begin
             viz_data = self.class.get_cluster_viz_data(@study, cluster, params)
           rescue ArgumentError => e
-            render json: {error: e.message}, status: 422 and return
+            render json: {error: e.message}, status: 404 and return
           end
           render json: viz_data
         end

--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -102,9 +102,10 @@ module Api
               render json: {error: "No cluster named #{cluster_name} could be found"}, status: 404 and return
             end
           end
-          viz_data = self.class.get_cluster_viz_data(@study, cluster, params)
-          if viz_data.nil?
-            render json: {error: 'Annotation could not be found'}, status: 404 and return
+          begin
+            viz_data = self.class.get_cluster_viz_data(@study, cluster, params)
+          rescue ArgumentError => e
+            render json: {error: e.message}, status: 422 and return
           end
           render json: viz_data
         end
@@ -118,7 +119,7 @@ module Api
                                                        annot_type: annot_params[:type],
                                                        annot_scope: annot_params[:scope])
           if !annotation
-            return nil
+            raise ArgumentError, "Annotation #{annot_params[:annot_name]} could not be found"
           end
 
           subsample = get_selected_subsample_threshold(url_params[:subsample], cluster)
@@ -141,6 +142,10 @@ module Api
               range = ClusterVizService.set_range(cluster, coordinates.values)
             end
           else
+            if genes.count == 0
+              # all searched genes do not exist in this study
+              raise ArgumentError, "No genes in this study matched your search"
+            end
             # For single-gene view of Explore tab (or collapsed multi-gene)
             is_collapsed_view = genes.length > 1 && consensus.present?
             y_axis_title = ExpressionVizService.load_expression_axis_title(study)

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -119,7 +119,11 @@ module Api
           subsample = ClustersController.get_selected_subsample_threshold(params[:subsample], cluster)
           genes = RequestUtils.get_genes_from_param(@study, params[:genes])
           if genes.empty?
-            render json: {error: 'You must supply at least one gene'}, status: 422
+            if params[:genes].empty?
+              render json: {error: 'You must supply at least one gene'}, status: 422
+            else
+              render json: {error: 'No genes in this study matched your search'}, status: 422
+            end
           else
             render_data = ExpressionVizService.get_global_expression_render_data(
               study: @study,

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -120,9 +120,9 @@ module Api
           genes = RequestUtils.get_genes_from_param(@study, params[:genes])
           if genes.empty?
             if params[:genes].empty?
-              render json: {error: 'You must supply at least one gene'}, status: 422
+              render json: {error: 'You must supply at least one gene'}, status: 400
             else
-              render json: {error: 'No genes in this study matched your search'}, status: 422
+              render json: {error: 'No genes in this study matched your search'}, status: 404
             end
           else
             render_data = ExpressionVizService.get_global_expression_render_data(

--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -47,7 +47,7 @@ export default function ExploreDisplayTabs(
 ) {
   const [, setRenderForcer] = useState({})
   const plotContainerClass = 'explore-plot-tab-content'
-  const {enabledTabs, isGeneList, isGene, isMultiGene} = getEnabledTabs(exploreInfo, exploreParams)
+  const { enabledTabs, isGeneList, isGene, isMultiGene } = getEnabledTabs(exploreInfo, exploreParams)
 
   // exploreParams object without genes specified, to pass to cluster comparison plots
   const referencePlotDataParams = _clone(exploreParams)
@@ -442,34 +442,32 @@ export default function ExploreDisplayTabs(
 
 /** return an array of the tabs that should be shown, given the exploreParams and exploreInfo */
 export function getEnabledTabs(exploreInfo, exploreParams) {
-  let isGeneList =  !!exploreParams.geneList
-  let isMultiGene = exploreParams?.genes?.length > 1
-  let isGene = exploreParams?.genes?.length > 0
-  let isConsensus = !!exploreParams.consensus
-  let hasSpatialGroups = exploreInfo && exploreInfo?.spatialGroups?.length > 0
-  let hasGenomeFiles = exploreInfo && exploreInfo?.bamBundleList?.length > 0
+  const isGeneList = !!exploreParams.geneList
+  const isMultiGene = exploreParams?.genes?.length > 1
+  const isGene = exploreParams?.genes?.length > 0
+  const isConsensus = !!exploreParams.consensus
+  const hasSpatialGroups = exploreInfo && exploreInfo?.spatialGroups?.length > 0
+  const hasGenomeFiles = exploreInfo && exploreInfo?.bamBundleList?.length > 0
   let enabledTabs = []
   if (isGeneList) {
     enabledTabs = ['heatmap']
-  } else {
-    if (isGene) {
-      if (isMultiGene) {
-        if (isConsensus) {
-          enabledTabs = ['scatter', 'distribution', 'dotplot']
-        } else if (hasSpatialGroups) {
-          enabledTabs = ['spatial', 'dotplot', 'heatmap']
-        } else {
-          enabledTabs = ['dotplot', 'heatmap']
-        }
+  } else if (isGene) {
+    if (isMultiGene) {
+      if (isConsensus) {
+        enabledTabs = ['scatter', 'distribution', 'dotplot']
+      } else if (hasSpatialGroups) {
+        enabledTabs = ['spatial', 'dotplot', 'heatmap']
       } else {
-        enabledTabs = ['scatter', 'distribution']
+        enabledTabs = ['dotplot', 'heatmap']
       }
     } else {
-      enabledTabs = ['cluster']
+      enabledTabs = ['scatter', 'distribution']
     }
+  } else {
+    enabledTabs = ['cluster']
   }
   if (hasGenomeFiles) {
     enabledTabs.push('genome')
   }
-  return {enabledTabs, isGeneList, isGene, isMultiGene}
+  return { enabledTabs, isGeneList, isGene, isMultiGene }
 }

--- a/app/javascript/components/explore/ExploreView.js
+++ b/app/javascript/components/explore/ExploreView.js
@@ -83,7 +83,6 @@ function RoutableExploreTab({ studyAccession }) {
 
   /** handles cluster selection to also populate the default spatial groups */
   function updateClusterParams(newParams) {
-
     if (newParams.cluster && !newParams.spatialGroups) {
       newParams.spatialGroups = getDefaultSpatialGroupsForCluster(newParams.cluster, exploreInfo.spatialGroups)
     }
@@ -91,7 +90,7 @@ function RoutableExploreTab({ studyAccession }) {
     // broken urls in the event of a default cluster/annotation changes
     // also, unset any gene lists as we're about to re-render the explore tab and having gene list selected will show
     // the wrong tabs
-    const updateParams = {geneList: ''}
+    const updateParams = { geneList: '' }
     const clusterParamNames = ['cluster', 'annotation', 'subsample', 'spatialGroups']
     clusterParamNames.forEach(param => {
       updateParams[param] = param in newParams ? newParams[param] : controlExploreParams[param]
@@ -101,7 +100,7 @@ function RoutableExploreTab({ studyAccession }) {
 
   /** handles gene list selection */
   function updateGeneList(geneList) {
-    updateExploreParams({ geneList: geneList })
+    updateExploreParams({ geneList })
   }
 
   useEffect(() => {
@@ -173,9 +172,9 @@ function RoutableExploreTab({ studyAccession }) {
 
             { exploreInfo?.geneLists?.length > 0 &&
               <GeneListSelector
-                  geneList={controlExploreParams.geneList}
-                  studyGeneLists={exploreInfo.geneLists}
-                  updateGeneList={updateGeneList}/>
+                geneList={controlExploreParams.geneList}
+                studyGeneLists={exploreInfo.geneLists}
+                updateGeneList={updateGeneList}/>
             }
             { exploreParams.genes.length > 1 &&
               <ExploreConsensusSelector

--- a/app/javascript/components/explore/GenomeView.js
+++ b/app/javascript/components/explore/GenomeView.js
@@ -102,7 +102,7 @@ export default SafeGenomeView
  * Get tracks for selected BAM files, to show sequencing reads
  */
 function getBamTracks(bamAndBaiFiles) {
-  let bam; let bamTrack; let i;
+  let bam; let bamTrack; let i
 
   const bamTracks = []
 

--- a/app/javascript/components/visualization/DotPlot.js
+++ b/app/javascript/components/visualization/DotPlot.js
@@ -27,7 +27,7 @@ export const dotPlotColorScheme = {
   * @param consensus {string} for multi-gene expression plots
   * @param dimensions {obj} object with height and width, to instruct plotly how large to render itself
   */
-function DotPlot({
+function RawDotPlot({
   studyAccession, genes=[], cluster, annotation={},
   subsample, annotationValues
 }) {
@@ -79,8 +79,8 @@ function DotPlot({
   )
 }
 
-const SafeDotPlot = withErrorBoundary(DotPlot)
-export default SafeDotPlot
+const DotPlot = withErrorBoundary(RawDotPlot)
+export default DotPlot
 
 /** Render Morpheus dot plot */
 function renderDotPlot({

--- a/app/javascript/components/visualization/Heatmap.js
+++ b/app/javascript/components/visualization/Heatmap.js
@@ -33,7 +33,7 @@ export const DEFAULT_FIT = ''
   * @param subsample {string} a string for the subsampel to be retrieved.
   * @param geneList {string} a string for the gene list (precomputed score) to be retrieved.
  */
-function Heatmap({
+function RawHeatmap({
   studyAccession, genes=[], cluster, annotation={}, subsample, geneList, heatmapFit, heatmapRowCentering
 }) {
   const [graphId] = useState(_uniqueId('heatmap-'))
@@ -116,8 +116,8 @@ function Heatmap({
 }
 
 
-const SafeHeatmap = withErrorBoundary(Heatmap)
-export default SafeHeatmap
+const Heatmap = withErrorBoundary(RawHeatmap)
+export default Heatmap
 
 /** Render Morpheus heatmap */
 function renderHeatmap({

--- a/app/javascript/components/visualization/Heatmap.js
+++ b/app/javascript/components/visualization/Heatmap.js
@@ -50,14 +50,16 @@ function Heatmap({
   let annotationCellValuesURL
   // determine where we get our column headers from
   if (!geneList) {
-    annotationCellValuesURL = getAnnotationCellValuesURL({studyAccession,
+    annotationCellValuesURL = getAnnotationCellValuesURL({
+      studyAccession,
       cluster,
       annotationName: annotation.name,
       annotationScope: annotation.scope,
       annotationType: annotation.type,
-      subsample})
+      subsample
+    })
   } else {
-    annotationCellValuesURL = getGeneListColsURL({studyAccession, geneList})
+    annotationCellValuesURL = getGeneListColsURL({ studyAccession, geneList })
   }
 
   useEffect(() => {
@@ -168,7 +170,7 @@ function renderHeatmap({
       { field: annotationName, order: 0 }
     ]
     config.columns = [
-      { field: 'id', display: 'text'},
+      { field: 'id', display: 'text' },
       { field: annotationName, display: 'color' }
     ]
     config.rows = [

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -45,7 +45,7 @@ export function ScatterPlot({
   const { ErrorComponent, setShowError, setErrorContent } = useErrorMessage()
   /** Process scatter plot data fetched from server */
   function handleResponse(clusterResponse) {
-    if (checkScpApiResponse(clusterResponse, () => Plotly.purge(graphElementId), setShowError, setErrorContent )) {
+    if (checkScpApiResponse(clusterResponse, () => Plotly.purge(graphElementId), setShowError, setErrorContent)) {
       // Get Plotly layout
       const layout = getPlotlyLayout(clusterResponse)
       const { width, height } = dimensions

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -45,7 +45,8 @@ export function ScatterPlot({
   const { ErrorComponent, setShowError, setErrorContent } = useErrorMessage()
   /** Process scatter plot data fetched from server */
   function handleResponse(clusterResponse) {
-    if (checkScpApiResponse(clusterResponse, () => Plotly.purge(graphElementId), setShowError, setErrorContent)) {
+   const apiOK = checkScpApiResponse(clusterResponse, () => Plotly.purge(graphElementId), setShowError, setErrorContent)
+    if (apiOK) {
       // Get Plotly layout
       const layout = getPlotlyLayout(clusterResponse)
       const { width, height } = dimensions

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -35,7 +35,7 @@ export const defaultScatterColor = 'Reds'
   * @plotPointsSelected {function} callback for when a user selects points on the plot, which corresponds
   *   to the plotly "points_selected" event
   */
-export function ScatterPlot({
+function RawScatterPlot({
   studyAccession, cluster, annotation, subsample, consensus, genes, scatterColor, dimensions,
   updateScatterColor, isCellSelecting=false, plotPointsSelected
 }) {
@@ -45,8 +45,11 @@ export function ScatterPlot({
   const { ErrorComponent, setShowError, setErrorContent } = useErrorMessage()
   /** Process scatter plot data fetched from server */
   function handleResponse(clusterResponse) {
-   const apiOK = checkScpApiResponse(clusterResponse, () => Plotly.purge(graphElementId), setShowError, setErrorContent)
-    if (apiOK) {
+    const apiOk = checkScpApiResponse(clusterResponse,
+      () => Plotly.purge(graphElementId),
+      setShowError,
+      setErrorContent)
+    if (apiOk) {
       // Get Plotly layout
       const layout = getPlotlyLayout(clusterResponse)
       const { width, height } = dimensions
@@ -155,8 +158,8 @@ export function ScatterPlot({
   )
 }
 
-const SafeScatterPlot = withErrorBoundary(ScatterPlot)
-export default SafeScatterPlot
+const ScatterPlot = withErrorBoundary(RawScatterPlot)
+export default ScatterPlot
 
 
 /** add trace marker colors to group annotations */

--- a/app/javascript/components/visualization/StudyViolinPlot.js
+++ b/app/javascript/components/visualization/StudyViolinPlot.js
@@ -41,7 +41,7 @@ export const defaultDistributionPoints = DISTRIBUTION_POINTS_OPTIONS[0].value
   */
 function StudyViolinPlot({
   studyAccession, genes, cluster, annotation, subsample, consensus, distributionPlot, distributionPoints,
-  updateDistributionPlot, setAnnotationList, dimensions
+  updateDistributionPlot, setAnnotationList, dimensions={}
 }) {
   const [isLoading, setIsLoading] = useState(false)
   // array of gene names as they are listed in the study itself

--- a/app/javascript/components/visualization/StudyViolinPlot.js
+++ b/app/javascript/components/visualization/StudyViolinPlot.js
@@ -62,7 +62,7 @@ function StudyViolinPlot({
       subsample,
       consensus
     )
-    if (checkScpApiResponse(results, () => Plotly.purge(graphElementId), setShowError, setErrorContent )) {
+    if (checkScpApiResponse(results, () => Plotly.purge(graphElementId), setShowError, setErrorContent)) {
       setStudyGeneNames(results.gene_names)
       let distributionPlotToUse = results.plotType
       if (distributionPlot) {

--- a/app/javascript/components/visualization/StudyViolinPlot.js
+++ b/app/javascript/components/visualization/StudyViolinPlot.js
@@ -39,7 +39,7 @@ export const defaultDistributionPoints = DISTRIBUTION_POINTS_OPTIONS[0].value
  *   fetch both the default expression data and the cluster menu options, a function that will be
  *   called with the annotationList returned by that call.
   */
-function StudyViolinPlot({
+function RawStudyViolinPlot({
   studyAccession, genes, cluster, annotation, subsample, consensus, distributionPlot, distributionPoints,
   updateDistributionPlot, setAnnotationList, dimensions={}
 }) {
@@ -62,7 +62,8 @@ function StudyViolinPlot({
       subsample,
       consensus
     )
-    if (checkScpApiResponse(results, () => Plotly.purge(graphElementId), setShowError, setErrorContent)) {
+    const apiOk = checkScpApiResponse(results, () => Plotly.purge(graphElementId), setShowError, setErrorContent)
+    if (apiOk) {
       setStudyGeneNames(results.gene_names)
       let distributionPlotToUse = results.plotType
       if (distributionPlot) {
@@ -145,8 +146,8 @@ function StudyViolinPlot({
   )
 }
 
-const SafeStudyViolinPlot = withErrorBoundary(StudyViolinPlot)
-export default SafeStudyViolinPlot
+const StudyViolinPlot = withErrorBoundary(RawStudyViolinPlot)
+export default StudyViolinPlot
 
 
 /** Formats expression data for Plotly, draws violin (or box) plot */

--- a/app/javascript/components/visualization/controls/GeneListSelector.js
+++ b/app/javascript/components/visualization/controls/GeneListSelector.js
@@ -4,12 +4,12 @@ import Select from 'react-select'
 import { clusterSelectStyle } from 'lib/cluster-utils'
 
 // value to render in select menu if user has not selected a gene list
-const noneSelected = "None selected..."
+const noneSelected = 'None selected...'
 
 /** takes the server response and returns gene list options suitable for react-select */
 function getGeneListOptions(studyGeneLists) {
-  const assignLabelsAndValues = x => ({label: x, value: x})
-  return [{label: noneSelected, value: ''}].concat(studyGeneLists.map(assignLabelsAndValues))
+  const assignLabelsAndValues = x => ({ label: x, value: x })
+  return [{ label: noneSelected, value: '' }].concat(studyGeneLists.map(assignLabelsAndValues))
 }
 
 

--- a/app/javascript/lib/error-message.js
+++ b/app/javascript/lib/error-message.js
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-
+import React, { useState, useEffect } from 'react'
+import { log } from 'lib/metrics-api'
 
 /** 
   * Hook for enabling the conditional display an error message.
@@ -16,6 +16,11 @@ export default function useErrorMessage() {
       { errorContent }
     </div>
   }
+  useEffect(() => {
+    if (showError) {
+      log('error-message', { text: errorContent })
+    }
+  }, [errorContent])
   return {
     showError, setShowError, setErrorContent, ErrorComponent
   }

--- a/app/javascript/lib/error-message.js
+++ b/app/javascript/lib/error-message.js
@@ -1,0 +1,57 @@
+import React, { useState } from 'react'
+
+
+/** Hook for enabling the conditional display an error message
+  * in the event of an error
+  * the returned ErrorComponent can be placed in the component's markup, and will be
+  * displayed with the content from setErrorContent if setShowError is called with true
+  */
+export default function useErrorMessage() {
+  const [showError, setShowError] = useState(false)
+  const [errorContent, setErrorContent] = useState('')
+
+  let ErrorComponent = <></>
+  if (showError) {
+    ErrorComponent = <div className="alert-danger text-center error-boundary">
+      { errorContent }
+    </div>
+  }
+  return {
+    showError, setShowError, setErrorContent, ErrorComponent
+  }
+}
+
+/**
+  * wraps a call to an scp-api function in error handling
+  * Once this code is good and stable, this should be folded into scp-api itself
+  */
+export function checkScpApiResponse(response, onError, setShowError, setErrorContent) {
+  // currently, scp-api just hands back a raw response if not ok,
+  // that isn't the best encapsulation of an API call, and should be refactored later
+  if ('ok' in response && !response.ok) {
+    response.json().then(response => {
+      onError()
+      setShowError(true)
+      setErrorContent(response.error)
+    })
+  } else {
+    return true
+  }
+}
+
+/** handler for morpheus errors that catches the error from an empty gene search to
+    replace it with a more useful display and error message. */
+export function morpheusErrorHandler($target, setShowError, setErrorContent) {
+  return err => {
+    // this is a brittle check, but morpheus doesn't give us any visibility into what error occured,
+    // other than that there was an error processing the results returned
+    if (err[0].includes('genes') && err[0].includes('opening')) {
+      setShowError(true)
+      setErrorContent('The gene search returned no results for this study')
+      // there doesn't seem to be any way to stop the morpheus dialog from popping up,
+      // so we do the next best thing and destroy it immediately
+      // see https://github.com/cmap/morpheus.js/blob/master/src/ui/heat_map.js:607
+      setTimeout(() => $target.find('.modal').remove(), 0)
+    }
+  }
+}

--- a/app/javascript/lib/error-message.js
+++ b/app/javascript/lib/error-message.js
@@ -1,10 +1,10 @@
 import React, { useState } from 'react'
 
 
-/** Hook for enabling the conditional display an error message
-  * in the event of an error
-  * the returned ErrorComponent can be placed in the component's markup, and will be
-  * displayed with the content from setErrorContent if setShowError is called with true
+/** 
+  * Hook for enabling the conditional display an error message.
+  * In the event of an error, the returned ErrorComponent can be placed in the component's markup, 
+  * and will be displayed with the content from setErrorContent if setShowError is called with true.
   */
 export default function useErrorMessage() {
   const [showError, setShowError] = useState(false)

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -386,7 +386,7 @@ export async function fetchAnnotation(studyAccession, clusterName, annotationNam
 }
 
 /** Get URL for a Morpheus-suitable annotation values file */
-export function getAnnotationCellValuesURL({studyAccession, clusterName, annotationName, annotationScope, annotationType, mock=false}) {
+export function getAnnotationCellValuesURL({ studyAccession, clusterName, annotationName, annotationScope, annotationType, mock=false }) {
   const paramObj = {
     cluster: clusterName,
     annotation_scope: annotationScope,
@@ -399,7 +399,7 @@ export function getAnnotationCellValuesURL({studyAccession, clusterName, annotat
 }
 
 /** get URL for Morpheus-suitable annotation values file for a gene list */
-export function getGeneListColsURL({studyAccession, geneList}) {
+export function getGeneListColsURL({ studyAccession, geneList }) {
   const apiUrl = `/studies/${studyAccession}/annotations/gene_lists/${encodeURIComponent(geneList)}`
   return getFullUrl(apiUrl)
 }

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -386,9 +386,9 @@ export async function fetchAnnotation(studyAccession, clusterName, annotationNam
 }
 
 /** Get URL for a Morpheus-suitable annotation values file */
-export function getAnnotationCellValuesURL({ studyAccession, clusterName, annotationName, annotationScope, annotationType, mock=false }) {
+export function getAnnotationCellValuesURL({ studyAccession, cluster, annotationName, annotationScope, annotationType, mock=false }) {
   const paramObj = {
-    cluster: clusterName,
+    cluster,
     annotation_scope: annotationScope,
     annotation_type: annotationType,
     url_safe_token: getURLSafeAccessToken()

--- a/app/javascript/lib/study-overview/explore-single.js
+++ b/app/javascript/lib/study-overview/explore-single.js
@@ -101,5 +101,4 @@ export default async function exploreSingle() {
   renderSingleGenePlots(study, gene)
 
   closeUserAnnotationsForm()
-
 }

--- a/app/javascript/lib/study-overview/explore.js
+++ b/app/javascript/lib/study-overview/explore.js
@@ -35,7 +35,7 @@ async function exploreScatterPlotsHorizontal(study, gene) {
 
   scatterPlot(apiParams, props)
 
-  const annotDisplayName = $("#annotation option:selected").text();
+  const annotDisplayName = $('#annotation option:selected').text()
 
   apiParams.gene = null
   props.selector = `${baseSelector} .row > div:nth-child(2)`

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -40,6 +40,7 @@ import exploreDefault from 'lib/study-overview/explore-default'
 import exploreSingle from 'lib/study-overview/explore-single'
 import { renderClusterAssociationSelect } from 'components/upload/ClusterAssociationSelect'
 import { renderExploreView } from 'components/explore/ExploreView'
+import { addCustomMorpheusErrorHandling } from 'lib/error-message'
 
 // Stub, for later
 // import exploreMultipleGenes from 'lib/study-overview/explore-multiple-genes'
@@ -78,6 +79,7 @@ window.$ = $
 window.jQuery = $
 window.Spinner = Spinner
 window.morpheus = morpheus
+
 window.igv = igv
 window.Ideogram = Ideogram
 window.getViolinProps = getViolinProps

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -40,7 +40,6 @@ import exploreDefault from 'lib/study-overview/explore-default'
 import exploreSingle from 'lib/study-overview/explore-single'
 import { renderClusterAssociationSelect } from 'components/upload/ClusterAssociationSelect'
 import { renderExploreView } from 'components/explore/ExploreView'
-import { addCustomMorpheusErrorHandling } from 'lib/error-message'
 
 // Stub, for later
 // import exploreMultipleGenes from 'lib/study-overview/explore-multiple-genes'
@@ -79,7 +78,6 @@ window.$ = $
 window.jQuery = $
 window.Spinner = Spinner
 window.morpheus = morpheus
-
 window.igv = igv
 window.Ideogram = Ideogram
 window.getViolinProps = getViolinProps

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -754,6 +754,11 @@ ul.pager li.dimmed {
   }
 }
 
+.error-boundary {
+	padding: 0.5em;
+	border-radius: 5px;
+}
+
 // Overridding some default CKEditor styles to allow for larger editor windows by default
 
 .ck-editor__editable {


### PR DESCRIPTION
Ooof, this was tougher than expected...  I created a standardized way of indicating errors in visualizations (see screenshot below), and extended it to our four main visualization types.  This also does some overriding of morpheus error handling so we can show a better error message when the user does a gene search with no results (previously a dialog with 'Error opening https:...' would show, which implied a connection problem, rather than an empty search)

This also ran `yarn lint --fix` to fix some outstanding code format issues

To test:

1. Load a study, with the react_explore feature flag on

2. Do a single gene search for a gene that doesn’t exist (e.g. ‘xxxxxx’).  confirm error message is display, similar to screenshot below

3. Do a multi-gene search where all genes don’t exist (e.g. ‘ddddddd’, ‘dfsadfasdf’).  confirm error message is displayed similar to below.


![image](https://user-images.githubusercontent.com/2800795/111369784-d3ecc980-866d-11eb-9e86-0c97f598ed0f.png)
