### PR TITLE
Adding error handling/reporting to `ClusterCacheService` (SCP-3439)

### DIFF
--- a/app/lib/cluster_cache_service.rb
+++ b/app/lib/cluster_cache_service.rb
@@ -28,29 +28,34 @@ class ClusterCacheService
   #   - (JSON) => ActionDispatch::Cache entry of JSON viz data
   def self.cache_study_defaults(study)
     Rails.logger.info "Checking defaults on #{study.accession} for pre-caching"
-    cluster = study.default_cluster
-    annotation = study.default_annotation
-    if cluster && annotation
-      annotation_name, annotation_type, annotation_scope = annotation.split('--')
-      # necessary for legacy cluster names that could contain slashes and other non URL-safe characters
-      sanitized_cluster_name = cluster.name.include?('/') ? CGI.escape(cluster.name) : cluster.name
-      full_params = {
-        annotation_name: annotation_name, annotation_scope: annotation_scope, annotation_type: annotation_type,
-        subsample: 'all', cluster_name: sanitized_cluster_name, fields: 'coordinates,cells,annotation'
-      }
-      default_params = {
-        cluster_name: '_default',
-        fields: 'coordinates,cells,annotation'
-      }
-      [default_params, full_params].each do |url_params|
-        path = format_request_path(:api_v1_study_cluster_path, study.accession, url_params[:cluster_name])
-        cache_path = RequestUtils.get_cache_path(path, url_params.with_indifferent_access)
-        viz_data = Api::V1::Visualization::ClustersController.get_cluster_viz_data(study, cluster, url_params)
-        Rails.logger.info "Pre-caching viz data for #{cache_path}"
-        Rails.cache.write(cache_path, viz_data.to_json)
+    begin
+      cluster = study.default_cluster
+      annotation = study.default_annotation
+      if cluster && annotation
+        annotation_name, annotation_type, annotation_scope = annotation.split('--')
+        # necessary for legacy cluster names that could contain slashes and other non URL-safe characters
+        sanitized_cluster_name = cluster.name.include?('/') ? CGI.escape(cluster.name) : cluster.name
+        full_params = {
+          annotation_name: annotation_name, annotation_scope: annotation_scope, annotation_type: annotation_type,
+          subsample: 'all', cluster_name: sanitized_cluster_name, fields: 'coordinates,cells,annotation'
+        }
+        default_params = {
+          cluster_name: '_default',
+          fields: 'coordinates,cells,annotation'
+        }
+        [default_params, full_params].each do |url_params|
+          path = format_request_path(:api_v1_study_cluster_path, study.accession, url_params[:cluster_name])
+          cache_path = RequestUtils.get_cache_path(path, url_params.with_indifferent_access)
+          viz_data = Api::V1::Visualization::ClustersController.get_cluster_viz_data(study, cluster, url_params)
+          Rails.logger.info "Pre-caching viz data for #{cache_path}"
+          Rails.cache.write(cache_path, viz_data.to_json)
+        end
+      else
+        Rails.logger.info "No defaults present for #{study.accession}; skip caching study defaults"
       end
-    else
-      Rails.logger.info "No defaults present for #{study.accession}; skip caching study defaults"
+    rescue => e
+      ErrorTracker.report_exception(e, nil, study)
+      Rails.logger.error "Error in caching defaults for #{study.accession}: (#{e.class.name}) #{e.message}"
     end
   end
 end


### PR DESCRIPTION
This update adds error handling to `ClusterCacheService#cache_study_defaults` to avoid issues with caching default visualization responses on server boot.  While rare, we have seen instances where some studies end up in a state where calling `default_annotation` or `default_cluster` throw an error, which would cause the entire cache warming job to fail.  Now, `cache_study_defaults` wraps the entire method in a `begin / rescue` clause, which will handle any errors and report them to Sentry for triage.

MANUAL TESTING

1. Pull this branch, and then edit `app/models/study.rb#default_annotation` on line `1043` to throw an error:
```
def default_annotation(cluster=self.default_cluster)
  raise 'this is an error'
  ...
```
2. In the rails console, run `ClusterCacheService.cache_all_defaults`
3. In `development.log`, note entries like:
```
Checking defaults on SCP13 for pre-caching
Suppressing error reporting to Sentry: RuntimeError:this is an error, context: ...
```

This PR satisfies SCP-3439.