### PR TITLE
Convert '10X' to '10x' in alexandria_convention BQ tables (SCP-3295) 

### DIFF
--- a/db/migrate/20210426191308_replace10_x_in_alexandria_convention.rb
+++ b/db/migrate/20210426191308_replace10_x_in_alexandria_convention.rb
@@ -1,0 +1,22 @@
+class Replace10XInAlexandriaConvention < Mongoid::Migration
+  # from https://cloud.google.com/bigquery/docs/updating-data#updating_data
+  def self.up
+    client = BigQueryClient.new.client
+    [CellMetadatum::BIGQUERY_DATASET, 'cell_metadata_test'].each do |dataset_name|
+      dataset = client.dataset(dataset_name)
+      if dataset.present?
+        col_name = 'library_preparation_protocol__ontology_label'
+        # query will match all instances of library_preparation_protocol__ontology_label beginning with the
+        # substring '10X ' and replace it with '10x ', e.g. "10X 3' v2 sequencing" => "10x 3' v2 sequencing"
+        update_query = "UPDATE #{CellMetadatum::BIGQUERY_TABLE}"
+        replace_clause = "SET #{col_name} = REGEXP_REPLACE(#{col_name}, r\"10X \", \"10x \")"
+        where_clause = "WHERE REGEXP_CONTAINS(#{col_name}, r\"^10X \")"
+        query_string = "#{update_query} #{replace_clause} #{where_clause}"
+        dataset.query query_string
+      end
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
A recent update of the Experimental Factor Ontology (EFO) ontology in EBI OLS has changed [all entries for 10x sequencing](https://www.ebi.ac.uk/ols/search?q=10x&ontology=efo) so that their existing labels read `10x` instead of `10X`.  As we have stored these labels in our BQ tables (from which all faceted search controls are rendered), we will have to update existing entries in BQ directly.

This update adds a migration that will update all affected rows.  This will only match entries that begin with the substring `10X`, and does an in-place replacement with the correct form of `10x`.

TO TEST:
1. Run the following query in your `alexandria_convention` BQ table:
```
SELECT DISTINCT(library_preparation_protocol__ontology_label) 
FROM `{name of your GCP project}.cell_metadata_development.alexandria_convention`
```
2. Note entry for `10X 3' v2 sequencing`
3. Pull this branch, run `rails_local_setup.rb`, and then run this migration with `bin/rails db:migrate`
4. Note migration succeeds after 5-10s
5. Re-run first query and note that `10X 3' v2 sequencing` now reads  `10x 3' v2 sequencing`

This PR satisfies SCP-3295.