### PR TITLE
fixing plotly usage in create annotation (SCP-3298)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -118,7 +118,7 @@ function RawScatterPlot({
     // Don't try to update the color if the graph hasn't loaded yet
     if (clusterData && !isLoading) {
       const newDragMode = getDragMode(isCellSelecting)
-      window.Plotly.relayout(graphElementId, { dragmode: newDragMode })
+      Plotly.relayout(graphElementId, { dragmode: newDragMode })
       if (!isCellSelecting) {
         Plotly.restyle(graphElementId, { selectedpoints: [null] })
       }

--- a/app/javascript/components/visualization/controls/CreateAnnotation.js
+++ b/app/javascript/components/visualization/controls/CreateAnnotation.js
@@ -169,11 +169,14 @@ function CreateAnnotation({
     setPlotlyTarget(target)
   }, [currentPointsSelected])
 
-  let createButton = (<button className="action" onClick={handlePanelToggle}>
+  let createButton = (<button className="action"
+    data-analytics-name="toggle-create-annotation"
+    onClick={handlePanelToggle}>
     <FontAwesomeIcon icon={showControl ? faMinus : faPlus}/> Create annotation
   </button>)
   if (!isUserLoggedIn()) {
     createButton = <button className="action"
+      data-analytics-name="toggle-create-annotation-signedout"
       data-toggle="tooltip"
       title="You must sign in to create custom annotations">
       <FontAwesomeIcon icon={faPlus}/> Create annotation

--- a/test/js/explore/create-annotations.test.js
+++ b/test/js/explore/create-annotations.test.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import CreateAnnotation from 'components/visualization/controls/CreateAnnotation'
+
+describe('create annotation toggles appropriately', () => {
+  it('lets you open the pane', async () => {
+    const wrapper = mount((
+      <CreateAnnotation
+        isSelecting={false}
+        setIsSelecting={() => {}}/>
+    ))
+    let panel = wrapper.find('Panel.create-annotation').first()
+    expect(panel.prop('expanded')).toEqual(false)
+    const createButton = wrapper.find('button[data-analytics-name="toggle-create-annotation"]').first()
+    createButton.simulate('click')
+    panel = wrapper.find('Panel.create-annotation').first()
+    expect(panel.prop('expanded')).toEqual(true)
+  })
+})


### PR DESCRIPTION
SCP-3298. 
This also adds a basic check to confirm that the component can render itself without error.  A full behavioral check is well beyond the capabilities of our current test framework.

TO TEST:
 0. sing in and open a study
 1.  click 'create annotations'
 2.  observe the create annotations controls render

