### PR TITLE
Hotfix: remove cluster_name from CellMetadatum/Study Mongo queries (SCP-3325)

### DIFF
--- a/app/models/cell_metadatum.rb
+++ b/app/models/cell_metadatum.rb
@@ -55,7 +55,7 @@ class CellMetadatum
   def concatenate_data_arrays(array_name, array_type)
     query = {name: array_name, array_type: array_type, linear_data_type: 'CellMetadatum', linear_data_id: self.id,
              study_id: self.study_id, study_file_id: self.study_file_id, cluster_group_id: nil,
-             cluster_name: self.study_file.upload_file_name, subsample_threshold: nil, subsample_annotation: nil}
+             subsample_threshold: nil, subsample_annotation: nil}
     DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce([], :+)
   end
 

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1252,8 +1252,8 @@ class Study
   def all_cells_array
     if self.metadata_file&.parsed? # nil-safed via &
       query = {name: 'All Cells', array_type: 'cells', linear_data_type: 'Study', linear_data_id: self.id,
-               cluster_name: self.metadata_file.upload_file_name, study_id: self.id, study_file_id: self.metadata_file.id,
-               cluster_group_id: nil, subsample_annotation: nil, subsample_threshold: nil}
+               study_id: self.id, study_file_id: self.metadata_file.id, cluster_group_id: nil, subsample_annotation: nil,
+               subsample_threshold: nil}
       DataArray.where(query).order(:array_index => 'asc').pluck(:values).reduce([], :+)
     else
       self.all_expression_matrix_cells
@@ -1273,8 +1273,7 @@ class Study
   # return the cells found in a single expression matrix
   def expression_matrix_cells(study_file)
     arrays = DataArray.where(name: "#{study_file.upload_file_name} Cells", array_type: 'cells', linear_data_type: 'Study',
-                             linear_data_id: self.id, study_file_id: study_file.id, cluster_group_id: nil,
-                             cluster_name: study_file.upload_file_name, subsample_annotation: nil,
+                             linear_data_id: self.id, study_file_id: study_file.id, cluster_group_id: nil, subsample_annotation: nil,
                              subsample_threshold: nil).order(:array_index => 'asc')
     arrays.pluck(:values).reduce([], :+)
   end


### PR DESCRIPTION
This is a hotfix to address the regression of loading `DataArray` documents from the `CellMetadatum` or `Study` class when the metadata file has slashes `/` in the name.  This can happen when a metadata file is synced, and resides in a folder.  The bug results in a discrepancy between the value of `metadata_file.upload_file_name` and the value that gets written to `cluster_name` on the `DataArray` documents.  This update removes `cluster_name` from the query.

Note: `cluster_name` is a vestigial value that predates an [early refactoring](https://github.com/broadinstitute/single_cell_portal_core/commit/34315c309735476030f3f05ddb188796dd5fe5ef#diff-f309375608a3c2b5c7cf2c6b8f93c4f89216c5fe33e5391d3465944b4bb1d2c3) when `DataArrays` only belonged to `ClusterGroup` documents.  This value is no longer required, and should be removed entirely, but that requires expensive data migrations and an update to `scp-ingest-pipeline` as well, all of which is out-of-scope for this hotfix.

This PR satisfies SCP-3325