### PR TITLE
fixing display of coordinate labels in 3d plots (SCP-3363)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -221,7 +221,7 @@ function getPlotlyLayout({
   hasCoordinateLabels,
   coordinateLabels,
   isAnnotatedScatter,
-  is3d,
+  is3D,
   isCellSelecting=false,
   gene,
   annotParams
@@ -231,8 +231,9 @@ function getPlotlyLayout({
     font: labelFont,
     dragmode: getDragMode(isCellSelecting)
   }
-  if (is3d) {
-    layout.scene = get3DScatterProps({ domainRanges, axes })
+  if (is3D) {
+    layout.scene = get3DScatterProps({ domainRanges, axes, hasCoordinateLabels,
+      coordinateLabels })
   } else {
     const props2d = get2DScatterProps({
       axes,
@@ -299,7 +300,8 @@ const baseCamera = {
 }
 
 /** Gets Plotly layout scene props for 3D scatter plot */
-export function get3DScatterProps({ domainRanges, axes }) {
+export function get3DScatterProps({ domainRanges, axes, hasCoordinateLabels,
+      coordinateLabels }) {
   const { titles, ranges, aspects } = axes
 
   const scene = {
@@ -323,6 +325,10 @@ export function get3DScatterProps({ domainRanges, axes }) {
       y: aspects.y,
       z: aspects.z
     }
+  }
+
+  if (hasCoordinateLabels) {
+    scene.annotations = coordinateLabels
   }
 
   return scene

--- a/db/seed/synthetic_studies/human_raw_counts/coordinate_labels.tsv
+++ b/db/seed/synthetic_studies/human_raw_counts/coordinate_labels.tsv
@@ -1,0 +1,4 @@
+X	Y	Z	LABELS
+0	0	0	Origin
+0.9	0.9	0.9	Quadrant 1
+-0.5	-0.5	-0.5	Negative 0.5 everything

--- a/db/seed/synthetic_studies/human_raw_counts/study_info.json
+++ b/db/seed/synthetic_studies/human_raw_counts/study_info.json
@@ -34,6 +34,11 @@
       "type": "Expression Matrix",
       "filename": "raw1_human_5k_cells_80_genes.processed_dense.txt",
       "species_scientific_name": "Homo sapiens"
+    },
+    {
+      "type": "Coordinate Labels",
+      "filename": "coordinate_labels.tsv",
+      "cluster_file_name": "raw1_human_5k_cells_80_genes.cluster_3D.txt"
     }
   ]
 }


### PR DESCRIPTION
TO TEST:
1. load a study with a 3d plot and coordinate labels -- e.g. the now-updated human raw counts study (note you'll have to repopulate it so you get the coordinate labels added here)
2. Confirm the coordinate labels appear