### PR TITLE
Change references to master/slave/black/white to more appropriate terms (SCP-3345)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ to log in with their Google accounts.  To do so:
   * Save the client id
   * You will also want to create a second OAuth Client ID to use in local development, using `localhost` as the hostname
 
-* **Whitelisting your OAuth Audience**
-  * Once you have exported your OAuth credentials, you will need to have your client id whitelisted to allow it to make
+* **Authorizing your OAuth Audience**
+  * Once you have exported your OAuth credentials, you will need to have your client id authorized to allow it to make
   authenticated requests into the Terra API as per [OpenID Connect 1.0](http://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation)
-    *  Send an email to **dsp-devops@broadinstitute.org** with your OAuth2 client ID(s) so it can be added to the whitelist
+    *  Send an email to **dsp-devops@broadinstitute.org** with your OAuth2 client ID(s) so it can be added to the authorized list
 
 * **GCP Service Account keys**: Regardless of where the portal is deployed, it requires a Google Cloud Platform Service
 Account in order to make authenticated calls into Terra and Google Cloud Storage.  Therefore, you must export the
@@ -147,7 +147,7 @@ To do so:
 	* Fill out all form fields and submit
 	* This must be done for both the 'main' and 'read-only' service accounts
 
-* **Creating a Terra Project**: Once your OAuth audience has been whitelisted, and before you can create studies, you
+* **Creating a Terra Project**: Once your OAuth audience has been authorized, and before you can create studies, you
 will need to create a Terra project that will own all the workspaces created in the portal. To do this:
 	* Create a [Google Billing Project](https://support.terra.bio/hc/en-us/articles/360026182251#How%20to%20create%20your%20own%20Google%20Billing%20Account).
 	* Using the same Google account that owns the billing project, log into the portal and select 'My Billing Projects' from the profile menu.

--- a/app/controllers/admin_configurations_controller.rb
+++ b/app/controllers/admin_configurations_controller.rb
@@ -397,7 +397,7 @@ class AdminConfigurationsController < ApplicationController
     @admin_configuration = AdminConfiguration.find(params[:id])
   end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
+  # Never trust parameters from the scary internet, only allow the permit list through.
   def admin_configuration_params
     params.require(:admin_configuration).permit(:config_type, :value_type, :value, :multiplier, configuration_options_attributes: [:id, :name, :value, :_destroy])
   end

--- a/app/controllers/analysis_configurations_controller.rb
+++ b/app/controllers/analysis_configurations_controller.rb
@@ -159,7 +159,7 @@ class AnalysisConfigurationsController < ApplicationController
       @analysis_parameter = AnalysisParameter.find_by(id: params[:analysis_parameter_id], analysis_configuration_id: params[:id])
     end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
+    # Never trust parameters from the scary internet, only allow the permit list through.
     def analysis_configuration_params
       params.require(:analysis_configuration).permit(:namespace, :name, :snapshot, :configuration_namespace,
                                                      :configuration_name, :configuration_snapshot, :user_id, :description,

--- a/app/controllers/api/v1/directory_listings_controller.rb
+++ b/app/controllers/api/v1/directory_listings_controller.rb
@@ -302,7 +302,7 @@ module Api
         head 403 unless @study.can_edit?(current_api_user)
       end
 
-      # study file params whitelist
+      # study file params list
       def directory_listing_params
         params.require(:directory_listing).permit(:id, :name, :description, :file_type, :sync_status, files: [:name, :size, :generation])
       end

--- a/app/controllers/api/v1/external_resources_controller.rb
+++ b/app/controllers/api/v1/external_resources_controller.rb
@@ -303,7 +303,7 @@ module Api
         head 403 unless @study.can_edit?(current_api_user)
       end
 
-      # study file params whitelist
+      # study file params list
       def external_resource_params
         params.require(:external_resource).permit(:id, :study_id, :title, :description, :url, :publication_url)
       end

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -566,7 +566,7 @@ module Api
         head 403 unless (@study.public || @study.can_view?(current_api_user))
       end
 
-      # study params whitelist
+      # study params list
       def study_params
         params.require(:study).permit(:name, :description, :public, :embargo, :use_existing_workspace, :firecloud_workspace,
                                       :firecloud_project, :branding_group_id, :cell_count, :gene_count, :view_order,

--- a/app/controllers/api/v1/study_file_bundles_controller.rb
+++ b/app/controllers/api/v1/study_file_bundles_controller.rb
@@ -252,7 +252,7 @@ module Api
         head 403 unless @study.can_edit?(current_api_user)
       end
 
-      # study file params whitelist
+      # study file params list
       def study_file_bundle_params
         params.require(:study_file_bundle).permit(:bundle_type, original_file_list: [:name, :file_type, :species, :assembly])
       end

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -575,7 +575,7 @@ module Api
         head 403 unless @study.can_edit?(current_api_user)
       end
 
-      # study file params whitelist
+      # study file params list
       def study_file_params
         params.require(:study_file).permit(:_id, :study_id, :taxon_id, :genome_assembly_id, :study_file_bundle_id, :name,
                                            :upload, :upload_file_name, :upload_content_type, :upload_file_size, :remote_location,

--- a/app/controllers/api/v1/study_search_results_objects.rb
+++ b/app/controllers/api/v1/study_search_results_objects.rb
@@ -53,7 +53,7 @@ module Api
           study_obj[:term_matches] = inferred_weight[:terms].keys
           study_obj[:term_search_weight] = inferred_weight[:total]
         end
-        if @preset_search.present? && @preset_search.accession_whitelist.include?(study.accession)
+        if @preset_search.present? && @preset_search.accession_list.include?(study.accession)
           study_obj[:preset_match] = true
         end
         if @gene_results.present?

--- a/app/controllers/api/v1/study_shares_controller.rb
+++ b/app/controllers/api/v1/study_shares_controller.rb
@@ -319,7 +319,7 @@ module Api
         head 403 unless @study.can_edit?(current_api_user)
       end
 
-      # study file params whitelist
+      # study file params list
       def study_share_params
         params.require(:study_share).permit(:id, :study_id, :email, :permission, :deliver_emails)
       end

--- a/app/controllers/branding_groups_controller.rb
+++ b/app/controllers/branding_groups_controller.rb
@@ -78,7 +78,7 @@ class BrandingGroupsController < ApplicationController
     @branding_group = BrandingGroup.find(params[:id])
   end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
+  # Never trust parameters from the scary internet, only allow the permit list through.
   def branding_group_params
     params.require(:branding_group).permit(:name, :tag_line, :background_color, :font_family, :font_color, :user_id,
                                            :splash_image, :banner_image, :footer_image, :external_link_url, :external_link_description)

--- a/app/controllers/preset_searches_controller.rb
+++ b/app/controllers/preset_searches_controller.rb
@@ -73,16 +73,16 @@ class PresetSearchesController < ApplicationController
     @preset_search = PresetSearch.find(params[:id])
   end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
+  # Never trust parameters from the scary internet, only allow the permit list through.
   def preset_search_params
-    params.require(:preset_search).permit(:name, :public, :accession_whitelist, :search_terms, :facet_filters)
+    params.require(:preset_search).permit(:name, :public, :accession_list, :search_terms, :facet_filters)
   end
 
   # convert text fields into arrays for saving
   # TODO: figure out a way to leverage this natively using array serialization w/ forms because this is gross as hell
   def serialize_preset_search_params
     form_params = preset_search_params.to_unsafe_hash
-    accessions = form_params[:accession_whitelist].blank? ? [] : form_params[:accession_whitelist].split.map(&:strip)
+    accessions = form_params[:accession_list].blank? ? [] : form_params[:accession_list].split.map(&:strip)
     facets = form_params[:facet_filters].blank? ? [] : form_params[:facet_filters].split('+').map(&:strip)
     terms = []
     if form_params[:search_terms].present? && form_params[:search_terms].include?("\"")
@@ -97,7 +97,7 @@ class PresetSearchesController < ApplicationController
       terms = form_params[:search_terms].split if form_params[:search_terms].present?
     end
     form_params[:search_terms] = terms.map(&:strip).delete_if(&:blank?)
-    form_params[:accession_whitelist] = accessions
+    form_params[:accession_list] = accessions
     form_params[:facet_filters] = facets
     form_params
   end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -728,7 +728,7 @@ class SiteController < ApplicationController
     end
   end
 
-  # whitelist parameters for updating studies on study settings tab (smaller list than in studies controller)
+  # permit parameters for updating studies on study settings tab (smaller list than in studies controller)
   def study_params
     params.require(:study).permit(:name, :description, :public, :embargo, :cell_count,
                                   :default_options => [:cluster, :annotation, :color_profile, :expression_label, :deliver_emails,
@@ -737,7 +737,7 @@ class SiteController < ApplicationController
                                   study_detail_attributes: [:id, :full_description])
   end
 
-  # whitelist parameters for creating custom user annotation
+  # permit parameters for creating custom user annotation
   def user_annotation_params
     params.require(:user_annotation).permit(:_id, :name, :study_id, :user_id, :cluster_group_id, :subsample_threshold,
                                             :loaded_annotation, :subsample_annotation, user_data_arrays_attributes: [:name, :values])

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -473,7 +473,7 @@ class StudiesController < ApplicationController
   # method to perform chunked uploading of data
   def do_upload
     upload = get_upload
-    # remove spaces and + (encoded whitespace character) from filename since this converted client-side,
+    # remove spaces and + (encoded space character) from filename since this converted client-side,
     # but original_filename is unchanged in headers
     filename = upload.original_filename.gsub(/[\s\+]/, '_')
     study_file = @study.study_files.detect {|sf| sf.upload_file_name == filename}
@@ -1078,7 +1078,7 @@ class StudiesController < ApplicationController
     @study = Study.find(params[:id])
   end
 
-  # study params whitelist
+  # study params list
   def study_params
     params.require(:study).permit(:name, :description, :public, :user_id, :embargo, :use_existing_workspace, :firecloud_workspace,
                                   :firecloud_project, :branding_group_id, study_shares_attributes: [:id, :_destroy, :email, :permission],
@@ -1086,7 +1086,7 @@ class StudiesController < ApplicationController
                                   study_detail_attributes: [:id, :full_description])
   end
 
-  # study file params whitelist
+  # study file params list
   def study_file_params
     params.require(:study_file).permit(:_id, :study_id, :name, :upload, :upload_file_name, :upload_content_type, :upload_file_size,
                                        :remote_location, :description, :file_type, :status, :human_fastq_url, :human_data, :use_metadata_convention,

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -96,7 +96,7 @@ class TaxonsController < ApplicationController
       @taxon = Taxon.find(params[:id])
     end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
+    # Never trust parameters from the scary internet, only allow the permit list through.
     def taxon_params
       params.require(:taxon).permit(:common_name, :scientific_name, :ncbi_taxid, :user_id, :notes, :aliases, :restricted,
                                     genome_assemblies_attributes: [:id, :name, :alias, :accession, :release_date, :_destroy,

--- a/app/controllers/user_annotations_controller.rb
+++ b/app/controllers/user_annotations_controller.rb
@@ -186,8 +186,8 @@ class UserAnnotationsController < ApplicationController
     @user_annotation = UserAnnotation.find(params[:id])
   end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
-  # whitelist parameters for creating custom user annotation
+  # Never trust parameters from the scary internet, only allow the permit list through.
+  # permit parameters for creating custom user annotation
   def user_annotation_params
     params.require(:user_annotation).permit(:_id, :name, :study_id, :user_id, :cluster_group_id, values: [],
                                             user_annotation_shares_attributes: [:id, :_destroy, :email, :permission])

--- a/app/javascript/components/visualization/StudyViolinPlot.js
+++ b/app/javascript/components/visualization/StudyViolinPlot.js
@@ -186,7 +186,7 @@ function getViolinTraces(
   resultValues, showPoints='none', plotType='violin'
 ) {
   const data = Object.entries(resultValues).map(([traceName, traceData], index) => {
-    // Plotly violin trace creation, adding to master array
+    // Plotly violin trace creation, adding to main array
     // get inputs for plotly violin creation
     const dist = traceData.y
 

--- a/app/lib/study_search_service.rb
+++ b/app/lib/study_search_service.rb
@@ -33,7 +33,7 @@ class StudySearchService
     {  genes_by_study: genes_by_study, study_ids: study_ids.uniq }
   end
 
-  # takes a gene param string and returns a sanitized, whitespace-stripped array of terms
+  # takes a gene param string and returns a sanitized, leading/trailing space-stripped array of terms
   def self.sanitize_gene_params(genes)
     delimiter = genes.include?(',') ? ',' : ' '
     raw_genes = genes.split(delimiter)

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -313,7 +313,7 @@ class ClusterGroup
       # or all values if requested_sample is larger than size of total values for group
       cells_taken = data[:x].size > requested_sample ? requested_sample : data[:x].size
       @cells_left -= cells_taken
-      # were done with this 'group', so remove from master list
+      # were done with this 'group', so remove from main list
       groups.delete(group)
       # recalculate num_per_group, unless last time
       unless index == group_order.size - 1

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -45,7 +45,7 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   BILLING_PROJECT_ROLES = %w(user owner)
   # List of projects where computes are not permitted (sets canCompute to false for all users by default, can only be overridden
   # by PROJECT_OWNER)
-  COMPUTE_BLACKLIST = %w(single-cell-portal)
+  COMPUTE_DENYLIST = %w(single-cell-portal)
   # Name of user group to set as workspace owner for user-controlled billing projects.  Reduces the amount of
   # groups the portal service account needs to be a member of
   # defaults to the Terra billing project this instance is configured against, plus "-sa-owner-group"

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -610,7 +610,7 @@ class Study
     end
     property :preset_match do
       key :type, :boolean
-      key :description, 'Indication this study was whitelisted by a preset search'
+      key :description, 'Indication this study was included by a preset search'
     end
     property :gene_matches do
       key :type, :array
@@ -897,7 +897,7 @@ class Study
   # primarily used when syncing study with FireCloud workspace
   def local_acl
     acl = {
-        "#{self.user.email}" => (Rails.env.production? && FireCloudClient::COMPUTE_BLACKLIST.include?(self.firecloud_project)) ? 'Edit' : 'Owner'
+        "#{self.user.email}" => (Rails.env.production? && FireCloudClient::COMPUTE_DENYLIST.include?(self.firecloud_project)) ? 'Edit' : 'Owner'
     }
     self.study_shares.each do |share|
       acl["#{share.email}"] = share.permission
@@ -1247,7 +1247,7 @@ class Study
     end
   end
 
-  # return an array of all single cell names in study, will check for master list of cells or concatenate all
+  # return an array of all single cell names in study, will check for main list of cells or concatenate all
   # cell lists from individual expression matrices
   def all_cells_array
     if self.metadata_file&.parsed? # nil-safed via &
@@ -1759,8 +1759,8 @@ class Study
           study_owner = self.user.email
           workspace_permission = 'WRITER'
           can_compute = true
-          # if study project is in the compute blacklist, revoke compute permission
-          if Rails.env.production? && FireCloudClient::COMPUTE_BLACKLIST.include?(self.firecloud_project)
+          # if study project is in the compute denylist, revoke compute permission
+          if Rails.env.production? && FireCloudClient::COMPUTE_DENYLIST.include?(self.firecloud_project)
             can_compute = false
           end
           acl = ApplicationController.firecloud_client.create_workspace_acl(study_owner, workspace_permission, true, can_compute)
@@ -1848,8 +1848,8 @@ class Study
         if self.firecloud_project == FireCloudClient::PORTAL_NAMESPACE
           workspace_permission = 'WRITER'
           can_compute = true
-          # if study project is in the compute blacklist, revoke compute permission
-          if Rails.env.production? && FireCloudClient::COMPUTE_BLACKLIST.include?(self.firecloud_project)
+          # if study project is in the compute denylist, revoke compute permission
+          if Rails.env.production? && FireCloudClient::COMPUTE_DENYLIST.include?(self.firecloud_project)
             can_compute = false
             Rails.logger.info "#{Time.zone.now}: Study: #{self.name} removing compute permissions"
             compute_acl = ApplicationController.firecloud_client.create_workspace_acl(self.user.email, workspace_permission, true, can_compute)

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1216,7 +1216,7 @@ class StudyFile
   #
   ###
 
-  # strip whitespace from name if the file is a cluster or gene list (will cause problems when rendering)
+  # strip space from name if the file is a cluster or gene list (will cause problems when rendering)
   def sanitize_name
     if ['Gene List', 'Cluster'].include?(self.file_type)
       self.name.strip!

--- a/app/views/preset_searches/_form.html.erb
+++ b/app/views/preset_searches/_form.html.erb
@@ -19,7 +19,7 @@
     </div>
     <div id="preset-search-help" class="panel-collapse collapse <%= @preset_search.new_record? ? 'in' : nil %>">
       <div class="panel-body">
-        <h5>Whitelist</h5>
+        <h5>Accession List</h5>
         <p>
           Enter study accessions, space-delimited (no commas).  These studies will <strong>always</strong> be returned in results first.<br />
           <span class="help-block">Example: <code>SCP1 SCP2 SCP3</code></span>
@@ -53,8 +53,8 @@
       <%= form.select :public, options_for_select([['Yes',1],['No',0]], @preset_search.public? ? 1 : 0), {}, class: 'form-control' %>
     </div>
     <div class="col-sm-6">
-      <%= form.label :accession_whitelist, 'Whitelist' %>
-      <%= form.text_field :accession_whitelist, class: 'form-control' %>
+      <%= form.label :accession_list, 'Accession List' %>
+      <%= form.text_field :accession_list, class: 'form-control' %>
     </div>
   </div>
 

--- a/app/views/preset_searches/_preset_search.json.jbuilder
+++ b/app/views/preset_searches/_preset_search.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! preset_search, :id, :name, :identifier, :accession_whitelist, :search_terms, :facet_filters, :public, :created_at, :updated_at
+json.extract! preset_search, :id, :name, :identifier, :accession_list, :search_terms, :facet_filters, :public, :created_at, :updated_at
 json.url preset_search_url(stored_search, format: :json)

--- a/app/views/preset_searches/index.html.erb
+++ b/app/views/preset_searches/index.html.erb
@@ -9,7 +9,7 @@
           <tr>
             <th>Name</th>
             <th>Identifier</th>
-            <th>Whitelist</th>
+            <th>Accession List</th>
             <th>Search Terms</th>
             <th>Facets</th>
             <th>Public?</th>
@@ -23,7 +23,7 @@
               <td><%= preset_search.name %></td>
               <td><%= preset_search.identifier %></td>
               <td>
-                <% preset_search.accession_whitelist.each do |accession| %>
+                <% preset_search.accession_list.each do |accession| %>
                   <span class="btn btn-default"><%= scp_link_to accession, legacy_study_path(identifier: accession), target: :_blank %></span>
                 <% end %>
               </td>

--- a/app/views/preset_searches/show.html.erb
+++ b/app/views/preset_searches/show.html.erb
@@ -3,8 +3,8 @@
 <dl class="dl-horizontal" id="preset-search-attributes">
   <dt>Identifier</dt>
   <dd><%= @preset_search.identifier %></dd>
-  <dt>Whitelist</dt>
-  <dd><%= @preset_search.accession_whitelist.join(', ') %></dd>
+  <dt>Accession List</dt>
+  <dd><%= @preset_search.accession_list.join(', ') %></dd>
   <dt>Search Terms</dt>
   <dd><%= @preset_search.search_terms.join(', ') %></dd>
   <dt>Facets</dt>

--- a/db/migrate/20210512162401_rename_preset_search_fields.rb
+++ b/db/migrate/20210512162401_rename_preset_search_fields.rb
@@ -1,0 +1,10 @@
+class RenamePresetSearchFields < Mongoid::Migration
+  def self.up
+    PresetSearch.all.each do |search|
+      search.rename(accession_whitelist: :accession_list)
+    end
+  end
+
+  def self.down
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -195,7 +195,7 @@ BrandingGroup.create!(name: 'Test Brand', user_id: api_user.id, font_family: 'He
 
 # Preset search seeds
 PresetSearch.create!(name: 'Test Search', search_terms: ["Testing Study"],
-                     facet_filters: ['species:NCBITaxon_9606', 'disease:MONDO_0000001'], accession_whitelist: %w(SCP1))
+                     facet_filters: ['species:NCBITaxon_9606', 'disease:MONDO_0000001'], accession_list: %w(SCP1))
 FeatureFlag.create!(name: 'faceted_search')
 
 # seed BQ for search controller test

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -438,21 +438,21 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   test 'should run preset search' do
     puts "#{File.basename(__FILE__)}: #{self.method_name}"
 
-    # run whitelist only search
-    @preset_search = PresetSearch.create!(name: 'Preset Search Test', accession_whitelist: %w(SCP1))
-    whitelisted_study = Study.first
+    # run accession list only search
+    @preset_search = PresetSearch.create!(name: 'Preset Search Test', accession_list: %w(SCP1))
+    permitted_study = Study.first
     execute_http_request(:get, api_v1_search_path(type: 'study', preset_search: @preset_search.identifier))
     assert_response :success
-    whitelist_accessions = %w(SCP1)
-    assert json['matching_accessions'] == whitelist_accessions,
-           "Did not return correct studies for whitelisted preset search; expected #{whitelist_accessions} but found #{json['matching_accessions']}"
+    permitted_accessions = %w(SCP1)
+    assert json['matching_accessions'] == permitted_accessions,
+           "Did not return correct permitted studies for preset search; expected #{permitted_accessions} but found #{json['matching_accessions']}"
     found_preset = json['studies'].first
-    assert found_preset['accession'] == whitelisted_study.accession
-    assert found_preset['preset_match'], "Did not correctly mark whitelisted study as preset match; #{found_preset['preset_match']}"
+    assert found_preset['accession'] == permitted_study.accession
+    assert found_preset['preset_match'], "Did not correctly mark permitted study as preset match; #{found_preset['preset_match']}"
 
     # update to use user-search terms as well, include all studies to widen search
     all_accessions = Study.pluck(:accession)
-    @preset_search.update(accession_whitelist: all_accessions)
+    @preset_search.update(accession_list: all_accessions)
     @preset_search.reload
     search_terms = "\"API Test Study\""
     execute_http_request(:get, api_v1_search_path(type: 'study', preset_search: @preset_search.identifier, terms: search_terms))

--- a/test/controllers/preset_searches_controller_test.rb
+++ b/test/controllers/preset_searches_controller_test.rb
@@ -43,7 +43,7 @@ class PresetSearchesControllerTest < ActionDispatch::IntegrationTest
     preset_search_params = {
         preset_search: {
             name: 'My Preset Search',
-            accession_whitelist: study_accession,
+            accession_list: study_accession,
             search_terms: terms,
             facet_filters: facets
         }
@@ -53,8 +53,8 @@ class PresetSearchesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     @preset_search = PresetSearch.find_by(name: 'My Preset Search')
     assert @preset_search.present?, "Preset search did not get created"
-    assert_equal @preset_search.accession_whitelist, [study_accession],
-                 "Did not properly set whitelist: #{study_accession} is not in #{@preset_search.accession_whitelist}"
+    assert_equal @preset_search.accession_list, [study_accession],
+                 "Did not properly set accession list: #{study_accession} is not in #{@preset_search.accession_list}"
     assert_equal @preset_search.keyword_query_string, terms,
                  "Search terms not correctly set: #{@preset_search.keyword_query_string} != #{terms}"
     assert_equal @preset_search.facet_query_string, facets,
@@ -65,7 +65,7 @@ class PresetSearchesControllerTest < ActionDispatch::IntegrationTest
         preset_search: {
             search_terms: new_terms,
             facet_filters: facets,
-            accession_whitelist: study_accession
+            accession_list: study_accession
         }
     }
     patch preset_search_path(@preset_search), params: update_params
@@ -75,8 +75,8 @@ class PresetSearchesControllerTest < ActionDispatch::IntegrationTest
     assert @preset_search.present?, "Preset search did not get loaded"
     assert_equal @preset_search.keyword_query_string, new_terms,
                  "Search terms did not update: #{new_terms} is not in #{@preset_search.keyword_query_string}"
-    assert_equal @preset_search.accession_whitelist, [study_accession],
-                 "Accession whitelist changed when it shouldn't have; #{study_accession} is not in #{@preset_search.accession_whitelist}"
+    assert_equal @preset_search.accession_list, [study_accession],
+                 "Accession list changed when it shouldn't have; #{study_accession} is not in #{@preset_search.accession_list}"
     assert_equal @preset_search.facet_query_string, facets,
                  "Facets were changed when they shouldn't have; #{facets} != #{@preset_search.facet_query_string}"
 

--- a/test/integration/fire_cloud_client_test.rb
+++ b/test/integration/fire_cloud_client_test.rb
@@ -452,9 +452,9 @@ class FireCloudClientTest < ActiveSupport::TestCase
     projects = @fire_cloud_client.get_billing_projects
     assert projects.any?, 'Did not find any billing projects'
 
-    # select a project (only valid projects, not in the compute blacklist)
+    # select a project (only valid projects, not in the compute denylist)
     project_name = projects.select {|p| p['creationStatus'] == 'Ready' &&
-        !FireCloudClient::COMPUTE_BLACKLIST.include?(p['projectName']) &&
+        !FireCloudClient::COMPUTE_DENYLIST.include?(p['projectName']) &&
         p['role'] == 'Owner'}.sample['projectName']
     assert project_name.present?, 'Did not select a billing project'
 

--- a/test/models/preset_search_test.rb
+++ b/test/models/preset_search_test.rb
@@ -82,11 +82,11 @@ class PresetSearchTest < ActiveSupport::TestCase
     found_facet_error = @invalid_preset.errors.full_messages.first
     assert_equal expected_facet_error, found_facet_error, "Did not correctly find duplicated facets: #{found_facet_error}"
 
-    # non-existent studies in whitelist
+    # non-existent studies in accession list
     @invalid_preset.facet_filters = %w(disease:MONDO_0000001)
-    @invalid_preset.accession_whitelist = %w(SCP0)
+    @invalid_preset.accession_list = %w(SCP0)
     assert !@invalid_preset.valid?
-    expected_accession_error = 'Accession whitelist contains missing studies: SCP0'
+    expected_accession_error = 'Accession list contains missing studies: SCP0'
     found_accession_error = @invalid_preset.errors.full_messages.first
     assert_equal expected_accession_error, found_accession_error, "Did not correctly find missing studies: #{found_accession_error}"
 


### PR DESCRIPTION
In line with the industry-wide move away from computing terms that have a racial context, this update renames methods/variables that contain references to the above terms with one of the following replacements:

* `master`: `main`, or `parent`
* `slave`: `worker`, or `child`
* `black` (used to denote denial/restriction, rather than the actual color): `deny`
* `white` (used to denote allowed/accepted, rather than the actual color): `allow`, or `permit`

There is an associated ticket (SCP-3346) to rename the `master` branch in all SCP Github repositories to `main`.  This work impacts all of our automation for CI/deployments, so is not included in this update.

This PR satisfies SCP-3345.