### PR TITLE
fixing app import merge error (SCP-3263)

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -25,7 +25,6 @@ import morpheus from 'morpheus-app'
 import checkMissingAuthToken from 'lib/user-auth-tokens'
 // Below import resolves to '/app/javascript/components/HomePageContent.js'
 import HomePageContent from 'components/HomePageContent'
-import Covid19PageContent from 'components/covid19/Covid19PageContent'
 import {
   logPageView, logClick, logMenuChange, log
 } from 'lib/metrics-api'


### PR DESCRIPTION
This got lost in a merge.  What's particularly interesting is that even though this causes a total compilation failure locally, all our tests still pass, and staging is mostly normal (and has the offending change).  So there must be some sort of caching at work