### PR TITLE
cleanup explore tab code

### DIFF
--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -125,9 +125,13 @@ module Api
           subsample = get_selected_subsample_threshold(url_params[:subsample], cluster)
           consensus = url_params[:consensus].blank? ? nil : url_params[:consensus]
 
-
-
-          colorscale = url_params[:colorscale].blank? ? 'Reds' : url_params[:colorscale]
+          colorscale = url_params[:colorscale]
+          if colorscale.blank?
+            colorscale = study.default_color_profile
+            if colorscale.blank?
+              colorscale = 'Reds'
+            end
+          end
 
           is_annotated_scatter = !url_params[:is_annotated_scatter].blank?
 

--- a/app/controllers/api/v1/visualization/explore_controller.rb
+++ b/app/controllers/api/v1/visualization/explore_controller.rb
@@ -90,7 +90,8 @@ module Api
             # the react refactor is no longer feature-flagged
             spatialGroupNames: spatial_group_options.map { |opt| opt[:name] },
             spatialGroups: spatial_group_options,
-            clusterPointAlpha: @study.default_cluster_point_alpha
+            clusterPointAlpha: @study.default_cluster_point_alpha,
+            defaultColorProfile: @study.default_color_profile
           }
 
           render json: explore_props

--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -158,11 +158,6 @@ export default function ExploreDisplayTabs(
     return { width, height }
   }
 
-  /** helper function for Scatter plot color updates */
-  function updateScatterColor(color) {
-    updateExploreParams({ scatterColor: color }, false)
-  }
-
   /** on window resize call setRenderForcer, which is just trivial state to ensure a re-render
    * ensuring that the plots get passed fresh dimensions */
   useResizeEffect(() => {
@@ -219,7 +214,6 @@ export default function ExploreDisplayTabs(
                   <ScatterPlot
                     studyAccession={studyAccession}
                     {...exploreParams}
-                    updateScatterColor={updateScatterColor}
                     dimensions={getPlotDimensions({
                       numColumns: hasSelectedSpatialGroup ? 2 : 1,
                       hasTitle: true
@@ -235,7 +229,6 @@ export default function ExploreDisplayTabs(
                         <ScatterPlot
                           studyAccession={studyAccession}
                           {...params}
-                          updateScatterColor={updateScatterColor}
                           dimensions={getPlotDimensions({ numColumns: 2, hasTitle: true })}
                           isCellSelecting={isCellSelecting}
                           plotPointsSelected={plotPointsSelected}
@@ -260,7 +253,6 @@ export default function ExploreDisplayTabs(
                   <ScatterPlot
                     studyAccession={studyAccession}
                     {...exploreParams}
-                    updateScatterColor={updateScatterColor}
                     dimensions={getPlotDimensions({
                       numColumns: 2,
                       numRows: hasSelectedSpatialGroup ? 2 : 1,
@@ -275,7 +267,6 @@ export default function ExploreDisplayTabs(
                   <ScatterPlot
                     studyAccession={studyAccession}
                     {...referencePlotDataParams}
-                    updateScatterColor={updateScatterColor}
                     dimensions={getPlotDimensions({
                       numColumns: 2,
                       numRows: hasSelectedSpatialGroup ? 2 : 1,
@@ -294,7 +285,6 @@ export default function ExploreDisplayTabs(
                       <ScatterPlot
                         studyAccession={studyAccession}
                         {...spatialDataParamsArray[index]}
-                        updateScatterColor={updateScatterColor}
                         dimensions={getPlotDimensions({
                           numColumns: 2,
                           numRows: 2,
@@ -309,7 +299,6 @@ export default function ExploreDisplayTabs(
                       <ScatterPlot
                         studyAccession={studyAccession}
                         {...params}
-                        updateScatterColor={updateScatterColor}
                         dimensions={getPlotDimensions({
                           numColumns: 2,
                           numRows: 2,
@@ -339,7 +328,6 @@ export default function ExploreDisplayTabs(
                       <ScatterPlot
                         studyAccession={studyAccession}
                         {...spatialRefPlotDataParamsArray[0]}
-                        updateScatterColor={updateScatterColor}
                         dimensions={getPlotDimensions({ numColumns: 1, numRows: 2, hasTitle: true })}
                         isCellSelecting={isCellSelecting}
                         plotPointsSelected={plotPointsSelected}
@@ -360,7 +348,6 @@ export default function ExploreDisplayTabs(
                     <ScatterPlot
                       studyAccession={studyAccession}
                       {...spgDataParams}
-                      updateScatterColor={updateScatterColor}
                       dimensions={getPlotDimensions({ numColumns: 2, numRows: 2, hasTitle: true })}
                       isCellSelecting={isCellSelecting}
                       plotPointsSelected={plotPointsSelected}

--- a/app/javascript/components/explore/ExploreView.js
+++ b/app/javascript/components/explore/ExploreView.js
@@ -42,22 +42,14 @@ function RoutableExploreTab({ studyAccession }) {
   // we keep a separate 'controlExploreParams' object that updates after defaults are fetched from the server
   // this is kept separate so that the graphs do not see the change in cluster name from '' to
   // '<<default cluster>>' as a change that requires a re-fetch from the server
-  let controlExploreParams = _clone(exploreParams)
-  if (exploreInfo && !exploreParams.cluster && exploreInfo.clusterGroupNames.length > 0) {
-    // if the user hasn't specified anything yet, but we have the study defaults, use those
-    controlExploreParams = Object.assign(controlExploreParams,
-      getDefaultClusterParams(annotationList, exploreInfo.spatialGroups))
-    if (!exploreParams.userSpecified['spatialGroups']) {
-      exploreParams.spatialGroups = controlExploreParams.spatialGroups
-    } else {
-      controlExploreParams.spatialGroups = exploreParams.spatialGroups
-    }
-  }
+  const controlExploreParams = createExploreParamsWithDefaults(exploreParams, exploreInfo)
 
   let hasSpatialGroups = false
   if (exploreInfo) {
     hasSpatialGroups = exploreInfo.spatialGroups.length > 0
   }
+
+
 
   /** in the event a component takes an action which updates the list of annotations available
     * e.g. by creating a user annotation, this updates the list */
@@ -214,6 +206,25 @@ function RoutableExploreTab({ studyAccession }) {
       </div>
     </div>
   )
+}
+
+/** returns a clone of exploreParams with appropriate defaults from exploreInfo merged in */
+function createExploreParamsWithDefaults(exploreParams, exploreInfo) {
+  let controlExploreParams = _clone(exploreParams)
+  if (exploreInfo && !exploreParams.cluster && exploreInfo.clusterGroupNames.length > 0) {
+    // if the user hasn't specified anything yet, but we have the study defaults, use those
+    controlExploreParams = Object.assign(controlExploreParams,
+      getDefaultClusterParams(exploreInfo.annotationList, exploreInfo.spatialGroups))
+    if (!exploreParams.userSpecified['spatialGroups']) {
+      exploreParams.spatialGroups = controlExploreParams.spatialGroups
+    } else {
+      controlExploreParams.spatialGroups = exploreParams.spatialGroups
+    }
+  }
+  if (!exploreParams.userSpecified['scatterColor'] && exploreInfo?.defaultColorProfile) {
+    controlExploreParams.scatterColor = exploreInfo.defaultColorProfile
+  }
+  return controlExploreParams
 }
 
 /** wraps the explore tab in a Router object so it can use React hooks for routable parameters */

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -29,15 +29,13 @@ export const defaultScatterColor = 'Reds'
   * @param consensus {string} for multi-gene expression plots
   * @param dimensions {obj} object with height and width, to instruct plotly how large to render itself
   *   this is useful for rendering to hidden divs
-  * @param updateScatterColor {function} function for updating the scatter color -- will be called if no
-  *   scatterColor is specified, but the retrieved graph data does specify a scatter color
   * @param isCellSelecting whether plotly's lasso selection tool is enabled
   * @plotPointsSelected {function} callback for when a user selects points on the plot, which corresponds
   *   to the plotly "points_selected" event
   */
 function RawScatterPlot({
   studyAccession, cluster, annotation, subsample, consensus, genes, scatterColor, dimensions,
-  updateScatterColor, isCellSelecting=false, plotPointsSelected
+   isCellSelecting=false, plotPointsSelected
 }) {
   const [isLoading, setIsLoading] = useState(false)
   const [clusterData, setClusterData] = useState(null)
@@ -88,9 +86,6 @@ function RawScatterPlot({
 
       log('plot:scatter', perfLogProps)
 
-      if (dataScatterColor !== scatterColor) {
-        updateScatterColor(dataScatterColor)
-      }
       setClusterData(scatter)
       setShowError(false)
     }
@@ -112,7 +107,6 @@ function RawScatterPlot({
   useUpdateEffect(() => {
     // Don't try to update the color if the graph hasn't loaded yet
     if (clusterData && !isLoading) {
-      console.log('updating color scale')
       const dataUpdate = { 'marker.colorscale': scatterColor }
       Plotly.update(graphElementId, dataUpdate)
     }
@@ -122,7 +116,6 @@ function RawScatterPlot({
   useUpdateEffect(() => {
     // Don't try to update the color if the graph hasn't loaded yet
     if (clusterData && !isLoading) {
-      console.log('updating drag mode')
       const newDragMode = getDragMode(isCellSelecting)
       window.Plotly.relayout(graphElementId, { dragmode: newDragMode })
       if (!isCellSelecting) {

--- a/app/javascript/components/visualization/StudyViolinPlot.js
+++ b/app/javascript/components/visualization/StudyViolinPlot.js
@@ -66,10 +66,7 @@ function RawStudyViolinPlot({
     const apiOk = checkScpApiResponse(results, () => Plotly.purge(graphElementId), setShowError, setErrorContent)
     if (apiOk) {
 
-      let distributionPlotToUse = results.plotType
-      if (distributionPlot) {
-        distributionPlotToUse = distributionPlot
-      }
+      distributionPlotToUse = distributionPlot
       if (!distributionPlotToUse) {
         distributionPlotToUse = defaultDistributionPlot
       }
@@ -94,9 +91,6 @@ function RawStudyViolinPlot({
       setStudyGeneNames(results.gene_names)
       if (setAnnotationList) {
         setAnnotationList(results.annotation_list)
-      }
-      if (updateDistributionPlot) {
-        updateDistributionPlot(distributionPlotToUse)
       }
       setShowError(false)
     }

--- a/app/javascript/lib/scatter-plot.js
+++ b/app/javascript/lib/scatter-plot.js
@@ -31,7 +31,6 @@ export function getScatterPlots() {
  * Resize Plotly scatter plots, e.g. on window resize or "View Options" click
  */
 export function resizeScatterPlots() {
-  console.log('in resizeScatterPlots')
   scatterPlots.forEach(rawPlot => {
     const target = rawPlot.plotId
     const layout = getScatterPlotLayout(rawPlot)

--- a/test/api/visualization/clusters_controller_test.rb
+++ b/test/api/visualization/clusters_controller_test.rb
@@ -24,7 +24,8 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
                                                      y: [7, 5, 3],
                                                      cells: ['A', 'B', 'C']
                                                   },
-                                                  annotation_input: [{name: 'foo', type: 'group', values: ['bar', 'bar', 'baz']}])
+                                                  annotation_input: [{name: 'foo', type: 'group', values: ['bar', 'bar', 'baz']},
+                                                                     {name: 'intensity', type: 'numeric', values: [1, 2, 5]}])
 
     @basic_study_metadata_file = FactoryBot.create(:metadata_file,
                                                    name: 'metadata.txt',
@@ -73,6 +74,17 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
     assert_equal false, json['is3D']
     bar_data = json['data'].find{|d| d['name'] == 'bar (2 points)'}
     assert_equal [1, 4], bar_data['x']
+  end
+
+  test 'show should handle numeric clusters' do
+    sign_in_and_update @user
+    execute_http_request(:get, api_v1_study_cluster_path(@basic_study, 'clusterA.txt', {annotation_name: 'intensity', annotation_scope: 'cluster', annotation_type: 'numeric'}))
+    assert_equal 'Reds', json['data'][0]['marker']['colorscale']
+    @basic_study.update!({default_options: {color_profile: 'Portland'}})
+    # since we're going to send a duplicate request, clear the API cache so we can get fresh results
+    Rails.cache.clear
+    execute_http_request(:get, api_v1_study_cluster_path(@basic_study, 'clusterA.txt', {annotation_name: 'intensity', annotation_scope: 'cluster', annotation_type: 'numeric'}))
+    assert_equal 'Portland', json['data'][0]['marker']['colorscale']
   end
 
   test 'should load clusters with slashes in name' do


### PR DESCRIPTION
This fixes a bug where, depending on ordering of requests, we might not respect study default color profile.  It also streamlines and clarifies the application of study default data to the explore params, reducing the number of rerenders.

To test:
0. open a study with a numeric annotation in the explore tab with react_explore, and do not manually specify a color profile
1. change the study default color profile
2. go back to the explore tab, and confirm the new color profile is applied