### PR TITLE
Removing reference to removed field :authentication_token (SCP-3262)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ arch: amd64
 rvm:
   - 2.6.6
 install:
-  - gem install travis
+  - gem install puma
 branches:
   only:
     - master

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -55,7 +55,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
 
     if @user.persisted?
-      @user.update(authentication_token: Devise.friendly_token(32))
       @user.generate_access_token
       # update a user's FireCloud status
       @user.delay.update_firecloud_status


### PR DESCRIPTION
This is a bugfix to support SCP-3250 and SCP-3262.  Currently sign in using the `google_billing` provider to add the `cloud-billing.readonly` OAuth scope is broken due to a reference to the recently removed `User` field `:authentication_token`.  

This also fixes an issue in Travis builds due to a problem with the latest release of the `travis` gem not being able to install as a standalone due to a circular dependency error.