### PR TITLE
Changing cluster_group.points to field, adding setter (SCP-3104)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,7 @@ GEM
     ruby-prof (0.17.0)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
-    ruby_native_statistics (0.8)
+    ruby_native_statistics (0.10.1)
     rubyzip (1.3.0)
     sass (3.5.6)
       sass-listen (~> 4.0.0)

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -210,7 +210,6 @@ class ClusterVizService
   # uses cluster_group model and loads annotation for both group & numeric plots
   # data values are pulled from associated data_array entries for each axis and annotation/text value
   def self.load_cluster_group_data_array_points(study, cluster, annotation, subsample_threshold=nil, colorscale=nil)
-    Rails.logger.info "raw annotation: #{annotation}"
     # construct annotation key to load subsample data_arrays if needed, will be identical to params[:annotation]
     subsample_annotation = "#{annotation[:name]}--#{annotation[:type]}--#{annotation[:scope]}"
     x_array = cluster.concatenate_data_arrays('x', 'coordinates', subsample_threshold, subsample_annotation)
@@ -238,8 +237,6 @@ class ClusterVizService
       annotation[:values] = AnnotationVizService.sanitize_values_array(metadata_obj.values, annotation[:type])
     end
     annotation_array = AnnotationVizService.sanitize_values_array(annotation_array, annotation[:type])
-    Rails.logger.info "annotation array: #{annotation_array}"
-    Rails.logger.info "annotation[:values]: #{annotation[:values]}"
     coordinates = {}
     if annotation[:type] == 'numeric'
       text_array = []

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -12,6 +12,7 @@ class ClusterGroup
   field :cluster_type, type: String
   field :cell_annotations, type: Array
   field :domain_ranges, type: Hash
+  field :points, type: Integer
   # subsampling flags
   # :subsampled => whether subsampling has completed
   # :is_subsampling => whether subsampling has been initiated
@@ -83,11 +84,6 @@ class ClusterGroup
         data_array.values
       end
     end
-  end
-
-  # return number of points in cluster_group, use x axis as all cluster_groups must have either x or y
-  def points
-    self.concatenate_data_arrays('x', 'coordinates').count
   end
 
   def is_3d?
@@ -354,6 +350,12 @@ class ClusterGroup
       # check if there are any data arrays belonging to this cluster that have a subsample threshold & annotation
       !self.find_subsampled_data_arrays.any?
     end
+  end
+
+  # set the point count for a cluster_group
+  def set_point_count
+    points = self.concatenate_data_arrays('x', 'coordinates').count
+    self.update!(points: points)
   end
 
   ##

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -352,10 +352,11 @@ class ClusterGroup
     end
   end
 
-  # set the point count for a cluster_group
-  def set_point_count
+  # set the point count for a cluster_group and return value
+  def set_point_count!
     points = self.concatenate_data_arrays('x', 'coordinates').count
     self.update!(points: points)
+    self.points
   end
 
   ##
@@ -363,6 +364,12 @@ class ClusterGroup
   # CLASS INSTANCE METHODS
   #
   ##
+
+  def self.set_all_point_counts!
+    self.all.each do |cluster|
+      cluster.set_point_count!
+    end
+  end
 
   def self.generate_new_data_arrays
     start_time = Time.zone.now

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -396,7 +396,6 @@ class IngestJob
   #   - sets the :points attribute on a ClusterGroup
   def set_cluster_point_count
     cluster_group = ClusterGroup.find_by(study_id: self.study.id, study_file_id: self.study_file.id)
-    Rails.logger.info "Setting point count on #{cluster_group.name}:#{cluster_group.id}"
     cluster_group.set_point_count!
     Rails.logger.info "Point count on #{cluster_group.name}:#{cluster_group.id} set to #{cluster_group.points}"
   end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -352,6 +352,7 @@ class IngestJob
       self.study.delay.set_gene_count
     when 'Cluster'
       self.set_study_default_options
+      self.set_cluster_point_count
       self.launch_subsample_jobs
       self.set_subsampling_flags
     end
@@ -387,6 +388,17 @@ class IngestJob
     end
     Rails.logger.info "Setting default options in #{self.study.name}: #{self.study.default_options}"
     self.study.save
+  end
+
+  # set the point count on a cluster group after successful ingest
+  #
+  # * *yields*
+  #   - sets the :points attribute on a ClusterGroup
+  def set_cluster_point_count
+    cluster_group = ClusterGroup.find_by(study_id: self.study.id, study_file_id: self.study_file.id)
+    Rails.logger.info "Setting point count on #{cluster_group.name}:#{cluster_group.id}"
+    cluster_group.set_point_count!
+    Rails.logger.info "Point count on #{cluster_group.name}:#{cluster_group.id} set to #{cluster_group.points}"
   end
 
   # Set the study "initialized" attribute if all main models are populated

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -304,12 +304,12 @@ class IngestJob
       self.study_file.bundled_files.each { |sf| sf.update(parse_status: 'parsed') }
       self.study.reload # refresh cached instance of study
       self.study_file.reload # refresh cached instance of study_file
-      subject = "#{self.study_file.file_type} file: '#{self.study_file.upload_file_name}' has completed parsing"
-      message = self.generate_success_email_array
-      SingleCellMailer.notify_user_parse_complete(self.user.email, subject, message, self.study).deliver_now
       self.set_study_state_after_ingest
       self.study_file.invalidate_cache_by_file_type # clear visualization caches for file
       self.log_to_mixpanel
+      subject = "#{self.study_file.file_type} file: '#{self.study_file.upload_file_name}' has completed parsing"
+      message = self.generate_success_email_array
+      SingleCellMailer.notify_user_parse_complete(self.user.email, subject, message, self.study).deliver_now
     elsif self.done? && self.failed?
       Rails.logger.error "IngestJob poller: #{self.pipeline_name} has failed."
       # log errors to application log for inspection
@@ -351,8 +351,8 @@ class IngestJob
     when /Matrix/
       self.study.delay.set_gene_count
     when 'Cluster'
-      self.set_study_default_options
       self.set_cluster_point_count
+      self.set_study_default_options
       self.launch_subsample_jobs
       self.set_subsampling_flags
     end

--- a/db/migrate/20210326153355_add_points_to_cluster_groups.rb
+++ b/db/migrate/20210326153355_add_points_to_cluster_groups.rb
@@ -1,0 +1,9 @@
+class AddPointsToClusterGroups < Mongoid::Migration
+  def self.up
+    ClusterGroup.all.each {|cluster| cluster.set_point_count }
+  end
+
+  def self.down
+    ClusterGroup.all.each {|cluster| cluster.unset(:points) }
+  end
+end

--- a/db/migrate/20210326153355_add_points_to_cluster_groups.rb
+++ b/db/migrate/20210326153355_add_points_to_cluster_groups.rb
@@ -1,6 +1,7 @@
 class AddPointsToClusterGroups < Mongoid::Migration
   def self.up
-    ClusterGroup.all.each {|cluster| cluster.set_point_count }
+    # run in background to prevent delays on starting server after deployment
+    ClusterGroup.delay.set_all_point_counts!
   end
 
   def self.down

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -104,6 +104,9 @@ cluster_cat_array.save!
 cluster_int_array = cluster.data_arrays.build(name: 'Intensity', cluster_name: cluster.name, array_type: 'annotations', array_index: 1,
                                     study_id: study.id, values: intensity_array, study_file_id: cluster_file.id)
 cluster_int_array.save!
+# set point count on cluster after arrays are saved
+cluster.set_point_count!
+
 cell_metadata_1 = CellMetadatum.create!(name: 'Label', annotation_type: 'group', study_id: study.id,
                                         values: metadata_label_array.uniq, study_file_id: metadata_file.id)
 cell_metadata_2 = CellMetadatum.create!(name: 'Score', annotation_type: 'numeric', study_id: study.id,

--- a/test/factories/cluster_group.rb
+++ b/test/factories/cluster_group.rb
@@ -66,6 +66,7 @@ FactoryBot.define do
                             values: annotation[:values],
                             study_file: evaluator.study_file)
         end
+        cluster.set_point_count!
       end
     end
   end

--- a/test/integration/study_creation_test.rb
+++ b/test/integration/study_creation_test.rb
@@ -122,6 +122,10 @@ class StudyCreationTest < ActionDispatch::IntegrationTest
 
     assert_equal initial_bq_row_count + 30, get_bq_row_count(study)
 
+    # check that the cluster_group set the point count
+    cluster_group = study.cluster_groups.first
+    assert_equal 30, cluster_group.points
+
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
 

--- a/test/models/cluster_group_test.rb
+++ b/test/models/cluster_group_test.rb
@@ -1,13 +1,34 @@
 require "test_helper"
 
 class ClusterGroupTest < ActiveSupport::TestCase
-  def setup
-    @cluster_group = ClusterGroup.first
+  include Minitest::Hooks
+  include SelfCleaningSuite
+  include TestInstrumentor
+
+  before(:all) do
+    @user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    @study = FactoryBot.create(:detached_study, name_prefix: 'Basic Viz', test_array: @@studies_to_clean)
+    @cluster_file = FactoryBot.create(:cluster_file,
+                                                  name: 'cluster_1.txt', study: @study,
+                                                  cell_input: {
+                                                    x: [1, 4 ,6],
+                                                    y: [7, 5, 3],
+                                                    z: [2, 8, 9],
+                                                    cells: ['A', 'B', 'C']
+                                                  },
+                                                  x_axis_label: 'PCA 1',
+                                                  y_axis_label: 'PCA 2',
+                                                  z_axis_label: 'PCA 3',
+                                                  cluster_type: '3d',
+                                                  annotation_input: [
+                                                    {name: 'Category', type: 'group', values: ['bar', 'bar', 'baz']},
+                                                    {name: 'Intensity', type: 'numeric', values: [1.1, 2.2, 3.3]}
+                                                  ])
+
+    @cluster = @study.cluster_groups.first
   end
 
   test 'should not visualize unique group annotations over 100' do
-    puts "#{File.basename(__FILE__)}: #{self.method_name}"
-
     annotation_values = []
     300.times { annotation_values << SecureRandom.uuid }
     cell_annotation = {name: 'Group Annotation', type: 'group', values: annotation_values}
@@ -20,8 +41,19 @@ class ClusterGroupTest < ActiveSupport::TestCase
     cluster.cell_annotations << new_cell_annotation
     can_visualize_numeric  = cluster.can_visualize_cell_annotation?(new_cell_annotation)
     assert can_visualize_numeric, "Should be able to visualize numeric cell annotation at any level: #{can_visualize_numeric}"
+  end
 
-    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  test 'should set point count on cluster group' do
+    # ensure cluster point count was set by FactoryBot
+    assert_equal 3, @cluster.points
+
+    @cluster.update!(points: nil)
+    assert_nil @cluster.points
+
+    # test both return value and assignment for set_point_count!
+    points = @cluster.set_point_count!
+    assert_equal 3, points
+    assert_equal 3, @cluster.points
   end
 end
 


### PR DESCRIPTION
Currently, when attempting to determine the number of points in a given `ClusterGroup`, calling the method `points` will pull out all of the X coordinates in the database and calculate the length of the array.  While this method ensures that it always returns the correct value, this is unnecessary as the number of points does not change dynamically.  The only way the number of points can change is if the clustering file is re-ingested, in which case the `ClusterGroup` object will have been destroyed.  This update changes `points` from a method to a static field, and adds the method `set_point_count!` to set the number of points after a successful ingest.  

As a part of the associated ticket SCP-3104, benchmarking was performed before & after the refactoring to determine how this will impact the performance of loading clustering data.  The median wall (elapsed real) times in seconds for calling both `cluster.points` and `ClustersController.get_cluster_viz_data` w/ 1.3M cell data are shown below.

BEFORE refactoring:

- `cluster.points` : 1.883
- `ClustersController.get_cluster_viz_data` : 24.293

AFTER refactoring

- `cluster.points` : 0.000027
- `ClustersController.get_cluster_viz_data` : 22.535

As shown, this reduces the elapsed time for calling `points` to essentially 0.  Since `points` can be called up to 4 times during a normal visualization request (in `ClustersController.get_cluster_viz_data`, `Api::V1::Visualization::ExploreController#show`, and in both `ClusterVizService.subsampling_options` and `ClusterVizService.default_subsampling`), this can potentially shave many seconds off of the entire visualization request.

This PR satisfies SCP-3104.

_Note: originally this ticket also looked to make other refinements to loading clustering data by skipping assignment of Z axis or coordinate label information if not present, but these refinements proved to have no impact at all on performance and were summarily dropped._