### PR TITLE
Terra Data Repo API client scaffold (SCP-3353)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,6 +45,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def self.data_repo_client
+    @@data_repo_client ||= DataRepoClient.new
+  end
+
   # method to renew firecloud client (forces new access token for API and reinitializes storage driver)
   def self.refresh_firecloud_client
     begin

--- a/app/lib/user_asset_service.rb
+++ b/app/lib/user_asset_service.rb
@@ -16,7 +16,7 @@ class UserAssetService
   ASSET_TYPES = ASSET_PATHS_BY_TYPE.keys.freeze
 
   # Bucket info; each Rails environment per project has a bucket
-  STORAGE_BUCKET_NAME = "#{self.class.compute_project}-#{Rails.env}-asset-storage".freeze
+  STORAGE_BUCKET_NAME = "#{self.compute_project}-#{Rails.env}-asset-storage".freeze
 
   # initialize GCS driver with same credentials as FireCloudClient
   # will return existing instance after first call is made (does not re-instantiate)

--- a/app/lib/user_asset_service.rb
+++ b/app/lib/user_asset_service.rb
@@ -4,11 +4,7 @@
 ##
 
 class UserAssetService
-
-  # GCP Compute project to run reads/writes in
-  COMPUTE_PROJECT = ENV['GOOGLE_CLOUD_PROJECT'].blank? ? '' : ENV['GOOGLE_CLOUD_PROJECT']
-  # Service account JSON credentials
-  SERVICE_ACCOUNT_KEY = !ENV['SERVICE_ACCOUNT_KEY'].blank? ? File.absolute_path(ENV['SERVICE_ACCOUNT_KEY']) : ''
+  extend ServiceAccountManager
 
   # Asset Path helpers
   RAILS_PUBLIC_PATH = Rails.root.join('public', 'single_cell')
@@ -20,7 +16,7 @@ class UserAssetService
   ASSET_TYPES = ASSET_PATHS_BY_TYPE.keys.freeze
 
   # Bucket info; each Rails environment per project has a bucket
-  STORAGE_BUCKET_NAME = "#{COMPUTE_PROJECT}-#{Rails.env}-asset-storage".freeze
+  STORAGE_BUCKET_NAME = "#{self.class.compute_project}-#{Rails.env}-asset-storage".freeze
 
   # initialize GCS driver with same credentials as FireCloudClient
   # will return existing instance after first call is made (does not re-instantiate)
@@ -28,7 +24,7 @@ class UserAssetService
   # * *yields*
   #   - +Google::Cloud::Storage+
   def self.storage_service
-    @@storage_service ||= Google::Cloud::Storage.new(keyfile: SERVICE_ACCOUNT_KEY)
+    @@storage_service ||= Google::Cloud::Storage.new(keyfile: self.get_primary_keyfile)
   end
 
   # get storage driver access token

--- a/app/models/big_query_client.rb
+++ b/app/models/big_query_client.rb
@@ -2,20 +2,16 @@
 # BigQueryClient: lightweight shim around Google::Cloud::BigQuery library to DRY up references to credentials/datasets
 
 class BigQueryClient < Struct.new(:project, :service_account_credentials, :client)
+  extend ServiceAccountManager
 
-  # GCP Compute project to run reads/writes in
-  COMPUTE_PROJECT = ENV['GOOGLE_CLOUD_PROJECT'].blank? ? '' : ENV['GOOGLE_CLOUD_PROJECT']
-  # Service account JSON credentials
-  SERVICE_ACCOUNT_KEY = !ENV['SERVICE_ACCOUNT_KEY'].blank? ? File.absolute_path(ENV['SERVICE_ACCOUNT_KEY']) : ''
-
-  def initialize
+  def initialize(service_account=self.class.get_primary_keyfile, compute_project=self.class.compute_project)
     Google::Cloud::Bigquery.configure do |config|
-      config.project_id  = COMPUTE_PROJECT
-      config.credentials = SERVICE_ACCOUNT_KEY
+      config.project_id  = compute_project
+      config.credentials = service_account
       config.timeout = 120
     end
-    self.project = COMPUTE_PROJECT
-    self.service_account_credentials = SERVICE_ACCOUNT_KEY
+    self.project = compute_project
+    self.service_account_credentials = service_account
     self.client = Google::Cloud::Bigquery.new
   end
 

--- a/app/models/data_repo_client.rb
+++ b/app/models/data_repo_client.rb
@@ -1,0 +1,339 @@
+##
+# API client bindings for retrieving information about Terra Data Repo datasets/snapshots/schemas from their API
+##
+class DataRepoClient < Struct.new(:access_token, :api_root, :storage, :expires_at, :service_account_credentials)
+  # path to read-only service account JSON keyfile
+  SERVICE_ACCOUNT_KEY = !ENV['READ_ONLY_SERVICE_ACCOUNT_KEY'].blank? ? (ENV['NOT_DOCKERIZED'] ? ENV['READ_ONLY_SERVICE_ACCOUNT_KEY'] : File.absolute_path(ENV['READ_ONLY_SERVICE_ACCOUNT_KEY'])) : ''
+  # Google authentication scopes necessary for querying TDR API
+  GOOGLE_SCOPES = %w(openid email profile)
+  # GCP Compute project
+  COMPUTE_PROJECT = ENV['GOOGLE_CLOUD_PROJECT'].blank? ? '' : ENV['GOOGLE_CLOUD_PROJECT']
+  # Base API URL to request against
+  BASE_URL = Rails.application.config.tdr_api_base_url
+  # constant used for retry loops in process_firecloud_request and execute_gcloud_method
+  MAX_RETRY_COUNT = 5
+  # constant used for incremental backoffs on retries (in seconds); ignored when running unit/integration test suite
+  RETRY_INTERVAL = Rails.env.test? ? 0 : 15
+
+  # control variables
+  SORT_DIRECTIONS = %w(asc desc).freeze
+  SORT_OPTIONS = %w(name description created_date).freeze
+  DATASET_INCLUDE_FIELDS = %w(NONE SCHEMA ACCESS_INFORMATION PROFILE DATA_PROJECT STORAGE).freeze
+  ALL_DATASET_FIELDS = %w(SCHEMA ACCESS_INFORMATION PROFILE DATA_PROJECT STORAGE).freeze
+
+  ##
+  # Constructors & token management methods
+  ##
+
+  # initialize is called after instantiating with DataRepoClient.new
+  # will set the access token, TDR base api url root and GCP storage driver instance
+  #
+  # * *params*
+  #   - +service_account_key+: (String, Pathname) => Path to service account JSON keyfile
+  # * *return*
+  #   - +DataRepoClient+ object
+  def initialize(service_account=SERVICE_ACCOUNT_KEY)
+    # GCS storage driver attributes
+    storage_attr = {
+      project: COMPUTE_PROJECT,
+      timeout: 3600,
+      keyfile: service_account
+    }
+
+    self.service_account_credentials = service_account
+    self.access_token = self.class.generate_access_token(service_account)
+    self.storage = Google::Cloud::Storage.new(storage_attr)
+    self.expires_at = Time.zone.now + self.access_token['expires_in']
+    self.api_root = BASE_URL
+  end
+
+  # generate an access token to use for all requests
+  #
+  # * *return*
+  #   - +Hash+ of Google Auth access token (contains access_token (string), token_type (string) and expires_in (integer, in seconds)
+  def self.generate_access_token(service_account)
+    # if no keyfile present, use environment variables
+    creds_attr = {scope: GOOGLE_SCOPES}
+    if !service_account.blank?
+      creds_attr.merge!(json_key_io: File.open(service_account))
+    end
+    creds = Google::Auth::ServiceAccountCredentials.make_creds(creds_attr)
+    token = creds.fetch_access_token!
+    token
+  end
+
+  # refresh access_token when expired and stores back in FireCloudClient instance
+  #
+  # * *return*
+  #   - +DateTime+ timestamp of new access token expiration
+  def refresh_access_token
+    new_token = self.class.generate_access_token(self.service_account_credentials)
+    new_expiry = Time.zone.now + new_token['expires_in']
+    self.access_token = new_token
+    self.expires_at = new_expiry
+  end
+
+  # check if an access_token is expired
+  #
+  # * *return*
+  #   - +Boolean+ of token expiration
+  def access_token_expired?
+    Time.zone.now >= self.expires_at
+  end
+
+  # return a valid access token
+  #
+  # * *return*
+  #   - +Hash+ of access token
+  def valid_access_token
+    self.access_token_expired? ? self.refresh_access_token : self.access_token
+  end
+
+  # get issuer of storage credentials
+  #
+  # * *return*
+  #   - +String+ of issuer email
+  def issuer
+    self.storage.service.credentials.issuer
+  end
+
+  ##
+  # Abstract request handlers
+  ##
+
+  # submit a request to TDR API
+  def process_api_request(http_method, path, payload: nil, retry_count: 0)
+    # Log API call for auditing/tracking purposes
+    Rails.logger.info "Terra Data Repo API request (#{http_method.to_s.upcase}) #{path}"
+    # check for token expiry first before executing
+    if self.access_token_expired?
+      Rails.logger.info "DataRepoClient token expired, refreshing access token"
+      self.refresh_access_token
+    end
+    # set default headers, appending application identifier including hostname for disambiguation
+    headers = {
+      'Authorization' => "Bearer #{self.access_token['access_token']}",
+      'Accept' => 'application/json',
+      'x-app-id' => "single-cell-portal",
+      'x-domain-id' => "#{ENV['HOSTNAME']}"
+    }
+
+    # process request
+    begin
+      response = RestClient::Request.execute(method: http_method, url: path, payload: payload, headers: headers)
+      # handle response using helper
+      handle_response(response)
+    rescue RestClient::Exception => e
+      current_retry = retry_count + 1
+      context = " encountered when requesting '#{path}', attempt ##{current_retry}"
+      log_message = "#{e.message}: #{e.http_body}; #{context}"
+      Rails.logger.error log_message
+      retry_time = retry_count * RETRY_INTERVAL
+      sleep(retry_time)
+      # only retry if status code indicates a possible temporary error, and we are under the retry limit and
+      # not calling a method that is blocked from retries
+      if should_retry?(e.http_code) && retry_count < MAX_RETRY_COUNT
+        process_api_request(http_method, path, payload: payload, retry_count: current_retry)
+      else
+        # we have reached our retry limit or the response code indicates we should not retry
+        ErrorTracker.report_exception(e, self.issuer, {
+          method: http_method, url: path, payload: payload, retry_count: retry_count
+        })
+        error_message = parse_response_body(e.message)
+        Rails.logger.error "Retry count exceeded when requesting '#{path}' - #{error_message}"
+        raise e
+      end
+    end
+  end
+
+  # check if OK response code was found
+  #
+  # * *params*
+  #   - +code+ (Integer) => integer HTTP response code
+  #
+  # * *return*
+  #   - +Boolean+ of whether or not response is a known 'OK' response
+  def ok?(code)
+    [200, 201, 202, 204, 206].include?(code)
+  end
+
+  # determine if request should be retried based on response code, and will retry if necessary
+  # only 502 (Bad Gateway), 503 (Service Unavailable), and 504 (Gateway Timeout) will be retried
+  # all other 4xx and 5xx responses will not as they are deemed 'unrecoverable'
+  #
+  # * *params*
+  #   - +code+ (Integer) => integer HTTP response code
+  #
+  # * *return*
+  #   - +Boolean+ of whether or not response code indicates a retry should be executed
+  def should_retry?(code)
+    code.nil? || [502, 503, 504].include?(code)
+  end
+
+  # merge hash of options into single URL query string, will reject query params with empty values
+  #
+  # * *params*
+  #   - +opts+ (Hash) => hash of query parameter key/value pairs
+  #
+  # * *return*
+  #   - +String+ of concatenated query params
+  def merge_query_options(opts={})
+    return nil if opts.blank?
+    '?' + opts.reject {|k,v| v.blank?}.to_a.map {|k,v| uri_encode("#{k}=#{v}")}.join('&')
+  end
+
+  # handle a RestClient::Response object
+  #
+  # * *params*
+  #   - +response+ (String) => an RestClient response object
+  #
+  # * *return*
+  #   - +Hash+ if response body is JSON, or +String+ of original body
+  def handle_response(response)
+    begin
+      if ok?(response.code)
+        response.body.present? ? parse_response_body(response.body) : true # blank body
+      else
+        response.message || parse_response_body(response.body)
+      end
+    rescue
+      # don't report, just return
+      response.message
+    end
+  end
+
+  # parse a response body based on the content
+  #
+  # * *params*
+  #   - +response_body+ (String) => an RestClient response body
+  #
+  # * *return*
+  #   - +Hash+ if response body is JSON, or +String+ of original body
+  def parse_response_body(response_body)
+    begin
+      JSON.parse(response_body)
+    rescue
+      response_body
+    end
+  end
+
+  # URI-encode parameters for use in API requests
+  #
+  # * *params*
+  #   - +parameter+ (String) => Parameter to encode
+  #
+  # * *returns*
+  #   - +String+ => URI-encoded parameter
+  def uri_encode(parameter)
+    URI.escape(parameter)
+  end
+
+  ##
+  # API ENDPOINT BINDINGS
+  ##
+
+  ##
+  # Datasets
+  ##
+
+  # fetch all available datasets
+  #
+  # * *params*
+  #   - +direction+ (String) => Sort direction (default: desc)
+  #   - +filter+ (String) => Filter the results where this string is a case insensitive match in the name or description.
+  #   - +limit+ (Integer) => The numbers datasets to retrieve
+  #   - +offset+ (Integer) => The number of datasets to skip before when retrieving the next page
+  #   - +sort+ (String) => The field to use for sorting: (name, description, created_date)
+  #
+  # * *returns*
+  #   - (Array<Hash>) => Array of dataset JSON attributes
+  def datasets(direction: 'desc', filter: nil, limit: 100, offset: 0, sort: 'name')
+    validate_argument(:direction, direction, SORT_DIRECTIONS)
+    validate_argument(:sort, sort, SORT_OPTIONS)
+    query_opts = merge_query_options({direction: direction, filter: filter, limit: limit, offset: offset, sort: sort})
+    path = api_root + '/api/repository/v1/datasets' + query_opts
+    process_api_request(:get, path)
+  end
+
+  # fetch a single dataset
+  #
+  # * *params*
+  #   - +dataset_id+ (String: UUID) => Dataset UUID
+  #   - +include+ (Array) => Dataset fields to return from DATASET_INCLUDE_FIELDS (default: SCHEMA,PROFILE,DATA_PROJECT,STORAGE)
+  #
+  # * *returns*
+  #   - (Hash) => Hash of dataset JSON attributes
+  def dataset(dataset_id, include: ALL_DATASET_FIELDS)
+    path = api_root + "/api/repository/v1/datasets/#{dataset_id}"
+    if include.any?
+      validate_argument(:include, include, DATASET_INCLUDE_FIELDS)
+      query_opts = include.map {|i| "include=#{i}"}.join('&')
+      path += "?#{query_opts}"
+    end
+    process_api_request(:get, path)
+  end
+
+  ##
+  # Snapshots
+  ##
+
+  # fetch all available snapshots
+  #
+  # * *params*
+  #   - +datasetIds+ (Array<String>) => Filter the results where these datasetIds are source datasets.
+  #   - +direction+ (String) => Sort direction (default: desc)
+  #   - +filter+ (String) => Filter the results where this string is a case insensitive match in the name or description.
+  #   - +limit+ (Integer) => The numbers datasets to retrieve
+  #   - +offset+ (Integer) => The number of datasets to skip before when retrieving the next page
+  #   - +sort+ (String) => The field to use for sorting: (name, description, created_date)
+  #
+  # * *returns*
+  #   - (Array<Hash>) => Array of snapshot JSON atributes
+  def snapshots(datasetIds: [], direction: 'desc', filter: nil, limit: 100, offset: 0, sort: 'name')
+    validate_argument(:direction, direction, SORT_DIRECTIONS)
+    validate_argument(:sort, sort, SORT_OPTIONS)
+    query_opts = merge_query_options(
+      {
+        datasetIds: datasetIds.join(','), direction: direction, filter: filter,
+        limit: limit, offset: offset, sort: sort
+      }
+    )
+    path = api_root + '/api/repository/v1/snapshots' + query_opts
+    process_api_request(:get, path)
+  end
+
+  # fetch an individual snapshot
+  #
+  # * *params*
+  #   - +snapshot_id+ (UUID) => Snapshot UUID
+  #
+  # * *returns*
+  #   - (Hash) => Hash of snapshot JSON attributes
+  def snapshot(snapshot_id)
+    path = api_root + "/api/repository/v1/snapshots/#{snapshot_id}"
+    process_api_request(:get, path)
+  end
+
+  private
+
+  # generic validator for an argument to a method
+  #
+  # * *params*
+  #   - +name+ (String, Symbol) => argument name
+  #   - +value+ (Various) => Value for argument
+  #   - +control+ (Array) => Array of acceptable values
+  #
+  # * *raises*
+  #   - (ArgumentError) => if value is not a member of control
+  def validate_argument(name, value, control)
+    if value.is_a?(Array)
+      # use array subtraction to find non-control values
+      invalid = value - control
+      if invalid.any?
+        raise ArgumentError.new("invalid values for #{name}: #{invalid.join(',')}, must be a member of #{control}")
+      end
+    else
+      raise ArgumentError.new("invalid value for #{name}: #{value}; must be a member of #{control}") if !control.include?(value)
+    end
+  end
+end

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -9,6 +9,9 @@
 # Author::  Jon Bistline  (mailto:bistline@broadinstitute.org)
 
 class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :storage, :expires_at, :service_account_credentials)
+  extend AccessTokenGenerator # class method for generating OAuth2 access tokens
+  include GoogleServiceClient # helper module for refreshing access tokens, accessing GCS storage driver attributes
+  include ApiHelpers # process external API requests/responses
 
   #
   # CONSTANTS
@@ -103,7 +106,7 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
         self.service_account_credentials = service_account
       end
 
-      self.access_token = FireCloudClient.generate_access_token(service_account)
+      self.access_token = self.class.generate_access_token(service_account)
       self.project = PORTAL_NAMESPACE
 
       self.storage = Google::Cloud::Storage.new(storage_attr)
@@ -152,66 +155,9 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   # TOKEN METHODS
   #
 
-  # generate an access token to use for all requests
-  #
-  # * *return*
-  #   - +Hash+ of Google Auth access token (contains access_token (string), token_type (string) and expires_in (integer, in seconds)
-  def self.generate_access_token(service_account)
-    # if no keyfile present, use environment variables
-    creds_attr = {scope: GOOGLE_SCOPES}
-    if !service_account.blank?
-      creds_attr.merge!(json_key_io: File.open(service_account))
-    end
-    creds = Google::Auth::ServiceAccountCredentials.make_creds(creds_attr)
-    token = creds.fetch_access_token!
-    token
-  end
-
-  # refresh access_token when expired and stores back in FireCloudClient instance
-  #
-  # * *return*
-  #   - +DateTime+ timestamp of new access token expiration
-  def refresh_access_token
-    if self.user.nil?
-      new_token = FireCloudClient.generate_access_token(self.service_account_credentials)
-      new_expiry = Time.zone.now + new_token['expires_in']
-      self.access_token = new_token
-      self.expires_at = new_expiry
-    else
-      new_token = self.user.generate_access_token
-      self.access_token = new_token
-      self.expires_at = new_token['expires_at']
-    end
-    new_token
-  end
-
-  # check if an access_token is expired
-  #
-  # * *return*
-  #   - +Boolean+ of token expiration
-  def access_token_expired?
-    Time.zone.now >= self.expires_at
-  end
-
-  # return a valid access token
-  #
-  # * *return*
-  #   - +Hash+ of access token
-  def valid_access_token
-    self.access_token_expired? ? self.refresh_access_token : self.access_token
-  end
-
   ##
   ## STORAGE INSTANCE METHODS
   ##
-
-  # get instance information about the storage driver
-  #
-  # * *return*
-  #   - +JSON+ object of storage driver instance attributes
-  def storage_attributes
-    JSON.parse self.storage.to_json
-  end
 
   # renew the storage driver
   #
@@ -231,46 +177,6 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
     new_storage = Google::Cloud::Storage.new(storage_attr)
     self.storage = new_storage
     new_storage
-  end
-
-  # get storage driver access token
-  #
-  # * *return*
-  #   - +String+ access token
-  def storage_access_token
-    self.storage.service.credentials.client.access_token
-  end
-
-  # get storage driver issue timestamp
-  #
-  # * *return*
-  #   - +DateTime+ issue timestamp
-  def storage_issued_at
-    self.storage.service.credentials.client.issued_at
-  end
-
-  # get issuer of storage credentials
-  #
-  # * *return*
-  #   - +String+ of issuer email
-  def storage_issuer
-    self.storage.service.credentials.issuer
-  end
-
-  # get issuer of access_token
-  #
-  # * *return*
-  #   - +String+ of access_token issuer email
-  def issuer
-    self.user.nil? ? self.storage_issuer : self.user.email
-  end
-
-  # get issuer object of access_token (either instance of User, or email of service account)
-  #
-  # * *return*
-  #   - +User+ of access_token issuer or +String+ of service account email
-  def issuer_object
-    self.user.nil? ? self.storage_issuer : self.user
   end
 
   # identify user initiating a request; either self.user, Current.user, or service account
@@ -1694,94 +1600,6 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
     map
   end
 
-  # check if OK response code was found
-  #
-  # * *params*
-  #   - +code+ (Integer) => integer HTTP response code
-  #
-  # * *return*
-  #   - +Boolean+ of whether or not response is a known 'OK' response
-  def ok?(code)
-    [200, 201, 202, 204, 206].include?(code)
-  end
-
-  # determine if request should be retried based on response code
-  #
-  # * *params*
-  #   - +code+ (Integer) => integer HTTP response code
-  #
-  # * *return*
-  #   - +Boolean+ of whether or not response code indicates a retry should be executed
-  def should_retry?(code)
-    # if code is nil, we're not sure so retry anyway
-    code.nil? || [502, 503].include?(code)
-  end
-
-  # merge hash of options into single URL query string
-  #
-  # * *params*
-  #   - +opts+ (Hash) => hash of query parameter key/value pairs
-  #
-  # * *return*
-  #   - +String+ of concatenated query params
-  def merge_query_options(opts)
-    # return nil if opts is empty, else concat
-    opts.blank? ? nil : '?' + opts.to_a.map {|k,v| "#{k}=#{v}"}.join("&")
-  end
-
-  # handle a RestClient::Response object
-  #
-  # * *params*
-  #   - +response+ (String) => an RestClient response object
-  #
-  # * *return*
-  #   - +Hash+ if response body is JSON, or +String+ of original body
-  def handle_response(response)
-    begin
-      if ok?(response.code)
-        if response.body.present?
-          parse_response_body(response.body)
-        else
-          true # blank body
-        end
-      else
-        Rails.logger.info "Unexpected response #{response.code}, not sure what to do here..."
-        response.message
-      end
-    rescue => e
-      # don't report, just return
-      response.message
-    end
-  end
-
-  # parse a response body based on the content
-  #
-  # * *params*
-  #   - +response_body+ (String) => an RestClient response body
-  #
-  # * *return*
-  #   - +Hash+ if response body is JSON, or +String+ of original body
-  def parse_response_body(response_body)
-    is_json?(response_body) ? JSON.parse(response_body) : response_body
-  end
-
-  # determine if a response body is parseable as JSON
-  #
-  # * *params*
-  #   - +content+ (String) => an RestClient response body
-  #
-  # * *return*
-  #   - +Boolean+ indication if content is JSON
-  def is_json?(content)
-    if content.present?
-      sanitized_content = content.gsub(/\n/, '') # remove newlines that may break this check
-      chars = [sanitized_content[0], sanitized_content[sanitized_content.size - 1]]
-      chars == %w({ }) || chars == %w([ ])
-    else
-      false
-    end
-  end
-
   # return a more user-friendly error message
   #
   # * *params*
@@ -1820,16 +1638,5 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
         error.message + ': ' + error.http_body
       end
     end
-  end
-
-  # URI-encode workspace identifiers (namespaces, workspaces) for use in API requests
-  #
-  # * *params*
-  #   - +identifier+ (String) => Name of Terra namespace/workspace
-  #
-  # * *returns*
-  #   - +String+ => URI-encoded namespace/workspace
-  def uri_encode(identifier)
-    URI.escape(identifier)
   end
 end

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -164,7 +164,7 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
         timeout: 3600
     }
     if !ENV['SERVICE_ACCOUNT_KEY'].blank?
-      storage_attr.merge!(keyfile: SERVICE_ACCOUNT_KEY)
+      storage_attr.merge!(keyfile: self.class.get_primary_keyfile)
     end
     new_storage = Google::Cloud::Storage.new(storage_attr)
     self.storage = new_storage

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -201,7 +201,7 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
         'MONGODB_USERNAME' => 'single_cell',
         'MONGODB_PASSWORD' => ENV['PROD_DATABASE_PASSWORD'],
         'DATABASE_NAME' => Mongoid::Config.clients["default"]["database"],
-        'GOOGLE_PROJECT_ID' => COMPUTE_PROJECT,
+        'GOOGLE_PROJECT_ID' => self.project,
         'SENTRY_DSN' => ENV['SENTRY_DSN'],
         'BARD_HOST_URL' => Rails.application.config.bard_host_url
     }
@@ -216,7 +216,7 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   #   - (Google::Apis::GenomicsV2alpha1::Resources)
   def create_resources_object(regions:)
     Google::Apis::GenomicsV2alpha1::Resources.new(
-         project_id: COMPUTE_PROJECT,
+         project_id: self.project,
          regions: regions,
          virtual_machine: self.create_virtual_machine_object
     )

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -7,13 +7,10 @@
 # Author::  Jon Bistline  (mailto:bistline@broadinstitute.org)
 
 class PapiClient < Struct.new(:project, :service_account_credentials, :service)
+  extend ServiceAccountManager
 
-  # Service account JSON credentials
-  SERVICE_ACCOUNT_KEY = !ENV['SERVICE_ACCOUNT_KEY'].blank? ? (ENV['NOT_DOCKERIZED'] ? ENV['SERVICE_ACCOUNT_KEY'] : File.absolute_path(ENV['SERVICE_ACCOUNT_KEY'])) : ''
-  # Google authentication scopes necessary for running pipelines
+   # Google authentication scopes necessary for running pipelines
   GOOGLE_SCOPES = %w(https://www.googleapis.com/auth/cloud-platform)
-  # GCP Compute project to run pipelines in
-  COMPUTE_PROJECT = ENV['GOOGLE_CLOUD_PROJECT'].blank? ? '' : ENV['GOOGLE_CLOUD_PROJECT']
   # Network and sub-network names, if needed
   GCP_NETWORK_NAME = ENV['GCP_NETWORK_NAME']
   GCP_SUB_NETWORK_NAME = ENV['GCP_SUB_NETWORK_NAME']
@@ -32,15 +29,12 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   #   - +project+: (Path) => Absolute filepath to service account credentials
   # * *return*
   #   - +PapiClient+
-  def initialize(project=COMPUTE_PROJECT, service_account_credentials=SERVICE_ACCOUNT_KEY)
+  def initialize(project=self.class.compute_project, service_account_credentials=self.class.get_primary_keyfile)
 
     credentials = {
-        scope: GOOGLE_SCOPES
+        scope: GOOGLE_SCOPES,
+        json_key_io: File.open(service_account_credentials)
     }
-
-    if SERVICE_ACCOUNT_KEY.present?
-      credentials.merge!({json_key_io: File.open(service_account_credentials)})
-    end
 
     authorizer = Google::Auth::ServiceAccountCredentials.make_creds(credentials)
     genomics_service = Google::Apis::GenomicsV2alpha1::GenomicsService.new

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -67,7 +67,7 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   #   - (Google::Apis::ClientError) =>  The request is invalid and should not be retried without modification
   #   - (Google::Apis::AuthorizationError) => Authorization is required
   def list_pipelines(page_token: nil)
-    self.service.list_project_operations("projects/#{COMPUTE_PROJECT}/operations", page_token: page_token)
+    self.service.list_project_operations("projects/#{self.project}/operations", page_token: page_token)
   end
 
   # Runs a pipeline.  Will call sub-methods to instantiate required objects to pass to

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,9 @@ module SingleCellPortal
     # Docker image for file parsing via scp-ingest-pipeline
     config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.10.2'
 
+    # Terra Data Repo API base url
+    config.tdr_api_base_url = 'https://jade-terra.datarepo-prod.broadinstitute.org/'
+
     config.autoload_paths << Rails.root.join('lib')
 
     # Google OAuth2 Scopes

--- a/lib/access_token_generator.rb
+++ b/lib/access_token_generator.rb
@@ -1,0 +1,21 @@
+module AccessTokenGenerator
+  # generate an access token from a service account JSON keyfile
+  #
+  # * *params*
+  #   - +service_account+ (Pathname) => path to service account JSON keyfile
+  #
+  # * *returns*
+  #   - (Hash) => OAuth2 access token hash, with the following attributes
+  #     - +access_token+ (String) => OAuth2 access token
+  #     - +expires_in+ (Integer) => duration of token, in seconds
+  #     - +token_type+ (String) => type of access token (e.g. 'Bearer')
+  def generate_access_token(service_account)
+    creds_attr = {scope: self::GOOGLE_SCOPES}
+    if !service_account.blank?
+      creds_attr.merge!(json_key_io: File.open(service_account))
+    end
+    creds = Google::Auth::ServiceAccountCredentials.make_creds(creds_attr)
+    token = creds.fetch_access_token!
+    token
+  end
+end

--- a/lib/api_helpers.rb
+++ b/lib/api_helpers.rb
@@ -1,0 +1,101 @@
+##
+# helper methods for handing external API requests/responses
+##
+module ApiHelpers
+  # check if OK response code was found
+  #
+  # * *params*
+  #   - +code+ (Integer) => integer HTTP response code
+  #
+  # * *return*
+  #   - +Boolean+ of whether or not response is a known 'OK' response
+  def ok?(code)
+    [200, 201, 202, 204, 206].include?(code)
+  end
+
+  # determine if request should be retried based on response code, and will retry if necessary
+  # only 502 (Bad Gateway), 503 (Service Unavailable), and 504 (Gateway Timeout) will be retried
+  # all other 4xx and 5xx responses will not as they are deemed 'unrecoverable'
+  #
+  # * *params*
+  #   - +code+ (Integer) => integer HTTP response code
+  #
+  # * *return*
+  #   - +Boolean+ of whether or not response code indicates a retry should be executed
+  def should_retry?(code)
+    code.nil? || [502, 503, 504].include?(code)
+  end
+
+  # merge hash of options into single URL query string, will reject query params with empty values
+  #
+  # * *params*
+  #   - +opts+ (Hash) => hash of query parameter key/value pairs
+  #
+  # * *return*
+  #   - +String+ of concatenated query params
+  def merge_query_options(opts={})
+    return nil if opts.blank?
+    '?' + opts.reject {|k,v| v.blank?}.to_a.map {|k,v| uri_encode("#{k}=#{v}")}.join('&')
+  end
+
+  # handle a RestClient::Response object
+  #
+  # * *params*
+  #   - +response+ (String) => an RestClient response object
+  #
+  # * *return*
+  #   - +Hash+ if response body is JSON, or +String+ of original body
+  def handle_response(response)
+    begin
+      if ok?(response.code)
+        response.body.present? ? parse_response_body(response.body) : true # blank body
+      else
+        response.message || parse_response_body(response.body)
+      end
+    rescue
+      # don't report, just return
+      response.message
+    end
+  end
+
+  # parse a response body based on the content
+  #
+  # * *params*
+  #   - +response_body+ (String) => an RestClient response body
+  #
+  # * *return*
+  #   - +Hash+ if response body is JSON, or +String+ of original body
+  def parse_response_body(response_body)
+    begin
+      JSON.parse(response_body)
+    rescue
+      response_body
+    end
+  end
+
+  # determine if a response is JSON
+  #
+  # * *params*
+  #   - +content+ (String) => RestClient response body
+  #
+  # * *returns*
+  #   - (Boolean) => indication if content is JSON
+  def is_json?(content)
+    begin
+      !!JSON.parse(content)
+    rescue
+      false
+    end
+  end
+
+  # URI-encode parameters for use in API requests
+  #
+  # * *params*
+  #   - +parameter+ (String) => Parameter to encode
+  #
+  # * *returns*
+  #   - +String+ => URI-encoded parameter
+  def uri_encode(parameter)
+    URI.escape(parameter)
+  end
+end

--- a/lib/api_helpers.rb
+++ b/lib/api_helpers.rb
@@ -1,7 +1,13 @@
 ##
 # helper methods for handing external API requests/responses
+# should be used in other classes via include, e.g. `include ApiHelpers`
 ##
 module ApiHelpers
+  # max number of retries if should_retry? is true
+  MAX_RETRY_COUNT = 5
+  # interval for retry backoff on request retries
+  RETRY_INTERVAL = Rails.env.test? ? 0 : 15
+
   # check if OK response code was found
   #
   # * *params*

--- a/lib/google_service_client.rb
+++ b/lib/google_service_client.rb
@@ -1,0 +1,91 @@
+##
+# module of generic GCP-centric methods, such as handling authorization/tokens, or GCS drivers
+##
+module GoogleServiceClient
+  ##
+  # OAuth token methods
+  ##
+
+  # refresh access_token when expired and stores back in instance of parent class
+  #
+  # * *return*
+  #   - +DateTime+ timestamp of new access token expiration
+  def refresh_access_token!
+    Rails.logger.info "#{self.class.name} token expired, refreshing access token"
+    # determine if token source is a regular Google account (User) or a service account
+    token_source = self.respond_to?(:user) && self.user.present? ? self.user : self.class
+    new_token = token_source.generate_access_token(self.service_account_credentials)
+    new_expiry = Time.zone.now + new_token['expires_in']
+    self.access_token = new_token
+    self.expires_at = new_expiry
+    new_token
+  end
+
+  # check if an access_token is expired
+  #
+  # * *return*
+  #   - +Boolean+ of token expiration
+  def access_token_expired?
+    Time.zone.now >= self.expires_at
+  end
+
+  # return a valid access token
+  #
+  # * *return*
+  #   - +Hash+ of access token
+  def valid_access_token
+    self.access_token_expired? ? self.refresh_access_token! : self.access_token
+  end
+
+  ##
+  # GCS Storage instance methods
+  ##
+
+  # get instance information about the storage driver
+  #
+  # * *return*
+  #   - +JSON+ object of storage driver instance attributes
+  def storage_attributes
+    JSON.parse self.storage.to_json
+  end
+
+  # get storage driver access token
+  #
+  # * *return*
+  #   - +String+ access token
+  def storage_access_token
+    self.storage.service.credentials.client.access_token
+  end
+
+  # get storage driver issue timestamp
+  #
+  # * *return*
+  #   - +DateTime+ issue timestamp
+  def storage_issued_at
+    self.storage.service.credentials.client.issued_at
+  end
+
+  # get issuer of storage credentials
+  #
+  # * *return*
+  #   - +String+ of issuer email
+  def storage_issuer
+    self.storage.service.credentials.issuer
+  end
+
+  # get issuer of access_token
+  #
+  # * *return*
+  #   - +String+ of access_token issuer email
+  def issuer
+    self.respond_to?(:user) && self.user.present? ? self.user.email : self.storage_issuer
+  end
+
+  # get issuer object of access_token (either instance of User, or email of service account)
+  #
+  # * *return*
+  #   - +User+ of access_token issuer or +String+ of service account email
+  def issuer_object
+    self.user.nil? ? self.storage_issuer : self.user
+  end
+end

--- a/lib/google_service_client.rb
+++ b/lib/google_service_client.rb
@@ -1,5 +1,6 @@
 ##
-# module of generic GCP-centric methods, such as handling authorization/tokens, or GCS drivers
+# generic GCP-centric methods, such as handling authorization/tokens, or GCS drivers
+# should be used in other classes via include, e.g. `include GoogleServiceClient`
 ##
 module GoogleServiceClient
   ##

--- a/lib/service_account_manager.rb
+++ b/lib/service_account_manager.rb
@@ -1,4 +1,8 @@
-module AccessTokenGenerator
+##
+# class methods for loading service account keyfiles & generating OAuth2 access tokens
+# should be used in other classes via extend, e.g. `extend ServiceAccountManager`
+##
+module ServiceAccountManager
   # generate an access token from a service account JSON keyfile
   #
   # * *params*
@@ -17,5 +21,20 @@ module AccessTokenGenerator
     creds = Google::Auth::ServiceAccountCredentials.make_creds(creds_attr)
     token = creds.fetch_access_token!
     token
+  end
+
+  # return the GCP project this instance is running in
+  def compute_project
+    ENV['GOOGLE_CLOUD_PROJECT']
+  end
+
+  # resolve filepath to primary service account (e.g. project owner) keyfile
+  def get_primary_keyfile
+    ENV['NOT_DOCKERIZED'] ? ENV['SERVICE_ACCOUNT_KEY']: File.absolute_path(ENV['SERVICE_ACCOUNT_KEY'])
+  end
+
+  # resolve filepath to primary service account (e.g. project owner) keyfile
+  def get_read_only_keyfile
+    ENV['NOT_DOCKERIZED'] ? ENV['READ_ONLY_SERVICE_ACCOUNT_KEY'] : File.absolute_path(ENV['READ_ONLY_SERVICE_ACCOUNT_KEY'])
   end
 end

--- a/lib/service_account_manager.rb
+++ b/lib/service_account_manager.rb
@@ -30,7 +30,7 @@ module ServiceAccountManager
 
   # resolve filepath to primary service account (e.g. project owner) keyfile
   def get_primary_keyfile
-    ENV['NOT_DOCKERIZED'] ? ENV['SERVICE_ACCOUNT_KEY']: File.absolute_path(ENV['SERVICE_ACCOUNT_KEY'])
+    ENV['NOT_DOCKERIZED'] ? ENV['SERVICE_ACCOUNT_KEY'] : File.absolute_path(ENV['SERVICE_ACCOUNT_KEY'])
   end
 
   # resolve filepath to primary service account (e.g. project owner) keyfile

--- a/test/integration/data_repo_client_test.rb
+++ b/test/integration/data_repo_client_test.rb
@@ -1,0 +1,114 @@
+require "test_helper"
+
+class DataRepoClientTest < ActiveSupport::TestCase
+  include Minitest::Hooks
+  include TestInstrumentor
+
+  before(:all) do
+    @data_repo_client = ApplicationController.data_repo_client
+  end
+
+  test 'should instantiate client' do
+    client = DataRepoClient.new
+    assert client.present?
+    assert_equal Rails.application.config.tdr_api_base_url, client.api_root
+  end
+
+  test 'should refresh access token' do
+    token = @data_repo_client.access_token
+    current_expiry = @data_repo_client.expires_at
+    sleep 1
+    new_token = @data_repo_client.refresh_access_token!
+    assert_not_equal token, new_token
+    assert current_expiry < @data_repo_client.expires_at
+  end
+
+  test 'should get token expiration' do
+    refute @data_repo_client.access_token_expired?
+    @data_repo_client.expires_at = 1.day.ago
+    assert @data_repo_client.access_token_expired?
+  end
+
+  test 'should get valid access token' do
+    @data_repo_client.refresh_access_token!
+    access_token = @data_repo_client.access_token
+    current_expiry = @data_repo_client.expires_at
+    valid_token = @data_repo_client.valid_access_token
+    assert_equal access_token, valid_token
+    @data_repo_client.expires_at = 1.day.ago
+    sleep 1
+    new_token = @data_repo_client.valid_access_token
+    assert_not_equal access_token, new_token
+    assert current_expiry < @data_repo_client.expires_at
+  end
+
+  test 'should get issuer email' do
+    service_account_email = JSON.parse(File.open(@data_repo_client.service_account_credentials).read).dig('client_email')
+    assert_equal service_account_email, @data_repo_client.issuer
+  end
+
+  test 'should determine ok response code' do
+    200.upto(206) do |code|
+      # only 203 & 205 should not return OK
+      if code.even? || code == 201
+        assert @data_repo_client.ok?(code)
+      else
+        refute @data_repo_client.ok?(code)
+      end
+    end
+    refute @data_repo_client.ok?(404)
+  end
+
+  test 'should determine retry from response code' do
+    [nil, 502, 503, 504].each do |code|
+      assert @data_repo_client.should_retry?(code)
+    end
+    refute @data_repo_client.should_retry?(404)
+  end
+
+  test 'should merge query string params from hash' do
+    opts = {foo: 'bar', bing: 'baz'}
+    expected_query = "?foo=bar&bing=baz"
+    assert_equal expected_query, @data_repo_client.merge_query_options(opts)
+    # ensure params are uri-encoded
+    new_opts = {one: 'foo', two: 'bar bing'}
+    expected_encoded_query = "?one=foo&two=bar%20bing"
+    assert_equal expected_encoded_query, @data_repo_client.merge_query_options(new_opts)
+  end
+
+  test 'should parse response body' do
+    response = {
+      total: 1,
+      items: [
+        {
+          id: SecureRandom.uuid, name: 'My Dataset', description: 'This is the description',
+          createdDate: Time.now.to_s(:db), profileId: SecureRandom.uuid
+        }
+      ]
+    }.with_indifferent_access
+    parsed_response = @data_repo_client.parse_response_body(response.to_json)
+    assert_equal response, parsed_response.with_indifferent_access
+
+    string_response = "This is the response"
+    parsed_string = @data_repo_client.parse_response_body(string_response)
+    assert_equal string_response, parsed_string
+  end
+
+  test 'should get datasets' do
+    datasets = @data_repo_client.datasets
+    assert datasets.dig('total').present?
+    skip 'got empty response for datasets' if datasets.dig('items').empty?
+    dataset_id = datasets.dig('items').first.dig('id')
+    dataset = @data_repo_client.dataset(dataset_id)
+    assert dataset.present?
+  end
+
+  test 'should get snapshots' do
+    snapshots = @data_repo_client.snapshots
+    assert snapshots.dig('total').present?
+    skip 'got empty response for snapshots' if snapshots.dig('items').empty?
+    snapshot_id = snapshots.dig('items').first.dig('id')
+    snapshot = @data_repo_client.snapshot(snapshot_id)
+    assert snapshot.present?
+  end
+end

--- a/test/integration/fire_cloud_client_test.rb
+++ b/test/integration/fire_cloud_client_test.rb
@@ -30,7 +30,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
 
     expires_at = @fire_cloud_client.expires_at
     assert !@fire_cloud_client.access_token_expired?, 'Token should not be expired for new clients'
-    @fire_cloud_client.refresh_access_token
+    @fire_cloud_client.refresh_access_token!
     assert @fire_cloud_client.expires_at > expires_at, "Expiration date did not update, #{@fire_cloud_client.expires_at} is not greater than #{expires_at}"
 
     puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
@@ -577,13 +577,10 @@ class FireCloudClientTest < ActiveSupport::TestCase
 
     # download remote file to local
     puts 'downloading file...'
-    # load study for place to download files to
-    @study = Study.first
-    # ensure download path is available in case it did not get created
-    @study.make_data_dir
-    downloaded_file = @fire_cloud_client.execute_gcloud_method(:download_workspace_file, 0, workspace['bucketName'], file.name, @study.data_store_path)
+    download_path = Rails.root.join('tmp')
+    downloaded_file = @fire_cloud_client.execute_gcloud_method(:download_workspace_file, 0, workspace['bucketName'], file.name, download_path)
     assert downloaded_file.present?, 'Did not download local copy of file'
-    assert downloaded_file.to_path == File.join(@study.data_store_path, file.name), "Did not download #{file.name} to #{@study.data_store_path}, downloaded file is at #{downloaded_file.to_path}"
+    assert downloaded_file.to_path == File.join(download_path, file.name), "Did not download #{file.name} to #{download_path}, downloaded file is at #{downloaded_file.to_path}"
     # clean up download
     File.delete(downloaded_file.to_path)
 


### PR DESCRIPTION
This update adds a minimal client for [Terra Data Repo API](https://jade-terra.datarepo-prod.broadinstitute.org/swagger-ui.html) bindings.  This will be used as the scaffold on which all future "cross-dataset search" work can be done.

The client is structured very similarly to all of the other external API client classes: `FireCloudClient` and `PapiClient`.  Currently, the client has methods to retrieve datasets and snapshots, as well as abstract methods for making requests and processing responses.

This PR satisfies parts of SCP-3353.