### PR TITLE
upgrading plotly version, and using new legendrank feature (SCP-3464)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jquery": "3.5.1",
     "jquery-ui": "1.12.1",
     "morpheus-app": "1.0.18",
-    "plotly.js-dist": "1.58.4",
+    "plotly.js-dist": "2.2.0",
     "pluralize": "^8.0.0",
     "pnp-webpack-plugin": "^1.6.4",
     "postcss-cssnext": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10955,10 +10955,10 @@ pleeease-filters@^4.0.0:
     onecolor "^3.0.4"
     postcss "^6.0.1"
 
-plotly.js-dist@1.58.4:
-  version "1.58.4"
-  resolved "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.58.4.tgz"
-  integrity sha512-oXCTRJFN8FBsHZSQPYoM3LuJQchPUrf6sOXFC0EFdvcr5lmJmLcAsW74jDy9PkRpm3PB+A+2oY1hsUMmk2eZbw==
+plotly.js-dist@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/plotly.js-dist/-/plotly.js-dist-2.2.0.tgz#a42c9310f5dd29d5cd437457925407fb952e6fba"
+  integrity sha512-8frGW2md+erSEZdOHiHc7xyOORK3Oq01nsJk546kDdjyCHLGqan4pqNdoHlwlPemlcdqBnrsahYY6z2rLU6srw==
 
 pluralize@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
legendrank sorting, added in plotly 2.1, allows us to avoid manually sorting the SVG of the legend, which led to a lot of subtle bugs. Note that there is not a large difference between plotly 1.x and plotly 2.x -- the v2 got added just because they updated/deprecated some rarely-used features (which we do not use)

MANUAL TEST:
0. load a study, and go to explore tab
1. click around a bunch of different categorized scatter plots
2. Observe that the legend is correct, and correctly sorted (first red, then blue, etc...)