### PR TITLE
Using built-in `Host` header validation middleware (SCP-3373)

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -13,7 +13,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     begin
       provider = request.env["omniauth.auth"].dig('provider')
       self.class.validate_scopes_from_params(params, provider)
-      self.class.validate_host_header_on_callback(request.headers)
     rescue SecurityError => e
       logger.error e.message
       context = ErrorTracker.format_extra_context(params)
@@ -46,7 +45,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     begin
       provider = request.env["omniauth.auth"].dig('provider')
       self.class.validate_scopes_from_params(params, provider)
-      self.class.validate_host_header_on_callback(request.headers)
     rescue SecurityError => e
       logger.error e.message
       context = ErrorTracker.format_extra_context(params)
@@ -85,15 +83,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         error_message = "Invalid scope requested in OAuth callback: #{scope_name}, not configured for #{provider}: #{configured_scopes}"
         raise SecurityError.new(error_message)
       end
-    end
-  end
-
-  # ensure that no host header injection has taken place
-  def self.validate_host_header_on_callback(headers)
-    host_header = headers['HTTP_HOST']&.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
-    if host_header.present? && host_header != RequestUtils.get_hostname
-      error_message = "Invalid host header in callback: #{host_header}, does not match #{RequestUtils.get_hostname}"
-      raise SecurityError.new(error_message)
     end
   end
 end

--- a/config/environments/pentest.rb
+++ b/config/environments/pentest.rb
@@ -113,4 +113,8 @@ Rails.application.configure do
   config.disable_admin_notifications = true
 
   config.bard_host_url = 'https://terra-bard-dev.appspot.com'
+
+  # Host header injection protection
+  # from https://guides.rubyonrails.org/configuring.html#configuring-middleware
+  config.hosts << ENV['PROD_HOSTNAME']
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -113,4 +113,8 @@ Rails.application.configure do
   config.disable_admin_notifications = false
 
   config.bard_host_url = 'https://terra-bard-prod.appspot.com'
+
+  # Host header injection protection
+  # from https://guides.rubyonrails.org/configuring.html#configuring-middleware
+  config.hosts << ENV['PROD_HOSTNAME']
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -113,4 +113,8 @@ Rails.application.configure do
   config.disable_admin_notifications = true
 
   config.bard_host_url = 'https://terra-bard-dev.appspot.com'
+
+  # Host header injection protection
+  # from https://guides.rubyonrails.org/configuring.html#configuring-middleware
+  config.hosts << ENV['PROD_HOSTNAME']
 end

--- a/test/controllers/users/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/users/omniauth_callbacks_controller_test.rb
@@ -36,19 +36,4 @@ class User::OmniauthCallbacksControllerTest < ActiveSupport::TestCase
       Users::OmniauthCallbacksController.validate_scopes_from_params(@google_billing_params, provider)
     end
   end
-
-  test 'should validate host header on callback' do
-    RequestUtils.stub :get_hostname, 'localhost:3000' do
-      assert_nothing_raised do
-        Users::OmniauthCallbacksController.validate_host_header_on_callback({'HTTP_HOST' => 'localhost:3000'})
-      end
-
-      %w(localhost localhost:12345 malicious.com).each do |host|
-        invalid_headers = {'HTTP_HOST' => host}
-        assert_raise SecurityError do
-          Users::OmniauthCallbacksController.validate_host_header_on_callback(invalid_headers)
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
This update removes the custom `Host` header validation in `users/omniauth_callbacks_controller.rb` and replaces it with the new built-in `Host` header validation in Rails 6.1.  This is controlled by adding approved hostnames to `Rails.application.config.hosts`.  In development, this is turned on by default, but is not enabled in other environments.  This is being done in response to a request from AppSec as the [previous remediation](https://github.com/broadinstitute/single_cell_portal_core/pull/1043) did not work.

TO TEST:

Testing this is somewhat convoluted as we cannot use a tool like Burp to intercept traffic and add headers.  However, this can be tested to an extent in `curl`:

1. Pull this branch and boot portal as normal and sign in with an account
2. In `development.log`, copy the quoted request path for the OAuth callback, which will look like the following in the log:
```
D, [2021-05-26T11:08:50.044257 #30071] DEBUG -- omniauth: (google) Request phase initiated.
Started GET "/single_cell/users/auth/google/callback?state=f53303c40ad362fc49d876c468d289d42e3ab36bf01eac59&code=4/0AY0e-g5sg9Ej1hR3CpaDyRNjFt0oOchV9CvQV2hTaYRuqzEWPI1SU0DksJA07qXGEKEArw&scope=email%20profile%20https://www.googleapis.com/auth/userinfo.email%20https://www.googleapis.com/auth/userinfo.profile%20openid&authuser=0&hd=broadinstitute.org&prompt=consent" for 127.0.0.1 at 2021-05-26 11:08:52 -0400
D, [2021-05-26T11:08:52.453752 #30071] DEBUG -- omniauth: (google) Callback phase initiated.
```
3. In a new terminal window, execute the following `curl` call:
```
curl -I --location --request GET 'https://locahost:3000/[ ... request path from above ... ]' --header 'Host: malicious.com'
```
4. Validate the response is `403`:
```
HTTP/1.1 403 Forbidden
Content-Type: text/html; charset=UTF-8
Strict-Transport-Security: max-age=15768000; includeSubdomains; preload
...
```
_Note: as this is handled at the middleware level, the bad request will not show up in `development.log`._

This PR satisfies SCP-3373.