### PR TITLE
Undoing config.hosts (SCP-3373)

### DIFF
--- a/config/environments/pentest.rb
+++ b/config/environments/pentest.rb
@@ -113,8 +113,4 @@ Rails.application.configure do
   config.disable_admin_notifications = true
 
   config.bard_host_url = 'https://terra-bard-dev.appspot.com'
-
-  # Host header injection protection
-  # from https://guides.rubyonrails.org/configuring.html#configuring-middleware
-  config.hosts << ENV['PROD_HOSTNAME']
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -113,8 +113,4 @@ Rails.application.configure do
   config.disable_admin_notifications = false
 
   config.bard_host_url = 'https://terra-bard-prod.appspot.com'
-
-  # Host header injection protection
-  # from https://guides.rubyonrails.org/configuring.html#configuring-middleware
-  config.hosts << ENV['PROD_HOSTNAME']
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -113,8 +113,4 @@ Rails.application.configure do
   config.disable_admin_notifications = true
 
   config.bard_host_url = 'https://terra-bard-dev.appspot.com'
-
-  # Host header injection protection
-  # from https://guides.rubyonrails.org/configuring.html#configuring-middleware
-  config.hosts << ENV['PROD_HOSTNAME']
 end


### PR DESCRIPTION
This PR removes the new configurations introduced in #1050 as it breaks deployed environments.