### PR TITLE
fixing mobile layout of footer (SCP-3225)

### DIFF
--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -104,7 +104,7 @@
   padding-left: 25px;
   position: relative;
   margin-top: -108px; /* negative value of footer height */
-  height: 108px;
+  min-height: 108px;
   clear:both;
   p {
     font-size: 14px;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -186,13 +186,13 @@
       <%= scp_link_to 'Privacy Policy', privacy_policy_path %>
       &nbsp;
       <%= scp_link_to "Terms of Service".html_safe, terms_of_service_path %>
+      &nbsp;
+      <% if @selected_branding_group.present? %>
+        <%= link_to "<i class='fas fa-chevron-circle-left fa-fw'></i> Return to Single Cell Portal".html_safe, site_path %>
+      <% end %>
     </div>
+    <div class="clearfix"></div>
 
-  <% if @selected_branding_group.present? %>
-    <div class="footer-text-block">
-      <%= link_to "<i class='fas fa-chevron-circle-left fa-fw'></i> Return to Single Cell Portal".html_safe, site_path %>
-    </div>
-  <% end %>
 </div>
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
 


### PR DESCRIPTION
This fixes a longstanding issue in how the footer wraps when the screen is less than ~1000px wide.  I demoed this last week, and could have sworn this was included in https://github.com/broadinstitute/single_cell_portal_core/pull/970. (see the screenshots there for behavior.). But somehow got missed, or merge-conflicted out.

To test:

Open the home page, confirm the footer contains both the privacy policy and terms of service links
Confirm they render reasonably at various widths