### PR TITLE
Extending DataRepoClient functionality (SCP-3354, SCP-3398)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -178,7 +178,7 @@ module Api
           if @preset_search.accession_list.any?
             sort_type = :accession_list if params[:terms].blank?
             @accession_list = @preset_search.accession_list
-            Rails.logger.info "Scoping search results to accessions from preset search: #{@preset_search.name}: #{@accession_list}"
+            logger.info "Scoping search results to accessions from preset search: #{@preset_search.name}: #{@accession_list}"
             @viewable = @viewable.where(:accession.in => @accession_list)
           end
         end
@@ -291,8 +291,16 @@ module Api
           end
         end
 
+        # perform TDR search, if enabled & user performed faceted search
+        if @facets.any? && User.feature_flag_for_instance(current_api_user, 'cross_dataset_search_backend')
+          @trd_results = self.class.get_tdr_results(@facets)
+          # just log for now
+          logger.info "Found #{@trd_results.keys.size} results in Terra Data Repo"
+          logger.info pp @trd_results
+        end
+
         @matching_accessions = @studies.map(&:accession)
-        Rails.logger.info "Final list of matching studies: #{@matching_accessions}"
+        logger.info "Final list of matching studies: #{@matching_accessions}"
         @results = @studies.paginate(page: params[:page], per_page: Study.per_page)
         render json: search_results_obj, status: 200
       end
@@ -925,6 +933,48 @@ module Api
         else
           return matching_facet[:filters].detect { |filter| filter[:id] == search_result[result_key] }
         end
+      end
+
+      # execute a search in TDR and get back normalized results
+      def self.get_tdr_results(selected_facets)
+        query_json = ApplicationController.data_repo_client.generate_query_from_facets(selected_facets)
+        raw_tdr_results = ApplicationController.data_repo_client.query_snapshot_indexes(query_json)
+        results = {}
+        raw_tdr_results.dig('result').each do |result_row|
+          short_name = result_row.dig('project_short_name')
+          results[short_name] ||= {
+            name: result_row.dig('project_title'),
+            description: result_row.dig('project_description'),
+            matches: []
+          }
+          # determine facet filter matches
+          selected_facets.each do |facet|
+            matches = get_facet_match_for_tdr_result(facet, result_row)
+            matches.each do |col_name, matched_val|
+              entry = {col_name => matched_val}
+              results[short_name][:matches] << entry unless results[short_name][:matches].include?(entry)
+            end
+          end
+        end
+        results
+      end
+
+      # determine facet matches for an individual result row from TDR
+      def self.get_facet_match_for_tdr_result(facet, result_row)
+        tdr_name = FacetNameConverter.to_hca(facet[:id])
+        if facet[:filters].is_a? Hash
+          # this is a numeric facet, so convert to range for match
+          # TODO: determine correct unit/datatype and convert
+          filter_value = "#{facet.dig(:filters, :min).to_i}-#{facet.dig(:filters, :max).to_i}"
+          matches = result_row.each_pair.select {|col, val| col == tdr_name && val == filter_value}
+        else
+          matches = []
+          facet[:filters].each do |filter|
+            # look for match on the column name, and see which filter value also matched (ontology label or id)
+            matches << result_row.each_pair.select {|col, val| col == tdr_name && (val == filter[:name] || filter[:id])}.flatten
+          end
+        end
+        matches
       end
     end
   end

--- a/app/models/data_repo_client.rb
+++ b/app/models/data_repo_client.rb
@@ -12,6 +12,8 @@ class DataRepoClient < Struct.new(:access_token, :api_root, :storage, :expires_a
   BASE_URL = Rails.application.config.tdr_api_base_url.freeze
   # Hostname of repo, needed for parsing out DRS identifiers
   REPOSITORY_HOSTNAME = URI(BASE_URL).host.freeze
+  # prefix used to identify valid DRS ids
+  DRS_PREFIX = "drs://#{REPOSITORY_HOSTNAME}/".freeze
 
   # control variables
   SORT_DIRECTIONS = %w(asc desc).freeze
@@ -338,8 +340,8 @@ class DataRepoClient < Struct.new(:access_token, :api_root, :storage, :expires_a
   # * *raises*
   #   - (ArgumentError) => if drs_id is not formatted correctly
   def parse_drs_id(drs_id)
-    raise ArgumentError.new("#{drs_id} is not a valid DRS id") unless drs_id.starts_with?("drs://#{REPOSITORY_HOSTNAME}/")
-    drs_id.split("drs://#{REPOSITORY_HOSTNAME}/").last
+    raise ArgumentError.new("#{drs_id} is not a valid DRS id") unless drs_id.starts_with?(DRS_PREFIX)
+    drs_id.split(DRS_PREFIX).last
   end
 
   ##

--- a/app/models/data_repo_client.rb
+++ b/app/models/data_repo_client.rb
@@ -7,7 +7,7 @@ class DataRepoClient < Struct.new(:access_token, :api_root, :storage, :expires_a
   include ApiHelpers
 
   # Google authentication scopes necessary for querying TDR API
-  GOOGLE_SCOPES = %w(openid email profile)
+  GOOGLE_SCOPES = %w(openid email profile https://www.googleapis.com/auth/devstorage.read_only)
    # Base API URL to request against
   BASE_URL = Rails.application.config.tdr_api_base_url.freeze
   # Hostname of repo, needed for parsing out DRS identifiers

--- a/app/models/data_repo_client.rb
+++ b/app/models/data_repo_client.rb
@@ -57,13 +57,7 @@ class DataRepoClient < Struct.new(:access_token, :api_root, :storage, :expires_a
     Rails.logger.info "Terra Data Repo API request (#{http_method.to_s.upcase}) #{path}"
 
     # set default headers, appending application identifier including hostname for disambiguation
-    headers = {
-      'Authorization' => "Bearer #{self.valid_access_token['access_token']}",
-      'Accept' => 'application/json',
-      'Content-Type' => 'application/json',
-      'x-app-id' => "single-cell-portal",
-      'x-domain-id' => "#{ENV['HOSTNAME']}"
-    }
+    headers = get_default_headers
 
     # process request
     begin

--- a/app/models/data_repo_client.rb
+++ b/app/models/data_repo_client.rb
@@ -183,7 +183,7 @@ class DataRepoClient < Struct.new(:access_token, :api_root, :storage, :expires_a
   #
   # * *returns*
   #   - (Array<Hash>) => Array of hashes of all tables/columns in a given snapshot that are file-based
-  def get_snapshot_file(snapshot_id)
+  def get_snapshot_file(snapshot_id, file_id)
     path = api_root + "/api/repository/v1/snapshots/#{snapshot_id}/files/#{file_id}"
     process_api_request(:get, path)
   end

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -218,9 +218,9 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
     # set default headers, appending application identifier including hostname for disambiguation
     headers = get_default_headers
 
-    # if uploading a file, remove Content-Type header to use default x-www-form-urlencoded type on POSTs
+    # if uploading a file, remove Content-Type/Accept headers to use default x-www-form-urlencoded type on POSTs
     if request_opts[:file_upload]
-      headers.reject! {|k,v| k == 'Content-Type'}
+      headers.reject! {|header, value| %w(Content-Type Accept).include? header }
     end
 
     # process request

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -220,7 +220,7 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
 
     # if uploading a file, remove Content-Type header to use default x-www-form-urlencoded type on POSTs
     if request_opts[:file_upload]
-      headers.delete!({'Content-Type' => 'application/json'})
+      headers.reject! {|k,v| k == 'Content-Type'}
     end
 
     # process request

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,9 +31,6 @@ module SingleCellPortal
     # Docker image for file parsing via scp-ingest-pipeline
     config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.10.2'
 
-    # Terra Data Repo API base url
-    config.tdr_api_base_url = 'https://jade-terra.datarepo-prod.broadinstitute.org/'
-
     config.autoload_paths << Rails.root.join('lib')
 
     # Google OAuth2 Scopes

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -110,4 +110,7 @@ Rails.application.configure do
   end
 
   config.bard_host_url = 'https://terra-bard-dev.appspot.com'
+
+  # Terra Data Repo API base url
+  config.tdr_api_base_url = 'https://jade.datarepo-dev.broadinstitute.org'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -114,6 +114,9 @@ Rails.application.configure do
 
   config.bard_host_url = 'https://terra-bard-prod.appspot.com'
 
+  # Terra Data Repo API base url
+  config.tdr_api_base_url = 'https://jade-terra.datarepo-prod.broadinstitute.org'
+
   # DNS rebinding/host header injection protection
   # CIDR ip ranges from https://cloud.google.com/load-balancing/docs/health-checks#firewall_rules
   config.hosts = [

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -114,6 +114,9 @@ Rails.application.configure do
 
   config.bard_host_url = 'https://terra-bard-dev.appspot.com'
 
+  # Terra Data Repo API base url
+  config.tdr_api_base_url = 'https://jade.datarepo-dev.broadinstitute.org'
+
   # DNS rebinding/host header injection protection
   # CIDR ip ranges from https://cloud.google.com/load-balancing/docs/health-checks#firewall_rules
   config.hosts = [

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,4 +76,7 @@ Rails.application.configure do
   Mongoid.logger.level = Logger::INFO
 
   config.bard_host_url = 'https://terra-bard-dev.appspot.com'
+
+  # Terra Data Repo API base url
+  config.tdr_api_base_url = 'https://jade.datarepo-dev.broadinstitute.org'
 end

--- a/lib/api_helpers.rb
+++ b/lib/api_helpers.rb
@@ -8,6 +8,20 @@ module ApiHelpers
   # interval for retry backoff on request retries
   RETRY_INTERVAL = Rails.env.test? ? 0 : 15
 
+  # get default HTTP headers for making requests
+  #
+  # * *returns*
+  #   - (Hash) => Hash of default HTTP headers, e.g. Authorization, Content-Type
+  def get_default_headers
+    {
+      'Authorization' => "Bearer #{self.valid_access_token['access_token']}",
+      'Accept' => 'application/json',
+      'Content-Type' => 'application/json',
+      'x-app-id' => 'single-cell-portal',
+      'x-domain-id' => "#{ENV['HOSTNAME']}"
+    }
+  end
+
   # check if OK response code was found
   #
   # * *params*

--- a/lib/facet_name_converter.rb
+++ b/lib/facet_name_converter.rb
@@ -1,0 +1,35 @@
+# class for converting from alexandria convention names to HCA or TIM metadata model names (i.e. columns, not individual values)
+# this is currently for PoC work on XDSS - eventually this will be replaced by an onotology server that can handle
+# conversions programmatically
+class FacetNameConverter
+  # map of alexandria metadata convention names to HCA 'short' names
+  # not fully namespaced as this is what is indexed in TDR
+  ALEXANDRIA_TO_HCA = {
+    biosample_id: 'biosample_id',
+    cell_type: 'cell_type',
+    donor_id: 'donor_id',
+    disease: 'disease',
+    library_preparation_protocol: 'library_construction_method',
+    organ: 'organ',
+    organism_age: 'organism_age',
+    sex: 'sex',
+    species: 'genus_species',
+    study_name: 'project_title',
+    study_description: 'project_description'
+  }
+
+  # TBA, not needed yet
+  ALEXANDRIA_TO_TIM = {}
+
+  # convert from SCP metadata names to HCA short names
+  #
+  # * *params*
+  #   - +name+
+  def self.to_hca(name)
+    ALEXANDRIA_TO_HCA.dig(name.to_sym)
+  end
+
+  def self.to_terra_model(name)
+    ALEXANDRIA_TO_TIM.dig(name.to_sym)
+  end
+end

--- a/test/integration/data_repo_client_test.rb
+++ b/test/integration/data_repo_client_test.rb
@@ -11,7 +11,9 @@ class DataRepoClientTest < ActiveSupport::TestCase
     @file_id = '5009a1f8-c2ee-4ceb-8ddb-40c3ddee5472' # ID of sequence file in PulmonaryFibrosisGSE135893 snapshot
     @filename = 'IPF_VUILD54_1_LU_Whole_C1_X5SCR_F00207_HMWLCBGX7_ATTTGCTA_L001_R1_001.fastq.gz' # name of above file
     @drs_file_id = "drs://#{DataRepoClient::REPOSITORY_HOSTNAME}/v1_#{@snapshot_id}_#{@file_id}" # computed DRS id
-    @gs_url = "gs://broad-jade-dev-data-bucket/#{@dataset_id}/#{@file_id}/#{@filename}" # computed GS url
+    bucket_id = 'broad-jade-dev-data-bucket'
+    @gs_url = "gs://#{bucket_id}/#{@dataset_id}/#{@file_id}/#{@filename}" # computed GS url
+    @https_url = "https://www.googleapis.com/storage/v1/b/#{bucket_id}/o/#{@dataset_id}%2F#{@file_id}%2F#{@filename}?alt=media"
   end
 
   # skip a test if the TDR API is not up (since it is their dev instance there is no uptime guarantee)
@@ -212,14 +214,17 @@ class DataRepoClientTest < ActiveSupport::TestCase
     end
   end
 
-  test 'should get gs url from drs id' do
+  test 'should get access url from drs id' do
     skip_if_api_down
-    found_gs_url = @data_repo_client.get_gs_url_from_drs_id(@drs_file_id)
+    found_gs_url = @data_repo_client.get_access_url_from_drs_id(@drs_file_id, :gs)
     assert_equal @gs_url, found_gs_url
+
+    found_https_url = @data_repo_client.get_access_url_from_drs_id(@drs_file_id, :https)
+    assert_equal @https_url, found_https_url
 
     # ensure error handling
     assert_raise ArgumentError do
-      @data_repo_client.get_drs_file_info('foo')
+      @data_repo_client.get_access_url_from_drs_id('foo', :gs)
     end
   end
 end

--- a/test/integration/data_repo_client_test.rb
+++ b/test/integration/data_repo_client_test.rb
@@ -15,8 +15,10 @@ class DataRepoClientTest < ActiveSupport::TestCase
   end
 
   # skip a test if the TDR API is not up (since it is their dev instance there is no uptime guarantee)
-  def skip_if_api_down(test_name)
-    skip "skipping #{test_name} due to TDR API being unavailable" if !@data_repo_client.api_available?
+  def skip_if_api_down
+    if !@data_repo_client.api_available?
+      puts "-- skipping due to TDR API being unavailable --" ; skip
+    end
   end
 
   test 'should instantiate client' do
@@ -106,18 +108,18 @@ class DataRepoClientTest < ActiveSupport::TestCase
   end
 
   test 'should get api status' do
-    skip_if_api_down(self.method_name)
+    skip_if_api_down
     status = @data_repo_client.api_status
     assert status['ok']
   end
 
   test 'should check if api is available' do
-    skip_if_api_down(self.method_name)
+    skip_if_api_down
     assert @data_repo_client.api_available?
   end
 
   test 'should get datasets' do
-    skip_if_api_down(self.method_name)
+    skip_if_api_down
     datasets = @data_repo_client.get_datasets
     assert datasets.dig('total').present?
     skip 'got empty response for datasets' if datasets.dig('items').empty?
@@ -127,7 +129,7 @@ class DataRepoClientTest < ActiveSupport::TestCase
   end
 
   test 'should get snapshots' do
-    skip_if_api_down(self.method_name)
+    skip_if_api_down
     snapshots = @data_repo_client.get_snapshots
     assert snapshots.dig('total').present?
     skip 'got empty response for snapshots' if snapshots.dig('items').empty?
@@ -137,7 +139,7 @@ class DataRepoClientTest < ActiveSupport::TestCase
   end
 
   test 'should get snapshot' do
-    skip_if_api_down(self.method_name)
+    skip_if_api_down
     snapshot = @data_repo_client.get_snapshot(@snapshot_id)
     assert snapshot.present?
     expected_keys = %w(id name description createdDate source tables
@@ -146,7 +148,7 @@ class DataRepoClientTest < ActiveSupport::TestCase
   end
 
   test 'should get file in snapshot' do
-    skip_if_api_down(self.method_name)
+    skip_if_api_down
     file_info = @data_repo_client.get_snapshot_file_info(@snapshot_id, @file_id)
     assert file_info.present?
     assert_equal @file_id, file_info.dig('fileId')
@@ -168,7 +170,7 @@ class DataRepoClientTest < ActiveSupport::TestCase
   end
 
   test 'should query snapshot index' do
-    skip_if_api_down(self.method_name)
+    skip_if_api_down
     selected_facets = [
       {id: :species, filters: [{id: 'NCBITaxon9609', name: 'Homo sapiens'}]}
     ]
@@ -195,7 +197,7 @@ class DataRepoClientTest < ActiveSupport::TestCase
   end
 
   test 'should get file info from drs id' do
-    skip_if_api_down(self.method_name)
+    skip_if_api_down
     file_info = @data_repo_client.get_drs_file_info(@drs_file_id)
     assert file_info.present?
     expected_id = @drs_file_id.split('/').last
@@ -211,7 +213,7 @@ class DataRepoClientTest < ActiveSupport::TestCase
   end
 
   test 'should get gs url from drs id' do
-    skip_if_api_down(self.method_name)
+    skip_if_api_down
     found_gs_url = @data_repo_client.get_gs_url_from_drs_id(@drs_file_id)
     assert_equal @gs_url, found_gs_url
 

--- a/test/integration/data_repo_client_test.rb
+++ b/test/integration/data_repo_client_test.rb
@@ -164,8 +164,8 @@ class DataRepoClientTest < ActiveSupport::TestCase
       {id: :species, filters: [{id: 'NCBITaxon9609', name: 'Homo sapiens'}]},
       {id: :disease, filters: [{id: 'MONDO_0018076', name: 'tuberculosis'},{id: 'MONDO_0005109', name: 'HIV infectious disease'}]}
     ]
-    expected_query = "(species:NCBITaxon9609 OR species:Homo sapiens) AND (disease:MONDO_0018076 OR disease:tuberculosis " \
-                     "OR disease:MONDO_0005109 OR disease:HIV infectious disease)"
+    expected_query = "(genus_species:NCBITaxon9609 OR genus_species:Homo sapiens) AND (disease:MONDO_0018076 OR " \
+                     "disease:tuberculosis OR disease:MONDO_0005109 OR disease:HIV infectious disease)"
 
     query_json = @data_repo_client.generate_query_from_facets(selected_facets)
     assert_equal expected_query, query_json.dig(:query_string, :query)

--- a/test/integration/data_repo_client_test.rb
+++ b/test/integration/data_repo_client_test.rb
@@ -95,20 +95,20 @@ class DataRepoClientTest < ActiveSupport::TestCase
   end
 
   test 'should get datasets' do
-    datasets = @data_repo_client.datasets
+    datasets = @data_repo_client.get_datasets
     assert datasets.dig('total').present?
     skip 'got empty response for datasets' if datasets.dig('items').empty?
     dataset_id = datasets.dig('items').first.dig('id')
-    dataset = @data_repo_client.dataset(dataset_id)
+    dataset = @data_repo_client.get_dataset(dataset_id)
     assert dataset.present?
   end
 
   test 'should get snapshots' do
-    snapshots = @data_repo_client.snapshots
+    snapshots = @data_repo_client.get_snapshots
     assert snapshots.dig('total').present?
     skip 'got empty response for snapshots' if snapshots.dig('items').empty?
     snapshot_id = snapshots.dig('items').first.dig('id')
-    snapshot = @data_repo_client.snapshot(snapshot_id)
+    snapshot = @data_repo_client.get_snapshot(snapshot_id)
     assert snapshot.present?
   end
 end


### PR DESCRIPTION
This update adds more functionality to `DataRepoClient`, including the ability to query snapshot indexes (dev only), and resolving references to files in Terra Data Repo (TDR) using DRS ids.  Currently these IDs are not available in search results, but once [this ticket](https://broadworkbench.atlassian.net/browse/DR-1870) is implemented, those should be available in row-level results.

This also adds `FacetNameConverter`, which is a stopgap solution for converting from SCP metadata convention names to HCA metadata short names (not fully namespaced, as this is not how the data is currently indexed).   This is _only_ intended for current "proof of concept" work, and will not be the eventual implementation for handling name conversions across schemas.

For now, searching is behind the `cross_dataset_search_backend` feature flag, and results are printed to the log only, and are not rendered in the UI.  As this is still all at the PoC level, there is some necessary "hand waving" in terms of terms/values being hard-coded, for now.  Searches are currently only implemented at the string-matching level.  Still to be implemented are numeric range queries, and handling conversion of time units.

TO TEST:
1. Pull this branch and boot as normal
2. Enable the `cross_dataset_search_backend` feature flag in the "Admin => User Roles" panel for your user account
3. Perform a faceted search in the front end, using `"species: Homo sapiens"` and `"organism_age: 46-72"`
4. Note results in the log, detailing the project that was found, including the facet matches:
```
Found 1 results in Terra Data Repo
{"PulmonaryFibrosisGSE135893"=>{:name=>"Single-cell RNA-sequencing reveals profibrotic roles of distinct epithelial and mesenchymal lineages in pulmonary fibrosis", :description=>"Pulmonary fibrosis (PF) is a form of chronic lung disease characterized by progressive destruction of normal alveolar gas-exchange surfaces and accumulation of extracellular matrix (ECM). In order to comprehensively define the cell types, mechanisms and mediators driving ECM deposition and fibrotic remodeling in lungs with pulmonary fibrosis, we performed single-cell RNA-sequencing (scRNA-seq) of single-cell suspensions generated from non-fibrotic control and PF lungs. Analysis of over 114,000 cells from 20 PF and 10 control lungs identified 31 distinct cell types. We identified multiple distinct lineages directly contribute to ECM expansion, including a novel HAS1hi fibroblast subtype and a previously undescribed KRT5-/KRT17+, collagen and ECM-producing epithelial cell population that was highly enriched in PF lungs. Together these data provide high-resolution insights into the basic mechanisms of pulmonary fibrosis, and indicate a direct profibrotic role of the lung epithelium in PF pathogenesis. Overall design: We performed single-cell RNA-sequencing (scRNA-seq) of single-cell suspensions generated from non-fibrotic control and pulmonary fibrosis (PF) lungs", :matches=>[{"genus_species"=>"Homo sapiens"}, {"organism_age"=>"46-72"}]}}
```