### PR TITLE
Refine Mixpanel click logging for radio inputs (SCP-3081)

### DIFF
--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -163,17 +163,24 @@ function getLabelsForElement(element) {
  * Log click on input by type, e.g. text, number, checkbox
  */
 function logClickInput(target) {
-  const domLabels = getLabelsForElement(target)
+  let props
+  if (target.type === 'radio') {
+    const id = 'id' in target ? target.id : ''
+    const inputName = target.name
+    const value = target.value
+    props = { id, 'input-name': inputName, value }
+  } else {
+    const domLabels = getLabelsForElement(target)
 
-  // User-facing label
-  const label = domLabels.length > 0 ? getNameForClickTarget(domLabels[0]) : ''
+    // User-facing label
+    const label = domLabels.length > 0 ? getNameForClickTarget(domLabels[0]) : ''
 
-  const props = { label }
+    props = { label }
 
-  if (target.type === 'submit') {
-    props.text = target.value
+    if (target.type === 'submit') {
+      props.text = target.value
+    }
   }
-
   const element = `input-${target.type}`
   log(`click:${element}`, props)
 

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -165,7 +165,7 @@ function getLabelsForElement(element) {
 function logClickInput(target) {
   let props
   if (target.type === 'radio') {
-    const id = 'id' in target ? target.id : ''
+    const id = target.id
     const inputName = target.name
     const value = target.value
     props = { id, 'input-name': inputName, value }


### PR DESCRIPTION
This provides useful Mixpanel logging for clicks on radio-type inputs, as seen in e.g. expression matrix upload UI.

Previously, such clicks were logged but had essentially worthless analytics: `label` was empty and no specific information was provided beyond "there was a radio button click on this page".  Now, we record the `id`, `input-name`, and `value` of the selected radio button option.  

That allows us to analyze things like "What do users do after clicking 'Yes' for 'Is this a raw counts matrix'?"

Due to the complicated nature of radio inputs and how we use them, the raw HTML attribute values are logged rather than their human-friendly labels.  So radio button analysis will need a bit of effort, but is now at least possible -- and the instrumentation is easy to maintain.

To test:
* Go to the Upload Wizard for a study.
* Open Network panel in DevTools, filter to "bard method:POST".
* In the "Expression" tab, click a radio button.
* Verify that an event is sent to Bard with non-empty values for `id`, `input-name`, and `value`.

This is needed for SCP-3081.