### PR TITLE
Adding user-friendly error message to prod environments (SCP-3427)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,8 @@ module.exports = {
         'Spinner': 'readonly',
         'morpheus': 'readonly',
         'ga': 'readonly',
-        'bamAndBaiFiles': 'readonly'
+        'bamAndBaiFiles': 'readonly',
+        'process': 'readonly'
     },
     'parser': 'babel-eslint',
     'parserOptions': {

--- a/app/javascript/components/explore/ExploreView.js
+++ b/app/javascript/components/explore/ExploreView.js
@@ -8,6 +8,7 @@ import { getDefaultClusterParams } from 'lib/cluster-utils'
 import MessageModal from 'lib/MessageModal'
 
 import { fetchExplore } from 'lib/scp-api'
+import ErrorBoundary from 'lib/ErrorBoundary'
 import useExploreTabRouter from './ExploreTabRouter'
 
 /**
@@ -64,9 +65,11 @@ function createExploreParamsWithDefaults(exploreParams, exploreInfo) {
 /** wraps the explore tab in a Router object so it can use React hooks for routable parameters */
 export default function ExploreTab({ studyAccession }) {
   return (
-    <Router>
-      <RoutableExploreTab studyAccession={studyAccession} default/>
-    </Router>
+    <ErrorBoundary>
+      <Router>
+        <RoutableExploreTab studyAccession={studyAccession} default/>
+      </Router>
+    </ErrorBoundary>
   )
 }
 

--- a/app/javascript/components/explore/ScatterTab.js
+++ b/app/javascript/components/explore/ScatterTab.js
@@ -34,32 +34,34 @@ export default function ScatterTab({
   }, [])
 
   return <div className="row">
-    { scatterParams.map((params, index) => {
-      const isTwoColRow = isTwoColumn && !(index === 0 && firstRowSingleCol)
-      const key = getKeyFromScatterParams(params)
-      let rowDivider = <span key={`d${index}`}></span>
-      if (index % 2 === 1) {
-        // Use a full-width empty column to make sure plots align into rows, even if they are unequal height
-        rowDivider = <div className="col-md-12" key={`d${index}`}></div>
-      }
-      return [
-        <div className={isTwoColRow ? 'col-md-6' : 'col-md-12'} key={key}>
-          <ScatterPlot
-            {...{
-              studyAccession, plotPointsSelected, isCellSelecting, updateScatterColor
-            }}
-            {...params}
-            dataCache={dataCache}
-            dimensions={getPlotDimensions({
-              isMultiRow,
-              isTwoColumn: isTwoColRow,
-              hasTitle: true
-            })}
-          />
-        </div>,
-        rowDivider
-      ]
-    }).reduce((acc, val) => acc.concat(val), [])} // equivalent to .flat(), but .flat() isn't supported in travis node yet
+    {
+      scatterParams.map((params, index) => {
+        const isTwoColRow = isTwoColumn && !(index === 0 && firstRowSingleCol)
+        const key = getKeyFromScatterParams(params)
+        let rowDivider = <span key={`d${index}`}></span>
+        if (index % 2 === 1) {
+          // Use a full-width empty column to make sure plots align into rows, even if they are unequal height
+          rowDivider = <div className="col-md-12" key={`d${index}`}></div>
+        }
+        return [
+          <div className={isTwoColRow ? 'col-md-6' : 'col-md-12'} key={key}>
+            <ScatterPlot
+              {...{
+                studyAccession, plotPointsSelected, isCellSelecting, updateScatterColor
+              }}
+              {...params}
+              dataCache={dataCache}
+              dimensions={getPlotDimensions({
+                isMultiRow,
+                isTwoColumn: isTwoColRow,
+                hasTitle: true
+              })}
+            />
+          </div>,
+          rowDivider
+        ]
+      }).reduce((acc, val) => acc.concat(val), []) // equivalent to .flat(), but .flat() isn't supported in travis node yet
+    }
     { scatterParams.length > MAX_PLOTS &&
       <div className="panel">
         <span>Due to browser limitations, only 8 plots can be shown at one time.  Deselect some spatial groups</span>

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -42,7 +42,7 @@ function RawScatterPlot({
   studyAccession, cluster, annotation, subsample, consensus, genes, scatterColor, dimensions,
   isAnnotatedScatter=false, isCorrelatedScatter=false, isCellSelecting=false, plotPointsSelected, dataCache
 }) {
-  const [isLoading, setIsLoading] = duseState(false)
+  const [isLoading, setIsLoading] = useState(false)
   const [spearman, setSpearman] = useState(null)
   const [scatterData, setScatterData] = useState(null)
   const [graphElementId] = useState(_uniqueId('study-scatter-'))

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -42,7 +42,7 @@ function RawScatterPlot({
   studyAccession, cluster, annotation, subsample, consensus, genes, scatterColor, dimensions,
   isAnnotatedScatter=false, isCorrelatedScatter=false, isCellSelecting=false, plotPointsSelected, dataCache
 }) {
-  const [isLoading, setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = duseState(false)
   const [spearman, setSpearman] = useState(null)
   const [scatterData, setScatterData] = useState(null)
   const [graphElementId] = useState(_uniqueId('study-scatter-'))

--- a/app/javascript/lib/ErrorBoundary.js
+++ b/app/javascript/lib/ErrorBoundary.js
@@ -34,19 +34,14 @@ export default class ErrorBoundary extends Component {
   /** show an error if one exists, otherwise show the component */
   render() {
     if (this.state.error) {
-      let displayMessage = jsErrorEnd
-      if (process.env.VIEW_ENV === 'development') {
-        displayMessage = <pre>
-          {this.state.error.message}
-          {this.state.info.componentStack}
-        </pre>
-      }
-      // consider using node_env to decide whether or not to render the full trace
-      // See related ticket SCP-2237
       return (
         <div className="alert-danger text-center error-boundary">
           <span className="font-italic ">Something went wrong.</span><br/>
-          { displayMessage }
+          {jsErrorEnd}
+          <pre>
+            {this.state.error.message}
+            {this.state.info.componentStack}
+          </pre>
         </div>
       )
     }

--- a/app/javascript/lib/ErrorBoundary.js
+++ b/app/javascript/lib/ErrorBoundary.js
@@ -35,7 +35,7 @@ export default class ErrorBoundary extends Component {
   render() {
     if (this.state.error) {
       let displayMessage = jsErrorEnd
-      if (process.env.VIEW_ENV != 'production') {
+      if (process.env.VIEW_ENV === 'development') {
         displayMessage = <pre>
           {this.state.error.message}
           {this.state.info.componentStack}

--- a/app/javascript/lib/ErrorBoundary.js
+++ b/app/javascript/lib/ErrorBoundary.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import { logError } from 'lib/metrics-api'
+import { jsErrorEnd } from 'lib/error-utils'
 /** convert to readable message  e.g.
  * "foobar is not defined    in ResultsPanel (at HomePageContent.js:22)"
  */
@@ -33,12 +34,19 @@ export default class ErrorBoundary extends Component {
   /** show an error if one exists, otherwise show the component */
   render() {
     if (this.state.error) {
+      let displayMessage = jsErrorEnd
+      if (process.env.VIEW_ENV != 'production') {
+        displayMessage = <pre>
+          {this.state.error.message}
+          {this.state.info.componentStack}
+        </pre>
+      }
       // consider using node_env to decide whether or not to render the full trace
       // See related ticket SCP-2237
       return (
         <div className="alert-danger text-center error-boundary">
           <span className="font-italic ">Something went wrong.</span><br/>
-          {readableErrorMessage(this.state.error, this.state.info)}
+          { displayMessage }
         </div>
       )
     }

--- a/app/javascript/lib/error-utils.js
+++ b/app/javascript/lib/error-utils.js
@@ -7,6 +7,13 @@ export const supportEmailLink = (
   </a>
 )
 
+export const jsErrorEnd = <div>
+  Please try reloading the page. If this error persists, or you require assistance, please
+  contact support at
+  <br/>
+  {supportEmailLink}
+</div>
+
 export const serverErrorEnd = <div>
   Sorry, an error has occurred. Support has been notified. Please try
   again. If this error persists, or you require assistance, please

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -1,5 +1,9 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+// we copy over the NODE_ENV to a property called VIEW_ENV, which is used in user-facing JS
+// this allows this property to easily be toggled here for development, without impacting build steps
+process.env.VIEW_ENV = process.env.NODE_ENV
 
 const environment = require('./environment')
+
 
 module.exports = environment.toWebpackConfig()

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,5 +1,7 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
 const environment = require('./environment')
-
+// we copy over the NODE_ENV to a property called VIEW_ENV, which is used in user-facing JS
+// this allows this property to easily be toggled here for development, without impacting build steps
+process.env.VIEW_ENV = process.env.NODE_ENV
 module.exports = environment.toWebpackConfig()

--- a/config/webpack/staging.js
+++ b/config/webpack/staging.js
@@ -1,5 +1,7 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'staging'
 
 const environment = require('./environment')
-
+// we copy over the NODE_ENV to a property called VIEW_ENV, which is used in user-facing JS
+// this allows this property to easily be toggled here for development, without impacting build steps
+process.env.VIEW_ENV = process.env.NODE_ENV
 module.exports = environment.toWebpackConfig()

--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -1,5 +1,7 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'development'
 
 const environment = require('./environment')
-
+// we copy over the NODE_ENV to a property called VIEW_ENV, which is used in user-facing JS
+// this allows this property to easily be toggled here for development, without impacting build steps
+process.env.VIEW_ENV = process.env.NODE_ENV
 module.exports = environment.toWebpackConfig()


### PR DESCRIPTION
SCP-3427 This updates the ErrorBoundary code to display a user-friendly error message in production, but a full stack trace in all other environments.  (as a reminder -- ErrorBoundary handles errors that occur during the direct rendering of React components.  Errors that occur during callbacks/async operations cannot be handled by ErrorBoundary)
PRODUCTION VIEW:
![image](https://user-images.githubusercontent.com/2800795/122457304-80479000-cf7c-11eb-9939-393031ffb8b2.png)

OTHER ENVIRONMENTS:
![image](https://user-images.githubusercontent.com/2800795/122457352-8c335200-cf7c-11eb-93e8-e6e510a4cc63.png)

 `process.env.VIEW_ENV` is introduced as the variable that tracks the environment, this allows it to be easily changed during development workflow.  To see the production view,  just change line 4 of development.js to `process.env.VIEW_ENV = 'production'`, and restart the webpack server.  
 The alternative, using either NODE_ENV or RAILS_ENV directly, would mean that you couldn't test the production views without doing a full production build, which disables the live reload server and breaks the non-dockerized development workflow.  

This change therefore partially addresses SCP-2237, but I will hold off on updating the other environment references in JS until this is confirmed to work in actual production.

TO TEST:
 1. update a component that's within an error boundary to have an obvious JS error in its main render path.  (e.g. change line 45 of ScatterPlot.js to be `const [isLoading, setIsLoading] = foobar(false)`
 2. Load the explore tab for a study
 3. confirm an error message appears with full stack trace
 4. edit `config/webpack/development.js:4` to be `process.env.VIEW_ENV = 'production'`
 5. restart your webpack dev server and reload the page
 6. confirm the user-friendly error message appears with the support email