### PR TITLE
Refactoring `CellMetadatum#cell_annotations` for performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
   only:
     - master
     - development
+    - db-optimized-cluster-endpoint
 services:
   - docker
 before_install:

--- a/app/models/cell_metadatum.rb
+++ b/app/models/cell_metadatum.rb
@@ -55,7 +55,7 @@ class CellMetadatum
     query = {name: array_name, array_type: array_type, linear_data_type: 'CellMetadatum', linear_data_id: self.id,
              study_id: self.study_id, study_file_id: self.study_file_id, cluster_group_id: nil,
              cluster_name: self.study_file.upload_file_name, subsample_threshold: nil, subsample_annotation: nil}
-    DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce(&:+)
+    DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce([], :+)
   end
 
   # create dropdown menu value for annotation select

--- a/app/models/cell_metadatum.rb
+++ b/app/models/cell_metadatum.rb
@@ -43,7 +43,7 @@ class CellMetadatum
 
   # concatenate all the necessary data_array objects and construct a hash of cell names => expression values
   def cell_annotations
-    cells = self.study.all_cells_array
+    cells = self.all_study_cells
     # replace blank/nil values with default missing label
     annot_values = AnnotationVizService.sanitize_values_array(
       self.concatenate_data_arrays(self.name, 'annotations'), self.annotation_type
@@ -51,15 +51,18 @@ class CellMetadatum
     Hash[cells.zip(annot_values)]
   end
 
-  # concatenate data arrays of a given name/type in order
+  def all_study_cells
+    query = {name: 'All Cells', array_type: 'cells', linear_data_type: 'Study', linear_data_id: self.study_id,
+             cluster_name: self.study_file.upload_file_name, study_id: self.study_id, study_file_id: self.study_file_id,
+             cluster_group_id: nil, subsample_annotation: nil, subsample_threshold: nil}
+    DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce([], :+)
+  end
+
   def concatenate_data_arrays(array_name, array_type)
-    data_arrays = DataArray.where(name: array_name, array_type: array_type, linear_data_type: 'CellMetadatum',
-                                  linear_data_id: self.id).order(:array_index => 'asc')
-    all_values = []
-    data_arrays.each do |array|
-      all_values += array.values
-    end
-    all_values
+    query = {name: array_name, array_type: array_type, linear_data_type: 'CellMetadatum', linear_data_id: self.id,
+             study_id: self.study_id, study_file_id: self.study_file_id, cluster_group_id: nil,
+             cluster_name: self.study_file.upload_file_name, subsample_threshold: nil, subsample_annotation: nil}
+    DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce([], :+)
   end
 
   # create dropdown menu value for annotation select

--- a/app/models/cell_metadatum.rb
+++ b/app/models/cell_metadatum.rb
@@ -43,7 +43,7 @@ class CellMetadatum
 
   # concatenate all the necessary data_array objects and construct a hash of cell names => expression values
   def cell_annotations
-    cells = self.all_study_cells
+    cells = self.study.all_cells_array
     # replace blank/nil values with default missing label
     annot_values = AnnotationVizService.sanitize_values_array(
       self.concatenate_data_arrays(self.name, 'annotations'), self.annotation_type
@@ -51,18 +51,11 @@ class CellMetadatum
     Hash[cells.zip(annot_values)]
   end
 
-  def all_study_cells
-    query = {name: 'All Cells', array_type: 'cells', linear_data_type: 'Study', linear_data_id: self.study_id,
-             cluster_name: self.study_file.upload_file_name, study_id: self.study_id, study_file_id: self.study_file_id,
-             cluster_group_id: nil, subsample_annotation: nil, subsample_threshold: nil}
-    DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce([], :+)
-  end
-
   def concatenate_data_arrays(array_name, array_type)
     query = {name: array_name, array_type: array_type, linear_data_type: 'CellMetadatum', linear_data_id: self.id,
              study_id: self.study_id, study_file_id: self.study_file_id, cluster_group_id: nil,
              cluster_name: self.study_file.upload_file_name, subsample_threshold: nil, subsample_annotation: nil}
-    DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce([], :+)
+    DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce(&:+)
   end
 
   # create dropdown menu value for annotation select

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1250,7 +1250,7 @@ class Study
   # return an array of all single cell names in study, will check for master list of cells or concatenate all
   # cell lists from individual expression matrices
   def all_cells_array
-    if study.metadata_file&.parsed? # nil-safed via &
+    if self.metadata_file&.parsed? # nil-safed via &
       query = {name: 'All Cells', array_type: 'cells', linear_data_type: 'Study', linear_data_id: self.id,
                cluster_name: self.metadata_file.upload_file_name, study_id: self.id, study_file_id: self.metadata_file.id,
                cluster_group_id: nil, subsample_annotation: nil, subsample_threshold: nil}

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1250,9 +1250,11 @@ class Study
   # return an array of all single cell names in study, will check for master list of cells or concatenate all
   # cell lists from individual expression matrices
   def all_cells_array
-    arrays = DataArray.where(study_id: self.id, linear_data_type: 'Study', linear_data_id: self.id, name: 'All Cells').order_by(&:array_index)
-    if arrays.any?
-      arrays.pluck(:values).reduce(&:+)
+    if self.metadata_file.present? && self.metadata_file.parsed?
+      query = {name: 'All Cells', array_type: 'cells', linear_data_type: 'Study', linear_data_id: self.id,
+               cluster_name: self.metadata_file.upload_file_name, study_id: self.id, study_file_id: self.metadata_file.id,
+               cluster_group_id: nil, subsample_annotation: nil, subsample_threshold: nil}
+      DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce(&:+)
     else
       self.all_expression_matrix_cells
     end
@@ -1270,8 +1272,10 @@ class Study
 
   # return the cells found in a single expression matrix
   def expression_matrix_cells(study_file)
-    arrays = DataArray.where(name: "#{study_file.name} Cells", array_type: 'cells', linear_data_type: 'Study',
-                             linear_data_id: self.id, study_file_id: study_file.id).order_by(&:array_index)
+    arrays = DataArray.where(name: "#{study_file.upload_file_name} Cells", array_type: 'cells', linear_data_type: 'Study',
+                             linear_data_id: self.id, study_file_id: study_file.id, cluster_group_id: nil,
+                             cluster_name: study_file.upload_file_name, subsample_annotation: nil,
+                             subsample_threshold: nil).order(:array_index => 'asc')
     arrays.pluck(:values).reduce(&:+)
   end
 

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1250,11 +1250,11 @@ class Study
   # return an array of all single cell names in study, will check for master list of cells or concatenate all
   # cell lists from individual expression matrices
   def all_cells_array
-    if self.metadata_file.present? && self.metadata_file.parsed?
+    if study.metadata_file&.parsed? # nil-safed via &
       query = {name: 'All Cells', array_type: 'cells', linear_data_type: 'Study', linear_data_id: self.id,
                cluster_name: self.metadata_file.upload_file_name, study_id: self.id, study_file_id: self.metadata_file.id,
                cluster_group_id: nil, subsample_annotation: nil, subsample_threshold: nil}
-      DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce(&:+)
+      DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce([], :+)
     else
       self.all_expression_matrix_cells
     end
@@ -1276,7 +1276,7 @@ class Study
                              linear_data_id: self.id, study_file_id: study_file.id, cluster_group_id: nil,
                              cluster_name: study_file.upload_file_name, subsample_annotation: nil,
                              subsample_threshold: nil).order(:array_index => 'asc')
-    arrays.pluck(:values).reduce(&:+)
+    arrays.pluck(:values).reduce([], :+)
   end
 
   # return a hash keyed by cell name of the requested study_metadata values


### PR DESCRIPTION
This refactoring has three key improvements:

1. Fully leverages the unique `linear_data_arrays_index` on the `DataArray` collection
2. Uses `pluck` and `reduce` to concatenate values rather than `each` and `+=`
3. Avoids calling `any?` on query cursor to prevent running count operation (~2s)

When [profiled](https://docs.google.com/spreadsheets/d/1WHJzz7vL5XDhyKuLp16Cx10_BhhzIJyD28VyLeqny3U/edit#gid=0) with `GenericProfiler`, this showed a 26% improvement over the original implementation.