### PR TITLE
Refining regular expression, update filters in Mongo after migration runs (SCP-3295)

### DIFF
--- a/db/migrate/20210426191308_replace10_x_in_alexandria_convention.rb
+++ b/db/migrate/20210426191308_replace10_x_in_alexandria_convention.rb
@@ -9,12 +9,14 @@ class Replace10XInAlexandriaConvention < Mongoid::Migration
         # query will match all instances of library_preparation_protocol__ontology_label beginning with the
         # substring '10X ' and replace it with '10x ', e.g. "10X 3' v2 sequencing" => "10x 3' v2 sequencing"
         update_query = "UPDATE #{CellMetadatum::BIGQUERY_TABLE}"
-        replace_clause = "SET #{col_name} = REGEXP_REPLACE(#{col_name}, r\"10X \", \"10x \")"
+        replace_clause = "SET #{col_name} = REGEXP_REPLACE(#{col_name}, r\"^10X \", \"10x \")"
         where_clause = "WHERE REGEXP_CONTAINS(#{col_name}, r\"^10X \")"
         query_string = "#{update_query} #{replace_clause} #{where_clause}"
         dataset.query query_string
       end
     end
+    # update cached entries
+    SearchFacet.update_all_facet_filters
   end
 
   def self.down


### PR DESCRIPTION
This is an update to #1007 that refines the regular expression to only match & update `library_preparation_protocol__ontology_label` entries that _begin_ with `10X`.  The previous version would update `10X` anywhere in the label, as opposed to only the beginning.  Also, this adds a call to update the cached filter values in MongoDB via `SearchFacet.update_all_facet_filters`.  Without this call, the faceted search filter values will still contain the old values with `10X`.