### PR TITLE
Restore plain JS imports to fix "Create Annotations" (SCP-3190)

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -41,7 +41,6 @@ import exploreSingle from 'lib/study-overview/explore-single'
 import { renderClusterAssociationSelect } from 'components/upload/ClusterAssociationSelect'
 import { renderExploreView } from 'components/explore/ExploreView'
 
-
 document.addEventListener('DOMContentLoaded', () => {
   // Logs only page views for faceted search UI
   logPageView()
@@ -84,6 +83,12 @@ window.SCP.exploreSingle = exploreSingle
 window.SCP.renderClusterAssociationSelect = renderClusterAssociationSelect
 window.SCP.renderExploreView = renderExploreView
 window.Plotly = Plotly
+
+// Remove the block below only after launching React Explore refactor
+import { getScatterPlots } from 'lib/scatter-plot'
+import userAnnotations from 'lib/study-overview/user-annotations'
+window.SCP.getScatterPlots = getScatterPlots
+window.SCP.userAnnotations = userAnnotations
 
 /*
  * For down the road, when we use ES6 imports in SCP JS app code


### PR DESCRIPTION
This restores plain JS imports to fix "Create Annotations", satisfying SCP-3190.

To test:
* Go to a study with initializations visualized
* Sign in
* Follow steps in release engineer manual tests starting at "[Create annotation](https://docs.google.com/document/d/1rKcOQPtkbhZCbTqxTnaT-4E29VLzkJrm0kAoWjLx3QA/edit#heading=h.pxw61pnmyz5e)"