### PR TITLE
fix infinite gene search (SCP-3203)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -56,9 +56,9 @@ export default function ExploreDisplayTabs(
   referencePlotDataParams.genes = []
 
   /** helper function so that StudyGeneField doesn't have to see the full exploreParams object */
-  function searchGenes(genes, logProps, wasUserSpecified=true) {
+  function searchGenes(genes) {
     // also unset any selected gene lists or ideogram files
-    updateExploreParams({ genes, geneList: '', ideogramFileId: '' }, wasUserSpecified)
+    updateExploreParams({ genes, geneList: '', ideogramFileId: '' })
   }
 
   // Handle spatial transcriptomics data

--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -56,9 +56,9 @@ export default function ExploreDisplayTabs(
   referencePlotDataParams.genes = []
 
   /** helper function so that StudyGeneField doesn't have to see the full exploreParams object */
-  function searchGenes(genes, logProps) {
+  function searchGenes(genes, logProps, wasUserSpecified=true) {
     // also unset any selected gene lists or ideogram files
-    updateExploreParams({ genes, geneList: '', ideogramFileId: '' })
+    updateExploreParams({ genes, geneList: '', ideogramFileId: '' }, wasUserSpecified)
   }
 
   // Handle spatial transcriptomics data
@@ -168,7 +168,6 @@ export default function ExploreDisplayTabs(
   useResizeEffect(() => {
     setRenderForcer({})
   }, 300)
-  console.log('rerendering ExploreDisplayTabs')
 
   return (
     <>

--- a/app/javascript/components/explore/ExploreTabRouter.js
+++ b/app/javascript/components/explore/ExploreTabRouter.js
@@ -32,8 +32,11 @@ export default function useExploreTabRouter() {
       Object.keys(newOptions).forEach(key => {
         mergedOpts.userSpecified[key] = true
       })
-      if (newOptions.consensus || newOptions.genes) {
-        // if the user does a gene search or changes the consensus, switch back to the default tab
+      // if the user does a gene search from the cluster view,
+      // or if they've switched to/from consensus view
+      // reset the tab to the default
+      if (mergedOpts.tab === 'cluster' && newOptions.genes ||
+          !!newOptions.consensus != !!exploreParams.consensus) {
         delete mergedOpts.tab
         delete mergedOpts.userSpecified.tab
       }

--- a/app/javascript/components/explore/ExploreTabRouter.js
+++ b/app/javascript/components/explore/ExploreTabRouter.js
@@ -7,12 +7,6 @@ import { getIdentifierForAnnotation } from 'lib/cluster-utils'
 import { DEFAULT_ROW_CENTERING } from 'components/visualization/Heatmap'
 import { logStudyGeneSearch } from 'lib/metrics-api'
 
-export const emptyDataParams = {
-  cluster: '',
-  annotation: '',
-  subsample: '',
-  consensus: null
-}
 
 const SPATIAL_GROUPS_EMPTY = '--'
 
@@ -24,34 +18,6 @@ export default function useExploreTabRouter() {
   const routerLocation = useLocation()
   const exploreParams = buildExploreParamsFromQuery(routerLocation.search)
 
-  /** Merges the received update into the exploreParams, and updates the page URL if need */
-  function updateExploreParams(newOptions, wasUserSpecified=true) {
-    // rebuild the params from the actual URL to avoid races
-    const search = location.search
-    const currentParams = buildExploreParamsFromQuery(search)
-    const mergedOpts = Object.assign({}, currentParams, newOptions)
-    if (wasUserSpecified) {
-      // this is just default params being fetched from the server, so don't change the url
-      Object.keys(newOptions).forEach(key => {
-        mergedOpts.userSpecified[key] = true
-      })
-      // if the user does a gene search from the cluster view,
-      // or if they've switched to/from consensus view
-      // reset the tab to the default
-      if (mergedOpts.tab === 'cluster' && newOptions.genes ||
-          !!newOptions.consensus != !!exploreParams.consensus) {
-        delete mergedOpts.tab
-        delete mergedOpts.userSpecified.tab
-      }
-    }
-
-    const query = buildQueryFromParams(mergedOpts)
-    // view options settings should not add history entries
-    // e.g. when a user hits 'back', it shouldn't undo their cluster selection,
-    // it should take them to the page they were on before they came to the explore tab
-    navigate(`${query}#study-visualize`, { replace: true })
-  }
-
   useEffect(() => {
     // if this is the first render, and there are already genes specified, that means they came
     // from the url directly
@@ -61,6 +27,35 @@ export default function useExploreTabRouter() {
     }
   }, [])
   return { exploreParams, updateExploreParams, routerLocation }
+}
+
+
+/** Merges the received update into the exploreParams, and updates the page URL if need */
+function updateExploreParams(newOptions, wasUserSpecified=true) {
+  // rebuild the params from the actual URL to avoid races
+  const search = location.search
+  const currentParams = buildExploreParamsFromQuery(search)
+  const mergedOpts = Object.assign({}, currentParams, newOptions)
+  if (wasUserSpecified) {
+    // this is just default params being fetched from the server, so don't change the url
+    Object.keys(newOptions).forEach(key => {
+      mergedOpts.userSpecified[key] = true
+    })
+    // if the user does a gene search from the cluster view,
+    // or if they've switched to/from consensus view
+    // reset the tab to the default
+    if (mergedOpts.tab === 'cluster' && newOptions.genes ||
+        !!newOptions.consensus != !!currentParams.consensus) {
+      delete mergedOpts.tab
+      delete mergedOpts.userSpecified.tab
+    }
+  }
+
+  const query = buildQueryFromParams(mergedOpts)
+  // view options settings should not add history entries
+  // e.g. when a user hits 'back', it shouldn't undo their cluster selection,
+  // it should take them to the page they were on before they came to the explore tab
+  navigate(`${query}#study-visualize`, { replace: true })
 }
 
 /** converts query string parameters into the dataParams objet */

--- a/app/javascript/components/explore/ExploreTabRouter.js
+++ b/app/javascript/components/explore/ExploreTabRouter.js
@@ -26,7 +26,10 @@ export default function useExploreTabRouter() {
 
   /** Merges the received update into the exploreParams, and updates the page URL if need */
   function updateExploreParams(newOptions, wasUserSpecified=true) {
-    const mergedOpts = Object.assign({}, exploreParams, newOptions)
+    // rebuild the params from the actual URL to avoid races
+    const search = location.search
+    const currentParams = buildExploreParamsFromQuery(search)
+    const mergedOpts = Object.assign({}, currentParams, newOptions)
     if (wasUserSpecified) {
       // this is just default params being fetched from the server, so don't change the url
       Object.keys(newOptions).forEach(key => {

--- a/app/javascript/components/explore/StudyGeneField.js
+++ b/app/javascript/components/explore/StudyGeneField.js
@@ -19,7 +19,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes }) {
   let geneOptions = []
   if (allGenes) {
     // Autocomplete when user starts typing
-    if (inputText && inputText.length > 0) {
+    if (inputText && inputText.length > 1) {
       const lowerCaseInput = inputText.toLowerCase()
       geneOptions = getOptionsFromGenes(allGenes.filter(geneName => {
         return geneName.toLowerCase().includes(lowerCaseInput)
@@ -61,7 +61,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes }) {
     if (!inputTextValues.length || !inputTextValues[0].length) {
       return geneArray
     }
-    const newGeneArray = geneArray.concat(inputTextValues.map(gene => ({ label: gene, value: gene })))
+    const newGeneArray = geneArray.concat(getOptionsFromGenes(inputTextValues))
     logGeneArrayChange(newGeneArray)
     setInputText(' ')
     setGeneArray(newGeneArray)

--- a/app/javascript/components/visualization/RelatedGenesIdeogram.js
+++ b/app/javascript/components/visualization/RelatedGenesIdeogram.js
@@ -31,7 +31,7 @@ function onClickAnnot(annot) {
 
   otherProps['trigger'] = 'click-related-genes'
   logStudyGeneSearch([annot.name], null, null, otherProps)
-  ideogram.SCP.searchGenes([annot.name])
+  ideogram.SCP.searchGenes([annot.name], null, false)
 }
 
 /**

--- a/app/javascript/components/visualization/RelatedGenesIdeogram.js
+++ b/app/javascript/components/visualization/RelatedGenesIdeogram.js
@@ -31,7 +31,7 @@ function onClickAnnot(annot) {
 
   otherProps['trigger'] = 'click-related-genes'
   logStudyGeneSearch([annot.name], null, null, otherProps)
-  ideogram.SCP.searchGenes([annot.name], null, false)
+  ideogram.SCP.searchGenes([annot.name])
 }
 
 /**

--- a/app/javascript/components/visualization/StudyViolinPlot.js
+++ b/app/javascript/components/visualization/StudyViolinPlot.js
@@ -65,7 +65,7 @@ function RawStudyViolinPlot({
     )
     const apiOk = checkScpApiResponse(results, () => Plotly.purge(graphElementId), setShowError, setErrorContent)
     if (apiOk) {
-      setStudyGeneNames(results.gene_names)
+
       let distributionPlotToUse = results.plotType
       if (distributionPlot) {
         distributionPlotToUse = distributionPlot
@@ -91,7 +91,7 @@ function RawStudyViolinPlot({
         'perfTime:backend': perfTime,
         'perfTime:frontend': Math.round(perfTimeFrontend)
       })
-
+      setStudyGeneNames(results.gene_names)
       if (setAnnotationList) {
         setAnnotationList(results.annotation_list)
       }

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -238,8 +238,7 @@ class ClusterVizService
       annotation[:values] = AnnotationVizService.sanitize_values_array(metadata_obj.values, annotation[:type])
     end
     annotation_array = AnnotationVizService.sanitize_values_array(annotation_array, annotation[:type])
-    Rails.logger.info "annotation array: #{annotation_array}"
-    Rails.logger.info "annotation[:values]: #{annotation[:values]}"
+
     coordinates = {}
     if annotation[:type] == 'numeric'
       text_array = []

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -210,7 +210,6 @@ class ClusterVizService
   # uses cluster_group model and loads annotation for both group & numeric plots
   # data values are pulled from associated data_array entries for each axis and annotation/text value
   def self.load_cluster_group_data_array_points(study, cluster, annotation, subsample_threshold=nil, colorscale=nil)
-    Rails.logger.info "raw annotation: #{annotation}"
     # construct annotation key to load subsample data_arrays if needed, will be identical to params[:annotation]
     subsample_annotation = "#{annotation[:name]}--#{annotation[:type]}--#{annotation[:scope]}"
     x_array = cluster.concatenate_data_arrays('x', 'coordinates', subsample_threshold, subsample_annotation)

--- a/test/js/explore/explore-tab-router.test.js
+++ b/test/js/explore/explore-tab-router.test.js
@@ -15,6 +15,17 @@ function FakeRouterComponent({testObj}) {
   return <span>Mock</span>
 }
 
+/** useExploreTabRouter reads the location.search to merge update params, so we need to mock it
+  * here.  We also mock pathname since that is used in metrics-api */
+function mockWindowLocationSearch(searchString) {
+  delete global.window.location
+  global.window = Object.create(window)
+  global.window.location = {
+    search: searchString,
+    pathname: '/single_cell/mock'
+  }
+}
+
 describe('dataParams are appropriately managed on the url', () => {
   it('provides empty cluster params from a blank url', async () => {
     const routerNav = jest.spyOn(Reach, 'navigate')
@@ -35,8 +46,10 @@ describe('dataParams are appropriately managed on the url', () => {
   it('provides cluster params from a url with a cluster', async () => {
     const routerNav = jest.spyOn(Reach, 'navigate')
     routerNav.mockImplementation(() => {})
+    const searchString = '?cluster=foo&annotation=bar--group--study'
     const locationMock = jest.spyOn(Reach, 'useLocation')
-    locationMock.mockImplementation(() => ({ search: '?cluster=foo&annotation=bar--group--study' }))
+    locationMock.mockImplementation(() => ({ search: searchString }))
+    mockWindowLocationSearch(searchString)
     const testObj = {}
     const wrapper = mount(<FakeRouterComponent testObj={testObj}/>)
 
@@ -59,6 +72,7 @@ describe('dataParams are appropriately managed on the url', () => {
     urlString += '&spatialGroups=square,circle&consensus=mean&heatmapRowCentering=z-score&bamFileName=sample1.bam'
     urlString += '&ideogramFileId=604fc5c4e241391a8ff93271'
     locationMock.mockImplementation(() => ({ search: urlString }))
+    mockWindowLocationSearch(urlString)
     const testObj = {}
     const wrapper = mount(<FakeRouterComponent testObj={testObj}/>)
 


### PR DESCRIPTION
This PR has some general cleanup, what really fixed the bug was the change to `updateExploreParams` that rebuilds the current params from the URL.  I still don't fully understand the root cause of this, as somehow the location of the Reach router was getting updated via a means that wasn't the `navigate` call in updateExploreParams (which is the only navigate call in the Explore component tree).  But this fix is a good idea generally, and fixes the infinite loop, so I think it will be good to have while the underlying cause is still a mystery.   

To test:
0. open a large-ish study with react_explore on
1. Do a gene search, and then VERY quickly delete the gene and type another gene and hit enter to trigger another search (you need to trigger the next search before the previous one finishes)
2. Observe that an infinite toggle between the two genes does NOT occur

