### PR TITLE
fixing inclusion/exclusion of annotation values in expression endpoint (SCP-3423)

### DIFF
--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -223,7 +223,7 @@ module Api
             else
               # For "Scatter" tab
               plot_data = ExpressionVizService.load_expression_data_array_points(study, genes, cluster, annotation, subsample,
-                consensus: consensus, expression_only: !include_coordinates)
+                consensus: consensus, include_coords: include_coordinates, include_annotation: include_annotation, include_cells: include_cells)
             end
           end
 

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -127,9 +127,9 @@ class ExpressionVizService
   # load cluster_group data_array values, but use expression scores to set numerical color array
   # this is the scatter plot shown in the "scatter" tab next to "distribution" on gene-based views
   def self.load_expression_data_array_points(study, genes, cluster, annotation, subsample=nil,
-    consensus: nil, expression_only: false)
+    consensus: nil, include_coords: true, include_annotation: true, include_cells: true)
     viz_data = ClusterVizService.load_cluster_group_data_array_points(study, cluster, annotation, subsample,
-      include_annotations: !expression_only, include_coords: !expression_only)
+      include_annotations: include_annotation, include_coords: include_coords)
 
     viz_data[:expression] = viz_data[:cells].map do |cell|
       if consensus == 'median'
@@ -142,7 +142,7 @@ class ExpressionVizService
       expression_score
     end
 
-    if expression_only
+    if !include_coords
       # x and y will already be excluded, but we had to return the cells from the above call to
       # match the appropriate gene scores
       viz_data.delete(:cells)


### PR DESCRIPTION
SCP-3423  Certain patterns of gene searches meant that the cache would request only the expression and annotation values.  The API endpoint would then only return the expression values, causing the error.

TO TEST:
1. do a single-gene search in.a study
2. add a gene, and search again
3.  remove the first gene from the list, then search again
4. confirm the plots render correctly