### PR TITLE
Improving scp-api error handling (SCP-3379)

### DIFF
--- a/app/controllers/api/v1/user_annotations_controller.rb
+++ b/app/controllers/api/v1/user_annotations_controller.rb
@@ -77,7 +77,7 @@ module Api
 
           # Don't log data_arrays to Sentry; it's too big
           log_params.delete(:user_data_arrays_attributes)
-
+          raise 'foo happpend'
           cluster = params[:cluster]
 
           annotations = UserAnnotationService.create_user_annotation(

--- a/app/controllers/api/v1/user_annotations_controller.rb
+++ b/app/controllers/api/v1/user_annotations_controller.rb
@@ -77,7 +77,6 @@ module Api
 
           # Don't log data_arrays to Sentry; it's too big
           log_params.delete(:user_data_arrays_attributes)
-          raise 'foo happpend'
           cluster = params[:cluster]
 
           annotations = UserAnnotationService.create_user_annotation(

--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -207,7 +207,7 @@ module Api
               if is_collapsed_view
                 plot_data = ExpressionVizService.load_gene_set_expression_data_arrays(study, genes, cluster, annotation, consensus, subsample, !include_coordinates)
               else
-                plot_data = ExpressionVizService.load_expression_data_array_points(study, genes[0], cluster, annotation, subsample, !include_coordinates)
+                plot_data = ExpressionVizService.load_expression_data_array_points(study, genes[0], cluster, annotation, subsample, include_coordinates, include_annotation)
               end
             end
           end

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -118,6 +118,7 @@ module Api
                                                                     annot_scope: params[:annotation_scope])
           subsample = ClustersController.get_selected_subsample_threshold(params[:subsample], cluster)
           genes = RequestUtils.get_genes_from_param(@study, params[:genes])
+
           if genes.empty?
             if params[:genes].empty?
               render json: {error: 'You must supply at least one gene'}, status: 400

--- a/app/javascript/components/explore/plot-data-cache.js
+++ b/app/javascript/components/explore/plot-data-cache.js
@@ -210,6 +210,8 @@ export function createCache() {
       })
       return mergedResult
     }).catch(error => {
+      // rather than try to reconstruct partial responses, clear the entire cache if an error occurs
+      cache.clear()
       throw error
     })
   }

--- a/app/javascript/components/explore/plot-data-cache.js
+++ b/app/javascript/components/explore/plot-data-cache.js
@@ -209,6 +209,8 @@ export function createCache() {
         mergedResult = cache._mergeClusterResponse(studyAccession, result, cluster, subsample)
       })
       return mergedResult
+    }).catch(error => {
+      throw error
     })
   }
 

--- a/app/javascript/components/explore/plot-data-cache.js
+++ b/app/javascript/components/explore/plot-data-cache.js
@@ -95,9 +95,14 @@ const Fields = {
     },
     merge: (entry, scatter) => {
       if (scatter.data.annotations) {
-        Fields.annotation.putInEntry(entry, scatter.annotParams.name, scatter.annotParams.scope, scatter.data.annotations)
+        Fields.annotation.putInEntry(entry,
+          scatter.annotParams.name,
+          scatter.annotParams.scope,
+          scatter.data.annotations)
       } else {
-        scatter.data.annotations = Fields.annotation.getFromEntry(entry, scatter.annotParams.name, scatter.annotParams.scope)
+        scatter.data.annotations = Fields.annotation.getFromEntry(entry,
+          scatter.annotParams.name,
+          scatter.annotParams.scope)
       }
     }
   },
@@ -109,7 +114,7 @@ const Fields = {
     },
     putInEntry: (entry, genes, consensus, expression) => {
       const key = getExpressionKey(genes, consensus)
-       // we only cache one set of expression data at a time, so for now, delete any others
+      // we only cache one set of expression data at a time, so for now, delete any others
       entry.expression = {}
       entry.expression[key] = expression
     },
@@ -139,6 +144,7 @@ const Fields = {
     putInEntry: (entry, clusterProps) => entry.clusterProps = clusterProps,
     merge: (entry, scatter) => {
       // clusterProps caches everything except the data and allDataFromCache properties
+      // eslint-disable-next-line no-unused-vars
       const { data, allDataFromCache, ...clusterProps } = scatter
       Object.assign(entry.clusterProps, clusterProps)
       Object.assign(scatter, entry.clusterProps)
@@ -191,8 +197,10 @@ export function createCache() {
           data: {},
           allDataFromCache: true // set a flag indicating that no fresh request to the server was needed
         }, {
-          url: fetchClusterUrl({ studyAccession, cluster, annotation,
-            subsample, consensus, genes, isAnnotatedScatter }),
+          url: fetchClusterUrl({
+            studyAccession, cluster, annotation,
+            subsample, consensus, genes, isAnnotatedScatter
+          }),
           legacyBackend: STEP_NOT_NEEDED,
           isClientCache: true,
           parse: STEP_NOT_NEEDED,

--- a/app/javascript/components/search/results/ResultsPanel.js
+++ b/app/javascript/components/search/results/ResultsPanel.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faDna, faExclamationCircle, faInfoCircle } from '@fortawesome/free-solid-svg-icons'
+import { faDna, faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 
 import StudyResults from './StudyResults'
 import Study from './Study'

--- a/app/javascript/components/search/results/ResultsPanel.js
+++ b/app/javascript/components/search/results/ResultsPanel.js
@@ -7,6 +7,7 @@ import Study from './Study'
 import SearchQueryDisplay from './SearchQueryDisplay'
 import { UserContext } from 'providers/UserProvider'
 import { getNumFacetsAndFilters } from 'providers/StudySearchProvider'
+import { serverErrorEnd } from 'lib/error-utils'
 
 
 /**
@@ -22,17 +23,8 @@ const ResultsPanel = ({ studySearchState, studyComponent, noResultsDisplay }) =>
   let panelContent
   if (studySearchState.isError) {
     panelContent = (
-      <div className="error-panel  col-md-6 col-md-offset-3">
-        <FontAwesomeIcon
-          icon={faExclamationCircle}
-          className="left-margin-icon"
-        />
-        Sorry, an error has occurred. Support has been notified. Please try
-        again. If this error persists, or you require assistance, please contact
-        support at &nbsp;
-        <a href="mailto:scp-support@broadinstitute.zendesk.com">
-          scp-support@broadinstitute.zendesk.com
-        </a>
+      <div className="error-panel col-md-6 col-md-offset-3">
+        { serverErrorEnd }
       </div>
     )
   } else if (!studySearchState.isLoaded) {

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -11,7 +11,7 @@ import { labelFont, getColorBrewerColor } from 'lib/plot'
 import { UNSPECIFIED_ANNOTATION_NAME } from 'lib/cluster-utils'
 import { useUpdateEffect } from 'hooks/useUpdate'
 import PlotTitle from './PlotTitle'
-import useErrorMessage, { checkScpApiResponse } from 'lib/error-message'
+import useErrorMessage from 'lib/error-message'
 import { withErrorBoundary } from 'lib/ErrorBoundary'
 
 // sourced from https://github.com/plotly/plotly.js/blob/master/src/components/colorscale/scales.js
@@ -87,7 +87,7 @@ function RawScatterPlot({
   useEffect(() => {
     setIsLoading(true)
     // use a data cache if one has been provided, otherwise query scp-api directly
-    let fetchMethod = dataCache ? dataCache.fetchCluster : fetchCluster
+    const fetchMethod = dataCache ? dataCache.fetchCluster : fetchCluster
     fetchMethod({
       studyAccession,
       cluster,
@@ -136,7 +136,7 @@ function RawScatterPlot({
         graphElementId,
         isAnnotatedScatter,
         annotType: annotation.type,
-        genes: genes
+        genes
       })
     }
   }, [dimensions.width, dimensions.height])
@@ -299,8 +299,8 @@ function sortLegend({ graphElementId, isAnnotatedScatter, annotType, genes }) {
     return traceEl.textContent.match(legendTitleRegex)[1]
   })
   const sortedNames = [...legendNames].sort((a, b) => {
-    if (a === UNSPECIFIED_ANNOTATION_NAME) { return 1 }
-    if (b === UNSPECIFIED_ANNOTATION_NAME) { return -1 }
+    if (a === UNSPECIFIED_ANNOTATION_NAME) {return 1}
+    if (b === UNSPECIFIED_ANNOTATION_NAME) {return -1}
     return a.localeCompare(b)
   })
   const legendTransforms = legendTraces.map(traceEl => traceEl.getAttribute('transform'))
@@ -363,8 +363,10 @@ function getPlotlyLayout({ width, height }={}, {
     dragmode: getDragMode(isCellSelecting)
   }
   if (is3D) {
-    layout.scene = get3DScatterProps({ userSpecifiedRanges, axes, hasCoordinateLabels,
-      coordinateLabels })
+    layout.scene = get3DScatterProps({
+      userSpecifiedRanges, axes, hasCoordinateLabels,
+      coordinateLabels
+    })
   } else {
     const props2d = get2DScatterProps({
       axes,
@@ -437,8 +439,10 @@ const baseCamera = {
 }
 
 /** Gets Plotly layout scene props for 3D scatter plot */
-export function get3DScatterProps({ userSpecifiedRanges, axes, hasCoordinateLabels,
-      coordinateLabels }) {
+export function get3DScatterProps({
+  userSpecifiedRanges, axes, hasCoordinateLabels,
+  coordinateLabels
+}) {
   const { titles, ranges, aspects } = axes
 
   const scene = {

--- a/app/javascript/components/visualization/StudyViolinPlot.js
+++ b/app/javascript/components/visualization/StudyViolinPlot.js
@@ -185,7 +185,9 @@ function updateViolinPlot(target, plotType, showPoints) {
 function getViolinTraces(
   resultValues, showPoints='none', plotType='violin'
 ) {
-  const data = Object.entries(resultValues).map(([traceName, traceData], index) => {
+  const data = Object.entries(resultValues)
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([traceName, traceData], index) => {
     // Plotly violin trace creation, adding to main array
     // get inputs for plotly violin creation
     const dist = traceData.y

--- a/app/javascript/components/visualization/StudyViolinPlot.js
+++ b/app/javascript/components/visualization/StudyViolinPlot.js
@@ -9,7 +9,7 @@ import Plotly from 'plotly.js-dist'
 
 import { useUpdateEffect } from 'hooks/useUpdate'
 import { withErrorBoundary } from 'lib/ErrorBoundary'
-import useErrorMessage, { checkScpApiResponse } from 'lib/error-message'
+import useErrorMessage from 'lib/error-message'
 import { logViolinPlot } from 'lib/scp-api-metrics'
 
 
@@ -191,61 +191,61 @@ function getViolinTraces(
     .map(([traceName, traceData], index) => {
     // Plotly violin trace creation, adding to main array
     // get inputs for plotly violin creation
-    const dist = traceData.y
+      const dist = traceData.y
 
-    // Replace the none selection with bool false for plotly
-    if (showPoints === 'none' || !showPoints) {
-      showPoints = false
-    }
+      // Replace the none selection with bool false for plotly
+      if (showPoints === 'none' || !showPoints) {
+        showPoints = false
+      }
 
-    // Check if there is a distribution before adding trace
-    if (arrayMax(dist) !== arrayMin(dist) && plotType === 'violin') {
+      // Check if there is a distribution before adding trace
+      if (arrayMax(dist) !== arrayMin(dist) && plotType === 'violin') {
       // Make a violin plot if there is a distribution
-      return {
-        type: 'violin',
-        name: traceName,
-        y: dist,
-        points: showPoints,
-        pointpos: 0,
-        jitter: 0.85,
-        spanmode: 'hard',
-        box: {
-          visible: true,
-          fillcolor: '#ffffff',
-          width: .1
-        },
-        marker: {
-          size: 2,
-          color: '#000000',
-          opacity: 0.8
-        },
-        fillcolor: getColorBrewerColor(index),
-        line: {
-          color: '#000000',
-          width: 1.5
-        },
-        meanline: {
-          visible: false
+        return {
+          type: 'violin',
+          name: traceName,
+          y: dist,
+          points: showPoints,
+          pointpos: 0,
+          jitter: 0.85,
+          spanmode: 'hard',
+          box: {
+            visible: true,
+            fillcolor: '#ffffff',
+            width: .1
+          },
+          marker: {
+            size: 2,
+            color: '#000000',
+            opacity: 0.8
+          },
+          fillcolor: getColorBrewerColor(index),
+          line: {
+            color: '#000000',
+            width: 1.5
+          },
+          meanline: {
+            visible: false
+          }
+        }
+      } else {
+      // Make a boxplot for data with no distribution
+        return {
+          type: 'box',
+          name: traceName,
+          y: dist,
+          boxpoints: showPoints,
+          marker: {
+            color: getColorBrewerColor(index),
+            size: 2,
+            line: {
+              color: plotlyDefaultLineColor
+            }
+          },
+          boxmean: true
         }
       }
-    } else {
-      // Make a boxplot for data with no distribution
-      return {
-        type: 'box',
-        name: traceName,
-        y: dist,
-        boxpoints: showPoints,
-        marker: {
-          color: getColorBrewerColor(index),
-          size: 2,
-          line: {
-            color: plotlyDefaultLineColor
-          }
-        },
-        boxmean: true
-      }
-    }
-  })
+    })
   return data
 }
 

--- a/app/javascript/components/visualization/StudyViolinPlot.js
+++ b/app/javascript/components/visualization/StudyViolinPlot.js
@@ -50,8 +50,8 @@ function RawStudyViolinPlot({
   const [graphElementId] = useState(_uniqueId('study-violin-'))
   const { ErrorComponent, setShowError, setErrorContent } = useErrorMessage()
 
-  /** gets expression data from the server */
-  function loadData([results, perfTimes]) {
+  /** renders received expression data from the server */
+  function renderData([results, perfTimes]) {
     let distributionPlotToUse = distributionPlot
     if (!distributionPlotToUse) {
       distributionPlotToUse = defaultDistributionPlot
@@ -89,7 +89,7 @@ function RawStudyViolinPlot({
       annotation.scope,
       subsample,
       consensus
-    ).then(loadData).catch(error => {
+    ).then(renderData).catch(error => {
       Plotly.purge(graphElementId)
       setErrorContent(error.message)
       setShowError(true)

--- a/app/javascript/components/visualization/controls/CreateAnnotation.js
+++ b/app/javascript/components/visualization/controls/CreateAnnotation.js
@@ -11,7 +11,7 @@ import { isUserLoggedIn } from 'providers/UserProvider'
 import { getIdentifierForAnnotation, getDefaultAnnotationForCluster } from 'lib/cluster-utils'
 import { createUserAnnotation } from 'lib/scp-api'
 import { withErrorBoundary } from 'lib/ErrorBoundary'
-import { userErrorEnd, serverErrorEnd } from 'lib/error-utils'
+import { serverErrorEnd } from 'lib/error-utils'
 
 
 /** A control for adding a new user-defined annotation */
@@ -58,8 +58,8 @@ function CreateAnnotation({
   }
 
   /** renders an appropriate modal and updates the cluster params with the response from the server */
-  function handleCreateResponse({ message, annotations, errorType, newAnnotations }) {
-    if (!errorType) {
+  function handleCreateResponse({ message, annotations, newAnnotations, error }) {
+    if (!error) {
       setResponseModalContent({
         message: `User Annotation: ${annotationName} successfully saved`,
         footer: 'You can now view this annotation via the "Annotations" dropdown.'
@@ -77,8 +77,8 @@ function CreateAnnotation({
       })
     } else {
       setResponseModalContent({
-        message: `User Annotation: ${annotationName} successfully saved`,
-        footer: errorType === 'server' ? serverErrorEnd : userErrorEnd
+        message: error.message,
+        footer: serverErrorEnd
       })
     }
     setShowResponseModal(true)
@@ -112,7 +112,9 @@ function CreateAnnotation({
       subsample,
       annotationName,
       selectionPayload
-    ).then(handleCreateResponse)
+    ).then(handleCreateResponse).catch(error => {
+      handleCreateResponse({error: error})
+    })
   }
 
   /** creates a new label entry for the given cell names */

--- a/app/javascript/components/visualization/controls/CreateAnnotation.js
+++ b/app/javascript/components/visualization/controls/CreateAnnotation.js
@@ -113,7 +113,7 @@ function CreateAnnotation({
       annotationName,
       selectionPayload
     ).then(handleCreateResponse).catch(error => {
-      handleCreateResponse({error: error})
+      handleCreateResponse({ error })
     })
   }
 

--- a/app/javascript/lib/error-message.js
+++ b/app/javascript/lib/error-message.js
@@ -26,24 +26,6 @@ export default function useErrorMessage() {
   }
 }
 
-/**
-  * wraps a call to an scp-api function in error handling
-  * Once this code is good and stable, this should be folded into scp-api itself
-  */
-export function checkScpApiResponse(response, onError, setShowError, setErrorContent) {
-  // currently, scp-api just hands back a raw response if not ok,
-  // that isn't the best encapsulation of an API call, and should be refactored later
-  if ('ok' in response && !response.ok) {
-    response.json().then(response => {
-      onError()
-      setShowError(true)
-      setErrorContent(response.error)
-    })
-  } else {
-    return true
-  }
-}
-
 /** handler for morpheus errors that catches the error from an empty gene search to
     replace it with a more useful display and error message. */
 export function morpheusErrorHandler($target, setShowError, setErrorContent) {

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -600,13 +600,17 @@ export default async function scpApi(
       // Converts API's snake_case to JS-preferrable camelCase,
       // for easy destructuring assignment.
       if (camelCase) {
-        return [camelcaseKeys(json), perfTimes]
+        return [camelcaseKeys(json), perfTimes, true]
       } else {
-        return [json, perfTimes]
+        return [json, perfTimes, true]
       }
     } else {
-      return [response, perfTimes]
+      return [response, perfTimes, true]
     }
   }
-  return [response, perfTimes]
+  if (toJson) {
+    const json = await response.json()
+    throw new Error(json.error)
+  }
+  throw new Error(response)
 }

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -249,9 +249,10 @@ export async function fetchCluster({
   studyAccession, cluster, annotation, subsample, consensus, genes=null,
   isAnnotatedScatter=null, fields=[], mock=false
 }) {
-
-  const apiUrl = fetchClusterUrl({ studyAccession, cluster, annotation, subsample,
-    consensus, genes, isAnnotatedScatter, fields })
+  const apiUrl = fetchClusterUrl({
+    studyAccession, cluster, annotation, subsample,
+    consensus, genes, isAnnotatedScatter, fields
+  })
   // don't camelcase the keys since those can be cluster names,
   // so send false for the 4th argument
   const [scatter, perfTimes] = await scpApi(apiUrl, defaultInit(), mock, false)
@@ -288,7 +289,7 @@ export function fetchClusterUrl({
   if (!cluster || cluster === '') {
     cluster = '_default'
   }
-  return`/studies/${studyAccession}/clusters/${encodeURIComponent(cluster)}${params}`
+  return `/studies/${studyAccession}/clusters/${encodeURIComponent(cluster)}${params}`
 }
 
 /**

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -117,36 +117,17 @@ export async function createUserAnnotation(
   })
 
   const apiUrl = `/studies/${studyAccession}/user_annotations`
-  const [jsonOrResponse] = await scpApi(apiUrl, init, mock)
 
-  let message = ''
-  let annotations = {}
-  let errorType = null
-  let newAnnotations = []
+  const [response] = await scpApi(apiUrl, init, mock)
 
-  // Consider refactoring this when migrating user-annotations.js to
-  // React, so components share more error handling logic and UI
-  if (jsonOrResponse.ok === false) {
-    const json = await jsonOrResponse.json()
-    message = json.error
-    const status = jsonOrResponse.status
-    if (status === 400) {
-      errorType = 'user'
-    } else if (status === 500) {
-      errorType = 'server'
-    } else {
-      errorType = 'other'
-    }
-  } else {
-    // Parse JSON of successful response
-    message = jsonOrResponse.message
-    annotations = jsonOrResponse.annotations
-    newAnnotations = jsonOrResponse.annotationList
-  }
+  // Parse JSON of successful response
+  const message = response.message
+  const annotations = response.annotations
+  const newAnnotations = response.annotationList
 
   logCreateUserAnnotation()
 
-  return { message, annotations, errorType, newAnnotations }
+  return { message, annotations, newAnnotations }
 }
 
 /**

--- a/app/javascript/providers/GeneSearchProvider.js
+++ b/app/javascript/providers/GeneSearchProvider.js
@@ -73,7 +73,7 @@ export function PropsGeneSearchProvider(props) {
         page: searchParams.page,
         genes: searchParams.genes,
         preset: searchParams.preset
-    }).then(results => {
+      }).then(results => {
       setSearchState({
         params: searchParams,
         isError: false,
@@ -92,8 +92,6 @@ export function PropsGeneSearchProvider(props) {
         updateSearch
       })
     })
-
-
   }
 
   if (!_isEqual(searchParams, searchState.params ||

--- a/app/javascript/providers/GeneSearchProvider.js
+++ b/app/javascript/providers/GeneSearchProvider.js
@@ -63,28 +63,37 @@ export function PropsGeneSearchProvider(props) {
   }
 
   /** perform the actual API search */
-  async function performSearch() {
+  function performSearch() {
     // reset the scroll in case they scrolled down to read prior results
     window.scrollTo(0, 0)
 
-    const results = await fetchSearch(
+    fetchSearch(
       // Ensures event properties include "type": "gene" in search logging.
-      'gene',
-      {
+      'gene', {
         page: searchParams.page,
         genes: searchParams.genes,
         preset: searchParams.preset
-      }
-    )
-
-    setSearchState({
-      params: searchParams,
-      isError: results.ok === false,
-      isLoading: false,
-      isLoaded: true,
-      results,
-      updateSearch
+    }).then(results => {
+      setSearchState({
+        params: searchParams,
+        isError: false,
+        isLoading: false,
+        isLoaded: true,
+        results,
+        updateSearch
+      })
+    }).catch(error => {
+      setSearchState({
+        params: searchParams,
+        isError: true,
+        isLoading: false,
+        isLoaded: true,
+        results: error,
+        updateSearch
+      })
     })
+
+
   }
 
   if (!_isEqual(searchParams, searchState.params ||

--- a/app/javascript/providers/StudySearchProvider.js
+++ b/app/javascript/providers/StudySearchProvider.js
@@ -115,19 +115,28 @@ export function PropsStudySearchProvider(props) {
   }
 
   /** perform the actual API search based on current params */
-  async function performSearch() {
+  function performSearch() {
     // reset the scroll in case they scrolled down to read prior results
     window.scrollTo(0, 0)
 
-    const results = await fetchSearch('study', searchParams)
-
-    setSearchState({
-      params: searchParams,
-      isError: results.ok === false,
-      isLoading: false,
-      isLoaded: true,
-      results,
-      updateSearch
+    fetchSearch('study', searchParams).then(results => {
+      setSearchState({
+        params: searchParams,
+        isError: false,
+        isLoading: false,
+        isLoaded: true,
+        results,
+        updateSearch
+      })
+    }).catch(error => {
+      setSearchState({
+        params: searchParams,
+        isError: true,
+        isLoading: false,
+        isLoaded: true,
+        results: error,
+        updateSearch
+      })
     })
   }
 

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -126,13 +126,12 @@ class ExpressionVizService
 
   # load cluster_group data_array values, but use expression scores to set numerical color array
   # this is the scatter plot shown in the "scatter" tab next to "distribution" on gene-based views
-  def self.load_expression_data_array_points(study, gene, cluster, annotation, subsample_threshold=nil, expression_only=false)
-    viz_data = ClusterVizService.load_cluster_group_data_array_points(study, cluster, annotation, subsample_threshold=nil, include_annotations: !expression_only, include_coords: !expression_only)
+  def self.load_expression_data_array_points(study, gene, cluster, annotation, subsample_threshold=nil, include_coords=true, include_annotations=true)
+    viz_data = ClusterVizService.load_cluster_group_data_array_points(study, cluster, annotation, subsample_threshold=nil, include_annotations: include_annotations, include_coords: include_coords)
 
     viz_data[:expression] = viz_data[:cells].map { |cell| gene['scores'][cell].to_f.round(4) }
 
-    if expression_only
-      viz_data.delete(:annotations)
+    if !include_coords
       viz_data.delete(:cells)
     end
     viz_data
@@ -247,8 +246,8 @@ class ExpressionVizService
   # load scatter expression scores with average of scores across each gene for all cells
   # uses data_array as source for each axis
   # will support a variety of consensus modes (default is mean)
-  def self.load_gene_set_expression_data_arrays(study, genes, cluster, annotation, consensus, subsample_threshold=nil, expression_only=false)
-    viz_data = ClusterVizService.load_cluster_group_data_array_points(study, cluster, annotation, subsample_threshold=nil, include_coords: !expression_only)
+  def self.load_gene_set_expression_data_arrays(study, genes, cluster, annotation, consensus, subsample_threshold=nil, include_coords=true, include_annotations=true)
+    viz_data = ClusterVizService.load_cluster_group_data_array_points(study, cluster, annotation, subsample_threshold=nil, include_coords: include_coords, include_annotations: include_annotations)
 
     viz_data[:expression] = viz_data[:cells].map do |cell|
       if consensus == 'median'

--- a/test/js/scp-api.test.js
+++ b/test/js/scp-api.test.js
@@ -44,19 +44,20 @@ describe('JavaScript client for SCP REST API', () => {
   })
 
   it('catches 500 errors', async () => {
+    expect.assertions(1)
     const mockErrorResponse = {
-      type: 'basic',
-      url: 'http://localhost:3000/single_cell/api/v1/search?type=study',
-      redirected: false,
-      status: 500,
-      ok: false,
-      statusText: 'Internal Server Error'
+      json: () => Promise.resolve({
+        error: 'Internal Server Error'
+      })
     }
     jest
       .spyOn(global, 'fetch')
       .mockReturnValue(Promise.resolve(mockErrorResponse))
-    const [actualResponse, perfTime] = await scpApi('/test/path', {}, false)
-    expect(actualResponse.status).toEqual(500)
-    expect(actualResponse.ok).toEqual(false)
+
+    return scpApi('/test/path', {}, false)
+      .then(() => {})
+      .catch(error => {
+        expect(error.message).toEqual('Internal Server Error')
+      })
   })
 })


### PR DESCRIPTION
SCP-3379  Moving to thrown Errors in the case of bad server responses, which should enable more sophisticated error handling in other places as well.  This also cleans up a bug where particular sequences of gene/annotation switching could cause cache errors

TO TEST: 
1. load a study
2. do a gene search for a gene that does not exist in the study
3. confirm that suitable error messages are displayed in each of the scatter and violin plots
4. do a search for a gene that does exist
5.  confirm the plot renders with the existent gene
6. switch the annotation, and confirm both scatter plots load successfully
7. reload the page, confirm it reloads successfully
8. switch the annotation again, and confirm both scatter plots update successfully