### PR TITLE
Honor user-provided domain ranges on 3d clusters (SCP-3440)

### DIFF
--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -233,8 +233,7 @@ module Api
 
           axes_full = {
             titles: titles,
-            aspects: aspect,
-            ranges: cluster.domain_ranges
+            aspects: aspect
           }
 
           coordinate_labels = ClusterVizService.load_cluster_group_coordinate_labels(cluster)

--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -228,12 +228,13 @@ module Api
           end
 
           if cluster.is_3d? && cluster.has_range?
-            aspect = ClusterVizService.compute_aspect_ratios(range)
+            aspect = ClusterVizService.compute_aspect_ratios(cluster.domain_ranges)
           end
 
           axes_full = {
             titles: titles,
-            aspects: aspect
+            aspects: aspect,
+            ranges: cluster.domain_ranges
           }
 
           coordinate_labels = ClusterVizService.load_cluster_group_coordinate_labels(cluster)

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -489,7 +489,7 @@ export function get3DScatterProps({
   userSpecifiedRanges, axes, hasCoordinateLabels,
   coordinateLabels
 }) {
-  const { titles, ranges, aspects } = axes
+  const { titles, aspects } = axes
 
   const scene = {
     baseCamera,
@@ -501,11 +501,11 @@ export function get3DScatterProps({
 
   if (userSpecifiedRanges) {
     scene.xaxis.autorange = false
-    scene.xaxis.range = ranges.x
+    scene.xaxis.range = userSpecifiedRanges.x
     scene.yaxis.autorange = false
-    scene.yaxis.range = ranges.y
+    scene.yaxis.range = userSpecifiedRanges.y
     scene.zaxis.autorange = false
-    scene.zaxis.range = ranges.x
+    scene.zaxis.range = userSpecifiedRanges.z
     scene.aspectmode = aspects.mode,
     scene.aspectratio = {
       x: aspects.x,

--- a/test/api/visualization/clusters_controller_test.rb
+++ b/test/api/visualization/clusters_controller_test.rb
@@ -89,7 +89,7 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
       "isAnnotatedScatter"=>false,
       "isCorrelatedScatter"=>false,
       "numPoints"=>3,
-      "axes"=>{"titles"=>{"x"=>"X", "y"=>"Y", "z"=>"Z", "magnitude" => "Expression"}, "aspects"=>nil, "ranges"=>nil},
+      "axes"=>{"titles"=>{"x"=>"X", "y"=>"Y", "z"=>"Z", "magnitude" => "Expression"}, "aspects"=>nil},
       "hasCoordinateLabels"=>false,
       "coordinateLabels"=>[],
       "pointAlpha"=>1.0,
@@ -166,7 +166,7 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
                                      z_axis_min: 4, z_axis_max: 9
     )
     sign_in_and_update @user
-    execute_http_request(:get, api_v1_study_cluster_path(study, cluster_name, ))
+    execute_http_request(:get, api_v1_study_cluster_path(study, cluster_name))
     # aspect should be 'cube' as domain range of each axis is equal (5)
     expected_aspect = {
       mode: 'cube', x: 1.0, y: 1.0, z: 1.0
@@ -180,6 +180,6 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
 
     assert viz_data.dig(:is3D)
     assert_equal expected_aspect, viz_data.dig(:axes, :aspects)
-    assert_equal expected_ranges, viz_data.dig(:axes, :ranges)
+    assert_equal expected_ranges, viz_data.dig(:userSpecifiedRanges)
   end
 end

--- a/test/api/visualization/clusters_controller_test.rb
+++ b/test/api/visualization/clusters_controller_test.rb
@@ -89,7 +89,7 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
       "isAnnotatedScatter"=>false,
       "isCorrelatedScatter"=>false,
       "numPoints"=>3,
-      "axes"=>{"titles"=>{"x"=>"X", "y"=>"Y", "z"=>"Z", "magnitude" => "Expression"}, "aspects"=>nil},
+      "axes"=>{"titles"=>{"x"=>"X", "y"=>"Y", "z"=>"Z", "magnitude" => "Expression"}, "aspects"=>nil, "ranges"=>nil},
       "hasCoordinateLabels"=>false,
       "coordinateLabels"=>[],
       "pointAlpha"=>1.0,
@@ -142,5 +142,44 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
     expected_error = {"error"=>"No cluster named data%2Fcluster_with_slash.txt could be found"}
     assert_equal expected_error, json
+  end
+
+  test 'should set aspect ratio and domains when provided' do
+    study = FactoryBot.create(:detached_study,
+                              name_prefix: 'Domain Range Study',
+                              test_array: @@studies_to_clean)
+    cluster_name = 'cluster_domains.txt'
+    cluster_file = FactoryBot.create(:cluster_file,
+                                     name: cluster_name,
+                                     study: study,
+                                     cell_input: {
+                                       x: [1, 2 , 3, 4],
+                                       y: [3, 4, 5, 6],
+                                       z: [5, 6, 7, 8],
+                                       cells: %w(A B C D)
+                                     },
+                                     annotation_input: [
+                                       {name: 'species', type: 'group', values: ['dog', 'cat', 'dog']}
+                                     ],
+                                     x_axis_min: 0, x_axis_max: 5,
+                                     y_axis_min: 2, y_axis_max: 7,
+                                     z_axis_min: 4, z_axis_max: 9
+    )
+    sign_in_and_update @user
+    execute_http_request(:get, api_v1_study_cluster_path(study, cluster_name, ))
+    # aspect should be 'cube' as domain range of each axis is equal (5)
+    expected_aspect = {
+      mode: 'cube', x: 1.0, y: 1.0, z: 1.0
+    }.with_indifferent_access
+    expected_ranges = {
+      x: [cluster_file.x_axis_min, cluster_file.x_axis_max],
+      y: [cluster_file.y_axis_min, cluster_file.y_axis_max],
+      z: [cluster_file.z_axis_min, cluster_file.z_axis_max]
+    }.with_indifferent_access
+    viz_data = json.with_indifferent_access
+
+    assert viz_data.dig(:is3D)
+    assert_equal expected_aspect, viz_data.dig(:axes, :aspects)
+    assert_equal expected_ranges, viz_data.dig(:axes, :ranges)
   end
 end

--- a/test/factories/cluster_group.rb
+++ b/test/factories/cluster_group.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   # creates a ClusterGroup object
   factory :cluster_group do
-    cluster_type { '2d' }
+    cluster_type { }
     cell_annotations { [] }
     name { study_file.name }
     study { study_file.study }

--- a/test/factories/cluster_group.rb
+++ b/test/factories/cluster_group.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   # creates a ClusterGroup object
   factory :cluster_group do
-    cluster_type { }
+    cluster_type { '2d' }
     cell_annotations { [] }
     name { study_file.name }
     study { study_file.study }

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -48,7 +48,7 @@ FactoryBot.define do
         cell_input {
           {}
         }
-        cluster_type { '2d' }
+        cluster_type { cell_input.dig(:z).present? ? '3d' : '2d' }
         # annotation_input is an array of objects specifying name, type, and values for annotations
         # values should be an array in the same length and order as the 'cells' array above
         # e.g. [{ name: 'category', type: 'group', values: ['foo', 'foo', 'bar'] }]


### PR DESCRIPTION
This update fixes a bug where study owner-provided domain ranges (i.e. x, y, and z axis bounds) were no longer being set in visualization requests, and produced an error in rendering when trying to compute the aspect ratio for 3d clusters.  These ranges are now included in all visualization requests for scatter plots (under the `axes` key).

MANUAL TESTING
As there are no 3d clusters in the synthetic studies, you will need to ingest a 3d cluster using [this cluster file](https://github.com/broadinstitute/single_cell_portal_core/blob/development/test/test_data/cluster_example.txt) from the `test/test_data` directory.  It can be added to any existing study and visualized by itself as it contains cluster-specific annotations.  When the file is uploaded, please use the following values for the various axis min/max settings:
```
x_axis_min: -65
x_axis_max: 65
y_axis_min: -55
y_axis_max: 55
z_axis_min: -75
z_axis_max: 75
```

Once this file has been ingested:
1. Load the selected study/cluster, and select the `Category` annotation
2. Verify that the cluster has a non-cube aspect ratio and looks like the following:
![Screen Shot 2021-06-15 at 2 59 18 PM](https://user-images.githubusercontent.com/729968/122108663-74c45f80-cdea-11eb-916e-b19a91cb5b0d.png)

This PR satisfies SCP-3440.