### PR TITLE
Adding loading spinner to violin plot dropdowns (SCP-3186)

### DIFF
--- a/app/javascript/components/visualization/StudyViolinPlot.js
+++ b/app/javascript/components/visualization/StudyViolinPlot.js
@@ -103,7 +103,11 @@ function RawStudyViolinPlot({
   useUpdateEffect(() => {
     // Don't try to update the if the data hasn't loaded yet
     if (!isLoading && studyGeneNames.length > 0) {
-      updateViolinPlot(graphElementId, distributionPlot, distributionPoints)
+      setIsLoading(true)
+      setTimeout(() => {
+        updateViolinPlot(graphElementId, distributionPlot, distributionPoints)
+        setIsLoading(false)
+      }, 0)
     }
   }, [distributionPlot, distributionPoints])
 

--- a/app/javascript/components/visualization/controls/SubsampleSelector.js
+++ b/app/javascript/components/visualization/controls/SubsampleSelector.js
@@ -16,7 +16,8 @@ function getSubsampleOptions(annotationList, clusterName) {
       clusterSubsamples = []
     }
     subsampleOptions = subsampleOptions.concat(clusterSubsamples.map(num => {
-      return { label: `${num}`, value: num }
+      // convert everything to strings to make the comparisons easier
+      return { label: `${num}`, value: `${num}` }
     }))
   }
   subsampleOptions.push({ label: 'All Cells', value: 'all' })
@@ -52,8 +53,8 @@ export default function SubsampleSelector({
       </label>
       <Select options={subsampleOptions}
         value={{
-          label: subsample == 'all' ? 'All Cells' : subsample,
-          value: subsample
+          label: subsample == 'all' ? 'All Cells' : `${subsample}`,
+          value: `${subsample}`
         }}
         onChange={newSubsample => updateClusterParams({
           subsample: newSubsample.value


### PR DESCRIPTION
SCP-3186  Jean reported a lot of flakiness in the 'distribution' dropdowns.  I couldn't reproduce it locally, so I'm imagining some must have been fixed by the subsample dropdown fix, and others may be caused by the fact that she was rendering studies with 10000 points, and so the lag between plotly redraws of the violin plot can be enormous, and there was no visual indication of when it was done.  I've attempted to address this by adding a loading spinner for when a user changes a distribution setting.

To test:
1.  Load a single-gene search of a study with react_explore on
2. In the distribution menu, change 'Data Points' from 'None' to 'all'.
3. Confirm a spinner appears while the graph is updating
