### PR TITLE
fixing subsample selector dropdown (SCP-3182)

### DIFF
--- a/app/javascript/components/visualization/controls/SubsampleSelector.js
+++ b/app/javascript/components/visualization/controls/SubsampleSelector.js
@@ -16,7 +16,8 @@ function getSubsampleOptions(annotationList, clusterName) {
       clusterSubsamples = []
     }
     subsampleOptions = subsampleOptions.concat(clusterSubsamples.map(num => {
-      return { label: `${num}`, value: num }
+      // convert everything to strings to make the comparisons easier
+      return { label: `${num}`, value: `${num}` }
     }))
   }
   subsampleOptions.push({ label: 'All Cells', value: 'all' })
@@ -52,8 +53,8 @@ export default function SubsampleSelector({
       </label>
       <Select options={subsampleOptions}
         value={{
-          label: subsample == 'all' ? 'All Cells' : subsample,
-          value: subsample
+          label: subsample == 'all' ? 'All Cells' : `${subsample}`,
+          value: `${subsample}`
         }}
         onChange={newSubsample => updateClusterParams({
           subsample: newSubsample.value


### PR DESCRIPTION
SCP-3182.  The bug was caused by the selector getting the subsample value as a string "1000" from the url parameter, but the options from the server were integers.  I've taken the simple approach of having it convert everything to strings, since it's always going to get sent to the server as a string anyway, and we have to represent 'all' as a string. 

To test:
1. open a study with at least 1000 cells in the react_explore tab
2. change the subsample to an option other than All cells
3. confirm the visualization updates correctly, and the new option is indicated with dark-blue as the selected option in the dropdown
![image](https://user-images.githubusercontent.com/2800795/111825923-6edbe280-88be-11eb-9ce2-349df9f7f873.png)
