### PR TITLE
Add Zendesk email to user-facing error modals (SCP-3321, SCP-3332)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,9 +4,9 @@ class ApplicationController < ActionController::Base
   include RealIpLogger
 
   # Error modal contact message
-  ZENDESK_CONTACT = "If this error persists and you require assistance, please contact support at " \
-                    "<a href='mailto:scp-support@broadinstitute.zendesk.com' id='zendesk-alert-email'>" \
-                    "scp-support@broadinstitute.zendesk.com</a>."
+  SCP_SUPPORT_EMAIL = "If this error persists and you require assistance, please contact support at:<br /><br />" \
+                      "<a href='mailto:scp-support@broadinstitute.zendesk.com' data-analytics-name='scp-support-email' " \
+                      "class='no-wrap'>scp-support@broadinstitute.zendesk.com</a>"
 
   ###
   #
@@ -76,14 +76,14 @@ class ApplicationController < ActionController::Base
   # auth action for portal admins
   def authenticate_admin
     unless current_user.admin?
-      redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: "You do not have permission to access that page.  #{ZENDESK_CONTACT}" and return
+      redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: "You do not have permission to access that page.  #{SCP_SUPPORT_EMAIL}" and return
     end
   end
 
   # auth action for portal reporters
   def authenticate_reporter
     unless current_user.acts_like_reporter?
-      redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: "You do not have permission to access that page.  #{ZENDESK_CONTACT}" and return
+      redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: "You do not have permission to access that page.  #{SCP_SUPPORT_EMAIL}" and return
     end
   end
 
@@ -102,7 +102,7 @@ class ApplicationController < ActionController::Base
     redirect = request.referrer.nil? ? site_path : request.referrer
     access = AdminConfiguration.firecloud_access_enabled?
     if !access
-      redirect_to merge_default_redirect_params(redirect, scpbr: params[:scpbr]), alert: "Study access has been temporarily disabled by the site adminsitrator.  #{ZENDESK_CONTACT}" and return
+      redirect_to merge_default_redirect_params(redirect, scpbr: params[:scpbr]), alert: "Study access has been temporarily disabled by the site adminsitrator.  #{SCP_SUPPORT_EMAIL}" and return
     end
   end
 
@@ -207,7 +207,7 @@ class ApplicationController < ActionController::Base
 
     if redirect_parameters.any?
       redirect_to merge_default_redirect_params(redirect_parameters[:url], scpbr: params[:scpbr]),
-                  alert: redirect_messages.dig(redirect_parameters[:message_key]) + "  #{ZENDESK_CONTACT}" and return
+                  alert: redirect_messages.dig(redirect_parameters[:message_key]) + "  #{SCP_SUPPORT_EMAIL}" and return
     end
 
     # next check if downloads have been disabled by administrator, this will abort the download
@@ -226,7 +226,7 @@ class ApplicationController < ActionController::Base
       requested_file = ApplicationController.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, study.bucket_id, params[:filename])
       if params[:filename].blank?
         redirect_to merge_default_redirect_params(view_study_path(accession: study.accession, study_name: study.url_safe_name), scpbr: params[:scpbr]),
-                      alert: "We are unable to process your download in #{study.accession} because there is no file name provided.  #{ZENDESK_CONTACT}" and return
+                      alert: "We are unable to process your download in #{study.accession} because there is no file name provided.  #{SCP_SUPPORT_EMAIL}" and return
       end
       if requested_file.present?
         filesize = requested_file.size
@@ -237,7 +237,7 @@ class ApplicationController < ActionController::Base
           current_user.update(daily_download_quota: user_quota)
         else
           redirect_to merge_default_redirect_params(view_study_path(accession: study.accession, study_name: study.url_safe_name), scpbr: params[:scpbr]),
-                      alert: "You have exceeded your current daily download quota.  You must wait until tomorrow to download this file.  #{ZENDESK_CONTACT}" and return
+                      alert: "You have exceeded your current daily download quota.  You must wait until tomorrow to download this file.  #{SCP_SUPPORT_EMAIL}" and return
         end
         # redirect directly to file to trigger download
         # validate that the signed_url is in fact the correct URL - it must be a GCS lin
@@ -245,13 +245,13 @@ class ApplicationController < ActionController::Base
           redirect_to @signed_url
         else
           redirect_to merge_default_redirect_params(view_study_path(accession: study.accession, study_name: study.url_safe_name), scpbr: params[:scpbr]),
-                      alert: "We are unable to process your download for #{study.accession}:#{params[:filename]}.  Please try again later.  #{ZENDESK_CONTACT}" and return
+                      alert: "We are unable to process your download for #{study.accession}:#{params[:filename]}.  Please try again later.  #{SCP_SUPPORT_EMAIL}" and return
         end
       else
         # send notification to the study owner that file is missing (if notifications turned on)
         SingleCellMailer.user_download_fail_notification(study, params[:filename]).deliver_now
         redirect_to merge_default_redirect_params(view_study_path(accession: study.accession, study_name: study.url_safe_name), scpbr: params[:scpbr]),
-                    alert: "#{study.accession}:#{params[:filename]} could not be found.  Please contact the study owner if you require access to this file.  #{ZENDESK_CONTACT}" and return
+                    alert: "#{study.accession}:#{params[:filename]} could not be found.  Please contact the study owner if you require access to this file.  #{SCP_SUPPORT_EMAIL}" and return
       end
     rescue => e
       error_context = ErrorTracker.format_extra_context(@study, {params: params})
@@ -260,7 +260,7 @@ class ApplicationController < ActionController::Base
       logger.error "#{Time.zone.now}: error generating signed url for #{params[:filename]}; #{e.message}."
       redirect_to merge_default_redirect_params(request.referrer, scpbr: params[:scpbr]),
                   alert: "We were unable to download the file #{study.accession}:#{params[:filename]} do to an error: " \
-                         "#{view_context.simple_format(e.message)}.  #{ZENDESK_CONTACT}" and return
+                         "#{view_context.simple_format(e.message)}.  #{SCP_SUPPORT_EMAIL}" and return
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   include RealIpLogger
 
   # Error modal contact message
-  SCP_SUPPORT_EMAIL = "If this error persists and you require assistance, please contact support at:<br /><br />" \
+  SCP_SUPPORT_EMAIL = "If this error persists, please contact support at:<br /><br />" \
                       "<a href='mailto:scp-support@broadinstitute.zendesk.com' data-analytics-name='scp-support-email' " \
                       "class='no-wrap'>scp-support@broadinstitute.zendesk.com</a>"
 

--- a/app/controllers/billing_projects_controller.rb
+++ b/app/controllers/billing_projects_controller.rb
@@ -68,7 +68,7 @@ class BillingProjectsController < ApplicationController
       ErrorTracker.report_exception(e, current_user, params.to_unsafe_hash)
       logger.error "Unable to create new billing project #{project_name} due to error: #{e.message}"
       redirect_to merge_default_redirect_params(billing_projects_path, scpbr: params[:scpbr]),
-                  alert: "We were unable to create your new project due to the following error: #{e.message}.  #{ZENDESK_CONTACT}" and return
+                  alert: "We were unable to create your new project due to the following error: #{e.message}.  #{SCP_SUPPORT_EMAIL}" and return
     end
   end
 
@@ -87,7 +87,7 @@ class BillingProjectsController < ApplicationController
       ErrorTracker.report_exception(e, current_user, params.to_unsafe_hash)
       logger.error "Unable to add #{email} to #{params[:project_name]} due to error: #{e.message}"
       redirect_to merge_default_redirect_params(new_billing_project_user_path, scpbr: params[:scpbr]),
-                  alert: "We were unable to add #{email} to #{params[:project_name]} due to the following error: #{e.message}.  #{ZENDESK_CONTACT}" and return
+                  alert: "We were unable to add #{email} to #{params[:project_name]} due to the following error: #{e.message}.  #{SCP_SUPPORT_EMAIL}" and return
     end
   end
 
@@ -103,7 +103,7 @@ class BillingProjectsController < ApplicationController
       logger.error "Unable to remove #{email} from #{params[:project_name]} due to error: #{e.message}"
       redirect_to merge_default_redirect_params(billing_projects_path, scpbr: params[:scpbr]),
                   alert: "We were unable to remove #{email} from #{params[:project_name]} due to the following error: " \
-                         "#{e.message}'.  #{ZENDESK_CONTACT}" and return
+                         "#{e.message}'.  #{SCP_SUPPORT_EMAIL}" and return
     end
   end
 
@@ -240,7 +240,7 @@ class BillingProjectsController < ApplicationController
   # make sure a user is registered for firecloud before showing billing information
   def check_firecloud_registration
     unless current_user.registered_for_firecloud
-      alert = "You must complete your FireCloud registration before viewing your available billing projects.  #{ZENDESK_CONTACT}"
+      alert = "You must complete your FireCloud registration before viewing your available billing projects.  #{SCP_SUPPORT_EMAIL}"
       redirect_to view_profile_path(current_user.id) + '#profile-firecloud', alert: alert and return
     end
   end
@@ -250,14 +250,14 @@ class BillingProjectsController < ApplicationController
     projects = @fire_cloud_client.get_billing_projects
     unless projects.map {|project| project['projectName']}.include?(params[:project_name])
       redirect_to merge_default_redirect_params(billing_projects_path, scpbr: params[:scpbr]),
-                  alert: "You do not have permission to perform that action.  #{ZENDESK_CONTACT}" and return
+                  alert: "You do not have permission to perform that action.  #{SCP_SUPPORT_EMAIL}" and return
     end
   end
 
   # check on FireCloud API status and respond accordingly
   def check_firecloud_status
     unless ApplicationController.firecloud_client.services_available?(FireCloudClient::THURLOE_SERVICE)
-      alert = "Billing projects are temporarily unavailable, so we cannot complete your request.  Please try again later.  #{ZENDESK_CONTACT}"
+      alert = "Billing projects are temporarily unavailable, so we cannot complete your request.  Please try again later.  #{SCP_SUPPORT_EMAIL}"
       respond_to do |format|
         format.js {render js: "$('.modal').modal('hide'); alert('#{alert}')" and return}
         format.html {redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -106,7 +106,8 @@ class ProfilesController < ApplicationController
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), notice: 'Terms of Service response successfully recorded.' and return
     else
       sign_out @user
-      redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: 'You must accept the Terms of Use in order to sign in.' and return
+      redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
+                  alert: "You must accept the Terms of Use in order to sign in.  #{ZENDESK_CONTACT}" and return
     end
   end
 
@@ -120,7 +121,8 @@ class ProfilesController < ApplicationController
   # make sure the current user is the same as the requested profile
   def check_profile_access
     if current_user.email != @user.email
-      redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: 'You do not have permission to perform that action.' and return
+      redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
+                  alert: "You do not have permission to perform that action.  #{ZENDESK_CONTACT}" and return
     end
   end
 
@@ -129,7 +131,7 @@ class ProfilesController < ApplicationController
       terra_link = view_context.link_to('registered with Terra',
                                         'https://support.terra.bio/hc/en-us/articles/360028235911-How-to-register-for-a-Terra-account',
                                         target: :_blank)
-      alert = "You may not update your Terra profile until you have #{terra_link}."
+      alert = "You may not update your Terra profile until you have #{terra_link}.  #{ZENDESK_CONTACT}"
       redirect_to view_profile_path(current_user.id), alert: alert and return
     end
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -107,7 +107,7 @@ class ProfilesController < ApplicationController
     else
       sign_out @user
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
-                  alert: "You must accept the Terms of Use in order to sign in.  #{ZENDESK_CONTACT}" and return
+                  alert: "You must accept the Terms of Use in order to sign in.  #{SCP_SUPPORT_EMAIL}" and return
     end
   end
 
@@ -122,7 +122,7 @@ class ProfilesController < ApplicationController
   def check_profile_access
     if current_user.email != @user.email
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
-                  alert: "You do not have permission to perform that action.  #{ZENDESK_CONTACT}" and return
+                  alert: "You do not have permission to perform that action.  #{SCP_SUPPORT_EMAIL}" and return
     end
   end
 
@@ -131,7 +131,7 @@ class ProfilesController < ApplicationController
       terra_link = view_context.link_to('registered with Terra',
                                         'https://support.terra.bio/hc/en-us/articles/360028235911-How-to-register-for-a-Terra-account',
                                         target: :_blank)
-      alert = "You may not update your Terra profile until you have #{terra_link}.  #{ZENDESK_CONTACT}"
+      alert = "You may not update your Terra profile until you have #{terra_link}.  #{SCP_SUPPORT_EMAIL}"
       redirect_to view_profile_path(current_user.id), alert: alert and return
     end
   end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -79,7 +79,7 @@ class SiteController < ApplicationController
                                                                 scpbr: params[:scpbr])) and return
     else
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
-                  alert: "You either do not have permission to perform that action, or #{params[:identifier]} does not exist.  #{ZENDESK_CONTACT}" and return
+                  alert: "You either do not have permission to perform that action, or #{params[:identifier]} does not exist.  #{SCP_SUPPORT_EMAIL}" and return
     end
   end
 
@@ -621,7 +621,7 @@ class SiteController < ApplicationController
         # redirect if study is not found
     if @study.nil?
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
-                  alert: "You either do not have permission to perform that action, or #{params[:accession]} does not exist.  #{ZENDESK_CONTACT}" and return
+                  alert: "You either do not have permission to perform that action, or #{params[:accession]} does not exist.  #{SCP_SUPPORT_EMAIL}" and return
     end
         #Check if current url_safe_name matches model
     unless @study.url_safe_name == params[:study_name]
@@ -753,7 +753,7 @@ class SiteController < ApplicationController
       if (!user_signed_in? && !@study.public?)
         authenticate_user!
       elsif (user_signed_in? && !@study.can_view?(current_user))
-        alert = "You do not have permission to perform that action.  #{ZENDESK_CONTACT}"
+        alert = "You do not have permission to perform that action.  #{SCP_SUPPORT_EMAIL}"
         respond_to do |format|
           format.js {render js: "alert('#{alert}')" and return}
           format.html {redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: alert and return}
@@ -766,7 +766,7 @@ class SiteController < ApplicationController
   def check_compute_permissions
     if ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE, FireCloudClient::RAWLS_SERVICE)
       if !user_signed_in? || !@study.can_compute?(current_user)
-        @alert = "You do not have permission to perform that action.  #{ZENDESK_CONTACT}"
+        @alert = "You do not have permission to perform that action.  #{SCP_SUPPORT_EMAIL}"
         respond_to do |format|
           format.js {render action: :notice}
           format.html {redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: @alert and return}
@@ -774,7 +774,7 @@ class SiteController < ApplicationController
         end
       end
     else
-      @alert = "Compute services are currently unavailable - please check back later.  #{ZENDESK_CONTACT}"
+      @alert = "Compute services are currently unavailable - please check back later.  #{SCP_SUPPORT_EMAIL}"
       respond_to do |format|
         format.js {render action: :notice}
         format.html {redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: @alert and return}
@@ -787,7 +787,7 @@ class SiteController < ApplicationController
   def check_study_detached
     if @study.detached?
       @alert = "We were unable to complete your request as #{@study.accession} is detached from the workspace " \
-               "(maybe the workspace was deleted?).  #{ZENDESK_CONTACT}"
+               "(maybe the workspace was deleted?).  #{SCP_SUPPORT_EMAIL}"
       respond_to do |format|
         format.js {render js: "alert('#{@alert}');"}
         format.html {redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: @alert and return}

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -79,7 +79,7 @@ class SiteController < ApplicationController
                                                                 scpbr: params[:scpbr])) and return
     else
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
-                  alert: "You either do not have permission to perform that action, or #{params[:identifier]} does not exist." and return
+                  alert: "You either do not have permission to perform that action, or #{params[:identifier]} does not exist.  #{ZENDESK_CONTACT}" and return
     end
   end
 
@@ -621,7 +621,7 @@ class SiteController < ApplicationController
         # redirect if study is not found
     if @study.nil?
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
-                  alert: "You either do not have permission to perform that action, or #{params[:accession]} does not exist." and return
+                  alert: "You either do not have permission to perform that action, or #{params[:accession]} does not exist.  #{ZENDESK_CONTACT}" and return
     end
         #Check if current url_safe_name matches model
     unless @study.url_safe_name == params[:study_name]
@@ -753,7 +753,7 @@ class SiteController < ApplicationController
       if (!user_signed_in? && !@study.public?)
         authenticate_user!
       elsif (user_signed_in? && !@study.can_view?(current_user))
-        alert = 'You do not have permission to perform that action.'
+        alert = "You do not have permission to perform that action.  #{ZENDESK_CONTACT}"
         respond_to do |format|
           format.js {render js: "alert('#{alert}')" and return}
           format.html {redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: alert and return}
@@ -766,7 +766,7 @@ class SiteController < ApplicationController
   def check_compute_permissions
     if ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE, FireCloudClient::RAWLS_SERVICE)
       if !user_signed_in? || !@study.can_compute?(current_user)
-        @alert ='You do not have permission to perform that action.'
+        @alert = "You do not have permission to perform that action.  #{ZENDESK_CONTACT}"
         respond_to do |format|
           format.js {render action: :notice}
           format.html {redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: @alert and return}
@@ -774,7 +774,7 @@ class SiteController < ApplicationController
         end
       end
     else
-      @alert ='Compute services are currently unavailable - please check back later.'
+      @alert = "Compute services are currently unavailable - please check back later.  #{ZENDESK_CONTACT}"
       respond_to do |format|
         format.js {render action: :notice}
         format.html {redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: @alert and return}
@@ -786,7 +786,8 @@ class SiteController < ApplicationController
   # check if a study is 'detached' from a workspace
   def check_study_detached
     if @study.detached?
-      @alert = "We were unable to complete your request as #{@study.accession} is detached from the workspace (maybe the workspace was deleted?)"
+      @alert = "We were unable to complete your request as #{@study.accession} is detached from the workspace " \
+               "(maybe the workspace was deleted?).  #{ZENDESK_CONTACT}"
       respond_to do |format|
         format.js {render js: "alert('#{@alert}');"}
         format.html {redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: @alert and return}

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -163,7 +163,7 @@ class StudiesController < ApplicationController
       MetricsService.report_error(e, request, current_user, @study)
       logger.error "#{Time.zone.now}: error syncing ACLs in workspace bucket #{@study.firecloud_workspace} due to error: #{e.message}"
       redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
-                  alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}.  #{ZENDESK_CONTACT}" and return
+                  alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}.  #{SCP_SUPPORT_EMAIL}" and return
     end
 
     # begin determining sync status with study_files and primary or other data
@@ -183,7 +183,7 @@ class StudiesController < ApplicationController
       MetricsService.report_error(e, request, current_user, @study)
       logger.error "#{Time.zone.now}: error syncing files in workspace bucket #{@study.firecloud_workspace} due to error: #{e.message}"
       redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
-                  alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}.  #{ZENDESK_CONTACT}" and return
+                  alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}.  #{SCP_SUPPORT_EMAIL}" and return
     end
 
     files_to_remove = []
@@ -352,7 +352,7 @@ class StudiesController < ApplicationController
       MetricsService.report_error(e, request, current_user, @study)
       redirect_to merge_default_redirect_params(request.referrer, scpbr: params[:scpbr]),
                   alert: "We were unable to sync the outputs from submission #{params[:submission_id]} due to the " \
-                         "following error: #{e.message}.  #{ZENDESK_CONTACT}"
+                         "following error: #{e.message}.  #{SCP_SUPPORT_EMAIL}"
     end
   end
 
@@ -424,7 +424,7 @@ class StudiesController < ApplicationController
           logger.error "#{Time.zone.now} unable to delete workspace: #{@study.firecloud_workspace}; #{e.message}"
           redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
                       alert: "We were unable to delete your study due to: #{view_context.simple_format(e.message)}.<br />" \
-                             "<br />No files or database records have been deleted.  Please try again later.  #{ZENDESK_CONTACT}" and return
+                             "<br />No files or database records have been deleted.  Please try again later.  #{SCP_SUPPORT_EMAIL}" and return
         end
       end
 
@@ -445,7 +445,7 @@ class StudiesController < ApplicationController
       end
     else
       redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
-                  alert: "You do not have permission to perform that action.  #{ZENDESK_CONTACT}" and return
+                  alert: "You do not have permission to perform that action.  #{SCP_SUPPORT_EMAIL}" and return
     end
   end
 
@@ -798,7 +798,7 @@ class StudiesController < ApplicationController
           logger.error "#{Time.zone.now}: error in deleting #{@study_file.upload_file_name} from workspace: #{@study.firecloud_workspace}; #{e.message}"
           redirect_to merge_default_redirect_params(request.referrer, scpbr: params[:scpbr]),
                       alert: "We were unable to delete #{@study_file.upload_file_name} due to an error: " \
-                             "#{view_context.simple_format(e.message)}.  Please try again later.  #{ZENDESK_CONTACT}"
+                             "#{view_context.simple_format(e.message)}.  Please try again later.  #{SCP_SUPPORT_EMAIL}"
         end
         changes = ["Study file deleted: #{@study_file.upload_file_name}"]
         if @study.study_shares.any?
@@ -1178,7 +1178,7 @@ class StudiesController < ApplicationController
 
   def check_edit_permissions
     if !user_signed_in? || !@study.can_edit?(current_user)
-      alert = "You do not have permission to perform that action.  #{ZENDESK_CONTACT}"
+      alert = "You do not have permission to perform that action.  #{SCP_SUPPORT_EMAIL}"
       respond_to do |format|
         format.js {render js: "alert('#{alert}')" and return}
         format.html {redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
@@ -1190,7 +1190,7 @@ class StudiesController < ApplicationController
   # check on FireCloud API status and respond accordingly
   def check_firecloud_status
     unless ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE, FireCloudClient::RAWLS_SERVICE)
-      alert = "Study workspaces are temporarily unavailable, so we cannot complete your request.  Please try again later.  #{ZENDESK_CONTACT}"
+      alert = "Study workspaces are temporarily unavailable, so we cannot complete your request.  Please try again later.  #{SCP_SUPPORT_EMAIL}"
       respond_to do |format|
         format.js {render js: "$('.modal').modal('hide'); alert('#{alert}')" and return}
         format.html {redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
@@ -1205,7 +1205,7 @@ class StudiesController < ApplicationController
     if @study.detached
       redirect_to merge_default_redirect_params(request.referrer, scpbr: params[:scpbr]),
                   alert: "We were unable to complete your request as the study is question is detached from the workspace " \
-                         "(maybe the workspace was deleted?).  #{ZENDESK_CONTACT}" and return
+                         "(maybe the workspace was deleted?).  #{SCP_SUPPORT_EMAIL}" and return
 
     end
   end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -162,7 +162,8 @@ class StudiesController < ApplicationController
       ErrorTracker.report_exception(e, current_user, error_context)
       MetricsService.report_error(e, request, current_user, @study)
       logger.error "#{Time.zone.now}: error syncing ACLs in workspace bucket #{@study.firecloud_workspace} due to error: #{e.message}"
-      redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]), alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}" and return
+      redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
+                  alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}.  #{ZENDESK_CONTACT}" and return
     end
 
     # begin determining sync status with study_files and primary or other data
@@ -181,7 +182,8 @@ class StudiesController < ApplicationController
       ErrorTracker.report_exception(e, current_user, error_context)
       MetricsService.report_error(e, request, current_user, @study)
       logger.error "#{Time.zone.now}: error syncing files in workspace bucket #{@study.firecloud_workspace} due to error: #{e.message}"
-      redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]), alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}" and return
+      redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
+                  alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}.  #{ZENDESK_CONTACT}" and return
     end
 
     files_to_remove = []
@@ -348,7 +350,9 @@ class StudiesController < ApplicationController
       error_context = ErrorTracker.format_extra_context(@study, {params: params})
       ErrorTracker.report_exception(e, current_user, error_context)
       MetricsService.report_error(e, request, current_user, @study)
-      redirect_to merge_default_redirect_params(request.referrer, scpbr: params[:scpbr]), alert: "We were unable to sync the outputs from submission #{params[:submission_id]} due to the following error: #{e.message}"
+      redirect_to merge_default_redirect_params(request.referrer, scpbr: params[:scpbr]),
+                  alert: "We were unable to sync the outputs from submission #{params[:submission_id]} due to the " \
+                         "following error: #{e.message}.  #{ZENDESK_CONTACT}"
     end
   end
 
@@ -418,7 +422,9 @@ class StudiesController < ApplicationController
           ErrorTracker.report_exception(e, current_user, error_context)
           MetricsService.report_error(e, request, current_user, @study)
           logger.error "#{Time.zone.now} unable to delete workspace: #{@study.firecloud_workspace}; #{e.message}"
-          redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]), alert: "We were unable to delete your study due to: #{view_context.simple_format(e.message)}.<br /><br />No files or database records have been deleted.  Please try again later" and return
+          redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
+                      alert: "We were unable to delete your study due to: #{view_context.simple_format(e.message)}.<br />" \
+                             "<br />No files or database records have been deleted.  Please try again later.  #{ZENDESK_CONTACT}" and return
         end
       end
 
@@ -438,7 +444,8 @@ class StudiesController < ApplicationController
         format.json { head :no_content }
       end
     else
-      redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]), alert: 'You do not have permission to perform that action' and return
+      redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
+                  alert: "You do not have permission to perform that action.  #{ZENDESK_CONTACT}" and return
     end
   end
 
@@ -790,7 +797,8 @@ class StudiesController < ApplicationController
           MetricsService.report_error(e, request, current_user, @study)
           logger.error "#{Time.zone.now}: error in deleting #{@study_file.upload_file_name} from workspace: #{@study.firecloud_workspace}; #{e.message}"
           redirect_to merge_default_redirect_params(request.referrer, scpbr: params[:scpbr]),
-                      alert: "We were unable to delete #{@study_file.upload_file_name} due to an error: #{view_context.simple_format(e.message)}.  Please try again later."
+                      alert: "We were unable to delete #{@study_file.upload_file_name} due to an error: " \
+                             "#{view_context.simple_format(e.message)}.  Please try again later.  #{ZENDESK_CONTACT}"
         end
         changes = ["Study file deleted: #{@study_file.upload_file_name}"]
         if @study.study_shares.any?
@@ -1170,7 +1178,7 @@ class StudiesController < ApplicationController
 
   def check_edit_permissions
     if !user_signed_in? || !@study.can_edit?(current_user)
-      alert = 'You do not have permission to perform that action.'
+      alert = "You do not have permission to perform that action.  #{ZENDESK_CONTACT}"
       respond_to do |format|
         format.js {render js: "alert('#{alert}')" and return}
         format.html {redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
@@ -1182,7 +1190,7 @@ class StudiesController < ApplicationController
   # check on FireCloud API status and respond accordingly
   def check_firecloud_status
     unless ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE, FireCloudClient::RAWLS_SERVICE)
-      alert = 'Study workspaces are temporarily unavailable, so we cannot complete your request.  Please try again later.'
+      alert = "Study workspaces are temporarily unavailable, so we cannot complete your request.  Please try again later.  #{ZENDESK_CONTACT}"
       respond_to do |format|
         format.js {render js: "$('.modal').modal('hide'); alert('#{alert}')" and return}
         format.html {redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
@@ -1196,7 +1204,8 @@ class StudiesController < ApplicationController
   def check_study_detached
     if @study.detached
       redirect_to merge_default_redirect_params(request.referrer, scpbr: params[:scpbr]),
-                  alert: "We were unable to complete your request as the study is question is detached from the workspace (maybe the workspace was deleted?)" and return
+                  alert: "We were unable to complete your request as the study is question is detached from the workspace " \
+                         "(maybe the workspace was deleted?).  #{ZENDESK_CONTACT}" and return
 
     end
   end

--- a/app/controllers/user_annotations_controller.rb
+++ b/app/controllers/user_annotations_controller.rb
@@ -200,7 +200,7 @@ class UserAnnotationsController < ApplicationController
     end
     if !@user_annotation.can_edit?(current_user)
       redirect_to merge_default_redirect_params(user_annotations_path, scpbr: params[:scpbr]),
-                  alert: "You don't have permission to perform that action.  #{ZENDESK_CONTACT}"
+                  alert: "You don't have permission to perform that action.  #{SCP_SUPPORT_EMAIL}"
     end
   end
 end

--- a/app/controllers/user_annotations_controller.rb
+++ b/app/controllers/user_annotations_controller.rb
@@ -200,7 +200,7 @@ class UserAnnotationsController < ApplicationController
     end
     if !@user_annotation.can_edit?(current_user)
       redirect_to merge_default_redirect_params(user_annotations_path, scpbr: params[:scpbr]),
-                  alert: "You don't have permission to perform that action"
+                  alert: "You don't have permission to perform that action.  #{ZENDESK_CONTACT}"
     end
   end
 end

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -108,9 +108,20 @@ export function logClickOther(target) {
 export function logCopy(event) {
   const props = {
     text: getNameForClickTarget(event.target),
+    classList: getClassListAsArray(event.target),
     id: event.target.id
   }
   log('copy', props)
+}
+
+/** Log contextmenu events, such right-click to "Save target as" or "Copy email address" */
+export function logContextMenu(event) {
+  const props = {
+    text: getNameForClickTarget(event.target),
+    classList: getClassListAsArray(event.target),
+    id: event.target.id
+  }
+  log('contextmenu', props)
 }
 
 /**

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -104,6 +104,15 @@ export function logClickOther(target) {
   log('click:other', props)
 }
 
+/** Log copy events, such as copying the SCP Zendesk support email */
+export function logCopy(event) {
+  const props = {
+    text: getNameForClickTarget(event.target),
+    id: event.target.id
+  }
+  log('copy', props)
+}
+
 /**
   * If the element itself has a data-analytics-name, use that as the name
   * this allows names to be specified for elements that do not have text (e.g. icon buttons)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -26,7 +26,7 @@ import checkMissingAuthToken from 'lib/user-auth-tokens'
 // Below import resolves to '/app/javascript/components/HomePageContent.js'
 import HomePageContent from 'components/HomePageContent'
 import {
-  logPageView, logClick, logMenuChange, setupPageTransitionLog, log
+  logPageView, logClick, logMenuChange, setupPageTransitionLog, log, logCopy
 } from 'lib/metrics-api'
 import * as ScpApi from 'lib/scp-api'
 import { renderClusterAssociationSelect } from 'components/upload/ClusterAssociationSelect'
@@ -38,6 +38,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   $(document).on('click', 'body', logClick)
   $(document).on('change', 'select', logMenuChange)
+  $(document).on('copy', 'body', logCopy)
+  // contextmenu event is to handle when users use context menu "copy email address" instead of cmd+C copy event as
+  // this does not emit the copy event
+  $(document).on('contextmenu', '#zendesk-alert-email', logCopy)
 
   setupPageTransitionLog()
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -26,7 +26,7 @@ import checkMissingAuthToken from 'lib/user-auth-tokens'
 // Below import resolves to '/app/javascript/components/HomePageContent.js'
 import HomePageContent from 'components/HomePageContent'
 import {
-  logPageView, logClick, logMenuChange, setupPageTransitionLog, log, logCopy
+  logPageView, logClick, logMenuChange, setupPageTransitionLog, log, logCopy, logContextMenu
 } from 'lib/metrics-api'
 import * as ScpApi from 'lib/scp-api'
 import { renderClusterAssociationSelect } from 'components/upload/ClusterAssociationSelect'
@@ -41,7 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
   $(document).on('copy', 'body', logCopy)
   // contextmenu event is to handle when users use context menu "copy email address" instead of cmd+C copy event as
   // this does not emit the copy event
-  $(document).on('contextmenu', '#zendesk-alert-email', logCopy)
+  $(document).on('contextmenu', 'body', logContextMenu)
 
   setupPageTransitionLog()
 

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -779,3 +779,7 @@ ul.pager li.dimmed {
 figcaption.ck-editor__editable {
   min-height: 0;
 }
+
+.no-wrap {
+  whitespace: no-wrap;
+}


### PR DESCRIPTION
This update adds the `scp-support@broadinstitute.zendesk.com` email to all user-facing error modal messages.  Note: this update only covers modals where an error has been handled, and the page is redirected back to another action and the `alert` property has been set on the `redirect_to` call in the non-API portion of SCP.  This covers the vast majority of known error modes, but it should be noted that there may be others that are not addressed by this change.  It does cover the main error modes of users attempting to access resources (studies, files, profiles, etc.) they do not have permission to view, or other portions of SCP that require admin access.

Preview:
![scp-error-modal](https://user-images.githubusercontent.com/729968/117156808-0c667500-ad8c-11eb-8207-47752e41c9e3.png)

In addition, this will log the `copy` and `contextmenu` events to Mixpanel when a user copies the support email address, either by using the context menu on the anchor tag, or manually using `cmd + C`.

TO TEST:
1. [Sign in with registeredinscpandterra@gmail.com](https://broadinstitute.slack.com/archives/CBEHTH601/p1600365349124700?thread_ts=1600365317.124600&cid=CBEHTH601), or any other non-admin Google account
2. Go to https://localhost:3000/single_cell/admin
3. Note the `scp-support@broadinstitute.zendesk.com` address in the error modal, and that the modal does not close until manually cleared.
4. Open the "Network" tab in Chrome Dev Tools
5. Right click on the support email and select "copy email address"
6. Note in the Network tab the `copy` event posted to Mixpanel with the support email as the `text` property

This PR satisfies SCP-3321 & SCP-3332.