### PR TITLE
Reverting to sprockets 3.7.2 re: segfault errors on ubuntu (SCP-3387)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,7 +457,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.3)
-    sprockets (4.0.2)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.2)


### PR DESCRIPTION
This update downgrades the `sprockets` gem to `3.7.2` due to the [known issue](https://github.com/rails/sprockets/issues/633) with segfaults when compiling static assets on ubuntu.  There is no dependency in Rails 6 for using v4, so this downgrading should be fine moving forward, at least until they address the issue.  This will help with both test stability and remove the chance that this issue will happen during a deployment.

This PR satisfies SCP-3387.