### PR TITLE
Always return annotation from Study#default_annotation (SCP-3453, SCP-3456)

### DIFF
--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -366,7 +366,7 @@ class IngestJob
     case self.study_file.file_type
     when 'Metadata'
       if self.study.default_options[:annotation].blank?
-        cell_metadatum = study.cell_metadata.keep_if {|meta| meta.can_visualize?}.first
+        cell_metadatum = study.cell_metadata.keep_if(&:can_visualize?).first || study.cell_metadata.first
         self.study.default_options[:annotation] = cell_metadatum.annotation_select_value
         if cell_metadatum.annotation_type == 'numeric'
           self.study.default_options[:color_profile] = 'Reds'
@@ -377,7 +377,8 @@ class IngestJob
         cluster = study.cluster_groups.by_name(self.study_file.name)
         self.study.default_options[:cluster] = cluster.name
         if self.study.default_options[:annotation].blank? && cluster.cell_annotations.any?
-          annotation = cluster.cell_annotations.select {|annot| cluster.can_visualize_cell_annotation?(annot)}.first
+          annotation = cluster.cell_annotations.select { |annot| cluster.can_visualize_cell_annotation?(annot) }.first ||
+            cluster.cell_annotations.first
           self.study.default_options[:annotation] = cluster.annotation_select_value(annotation)
           if annotation[:type] == 'numeric'
             self.study.default_options[:color_profile] = 'Reds'

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1046,20 +1046,21 @@ class Study
 
   # helper to return default annotation to load, will fall back to first available annotation if no preference has been set
   # or default annotation cannot be loaded.  returns a hash of {name: ,type:, scope: }
-  def default_annotation_params(cluster=self.default_cluster)
-    default_annot = self.default_options[:annotation]
+  def default_annotation_params(cluster=default_cluster)
+    default_annot = default_options[:annotation]
     annot_params = nil
     # in case default has not been set
     if default_annot.nil?
       if !cluster.nil? && cluster.cell_annotations.any?
-        annot = cluster.cell_annotations.first
+        annot = cluster.cell_annotations.select { |annot| cluster.can_visualize_cell_annotation?(annot) }.first ||
+          cluster.cell_annotations.first
         annot_params = {
           name: annot[:name],
           type: annot[:type],
           scope: 'cluster'
         }
-      elsif self.cell_metadata.any?
-        metadatum = self.cell_metadata.keep_if {|meta| meta.can_visualize?}.first
+      elsif cell_metadata.any?
+        metadatum = cell_metadata.keep_if(&:can_visualize?).first || cell_metadata.first
         annot_params = {
           name: metadatum.name,
           type: metadatum.annotation_type,

--- a/test/models/study_test.rb
+++ b/test/models/study_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class StudyTest < ActiveSupport::TestCase
+  include Minitest::Hooks
+  include SelfCleaningSuite
+  include TestInstrumentor
+
   def setup
     @study = Study.first
     @exp_matrix = @study.expression_matrix_files.first
@@ -32,8 +36,6 @@ class StudyTest < ActiveSupport::TestCase
   end
 
   test 'should honor case in gene search within study' do
-    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
-
     gene_name = @gene_names.sample
     matrix_ids = @study.expression_matrix_files.pluck(:id)
     # search with case sensitivity first
@@ -57,13 +59,9 @@ class StudyTest < ActiveSupport::TestCase
                  "Did not return correct gene from #{lower_case}; expected #{gene_name} but found #{gene_3['name']}"
     assert_equal expected_scores, gene_3['scores'],
                  "Did not load correct expression data from #{lower_case}; expected #{expected_scores} but found #{gene_3['scores']}"
-
-    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
   end
 
   test 'should skip permission and group check during firecloud service outage' do
-    puts "#{File.basename(__FILE__)}: '#{self.method_name}'"
-
     # assert that under normal conditions user has compute permissions
     user = @study.user
     compute_permission = @study.can_compute?(user)
@@ -93,7 +91,19 @@ class StudyTest < ActiveSupport::TestCase
       refute compute_in_outage, "Should not have compute permissions in outage, but can_compute? is #{compute_in_outage}"
       refute group_share_in_outage, "Should not have group share in outage, but user_in_group_share? is #{group_share_in_outage}"
     end
+  end
 
-    puts "#{File.basename(__FILE__)}: '#{self.method_name}' successful!"
+  test 'should default to first available annotation' do
+    user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    study = FactoryBot.create(:detached_study, name_prefix: 'Default Annotation Test', test_array: @@studies_to_clean)
+    assert study.default_annotation.nil?
+    FactoryBot.create(:metadata_file,
+                      name: 'metadata.txt',
+                      study: study,
+                      cell_input: %w[A B C],
+                      annotation_input: [
+                        { name: 'species', type: 'group', values: %w[dog dog dog] }
+                      ])
+    assert_equal 'species--group--study', study.default_annotation
   end
 end


### PR DESCRIPTION
This update nil-safes `Study#default_annotation` to always return an annotation, if any are present.  This is to avoid a corner case where a user uploads cluster/metadata files where all the defined annotations are considered "not visualizable".  This can happen if all of the annotations are group-based, and either have only 1 unique value, or more than 200.  In these situations, the user cannot visualize any plots, nor can they load various pages where `default_annotation` is read.  Instead, they see the "We're sorry, something went wrong" page, and it is completely opaque as to what the actual error is.

Now, if there are no visualizable annotations, the portal will simply return the first available annotation, if any are present (not having any annotations at all is covered by existing error handling and is not of concern here). **Note**: this fallback default annotation will not show up as a selectable option in any dropdown menus that handle study annotations.  Work for showing them is tracked in SCP-3436.

MANUAL TESTING

To test this, you will need a metadata file that has only one annotation with a single unique value, like this:
```
NAME	Cluster
TYPE	group
CELL_0001	CLST_A
CELL_0002	CLST_A
CELL_0003	CLST_A
CELL_0004	CLST_A
CELL_0005	CLST_A
CELL_0006	CLST_A
CELL_0007	CLST_A
CELL_0008	CLST_A
CELL_0009	CLST_A
CELL_00010	CLST_A
CELL_00011	CLST_A
CELL_00012	CLST_A
CELL_00013	CLST_A
CELL_00014	CLST_A
CELL_00015	CLST_A
```
Once you create this file:

1. Boot the portal and create a new study
2. Upload the metadata file, selecting "No" for using the metadata convention
3. Once the file ingests, enter the Rails console, load the study, and check the default annotation:
```
study = Study.last
study.default_annotation
=> "Cluster--group--study"
```

This PR satisfies SCP-3453 & SCP-3456.