### PR TITLE
Add informational tooltip for "Scaled mean expression" in dot plot (SCP-3193)

### DIFF
--- a/app/assets/javascripts/scp-dot-plot.js
+++ b/app/assets/javascripts/scp-dot-plot.js
@@ -59,10 +59,7 @@ function getLegendSvg(rects) {
       <g id="dp-legend-color" transform="translate(200, 0)">
         ${rects}
         <text x="-40" y="50">Scaled mean expression</text>
-        <circle cx="125" cy="45" r="8" fill="#aeaeae"></circle>
-        <a id="dot-plot-scaling-link" xlink:href="https://github.com/broadinstitute/single_cell_portal/wiki/dot-plots-detail#scaled-mean-expression" style="text-decoration: none" target="_blank">
-          <text x="125" y="50" text-anchor="middle" fill="white" font-size="" font-family="Arial" dy="">?</text>
-        </a>
+        ${nonzeroNote}
       </g>
     <svg>`
   )

--- a/app/assets/javascripts/scp-dot-plot.js
+++ b/app/assets/javascripts/scp-dot-plot.js
@@ -59,7 +59,10 @@ function getLegendSvg(rects) {
       <g id="dp-legend-color" transform="translate(200, 0)">
         ${rects}
         <text x="-40" y="50">Scaled mean expression</text>
-        ${nonzeroNote}
+        <circle cx="125" cy="45" r="8" fill="#aeaeae"></circle>
+        <a id="dot-plot-scaling-link" xlink:href="https://github.com/broadinstitute/single_cell_portal/wiki/dot-plots-detail#scaled-mean-expression" style="text-decoration: none" target="_blank">
+          <text x="125" y="50" text-anchor="middle" fill="white" font-size="" font-family="Arial" dy="">?</text>
+        </a>
       </g>
     <svg>`
   )

--- a/app/javascript/components/visualization/DotPlotLegend.js
+++ b/app/javascript/components/visualization/DotPlotLegend.js
@@ -5,7 +5,7 @@ import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import _uniqueId from 'lodash/uniqueId'
 
-const consensusPopover = (
+const scaledPopover = (
   <Popover id="scaled-mean-expression-helptext">
     Scaling is relative to the each gene's expression for all cells in each
     annotation selection, i.e. cells associated with each column label in
@@ -62,7 +62,7 @@ export default function DotPlotLegend() {
         <text x={colorBarWidth - 5} y={numberYPos}>1</text>
         <rect fill="#CC0088" width="3" height="10" x={colorBarWidth / 2} y={numberYPos - 20} ry="2"/>
         <text x="-22" y={labelTextYPos}>Scaled mean expression</text>
-        <OverlayTrigger trigger="click" rootClose placement="top" overlay={consensusPopover}>
+        <OverlayTrigger trigger="click" rootClose placement="top" overlay={scaledPopover}>
           <FontAwesomeIcon className="action" icon={faInfoCircle} transform="shrink-12 left-16 down-3" />
         </OverlayTrigger>
       </g>

--- a/app/javascript/components/visualization/DotPlotLegend.js
+++ b/app/javascript/components/visualization/DotPlotLegend.js
@@ -1,6 +1,18 @@
 import React from 'react'
 import { dotPlotColorScheme } from './DotPlot'
+import { Popover, OverlayTrigger } from 'react-bootstrap'
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import _uniqueId from 'lodash/uniqueId'
+
+const consensusPopover = (
+  <Popover id="explore-subsampling-helptext">
+    Scaling is relative to the each gene's expression for all cells in each
+    annotation selection, i.e. cells associated with the each column label in
+    the dot plot.
+  </Popover>
+)
+
 
 /** renders an svg legend for a dotplot with color and size indicators */
 export default function DotPlotLegend() {
@@ -49,12 +61,10 @@ export default function DotPlotLegend() {
         <text x={colorBarWidth / 2 - 7} y={numberYPos}>0.5</text>
         <text x={colorBarWidth - 5} y={numberYPos}>1</text>
         <rect fill="#CC0088" width="3" height="10" x={colorBarWidth / 2} y={numberYPos - 20} ry="2"/>
-        <text x="-22" y={labelTextYPos}>Scaled mean expression</text>
-        <circle cx="130" cy="47" r="8" fill="#aeaeae"></circle>
-        <a id="dot-plot-scaling-link" xlinkHref="https://github.com/broadinstitute/single_cell_portal/wiki/dot-plots-detail#scaled-mean-expression" style={{ textDecoration: 'none' }} target="_blank">
-          <text x="130" y="52" textAnchor="middle" fill="white" fontSize="" fontFamily="Arial" dy="">?</text>
-        </a>
-        {nonzeroNote}
+        <text id="scaled-mean-expression-legend" x="-22" y={labelTextYPos}>Scaled mean expression</text>
+        <OverlayTrigger trigger="click" rootClose placement="top" overlay={consensusPopover}>
+          <FontAwesomeIcon className="action" icon={faInfoCircle} transform="shrink-12 left-16 down-2" />
+        </OverlayTrigger>
       </g>
     </svg>
   )

--- a/app/javascript/components/visualization/DotPlotLegend.js
+++ b/app/javascript/components/visualization/DotPlotLegend.js
@@ -62,7 +62,7 @@ export default function DotPlotLegend() {
         <text x={colorBarWidth - 5} y={numberYPos}>1</text>
         <rect fill="#CC0088" width="3" height="10" x={colorBarWidth / 2} y={numberYPos - 20} ry="2"/>
         <text x="-22" y={labelTextYPos}>Scaled mean expression</text>
-        <OverlayTrigger trigger="click" rootClose placement="top" overlay={scaledPopover}>
+        <OverlayTrigger trigger="click" rootClose placement="right" overlay={scaledPopover}>
           <FontAwesomeIcon id="scaled-mean-expression-help-icon" className="action logged-svg" icon={faInfoCircle} transform="shrink-12 left-16 down-3" />
         </OverlayTrigger>
       </g>

--- a/app/javascript/components/visualization/DotPlotLegend.js
+++ b/app/javascript/components/visualization/DotPlotLegend.js
@@ -63,7 +63,11 @@ export default function DotPlotLegend() {
         <rect fill="#CC0088" width="3" height="10" x={colorBarWidth / 2} y={numberYPos - 20} ry="2"/>
         <text x="-22" y={labelTextYPos}>Scaled mean expression</text>
         <OverlayTrigger trigger="click" rootClose placement="right" overlay={scaledPopover}>
-          <FontAwesomeIcon id="scaled-mean-expression-help-icon" className="action logged-svg" icon={faInfoCircle} transform="shrink-12 left-16 down-3" />
+          <FontAwesomeIcon
+            data-analytics-name="scaled-mean-expression-help-icon"
+            className="action logged-svg help-icon"
+            icon={faInfoCircle}
+            transform="shrink-12 left-16 down-3" />
         </OverlayTrigger>
       </g>
     </svg>

--- a/app/javascript/components/visualization/DotPlotLegend.js
+++ b/app/javascript/components/visualization/DotPlotLegend.js
@@ -8,7 +8,7 @@ import _uniqueId from 'lodash/uniqueId'
 const consensusPopover = (
   <Popover id="explore-subsampling-helptext">
     Scaling is relative to the each gene's expression for all cells in each
-    annotation selection, i.e. cells associated with the each column label in
+    annotation selection, i.e. cells associated with each column label in
     the dot plot.
   </Popover>
 )
@@ -63,7 +63,7 @@ export default function DotPlotLegend() {
         <rect fill="#CC0088" width="3" height="10" x={colorBarWidth / 2} y={numberYPos - 20} ry="2"/>
         <text id="scaled-mean-expression-legend" x="-22" y={labelTextYPos}>Scaled mean expression</text>
         <OverlayTrigger trigger="click" rootClose placement="top" overlay={consensusPopover}>
-          <FontAwesomeIcon className="action" icon={faInfoCircle} transform="shrink-12 left-16 down-2" />
+          <FontAwesomeIcon className="action" icon={faInfoCircle} transform="shrink-12 left-16 down-3" />
         </OverlayTrigger>
       </g>
     </svg>

--- a/app/javascript/components/visualization/DotPlotLegend.js
+++ b/app/javascript/components/visualization/DotPlotLegend.js
@@ -65,7 +65,7 @@ export default function DotPlotLegend() {
         <OverlayTrigger trigger="click" rootClose placement="right" overlay={scaledPopover}>
           <FontAwesomeIcon
             data-analytics-name="scaled-mean-expression-help-icon"
-            className="action logged-svg help-icon"
+            className="action log-click help-icon"
             icon={faInfoCircle}
             transform="shrink-12 left-16 down-3" />
         </OverlayTrigger>

--- a/app/javascript/components/visualization/DotPlotLegend.js
+++ b/app/javascript/components/visualization/DotPlotLegend.js
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import _uniqueId from 'lodash/uniqueId'
 
 const consensusPopover = (
-  <Popover id="explore-subsampling-helptext">
+  <Popover id="scaled-mean-expression-helptext">
     Scaling is relative to the each gene's expression for all cells in each
     annotation selection, i.e. cells associated with each column label in
     the dot plot.
@@ -61,7 +61,7 @@ export default function DotPlotLegend() {
         <text x={colorBarWidth / 2 - 7} y={numberYPos}>0.5</text>
         <text x={colorBarWidth - 5} y={numberYPos}>1</text>
         <rect fill="#CC0088" width="3" height="10" x={colorBarWidth / 2} y={numberYPos - 20} ry="2"/>
-        <text id="scaled-mean-expression-legend" x="-22" y={labelTextYPos}>Scaled mean expression</text>
+        <text x="-22" y={labelTextYPos}>Scaled mean expression</text>
         <OverlayTrigger trigger="click" rootClose placement="top" overlay={consensusPopover}>
           <FontAwesomeIcon className="action" icon={faInfoCircle} transform="shrink-12 left-16 down-3" />
         </OverlayTrigger>

--- a/app/javascript/components/visualization/DotPlotLegend.js
+++ b/app/javascript/components/visualization/DotPlotLegend.js
@@ -50,6 +50,10 @@ export default function DotPlotLegend() {
         <text x={colorBarWidth - 5} y={numberYPos}>1</text>
         <rect fill="#CC0088" width="3" height="10" x={colorBarWidth / 2} y={numberYPos - 20} ry="2"/>
         <text x="-22" y={labelTextYPos}>Scaled mean expression</text>
+        <circle cx="130" cy="47" r="8" fill="#aeaeae"></circle>
+        <a id="dot-plot-scaling-link" xlinkHref="https://github.com/broadinstitute/single_cell_portal/wiki/dot-plots-detail#scaled-mean-expression" style={{ textDecoration: 'none' }} target="_blank">
+          <text x="130" y="52" textAnchor="middle" fill="white" fontSize="" fontFamily="Arial" dy="">?</text>
+        </a>
         {nonzeroNote}
       </g>
     </svg>

--- a/app/javascript/components/visualization/DotPlotLegend.js
+++ b/app/javascript/components/visualization/DotPlotLegend.js
@@ -63,7 +63,7 @@ export default function DotPlotLegend() {
         <rect fill="#CC0088" width="3" height="10" x={colorBarWidth / 2} y={numberYPos - 20} ry="2"/>
         <text x="-22" y={labelTextYPos}>Scaled mean expression</text>
         <OverlayTrigger trigger="click" rootClose placement="top" overlay={scaledPopover}>
-          <FontAwesomeIcon className="action" icon={faInfoCircle} transform="shrink-12 left-16 down-3" />
+          <FontAwesomeIcon id="scaled-mean-expression-help-icon" className="action logged-svg" icon={faInfoCircle} transform="shrink-12 left-16 down-3" />
         </OverlayTrigger>
       </g>
     </svg>

--- a/app/javascript/components/visualization/controls/ConsensusSelector.js
+++ b/app/javascript/components/visualization/controls/ConsensusSelector.js
@@ -63,7 +63,7 @@ export function ExploreConsensusSelector({
     <div className="form-group">
       <label>
         <OverlayTrigger trigger="click" rootClose placement="top" overlay={exploreConsensusPopover}>
-          <span>Collapse genes by <FontAwesomeIcon data-analytics-name="consensus-help-icon" className="action logged-svg help-icon" icon={faInfoCircle}/></span>
+          <span>Collapse genes by <FontAwesomeIcon data-analytics-name="consensus-help-icon" className="action log-click help-icon" icon={faInfoCircle}/></span>
         </OverlayTrigger>
       </label>
       <Select options={exploreConsensusOptions}

--- a/app/javascript/components/visualization/controls/ConsensusSelector.js
+++ b/app/javascript/components/visualization/controls/ConsensusSelector.js
@@ -63,7 +63,7 @@ export function ExploreConsensusSelector({
     <div className="form-group">
       <label>
         <OverlayTrigger trigger="click" rootClose placement="top" overlay={exploreConsensusPopover}>
-          <span>Collapse genes by <FontAwesomeIcon className="action" icon={faInfoCircle}/></span>
+          <span>Collapse genes by <FontAwesomeIcon id="consensus-help-icon" className="action logged-svg" icon={faInfoCircle}/></span>
         </OverlayTrigger>
       </label>
       <Select options={exploreConsensusOptions}

--- a/app/javascript/components/visualization/controls/ConsensusSelector.js
+++ b/app/javascript/components/visualization/controls/ConsensusSelector.js
@@ -63,7 +63,7 @@ export function ExploreConsensusSelector({
     <div className="form-group">
       <label>
         <OverlayTrigger trigger="click" rootClose placement="top" overlay={exploreConsensusPopover}>
-          <span>Collapse genes by <FontAwesomeIcon id="consensus-help-icon" className="action logged-svg" icon={faInfoCircle}/></span>
+          <span>Collapse genes by <FontAwesomeIcon data-analytics-name="consensus-help-icon" className="action logged-svg help-icon" icon={faInfoCircle}/></span>
         </OverlayTrigger>
       </label>
       <Select options={exploreConsensusOptions}

--- a/app/javascript/components/visualization/controls/SubsampleSelector.js
+++ b/app/javascript/components/visualization/controls/SubsampleSelector.js
@@ -48,7 +48,7 @@ export default function SubsampleSelector({
     <div className="form-group">
       <label>
         <OverlayTrigger trigger="click" rootClose placement="top" overlay={subsamplingPopover}>
-          <span>Subsampling <FontAwesomeIcon id="subsampling-help-icon" className="action logged-svg" icon={faInfoCircle}/></span>
+          <span>Subsampling <FontAwesomeIcon data-analytics-name="subsampling-help-icon" className="action logged-svg help-icon" icon={faInfoCircle}/></span>
         </OverlayTrigger>
       </label>
       <Select options={subsampleOptions}

--- a/app/javascript/components/visualization/controls/SubsampleSelector.js
+++ b/app/javascript/components/visualization/controls/SubsampleSelector.js
@@ -47,8 +47,8 @@ export default function SubsampleSelector({
   return (
     <div className="form-group">
       <label>
-        <OverlayTrigger trigger="click" rootClose placement="top" overlay={consensusPopover}>
-          <span>Subsampling <FontAwesomeIcon className="action" icon={faInfoCircle}/></span>
+        <OverlayTrigger trigger="click" rootClose placement="top" overlay={subsamplingPopover}>
+          <span>Subsampling <FontAwesomeIcon id="subsampling-help-icon" className="action logged-svg" icon={faInfoCircle}/></span>
         </OverlayTrigger>
       </label>
       <Select options={subsampleOptions}
@@ -64,7 +64,7 @@ export default function SubsampleSelector({
   )
 }
 
-const consensusPopover = (
+const subsamplingPopover = (
   <Popover id="explore-subsampling-helptext">
     Show a representative subsample of the current clusters
     (<a href='https://github.com/broadinstitute/single_cell_portal/wiki/Subsampling-Cluster-Files'

--- a/app/javascript/components/visualization/controls/SubsampleSelector.js
+++ b/app/javascript/components/visualization/controls/SubsampleSelector.js
@@ -48,7 +48,7 @@ export default function SubsampleSelector({
     <div className="form-group">
       <label>
         <OverlayTrigger trigger="click" rootClose placement="top" overlay={subsamplingPopover}>
-          <span>Subsampling <FontAwesomeIcon data-analytics-name="subsampling-help-icon" className="action logged-svg help-icon" icon={faInfoCircle}/></span>
+          <span>Subsampling <FontAwesomeIcon data-analytics-name="subsampling-help-icon" className="action log-click help-icon" icon={faInfoCircle}/></span>
         </OverlayTrigger>
       </label>
       <Select options={subsampleOptions}

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -81,8 +81,9 @@ export function logClick(event) {
     logClickButton(target.closest('button')[0])
   } else if (target.closest('input').length) {
     logClickInput(target.closest('input')[0])
-  } else {
+  } else if (target.closest('.logged-svg').length > 0) {
     logClickSvg(target.closest('.logged-svg')[0])
+  } else {
     // Perhaps uncomment when Mixpanel quota increases
     // logClickOther(target)
   }
@@ -91,8 +92,8 @@ export function logClick(event) {
 /** Log clicks on SVG element of analytics interest */
 export function logClickSvg(target) {
   const props = {
-    classList: getClassListAsArray(target),
-    id: target.id
+    'classList': getClassListAsArray(target),
+    'analytics-name': getNameForClickTarget(target)
   }
   log('click:svg', props)
 }

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -81,21 +81,18 @@ export function logClick(event) {
     logClickButton(target.closest('button')[0])
   } else if (target.closest('input').length) {
     logClickInput(target.closest('input')[0])
-  } else if (target.closest('.logged-svg').length > 0) {
-    logClickSvg(target.closest('.logged-svg')[0])
-  } else {
-    // Perhaps uncomment when Mixpanel quota increases
-    // logClickOther(target)
+  } else if (target.closest('.log-click').length > 0) {
+    logClickOther(target.closest('.log-click')[0])
   }
 }
 
 /** Log clicks on SVG element of analytics interest */
-export function logClickSvg(target) {
+export function logClickOther(target) {
   const props = {
-    'classList': getClassListAsArray(target),
-    'analytics-name': getNameForClickTarget(target)
+    classList: getClassListAsArray(target),
+    text: getNameForClickTarget(target)
   }
-  log('click:svg', props)
+  log('click:other', props)
 }
 
 /**
@@ -195,17 +192,6 @@ function logClickInput(target) {
 
   // Google Analytics fallback: remove once Bard and Mixpanel are ready for SCP
   ga('send', 'event', 'click', element) // eslint-disable-line no-undef
-}
-
-/**
- * Log clicks on elements that are not otherwise classified
- */
-function logClickOther(target) { // eslint-disable-line no-unused-vars
-  const props = { text: target.text }
-  log('click:other', props)
-
-  // Google Analytics fallback: remove once Bard and Mixpanel are ready for SCP
-  ga('send', 'event', 'click', 'other') // eslint-disable-line no-undef
 }
 
 /** Log text of selected option when dropdown menu (i.e., select) changes */

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -82,9 +82,19 @@ export function logClick(event) {
   } else if (target.closest('input').length) {
     logClickInput(target.closest('input')[0])
   } else {
+    logClickSvg(target.closest('.logged-svg')[0])
     // Perhaps uncomment when Mixpanel quota increases
     // logClickOther(target)
   }
+}
+
+/** Log clicks on SVG element of analytics interest */
+export function logClickSvg(target) {
+  const props = {
+    classList: getClassListAsArray(target),
+    id: target.id
+  }
+  log('click:svg', props)
 }
 
 /**
@@ -100,13 +110,18 @@ function getNameForClickTarget(target) {
   return targetName
 }
 
+/** Convert DOM classList to array, for easy exploration in Mixpanel */
+function getClassListAsArray(target) {
+  return 'classList' in target? Array.from(target.classList) : []
+}
+
 /**
  * Log click on link, i.e. anchor (<a ...) tag
  */
 export function logClickLink(target) {
   const props = {
     text: getNameForClickTarget(target),
-    classList: 'classList' in target? Array.from(target.classList) : [],
+    classList: getClassListAsArray(target),
     id: target.id
   }
   // Check if target is a tab that's not a part of a menu


### PR DESCRIPTION
This adds a small tooltip beside the "Scaled mean expression" legend entry in dot plots.  At least two users have been confused by the label.  This tooltip adds the explanation we've given them, now placed in a context where it will more easily help other users.

Clicks on such help icons are also now logged to Mixpanel, so we can assess their usage.

Default icon:
<img width="1680" alt="Dot_plot_information_icon_SCP_2021-03-24" src="https://user-images.githubusercontent.com/1334561/112353266-f8662880-8ca1-11eb-822d-9f890bdd537b.png">

Active icon:
<img width="702" alt="Dot_plot_information_icon_active_SCP_2021-03-24" src="https://user-images.githubusercontent.com/1334561/112375856-26576700-8cba-11eb-9ec9-fb4a358c0b58.png">

This satisfies SCP-3193.