### PR TITLE
Fix gene search style (SCP-3199, SCP-3200)

### DIFF
--- a/app/javascript/components/explore/ExploreTabRouter.js
+++ b/app/javascript/components/explore/ExploreTabRouter.js
@@ -15,9 +15,6 @@ export const emptyDataParams = {
 }
 
 const SPATIAL_GROUPS_EMPTY = '--'
-// because we only allow a single ExploreTabRouter component we can track global state here, instead
-// of useRef, which would trigger a rerender
-let isInitialLoad = true
 
 /**
  * manages view options and basic layout for the explore tab
@@ -26,12 +23,6 @@ let isInitialLoad = true
 export default function useExploreTabRouter() {
   const routerLocation = useLocation()
   const exploreParams = buildExploreParamsFromQuery(routerLocation.search)
-
-  if (isInitialLoad && exploreParams.genes.length > 0) {
-    // note that we can't pass the species list because we don't know it yet.
-    logStudyGeneSearch(exploreParams.genes, 'url')
-  }
-  isInitialLoad = false
 
   /** Merges the received update into the exploreParams, and updates the page URL if need */
   function updateExploreParams(newOptions, wasUserSpecified=true) {
@@ -56,12 +47,13 @@ export default function useExploreTabRouter() {
   }
 
   useEffect(() => {
-    // this cleanup isn't strictly necessary now, but if we ever start linking to gene searches
-    // within SCP, or not reloading the page when going from search results to explore, it will be needed
-    return function cleanup() {
-      isInitialLoad = true
+    // if this is the first render, and there are already genes specified, that means they came
+    // from the url directly
+    if (exploreParams.genes.length > 0) {
+      // note that we can't pass the species list because we don't know it yet.
+      logStudyGeneSearch(exploreParams.genes, 'url')
     }
-  })
+  }, [])
   return { exploreParams, updateExploreParams, routerLocation }
 }
 

--- a/app/javascript/components/explore/StudyGeneField.js
+++ b/app/javascript/components/explore/StudyGeneField.js
@@ -21,11 +21,8 @@ export default function StudyGeneField({ genes, searchGenes, allGenes }) {
     // Autocomplete when user starts typing
     if (inputText && inputText.length > 0) {
       const lowerCaseInput = inputText.toLowerCase()
-      geneOptions = allGenes.filter(geneName => {
+      geneOptions = getOptionsFromGenes(allGenes.filter(geneName => {
         return geneName.toLowerCase().includes(lowerCaseInput)
-      }).map(geneName => ({
-        label: geneName,
-        value: geneName
       }))
     }
   }
@@ -167,6 +164,11 @@ export default function StudyGeneField({ genes, searchGenes, allGenes }) {
                 ...provided,
                 maxHeight: '32px',
                 overflow: 'auto'
+              }),
+              menuList: (provided, state) => ({
+                ...provided,
+                zIndex: 999,
+                background: '#fff'
               })
             }}
           />

--- a/app/javascript/components/visualization/RelatedGenesIdeogram.js
+++ b/app/javascript/components/visualization/RelatedGenesIdeogram.js
@@ -23,14 +23,14 @@ function onClickAnnot(annot) {
 
   // Enable merge of related-genes log props into search log props
   // This helps profile the numerator of click-through-rate
-  const event = {}
+  const otherProps = {}
   const props = getRelatedGenesAnalytics(ideogram)
   Object.entries(props).forEach(([key, value]) => {
-    event[`relatedGenes:${key}`] = value
+    otherProps[`relatedGenes:${key}`] = value
   })
 
-  event['type'] = 'click-related-genes'
-  logStudyGeneSearch('click-related-genes', null, null, props)
+  otherProps['trigger'] = 'click-related-genes'
+  logStudyGeneSearch([annot.name], null, null, otherProps)
   ideogram.SCP.searchGenes([annot.name])
 }
 

--- a/app/javascript/styles/_keywordSearch.scss
+++ b/app/javascript/styles/_keywordSearch.scss
@@ -12,7 +12,7 @@
   width: 340px;
   white-space: nowrap;
 
-  input.form-control, .gene-keyword-search-input > div {
+  input.form-control, .gene-keyword-search-input > div:first-of-type {
     background-color: white;
     border: 1px solid $action-color;
     border-radius: 15px 0px 0px 15px;


### PR DESCRIPTION
SCP-3199, SCP-3200 This fixes stylistic issues with the gene list dropdown on the explore tab, and also fixes the double-logged gene searches

![image](https://user-images.githubusercontent.com/2800795/112512699-fc5d7d80-8d69-11eb-8b28-6752e0666db6.png)

To test
 0. Go to study explore tab with react_explore feature flag on
 1. start typing a gene
 2. observe the gene list appears with a white (as opposed to transparent) background
 3. clear your network tab in chrome debugger
 4. Perform a gene search
 5. Observe that only a single 'search' event gets sent to bard 