### PR TITLE
Further GenericProfiler test fixes (SCP-3248)

### DIFF
--- a/lib/generic_profiler.rb
+++ b/lib/generic_profiler.rb
@@ -73,11 +73,15 @@ class GenericProfiler
   # * *yields*
   #   - (File) => report file of requested type at specified path
   def self.write_report(report_path, printer)
+    report = File.new(report_path, 'w+')
     begin
-      report = File.new(report_path, 'w+')
       printer.print(report)
+    rescue Errno::ENOENT => e
+      # this rescue is mainly for test stability
+      puts "error writing report: #{e.message}"
     ensure
       report.close
+      report
     end
   end
 

--- a/lib/generic_profiler.rb
+++ b/lib/generic_profiler.rb
@@ -73,15 +73,15 @@ class GenericProfiler
   # * *yields*
   #   - (File) => report file of requested type at specified path
   def self.write_report(report_path, printer)
-    report = File.new(report_path, 'w+')
     begin
+      report = File.new(report_path, 'w+')
       printer.print(report)
     rescue Errno::ENOENT => e
       # this rescue is mainly for test stability
       puts "error writing report: #{e.message}"
+      report_path
     ensure
-      report.close
-      report
+      report.try(:close)
     end
   end
 

--- a/test/lib/generic_profiler_test.rb
+++ b/test/lib/generic_profiler_test.rb
@@ -102,4 +102,14 @@ class GenericProfilerTest < ActiveSupport::TestCase
     assert args_file.include?('foo: "bar"')
     assert args_file.include?('bing: "baz"')
   end
+  
+  test 'should capture error when writing report' do
+    non_existent_file = Rails.root.join('does', 'not', 'exist.txt')
+    profile = RubyProf.profile { puts "test" }
+    printer = RubyProf::FlatPrinter.new(profile)
+
+    # write_report should capture the error when trying to write to the non-existent filepath and still return
+    report = GenericProfiler.write_report(non_existent_file, printer)
+    refute report.exist?
+  end
 end


### PR DESCRIPTION
This update contains further updates to address CI instability for `GenericProfilerTest` runs beyond what was done in #971.  Since all of the errors were instances of `Errno::ENOENT`, `GenericProfiler` will now explicitly catch this error when calling `write_report` in an effort to reduce false negatives during CI, and adds a test that directly invokes the error to prove that it has been addressed as far as the scope of this ticket is concerned.  

It should be noted that while the underlying cause of `Errno::ENOENT: No such file or directory - getcwd` errors during test runs has not been completely identified, efforts through #938, #949 and #971 have drastically reduced the incidence of this particular error.

This PR further supports SCP-3248.