### PR TITLE
Updating API caching to hash genes query string re: % encoding errors (SCP-3214)

### DIFF
--- a/test/integration/cache_management_test.rb
+++ b/test/integration/cache_management_test.rb
@@ -12,10 +12,8 @@ class CacheManagementTest < ActionDispatch::IntegrationTest
 
     study = Study.find_by(name: "Testing Study #{@random_seed}")
     cluster = study.cluster_groups.first
-    cluster_name = cluster.name.split.join('-')
     cluster_underscore = cluster.name.split.join('_') # for API cache paths
     genes = study.genes.map(&:name)
-    gene = genes.sample
     genes_hash = Digest::SHA256.hexdigest genes.sort.join
     cluster.cell_annotations.each do |cell_annotation|
       annotation = "#{cell_annotation[:name]}--#{cell_annotation[:type]}--cluster"
@@ -35,7 +33,7 @@ class CacheManagementTest < ActionDispatch::IntegrationTest
       # construct various cache keys for direct lookup (cannot lookup via regex)
       study_clusters_key = "_single_cell_api_v1_studies_#{study.accession}_clusters_"
       study_cluster_key = "#{study_clusters_key}#{cluster_underscore}_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_cluster_name_#{cluster_underscore}"
-      expression_mean_key = "_single_cell_api_v1_studies_#{study.accession}_expression_violin_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_cluster_name_#{cluster_underscore}_consensus_mean_genes_#{genes.join(',')}_data_type_violin"
+      expression_mean_key = "_single_cell_api_v1_studies_#{study.accession}_expression_violin_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_cluster_name_#{cluster_underscore}_consensus_mean_genes_#{genes_hash}_data_type_violin"
       assert Rails.cache.exist?(study_clusters_key), "Did not find matching API clusters cache entry at #{study_clusters_key}"
       assert Rails.cache.exist?(study_cluster_key), "Did not find matching API single cluster cache entry at #{study_cluster_key}"
       assert Rails.cache.exist?(expression_mean_key), "Did not find matching API expression mean cache entry at #{expression_mean_key}"
@@ -64,7 +62,8 @@ class CacheManagementTest < ActionDispatch::IntegrationTest
     cell_annotation = cluster.cell_annotations.sample
     sanitized_cache_path = "#{study_clusters_key}#{cluster_underscore}_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_foo_bar_cluster_name_#{cluster_underscore}"
     genes = study.genes.map(&:name)
-    sanitized_expression_path = "_single_cell_api_v1_studies_#{study.accession}_expression_violin_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_cluster_name_#{cluster_underscore}_consensus_mean_genes_#{genes.join(',')}_data_type_violin"
+    genes_hash = Digest::SHA256.hexdigest genes.sort.join
+    sanitized_expression_path = "_single_cell_api_v1_studies_#{study.accession}_expression_violin_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_cluster_name_#{cluster_underscore}_consensus_mean_genes_#{genes_hash}_data_type_violin"
 
     # make request with extra parameter with % sign
     get api_v1_study_cluster_path(study_id: study.accession, annotation_name: cell_annotation[:name],


### PR DESCRIPTION
For the last several months, we have noticed a (very) frequently [recurring error](https://sentry.io/organizations/broad-institute/issues/2178215554/?project=1424198&query=is%3Aunresolved+ArgumentError&statsPeriod=14d) in Sentry where attempts to purge entries from the visualization cache fails silently in the background.  While we have been unable to reproduce the error locally, the main issue appears to be that comma-delimited lists of gene names occasionally get corrupted when being transformed into a file path to store responses in the visualization cache. The URL-encoded form of a comma (`%2C`) ends up getting transformed into `%2/C`, or something similar that is not a valid URL-encoded character.  Since all cache expiration is based on regular expression matching, this invalid encoding breaks all `CacheRemovalJob` calls, and ends up preventing caches from being expired when users update files.  Once an invalid cache entry is written, it **_breaks all cache clearing for the entire portal_** until the entire cache is expired on either a deployment, or an administrator running `Rails.cache.clear` in the production console.

This update changes `ApiCaching#get_cache_key` to hash the value of the `genes` query string parameter when computing the cache entry's filename. This will result in more consistently-sized filenames on cache entries by using a hex digest value that maps to the sorted & hashed list of gene names from the request.  

It is worth noting that this feature was actually in place before when visualization requests were handled by `app/controllers/site_controller.rb`, and has now been ported over to `api_caching.rb`.

### Testing

Unfortunately, we have been unable to recreate the conditions where this error occurs.  However, it is possible to test that this new feature works and cache clearing is not impacted.  To test this:

1. Pull this branch, and ensure caching is enabled locally by making sure that the file `tmp/caching-dev.txt` is present.
2. Boot portal and load the `Human HIV and Tuberculosis, blood study`
3. In a separate terminal, enter the rails console and run `Rails.cache.clear` to clear out any existing caches
4. Back in the portal, run a gene search for `APOE` and `AGPAT2`
5. Once the visualization loads, look in the `development.log` file and note the following lines:
```
Writing to API cache: _single_cell_api_v1_studies_SCP18_expression_heatmap_cluster_cluster_tsv_genes_e03d70d640ca9a2f81a83b5de74f3382c241e606f2e2214c8cd74c31ebbb9f50_data_type_heatmap
...
Reading from API cache: _single_cell_api_v1_studies_SCP18_expression_heatmap_cluster_cluster_tsv_genes_e03d70d640ca9a2f81a83b5de74f3382c241e606f2e2214c8cd74c31ebbb9f50_data_type_heatmap
Filter chain halted as :check_api_cache! rendered or redirected
```
6. Back in the rails console, and run the following commands to ensure cache clearing works:
```
study = Study.find_by(name: 'Human HIV and Tuberculosis, blood study')
CacheRemovalJob.new(study.accession).perform
=> true
```
7. Note back in `development.log` the following statements:
```
2021-04-21 14:33:08 -0400: Deleting caches for SCP18
2021-04-21 14:33:08 -0400: caches successfully cleared
```

This PR satisfies SCP-3214.