### PR TITLE
Adding Host header validation on auth callbacks (SCP-3373)

### DIFF
--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -79,15 +79,17 @@ class RequestUtils
     SANITIZER.sanitize(inputs).encode!(Encoding.find('ASCII-8BIT'), invalid: :replace, undef: :replace)
   end
 
+  # return the hostname (and port, if present) for this instance
+  # e.g. "localhost", "localhost:3000", "singlecell.broadinstitute.org"
+  def self.get_hostname
+    url_opts = ApplicationController.default_url_options
+    url_opts[:port].present? ? "#{url_opts[:host]}:#{url_opts[:port]}" : url_opts[:host]
+  end
+
   # helper method for getting the base url with protocol, hostname, and port
   # e.g. "https://localhost"
   def self.get_base_url
-    url_opts = ApplicationController.default_url_options
-    base_url = "#{url_opts[:protocol]}://#{url_opts[:host]}"
-    if url_opts[:port].present?
-      base_url += ":#{url_opts[:port]}"
-    end
-    base_url
+    "#{ApplicationController.default_url_options[:protocol]}://#{self.get_hostname}"
   end
 
   # extracts an array of genes from a comma-delimited string list of gene names

--- a/test/controllers/users/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/users/omniauth_callbacks_controller_test.rb
@@ -36,4 +36,19 @@ class User::OmniauthCallbacksControllerTest < ActiveSupport::TestCase
       Users::OmniauthCallbacksController.validate_scopes_from_params(@google_billing_params, provider)
     end
   end
+
+  test 'should validate host header on callback' do
+    RequestUtils.stub :get_hostname, 'localhost:3000' do
+      assert_nothing_raised do
+        Users::OmniauthCallbacksController.validate_host_header_on_callback({'HTTP_HOST' => 'localhost:3000'})
+      end
+
+      %w(localhost localhost:12345 malicious.com).each do |host|
+        invalid_headers = {'HTTP_HOST' => host}
+        assert_raise SecurityError do
+          Users::OmniauthCallbacksController.validate_host_header_on_callback(invalid_headers)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This update validates that all OAuth callbacks from Google have a valid `Host` header in the request.  This is to mitigate host header injection attacks which would redirect a user away from SCP after logging in.

This PR satisfies SCP-3373.