### PR TITLE
Persist plot type & points values when changing (SCP-3253)

### DIFF
--- a/app/javascript/components/visualization/PlotDisplayControls.js
+++ b/app/javascript/components/visualization/PlotDisplayControls.js
@@ -70,14 +70,14 @@ export default function RenderControls({ shownTab, exploreParams, updateExploreP
             value={distributionPlotValue}
             clearable={false}
             isSearchable={false}
-            onChange={option => updateExploreParams({ distributionPlot: option.value })}/>
+            onChange={option => updateExploreParams({ distributionPlot: option.value, distributionPoints: distributionPointsValue.value })}/>
           <label htmlFor="distribution-plot-picker">Data points </label>
           <Select name="distribution-points-picker"
             options={DISTRIBUTION_POINTS_OPTIONS}
             value={distributionPointsValue}
             clearable={false}
             isSearchable={false}
-            onChange={option => updateExploreParams({ distributionPoints: option.value })}/>
+            onChange={option => updateExploreParams({distributionPlot: distributionPlotValue.value, distributionPoints: option.value })}/>
         </Panel.Body>
       </Panel>
       <Panel className={shownTab === 'heatmap' ? '' : 'hidden'}>


### PR DESCRIPTION
This is a bugfix for persisting the values of of the "Plot Type" and "Data Points" select menus under the "Distribution" panel when selecting new values.  Previously, changing the value of one could cause the other to become unset if it had not already been changed (and persisted in the URL bar), and would cause it to switch to a different value.  This change now explicitly passes the value for both in the `onChange` handlers, using the cached value from the React state for the menu that is not being changed.  These values then get propagated to the URL bar so as to persist the state correctly.

To test:
1. Pull this branch and load "Chicken Raw Counts" synthetic study
2. Search "Foo"
3. Click "Distribution"
4. Note violin plot
5. In "Data points", select "All"
6. Validate plot type stays "Violin"
7. Change plot type to "Box"
8. Note data points stays "All"