### PR TITLE
Fix dot plot "Adjust" menu item (SCP-3235)

### DIFF
--- a/app/javascript/components/visualization/DotPlot.js
+++ b/app/javascript/components/visualization/DotPlot.js
@@ -172,6 +172,7 @@ export function morpheusTabManager($target) {
     },
     setTabTitle: () => {},
     setActiveTab: () => {},
+    getActiveTabId: () => {},
     getWidth: () => $target.actual('width'),
     getHeight: () => $target.actual('height'),
     getTabCount: () => 1


### PR DESCRIPTION
This fixes the Morpheus dot plot "Adjust" menu item, so users can e.g. show z-score for each dot.

To test:
1. search multiple genes in Study Overview,
2. in "Dot plot" tab, hover over top left dot and note first value shown in tooltip,
3. in dot plot menu, click "Tools", then "Adjust...",
4. select "Z-score", then click "OK",
5. hover over same dot as Step 2,
6. verify that value from Step 5 differs from value in Step 2.

Demo:

https://user-images.githubusercontent.com/1334561/113610007-918a2d00-961a-11eb-9f79-82ce63b8d32a.mov

Although this bug is React UI-specific, the React Explore refactor had fixed a Morpheus tab UI bug, so that is also now incidentally fixed.

This satisfies SCP-3235.