### PR TITLE
Removing redundant token refresh (SCP-3454)

### DIFF
--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -210,11 +210,7 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
 
     # Log API call for auditing/tracking purposes
     Rails.logger.info "FireCloud API request (#{http_method.to_s.upcase}) #{path} with tracking identifier: #{self.tracking_identifier}"
-    # check for token expiry first before executing
-    if self.access_token_expired?
-      Rails.logger.info "FireCloudClient token expired, refreshing access token"
-      self.refresh_access_token
-    end
+
     # set default headers, appending application identifier including hostname for disambiguation
     headers = get_default_headers
 


### PR DESCRIPTION
This update removes a redundant & broken reference to `refresh_access_token` for `FireCloudClient`.  Refactoring in #1044 and #1069 has consolidated setting HTTP headers on API calls with `get_default_headers`, and checking token expiry manually before executing requests is no longer necessary as `valid_access_token` takes care of this.

This PR satisfies SCP-3454.