### PR TITLE
Fixed routing constraints for gene list URL param (SCP-3265)

### DIFF
--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -127,13 +127,6 @@ module Api
               key :type, :string
             end
             parameter do
-              key :name, :gene_list
-              key :in, :query
-              key :description, 'Name of gene list (overrides other parameters)'
-              key :required, false
-              key :type, :string
-            end
-            parameter do
               key :name, :annotation_type
               key :in, :query
               key :description, 'Type of annotation. One of "group" or "numeric".'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,9 @@ Rails.application.routes.draw do
               get 'cell_values', to: 'visualization/annotations#cell_values'
             end
           end
-          get get 'annotations/gene_lists/:gene_list', to: 'visualization/annotations#gene_list'
+          get 'annotations/gene_lists/:gene_list', to: 'visualization/annotations#gene_list',
+              constraints: { gene_list: /[^\/]+/ },
+              as: :annotations_gene_list
 
           resources :user_annotations, only: [:create], params: :accession
         end

--- a/test/api/visualization/annotations_controller_test.rb
+++ b/test/api/visualization/annotations_controller_test.rb
@@ -34,6 +34,34 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
                                                      {name: 'species', type: 'group', values: ['dog', 'cat', 'dog']},
                                                      {name: 'disease', type: 'group', values: ['none', 'none', 'measles']}
                                                    ])
+
+    marker_cluster_list = %w(Cluster1 Cluster2 Cluster3)
+    @gene_list_file = FactoryBot.create(:gene_list,
+                                       study: @basic_study,
+                                       name: 'marker_gene_list.txt',
+                                       list_name: 'Marker List 1',
+                                       clusters_input: marker_cluster_list,
+                                       gene_scores_input: [
+                                         {
+                                           'PTEN' => Hash[marker_cluster_list.zip([1,2,3])]
+                                         },
+                                         {
+                                           'AGPAT2' => Hash[marker_cluster_list.zip([4,5,6])]
+                                         }
+                                       ])
+    @gene_list_file_2 = FactoryBot.create(:gene_list,
+                                         study: @basic_study,
+                                         name: 'marker_gene_list_2.txt',
+                                         list_name: 'gene_list.with.periods',
+                                         clusters_input: marker_cluster_list,
+                                         gene_scores_input: [
+                                           {
+                                             'APOE' => Hash[marker_cluster_list.zip([9,8,7])]
+                                           },
+                                           {
+                                             'ACTA2' => Hash[marker_cluster_list.zip([6,5,4])]
+                                           }
+                                         ])
   end
 
   teardown do
@@ -92,5 +120,16 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
                                                                            annotation_type: 'group',
                                                                            cluster: 'clusterA.txt'}))
     assert_equal json, "NAME\tfoo\nA\tbar\nB\tbar\nC\tbaz"
+  end
+
+  test 'should load gene list by name' do
+    sign_in_and_update @user
+    # normal request
+    execute_http_request(:get, api_v1_study_annotations_gene_list_path(@basic_study, 'Marker List 1'))
+    assert_response :success
+
+    # request w/ periods in name
+    execute_http_request(:get, api_v1_study_annotations_gene_list_path(@basic_study, 'gene_list.with.periods'))
+    assert_response :success
   end
 end

--- a/test/factories/precomputed_score.rb
+++ b/test/factories/precomputed_score.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  # create a precomputed_score (i.e "gene list")
+  factory :precomputed_score do
+    study { study_file.study }
+    name { }
+    clusters { }
+    gene_scores { }
+  end
+end

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -120,5 +120,21 @@ FactoryBot.define do
         }
       }
     end
+    factory :gene_list do
+      file_type { 'Gene List' }
+      parse_status { 'parsed' }
+      transient do
+        list_name {}
+        clusters_input {}
+        gene_scores_input {}
+      end
+      after(:create) do |file, evaluator|
+        FactoryBot.create(:precomputed_score,
+                          name: evaluator.list_name,
+                          clusters: evaluator.clusters_input,
+                          gene_scores: evaluator.gene_scores_input,
+                          study_file: file)
+      end
+    end
   end
 end

--- a/test/models/precomputed_score_test.rb
+++ b/test/models/precomputed_score_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class PrecomputedScoreTest < ActiveSupport::TestCase
+  include Minitest::Hooks
+  include TestInstrumentor
+  include SelfCleaningSuite
+
+  before(:all) do
+    @user = FactoryBot.create(:api_user, test_array: @@users_to_clean)
+    @basic_study = FactoryBot.create(:detached_study,
+                                     name_prefix: 'Gene List Study',
+                                     public: false,
+                                     user: @user,
+                                     test_array: @@studies_to_clean)
+    @cluster_list = %w(Cluster1 Cluster2 Cluster3)
+    @gene_scores = [
+      {
+        'PTEN' => Hash[@cluster_list.zip([1,2,3])]
+      },
+      {
+        'AGPAT2' => Hash[@cluster_list.zip([4,5,6])]
+      }
+    ]
+    @gene_list_file = FactoryBot.create(:gene_list,
+                                        study: @basic_study,
+                                        name: 'marker_gene_list.txt',
+                                        list_name: 'Marker List 1',
+                                        clusters_input: @cluster_list,
+                                        gene_scores_input: @gene_scores)
+  end
+
+  test 'should return GCT of expression scores' do
+    precomputed_score = @basic_study.precomputed_scores.by_name('Marker List 1')
+    assert precomputed_score.present?
+    gct = precomputed_score.to_gct
+    gct_list = gct.split("\n").map(&:strip)
+    expression_entries = gct_list[3..]
+    expression_entries.each do |line|
+      values = line.split("\t")
+      gene_name = values.first
+      expression_scores = values[2..].map(&:to_i) # must convert to Integer since this was rendered as text
+      matching_entry = @gene_scores.detect {|score| score.keys.first == gene_name }
+      assert matching_entry.present?
+      expected_clusters = matching_entry.values.first.keys
+      expected_expression = matching_entry.values.first.values
+      assert_equal expected_clusters, precomputed_score.clusters
+      assert_equal expected_expression, expression_scores
+    end
+  end
+end


### PR DESCRIPTION
This fixes an issue with loading gene lists from the `Api::V1::Visualization::AnnotationsController` when the requested gene list has periods or slashes in the name.  Previously it would treat periods as a format extension, and slashes as another subpath, both resulting in `404` responses.  This update adds a routing constraint to treat all characters after `:study_accession/annotations/gene_lists/` as the name of the gene list.  In addition, this adds more test coverage for `PrecomputedScore` (a.k.a gene list) entities.

This PR satisfies SCP-3265.