### PR TITLE
Gene search analytics and UX fixes (SCP-3147)

### DIFF
--- a/app/javascript/components/explore/StudyGeneField.js
+++ b/app/javascript/components/explore/StudyGeneField.js
@@ -102,9 +102,10 @@ export default function StudyGeneField({ genes, searchGenes, allGenes }) {
         actionName = 'remove'
         geneDiff = _differenceBy(geneArray, newArray, 'value')
       }
-      log('input:change', {
-        text: `study-gene-search:${actionName}`,
-        changedGenes: geneDiff.map(item => item.value).join(',')
+      log('change:multiselect', {
+        text: geneDiff.map(item => item.value).join(','),
+        action: actionName,
+        type: 'gene'
       })
     } catch (err) {
       // no-op, we just don't want logging fails to break the application

--- a/app/javascript/components/explore/StudyGeneField.js
+++ b/app/javascript/components/explore/StudyGeneField.js
@@ -105,7 +105,8 @@ export default function StudyGeneField({ genes, searchGenes, allGenes }) {
       log('change:multiselect', {
         text: geneDiff.map(item => item.value).join(','),
         action: actionName,
-        type: 'gene'
+        type: 'gene',
+        numPreviousGenes: geneArray.length
       })
     } catch (err) {
       // no-op, we just don't want logging fails to break the application

--- a/app/javascript/components/explore/StudyGeneField.js
+++ b/app/javascript/components/explore/StudyGeneField.js
@@ -5,6 +5,8 @@ import Button from 'react-bootstrap/lib/Button'
 import Modal from 'react-bootstrap/lib/Modal'
 import CreatableSelect from 'react-select/creatable'
 
+import { log } from 'lib/metrics-api'
+
 
 /** renders the gene text input
   * This shares a lot of logic with search/genes/GeneKeyword, but is kept as a separate component for
@@ -100,7 +102,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes }) {
       <div className="flexbox align-center">
         <div className="input-group">
           <div className="input-group-append">
-            <Button type="submit">
+            <Button type="submit" data-analytics-name="gene-search-submit">
               <FontAwesomeIcon icon={faSearch} />
             </Button>
           </div>
@@ -114,7 +116,14 @@ export default function StudyGeneField({ genes, searchGenes, allGenes }) {
             isValidNewOption={() => false}
             noOptionsMessage={() => (inputText.length > 1 ? 'No matching genes' : 'Type to search...')}
             options={geneOptions}
-            onChange={value => setGeneArray(value ? value : [])}
+            onChange={value => {
+              // react-select doesn't expose the actual click events, so we deduce the kind
+              // of operation based on whether it lengthened or shortened the list
+              const newValue = value ? value : []
+              const actionName = value.length > geneArray.length ? 'add' : 'remove'
+              log('input:change', { text: `study-gene-search:${actionName}` })
+              setGeneArray(newValue)
+            }}
             onInputChange={inputValue => setInputText(inputValue)}
             onKeyDown={handleKeyDown}
             // the default blur behavior removes any entered free text,

--- a/app/javascript/components/explore/StudyGeneField.js
+++ b/app/javascript/components/explore/StudyGeneField.js
@@ -4,6 +4,7 @@ import { faSearch, faFileUpload } from '@fortawesome/free-solid-svg-icons'
 import Button from 'react-bootstrap/lib/Button'
 import Modal from 'react-bootstrap/lib/Modal'
 import CreatableSelect from 'react-select/creatable'
+import _differenceBy from 'lodash/differenceBy'
 
 import { log } from 'lib/metrics-api'
 
@@ -55,12 +56,12 @@ export default function StudyGeneField({ genes, searchGenes, allGenes }) {
 
   /** Converts any current typed free text to a gene array entry */
   function syncGeneArrayToInputText() {
-    const inputTextTrimmed = inputText.trim().replace(/,/g, '')
-    if (!inputTextTrimmed) {
+    const inputTextValues = inputText.trim().split(/[\s,]+/)
+    if (!inputTextValues.length || !inputTextValues[0].length) {
       return geneArray
     }
-    const newGeneArray = [...geneArray, { label: inputTextTrimmed, value: inputTextTrimmed }]
-
+    const newGeneArray = geneArray.concat(inputTextValues.map(gene => ({ label: gene, value: gene })))
+    logGeneArrayChange(newGeneArray)
     setInputText(' ')
     setGeneArray(newGeneArray)
     return newGeneArray
@@ -87,6 +88,36 @@ export default function StudyGeneField({ genes, searchGenes, allGenes }) {
       searchGenes(newGenes)
     }
     fileReader.readAsText(file)
+  }
+
+  /** send analytics on how the gene search input changed */
+  function logGeneArrayChange(newArray) {
+    try {
+      let actionName = ''
+      let geneDiff = []
+      if (newArray.length > geneArray.length) {
+        actionName = 'add'
+        geneDiff = _differenceBy(newArray, geneArray, 'value')
+      } else {
+        actionName = 'remove'
+        geneDiff = _differenceBy(geneArray, newArray, 'value')
+      }
+      log('input:change', {
+        text: `study-gene-search:${actionName}`,
+        changedGenes: geneDiff.map(item => item.value).join(',')
+      })
+    } catch (err) {
+      // no-op, we just don't want logging fails to break the application
+    }
+  }
+
+  /** handles the change event corresponding a a user adding or clearing one or more genes */
+  function handleSelectChange(value) {
+    // react-select doesn't expose the actual click events, so we deduce the kind
+    // of operation based on whether it lengthened or shortened the list
+    const newValue = value ? value : []
+    logGeneArrayChange(newValue)
+    setGeneArray(newValue)
   }
 
   useEffect(() => {
@@ -116,20 +147,22 @@ export default function StudyGeneField({ genes, searchGenes, allGenes }) {
             isValidNewOption={() => false}
             noOptionsMessage={() => (inputText.length > 1 ? 'No matching genes' : 'Type to search...')}
             options={geneOptions}
-            onChange={value => {
-              // react-select doesn't expose the actual click events, so we deduce the kind
-              // of operation based on whether it lengthened or shortened the list
-              const newValue = value ? value : []
-              const actionName = value.length > geneArray.length ? 'add' : 'remove'
-              log('input:change', { text: `study-gene-search:${actionName}` })
-              setGeneArray(newValue)
-            }}
+            onChange={handleSelectChange}
             onInputChange={inputValue => setInputText(inputValue)}
             onKeyDown={handleKeyDown}
             // the default blur behavior removes any entered free text,
             // we want to instead auto-convert entered free text to a gene tag
             onBlur={syncGeneArrayToInputText}
             placeholder={'Genes (e.g. "PTEN NF2")'}
+            styles={{
+              // if more genes are entered than fit, use a vertical scrollbar
+              // this is probably not optimal UX, but good enough for first release and monitoring
+              valueContainer: (provided, state) => ({
+                ...provided,
+                maxHeight: '32px',
+                overflow: 'auto'
+              })
+            }}
           />
         </div>
         <label htmlFor="gene-list-upload"

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -41,21 +41,13 @@ import exploreSingle from 'lib/study-overview/explore-single'
 import { renderClusterAssociationSelect } from 'components/upload/ClusterAssociationSelect'
 import { renderExploreView } from 'components/explore/ExploreView'
 
-// Stub, for later
-// import exploreMultipleGenes from 'lib/study-overview/explore-multiple-genes'
-
 
 document.addEventListener('DOMContentLoaded', () => {
   // Logs only page views for faceted search UI
   logPageView()
 
-  $(document).on('click', 'body', event => {
-    logClick(event)
-  })
-
-  $(document).on('change', 'select', event => {
-    logMenuChange(event)
-  })
+  $(document).on('click', 'body', logClick)
+  $(document).on('change', 'select', logMenuChange)
 
   if (document.getElementById('home-page-content')) {
     ReactDOM.render(
@@ -78,6 +70,7 @@ window.$ = $
 window.jQuery = $
 window.Spinner = Spinner
 window.morpheus = morpheus
+
 window.igv = igv
 window.Ideogram = Ideogram
 window.getViolinProps = getViolinProps


### PR DESCRIPTION
This has a quick-and-dirty fix for handling too many genes in the bar
![image](https://user-images.githubusercontent.com/2800795/111533975-d0c10e80-873d-11eb-9fe2-4fd5be6412b0.png)
The scrollbar isn't great, but it's better than the previous behavior of overflowing into the graphs (and arguably no worse than the current too-small text field)
![image](https://user-images.githubusercontent.com/2800795/111534097-f9490880-873d-11eb-833c-692a6ef1e176.png)

This also improves handling of copy-pasted gene lists into the bar, as well as giving even more detail on events

To test:
1. open a study with react_explore feature flag enabled
2. paste a list of genes into the search bar (e.g. "foo bar baz") and then hit enter/tab/space
3. Observe the genes get divided appropriately
4. Add a lot of genes, and observe that a vertical scrollbar appears to scroll, rather than overflow 