### PR TITLE
improving logging of file downloads (SCP-3227)

### DIFF
--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -123,7 +123,7 @@ export function logClickLink(target) {
     id: target.id
   }
   // Check if target is a tab that's not a part of a menu
-  const parentTabList = $(target).closest('[data-analytics-name]')
+  const parentTabList = $(target).closest("[data-analytics-name][role='tablist']")
   if (parentTabList.length > 0) {
     // Grab name of tab list and add to props
     props.tabListName = parentTabList[0].attributes['data-analytics-name'].value

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -48,6 +48,12 @@ class BulkDownloadService
       manifest_config += "output=\"#{study.accession}/file_supplemental_info.tsv\""
       curl_configs << manifest_config
     end
+    byebug
+    MetricsService.log('file-download:curl-config', {
+      num_files: study_files.count,
+      num_studies: studies.count,
+      study_accesions: studies.map(&:accession)
+    }, user)
     curl_configs.join("\n\n")
   end
 

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -50,9 +50,9 @@ class BulkDownloadService
     end
     byebug
     MetricsService.log('file-download:curl-config', {
-      num_files: study_files.count,
-      num_studies: studies.count,
-      study_accesions: studies.map(&:accession)
+      numFiles: study_files.count,
+      numStudies: studies.count,
+      studyAccesions: studies.map(&:accession)
     }, user)
     curl_configs.join("\n\n")
   end

--- a/app/views/layouts/_download_link.html.erb
+++ b/app/views/layouts/_download_link.html.erb
@@ -9,7 +9,7 @@
       <% elsif !study_file.generation %>
             <span class="label label-warning no-download-available" title="You will be able to download this file once it has been uploaded to our remote data store.  Check back soon.", data-toggle="tooltip"><i class="fas fa-ban"></i> Awaiting remote file</span>
       <% else %>
-          <span class="btn btn-sm btn-danger disabled-download" title="This file exceeds your daily download quota of <%= number_to_human(@download_quota) %>.  Please wait until tomorrow.", data-toggle="tooltip"><i class="fas fa-times"></i> Exceeds Quota</span>
+          <span class="btn btn-sm btn-danger disabled-download" title="This file exceeds your daily download quota of <%= number_to_human_size(@download_quota) %>.  Please wait until tomorrow.", data-toggle="tooltip"><i class="fas fa-times"></i> Exceeds Quota</span>
       <% end %>
   <% end %>
 <% end %>

--- a/app/views/layouts/_download_link.html.erb
+++ b/app/views/layouts/_download_link.html.erb
@@ -2,14 +2,14 @@
     <span class="label label-warning embargoed-file"><i class="fas fa-ban"></i> Not available until <%= @study.embargo.to_s(:long) %></span>
 <% else %>
   <% if study_file.upload_file_name.nil? && study_file.human_data %>
-      <%= link_to "<span class='fas fa-cloud-download'></span> External".html_safe, study_file.download_path, class: 'btn btn-primary', target: :_blank %>
+      <%= link_to "<span class='fas fa-cloud-download'></span> External".html_safe, study_file.download_path, class: 'btn btn-primary', target: :_blank, data: {"analytics-name": 'file-download:study-single:external'} %>
   <% else %>
       <% if study_file.generation and current_user.daily_download_quota + study_file.upload_file_size <= @download_quota %>
-          <%= link_to "<span class='fas fa-download'></span> #{number_to_human_size(study_file.upload_file_size, prefix: :si)}".html_safe, study_file.download_path, class: "btn btn-primary dl-link #{study_file.file_type_class}", data: {filename: study_file.upload_file_name} %>
+          <%= link_to "<span class='fas fa-download'></span> #{number_to_human_size(study_file.upload_file_size, prefix: :si)}".html_safe, study_file.download_path, class: "btn btn-primary dl-link #{study_file.file_type_class}", data: {filename: study_file.upload_file_name, "analytics-name": 'file-download:study-single'} %>
       <% elsif !study_file.generation %>
             <span class="label label-warning no-download-available" title="You will be able to download this file once it has been uploaded to our remote data store.  Check back soon.", data-toggle="tooltip"><i class="fas fa-ban"></i> Awaiting remote file</span>
       <% else %>
-          <span class="btn btn-sm btn-danger disabled-download" title="This file exceeds your daily download quota of <%= number_to_human_size(@download_quota) %>.  Please wait until tomorrow.", data-toggle="tooltip"><i class="fas fa-times"></i> Exceeds Quota</span>
+          <span class="btn btn-sm btn-danger disabled-download" title="This file exceeds your daily download quota of <%= number_to_human(@download_quota) %>.  Please wait until tomorrow.", data-toggle="tooltip"><i class="fas fa-times"></i> Exceeds Quota</span>
       <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
* Adds some server-side logging to bulk download requests so that we'll be able to look at the number of files/studies being downloaded.  
* Improves the click tracking of users clicking on the 'download' links to individual files in the UI
* refines our tab-click detection

Please suggest better event names!

TO TEST:
 1. click on some tabs in the UI, confirm they are still logged as tab clicks
 2. perform a bulk download, confirm that a mixpanel event gets logged with name `file-download:curl-config` and `num_studies` and `num_files` properties
 3. download a single file from study overview, confirm a `file-download:study-single` event gets fired (with an `external` suffix if it's a genomic file hosted externally)
  