### PR TITLE
adding some missing analytics events

### DIFF
--- a/app/javascript/components/explore/StudyGeneField.js
+++ b/app/javascript/components/explore/StudyGeneField.js
@@ -5,6 +5,8 @@ import Button from 'react-bootstrap/lib/Button'
 import Modal from 'react-bootstrap/lib/Modal'
 import CreatableSelect from 'react-select/creatable'
 
+import { log } from 'lib/metrics-api'
+
 
 /** renders the gene text input
   * This shares a lot of logic with search/genes/GeneKeyword, but is kept as a separate component for
@@ -100,7 +102,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes }) {
       <div className="flexbox align-center">
         <div className="input-group">
           <div className="input-group-append">
-            <Button type="submit">
+            <Button type="submit" data-analytics-name="gene-search-submit">
               <FontAwesomeIcon icon={faSearch} />
             </Button>
           </div>
@@ -114,7 +116,14 @@ export default function StudyGeneField({ genes, searchGenes, allGenes }) {
             isValidNewOption={() => false}
             noOptionsMessage={() => (inputText.length > 1 ? 'No matching genes' : 'Type to search...')}
             options={geneOptions}
-            onChange={value => setGeneArray(value ? value : [])}
+            onChange={value => {
+              // react-select doesn't expose the actual click events, so we deduce the kind
+              // of operation based on whether it lengthened or shortened the list
+              const newValue = value ? value : []
+              const actionName = value.length > geneArray.length ? 'add' : 'remove'
+              log('input:change', { text: `study-gene-search:${actionName}` })
+              setGeneArray(newValue)
+            }}
             onInputChange={inputValue => setInputText(inputValue)}
             onKeyDown={handleKeyDown}
             // the default blur behavior removes any entered free text,

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -41,21 +41,13 @@ import exploreSingle from 'lib/study-overview/explore-single'
 import { renderClusterAssociationSelect } from 'components/upload/ClusterAssociationSelect'
 import { renderExploreView } from 'components/explore/ExploreView'
 
-// Stub, for later
-// import exploreMultipleGenes from 'lib/study-overview/explore-multiple-genes'
-
 
 document.addEventListener('DOMContentLoaded', () => {
   // Logs only page views for faceted search UI
   logPageView()
 
-  $(document).on('click', 'body', event => {
-    logClick(event)
-  })
-
-  $(document).on('change', 'select', event => {
-    logMenuChange(event)
-  })
+  $(document).on('click', 'body', logClick)
+  $(document).on('change', 'select', logMenuChange)
 
   if (document.getElementById('home-page-content')) {
     ReactDOM.render(
@@ -78,6 +70,7 @@ window.$ = $
 window.jQuery = $
 window.Spinner = Spinner
 window.morpheus = morpheus
+
 window.igv = igv
 window.Ideogram = Ideogram
 window.getViolinProps = getViolinProps


### PR DESCRIPTION
This cleans up a couple places in the explore tab where we weren't tracking events well

To test:
1. open a study with the react_explore feature flag on
2. Open the chrome debugger with the network tab
3. type/select a gene in the search box
4. confirm an event gets posted to bard with name 'input:change' and text `study-gene-search:add`
5. Hit enter or click the search bar. 
6. confirm an event gets posted to bard with name 'click:button' and text 'gene-search-submit'
7. use the 'x' or backspace to remove a gene entry from the search bar
8. confirm an event gets posted to bard with name 'input:change' and text `study-gene-search:remove`
