### PR TITLE
Cache in memory instead of files (SCP-3408)

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -97,11 +97,15 @@ clean_up
 echo "*** STARTING DELAYED_JOB for $PASSENGER_APP_ENV env ***"
 bin/delayed_job restart $PASSENGER_APP_ENV -n 6 || { echo "FAILED to start DELAYED_JOB" >&2; exit 1; } # WARNING: using "restart" with environment of test is a HACK that will prevent delayed_job from running in development mode, for example
 
-echo "Precompiling assets, yarn and webpacker..."
-export NODE_OPTIONS="--max-old-space-size=4096"
-RAILS_ENV=test NODE_ENV=test bin/bundle exec rake assets:clean
-RAILS_ENV=test NODE_ENV=test yarn install --force --trace
-RAILS_ENV=test NODE_ENV=test bin/bundle exec rake assets:precompile
+# If we're only running Ruby tests, then don't compile JavaScript
+if [[ "$TEST_FILEPATH" == "" ]]; then
+  echo "Precompiling assets, yarn and webpacker..."
+  export NODE_OPTIONS="--max-old-space-size=4096"
+  RAILS_ENV=test NODE_ENV=test bin/bundle exec rake assets:clean
+  RAILS_ENV=test NODE_ENV=test yarn install --force --trace
+  RAILS_ENV=test NODE_ENV=test bin/bundle exec rake assets:precompile
+fi
+
 echo "Generating random seed, seeding test database..."
 RANDOM_SEED=$(openssl rand -hex 16)
 echo $RANDOM_SEED > "$BASE_DIR/.random_seed"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,10 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :file_store, "#{root}/tmp/cache"
+    # config.cache_store = :file_store, "#{root}/tmp/cache"
+
+    config.cache_store = :memory_store, { size: 2.gigabytes }
+
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,8 +49,7 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store, , { size: 24.gigabytes }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -49,8 +49,7 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store, , { size: 24.gigabytes }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
This changes the Rails cache to use memory (RAM) instead of files read from SSD.  

For a cached default cluster for 1.3M cells in a local copy of [SCP383](https://singlecell.broadinstitute.org/single_cell/study/SCP383), this change:

* Decreases Rails-logged time by 0.37 seconds (88%)
* Decreases DevTools-measured [TTFB](https://developer.chrome.com/docs/devtools/network/reference/#timing-explanation) by 0.68 seconds (15%)

This should also speed up reads and writes of all other cached data.  Details and lower-level timing data for cluster scatter plot data caches are available in [SSD cache vs. RAM cache performance](https://docs.google.com/document/d/1Nb8bxPwsj6ZW6fINhrmr0UJoAvT2C3OAihCwkEUmBGQ/edit#).

Regarding the 24 GB in memory available for cache, note that our server [VM has 52 GB memory](https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-a/instances/singlecell-01?tab=details&project=broad-singlecellportal&rif_reserved), and [hasn't exceeded 21% (11 GB)](https://console.cloud.google.com/compute/instancesMonitoringDetail/zones/us-central1-a/instances/singlecell-01?project=broad-singlecellportal&tab=monitoring&pageState=(%22duration%22:(%22groupValue%22:%22P30D%22,%22customValue%22:null))) memory utilization in the last 6 weeks.  When the cache exceeds the allotted size, a cleanup will occur and the [least recently used entries will be removed](https://guides.rubyonrails.org/v3.2/caching_with_rails.html#activesupport-cache-memorystore).

To test:
* Pull this branch
* In terminal, `touch  tmp/caching-dev.txt`
* `rails s`
* In another terminal tab, `rails c`
* `Rails.cache.clear`
* Verify that `Rails.cache` returns `=> #<ActiveSupport::Cache::MemoryStore entries=0, size=0, options={:size=>2147483648, :compress=>false}> `
* In your web browser, load a study
* Reload study
* Open `development.log`, verify entry near end like:
```
Started GET "/single_cell/api/v1/studies/SCP86/clusters/Test?annotation_name=Cluster&annotation_scope=study&annotation_type=group&fields=coordinates%2Ccells%2Cannotation&subsample=all" for 127.0.0.1 at 2021-06-16 13:13:28 -0400
Processing by Api::V1::Visualization::ClustersController#show as JSON
  Parameters: {"annotation_name"=>"Cluster", "annotation_scope"=>"study", "annotation_type"=>"group", "fields"=>"coordinates,cells,annotation", "subsample"=>"all", "study_id"=>"SCP86", "cluster_name"=>"Test", "cluster"=>{}}
Reading from API cache: _single_cell_api_v1_studies_SCP86_clusters_Test_annotation_name_Cluster_annotation_scope_study_annotation_type_group_cluster_name_Test_fields_coordinates_cells_annotation_subsample_all
Filter chain halted as :check_api_cache! rendered or redirected
Completed 200 OK in 53ms (Views: 0.1ms | MongoDB: 0.0ms | Allocations: 1617)
```

This satisfies SCP-3408.