### PR TITLE
Fix Mixpanel search log for `trigger` and `speciesList` (SCP-3254)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -253,7 +253,7 @@ export default function ExploreDisplayTabs({
                 height={ideogramHeight}
                 genesInScope={exploreInfo.uniqueGenes}
                 searchGenes={searchGenes}
-                speciesList={exploreInfo.speciesList}
+                speciesList={exploreInfo.taxonNames}
               />
             }
             { !showViewOptionsControls &&

--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -214,7 +214,8 @@ export default function ExploreDisplayTabs({
           <div className="flexbox">
             <StudyGeneField genes={exploreParams.genes}
               searchGenes={searchGenes}
-              allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}/>
+              allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}
+              speciesList={exploreInfo ? exploreInfo.taxonNames : []}/>
             { /* show if this is gene search || gene list */ }
             <button className={isGene || isGeneList || hasIdeogramOutputs ? 'action fa-lg' : 'hidden'}
               onClick={() => searchGenes([])}
@@ -252,6 +253,7 @@ export default function ExploreDisplayTabs({
                 height={ideogramHeight}
                 genesInScope={exploreInfo.uniqueGenes}
                 searchGenes={searchGenes}
+                speciesList={exploreInfo.speciesList}
               />
             }
             { !showViewOptionsControls &&

--- a/app/javascript/components/explore/ExploreTabRouter.js
+++ b/app/javascript/components/explore/ExploreTabRouter.js
@@ -58,7 +58,7 @@ function updateExploreParams(newOptions, wasUserSpecified=true) {
   navigate(`${query}#study-visualize`, { replace: true })
 }
 
-/** converts query string parameters into the dataParams objet */
+/** converts query string parameters into the dataParams object */
 function buildExploreParamsFromQuery(query) {
   const exploreParams = {
     userSpecified: {}

--- a/app/javascript/components/explore/StudyGeneField.js
+++ b/app/javascript/components/explore/StudyGeneField.js
@@ -40,14 +40,14 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
   const [showEmptySearchModal, setShowEmptySearchModal] = useState(false)
 
   /** handles a user submitting a gene search */
-  function handleSubmit(event) {
+  function handleSearch(event) {
     event.preventDefault()
     const newGeneArray = syncGeneArrayToInputText()
     if (newGeneArray && newGeneArray.length) {
       const genesToSearch = newGeneArray.map(g => g.value)
-      if (event) {
-        // this was not a 'clear'
-        logStudyGeneSearch(genesToSearch, 'submit', speciesList)
+      if (event) { // this was not a 'clear'
+        const trigger = event.type // 'click' or 'submit'
+        logStudyGeneSearch(genesToSearch, trigger, speciesList)
       }
       searchGenes(genesToSearch)
     } else {
@@ -132,11 +132,11 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
   }, [genes.join(',')])
 
   return (
-    <form className="gene-keyword-search gene-study-keyword-search form-horizontal" onSubmit={handleSubmit}>
+    <form className="gene-keyword-search gene-study-keyword-search form-horizontal" onSubmit={handleSearch}>
       <div className="flexbox align-center">
         <div className="input-group">
           <div className="input-group-append">
-            <Button type="submit" data-analytics-name="gene-search-submit">
+            <Button type="button" data-analytics-name="gene-search-submit" onClick={handleSearch}>
               <FontAwesomeIcon icon={faSearch} />
             </Button>
           </div>

--- a/app/javascript/components/explore/StudyGeneField.js
+++ b/app/javascript/components/explore/StudyGeneField.js
@@ -13,7 +13,7 @@ import { log, logStudyGeneSearch } from 'lib/metrics-api'
   * This shares a lot of logic with search/genes/GeneKeyword, but is kept as a separate component for
   * now, as the need for autocomplete raises additional complexity
   */
-export default function StudyGeneField({ genes, searchGenes, allGenes }) {
+export default function StudyGeneField({ genes, searchGenes, allGenes, speciesList }) {
   const [inputText, setInputText] = useState('')
 
   let geneOptions = []
@@ -47,7 +47,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes }) {
       const genesToSearch = newGeneArray.map(g => g.value)
       if (event) {
         // this was not a 'clear'
-        logStudyGeneSearch(genesToSearch, 'submit')
+        logStudyGeneSearch(genesToSearch, 'submit', speciesList)
       }
       searchGenes(genesToSearch)
     } else {

--- a/app/javascript/components/visualization/RelatedGenesIdeogram.js
+++ b/app/javascript/components/visualization/RelatedGenesIdeogram.js
@@ -29,8 +29,9 @@ function onClickAnnot(annot) {
     otherProps[`relatedGenes:${key}`] = value
   })
 
-  otherProps['trigger'] = 'click-related-genes'
-  logStudyGeneSearch([annot.name], null, null, otherProps)
+  const trigger = 'click-related-genes'
+  const speciesList = ideogram.SCP.speciesList
+  logStudyGeneSearch([annot.name], trigger, speciesList, otherProps)
   ideogram.SCP.searchGenes([annot.name])
 }
 
@@ -134,7 +135,7 @@ function onPlotRelatedGenes() {
  * This is only done in the context of single-gene search in Study Overview
  */
 export default function RelatedGenesIdeogram({
-  gene, taxon, target, height, genesInScope, searchGenes
+  gene, taxon, target, height, genesInScope, searchGenes, speciesList
 }) {
   const verticalPad = 40 // Total top and bottom padding
 
@@ -161,7 +162,7 @@ export default function RelatedGenesIdeogram({
       Ideogram.initRelatedGenes(ideoConfig, genesInScope)
 
     // Extend ideogram with custom SCP function to search genes
-    window.ideogram.SCP = { searchGenes }
+    window.ideogram.SCP = { searchGenes, speciesList }
   }, [gene])
 
   return (

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
-    "ideogram": "1.28.0",
+    "ideogram": "1.29.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.12.1",
     "morpheus-app": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7063,10 +7063,10 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ideogram@1.28.0:
-  version "1.28.0"
-  resolved "https://registry.npmjs.org/ideogram/-/ideogram-1.28.0.tgz"
-  integrity sha512-xUvQX6ozPIEx5gHdKU+gWGPKkl2gFK0OK3bnm1FM2X7+qf8bestilnJea8dC9unhLMacd9l48s1DvF+InJW++w==
+ideogram@1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.29.0.tgz#65d0d44bf679f9a4dc4127f37f673fa8723e1735"
+  integrity sha512-ycshKSGctAF5dxRNrbU+Q8gTtdvpNiIw6vJ4smYvYT+mTCfSPhC0oeIpvz6VsByo2X/JPLs261DH9LSzsFaJ3A==
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"


### PR DESCRIPTION
This fixes regressions in how we log the `trigger` and `speciesList` properties for the `search` event in study gene search.

The `trigger` property had regressed to conflate `submit` and `click`, and the `speciesList` property was omitted.  As noted in our lexicon, the [`trigger`](https://mixpanel.com/project/2120588/view/19059/app/lexicon#transformations/event-properties/trigger) is the interaction by which search is initiated -- either `click` (on search button), `submit` (press "Enter" on keyboard), or `related-genes-ideogram` (clicking on a related gene in the ideogram).  The [`speciesList`](https://mixpanel.com/project/2120588/view/19059/app/lexicon#transformations/event-properties/speciesList) is the set of species that was available, i.e. associated with the study's expression matrices.

This also bumps the `ideogram` version, refining minor annotation details.

To test:
* Go to a study with visualizations, and an associated species
* Open DevTools, go to Network panel
* Type in a gene, click search icon
* In Network panel, filter to `bard method:POST`
* Look for the `search` event logged to Bard, verify it shows `trigger: "click"` and `speciesList: ["<Your species>"]`

This satisfies SCP-3254.