### PR TITLE
Refactor handling of temp/test files during test runs (SCP-3248)

### DIFF
--- a/lib/generic_profiler.rb
+++ b/lib/generic_profiler.rb
@@ -64,7 +64,7 @@ class GenericProfiler
   end
 
   # write a single report to specified path
-  # will ensure closure to avoid issues during testsing regarding file handlers & garbage collection
+  # will ensure closure to avoid issues during tests regarding file handlers & garbage collection
   #
   # * *params*
   #   - +report_path+ (String, Pathname) => path to specified report to be written

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -21,7 +21,6 @@ def perform_chunked_study_file_upload(filename, study_file_params, study_id)
     upload_response
   ensure
     source_file.close
-    file_upload.unlink if file_upload.present?
   end
 end
 

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -10,9 +10,9 @@ OmniAuth.config.test_mode = true
 # upload a large file (i.e. > 10MB) from the test_data directory to a study
 # simulates chunked upload by streaming file in 10MB chunks and then uploading in series
 def perform_chunked_study_file_upload(filename, study_file_params, study_id)
+  source_file = File.open(Rails.root.join('test', 'test_data', filename))
   begin
     upload_response = nil
-    source_file = File.open(Rails.root.join('test', 'test_data', filename))
     while chunk = source_file.read(10.megabytes)
       file_upload = Rack::Test::UploadedFile.new(StringIO.new(chunk), original_filename: filename) # mock original_filename header
       study_file_params[:study_file].merge!(upload: file_upload)
@@ -20,21 +20,21 @@ def perform_chunked_study_file_upload(filename, study_file_params, study_id)
     end
     upload_response
   ensure
-    source_file.try(:close)
-    file_upload.try(:unlink)
+    source_file.close
+    file_upload.unlink if file_upload.present?
   end
 end
 
 # upload a file from the test_data directory to a study
 def perform_study_file_upload(filename, study_file_params, study_id)
+  source_file = File.open(Rails.root.join('test', 'test_data', filename))
+  file_upload = Rack::Test::UploadedFile.new(source_file)
   begin
-    source_file = File.open(Rails.root.join('test', 'test_data', filename))
-    file_upload = Rack::Test::UploadedFile.new(source_file)
     study_file_params[:study_file].merge!(upload: file_upload)
     patch "/single_cell/studies/#{study_id}/upload", params: study_file_params, headers: {'Content-Type' => 'multipart/form-data'}
   ensure
-    source_file.try(:close)
-    file_upload.try(:unlink)
+    source_file.close
+    file_upload.unlink if file_upload.present?
   end
 end
 


### PR DESCRIPTION
As a part of ongoing work to address test/CI stability issues, this update changes how temp files are handled when performing simulated uploads during integration tests.  Since these tests accounted for the vast majority of `No such file or directory: getcwd` errors, the two file upload helpers in `integration_test_helper.rb` were refactored such that regardless of any issues with execution, all `Rack::Test::UploadedFile` objects (which are wrappers around `Tempfile`) will now explicitly close and unlink any IO objects via the `ensure` call.  This will run upon the completion of all simulated uploads, even if an error causes execution to halt.  This is the recommended way of handling `Tempfile` objects as per Ruby's own [documentation](https://ruby-doc.org/stdlib-2.6.6/libdoc/tempfile/rdoc/Tempfile.html#class-Tempfile-label-Explicit+close).  This paradigm has also been applied to the `GenericProfiler` class when writing report files, as it was raising the same error intermittently.

This PR satisfies SCP-3248