### PR TITLE
fixing displayed tabs for multigene consensus with numeric annotation (SCP-3416)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -501,7 +501,7 @@ export function getEnabledTabs(exploreInfo, exploreParams) {
     if (isMultiGene) {
       if (isConsensus) {
         if (exploreParams.annotation.type === 'numeric') {
-          enabledTabs = ['annotatedScatter', 'distribution', 'dotplot']
+          enabledTabs = ['annotatedScatter', 'dotplot', 'heatmap']
         } else {
           enabledTabs = ['scatter', 'distribution', 'dotplot']
         }


### PR DESCRIPTION
SCP-3416

To test:
1.  Load a study (e.g. male mouse brain) and do a multiple gene search (e.g. agpat2, apoe)
2. collapse by mean
3.  Select a numeric annotation (e.g. intensity)
4.  observe that the tabs shown become annotated scatter, dotplot, and heatmap, and they render without error