### PR TITLE
Fixing local asset paths for previously uploaded BrandingGroup images (SCP-3367)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,8 +102,8 @@ GEM
     bootsnap (1.7.5)
       msgpack (~> 1.0)
     brakeman (5.0.1)
-    browser (5.3.1)
     brotli (0.4.0)
+    browser (5.3.1)
     bson (4.12.0)
     bson_ext (1.5.1)
     builder (3.2.4)
@@ -559,8 +559,8 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   parallel
   puma
-  rails (= 6.1.3.2)
   rack-brotli
+  rails (= 6.1.3.2)
   rest-client
   rubocop
   rubocop-rails

--- a/db/migrate/20210518152311_move_image_uploads_to_carrierwave_path.rb
+++ b/db/migrate/20210518152311_move_image_uploads_to_carrierwave_path.rb
@@ -1,0 +1,31 @@
+# move any previously uploaded images not already inside 'original' version directory for Carrierwave to new location
+class MoveImageUploadsToCarrierwavePath < Mongoid::Migration
+  def self.up
+    branding_images = UserAssetService.get_local_assets(asset_type: :branding_images)
+    files_by_dir = {}
+    branding_images.each do |pathname|
+      dir_path, filename = pathname.split
+      files_by_dir[dir_path] ||= []
+      files_by_dir[dir_path] << filename
+    end
+    files_by_dir.each do |dir_path, files|
+      folder_name = File.basename(dir_path)
+      if folder_name != 'original'
+        carrierwave_dir = dir_path.join('original')
+        files.each do |file|
+          current_path = dir_path.join(file)
+          new_path = carrierwave_dir.join(file)
+          FileUtils.mkdir_p(carrierwave_dir)
+          FileUtils.mv(current_path, new_path)
+        end
+        # remove existing cached images at the deprecated path
+        UserAssetService.remove_assets_from_remote("branding_groups/#{folder_name}")
+      end
+    end
+    # back up all assets at correct paths
+    UserAssetService.push_assets_to_remote(asset_type: :branding_images)
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
With the removal of `paperclip` in #1030, previously uploaded `BrandingGroup` images that live on disk are not stored at the default path that `carrierwave` expects them to be at.  This leads to the images not displaying when the `BrandingGroup` is loaded.  This update adds a migration that moves all existing images into the "original" subfolder that `carrierwave` expects.  In addition, existing cached images that are managed via `UserAssetService` are also updated to be at the correct path in the remote storage bucket.

This also fixes a small issue with a merge conflict on #1030 that ended up incorrectly sorting `Gemfile.lock`.

To test:

If you do not have a previously created `BrandingGroup` with images, you can be simulate one via the following:
1. Create a new `BrandingGroup` at https://localhost:3000/single_cell/branding_groups, and make sure to upload images located at `test/test_data/branding_groups`:
    * Splash Image: SCP-logo-invert.png
    * Banner Image: SCP-Header-resize-invert.png
    * Footer Image: broad-logo-white-invert.png
2. Once the `BrandingGroup` is created, open the folder where the images are stored at `single_cell_portal_core/public/single_cell/branding_groups/#{branding_group_id}/original`
3. Move the uploaded files to the parent directory, and remove the `original` folder
4. Load the branding group via the profile menu, and note that the image links are broken
5. In a new terminal window. run `./rails_local_setup.rb && source config/secrets/.source_env.bash` and then `bin/rails db:migrate`
6. Refresh your browser window and note branding images now display, and note the image files have moved back into the "original" subfolder

This PR satisfies SCP-3367.