### PR TITLE
adding additional migrate to remove model instances of flag (SCP-3161)

### DIFF
--- a/db/migrate/20210318125925_remove_spatial_flag2.rb
+++ b/db/migrate/20210318125925_remove_spatial_flag2.rb
@@ -1,0 +1,10 @@
+class RemoveSpatialFlag2 < Mongoid::Migration
+  def self.up
+    FeatureFlaggable.remove_flag_from_model(User, 'spatial_transcriptomics')
+    FeatureFlaggable.remove_flag_from_model(BrandingGroup, 'spatial_transcriptomics')
+  end
+
+  def self.down
+    # we're not remembering which users had this feature, so there's no way to undo
+  end
+end


### PR DESCRIPTION
@bistline had actually already written the tool for doing this exact operation, but I forgot to use it in my prior migration script

To test:
1. checkout development, and run `rails db:migrate`
2. Update a user in your DB to have the spatial_transcriptomics feature flag set.
3. confirm that if you go to admin config and try to edit the user roles for that user, the page errors
4. checkout this branch
5. run rails db:migrate
6. confirm you can now edit the user roles for the given user 