### PR TITLE
Show stack trace for template errors when developing (SCP-3211)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 
+
 class ApplicationController < ActionController::Base
 
   ###
@@ -257,13 +258,15 @@ class ApplicationController < ActionController::Base
   end
 
   # generic exception handling for reporting to Mixpanel/Sentry
-  rescue_from Exception do |exception|
-    MetricsService.report_error(exception, request, current_user, @study)
-    error_context = ErrorTracker.format_extra_context(@study, {params: params})
-    ErrorTracker.report_exception(exception, current_user, error_context)
-    respond_to do |format|
-      format.html { render '/error_pages/500', layout: 'application', status: 500 }
-      format.json { render json: {error: exception.message}, status: 500}
+  if !Rails.env.development? # Show stack trace for template errors in dev
+    rescue_from Exception do |exception|
+      MetricsService.report_error(exception, request, current_user, @study)
+      error_context = ErrorTracker.format_extra_context(@study, {params: params})
+      ErrorTracker.report_exception(exception, current_user, error_context)
+      respond_to do |format|
+        format.html { render '/error_pages/500', layout: 'application', status: 500 }
+        format.json { render json: {error: exception.message}, status: 500}
+      end
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 
-
 class ApplicationController < ActionController::Base
 
   ###


### PR DESCRIPTION
This fixes an observability bug in which stack traces for template errors were inaccessible in development.

To test:
* In your local SCP, insert `<% if @foo.bar < 5 %>test<% end %>` atop `app/views/site/study.html.erb`
* Go to a Study Overview page
* Verify that page contains `NoMethodError in Site#study` error message and stack trace
* Change `development` to `test` in `if !Rails.env.development?` in `app/controllers/application_controller.rb`
* Refresh Study Overview page
* Verify that page contains simple "We're sorry, but something went wrong." message

This satisfies SCP-3211.