### PR TITLE
Providing fallback "Unspecified" label for missing group-based annotations (SCP-3070)

### DIFF
--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -210,6 +210,7 @@ class ClusterVizService
   # uses cluster_group model and loads annotation for both group & numeric plots
   # data values are pulled from associated data_array entries for each axis and annotation/text value
   def self.load_cluster_group_data_array_points(study, cluster, annotation, subsample_threshold=nil, colorscale=nil)
+    Rails.logger.info "raw annotation: #{annotation}"
     # construct annotation key to load subsample data_arrays if needed, will be identical to params[:annotation]
     subsample_annotation = "#{annotation[:name]}--#{annotation[:type]}--#{annotation[:scope]}"
     x_array = cluster.concatenate_data_arrays('x', 'coordinates', subsample_threshold, subsample_annotation)
@@ -234,8 +235,11 @@ class ClusterVizService
       # for study-wide annotations, load from study_metadata values instead of cluster-specific annotations
       metadata_obj = study.cell_metadata.by_name_and_type(annotation[:name], annotation[:type])
       annotation_hash = metadata_obj.cell_annotations
-      annotation[:values] = annotation_hash.values
+      annotation[:values] = AnnotationVizService.sanitize_values_array(metadata_obj.values, annotation[:type])
     end
+    annotation_array = AnnotationVizService.sanitize_values_array(annotation_array, annotation[:type])
+    Rails.logger.info "annotation array: #{annotation_array}"
+    Rails.logger.info "annotation[:values]: #{annotation[:values]}"
     coordinates = {}
     if annotation[:type] == 'numeric'
       text_array = []
@@ -301,9 +305,6 @@ class ClusterVizService
             coordinates[annotation_value][:z] << z_array[index]
           end
         end
-        coordinates.each do |key, data|
-          data[:name] << " (#{data[:x].size} points)"
-        end
       else
         cells.each_with_index do |cell, index|
           if annotation_hash.has_key?(cell)
@@ -318,15 +319,15 @@ class ClusterVizService
             end
           end
         end
-        coordinates.each do |key, data|
-          data[:name] << " (#{data[:x].size} points)"
-        end
 
       end
-
     end
-    # gotcha to remove entries in case a particular annotation value comes up blank since this is study-wide
+    # gotcha to remove entries in case a particular annotation value comes up blank
     coordinates.delete_if {|key, data| data[:x].empty?}
+    coordinates.each do |key, data|
+      existing_name = data[:name].dup
+      data[:name] = "#{existing_name} (#{data[:x].size} points)"
+    end
     coordinates
   end
 end

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -74,6 +74,7 @@ class ExpressionVizService
       )
       cells.each_with_index do |cell, index|
         values[annotations[index]][:y] << gene['scores'][cell].to_f.round(4)
+        values[annotations[index]][:cells] << cell
       end
     elsif annotation[:scope] == 'user'
       # for user annotations, we have to load by id as names may not be unique to clusters
@@ -86,6 +87,7 @@ class ExpressionVizService
       cells = user_annotation.concatenate_user_data_arrays('text', 'cells', subsample_threshold, subsample_annotation)
       cells.each_with_index do |cell, index|
         values[annotations[index]][:y] << gene['scores'][cell].to_f.round(4)
+        values[annotations[index]][:cells] << cell
       end
     else
       # since annotations are in a hash format, subsampling isn't necessary as we're going to retrieve values by key lookup

--- a/app/models/cell_metadatum.rb
+++ b/app/models/cell_metadatum.rb
@@ -44,7 +44,10 @@ class CellMetadatum
   # concatenate all the necessary data_array objects and construct a hash of cell names => expression values
   def cell_annotations
     cells = self.study.all_cells_array
-    annot_values = self.concatenate_data_arrays(self.name, 'annotations')
+    # replace blank/nil values with default missing label
+    annot_values = AnnotationVizService.sanitize_values_array(
+      self.concatenate_data_arrays(self.name, 'annotations'), self.annotation_type
+    )
     Hash[cells.zip(annot_values)]
   end
 

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1059,7 +1059,7 @@ class Study
           scope: 'cluster'
         }
       elsif self.cell_metadata.any?
-        metadatum = self.cell_metadata.first
+        metadatum = self.cell_metadata.keep_if {|meta| meta.can_visualize?}.first
         annot_params = {
           name: metadatum.name,
           type: metadatum.annotation_type,

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module SingleCellPortal
     config.middleware.use Rack::Deflater
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.10.1'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.10.2'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Since having blank values for group-based annotations is allowed by `scp-ingest-pipeline`, we need to account for this on the front end when rendering any visualization.  Blank strings/null values will cause any number of components to break or have a degraded UX.  This update sanitizes all annotation-based arrays to replace these empty values with a default value of `--Unspecified--`.  

This value was chosen for several reasons:
1. It conveys that the label value was not set by the study owner
1. The `--` characters reduce the risk of this value colliding with a study owner-specified label
1. It works in both Plotly & Morpheus (characters like `<>` do not)

This will work with both normal and array-based metadata, as well as cluster annotation columns.

Sample visualizations using this value:

Scatter:
![missing_cluster](https://user-images.githubusercontent.com/729968/111827704-97fd7280-88c0-11eb-9154-c11187d5e5dd.png)
Violin:
![missing_violin](https://user-images.githubusercontent.com/729968/111827714-9b90f980-88c0-11eb-9b12-74c22ef62cb0.png)
Dotplot:
![missing_dotplot](https://user-images.githubusercontent.com/729968/111827713-9b90f980-88c0-11eb-85f2-5b2e443bb16c.png)
Heatmap:
![missing_heatmap](https://user-images.githubusercontent.com/729968/111827715-9b90f980-88c0-11eb-93ea-b2cd5c9235ec.png)

This PR satisfies SCP-3070.

