### PR TITLE
Optimizing performance of loading annotation/cell name arrays (SCP-3302)

### DIFF
--- a/app/models/cell_metadatum.rb
+++ b/app/models/cell_metadatum.rb
@@ -53,13 +53,10 @@ class CellMetadatum
 
   # concatenate data arrays of a given name/type in order
   def concatenate_data_arrays(array_name, array_type)
-    data_arrays = DataArray.where(name: array_name, array_type: array_type, linear_data_type: 'CellMetadatum',
-                                  linear_data_id: self.id).order(:array_index => 'asc')
-    all_values = []
-    data_arrays.each do |array|
-      all_values += array.values
-    end
-    all_values
+    query = {name: array_name, array_type: array_type, linear_data_type: 'CellMetadatum', linear_data_id: self.id,
+             study_id: self.study_id, study_file_id: self.study_file_id, cluster_group_id: nil,
+             cluster_name: self.study_file.upload_file_name, subsample_threshold: nil, subsample_annotation: nil}
+    DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce(&:+)
   end
 
   # create dropdown menu value for annotation select

--- a/app/models/cell_metadatum.rb
+++ b/app/models/cell_metadatum.rb
@@ -56,7 +56,7 @@ class CellMetadatum
     query = {name: array_name, array_type: array_type, linear_data_type: 'CellMetadatum', linear_data_id: self.id,
              study_id: self.study_id, study_file_id: self.study_file_id, cluster_group_id: nil,
              cluster_name: self.study_file.upload_file_name, subsample_threshold: nil, subsample_annotation: nil}
-    DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce(&:+)
+    DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce([], :+)
   end
 
   # create dropdown menu value for annotation select

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1250,7 +1250,7 @@ class Study
   # return an array of all single cell names in study, will check for master list of cells or concatenate all
   # cell lists from individual expression matrices
   def all_cells_array
-    if study.metadata_file&.parsed? # nil-safed via &
+    if self.metadata_file&.parsed? # nil-safed via &
       query = {name: 'All Cells', array_type: 'cells', linear_data_type: 'Study', linear_data_id: self.id,
                cluster_name: self.metadata_file.upload_file_name, study_id: self.id, study_file_id: self.metadata_file.id,
                cluster_group_id: nil, subsample_annotation: nil, subsample_threshold: nil}

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1250,9 +1250,11 @@ class Study
   # return an array of all single cell names in study, will check for master list of cells or concatenate all
   # cell lists from individual expression matrices
   def all_cells_array
-    arrays = DataArray.where(study_id: self.id, linear_data_type: 'Study', linear_data_id: self.id, name: 'All Cells').order_by(&:array_index)
-    if arrays.any?
-      arrays.pluck(:values).reduce(&:+)
+    if self.metadata_file.present? && self.metadata_file.parsed?
+      query = {name: 'All Cells', array_type: 'cells', linear_data_type: 'Study', linear_data_id: self.id,
+               cluster_name: self.metadata_file.upload_file_name, study_id: self.id, study_file_id: self.metadata_file.id,
+               cluster_group_id: nil, subsample_annotation: nil, subsample_threshold: nil}
+      DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce(&:+)
     else
       self.all_expression_matrix_cells
     end
@@ -1270,8 +1272,10 @@ class Study
 
   # return the cells found in a single expression matrix
   def expression_matrix_cells(study_file)
-    arrays = DataArray.where(name: "#{study_file.name} Cells", array_type: 'cells', linear_data_type: 'Study',
-                             linear_data_id: self.id, study_file_id: study_file.id).order_by(&:array_index)
+    arrays = DataArray.where(name: "#{study_file.upload_file_name} Cells", array_type: 'cells', linear_data_type: 'Study',
+                             linear_data_id: self.id, study_file_id: study_file.id, cluster_group_id: nil,
+                             cluster_name: study_file.upload_file_name, subsample_annotation: nil,
+                             subsample_threshold: nil).order(:array_index => 'asc')
     arrays.pluck(:values).reduce(&:+)
   end
 

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1250,7 +1250,7 @@ class Study
   # return an array of all single cell names in study, will check for master list of cells or concatenate all
   # cell lists from individual expression matrices
   def all_cells_array
-    if !!study.metadata_file&.parsed? # nil-safed via &, !! converts to boolean: nil|false == false
+    if study.metadata_file&.parsed? # nil-safed via &, !! converts to boolean: nil|false == false
       query = {name: 'All Cells', array_type: 'cells', linear_data_type: 'Study', linear_data_id: self.id,
                cluster_name: self.metadata_file.upload_file_name, study_id: self.id, study_file_id: self.metadata_file.id,
                cluster_group_id: nil, subsample_annotation: nil, subsample_threshold: nil}

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1254,7 +1254,7 @@ class Study
       query = {name: 'All Cells', array_type: 'cells', linear_data_type: 'Study', linear_data_id: self.id,
                cluster_name: self.metadata_file.upload_file_name, study_id: self.id, study_file_id: self.metadata_file.id,
                cluster_group_id: nil, subsample_annotation: nil, subsample_threshold: nil}
-      DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce(&:+)
+      DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce([], :+)
     else
       self.all_expression_matrix_cells
     end
@@ -1276,7 +1276,7 @@ class Study
                              linear_data_id: self.id, study_file_id: study_file.id, cluster_group_id: nil,
                              cluster_name: study_file.upload_file_name, subsample_annotation: nil,
                              subsample_threshold: nil).order(:array_index => 'asc')
-    arrays.pluck(:values).reduce(&:+)
+    arrays.pluck(:values).reduce([], :+)
   end
 
   # return a hash keyed by cell name of the requested study_metadata values

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1250,7 +1250,7 @@ class Study
   # return an array of all single cell names in study, will check for master list of cells or concatenate all
   # cell lists from individual expression matrices
   def all_cells_array
-    if study.metadata_file&.parsed? # nil-safed via &, !! converts to boolean: nil|false == false
+    if study.metadata_file&.parsed? # nil-safed via &
       query = {name: 'All Cells', array_type: 'cells', linear_data_type: 'Study', linear_data_id: self.id,
                cluster_name: self.metadata_file.upload_file_name, study_id: self.id, study_file_id: self.metadata_file.id,
                cluster_group_id: nil, subsample_annotation: nil, subsample_threshold: nil}

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1250,7 +1250,7 @@ class Study
   # return an array of all single cell names in study, will check for master list of cells or concatenate all
   # cell lists from individual expression matrices
   def all_cells_array
-    if self.metadata_file.present? && self.metadata_file.parsed?
+    if !!study.metadata_file&.parsed? # nil-safed via &, !! converts to boolean: nil|false == false
       query = {name: 'All Cells', array_type: 'cells', linear_data_type: 'Study', linear_data_id: self.id,
                cluster_name: self.metadata_file.upload_file_name, study_id: self.id, study_file_id: self.metadata_file.id,
                cluster_group_id: nil, subsample_annotation: nil, subsample_threshold: nil}

--- a/test/factories/data_array.rb
+++ b/test/factories/data_array.rb
@@ -18,6 +18,8 @@ FactoryBot.define do
     cluster_name { cluster_group.try(:name) || study_file.try(:name) }
     cluster_group_id { cluster_group.try(:id) }
     linear_data_id { cluster_group.try(:id) || gene.try(:id) || cell_metadatum.try(:id) || study.id }
+    subsample_threshold { nil }
+    subsample_annotation { nil }
     linear_data_type do
       if cluster_group_id
         'ClusterGroup'

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     upload_file_name { name }
     factory :metadata_file do
       file_type { 'Metadata' }
+      parse_status { 'parsed' }
       transient do
         # cell_input is an array of all cell names
         # e.g.  ['cellA', 'cellB', 'cellC']
@@ -35,6 +36,7 @@ FactoryBot.define do
       # using this factory to create a sample cluster file with cells and annotations takes ~1.5 seconds
       # a cluster file without cells and annotations takes ~0.5secods
       file_type { 'Cluster' }
+      parse_status { 'parsed' }
       is_spatial { false }
       transient do
         # cell_input is a hash of three (or 4) arrays: cells, x and y and z
@@ -62,6 +64,7 @@ FactoryBot.define do
     end
     factory :expression_file do
       file_type { 'Expression Matrix' }
+      parse_status { 'parsed' }
       transient do
         # expression_input is a hash of gene names to expression values
         # expression values should be an array of arrays, where each sub array is a cellName->value pair
@@ -82,6 +85,7 @@ FactoryBot.define do
     end
     factory :coordinate_label_file do
       file_type { 'Coordinate Labels' }
+      parse_status { 'parsed' }
       transient do
         # label input is used for coordinate-based annotations
         label_input {}


### PR DESCRIPTION
This update optimizes performance of loading annotation/cell name arrays in the `Study` and `CellMetadatum` models.  The substantive changes are:

1. Leverage the entire `linear_data_arrays_index` in the `DataArray` model
2. Avoid calling `any?` after creating query cursor as this performs a document count - checking for the existence of a parsed metadata file achieves the same goal in a fraction of the time (~2s savings)
3. Use `pluck` and `reduce` instead of `each` and `+=` when concatenating values (20% faster)

When profiling in development, this showed an overall increase of 26% in load performance compared to the original implementation.

This PR satisfies SCP-3302.