### PR TITLE
harmonize syntax for headers/params re: strings vs. symbols as JSON (SCP-3293)

### DIFF
--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -35,8 +35,8 @@ class MetricsService
   def self.get_default_headers(user)
     access_token = user.token_for_api_call
     {
-      'Authorization': "Bearer #{access_token.present? ? access_token.dig('access_token') : nil }",
-      'Content-Type': 'application/json'
+      'Authorization' => "Bearer #{access_token.present? ? access_token.dig('access_token') : nil }",
+      'Content-Type' => 'application/json'
     }
   end
 
@@ -68,7 +68,7 @@ class MetricsService
     user.update(metrics_uuid: user_id) if user_id != user.metrics_uuid
 
     post_body = {
-      'anonId': user_id
+      'anonId' => user_id
     }.to_json
 
     params = {
@@ -79,7 +79,6 @@ class MetricsService
 
     # only post to /identify if user is registered, otherwise Bard responds 503 due to upstream errors in SAM
     self.post_to_bard(params, user) if user.registered_for_firecloud
-
   end
 
   # Log metrics to Mixpanel via Bard web service
@@ -113,7 +112,7 @@ class MetricsService
       props['authenticated'] = true
     end
 
-    post_body = {'event': name, 'properties': props}.to_json
+    post_body = {'event' => name, 'properties' => props}.to_json
 
     params = {
       url: BARD_ROOT + '/api/event',
@@ -122,7 +121,6 @@ class MetricsService
     }
 
     self.post_to_bard(params, user)
-
   end
 
   # Log error metrics to Mixpanel via Bard web service
@@ -176,18 +174,18 @@ class MetricsService
     end
 
     headers = {
-      'Content-Type': 'application/json'
+      'Content-Type' => 'application/json'
     }
 
     # configure properties/headers depending on user presence
     if user.present?
       props.merge!({ authenticated: true, registeredForTerra: user.registered_for_firecloud })
-      headers.merge!({'Authorization': "Bearer #{user.token_for_api_call.dig('access_token')}"})
+      headers.merge!({'Authorization' => "Bearer #{user.token_for_api_call.dig('access_token')}"})
     else
       props.merge!({ authenticated: false, distinct_id: request.cookies['user_id'] })
     end
 
-    post_body = {'event': 'error', 'properties': props}.to_json
+    post_body = {'event' => 'error', 'properties' => props}.to_json
 
     params = {
       url: BARD_ROOT + '/api/event',


### PR DESCRIPTION
There is discrepancy between the number Ingest error emails received on a daily basis vs. counts reported in our [Ingest Job Status report](https://mixpanel.com/project/2120588/view/19059/app/insights#report/11688551/ingest-job-status/~(columnWidths~(bar~())~description~'~displayOptions~(chartType~'line~plotStyle~'stacked~analysis~'linear~value~'absolute)~sorting~(bar~(sortBy~'column~colSortAttrs~(~(sortBy~'value~sortOrder~'desc)~(sortBy~'value~sortOrder~'desc)))~line~(sortBy~'value~sortOrder~'desc)~table~(sortBy~'column~colSortAttrs~(~(sortBy~'label~sortOrder~'asc)~(sortBy~'label~sortOrder~'asc))))~timeComparison~null~querySamplingEnabled~false~dashboard~(id~734187~title~'Ingest*20-*20Single*20Cell*20Portal)~sections~(show~(~(dataset~'!mixpanel~value~(name~'!all_events~resourceType~'events)~resourceType~'events~profileType~null~search~'~dataGroupId~null~math~'total~perUserAggregation~null~property~null))~group~(~(dataset~'!mixpanel~value~'jobStatus~resourceType~'events~profileType~null~search~'~dataGroupId~null~propertyType~'string~typeCast~null~unit~null))~filter~(clauses~(~(dataset~'!mixpanel~value~'jobStatus~resourceType~'events~profileType~null~search~'~dataGroupId~null~filterType~'string~defaultType~'string~filterOperator~'equals~filterValue~(~'failed~'success)~propertyObjectKey~null))~determiner~'all)~time~(~(dateRangeType~'in*20the*20last~unit~'day~window~(unit~'day~value~30))))~legend~())) in Mixpanel. Not all failures (and successes, for that matter) are being recorded in Mixpanel.  For instance: we received 8 error emails on April 20, 2021, but none were recorded in Mixpanel.  After inspecting the logs in production, it was noted that the calls were being made, but Bard was responding `503` to many of these calls, which is indicative of an error when attempting to harmonize the user credentials.  If the user is not registered for Terra, but an `Authorization: Bearer` header is provided with the request, Bard cannot find the corresponding user in SAM, and will respond `503` (which is also misleading, as it should be `401`).

Further inspection has determined that the cause of this error in SCP is due to a problem in how we are declaring header objects.  There was a mixture in the usage of strings and symbols (or even strings that contained symbols) when instantiating the Hash objects, that results in a bug when trying to remove certain headers as `"Authorization"` is not the same as `:Authorization` (or in some cases `":Authorization"`).  This update standardizes the format to use strings, as this is the standard for JSON/HTTP.  This also adds a test to ensure that non-Terra users do not pass the `Authorization: Bearer` token on any calls to Bard.

To test:
1. Prerequisite: sign in to your local instance at least once with a Google account that is not registered for Terra
2. In the Rails console, run this snippet:
```
email = "<email of non-Terra user>"
user = User.find_by(email: email)
MetricsService.log('my-fake-event', {foo: 'bar'}, user)
```
3. Note response in console of `<RestClient::Response 200 "">`

This PR satisfies SCP-3293.
