### PR TITLE
adding checksum validation to codecov uploader (SCP-3275)

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -138,7 +138,14 @@ if [[ $code -ne 0 ]]; then
 fi
 if [[ "$CODECOV_TOKEN" != "" ]] && [[ "$CI" == "true" ]]; then
   echo "uploading all coverage data to codecov"
-  bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
+  # code below adapted from https://docs.codecov.io/docs/about-the-codecov-bash-uploader
+  curl -s https://codecov.io/bash > codecov
+  CODECOV_VERSION=$(grep 'VERSION=\".*\"' codecov | cut -d'"' -f2);
+  for i in 1 256 512
+  do
+    diff <(shasum -a $i codecov) <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/$CODECOV_VERSION/SHA${i}SUM)  || { echo "CodeCov checksum validation failed!" >&2; exit 1; }
+  done
+  bash <codecov -t $CODECOV_TOKEN
 fi
 
 clean_up

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -138,14 +138,7 @@ if [[ $code -ne 0 ]]; then
 fi
 if [[ "$CODECOV_TOKEN" != "" ]] && [[ "$CI" == "true" ]]; then
   echo "uploading all coverage data to codecov"
-  # code below adapted from https://docs.codecov.io/docs/about-the-codecov-bash-uploader
-  curl -s https://codecov.io/bash > codecov
-  CODECOV_VERSION=$(grep 'VERSION=\".*\"' codecov | cut -d'"' -f2);
-  for i in 1 256 512
-  do
-    diff <(shasum -a $i codecov) <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/$CODECOV_VERSION/SHA${i}SUM)  || { echo "CodeCov checksum validation failed!" >&2; exit 1; }
-  done
-  bash <codecov -t $CODECOV_TOKEN
+  bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
 fi
 
 clean_up


### PR DESCRIPTION
SCP-3275.  Adapted from https://docs.codecov.io/docs/about-the-codecov-bash-uploader.  Tested locally to confirm the diff routine actually exits if the script has been modified (by modifying the script by hand after downloading.

TO TEST:
1. confirm CI still runs properly
2. confirm that you can run lines 140-147 locally
3. confirm that if you run lines 140-143, then manually alter the 'codecov' script file, line 146 exits with error