### PR TITLE
Fix occasional infinite loop in related genes ideogram (SCP-3203)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -56,9 +56,9 @@ export default function ExploreDisplayTabs(
   referencePlotDataParams.genes = []
 
   /** helper function so that StudyGeneField doesn't have to see the full exploreParams object */
-  function searchGenes(genes, logProps, wasUserSpecified=true) {
+  function searchGenes(genes) {
     // also unset any selected gene lists or ideogram files
-    updateExploreParams({ genes, geneList: '', ideogramFileId: '' }, wasUserSpecified)
+    updateExploreParams({ genes, geneList: '', ideogramFileId: '' })
   }
 
   // Handle spatial transcriptomics data

--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -56,9 +56,9 @@ export default function ExploreDisplayTabs(
   referencePlotDataParams.genes = []
 
   /** helper function so that StudyGeneField doesn't have to see the full exploreParams object */
-  function searchGenes(genes, logProps) {
+  function searchGenes(genes, logProps, wasUserSpecified=true) {
     // also unset any selected gene lists or ideogram files
-    updateExploreParams({ genes, geneList: '', ideogramFileId: '' })
+    updateExploreParams({ genes, geneList: '', ideogramFileId: '' }, wasUserSpecified)
   }
 
   // Handle spatial transcriptomics data
@@ -168,7 +168,6 @@ export default function ExploreDisplayTabs(
   useResizeEffect(() => {
     setRenderForcer({})
   }, 300)
-  console.log('rerendering ExploreDisplayTabs')
 
   return (
     <>

--- a/app/javascript/components/explore/ExploreTabRouter.js
+++ b/app/javascript/components/explore/ExploreTabRouter.js
@@ -32,8 +32,11 @@ export default function useExploreTabRouter() {
       Object.keys(newOptions).forEach(key => {
         mergedOpts.userSpecified[key] = true
       })
-      if (newOptions.consensus || newOptions.genes) {
-        // if the user does a gene search or changes the consensus, switch back to the default tab
+      // if the user does a gene search from the cluster view,
+      // or if they've switched to/from consensus view
+      // reset the tab to the default
+      if (mergedOpts.tab === 'cluster' && newOptions.genes ||
+          !!newOptions.consensus != !!exploreParams.consensus) {
         delete mergedOpts.tab
         delete mergedOpts.userSpecified.tab
       }

--- a/app/javascript/components/visualization/RelatedGenesIdeogram.js
+++ b/app/javascript/components/visualization/RelatedGenesIdeogram.js
@@ -31,7 +31,7 @@ function onClickAnnot(annot) {
 
   otherProps['trigger'] = 'click-related-genes'
   logStudyGeneSearch([annot.name], null, null, otherProps)
-  ideogram.SCP.searchGenes([annot.name])
+  ideogram.SCP.searchGenes([annot.name], null, false)
 }
 
 /**

--- a/app/javascript/components/visualization/RelatedGenesIdeogram.js
+++ b/app/javascript/components/visualization/RelatedGenesIdeogram.js
@@ -31,7 +31,7 @@ function onClickAnnot(annot) {
 
   otherProps['trigger'] = 'click-related-genes'
   logStudyGeneSearch([annot.name], null, null, otherProps)
-  ideogram.SCP.searchGenes([annot.name], null, false)
+  ideogram.SCP.searchGenes([annot.name])
 }
 
 /**


### PR DESCRIPTION
This fixes a bug seen in local development, seemingly caused by a race condition, in which searching via related genes ideogram causes that feature to infinitely loop.  The loop searches the clicked gene, then the previous gene, and repeats _ad infinitum_.

To test:
1. Go to a study in your local SCP with several real genes in SCP React Explore UI
2. Search a gene via the search box
3. Click a different gene in related genes ideogram
4. Wait a few seconds after step 3 completes, and verify that gene from step 2 is not searched again

This satisfies SCP-3203.