### PR TITLE
Add STARmap to library preparation protocol menu in expression matrix upload (SCP-3261)

### DIFF
--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -60,6 +60,7 @@ class ExpressionFileInfo
                                 'SeqFISH+',
                                 'Slide-seq',
                                 'smFISH',
+                                'STARmap',
                                 # single cell ChIP-seq assays
                                 'Drop-ChIP']
   validates :library_preparation_protocol, inclusion: {in: LIBRARY_PREPARATION_VALUES}


### PR DESCRIPTION
This adds [STARmap](https://science.sciencemag.org/content/361/6400/eaat5691) to the "Library Preparation Protocol" dropdown menu in the upload wizard's "Expression Matrix" tab.

STARmap has no EFO entry -- getting one is upstream work-in-progress.  So users can't specify STARmap in metadata files yet.  This is OK, as these expression file menu selections aren't yet coordinated with metadata validation and faceted search.  Such coordination is a future goal of [file-level metadata handling](https://docs.google.com/document/d/1xeTo-8bfyzDgoBKIycA0zIz3LB9XmFmRG0QJEpsyXV4/edit).

To test:
1. Go to upload wizard of an existing study
2. Change "Library preparation protocol" to "STARmap"
3. Save, refresh, and verify "STARmap" selection persists
4. Restore menu value from before step 2.

<img width="1679" alt="STARmap_in_library_preparation_protocol_menu_SCP_2021-04-13" src="https://user-images.githubusercontent.com/1334561/114625893-ec59ff00-9c80-11eb-9e7a-fd3b40cfd5d8.png">

This satisfies SCP-3261.