### PR TITLE
Log number of points plotted and other performance-relevant metrics for scatter plots (SCP-3357)

### DIFF
--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -147,6 +147,9 @@ export function logScatterPlot(
   const props = {
     'numPoints': scatter.numPoints, // How many cells are we plotting?
     genes,
+    'numPointsPlotted': scatter.data.cells.length,
+    'isSubsampled': scatter.isSubsampled,
+    'subsample': scatter.subsample,
     'gene': scatter.gene,
     'is3D': scatter.is3D,
     'layout:width': width, // Pixel width of graph


### PR DESCRIPTION
This adds Mixpanel instrumentation for a few properties important for analyzing for scatter plot performance.

To test:
* Open Network panel in DevTools 
* Load a study with many cells
* In Network panel, filter requests to `bard method:POST`
* Find `scatter:plot` event
* Verify that `numPointsPlotted` < `numPoints`

This satisfies SCP-3357.