### PR TITLE
hiding consensus control for genomes tab (SCP-3167)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -389,7 +389,7 @@ export default function ExploreDisplayTabs({ studyAccession, exploreInfo, explor
                 studyGeneLists={exploreInfo.geneLists}
                 updateGeneList={updateGeneList}/>
             }
-            { exploreParams.genes.length > 1 &&
+            { exploreParams.genes.length > 1 && !['genome', 'infercnv-genome'].includes(shownTab) &&
               <ExploreConsensusSelector
                 consensus={ exploreParamsWithDefaults.consensus}
                 updateConsensus={consensus => updateExploreParams({ consensus })}/>


### PR DESCRIPTION
SCP-3167.  The consensus control is not relevant to the genomes tab, so consistent with our UX, we should hide it when the genomes tab is focused.

To TEST:
0.  load a study with genomic information (e.g. male mouse brain synthetic study)
1.  do a multi-gene search
2. confirm the 'collapse genes by' control appears
3. select the 'genome' tab, and confirm the 'collapse genes by' control is hidden