### PR TITLE
hiding scatter color control for non-numeric annotations

### DIFF
--- a/app/javascript/components/visualization/PlotDisplayControls.js
+++ b/app/javascript/components/visualization/PlotDisplayControls.js
@@ -32,9 +32,13 @@ export default function RenderControls({ shownTab, exploreParams, updateExploreP
   if (!distributionPointsValue) {
     distributionPointsValue = DISTRIBUTION_POINTS_OPTIONS[0]
   }
+
+  const showScatter = shownTab === 'scatter' &&
+                      (exploreParams.annotation.type === 'numeric' || exploreParams.genes.length)
+
   return (
     <div className="render-controls">
-      <Panel className={shownTab === 'scatter' ? '' : 'hidden'}>
+      <Panel className={showScatter ? '' : 'hidden'}>
         <Panel.Heading>
           <Panel.Title>
             Scatter


### PR DESCRIPTION
This hides the color selector if it is not applicable to the current displayed plots (if it is just a cluster plot of a non-numeric annotation).  The value is still preserved though, so if the user is toggling back and forth, they don't have to reenter their choice

TO TEST:
1. open study "Male mouse brain"
2. observe that "Scatter" section with "Continuous color scale" dropdown menu is NOT shown when the default cluster/annotation are shown
3.  switch to the 'intensity' annotation -- observe the scatter color picker is restored
4.  search a single gene, e.g. "Apoe".  Observe the scatter color picker is not displayed on the annotated scatter, but is displayed on the scatter tab