### PR TITLE
Removing obsolete partial from legacy search (SCP-3417)

### DIFF
--- a/app/views/site/index.js.erb
+++ b/app/views/site/index.js.erb
@@ -1,1 +1,0 @@
-$("#studies").append("<%= escape_javascript(render '/site/search/studies_list' )%>");


### PR DESCRIPTION
This update removes a broken reference to partials/views that have been deprecated in favor of the new React-based advanced search UI.  The issue is that a client browser is making an AJAX request on the home page, which was what used to happen during the older "Facebook" style of endless pagination.  The React search UI does not do this, but there was still a single legacy view that would respond to and attempt to render when making AJAX requests to the root URL.  Now, with this partial deleted, the request will fall back to the default HTML partial and will no longer generate this error.

MANUAL TEST

The best way to test this manually is externally, via `curl`:
1. Run `curl -Ik 'https://localhost:3000/single_cell' -H 'Accept: application/javascript'` in a separate terminal once this branch is pulled and running locally
2. Note the `HTTP/1.1 200 OK` response at the top (previously it would have been `HTTP/1.1 500 Internal Server Error`)

This PR satisfies SCP-3417
