### PR TITLE
Switch base image to GCR-hosted version (SCP-3264)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM singlecellportal/rails-baseimage:1.1.2
+FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:1.1.3
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-2.6.6'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:1.1.3
+FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:1.2.0
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-2.6.6'


### PR DESCRIPTION
In order to resolve the [Docker Hub rate limit errors](https://www.docker.com/increase-rate-limits) we have been encountering during CI runs in Travis, this update switches the [Docker-hosted](https://hub.docker.com/repository/docker/singlecellportal/rails-baseimage) rails-baseimage to a [GCR-hosted mirror](https://console.cloud.google.com/gcr/images/broad-singlecellportal-staging/GLOBAL/rails-baseimage?project=broad-singlecellportal-staging&gcrImageListsize=30).  The base image will continue to be [published to both](https://github.com/broadinstitute/scp-rails-baseimage/pull/17/files#diff-ca012d969385d0ed162c422aab9ab523ba77567277a4a8bc534dfcf5a6b3c2fcR22) hosts, but SCP will only use the GCR version in order to prevent the rate limit errors from recurring.

This PR satisfies the remainder of SCP-3264.