### PR TITLE
Adding default value for ClusterGroup#points (SCP-3239)

### DIFF
--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -12,7 +12,7 @@ class ClusterGroup
   field :cluster_type, type: String
   field :cell_annotations, type: Array
   field :domain_ranges, type: Hash
-  field :points, type: Integer
+  field :points, type: Integer, default: 1
   # subsampling flags
   # :subsampled => whether subsampling has completed
   # :is_subsampling => whether subsampling has been initiated

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -12,7 +12,7 @@ class ClusterGroup
   field :cluster_type, type: String
   field :cell_annotations, type: Array
   field :domain_ranges, type: Hash
-  field :points, type: Integer, default: 1
+  field :points, type: Integer, default: 0
   # subsampling flags
   # :subsampled => whether subsampling has completed
   # :is_subsampling => whether subsampling has been initiated

--- a/test/integration/lib/cluster_viz_service_test.rb
+++ b/test/integration/lib/cluster_viz_service_test.rb
@@ -248,6 +248,7 @@ class ClusterVizServiceTest < ActiveSupport::TestCase
   # before cluster_group.set_point_count! is called at the end of successful ingest
   test 'should fallback to default points for new cluster' do
     new_cluster = @study.cluster_groups.build(name: 'New Cluster', cluster_type: '2d')
+    assert_equal 0, new_cluster.points
     assert_empty ClusterVizService.subsampling_options(new_cluster)
     assert_nil ClusterVizService.default_subsampling(new_cluster)
   end

--- a/test/integration/lib/cluster_viz_service_test.rb
+++ b/test/integration/lib/cluster_viz_service_test.rb
@@ -243,4 +243,12 @@ class ClusterVizServiceTest < ActiveSupport::TestCase
     computed_aspect = ClusterVizService.compute_aspect_ratios(cluster.domain_ranges)
     assert_equal expected_aspect, computed_aspect
   end
+
+  # ensure default value for cluster_group.points will prevent NoMethodError when getting subsampling options
+  # before cluster_group.set_point_count! is called at the end of successful ingest
+  test 'should fallback to default points for new cluster' do
+    new_cluster = @study.cluster_groups.build(name: 'New Cluster', cluster_type: '2d')
+    assert_empty ClusterVizService.subsampling_options(new_cluster)
+    assert_nil ClusterVizService.default_subsampling(new_cluster)
+  end
 end


### PR DESCRIPTION
This update adds a default value of `0` for calling `points` on an instance of `ClusterGroup`.  This is needed as there is a potential race condition when a cluster file has finished ingesting (and done writing data to MongoDB), but `IngestJob#poll_for_completion` has yet to pick up the finished job and run all of the success callbacks to set the various attributes for the study/cluster (one of which is `cluster.set_point_count!`).  During this window, if a user navigates to the study overview page and attempts to load that cluster, it will throw an error as the subsampling options cannot be rendered due to comparing a `nil` object to an integer.

The default value of `0` will allow rendering the cluster at the "All Cells" level, which at that point is the only data that will be present.  The standard ingest flow will then either continue (if subsampling is required) or exit as normal.

To Test: this unfortunately cannot be tested easily through normal portal usage, as it would require precise timing to pick up the moment when the cluster is present but `set_point_count!` has not yet been called.  Furthermore, calling `cluster.unset(:points)` or `cluster.remove_attribute(:points)` will not cause the default value to be returned, and instead it is simply set to `nil`, which causes the same error as before.

The functionality can be tested in a limited fashion with the following snippet (run in the rails console):

```
new_cluster = ClusterGroup.new
ClusterVizService.subsampling_options(new_cluster)
ClusterVizService.default_subsampling(new_cluster)
```
and should return:
```
=> #<ClusterGroup _id: 6076120ae24139008ee99d11, name: nil, cluster_type: nil, cell_annotations: nil, domain_ranges: nil, points: 1, subsampled: false, is_subsampling: false, study_id: nil, study_file_id: nil>
=> []
=> nil
```

This PR satisfies SCP-3239.