### PR TITLE
updating frontend error message with instructions to include trace (SCP-3427)

### DIFF
--- a/app/javascript/lib/ErrorBoundary.js
+++ b/app/javascript/lib/ErrorBoundary.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { logError } from 'lib/metrics-api'
-import { jsErrorEnd } from 'lib/error-utils'
+import { supportEmailLink } from 'lib/error-utils'
 /** convert to readable message  e.g.
  * "foobar is not defined    in ResultsPanel (at HomePageContent.js:22)"
  */
@@ -37,7 +37,12 @@ export default class ErrorBoundary extends Component {
       return (
         <div className="alert-danger text-center error-boundary">
           <span className="font-italic ">Something went wrong.</span><br/>
-          {jsErrorEnd}
+          <span>
+            Please try reloading the page. If this error persists, or you require assistance, please
+            contact support at
+            <br/>
+            {supportEmailLink} and include the error text below.
+          </span>
           <pre>
             {this.state.error.message}
             {this.state.info.componentStack}

--- a/app/javascript/lib/error-utils.js
+++ b/app/javascript/lib/error-utils.js
@@ -7,13 +7,6 @@ export const supportEmailLink = (
   </a>
 )
 
-export const jsErrorEnd = <div>
-  Please try reloading the page. If this error persists, or you require assistance, please
-  contact support at
-  <br/>
-  {supportEmailLink}
-</div>
-
 export const serverErrorEnd = <div>
   Sorry, an error has occurred. Support has been notified. Please try
   again. If this error persists, or you require assistance, please


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2800795/123149145-f477ad00-d42e-11eb-8d4d-b23f4627c88c.png)

MANUAL TEST:
 1. generate a front-end error, e.g. by updataing line 45 of ScatterPlot.js to say 'fuseState' instead of 'useState', and then load a study explore tab
 2. confirm error appears as shown above