### PR TITLE
relaxing template rules to prevent eslint breakage (SCP-3336)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
         'ga': 'readonly',
         'bamAndBaiFiles': 'readonly'
     },
+    'parser': 'babel-eslint',
     'parserOptions': {
         'ecmaFeatures': {
             'jsx': true
@@ -50,7 +51,9 @@ module.exports = {
         'eol-last': 'warn',
         'func-call-spacing': 'warn',
         // 'implicit-arrow-linebreak': 'warn',
-        'indent': ['warn', 2, { 'SwitchCase': 1, 'CallExpression': { 'arguments': 1 } }],
+        'indent': ['warn', 2, { 'SwitchCase': 1, 'CallExpression': { 'arguments': 1 },
+          "ignoredNodes": ["TemplateLiteral"]
+         }],
         'key-spacing': 'warn',
         'keyword-spacing': 'warn',
         'lines-between-class-members': 'warn',
@@ -88,7 +91,7 @@ module.exports = {
         'prefer-rest-params': 'warn',
         'prefer-spread': 'warn',
         'rest-spread-spacing': 'warn',
-        'template-curly-spacing': 'warn',
+        'template-curly-spacing': 'off',
         // React
         'react/prop-types': 'off',
         'react/jsx-key': 'off',


### PR DESCRIPTION
See https://github.com/babel/babel-eslint/issues/681.  This sidesteps a eslint/babel version issue that has broken linting in sublime and VSCode from time to time.  Since we don't care that much about formatting rules for inside of backticks, better to avoid this issue than have it keep resurfacing

TO TEST:
 0. open DotPlot.js in Sublime/VSCode
 1. confirm syntax highlighting works