### PR TITLE
Remove blanket Safari deprecation notice (SCP-3320)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -222,12 +222,6 @@ function deletePromise(event, message) {
 
 // attach various handlers to bootstrap items and turn on functionality
 function enableDefaultActions() {
-    // detect Safari and alert user of deprecation
-    if (navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') == -1) {
-        alert('WARNING: The Single Cell Portal no longer supports the Safari browser, and most functionality will be disabled.  ' +
-            'Please use either Chrome or FireFox instead.');
-    }
-
     // need to clear previous listener to prevent conflict
     $('.panel-collapse').off('show.bs.collapse hide.bs.collapse');
 


### PR DESCRIPTION
Now that we have migrated completely to the React-based explore tab, and are using the npm `plotly` library, we no longer need to warn users about issues when using SCP with the Safari browser.  Testing has shown that SCP visualizations work as expected in the latest version of Safari.  This update removes the JS alert telling users that SCP does not support Safari.  

To Test:
* Boot local instance and open home page w/ Safari
* Note that the alert modal saying `WARNING: The Single Cell Portal no longer supports the Safari browser` is no longer shown
* Navigate to any study w/ visualizations and note normal usage

This PR satisfies SCP-3320.