### PR TITLE
fixing stuck menu and other consensus-related bugs (SCP-3374)

### DIFF
--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -204,11 +204,8 @@ module Api
               }
             else
               # For "Scatter" tab
-              if is_collapsed_view
-                plot_data = ExpressionVizService.load_gene_set_expression_data_arrays(study, genes, cluster, annotation, consensus, subsample, !include_coordinates)
-              else
-                plot_data = ExpressionVizService.load_expression_data_array_points(study, genes[0], cluster, annotation, subsample, include_coordinates, include_annotation)
-              end
+              plot_data = ExpressionVizService.load_expression_data_array_points(study, genes, cluster, annotation, subsample,
+                consensus: consensus, expression_only: !include_coordinates)
             end
           end
 

--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -80,7 +80,12 @@ export default function ExploreDisplayTabs({
   /** helper function so that StudyGeneField doesn't have to see the full exploreParams object */
   function searchGenes(genes) {
     // also unset any selected gene lists or ideogram files
-    updateExploreParams({ genes, geneList: '', ideogramFileId: '' })
+    const newParams = { genes, geneList: '', ideogramFileId: '' }
+    if (genes.length < 2) {
+      // and unset the consensus if there are no longer 2+ genes
+      newParams.consensus = ''
+    }
+    updateExploreParams(newParams)
   }
 
   let shownTab = exploreParams.tab
@@ -469,7 +474,11 @@ export function getEnabledTabs(exploreInfo, exploreParams) {
   } else if (isGene) {
     if (isMultiGene) {
       if (isConsensus) {
-        enabledTabs = ['scatter', 'distribution', 'dotplot']
+        if (exploreParams.annotation.type === 'numeric') {
+          enabledTabs = ['annotatedScatter', 'distribution', 'dotplot']
+        } else {
+          enabledTabs = ['scatter', 'distribution', 'dotplot']
+        }
       } else if (hasSpatialGroups) {
         enabledTabs = ['scatter', 'dotplot', 'heatmap']
       } else {

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -126,12 +126,25 @@ class ExpressionVizService
 
   # load cluster_group data_array values, but use expression scores to set numerical color array
   # this is the scatter plot shown in the "scatter" tab next to "distribution" on gene-based views
-  def self.load_expression_data_array_points(study, gene, cluster, annotation, subsample_threshold=nil, include_coords=true, include_annotations=true)
-    viz_data = ClusterVizService.load_cluster_group_data_array_points(study, cluster, annotation, subsample_threshold=nil, include_annotations: include_annotations, include_coords: include_coords)
+  def self.load_expression_data_array_points(study, genes, cluster, annotation, subsample=nil,
+    consensus: nil, expression_only: false)
+    viz_data = ClusterVizService.load_cluster_group_data_array_points(study, cluster, annotation, subsample,
+      include_annotations: !expression_only, include_coords: !expression_only)
 
-    viz_data[:expression] = viz_data[:cells].map { |cell| gene['scores'][cell].to_f.round(4) }
+    viz_data[:expression] = viz_data[:cells].map do |cell|
+      if consensus == 'median'
+        expression_score = calculate_median(genes, cell)
+      elsif consensus == 'mean'
+        expression_score = calculate_mean(genes, cell)
+      else
+        expression_score = genes[0]['scores'][cell].to_f.round(4)
+      end
+      expression_score
+    end
 
-    if !include_coords
+    if expression_only
+      # x and y will already be excluded, but we had to return the cells from the above call to
+      # match the appropriate gene scores
       viz_data.delete(:cells)
     end
     viz_data
@@ -240,26 +253,6 @@ class ExpressionVizService
         viz_data[:cells] << cell
       end
     end
-    viz_data
-  end
-
-  # load scatter expression scores with average of scores across each gene for all cells
-  # uses data_array as source for each axis
-  # will support a variety of consensus modes (default is mean)
-  def self.load_gene_set_expression_data_arrays(study, genes, cluster, annotation, consensus, subsample_threshold=nil, include_coords=true, include_annotations=true)
-    viz_data = ClusterVizService.load_cluster_group_data_array_points(study, cluster, annotation, subsample_threshold=nil, include_coords: include_coords, include_annotations: include_annotations)
-
-    viz_data[:expression] = viz_data[:cells].map do |cell|
-      if consensus == 'median'
-        expression_score = calculate_median(genes, cell)
-      else
-        expression_score = calculate_mean(genes, cell)
-      end
-      expression_score
-    end
-
-    emin, emax = RequestUtils.get_minmax(viz_data[:expression])
-    viz_data[:expressionRange] = {min: emin, max: emax}
     viz_data
   end
 

--- a/test/integration/lib/expression_viz_service_test.rb
+++ b/test/integration/lib/expression_viz_service_test.rb
@@ -259,7 +259,7 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
     default_annot = @basic_study.default_annotation
     annot_name, annot_type, annot_scope = default_annot.split('--')
     annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: annot_name, annot_type: annot_type, annot_scope: annot_scope)
-    expression_scatter = ExpressionVizService.load_expression_data_array_points(@basic_study, gene, cluster, annotation,
+    expression_scatter = ExpressionVizService.load_expression_data_array_points(@basic_study, [gene], cluster, annotation,
                                                                                 nil)
     assert_equal(cluster.concatenate_data_arrays('x', 'coordinates'), expression_scatter[:x])
     assert_equal(cluster.concatenate_data_arrays('y', 'coordinates'), expression_scatter[:y])

--- a/test/integration/lib/expression_viz_service_test.rb
+++ b/test/integration/lib/expression_viz_service_test.rb
@@ -307,8 +307,8 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
     default_annot = @basic_study.default_annotation
     annot_name, annot_type, annot_scope = default_annot.split('--')
     annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: annot_name, annot_type: annot_type, annot_scope: annot_scope)
-    gene_set_exp_scatter = ExpressionVizService.load_gene_set_expression_data_arrays(
-        @basic_study, genes, cluster, annotation, 'mean'
+    gene_set_exp_scatter = ExpressionVizService.load_expression_data_array_points(
+        @basic_study, genes, cluster, annotation, consensus: 'mean'
     )
 
     # mean of values for scores across both genes for each cell


### PR DESCRIPTION
In addition to the mentioned bug, there were also some lingering issues in how consensus behaved when switching back and forth between annotations due to the caching bug.  those have been fixed, and addressed by consolidating a couple of service methods so this kind of thing is less likely to slip through the cracks in the future.

TO TEST:
 1. load a study and do a multi-gene search
 2. set consensus of median
 3. do a single-gene search
 4. confirm that 'consensus' no longer appears in the URL
 5. switch annotations
 6. confirm that plots still render as expected