### PR TITLE
Adding external resource link to branding groups (SCP-3225)

### DIFF
--- a/app/controllers/branding_groups_controller.rb
+++ b/app/controllers/branding_groups_controller.rb
@@ -81,6 +81,6 @@ class BrandingGroupsController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def branding_group_params
     params.require(:branding_group).permit(:name, :tag_line, :background_color, :font_family, :font_color, :user_id,
-                                           :splash_image, :banner_image, :footer_image)
+                                           :splash_image, :banner_image, :footer_image, :external_link_url, :external_link_description)
   end
 end

--- a/app/models/branding_group.rb
+++ b/app/models/branding_group.rb
@@ -11,6 +11,8 @@ class BrandingGroup
   field :font_family, type: String, default: 'Helvetica Neue, sans-serif'
   field :font_color, type: String, default: '#333333'
   field :feature_flags, type: Hash, default: {}
+  field :external_link_url, type: String
+  field :external_link_description, type: String
 
   # list of facets to show for this branding group (will restrict to only provided identifiers, if present)
   field :facet_list, type: Array, default: []

--- a/app/views/branding_groups/_form.html.erb
+++ b/app/views/branding_groups/_form.html.erb
@@ -69,6 +69,16 @@
       <% end %>
     </div>
   </div>
+  <div class="row">
+    <div class="col-md-12">
+      <%= f.label :external_link_url, 'External Link URL' %>
+      <%= f.text_field :external_link_url, class: 'form-control' %>
+      <br/>
+      <%= f.label :external_link_description, 'External Link Description' %>
+      <%= f.text_field :external_link_description, class: 'form-control' %>
+    </div>
+  </div>
+  <br/>
 
   <div class="form-group">
     <%= f.submit nil, class: 'btn btn-lg btn-success', id: 'save-branding-group' %>

--- a/app/views/branding_groups/show.html.erb
+++ b/app/views/branding_groups/show.html.erb
@@ -17,6 +17,12 @@
       <%= image_tag @branding_group.footer_image.url, class: 'img-thumbnail' %>
     </div>
   </div>
+  <div class="row">
+    <div class="col-md-12">
+      <p>External resource link: <%= @branding_group.external_link_url %></p>
+      <p>External resource description: <%= @branding_group.external_link_description %></p>
+    </div>
+  </div>
 </div>
 
 <p>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -17,8 +17,11 @@
 	<div class="collapse navbar-collapse" id="scp-navbar-dropdown-collapse">
 		<%= render partial: '/layouts/breadcrumbs' %>
 		<ul class="nav navbar-nav pull-right">
-			<li class='dropdown'><%= scp_link_to "<span class='fas fa-question-circle'></span> Help <span class='caret'></span>".html_safe, "#", class: "dropdown-toggle", "data-toggle" => "dropdown" %>
+			<li class='dropdown'><%= scp_link_to "<span class='fas fa-question-circle'></span> Help & Resources <span class='caret'></span>".html_safe, "#", class: "dropdown-toggle", "data-toggle" => "dropdown" %>
 				<ul class="dropdown-menu dropdown-menu-right">
+          <% if @selected_branding_group.present? && @selected_branding_group.external_link_url %>
+            <li><%= link_to "<span class='fas fa-fw fa-globe'></span> ".html_safe + @selected_branding_group.external_link_description.html_safe, @selected_branding_group.external_link_url, target: '_blank', class: 'check-upload' %></li>
+          <% end %>
           <li><%= scp_link_to "<span class='fas fa-fw fa-lock'></span> Privacy Policy".html_safe, privacy_policy_path, class: 'check-upload' %></li>
           <li><%= scp_link_to "<span class='fas fa-fw fa-balance-scale'></span> Terms of Service".html_safe, terms_of_service_path, class: 'check-upload' %></li>
           <li><%= link_to "<span class='fas fa-fw fa-info-circle'></span> Documentation/Wiki".html_safe, 'https://github.com/broadinstitute/single_cell_portal/wiki', target: '_blank' %></li>

--- a/db/seed/synthetic_branding_groups/human_group/branding_group_info.json
+++ b/db/seed/synthetic_branding_groups/human_group/branding_group_info.json
@@ -3,7 +3,9 @@
     "name" : "Human Research Group",
     "tag_line": "Synthetic branding group containing only human synthetic studies",
     "background_color": "lightgray",
-    "facet_list": ["organ", "disease"]
+    "facet_list": ["organ", "disease"],
+    "external_link_url": "https://en.wikipedia.org/wiki/Human",
+    "external_link_description": "Human wiki"
   },
   "images": {
     "splash_image": "SCP-logo-invert.png"


### PR DESCRIPTION
SCP-3225  This changes the Help menu heading to "Help & Resources" for everyone (which makes sense, since we have resources like the privacy policy under it).  And then for branding groups with the config, it will show an external link at the top of the menu.  I think that makes the most sense, since it's certainly more likely that users are interested in that than the privacy policy, but we can discuss whether it makes sense to use this opportunity to reorder that menu generally.

![image](https://user-images.githubusercontent.com/2800795/113625971-94dbe380-962f-11eb-8d1d-dfd3b1c55eed.png)

![image](https://user-images.githubusercontent.com/2800795/113626351-0d42a480-9630-11eb-92e4-736254062716.png)

To test:
  0. Open a branding group locally (use SyntheticBrandingGroupPopulator to create if you don't have any)
  1. edit the config to give it an external link and description
  2. confirm that the menu option then appears under the "help & resources" menu, and is clickable
  3. confirm that menu option does not appear outside of that branding group

As a side note, I'm a huge fan of OKRs that can be accomplished in less than an hour of coding :)