### PR TITLE
removing gene_study_filter feature flag (SCP-3228)

### DIFF
--- a/app/javascript/components/search/genes/GeneSearchView.js
+++ b/app/javascript/components/search/genes/GeneSearchView.js
@@ -1,36 +1,21 @@
-import React, { useContext, useState, useEffect } from 'react'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faPlusSquare, faMinusSquare } from '@fortawesome/free-solid-svg-icons'
+import React, { useContext, useEffect } from 'react'
 
 import { GeneSearchContext } from 'providers/GeneSearchProvider'
 import GeneKeyword from './GeneKeyword'
-import { hasSearchParams, StudySearchContext } from 'providers/StudySearchProvider'
-import SearchPanel from 'components/search/controls/SearchPanel'
 import ResultsPanel from 'components/search/results/ResultsPanel'
 import StudyGeneExpressions from './StudyGeneExpressions'
-import { UserContext } from 'providers/UserProvider'
 
 /**
   * Renders a gene search control panel and the associated results
-  * can also show study filter controls if the feature flag gene_study_filter is true
   */
 export default function GeneSearchView() {
-  const userState = useContext(UserContext)
-  const featureFlagState = userState.featureFlagsWithDefaults
   const geneSearchState = useContext(GeneSearchContext)
-  const studySearchState = useContext(StudySearchContext)
-
-  const [showStudyControls, setShowStudyControls] = useState(hasSearchParams(studySearchState.params))
-
 
   const showStudySearchResults = !geneSearchState.isLoaded &&
                                  !geneSearchState.isLoading &&
                                  !geneSearchState.isError
 
-  let geneSearchPlaceholder = 'Genes (e.g. "PTEN NF2")'
-  if (hasSearchParams(studySearchState.params) && featureFlagState.gene_study_filter) {
-    geneSearchPlaceholder = 'Search for genes in the filtered studies'
-  }
+  const geneSearchPlaceholder = 'Genes (e.g. "PTEN NF2")'
 
   useEffect(() => {
     // if a search isn't already happening, perform one
@@ -73,23 +58,6 @@ export default function GeneSearchView() {
           <GeneKeyword placeholder={geneSearchPlaceholder} helpTextContent={helpTextContent} />
         </div>
       </div>
-      { featureFlagState.gene_study_filter &&
-        <div className="row gene-study-filter">
-          <div className="col-md-2 text-right">
-            Study Filter &nbsp;
-            <FontAwesomeIcon icon={showStudyControls ? faMinusSquare : faPlusSquare}
-              className="action"
-              onClick={() => {setShowStudyControls(!showStudyControls)}}/>
-
-          </div>
-          <div className="col-md-10">
-            { showStudyControls &&
-              <SearchPanel
-                keywordPrompt="Filter studies by keyword"
-                showCommonButtons={false}
-                showDownloadButton={false}/> }
-          </div>
-        </div> }
       <div className="row">
         <div className="col-md-12">
           <ResultsPanel

--- a/db/migrate/20210405192922_remove_gene_search_flag.rb
+++ b/db/migrate/20210405192922_remove_gene_search_flag.rb
@@ -1,4 +1,4 @@
-class RemoveSpatialFeatureFlag < Mongoid::Migration
+class RemoveGeneStudyFilterFlag < Mongoid::Migration
   # mirror of FeatureFlag.rb, so this migration won't error if that class is renamed/altered
   class FeatureFlagMigrator
     include Mongoid::Document

--- a/db/migrate/20210405192922_remove_gene_search_flag.rb
+++ b/db/migrate/20210405192922_remove_gene_search_flag.rb
@@ -1,0 +1,22 @@
+class RemoveSpatialFeatureFlag < Mongoid::Migration
+  # mirror of FeatureFlag.rb, so this migration won't error if that class is renamed/altered
+  class FeatureFlagMigrator
+    include Mongoid::Document
+    store_in collection: 'feature_flags'
+    field :name, type: String
+    field :default_value, type: Boolean, default: false
+    field :description, type: String
+  end
+
+  def self.up
+    FeatureFlagMigrator.find_by(name: 'gene_study_filter').destroy
+    FeatureFlaggable.remove_flag_from_model(User, 'gene_study_filter')
+    FeatureFlaggable.remove_flag_from_model(BrandingGroup, 'gene_study_filter')
+  end
+
+  def self.down
+    FeatureFlagMigrator.create!(name: 'gene_study_filter',
+                                default_value: false,
+                                description: 'whether global gene search can be narrowed by a study filter')
+  end
+end

--- a/test/js/search/gene-search-view.test.js
+++ b/test/js/search/gene-search-view.test.js
@@ -21,13 +21,11 @@ describe('Gene search page landing', () => {
     searchState.isLoaded = true
     searchState.results = {studies: [{name: 'foo', description: 'bar'}]}
     const wrapper = mount((
-      <UserContext.Provider value={{featureFlagsWithDefaults: {gene_study_filter: false}}}>
-        <PropsStudySearchProvider searchParams={{terms: '', facets:{}, page: 1}}>
-          <GeneSearchContext.Provider value={searchState}>
-            <GeneSearchView/>
-          </GeneSearchContext.Provider>
-        </PropsStudySearchProvider>
-      </UserContext.Provider>
+      <PropsStudySearchProvider searchParams={{terms: '', facets:{}, page: 1}}>
+        <GeneSearchContext.Provider value={searchState}>
+          <GeneSearchView/>
+        </GeneSearchContext.Provider>
+      </PropsStudySearchProvider>
     ))
     expect(wrapper.find(Study)).toHaveLength(1)
   })
@@ -37,13 +35,11 @@ describe('Gene search page landing', () => {
     searchState.isLoaded = true
     searchState.results = {studies: [{name: 'foo', description: 'bar', gene_matches: ['agpat2']}]}
     const wrapper = mount((
-      <UserContext.Provider value={{featureFlagsWithDefaults: {gene_study_filter: false}}}>
-        <PropsStudySearchProvider searchParams={{terms: '', facets:{}, page: 1}}>
-          <GeneSearchContext.Provider  value={searchState}>
-            <GeneSearchView/>
-          </GeneSearchContext.Provider>
-        </PropsStudySearchProvider>
-      </UserContext.Provider>
+      <PropsStudySearchProvider searchParams={{terms: '', facets:{}, page: 1}}>
+        <GeneSearchContext.Provider  value={searchState}>
+          <GeneSearchView/>
+        </GeneSearchContext.Provider>
+      </PropsStudySearchProvider>
     ))
 
     expect(wrapper.find(Study)).toHaveLength(0)
@@ -56,13 +52,11 @@ describe('Gene search page landing', () => {
     searchState.isLoaded = true
     searchState.results = {studies: [{name: 'foo', description: 'bar', gene_matches: ['agpat2', 'farsa']}]}
     const wrapper = mount((
-      <UserContext.Provider value={{featureFlagsWithDefaults: {gene_study_filter: false}}}>
-        <PropsStudySearchProvider searchParams={{terms: '', facets:{}, page: 1}}>
-          <GeneSearchContext.Provider  value={searchState}>
-            <GeneSearchView/>
-          </GeneSearchContext.Provider>
-        </PropsStudySearchProvider>
-      </UserContext.Provider>
+      <PropsStudySearchProvider searchParams={{terms: '', facets:{}, page: 1}}>
+        <GeneSearchContext.Provider  value={searchState}>
+          <GeneSearchView/>
+        </GeneSearchContext.Provider>
+      </PropsStudySearchProvider>
     ))
 
     expect(wrapper.find(Study)).toHaveLength(0)


### PR DESCRIPTION
SCP-3228. This feature flag was added for prototype development last summer, and never ended up being expanded on.  Being deleted now as XDSS development will make it obsolete.