### PR TITLE
removing faceted search feature flag code (SCP-3227)

### DIFF
--- a/app/javascript/components/search/controls/SearchPanel.js
+++ b/app/javascript/components/search/controls/SearchPanel.js
@@ -16,7 +16,7 @@ const helpModalContent = (<div>
   Single Cell Portal supports searching studies by ontology classifications. For example, you can search on studies that
   have <b>species</b> of <b>&quot;Homo sapiens&quot;</b> or have an <b>organ</b> of <b>&quot;brain&quot;</b>.
   <br/><br/>
-    Currently, about <b>70 out of ~300</b> public studies in SCP provide this metadata information.
+    Currently, about 30% of public studies in SCP provide this metadata information.
   <br/><br/>
   For more detailed information, visit
   our <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Search-Studies" target="_blank" rel="noreferrer">wiki</a>.
@@ -74,7 +74,7 @@ export default function SearchPanel({
           { helpModalContent }
         </Modal.Body>
         <Modal.Footer>
-          <button className="btn btn-md btn-primary" onClick={closeSearchModal}>Ok</button>
+          <button className="btn btn-md btn-primary" onClick={closeSearchModal}>OK</button>
         </Modal.Footer>
       </Modal>
     </div>

--- a/app/javascript/components/search/results/ResultsPanel.js
+++ b/app/javascript/components/search/results/ResultsPanel.js
@@ -86,8 +86,9 @@ const FacetResultsFooter = ({ studySearchState }) => {
           <FontAwesomeIcon icon={faInfoCircle} className="fa-lg fa-fw icon-left"/>
         </div>
         <div className="">
-          <p>Our advanced search is metadata-powered.  By selecting filters, your search <b>targets only studies that use ontology terms</b> in their metadata file.
-          Currently, about 20% of public studies supply that metadata.</p>
+          <p>By selecting filters, your search targets <b>only studies that use ontology terms</b> in their metadata file.
+          <br/>
+          Currently, about 20% of public studies supply such metadata.</p>
           Learn more on our <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Search-Studies" target="_blank" rel="noreferrer">wiki</a>, and
           study authors can read our <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#Metadata-powered-Advanced-Search" target="_blank" rel="noreferrer">metadata guide</a>.
         </div>

--- a/app/javascript/components/search/results/ResultsPanel.js
+++ b/app/javascript/components/search/results/ResultsPanel.js
@@ -88,7 +88,7 @@ const FacetResultsFooter = ({ studySearchState }) => {
         <div className="">
           <p>By selecting filters, your search targets <b>only studies that use ontology terms</b> in their metadata file.
           <br/>
-          Currently, about 20% of public studies supply such metadata.</p>
+          Currently, about 30% of public studies supply such metadata.</p>
           Learn more on our <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Search-Studies" target="_blank" rel="noreferrer">wiki</a>, and
           study authors can read our <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#Metadata-powered-Advanced-Search" target="_blank" rel="noreferrer">metadata guide</a>.
         </div>

--- a/app/javascript/components/search/results/ResultsPanel.js
+++ b/app/javascript/components/search/results/ResultsPanel.js
@@ -88,8 +88,8 @@ const FacetResultsFooter = ({ studySearchState }) => {
         <div className="">
           <p>Our advanced search is metadata-powered.  By selecting filters, your search <b>targets only studies that use ontology terms</b> in their metadata file.
           Currently, about 20% of public studies supply that metadata.</p>
-          Learn more about our search capability on our <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Search-Studies" target="_blank" rel="noreferrer">wiki</a>.<br/>
-          Study authors looking to make their studies more accessible can read our <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#Metadata-powered-Advanced-Search" target="_blank" rel="noreferrer">metadata guide</a>.
+          Learn more on our <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Search-Studies" target="_blank" rel="noreferrer">wiki</a>, and
+          study authors can read our <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#Metadata-powered-Advanced-Search" target="_blank" rel="noreferrer">metadata guide</a>.
         </div>
       </div>
     )

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -491,7 +491,7 @@ h6,
 
 /* Override bootstrap styles to SCP colors */
 .alert.alert-info {
-  color: $action-color;
+  color: #334;
   border: none;
   border-left: 6px solid $action-color;
   border-radius: 0px;


### PR DESCRIPTION
SCP-3227. 

 Code is ready for review.  Actual merge will depend on PM signoff of https://docs.google.com/document/d/1kXnwyHtC__Tl15N7W4-c1F3zTlGiF1RGEBu_ATGWOHw/edit# (still in progress).  

Note that this removes the feature flag code, but does NOT remove the feature flag.  This is so we can revert this change if necessary, and not have lost the data on which users opted in.  Also, note that we have to remove the code, so this change will only be revertable via a release.  Just changing the feature flag to default-true wouldn't actually test what we want, since users would still have the option to opt-out, which we don't want.

This also updates the faceted search banner display as outlined in the doc. above.

To test:
0. go to home page
1. confirm faceted search appears, and clicking on the "?" icon does NOT give an opt-out option -- it just gives the information
2. confirm the faceted search appears regardless of your current feature flag status.