### PR TITLE
switching to annotated scatter when user changes annotation type (SCP-3383)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -138,6 +138,7 @@ export default function ExploreDisplayTabs({
       newParams.spatialGroups = getDefaultSpatialGroupsForCluster(newParams.cluster, exploreInfo.spatialGroups)
       dataCache.clear()
     }
+
     // if the user updates any cluster params, store all of them in the URL so we don't end up with
     // broken urls in the event of a default cluster/annotation changes
     // also, unset any gene lists as we're about to re-render the explore tab and having gene list selected will show
@@ -147,6 +148,12 @@ export default function ExploreDisplayTabs({
     clusterParamNames.forEach(param => {
       updateParams[param] = param in newParams ? newParams[param] : exploreParamsWithDefaults[param]
     })
+    // if a user switches to a numeric annotation, change the tab to annotated scatter (SCP-3833)
+    if (newParams.annotation?.type === 'numeric' &&
+      exploreParamsWithDefaults.genes.length &&
+      exploreParamsWithDefaults.annotation?.type !== 'numeric') {
+      updateParams.tab = 'annotatedScatter'
+    }
     updateExploreParams(updateParams)
   }
 


### PR DESCRIPTION
SCP-3383. Previously, once a user had manually selected a different tab, we would stay on that tab as long as they were on a view where that tab existed.  However, to increase the visibility of annotated scatter views, we want to make that tab appear on top whenever a user switches from group to numeric annotations.  

TO TEST:
1. open a study in explore tab, select a group-based annotation, and perform a gene search
2. click into the distribution or dotplot tabs
3. change to numeric annotation
4. confirm annotated scatter appears on top
