### PR TITLE
adding additional allowed suffixes (SCP-3296)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -48,7 +48,7 @@ var ALLOWED_FILE_TYPES = {
     plainText: /(\.|\/)(txt|text|tsv|csv)(\.gz)?$/i,
     primaryData: /((\.(fq|fastq)(\.tar)?\.gz$)|\.bam)/i,
     bundled: /(\.|\/)(txt|text|tsv|csv|bam\.bai)(\.gz)?$/i,
-    miscellaneous: /(\.|\/)(txt|text|tsv|csv|jpg|jpeg|png|pdf|doc|docx|xls|xlsx|ppt|pptx|zip|loom|h5|h5ad|h5an)(\.gz)?$/i
+    miscellaneous: /(\.|\/)(txt|text|tsv|csv|jpg|jpeg|png|pdf|doc|docx|xls|xlsx|ppt|pptx|zip|loom|h5|h5ad|h5an|ipynb|Rda|rda|Rds|rds)(\.gz)?$/i
 };
 
 // options for Spin.js


### PR DESCRIPTION
SCP-3296

TO TEST:
0. create a file with a `ipynb` `Rda` `rda` `Rds` or `rds` suffix
1. attempt to upload it to a study
2. confirm upload succeeds
3. create a file with a `foobar` suffix
4. confirm upload is still disallowed