### PR TITLE
redrawing plots with expired webgl contexts

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -62,7 +62,7 @@ function RawScatterPlot({
 
       const perfTimeFrontendStart = performance.now()
 
-      Plotly.newPlot(graphElementId, scatter.data, layout)
+      Plotly.react(graphElementId, scatter.data, layout)
 
       const perfTimeFrontend = performance.now() - perfTimeFrontendStart
 
@@ -134,14 +134,16 @@ function RawScatterPlot({
     }
   }, [dimensions.width, dimensions.height])
 
+
   useEffect(() => {
     $(`#${graphElementId}`).on('plotly_selected', plotPointsSelected)
     $(`#${graphElementId}`).on('plotly_legendclick', logLegendClick)
     $(`#${graphElementId}`).on('plotly_legenddoubleclick', logLegendDoubleClick)
     return () => {
-      $(`#${graphElementId}`).off('plotly_selected', plotPointsSelected)
-      $(`#${graphElementId}`).off('plotly_legendclick', logLegendClick)
-      $(`#${graphElementId}`).off('plotly_legenddoubleclick', logLegendDoubleClick)
+      $(`#${graphElementId}`).off('plotly_selected')
+      $(`#${graphElementId}`).off('plotly_legendclick')
+      $(`#${graphElementId}`).off('plotly_legenddoubleclick')
+      Plotly.purge(graphElementId)
     }
   }, [])
 


### PR DESCRIPTION
Here's what's happening for this bug
1. we render a large number of plots for a gene search w/ spatial data, which uses most of the webgl contexts
2. we do another gene search, which causes all the expression plots to be discarded, and then new ones put in their place, while the cluster plots remain.
3. Chrome hasn't yet garbage collected the webgl contexts of the discarded plots, but needs new contexts to render the new plots.
4. So chrome just expires the oldest webGl context (which is usually the cluster views, since those were rendered first)

There doesn't seem to be any way to manually tell Chrome "garbage collect *this* webgl context instead".  So for now, we'll solve this problem by using plotly.react, which reuses any existing webgl context in the given div, but is otherwise equivalent to newPlot.

To test:
0. load the study "chicken raw counts" with react_explore on
1. do a gene search, and select all the spatial groups to view
2. change the gene and execute another search
3. change the gene again to execute another search
4. observe the while the cluster plot may go away for a few seconds, it returns eventually

