### PR TITLE
restoring sorting to violin plots (SCP-3380)

### DIFF
--- a/app/javascript/components/visualization/StudyViolinPlot.js
+++ b/app/javascript/components/visualization/StudyViolinPlot.js
@@ -185,7 +185,9 @@ function updateViolinPlot(target, plotType, showPoints) {
 function getViolinTraces(
   resultValues, showPoints='none', plotType='violin'
 ) {
-  const data = Object.entries(resultValues).map(([traceName, traceData], index) => {
+  const data = Object.entries(resultValues)
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([traceName, traceData], index) => {
     // Plotly violin trace creation, adding to main array
     // get inputs for plotly violin creation
     const dist = traceData.y


### PR DESCRIPTION
To TEST:
1. load a study with expression data
2. do a search for a gene
3. confirm violin plot annotations are alphabetically sorted
4. change annotation
5. confirm violin plot annotations are still sorted