### PR TITLE
Restore overwritten security fix in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
     bootsnap (1.3.1)
       msgpack (~> 1.0)
     brakeman (4.3.1)
+    brotli (0.4.0)
     browser (5.3.0)
     bson (4.3.0)
     bson_ext (1.5.1)
@@ -319,6 +320,9 @@ GEM
       websocket (~> 1.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-brotli (1.1.0)
+      brotli (>= 0.1.7)
+      rack (>= 1.4)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -527,6 +531,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   parallel
   puma
+  rack-brotli
   rails (= 5.2.4.6)
   rest-client
   rubocop


### PR DESCRIPTION
This restores `Gemfile.lock` content that fixes #1025, which was inadvertently overwritten upon merging #1008.