### PR TITLE
removing 'url_safe_token' functionality (SCP-2955)

### DIFF
--- a/app/controllers/api/v1/concerns/authenticator.rb
+++ b/app/controllers/api/v1/concerns/authenticator.rb
@@ -11,15 +11,14 @@ module Api
           {controller: 'search', action: 'bulk_download'},
           {controller: 'studies', action: 'generate_manifest'}
         ]
-        URL_SAFE_TOKEN_ALLOWED_ACTIONS = [
-          {controller: 'expression', action: 'show'},
-          {controller: 'annotations', action: 'cell_values'}
-        ]
         # these are API actions that we allow logged-in site users to access using
         # regular rails session validation & csrf protection, which can be useful
         # to save from having to put a token in a URL
         COOKIE_ALLOWED_ACTIONS = [
-          {controller: 'reports', action: 'show'}
+          {controller: 'reports', action: 'show'},
+          {controller: 'expression', action: 'show'},
+          {controller: 'annotations', action: 'cell_values'},
+          {controller: 'studies', action: 'generate_manifest'}
         ]
         def authenticate_api_user!
           head 401 unless api_user_signed_in?
@@ -69,24 +68,12 @@ module Api
                 user.update_last_access_at!
                 return user
               end
-            else
-              if URL_SAFE_TOKEN_ALLOWED_ACTIONS.include?({controller: controller_name, action: action_name})
-                return find_user_from_url_safe_token
-              end
             end
           end
           nil
         end
 
         private
-
-        def find_user_from_url_safe_token
-          if params[:url_safe_token].present?
-            url_safe_token = params[:url_safe_token]
-            return User.find_by(authentication_token: url_safe_token)
-          end
-          nil
-        end
 
         def find_user_from_totat
           # check for a valid totat/action

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -361,16 +361,6 @@ module ApplicationHelper
     end
   end
 
-   # Return a scope-limited access token that can be used in URLs (e.g. in urls passed to Morpheus)
-   # this is different than a totat in that it can be re-used
-  def get_url_safe_access_token(user)
-    token = ''
-    if user.present?
-      token = user.authentication_token
-    end
-    token
-  end
-
   def pluralize_without_count(count, noun, text=nil)
     count.to_i == 1 ? "#{noun}#{text}" : "#{noun.pluralize}#{text}"
   end

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -10,7 +10,7 @@ import camelcaseKeys from 'camelcase-keys'
 import _compact from 'lodash/compact'
 import * as queryString from 'query-string'
 
-import { getAccessToken, getURLSafeAccessToken } from 'providers/UserProvider'
+import { getAccessToken } from 'providers/UserProvider'
 import {
   logSearch, logDownloadAuthorization, logCreateUserAnnotation,
   mapFiltersForLogging
@@ -394,8 +394,7 @@ export function getAnnotationCellValuesURL(
   const paramObj = {
     cluster,
     annotation_scope: annotationScope,
-    annotation_type: annotationType,
-    url_safe_token: getURLSafeAccessToken()
+    annotation_type: annotationType
   }
   annotationName = annotationName ? annotationName : '_default'
   const apiUrl = `/studies/${studyAccession}/annotations/${encodeURIComponent(annotationName)}/cell_values${stringifyQuery(paramObj)}`
@@ -428,7 +427,6 @@ export function getExpressionHeatmapURL({
     subsample,
     genes: geneArrayToParam(genes),
     row_centered: heatmapRowCentering,
-    url_safe_token: getURLSafeAccessToken(),
     gene_list: geneList
   }
   const path = `/studies/${studyAccession}/expression/heatmap${stringifyQuery(paramObj)}`

--- a/app/javascript/providers/UserProvider.js
+++ b/app/javascript/providers/UserProvider.js
@@ -18,15 +18,6 @@ export function isUserLoggedIn() {
   return !!getAccessToken()
 }
 
-/**
-  * Returns a scope-limited access token that can be used as a URL param
-  * window.SCP is not available when running via Jest tests,
-  * so default such cases to a string "test"
-  */
-export function getURLSafeAccessToken() {
-  return ('SCP' in window) ? window.SCP.URLSafeAccessToken : 'test'
-}
-
 /** Returns the feature flags with defaults for the current user */
 export function getFeatureFlagsWithDefaults() {
   // for now, read it off the home page.  Eventually, this will want to be an API call

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,6 @@
       }
 
       window.SCP.userAccessToken = '<%= get_user_access_token(current_user) %>';
-      window.SCP.URLSafeAccessToken = '<%= get_url_safe_access_token(current_user) %>'
       window.SCP.userSignedIn = <%= user_signed_in? %>;
       window.SCP.environment = '<%= Rails.env %>';
 

--- a/test/api/visualization/annotations_controller_test.rb
+++ b/test/api/visualization/annotations_controller_test.rb
@@ -55,13 +55,6 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_and_update @user
     execute_http_request(:get, api_v1_study_annotations_path(@basic_study, 'foo'), user: @user)
     assert_equal 200, response.status
-
-    # test url_safe_token capability
-    get cell_values_api_v1_study_annotation_path(@basic_study, 'foo', params: {url_safe_token: @user.authentication_token})
-    assert_equal 200, response.status
-
-    get cell_values_api_v1_study_annotation_path(@basic_study, 'foo', params: {url_safe_token: 'garbage'})
-    assert_equal 401, response.status
   end
 
   test 'index should return list of annotations' do

--- a/test/api/visualization/expression_controller_test.rb
+++ b/test/api/visualization/expression_controller_test.rb
@@ -16,6 +16,39 @@ class ExpressionControllerTest < ActionDispatch::IntegrationTest
                                      public: false,
                                      user: @user,
                                      test_array: @@studies_to_clean)
+
+    @basic_study_cluster_file = FactoryBot.create(:cluster_file,
+                                                  name: 'clusterA.txt',
+                                                  study: @basic_study,
+                                                  cell_input: {
+                                                     x: [1, 4 ,6],
+                                                     y: [7, 5, 3],
+                                                     cells: ['A', 'B', 'C']
+                                                  },
+                                                  annotation_input: [{name: 'foo', type: 'group', values: ['bar', 'bar', 'baz']}])
+
+    @basic_study_metadata_file = FactoryBot.create(:metadata_file,
+                                                   name: 'metadata.txt',
+                                                   study: @basic_study,
+                                                   cell_input: ['A', 'B', 'C'],
+                                                   annotation_input: [
+                                                     {name: 'species', type: 'group', values: ['dog', 'cat', 'dog']},
+                                                     {name: 'disease', type: 'group', values: ['none', 'none', 'measles']}
+                                                   ])
+    @basic_study_exp_file = FactoryBot.create(:study_file,
+                                              name: 'dense.txt',
+                                              file_type: 'Expression Matrix',
+                                              study: @basic_study)
+    @pten_gene = FactoryBot.create(:gene_with_expression,
+                                   name: 'PTEN',
+                                   study_file: @basic_study_exp_file,
+                                   expression_input: [['A', 0],['B', 3],['C', 1.5]])
+
+    @empty_study = FactoryBot.create(:detached_study,
+                                     name_prefix: 'Empty Expression Study',
+                                     public: false,
+                                     user: @user,
+                                     test_array: @@studies_to_clean)
   end
 
   teardown do
@@ -23,14 +56,46 @@ class ExpressionControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'methods should check view permissions' do
+    sign_in_and_update @user
+    execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'heatmap', {
+      cluster: 'clusterA.txt',
+      genes: 'PTEN'
+    }), user: @user)
+    assert_equal 200, response.status
+
     user2 = FactoryBot.create(:api_user, test_array: @@users_to_clean)
     sign_in_and_update user2
 
     execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'heatmap'), user: user2)
     assert_equal 403, response.status
+  end
 
+  test 'methods should return expected values' do
     sign_in_and_update @user
-    execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'heatmap'), user: @user)
-    assert_equal 400, response.status # response is 400 since study is non-visualizable
+    execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'heatmap', {
+      cluster: 'clusterA.txt',
+      genes: 'PTEN'
+    }), user: @user)
+    assert_equal 200, response.status
+    assert_equal "#1.2\n1\t3\nName\tDescription\tA\tB\tC\nPTEN\t\t0.0\t3.0\t1.5", response.body
+
+    execute_http_request(:get, api_v1_study_expression_path(@empty_study, 'heatmap', {
+      cluster: 'clusterA.txt',
+      genes: 'PTEN'
+    }), user: @user)
+    assert_equal 400, response.status # 400 since study is not visualizable
+
+    execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'violin', {
+      cluster: 'clusterA.txt',
+      genes: 'PTEN'
+    }), user: @user)
+    assert_equal 200, response.status
+    assert_equal({"y"=>[0.0, 3.0], "cells"=>["A", "B"], "annotations"=>[], "name"=>"bar"}, json['values']['bar'])
+
+    execute_http_request(:get, api_v1_study_expression_path(@empty_study, 'violin', {
+      cluster: 'clusterA.txt',
+      genes: 'PTEN'
+    }), user: @user)
+    assert_equal 400, response.status # 400 since study is not visualizable
   end
 end

--- a/test/api/visualization/expression_controller_test.rb
+++ b/test/api/visualization/expression_controller_test.rb
@@ -32,12 +32,5 @@ class ExpressionControllerTest < ActionDispatch::IntegrationTest
     sign_in_and_update @user
     execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'heatmap'), user: @user)
     assert_equal 400, response.status # response is 400 since study is non-visualizable
-
-    # test url_safe_token capability
-    get api_v1_study_expression_path(@basic_study, 'heatmap', params: {url_safe_token: @user.authentication_token})
-    assert_equal 400, response.status # response is 400 since study is non-visualizable
-
-    get api_v1_study_expression_path(@basic_study, 'heatmap', params: {url_safe_token: 'garbage'})
-    assert_equal 401, response.status
   end
 end


### PR DESCRIPTION
SCP-2955.  Now that we implemented 'cookie allowed API routes', url_safe_token is no longer needed.  url_safe _token was implemented to support passing an API url that morpheus could use, but since morpheus is always invoked on the SCP page itself, the cookie will be passed along, and we can authenticate with that.  

TO TEST:
 0. Sign in, go to a private study, do a multi-gene search
 1. confirm dotplot and heatmap load successfully.
 2. look in the console, and find the URL corresponding to the 'cell_values' request.  e.g. https://localhost:3000/single_cell/api/v1/studies/SCP4/annotations/biosample_id/cell_values?annotation_scope=study&annotation_type=group&cluster=X%20cluster
 3. sign out
 4. try to load that URL directly, confirm it fails