### PR TITLE
moving legal stuff from menu to footer (SCP-3225)

### DIFF
--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -22,8 +22,6 @@
           <% if @selected_branding_group.present? && @selected_branding_group.external_link_url %>
             <li><%= link_to "<span class='fas fa-fw fa-globe'></span> ".html_safe + @selected_branding_group.external_link_description.html_safe, @selected_branding_group.external_link_url, target: '_blank', class: 'check-upload' %></li>
           <% end %>
-          <li><%= scp_link_to "<span class='fas fa-fw fa-lock'></span> Privacy Policy".html_safe, privacy_policy_path, class: 'check-upload' %></li>
-          <li><%= scp_link_to "<span class='fas fa-fw fa-balance-scale'></span> Terms of Service".html_safe, terms_of_service_path, class: 'check-upload' %></li>
           <li><%= link_to "<span class='fas fa-fw fa-info-circle'></span> Documentation/Wiki".html_safe, 'https://github.com/broadinstitute/single_cell_portal/wiki', target: '_blank' %></li>
           <li><%= link_to "<span class='fas fa-fw fa-envelope'></span> Contact Us".html_safe, '#', id: 'open-contact-modal' %></li>
           <li><%= link_to "<span class='fab fa-fw fa-github'></span> Portal Source Code".html_safe, 'https://github.com/broadinstitute/single_cell_portal_core', target: '_blank' %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -184,7 +184,10 @@
     </div>
     <div class="footer-text-block pull-left left-border-0-5">
       <%= scp_link_to 'Privacy Policy', privacy_policy_path %>
+      &nbsp;
+      <%= scp_link_to "Terms of Service".html_safe, terms_of_service_path %>
     </div>
+
   <% if @selected_branding_group.present? %>
     <div class="footer-text-block">
       <%= link_to "<i class='fas fa-chevron-circle-left fa-fw'></i> Return to Single Cell Portal".html_safe, site_path %>


### PR DESCRIPTION
As shown in demo, this moves the legal stuff out of the help menu and into the footer.  

![image](https://user-images.githubusercontent.com/2800795/113953268-6ef83f80-97e5-11eb-82bb-48c72ea87a1c.png)

This also does a quick clean up of some behavior around the footer display on mobile -- previously the footer would not expand to accommodate when the text wraps on narrow screens.

Compare
![image](https://user-images.githubusercontent.com/2800795/113953334-96e7a300-97e5-11eb-8115-ea951e745f9a.png)
to 
![image](https://user-images.githubusercontent.com/2800795/113953391-b7176200-97e5-11eb-9254-3f9198542322.png)

To test:
1. Open the home page, confirm the footer contains both the privacy policy and terms of service links
2. Confirm they render reasonably at various widths
