### PR TITLE
fixing grid alignment of spatial ScatterPlots (SCP-3441)

### DIFF
--- a/app/javascript/components/explore/ScatterTab.js
+++ b/app/javascript/components/explore/ScatterTab.js
@@ -37,22 +37,29 @@ export default function ScatterTab({
     { scatterParams.map((params, index) => {
       const isTwoColRow = isTwoColumn && !(index === 0 && firstRowSingleCol)
       const key = getKeyFromScatterParams(params)
-
-      return <div className={isTwoColRow ? 'col-md-6' : 'col-md-12'} key={newContextMap[key]}>
-        <ScatterPlot
-          {...{
-            studyAccession, plotPointsSelected, isCellSelecting, updateScatterColor
-          }}
-          {...params}
-          dataCache={dataCache}
-          dimensions={getPlotDimensions({
-            isMultiRow,
-            isTwoColumn: isTwoColRow,
-            hasTitle: true
-          })}
-        />
-      </div>
-    })}
+      let rowDivider = <span key={`d${index}`}></span>
+      if (index % 2 === 1) {
+        // Use a full-width empty column to make sure plots align into rows, even if they are unequal height
+        rowDivider = <div className="col-md-12" key={`d${index}`}></div>
+      }
+      return [
+        <div className={isTwoColRow ? 'col-md-6' : 'col-md-12'} key={key}>
+          <ScatterPlot
+            {...{
+              studyAccession, plotPointsSelected, isCellSelecting, updateScatterColor
+            }}
+            {...params}
+            dataCache={dataCache}
+            dimensions={getPlotDimensions({
+              isMultiRow,
+              isTwoColumn: isTwoColRow,
+              hasTitle: true
+            })}
+          />
+        </div>,
+        rowDivider
+      ]
+    }).flat()}
     { scatterParams.length > MAX_PLOTS &&
       <div className="panel">
         <span>Due to browser limitations, only 8 plots can be shown at one time.  Deselect some spatial groups</span>

--- a/app/javascript/components/explore/ScatterTab.js
+++ b/app/javascript/components/explore/ScatterTab.js
@@ -59,7 +59,7 @@ export default function ScatterTab({
         </div>,
         rowDivider
       ]
-    }).flat()}
+    }).reduce((acc, val) => acc.concat(val), [])} // equivalent to .flat(), but .flat() isn't supported in travis node yet
     { scatterParams.length > MAX_PLOTS &&
       <div className="panel">
         <span>Due to browser limitations, only 8 plots can be shown at one time.  Deselect some spatial groups</span>

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@sheerun/mutationobserver-shim": "^0.3.3",
     "@testing-library/react": "^10.0.4",
+    "@testing-library/jest-dom": "^5.14.1",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.2.2",
     "enzyme": "^3.11.0",

--- a/test/js/explore/scatter-tab.test.js
+++ b/test/js/explore/scatter-tab.test.js
@@ -1,8 +1,92 @@
-import * as Reach from '@reach/router'
 import React from 'react'
-import { mount } from 'enzyme'
+import _cloneDeep from 'lodash/cloneDeep'
+import jquery from 'jquery'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import Plotly from 'plotly.js-dist'
 
-import { getNewContextMap } from 'components/explore/ScatterTab'
+import * as ScpApi from 'lib/scp-api'
+import { createCache } from 'components/explore//plot-data-cache'
+import ScatterTab, { getNewContextMap } from 'components/explore/ScatterTab'
+import * as ScpApiMetrics from 'lib/scp-api-metrics'
+
+// models a real response from api/v1/visualization/clusters
+const FETCH_CLUSTER_RESPONSE = {
+  data: {
+    annotations: ['foo', 'bar'],
+    cells: ['A', 'B'],
+    expression: [1, 2],
+    x: [11, 14],
+    y: [0, 1],
+  },
+  pointSize: 3,
+  userSpecifiedRanges: null,
+  showClusterPointBorders: false,
+  description: null,
+  is3D: false,
+  isSubsampled: false,
+  isAnnotatedScatter: false,
+  numPoints: 130,
+  axes: {
+    titles: {
+      x: 'X',
+      y: 'Y',
+      z: 'Z',
+      magnitude: 'Expression'
+    },
+    aspects: null
+  },
+  hasCoordinateLabels: false,
+  coordinateLabels: [],
+  pointAlpha: 1,
+  cluster: 'cluster.tsv',
+  genes: [],
+  annotParams: {
+    name: 'buzzwords',
+    type: 'group',
+    scope: 'study',
+    values: ['foo', 'bar'],
+    identifier: 'biosample_id--group--study'
+  },
+  subsample: 'all',
+  consensus: null
+}
+
+const CACHE_PERF_PARAMS = {
+  legacyBackend: 0,
+  parse: 0,
+  url: 'cache'
+}
+
+const MOCK_EXPLORE_RESPONSE = {
+  annotationList: {
+    default_cluster: 'clusterA',
+    annotations: [],
+    clusters: [],
+    default_annotation: {},
+    subsample_thresholds: {}
+  },
+  bamBundleList: [],
+  cluster: {numPoints: 40, isSubsampled: false},
+  clusterGroupNames: ['clusterA'],
+  clusterPointAlpha: 1,
+  colorProfile: null,
+  geneLists: [],
+  inferCNVIdeogramFiles: null,
+  spatialGroups: [],
+  taxonNames: ['Gallus gallus'],
+  uniqueGenes: ['Foo', 'Bar']
+}
+
+beforeAll(() => {
+  global.$ = jquery
+})
+// Note: tests that mock global.fetch must be cleared after every test
+afterEach(() => {
+  // Restores all mocks back to their original value
+  jest.restoreAllMocks()
+})
+
 
 describe('getNewContextMap correctly assigns contexts', () => {
   it('assigns correctly on first pass', async () => {
@@ -32,7 +116,7 @@ describe('getNewContextMap correctly assigns contexts', () => {
       annotation: { name: 'annotA' },
       genes: []
     }]
-    const newMap = getNewContextMap(scatterParams, {'clusterAannotA': 'A'})
+    const newMap = getNewContextMap(scatterParams, { 'clusterAannotA': 'A' })
     expect(newMap).toEqual({
       'clusterAgene1annotA': 'B',
       'clusterAannotA': 'A'
@@ -51,6 +135,51 @@ describe('getNewContextMap correctly assigns contexts', () => {
     })
     expect(newMap).toEqual({
       'clusterAannotA': 'B'
+    })
+  })
+
+  it('generates scatterPlots and titles for spatial plots', async () => {
+    const apiFetch = jest.spyOn(ScpApi, 'fetchCluster')
+    // pass in a clone of the response since it may get modified by the cache operations
+    apiFetch.mockImplementation(params => {
+      const response = _cloneDeep(FETCH_CLUSTER_RESPONSE)
+      response.cluster = params.cluster
+      response.genes = params.genes
+      return Promise.resolve([response, CACHE_PERF_PARAMS])
+    })
+    const fakePlot = jest.spyOn(Plotly, 'react')
+    fakePlot.mockImplementation(() => {})
+    const fakeLogScatter = jest.spyOn(ScpApiMetrics, 'logScatterPlot')
+    fakeLogScatter.mockImplementation(() => {})
+
+    render((
+      <ScatterTab studyAccession='SCP101'
+        exploreParams={{
+          cluster: 'clusterA',
+          spatialGroups: ['spatialClusterA'],
+          annotation: { name: 'foo', type: 'group' },
+          genes: ['farsa']
+        }}
+        updateExploreParams={() => {}}
+        exploreInfo={MOCK_EXPLORE_RESPONSE}
+        isGene={true}
+        isMultiGene={false}
+        getPlotDimensions={() => [10, 10]}
+        dataCache={createCache()}/>
+    ))
+
+    await screen.findByTestId('study-scatter-1')
+    const plotTitles = screen.getAllByRole('heading')
+
+    expect(plotTitles).toHaveLength(4)
+    const expectedTitles = [
+      'farsa expression clusterA',
+      'clusterA',
+      'farsa expression spatialClusterA',
+      'spatialClusterA'
+    ]
+    plotTitles.forEach((titleEl, index) => {
+      expect(titleEl).toHaveTextContent(expectedTitles[index])
     })
   })
 })

--- a/test/js/explore/scatter-tab.test.js
+++ b/test/js/explore/scatter-tab.test.js
@@ -138,7 +138,7 @@ describe('getNewContextMap correctly assigns contexts', () => {
     })
   })
 
-  it('generates scatterPlots and titles for spatial plots', async () => {
+  it('generates scatter plots and titles for spatial clusters', async () => {
     const apiFetch = jest.spyOn(ScpApi, 'fetchCluster')
     // pass in a clone of the response since it may get modified by the cache operations
     apiFetch.mockImplementation(params => {


### PR DESCRIPTION
SCP-3441 The automated test isn't directly related to the bugfix, just continuing to iterate on adding better testing around the explore tab.

MANUAL TESTING: 
 1. Load the chicken raw counts study, and do a gene search for 'foo'
 2. Observe a 2x2 grid of scatter plots, instead of an oddly formatted 2-1-1 arrangement.