### PR TITLE
applying dotplot legend style to explore tab (SCP-3185)

### DIFF
--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -759,6 +759,15 @@ ul.pager li.dimmed {
 	border-radius: 5px;
 }
 
+.dot-plot-legend-container {
+  margin-top: 1em;
+  width: 400px;
+  height: 70px;
+  text {
+    font-size: 0.9em;
+  }
+}
+
 // Overridding some default CKEditor styles to allow for larger editor windows by default
 
 .ck-editor__editable {

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -319,15 +319,6 @@ nav.search-links, #search-panel {
   div[data-name="toolbar"] {
     display: none;
   }
-
-  .dot-plot-legend-container {
-    margin-top: 1em;
-    width: 400px;
-    height: 70px;
-    text {
-      font-size: 0.9em;
-    }
-  }
 }
 
 .advanced-opts {
@@ -344,4 +335,3 @@ nav.search-links, #search-panel {
   font-weight: bold;
   color: #fff;
 }
-


### PR DESCRIPTION
SCP-3185. If we start to see more styles like this come out, it might be worth creating a 'visualization.scss' file, but for now, global works.

To test
1. Do a multi-gene search on a study with react_explore feature flag on
2. confirm the dotplot legend appears with appropriate space between it and the graph, and the full legend is displayed

![image](https://user-images.githubusercontent.com/2800795/111826768-79e34280-88bf-11eb-897a-6393bf1e4896.png)
