### PR TITLE
fixing gene expression hover text (SCP-3183)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -175,9 +175,13 @@ function formatMarkerColors(data, annotationType, gene) {
 function formatHoverLabels(data, annotationType, gene) {
   const groupHoverTemplate = '(%{x}, %{y})<br><b>%{text}</b><br>%{data.name}<extra></extra>'
   data.forEach(trace => {
+    trace.text = trace.cells
     if (annotationType === 'numeric' || gene) {
-      trace.text = trace.annotations
-      trace.hovertemplate = `(%{x}, %{y})<br>%{text}<br>${trace.marker.colorbar.title}: %{marker.color}<extra></extra>`
+      // use the 'meta' property so annotations are exposed to the hover template
+      // see https://community.plotly.com/t/hovertemplate-does-not-show-name-property/36139
+      trace.meta = trace.annotations
+      trace.hovertemplate = `(%{x}, %{y})<br>%{text} (%{meta})<br>
+        ${trace.marker.colorbar.title}: %{marker.color}<extra></extra>`
     } else {
       trace.text = trace.cells
       trace.hovertemplate = groupHoverTemplate


### PR DESCRIPTION
SCP-3183.  Adds the cell names back to the hover text for gene expression plots.  
![image](https://user-images.githubusercontent.com/2800795/111823359-3dade300-88bb-11eb-921d-89dcf167318a.png). 

To test:
1.  do a gene search in a study with the react_explore feature flag on
2. hover over a cell, and confirm the coordinates, cell name, annotation, and expression value all appear.