### PR TITLE
Make GenericProfiler available in all environments (SCP-3317)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,6 @@ group :development, :test do
   gem 'puma'
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
-  gem 'ruby-prof'
-  gem 'ruby-prof-flamegraph'
 end
 
 group :test do
@@ -96,3 +94,5 @@ gem 'time_difference'
 gem 'tcell_agent'
 gem 'sys-filesystem', require: 'sys/filesystem'
 gem 'browser'
+gem 'ruby-prof'
+gem 'ruby-prof-flamegraph'


### PR DESCRIPTION
This update moves the `ruby-prof` and `ruby-prof-flamegraph` gems to be available in all environments.  This will allow use of `GenericProfiler` in deployed environments to get real-world profiling information on proposed & newly-deployed changes.

This PR satisfies SCP-3317.