### PR TITLE
fixing subsampling dropdown bug for clusters with multiple thresholds (SCP-3182)

### DIFF
--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -22,11 +22,11 @@ export function getDefaultSubsampleForCluster(annotationList, clusterName) {
   const subsampleOptions = annotationList.subsample_thresholds[clusterName]
   if (subsampleOptions?.length) {
     // find the max subsample less than or equal to 10000
-    const defaultSubsample = Math.max(...subsampleOptions.filter(opt => opt <= 1000))
+    const defaultSubsample = Math.max(...subsampleOptions.filter(opt => opt <= 10000))
     // if it's 10000, that means the study has more than 10000 cells, and so the
     // default is to show 10000.  otherwise we'll show all cells by default
-    if (defaultSubsample === 1000) {
-      return 1000
+    if (defaultSubsample === 10000) {
+      return 10000
     }
   }
   return 'all'

--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -21,9 +21,12 @@ export const emptyDataParams = {
 export function getDefaultSubsampleForCluster(annotationList, clusterName) {
   const subsampleOptions = annotationList.subsample_thresholds[clusterName]
   if (subsampleOptions?.length) {
-    const defaultSubsample = Math.max(subsampleOptions.filter(opt => opt <= 10000))
-    if (defaultSubsample === 10000) {
-      return 10000
+    // find the max subsample less than or equal to 10000
+    const defaultSubsample = Math.max(...subsampleOptions.filter(opt => opt <= 1000))
+    // if it's 10000, that means the study has more than 10000 cells, and so the
+    // default is to show 10000.  otherwise we'll show all cells by default
+    if (defaultSubsample === 1000) {
+      return 1000
     }
   }
   return 'all'


### PR DESCRIPTION
argh, I confused Math.max 's behavior with Ruby's, and so this was broken for studies with more than one subsample threshold below the default (of which I didn't have any locally)

To test:

0. Open a study with more than 10,000 cells in react_explore tab, that's subsampled at 10000 and at least one subsample < 10000
1. Observe that the subsample dropdown indicates 10,000, which should also match the subsample indicated by the plot label.

Fun fact:  Did you know that `Math.max([200])` is 200, `Math.max([100], [200])` is 200, but `Math.max([100, 200])` is NaN ?