### PR TITLE
Updating to scp-ingest-pipeline:1.11.0 (SCP-3414)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.10.2'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.11.0'
 
     # Terra Data Repo API base url
     config.tdr_api_base_url = 'https://jade-terra.datarepo-prod.broadinstitute.org/'


### PR DESCRIPTION
Updates to the [latest release](https://github.com/broadinstitute/scp-ingest-pipeline/releases/tag/1.11.0) of `scp-ingest-pipline`.  This allows for matching on known synonyms in convention metadata files for any `__ontology_label` column entries.  

This PR satisfies the remainder of SCP-3414.