### PR TITLE
Rescue RuntimeError in token_for_storage_object to prevent downstream UI errors (SCP-3327)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -214,8 +214,14 @@ class User
   # will return nil if user is not registered for Terra as API call would return 401
   def token_for_storage_object(project=FireCloudClient::PORTAL_NAMESPACE)
     if self.refresh_token.present? && self.registered_for_firecloud
-      client = FireCloudClient.new(self, project)
-      client.get_pet_service_account_token(project)
+      begin
+        client = FireCloudClient.new(self, project)
+        client.get_pet_service_account_token(project)
+      rescue RuntimeError => e
+        # returning nil here will be caught at the UI level and show an error message
+        # see UserProvider.js -> getReadOnlyToken() and userHasTerraProfile()
+        nil
+      end
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -21,7 +21,7 @@ class UserTest < ActiveSupport::TestCase
 
   teardown do
     # reset user tokens
-    @user.update(access_token: @existing_access_token, api_access_token: @existing_api_token)
+    @user.update(access_token: @existing_access_token, api_access_token: @existing_api_token, refresh_token: nil)
     @user.update_last_access_at!
   end
 
@@ -82,5 +82,17 @@ class UserTest < ActiveSupport::TestCase
     empty_response = {}
     assert_equal empty_response, @user.valid_access_token
     assert_equal empty_response, @user.token_for_api_call
+  end
+
+  test 'should handle errors when generating pet service account token' do
+    # assign mock refresh token first
+    @user.update(refresh_token: @user.access_token.dig('access_token'))
+
+    # user does not actually have a Terra profile which will throw an error
+    # RuntimeError should be handled and not raised here
+    assert_nothing_raised do
+      token = @user.token_for_storage_object('single-cell-portal')
+      assert_nil token
+    end
   end
 end


### PR DESCRIPTION
When generating a pet service account token to stream a GCS object back to the client, if an error is thrown during the subsequent FireCloud API call, instead of a token being returned, and the contents of the error message get returned to the UI as the actual token value.  This causes a cascade of errors that will break the UI until the user refreshes the page.

This update explicitly rescues the `RuntimeError` that is raised from all FireCloud API errors, and now returns `nil`, which will then be handled downstream by the UI via `UserProvider` and the two genome visualization components that use this token (Ideogram and IGV).

TO TEST:
1. [Sign in with registeredinscpbutnotterra@gmail.com](https://broadinstitute.slack.com/archives/CBEHTH601/p1600365349124700?thread_ts=1600365317.124600&cid=CBEHTH601) (or any Google account that is not registered for Terra)
2. Run:
```
rails console
user = User.find_by(email: 'registeredinscpbutnotterra@gmail.com')
user.update(registered_for_firecloud: true)
```
3. Call `user.token_for_storage_object` and note the return value of `nil`, and no error is raised (would have been a `401`).
4. Cleanup: `user.update(registered_for_firecloud: false)`

This PR satisfies SCP-3327.