### PR TITLE
fixing inferred search result typo (SCP-3291)

### DIFF
--- a/app/javascript/components/search/results/Study.js
+++ b/app/javascript/components/search/results/Study.js
@@ -137,7 +137,7 @@ export default function Study({ study }) {
 
   let inferredBadge = <></>
   if (study.inferred_match) {
-    const helpText = `${study.termMatches.join(', ')} was not found in study metadata,
+    const helpText = `${termMatches.join(', ')} was not found in study metadata,
      only in study title or description`
     inferredBadge = <span className="badge soft-badge" data-toggle="tooltip" title={helpText}>text match only</span>
   }

--- a/db/seed/synthetic_studies/human_blood_no_metadata/study_info.json
+++ b/db/seed/synthetic_studies/human_blood_no_metadata/study_info.json
@@ -1,0 +1,8 @@
+{
+  "study": {
+    "name": "Human Blood Study with no metadata",
+    "description": "Some studies do not have metadata at all, much less convention compliant data.  We sought to identify whether those studies could be found correctly via faceted or regular search.  This study in particular should appear for searches on blood.  It should also appear on searches for Homo sapiens. We found the presence of this study in those search results was positively correlated with the correct functioning of inferred search, and text search more generally </p>",
+    "data_dir": "test"
+  },
+  "files": []
+}


### PR DESCRIPTION
SCP-3291

This also adds a synthetic study with no metadata so inferred matches are easier to find and test locally