### PR TITLE
Fix missing space before links in advanced search footer (SCP-3463)

### DIFF
--- a/app/javascript/components/search/controls/SearchPanel.js
+++ b/app/javascript/components/search/controls/SearchPanel.js
@@ -34,17 +34,18 @@ const helpModalContent = (<div>
   Single Cell Portal supports searching on specific facets of studies by ontology classifications.
   <br/><br/>
    For example, you can search on studies that
-  have <b>species</b> of <b>&quot;Homo sapiens&quot;</b> or have an <b>organ</b> of <b>&quot;brain&quot;</b>.
-  <br/>
-    Currently, about <b>70 out of ~300</b> public studies in SCP provide this metadata information.
+  have <b>species</b> of <b>&quot;Homo sapiens&quot;</b> or have an <b>organ</b> of <b>&quot;brain&quot;</b>.{' '}
+  Almost <b>25% (84 of ~350)</b> public studies in SCP provide this metadata information.
+  {/*
+    84 of 353 studies as of 2021-06-22,
+    per https://docs.google.com/spreadsheets/d/1FSpP2XTrG9FqAqD9X-BHxkCZae9vxZA3cQLow8mn-bk
+  */}
   <br/><br/>
   For more detailed information, visit
-  our
+  our{' '}
   <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Search-Studies"
     target="_blank" rel="noreferrer">wiki
-  </a>.
-  <br/>If you are a study creator and would like to provide that metadata for your study to be searchable,
-  see our
+  </a>.  Study authors looking to make their studies more accessible can read our{' '}
   <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#Metadata-powered-Advanced-Search"
     target="_blank" rel="noreferrer">metadata guide
   </a>.

--- a/app/javascript/components/search/results/ResultsPanel.js
+++ b/app/javascript/components/search/results/ResultsPanel.js
@@ -80,7 +80,11 @@ const FacetResultsFooter = ({ studySearchState }) => {
         <div className="">
           <p>Our advanced search is metadata-powered.
           By selecting filters, your search <b>targets only studies that use ontology terms</b> in their metadata file.
-          Currently, about 20% of public studies supply that metadata.</p>
+          Currently, almost 25% of public studies supply that metadata.</p>
+          {/*
+            84 of 353 studies as of 2021-06-22,
+            per https://docs.google.com/spreadsheets/d/1FSpP2XTrG9FqAqD9X-BHxkCZae9vxZA3cQLow8mn-bk
+          */}
           Learn more about our search capability on our{' '}
           <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Search-Studies"
             target="_blank" rel="noreferrer">wiki

--- a/app/javascript/components/search/results/ResultsPanel.js
+++ b/app/javascript/components/search/results/ResultsPanel.js
@@ -81,11 +81,10 @@ const FacetResultsFooter = ({ studySearchState }) => {
           <p>Our advanced search is metadata-powered.
           By selecting filters, your search <b>targets only studies that use ontology terms</b> in their metadata file.
           Currently, about 20% of public studies supply that metadata.</p>
-          Learn more about our search capability on our
+          Learn more about our search capability on our{' '}
           <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Search-Studies"
             target="_blank" rel="noreferrer">wiki
-          </a>.<br/>
-          Study authors looking to make their studies more accessible can read our
+          </a>.  Study authors looking to make their studies more accessible can read our{' '}
           {/* eslint-disable-next-line max-len */}
           <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#Metadata-powered-Advanced-Search"
             target="_blank" rel="noreferrer">metadata guide


### PR DESCRIPTION
This fixes missing spaces, along with some other updates and refinements, in user-facing text related to advanced search.

Before (see footer):
<img width="1677" alt="Screen Shot 2021-06-25 at 4 31 05 PM" src="https://user-images.githubusercontent.com/1334561/123485993-39d7de00-d5d9-11eb-9a21-90f30be49eab.png">

After:
<img width="1680" alt="Screen Shot 2021-06-25 at 5 10 03 PM" src="https://user-images.githubusercontent.com/1334561/123486009-43f9dc80-d5d9-11eb-8838-8b76d4ae4ff9.png">

This satisfies SCP-3463.