### PR TITLE
fixing bug in consensus view tab selection

### DIFF
--- a/app/javascript/components/explore/ExploreTabRouter.js
+++ b/app/javascript/components/explore/ExploreTabRouter.js
@@ -45,7 +45,7 @@ function updateExploreParams(newOptions, wasUserSpecified=true) {
     // or if they've switched to/from consensus view
     // reset the tab to the default
     if (mergedOpts.tab === 'cluster' && newOptions.genes ||
-        !!newOptions.consensus != !!currentParams.consensus) {
+        newOptions.consensus && !!newOptions.consensus != !!currentParams.consensus) {
       delete mergedOpts.tab
       delete mergedOpts.userSpecified.tab
     }


### PR DESCRIPTION
Fixes bug where tab selection couldn't be changed in consensus view.  

To test:
 0. open a study with react_explore tab
 1. do a multigene search
 2. select consensus-> mean
 3. confirm that you can change tabs to see distribution, etc...