### PR TITLE
Ease discovery by adding labels in related genes ideogram (SCP-3007)

### DIFF
--- a/app/javascript/components/visualization/RelatedGenesIdeogram.js
+++ b/app/javascript/components/visualization/RelatedGenesIdeogram.js
@@ -147,7 +147,6 @@ export default function RelatedGenesIdeogram({
       chrHeight: height - verticalPad,
       chrLabelSize: 12,
       annotationHeight: 7,
-      showAnnotLabels: false,
       onClickAnnot,
       onPlotRelatedGenes,
       onWillShowAnnotTooltip,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
-    "ideogram": "1.29.0",
+    "ideogram": "1.30.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.12.1",
     "morpheus-app": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7063,10 +7063,10 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ideogram@1.29.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.29.0.tgz#65d0d44bf679f9a4dc4127f37f673fa8723e1735"
-  integrity sha512-ycshKSGctAF5dxRNrbU+Q8gTtdvpNiIw6vJ4smYvYT+mTCfSPhC0oeIpvz6VsByo2X/JPLs261DH9LSzsFaJ3A==
+ideogram@1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.30.0.tgz#31d6bb816077fee657cd39f5f2566959348a1cbb"
+  integrity sha512-M/ci8CVZ2JM2gOvVsY7w+GDY+oo5RuYfnDi5fYl9CdcH6vmUQDWOHWWm+Tv+/XDvtbqZNZUxciIayUNmNlbjqw==
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"


### PR DESCRIPTION
This makes it easier to discover genes related to a gene of interest, by labeling them in related genes ideogram.

Previously, users had to hover over related genes to see their name and other information.  Now, the names are usually shown by default.  This lowers the interaction cost for discovery, while keeping the engaging biological visualization.  It also fulfills a user request made when earlier demonstrating the component.

Previously, related genes ideogram looked like this:
<img width="1670" alt="Related_genes_ideogram_with_no_labels_2021-05-11" src="https://user-images.githubusercontent.com/1334561/117818238-6953a680-b236-11eb-8549-0c09ce14fe9b.png">

Now it looks like this:
<img width="1675" alt="Related_genes_ideogram_with_labels_2021-05-11" src="https://user-images.githubusercontent.com/1334561/117818285-72dd0e80-b236-11eb-9886-16c4f58f5148.png">

Per another user request at a demo of a prototype of this enhancement, the active feature has some highlighting around the label and triangle -- a UI detail influenced by Google Maps:
<img width="908" alt="Tooltip_in_related_genes_ideogram_with_labels_2021-05-11" src="https://user-images.githubusercontent.com/1334561/117818615-c8b1b680-b236-11eb-99b7-7b81ed7f6a80.png">

Sometimes, many features appear, and labeling them all would cause overlaps that greatly degrade readability.  This is avoided by omitting certain feature labels when they would overlap.

To test:
* Go to a study that has visualizations and a typical number of genes (not a synthetic study)
* Search a gene
* Verify label for searched gene and related genes
* Hover over a related gene
* Verify that active feature label is highlighted

This satisfies SCP-3007.