### PR TITLE
Hotfix: Add STARmap to library preparation protocol menu in expression matrix upload (SCP-3261)

### DIFF
--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -60,6 +60,7 @@ class ExpressionFileInfo
                                 'SeqFISH+',
                                 'Slide-seq',
                                 'smFISH',
+                                'STARmap', # Note WIP for EFO term: https://broadinstitute.zendesk.com/agent/tickets/139334
                                 # single cell ChIP-seq assays
                                 'Drop-ChIP']
   validates :library_preparation_protocol, inclusion: {in: LIBRARY_PREPARATION_VALUES}


### PR DESCRIPTION
This applies `git cherry-pick ew-add-starmap` to release #824 as a hotfix, given an urgent support request.

This supports SCP-3261.