### PR TITLE
Fix Mixpanel logs for staging frontend (SCP-3309)

### DIFF
--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -26,7 +26,7 @@ const defaultInit = {
 
 const bardDomainsByEnv = {
   development: 'https://terra-bard-dev.appspot.com',
-  staging: 'https://terra-bard-alpha.appspot.com',
+  staging: 'https://terra-bard-dev.appspot.com',
   production: 'https://terra-bard-prod.appspot.com'
 }
 


### PR DESCRIPTION
This fixes Mixpanel logs for the staging frontend.  I've tested this quick fix on staging, and [it works](https://mixpanel.com/s/3mPtKW). A more robust (but less quick) fix is outlined in SCP-2866.

This satisfies SCP-3309.