### PR TITLE
Cache default visualization responses for all studies (SCP-2921, SCP-3308)

### DIFF
--- a/app/controllers/api/v1/concerns/api_caching.rb
+++ b/app/controllers/api/v1/concerns/api_caching.rb
@@ -14,7 +14,7 @@ module Api
         # check Rails cache for JSON response based off url/params
         # cache expiration is still handled by CacheRemovalJob
         def check_api_cache!
-          cache_path = get_cache_key
+          cache_path = RequestUtils.get_cache_path(request.path, params.to_unsafe_hash)
           if check_caching_config && Rails.cache.exist?(cache_path)
             Rails.logger.info "Reading from API cache: #{cache_path}"
             json_response = Rails.cache.fetch(cache_path)
@@ -24,7 +24,7 @@ module Api
 
         # write to the cache after a successful response
         def write_api_cache!
-          cache_path = get_cache_key
+          cache_path = RequestUtils.get_cache_path(request.path, params.to_unsafe_hash)
           if check_caching_config && !Rails.cache.exist?(cache_path)
             Rails.logger.info "Writing to API cache: #{cache_path}"
             Rails.cache.write(cache_path, response.body)
@@ -32,29 +32,6 @@ module Api
         end
 
         private
-
-        # construct cache_key for accessing Rails cache
-        def get_cache_key
-          # transform / into _ to avoid encoding as %2f
-          sanitized_path = sanitize_value(request.path)
-          # remove unwanted parameters from cache_key, as well as empty values
-          # this simplifies base key into smaller value, e.g. _single_cell_api_v1_studies_SCP123_explore_
-          params_key = params.to_unsafe_hash.reject {|name, value| CACHE_PATH_BLACKLIST.include?(name) || value.empty?}.
-              map do |parameter_name, parameter_value|
-            if parameter_name == 'genes'
-              "#{parameter_name}_#{construct_gene_list_hash(parameter_value)}"
-            else
-              "#{parameter_name}_#{sanitize_value(parameter_value).split.join('_')}"
-            end
-          end
-          [sanitized_path, params_key].join('_')
-        end
-
-        # remove url-encoded characters from parameter values
-        # extra gsub at the end will catch any mangled encodings and trim them
-        def sanitize_value(value)
-          value.gsub(PATH_REGEX, '_').gsub(/(%|\/)/, '')
-        end
 
         # check if caching is enabled/disabled in development environment
         # will always return true in all other environments
@@ -64,14 +41,6 @@ module Api
           else
             true
           end
-        end
-
-        # create a unique hex digest of a list of genes for use in get_cache_key
-        # this prevents long gene list queries from being split in the middle due to maximum filename length limits
-        # and resulting in invalid % encoding issue when trying to clear selected cache entries
-        def construct_gene_list_hash(query_list)
-          genes = query_list.split(',').map {|gene| gene.strip.gsub(/(%|\/)/, '')}.sort.join
-          Digest::SHA256.hexdigest genes
         end
       end
     end

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -168,8 +168,9 @@ module Api
       def update
         if @study.update(study_params)
           if @study.previous_changes.keys.include?('name')
-            # if user renames a study, invalidate all caches
+            # if user renames a study, invalidate all visualization caches and repopulate default cache
             CacheRemovalJob.new(@study.accession).delay(queue: :cache).perform
+            ClusterCacheService.delay(queue: :cache).cache_study_defaults(@study)
           end
           render :show
         else

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -126,7 +126,7 @@ class SiteController < ApplicationController
           # then check if FireCloud is available and disable download links if either is true
           @allow_downloads = ApplicationController.firecloud_client.services_available?(FireCloudClient::BUCKETS_SERVICE)
 
-          # warm all default caches
+          # warm all default caches for this study
           ClusterCacheService.delay(queue: :cache).cache_study_defaults(@study)
         end
         set_firecloud_permissions(@study.detached?)

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -125,6 +125,9 @@ class SiteController < ApplicationController
           # double check on download availability: first, check if administrator has disabled downloads
           # then check if FireCloud is available and disable download links if either is true
           @allow_downloads = ApplicationController.firecloud_client.services_available?(FireCloudClient::BUCKETS_SERVICE)
+
+          # warm all default caches
+          ClusterCacheService.delay(queue: :cache).cache_study_defaults(@study)
         end
         set_firecloud_permissions(@study.detached?)
         set_study_permissions(@study.detached?)

--- a/app/lib/cluster_cache_service.rb
+++ b/app/lib/cluster_cache_service.rb
@@ -1,5 +1,5 @@
 ##
-# ClusterCacheService: class for pre-caching cluster visualization responses to speed up loading default responses
+# For pre-caching cluster visualization responses to speed up loading default responses
 ##
 class ClusterCacheService
   # return the output from a url_helper, such as api_v1_study_cluster_path(study, cluster_name)
@@ -9,7 +9,7 @@ class ClusterCacheService
   #   - +params+ (*Array) => request parameters, supports path-level and query string (as Hash), passed with splat (*)
   #
   # * *returns*
-  #   - (String) => String representation of request path with all parameters interpolated in
+  #   - (String) => Request path with all parameters interpolated in
   def self.format_request_path(route_name, *params)
     Rails.application.routes.url_helpers.send(route_name, *params)
   end
@@ -49,7 +49,7 @@ class ClusterCacheService
         Rails.cache.write(cache_path, viz_data.to_json)
       end
     else
-      Rails.logger.info "No defaults present for #{study.accession}; skipping"
+      Rails.logger.info "No defaults present for #{study.accession}; skip caching study defaults"
     end
   end
 end

--- a/app/lib/cluster_cache_service.rb
+++ b/app/lib/cluster_cache_service.rb
@@ -33,10 +33,12 @@ class ClusterCacheService
     if cluster && annotation
       annotation_name, annotation_type, annotation_scope = annotation.split('--')
       default_path = format_request_path(:api_v1_study_cluster_path, study.accession, '_default')
-      named_path = format_request_path(:api_v1_study_cluster_path,study.accession, cluster.name)
+      # necessary for legacy cluster names that could contain slashes and other non URL-safe characters
+      sanitized_cluster_name = CGI.escape(cluster.name)
+      named_path = format_request_path(:api_v1_study_cluster_path,study.accession, sanitized_cluster_name)
       full_params = {
-        annotation_name: annotation_name, annotation_scope: annotation_scope, annotation_type: annotation_type,
-        subsample: 'all', cluster_name: cluster.name
+        annotation_name: CGI.escape(annotation_name), annotation_scope: annotation_scope, annotation_type: annotation_type,
+        subsample: 'all', cluster_name: sanitized_cluster_name
       }
       [default_path, named_path].each do |viz_request_path|
         # specify '_default' for cluster_name to form correct cache path, otherwise use all parameters

--- a/app/lib/cluster_cache_service.rb
+++ b/app/lib/cluster_cache_service.rb
@@ -1,0 +1,53 @@
+##
+# ClusterCacheService: class for pre-caching cluster visualization responses to speed up loading default responses
+##
+class ClusterCacheService
+  # return the output from a url_helper, such as api_v1_study_cluster_path(study, cluster_name)
+  #
+  # * *params*
+  #   - +route_name+ (String, Symbol) => name of route from routes.rb (as: declaration)
+  #   - +params+ (*Array) => request parameters, supports path-level and query string (as Hash), passed with splat (*)
+  #
+  # * *returns*
+  #   - (String) => String representation of request path with all parameters interpolated in
+  def self.format_request_path(route_name, *params)
+    Rails.application.routes.url_helpers.send(route_name, *params)
+  end
+
+  # pre-cache all default clusters/annotations for every study
+  def self.cache_all_defaults
+    Study.all.map {|study| cache_study_defaults(study) }
+  end
+
+  # pre-cache the default cluster & annotation for a given study
+  #
+  # * *params*
+  #   - +study+ (Study) => study to cache defaults for
+  #
+  # * *yields*
+  #   - (JSON) => ActionDispatch::Cache entry of JSON viz data
+  def self.cache_study_defaults(study)
+    Rails.logger.info "Checking defaults on #{study.accession} for pre-caching"
+    cluster = study.default_cluster
+    annotation = study.default_annotation
+    if cluster && annotation
+      annotation_name, annotation_type, annotation_scope = annotation.split('--')
+      default_path = format_request_path(:api_v1_study_cluster_path, study.accession, '_default')
+      named_path = format_request_path(:api_v1_study_cluster_path,study.accession, cluster.name)
+      full_params = {
+        annotation_name: annotation_name, annotation_scope: annotation_scope, annotation_type: annotation_type,
+        subsample: 'all', cluster_name: cluster.name
+      }
+      [default_path, named_path].each do |viz_request_path|
+        # specify '_default' for cluster_name to form correct cache path, otherwise use all parameters
+        url_params = viz_request_path.end_with?('_default') ? {cluster_name: '_default'} : full_params
+        cache_path = RequestUtils.get_cache_path(viz_request_path, url_params.with_indifferent_access)
+        viz_data = Api::V1::Visualization::ClustersController.get_cluster_viz_data(study, cluster, url_params)
+        Rails.logger.info "Pre-caching viz data for #{cache_path}"
+        Rails.cache.write(cache_path, viz_data.to_json)
+      end
+    else
+      Rails.logger.info "No defaults present for #{study.accession}; skipping"
+    end
+  end
+end

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -1,10 +1,55 @@
-require 'rails/commands/server/server_command'
-
+# RequestUtils: helper class for dealing with request parameters, sanitizing input, and setting
+# cache paths on visualization requests
 class RequestUtils
+
+  # list of parameters to reject from :get_cache_key as they will be represented by request.path
+  # format is always :json and therefore unnecessary
+  CACHE_PATH_BLACKLIST = %w(controller action format study_id)
+
+  # character regex to convert into underscores (_) for cache path setting
+  PATH_REGEX =/(\/|%2C|%2F|%20|\?|&|=|\.|,|\s)/
 
   # load same sanitizer as ActionView for stripping html/js from inputs
   # using FullSanitizer as it is the most strict
   SANITIZER ||= Rails::Html::FullSanitizer.new
+
+  ##
+  # Cache path methods
+  ##
+
+  def self.get_cache_path(request_path, url_params)
+    # transform / into _ to avoid encoding as %2f
+    sanitized_path = sanitize_value(request_path)
+    # remove unwanted parameters from cache_key, as well as empty values
+    # this simplifies base key into smaller value, e.g. _single_cell_api_v1_studies_SCP123_explore_
+    params_key = url_params.reject {|name, value| CACHE_PATH_BLACKLIST.include?(name) || value.empty?}.
+      map do |parameter_name, parameter_value|
+      if parameter_name == 'genes'
+        "#{parameter_name}_#{construct_gene_list_hash(parameter_value)}"
+      else
+        "#{parameter_name}_#{sanitize_value(parameter_value).split.join('_')}"
+      end
+    end
+    [sanitized_path, params_key].join('_')
+  end
+
+  # create a unique hex digest of a list of genes for use in get_cache_key
+  # this prevents long gene list queries from being split in the middle due to maximum filename length limits
+  # and resulting in invalid % encoding issue when trying to clear selected cache entries
+  def construct_gene_list_hash(query_list)
+    genes = query_list.split(',').map {|gene| gene.strip.gsub(/(%|\/)/, '')}.sort.join
+    Digest::SHA256.hexdigest genes
+  end
+
+  ##
+  # Sanitizer methods
+  ##
+
+  # remove url-encoded characters from request paths & parameter values
+  # extra gsub at the end will catch any mangled encodings and trim them
+  def self.sanitize_value(value)
+    value.gsub(PATH_REGEX, '_').gsub(/(%|\/)/, '')
+  end
 
   # sanitizes a page param into an integer.  Will default to 1 if the value
   # is nil or otherwise can't be read

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -4,7 +4,7 @@ class RequestUtils
 
   # list of parameters to reject from :get_cache_key as they will be represented by request.path
   # format is always :json and therefore unnecessary
-  CACHE_PATH_BLACKLIST = %w(controller action format study_id)
+  CACHE_PATH_EXCLUDE_LIST = %w(controller action format study_id)
 
   # character regex to convert into underscores (_) for cache path setting
   PATH_REGEX =/(\/|%2C|%2F|%20|\?|&|=|\.|,|\s)/
@@ -23,7 +23,7 @@ class RequestUtils
     # remove unwanted parameters from cache_key, as well as empty values
     # this simplifies base key into smaller value, e.g. _single_cell_api_v1_studies_SCP123_explore_
     # parameters must also be sorted by name to ensure cache paths are idempotent
-    params_key = url_params.reject {|name, value| CACHE_PATH_BLACKLIST.include?(name) || value.empty?}.sort_by {|k,v| k}.
+    params_key = url_params.reject {|name, value| CACHE_PATH_EXCLUDE_LIST.include?(name) || value.empty?}.sort_by {|k,v| k}.
       map do |parameter_name, parameter_value|
       if parameter_name == 'genes'
         "#{parameter_name}_#{construct_gene_list_hash(parameter_value)}"

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -388,7 +388,7 @@ class IngestJob
     end
     Rails.logger.info "Setting default options in #{self.study.name}: #{self.study.default_options}"
     self.study.save
-    # warm all default caches
+    # warm all default caches for this study
     ClusterCacheService.delay(queue: :cache).cache_study_defaults(self.study)
   end
 

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -388,6 +388,8 @@ class IngestJob
     end
     Rails.logger.info "Setting default options in #{self.study.name}: #{self.study.default_options}"
     self.study.save
+    # warm all default caches
+    ClusterCacheService.delay(queue: :cache).cache_study_defaults(self.study)
   end
 
   # set the point count on a cluster group after successful ingest

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -24,8 +24,6 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  config.action_controller.perform_caching = true
-
   config.public_file_server.headers = {
     'Cache-Control' => "public, max-age=#{2.days.to_i}"
   }

--- a/db/migrate/20210506205225_cache_all_study_defaults.rb
+++ b/db/migrate/20210506205225_cache_all_study_defaults.rb
@@ -1,0 +1,8 @@
+class CacheAllStudyDefaults < Mongoid::Migration
+  def self.up
+    ClusterCacheService.delay(queue: :cache).cache_all_defaults
+  end
+
+  def self.down
+  end
+end

--- a/rails_startup.bash
+++ b/rails_startup.bash
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 cd /home/app/webapp
-echo "*** CLEARING TMP CACHE ***"
-sudo -E -u app -H bin/rails RAILS_ENV=$PASSENGER_APP_ENV tmp:clear
 echo "*** COMPLETED ***"
 echo "*** ROLLING OVER LOGS ***"
 ruby /home/app/webapp/bin/cycle_logs.rb

--- a/test/integration/cache_management_test.rb
+++ b/test/integration/cache_management_test.rb
@@ -33,7 +33,7 @@ class CacheManagementTest < ActionDispatch::IntegrationTest
       # construct various cache keys for direct lookup (cannot lookup via regex)
       study_clusters_key = "_single_cell_api_v1_studies_#{study.accession}_clusters_"
       study_cluster_key = "#{study_clusters_key}#{cluster_underscore}_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_cluster_name_#{cluster_underscore}"
-      expression_mean_key = "_single_cell_api_v1_studies_#{study.accession}_expression_violin_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_cluster_name_#{cluster_underscore}_consensus_mean_genes_#{genes_hash}_data_type_violin"
+      expression_mean_key = "_single_cell_api_v1_studies_#{study.accession}_expression_violin_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_cluster_name_#{cluster_underscore}_consensus_mean_data_type_violin_genes_#{genes_hash}"
       assert Rails.cache.exist?(study_clusters_key), "Did not find matching API clusters cache entry at #{study_clusters_key}"
       assert Rails.cache.exist?(study_cluster_key), "Did not find matching API single cluster cache entry at #{study_cluster_key}"
       assert Rails.cache.exist?(expression_mean_key), "Did not find matching API expression mean cache entry at #{expression_mean_key}"
@@ -60,10 +60,10 @@ class CacheManagementTest < ActionDispatch::IntegrationTest
     cluster_underscore = cluster.name.split.join('_')
     study_clusters_key = "_single_cell_api_v1_studies_#{study.accession}_clusters_"
     cell_annotation = cluster.cell_annotations.sample
-    sanitized_cache_path = "#{study_clusters_key}#{cluster_underscore}_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_foo_bar_cluster_name_#{cluster_underscore}"
+    sanitized_cache_path = "#{study_clusters_key}#{cluster_underscore}_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_cluster_name_#{cluster_underscore}_foo_bar"
     genes = study.genes.map(&:name)
     genes_hash = Digest::SHA256.hexdigest genes.sort.join
-    sanitized_expression_path = "_single_cell_api_v1_studies_#{study.accession}_expression_violin_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_cluster_name_#{cluster_underscore}_consensus_mean_genes_#{genes_hash}_data_type_violin"
+    sanitized_expression_path = "_single_cell_api_v1_studies_#{study.accession}_expression_violin_annotation_name_#{cell_annotation[:name]}_annotation_scope_cluster_annotation_type_#{cell_annotation[:type]}_cluster_name_#{cluster_underscore}_consensus_mean_data_type_violin_genes_#{genes_hash}"
 
     # make request with extra parameter with % sign
     get api_v1_study_cluster_path(study_id: study.accession, annotation_name: cell_annotation[:name],

--- a/test/integration/lib/cluster_cache_service_test.rb
+++ b/test/integration/lib/cluster_cache_service_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+
+class ClusterCacheServiceTest < ActiveSupport::TestCase
+  include Minitest::Hooks
+  include TestInstrumentor
+  include SelfCleaningSuite
+
+  before(:all) do
+    @user = FactoryBot.create(:admin_user, test_array: @@users_to_clean)
+    @study = FactoryBot.create(:detached_study, name_prefix: 'Test Cache Study', test_array: @@studies_to_clean)
+    @study_cluster_file_1 = FactoryBot.create(:cluster_file,
+                                              name: 'cluster_1.txt', study: @study,
+                                              cell_input: {
+                                                x: [1, 4 ,6],
+                                                y: [7, 5, 3],
+                                                z: [2, 8, 9],
+                                                cells: ['A', 'B', 'C']
+                                              },
+                                              x_axis_label: 'PCA 1',
+                                              y_axis_label: 'PCA 2',
+                                              z_axis_label: 'PCA 3',
+                                              cluster_type: '3d',
+                                              annotation_input: [
+                                                {name: 'Category', type: 'group', values: ['bar', 'bar', 'baz']},
+                                                {name: 'Intensity', type: 'numeric', values: [1.1, 2.2, 3.3]}
+                                              ])
+
+    @study_metadata_file = FactoryBot.create(:metadata_file,
+                                             name: 'metadata.txt', study: @study,
+                                             cell_input: ['A', 'B', 'C'],
+                                             annotation_input: [
+                                               {name: 'species', type: 'group', values: ['dog', 'cat', 'dog']},
+                                               {name: 'disease', type: 'group', values: ['none', 'none', 'measles']}
+                                             ])
+
+    defaults = {
+      cluster: 'cluster_1.txt',
+      annotation: 'species--group--study'
+    }
+    @study.update(default_options: defaults)
+  end
+
+  test 'should format request path' do
+    # no parameters
+    expected_site_path = '/single_cell'
+    formatted_path = ClusterCacheService.format_request_path(:site_path)
+    assert_equal expected_site_path, formatted_path
+    # path-level parameters
+    expected_view_study_path = "/single_cell/study/#{@study.accession}/#{@study.url_safe_name}"
+    formatted_study_path = ClusterCacheService.format_request_path(:view_study_path,
+                                                                   @study.accession, @study.url_safe_name)
+    assert_equal expected_view_study_path, formatted_study_path
+    # query string-level parameters
+    cluster = @study.cluster_groups.first
+    expected_cluster_path = "/single_cell/api/v1/studies/#{@study.accession}/clusters/#{cluster.name}?annotation_name=species" \
+                            "&annotation_scope=study&annotation_type=group"
+    formatted_cluster_path = ClusterCacheService.format_request_path(:api_v1_study_cluster_path,
+                                                                     @study.accession, cluster_name: cluster.name,
+                                                                     annotation_name: 'species', annotation_scope: 'study',
+                                                                     annotation_type: 'group')
+    assert_equal expected_cluster_path, formatted_cluster_path
+  end
+
+  test 'should cache study defaults' do
+    cluster = @study.default_cluster
+    cluster_name = cluster.name.gsub(/\./, '_') # need to escape period in cluster name for cache path
+    annotation = @study.default_annotation
+    annotation_name, annotation_type, annotation_scope = annotation.split('--')
+    expected_default_path = "_single_cell_api_v1_studies_#{@study.accession}_clusters__default_cluster_name__default"
+    expected_named_path = "_single_cell_api_v1_studies_#{@study.accession}_clusters_#{cluster_name}_annotation_name_" \
+                          "#{annotation_name}_annotation_scope_#{annotation_scope}_annotation_type_#{annotation_type}_" \
+                          "cluster_name_#{cluster_name}_subsample_all"
+    ClusterCacheService.cache_study_defaults(@study)
+    assert Rails.cache.exist?(expected_default_path), "did not find default cache entry at #{expected_default_path}"
+    assert Rails.cache.exist?(expected_named_path), "did not find named cache entry at #{expected_named_path}"
+  end
+end


### PR DESCRIPTION
As part of the effort to improve performance and reduce overall visualization times, this update changes the behavior for generating/warming visualization caches.  Previously, a response would only be cached after first having been requested by a user, and that cache would live only until the next deployment, or until the study owner updated a file or setting that would cause the cache to be cleared.  Now, upon successful ingest of a cluster/metadata file, all "default" visualization caches will be stored proactively, and all visualization caches will persist indefinitely (i.e. through deployments).  If a user updates a default setting that would cause the default cache to be cleared, it is then immediately regenerated.  Furthermore, the defaults will be cached at both the default subsample and "All Cells". 

Note: this _only_ applies to the default cluster & annotation for each study.  In addition, this update refactors the logic for generating visualization cache file paths into the `RequestUtils` class.

Follow-on work to this update will be to measure the improvement to TTI (time to interactive) on the explore tab in the study overview page, and a determination as to whether we want to extend this behavior to all non-expression visualization caches.

This PR satisfies SCP-2921 and portions of SCP-3308.