### PR TITLE
adding annotated scatter tab for numeric annotation gene searches (SCP-3209)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -17,6 +17,7 @@ import useResizeEffect from 'hooks/useResizeEffect'
 const tabList = [
   { key: 'cluster', label: 'Cluster' },
   { key: 'scatter', label: 'Scatter' },
+  { key: 'annotatedScatter', label: 'Annotated Scatter' },
   { key: 'distribution', label: 'Distribution' },
   { key: 'dotplot', label: 'Dot Plot' },
   { key: 'heatmap', label: 'Heatmap' },
@@ -363,6 +364,23 @@ export default function ExploreDisplayTabs(
               </div>
             </div>
           }
+          { enabledTabs.includes('annotatedScatter') &&
+            <div className={shownTab === 'annotatedScatter' ? '' : 'hidden'}>
+              <ScatterPlot
+                studyAccession={studyAccession}
+                {...exploreParams}
+                isAnnotatedScatter={true}
+                dimensions={getPlotDimensions({
+                  numColumns: 1,
+                  numRows: hasSelectedSpatialGroup ? 2 : 1,
+                  hasTitle: true,
+                  showRelatedGenesIdeogram
+                })}
+                isCellSelecting={isCellSelecting}
+                plotPointsSelected={plotPointsSelected}
+              />
+            </div>
+          }
           { enabledTabs.includes('distribution') &&
             <div className={shownTab === 'distribution' ? '' : 'hidden'}>
               <StudyViolinPlot
@@ -441,7 +459,12 @@ export function getEnabledTabs(exploreInfo, exploreParams) {
         enabledTabs = ['dotplot', 'heatmap']
       }
     } else {
-      enabledTabs = ['scatter', 'distribution']
+      if (exploreParams.annotation.type === 'numeric') {
+        enabledTabs = ['scatter', 'annotatedScatter']
+      } else {
+        enabledTabs = ['scatter', 'distribution']
+      }
+
     }
   } else if (hasClusters) {
     enabledTabs = ['cluster']

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -35,7 +35,7 @@ export const defaultScatterColor = 'Reds'
   */
 function RawScatterPlot({
   studyAccession, cluster, annotation, subsample, consensus, genes, scatterColor, dimensions,
-   isCellSelecting=false, plotPointsSelected
+   isAnnotatedScatter=false, isCellSelecting=false, plotPointsSelected
 }) {
   const [isLoading, setIsLoading] = useState(false)
   const [clusterData, setClusterData] = useState(null)
@@ -57,7 +57,7 @@ function RawScatterPlot({
       layout.width = width
       layout.height = height
       formatMarkerColors(scatter.data, scatter.annotParams.type, scatter.gene)
-      formatHoverLabels(scatter.data, scatter.annotParams.type, scatter.gene)
+      formatHoverLabels(scatter.data, scatter.annotParams.type, scatter.gene, isAnnotatedScatter)
       const dataScatterColor = processTraceScatterColor(scatter.data, scatterColor)
 
       const perfTimeFrontendStart = performance.now()
@@ -100,8 +100,9 @@ function RawScatterPlot({
       annotation ? annotation : '',
       subsample,
       consensus,
-      genes).then(handleResponse)
-  }, [cluster, annotation.name, subsample, consensus, genes.join(',')])
+      genes,
+      isAnnotatedScatter).then(handleResponse)
+  }, [cluster, annotation.name, subsample, consensus, genes.join(','), isAnnotatedScatter])
 
   // Handles Plotly `data` updates, e.g. changes in color profile
   useUpdateEffect(() => {
@@ -194,11 +195,11 @@ function formatMarkerColors(data, annotationType, gene) {
 }
 
 /** makes the data trace attributes (cells, trace name) available via hover text */
-function formatHoverLabels(data, annotationType, gene) {
+function formatHoverLabels(data, annotationType, gene, isAnnotatedScatter) {
   const groupHoverTemplate = '(%{x}, %{y})<br><b>%{text}</b><br>%{data.name}<extra></extra>'
   data.forEach(trace => {
     trace.text = trace.cells
-    if (annotationType === 'numeric' || gene) {
+    if (!isAnnotatedScatter && (annotationType === 'numeric' || gene)) {
       // use the 'meta' property so annotations are exposed to the hover template
       // see https://community.plotly.com/t/hovertemplate-does-not-show-name-property/36139
       trace.meta = trace.annotations

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -279,7 +279,7 @@ export async function fetchCluster(
     gene = gene.join(',')
   }
   // eslint-disable-next-line camelcase
-  const is_annotated_scatter = isAnnotatedScatter
+  const is_annotated_scatter = isAnnotatedScatter ? true : ''
   const paramObj = {
     annotation_name: annotName,
     annotation_type: annotType,


### PR DESCRIPTION
Restores annotated scatter plot tab functionality for numeric annotations on gene searches

![image](https://user-images.githubusercontent.com/2800795/113086168-26220480-91af-11eb-9d23-25e6389677fd.png)

To test:
0: open a study with react_explore on (e.g. the human lymph node synthetic study)
1: Do a gene search
2: switch the annotation to a numeric facet
3: observe that the annotated scatter plot tab appears with the appropriate plot