### PR TITLE
Updating to scp-rails-baseimage:1.2.1 (SCP-3412)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:1.2.0
+FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:1.2.1
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-2.6.6'


### PR DESCRIPTION
Updating to the latest version of `scp-rails-baseimage` to apply regular security updates to the `ubuntu` base image.