### PR TITLE
Remove 'sequencing' from all 10x labels in BigQuery (SCP-3369)

### DIFF
--- a/db/migrate/20210521141041_update10x_labels_in_big_query.rb
+++ b/db/migrate/20210521141041_update10x_labels_in_big_query.rb
@@ -1,0 +1,24 @@
+class Update10xLabelsInBigQuery < Mongoid::Migration
+  # from https://cloud.google.com/bigquery/docs/updating-data#updating_data
+  def self.up
+    client = BigQueryClient.new.client
+    [CellMetadatum::BIGQUERY_DATASET, 'cell_metadata_test'].each do |dataset_name|
+      dataset = client.dataset(dataset_name)
+      if dataset.present?
+        col_name = 'library_preparation_protocol__ontology_label'
+        # query will match all instances of library_preparation_protocol__ontology_label beginning with the
+        # substring '10x ' and will truncate "sequencing" off of the end
+        update_query = "UPDATE #{CellMetadatum::BIGQUERY_TABLE}"
+        replace_clause = "SET #{col_name} = REGEXP_REPLACE(#{col_name}, r\" sequencing$\", \"\")"
+        where_clause = "WHERE REGEXP_CONTAINS(#{col_name}, r\"^10x.*sequencing$\")"
+        query_string = "#{update_query} #{replace_clause} #{where_clause}"
+        dataset.query query_string
+      end
+    end
+    # update cached entries
+    SearchFacet.update_all_facet_filters
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
This update removes the term "sequencing" from all `10x` entries in the `library_preparation_protocol__ontology_label` column in the Alexandria convention BQ table.  This is in keeping with the [recent update](https://github.com/EBISPOT/efo/issues/1091) to the EFO ontology in EBI OLS.  

This does not update corresponding entries in MongoDB, or in user's metadata files, as this would be both extremely expensive, and would violate our longstanding practice of not editing user's uploaded source files without their direct consent.  Only updating MongoDB would also create an inconsistency between visualizations and source data files.

TO TEST:

1. Run the following query in your alexandria_convention BQ table:
```
SELECT DISTINCT(library_preparation_protocol__ontology_label) 
FROM `{name of your GCP project}.cell_metadata_development.alexandria_convention`
```
2. Note entry for `10x 3' v2 sequencing`
3. Pull this branch, and run the migration via `./rails_local_setup.rb && source config/secrets/.source_env.bash && bin/rails db:migrate`
4. Note migration succeeds after 20-30s
5. Re-run first query and note that `10x 3' v2 sequencing` now reads `10x 3' v2`

This PR satisfies SCP-3369.