### PR TITLE
List non-plottable annotations in Annotation select (SCP-3436)

### DIFF
--- a/app/javascript/components/visualization/controls/AnnotationSelector.js
+++ b/app/javascript/components/visualization/controls/AnnotationSelector.js
@@ -9,7 +9,7 @@ function getAnnotationOptions(annotationList, clusterName) {
   return [{
     label: 'Study Wide',
     options: annotationList.annotations
-      .filter(annot => annot.scope == 'study').map(annot => annotationKeyProperties(annot))
+      .filter(annot => annot.scope === 'study').map(annot => annotationKeyProperties(annot))
   }, {
     label: 'Cluster-Based',
     options: annotationList.annotations
@@ -23,7 +23,7 @@ function getAnnotationOptions(annotationList, clusterName) {
   }, {
     label: 'Cannot Display',
     options: annotationList.annotations
-      .filter(annot => annot.scope == 'invalid' && (annot.cluster_name == clusterName || !annot.cluster_name))
+      .filter(annot => annot.scope === 'invalid' && (annot.cluster_name == clusterName || !annot.cluster_name))
       .map(annot => annotationKeyProperties(annot))
   }]
 }

--- a/app/javascript/components/visualization/controls/AnnotationSelector.js
+++ b/app/javascript/components/visualization/controls/AnnotationSelector.js
@@ -23,7 +23,8 @@ function getAnnotationOptions(annotationList, clusterName) {
   }, {
     label: 'Cannot Display',
     options: annotationList.annotations
-      .filter(annot => annot.scope == 'invalid').map(annot => annotationKeyProperties(annot))
+      .filter(annot => annot.scope == 'invalid' && (annot.cluster_name == clusterName || !annot.cluster_name))
+      .map(annot => annotationKeyProperties(annot))
   }]
 }
 

--- a/app/javascript/components/visualization/controls/AnnotationSelector.js
+++ b/app/javascript/components/visualization/controls/AnnotationSelector.js
@@ -20,6 +20,10 @@ function getAnnotationOptions(annotationList, clusterName) {
     options: annotationList.annotations
       .filter(annot => annot.cluster_name === clusterName && annot.scope === 'user')
       .map(annot => annotationKeyProperties(annot))
+  }, {
+    label: 'Cannot Display',
+    options: annotationList.annotations
+      .filter(annot => annot.scope == 'invalid').map(annot => annotationKeyProperties(annot))
   }]
 }
 
@@ -59,6 +63,7 @@ export default function AnnotationControl({
       <label>Annotation</label>
       <Select options={annotationOptions}
         value={shownAnnotation}
+        isOptionDisabled={annotation => annotation.isDisabled}
         getOptionLabel={annotation => annotation.name}
         getOptionValue={annotation => annotation.scope + annotation.name + annotation.cluster_name}
         onChange={newAnnotation => updateClusterParams({ annotation: newAnnotation })}

--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -43,7 +43,7 @@ export function annotationKeyProperties(annotation) {
     type: annotation.type,
     scope: annotation.scope,
     id: annotation.id,
-    isDisabled: annotation.scope == 'invalid'
+    isDisabled: annotation.scope === 'invalid'
   }
 }
 

--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -39,11 +39,24 @@ export function getDefaultSubsampleForCluster(annotationList, clusterName) {
   * key parameters for url state */
 export function annotationKeyProperties(annotation) {
   return {
-    name: annotation.name,
+    name: getAnnotationDisplayName(annotation),
     type: annotation.type,
     scope: annotation.scope,
     id: annotation.id,
     isDisabled: annotation.scope == 'invalid'
+  }
+}
+
+/** returns a display name for an annotation to use in the select menu
+ *
+ * @param annotation - annotation object
+ */
+export function getAnnotationDisplayName(annotation) {
+  if (annotation.scope === 'invalid') {
+    const annotLabel = annotation.values.length === 1 ? 'Only one label' : 'Too many labels'
+    return `${annotation.name} (${annotLabel})`
+  } else {
+    return annotation.name
   }
 }
 

--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -42,7 +42,8 @@ export function annotationKeyProperties(annotation) {
     name: annotation.name,
     type: annotation.type,
     scope: annotation.scope,
-    id: annotation.id
+    id: annotation.id,
+    isDisabled: annotation.scope == 'invalid'
   }
 }
 

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -139,6 +139,29 @@ class AnnotationVizService
       end
     end
     annotations.concat(cluster_annots)
+    # show 'invalid' annotations (e.g. cannot be visualized) as a courtesy, but don't allow selection
+    invalid_annots = []
+    study.cell_metadata.each do |meta|
+      unless meta.can_visualize?
+        invalid_annots << {
+          name: meta.name,
+          type: meta.annotation_type,
+          scope: 'invalid'
+        }
+      end
+    end
+    if cluster.present?
+      cluster.cell_annotations.each do |cell_annot|
+        unless cluster.can_visualize_cell_annotation?(cell_annot)
+          invalid_annots << {
+            name: cell_annot['name'],
+            type: cell_annot['annotation_type'],
+            scope: 'invalid'
+          }
+        end
+      end
+    end
+    annotations.concat(invalid_annots)
     annotations
   end
 

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -146,6 +146,7 @@ class AnnotationVizService
         invalid_annots << {
           name: meta.name,
           type: meta.annotation_type,
+          values: meta.values,
           scope: 'invalid'
         }
       end
@@ -156,6 +157,7 @@ class AnnotationVizService
           invalid_annots << {
             name: cell_annot['name'],
             type: cell_annot['annotation_type'],
+            values: cell_annot['values'],
             scope: 'invalid'
           }
         end

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -37,7 +37,8 @@ class ClusterVizService
         name: annot[:name],
         type: annot[:type],
         values: annot[:values],
-        scope: 'cluster',
+        # mark non-plottable annotations as 'invalid' so they show up in the dropdown but are not selectable
+        scope: cluster.can_visualize_cell_annotation?(annot) ? 'cluster' : 'invalid',
         cluster_name: cluster.name
       }
     end

--- a/app/models/cell_metadatum.rb
+++ b/app/models/cell_metadatum.rb
@@ -61,7 +61,7 @@ class CellMetadatum
 
   # create dropdown menu value for annotation select
   def annotation_select_value
-    "#{self.name}--#{self.annotation_type}--study"
+    "#{self.name}--#{self.annotation_type}--#{can_visualize? ? 'study' : 'invalid'}"
   end
 
   # generate a select box option for use in dropdowns that corresponds to this cell_metadatum

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -112,7 +112,8 @@ class ClusterGroup
 
   # formatted annotation select option value
   def annotation_select_value(annotation, prepend_name=false)
-    "#{prepend_name ? "#{self.name}--" : nil}#{annotation[:name]}--#{annotation[:type]}--cluster"
+    "#{prepend_name ? "#{self.name}--" : nil}#{annotation[:name]}--#{annotation[:type]}--" \
+    "#{can_visualize_cell_annotation?(annotation) ? 'cluster' : 'invalid'}"
   end
 
   # return a formatted array for use in a select dropdown that corresponds to a specific cell_annotation

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -130,9 +130,7 @@ class ClusterGroup
   end
 
   def cell_annotations_by_type(annotation_type=nil)
-    annotations = annotation_type.nil? ? self.cell_annotations : self.cell_annotations.select {|annot| annot[:type] == annotation_type}
-    annotations = annotations.keep_if {|annot| self.can_visualize_cell_annotation?(annot)}
-    annotations
+    annotation_type.nil? ? self.cell_annotations : self.cell_annotations.select {|annot| annot[:type] == annotation_type}
   end
 
   # list of cell annotation header values by type (group or numeric)

--- a/app/views/studies/_study_default_options_form.html.erb
+++ b/app/views/studies/_study_default_options_form.html.erb
@@ -21,7 +21,7 @@
         </div>
         <div class="col-sm-4">
           <%= f.label :annotation, 'Default Annotation' %><br />
-          <%= f.select :annotation, grouped_options_for_select(@default_cluster_annotations, @study.default_annotation), {},class: 'form-control' %>
+          <%= f.select :annotation, grouped_options_for_select(@default_cluster_annotations, @study.default_annotation), { disabled: @default_cluster_annotations['Invalid'].map(&:last) }, class: 'form-control' %>
         </div>
         <div class="col-sm-4">
           <%= f.label :color_profile, "Default Color Profile <i class='fas fa-info-circle' title='The default color profile only applies to the selected annotation (if the type is numeric)' data-toggle='tooltip'></i>".html_safe %><br />

--- a/app/views/studies/_study_default_options_form.html.erb
+++ b/app/views/studies/_study_default_options_form.html.erb
@@ -21,7 +21,7 @@
         </div>
         <div class="col-sm-4">
           <%= f.label :annotation, 'Default Annotation' %><br />
-          <%= f.select :annotation, grouped_options_for_select(@default_cluster_annotations, @study.default_annotation), { disabled: @default_cluster_annotations['Invalid'].map(&:last) }, class: 'form-control' %>
+          <%= f.select :annotation, grouped_options_for_select(@default_cluster_annotations, @study.default_annotation), {}, class: 'form-control' %>
         </div>
         <div class="col-sm-4">
           <%= f.label :color_profile, "Default Color Profile <i class='fas fa-info-circle' title='The default color profile only applies to the selected annotation (if the type is numeric)' data-toggle='tooltip'></i>".html_safe %><br />

--- a/test/integration/lib/annotation_viz_service_test.rb
+++ b/test/integration/lib/annotation_viz_service_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class AnnotationVizServiceTest < ActiveSupport::TestCase
   include Minitest::Hooks
@@ -9,69 +9,64 @@ class AnnotationVizServiceTest < ActiveSupport::TestCase
     @user = FactoryBot.create(:user, test_array: @@users_to_clean)
     @basic_study = FactoryBot.create(:detached_study, name_prefix: 'Basic Viz', test_array: @@studies_to_clean)
     @basic_study_cluster_file = FactoryBot.create(:cluster_file,
-                                              name: 'cluster_1.txt', study: @basic_study,
-                                              annotation_input: [
-                                                  {name: 'Category', type: 'group', values: ['bar', 'bar', 'baz']},
-                                                  {name: 'Intensity', type: 'numeric', values: [1.1, 2.2, 3.3]}
-                                              ])
+                                                  name: 'cluster_1.txt', study: @basic_study,
+                                                  annotation_input: [
+                                                    { name: 'Category', type: 'group', values: %w[bar bar baz] },
+                                                    { name: 'Intensity', type: 'numeric', values: [1.1, 2.2, 3.3] }
+                                                  ])
     @basic_study_cluster_file2 = FactoryBot.create(:cluster_file,
-                                              name: 'cluster_2.txt', study: @basic_study,
-                                              annotation_input: [
-                                                  {name: 'Fizziness', type: 'group', values: ['high', 'low', 'medium']},
-                                                  {name: 'Buzziness', type: 'group', values: ['large', 'medium', 'small']}
-                                              ])
+                                                   name: 'cluster_2.txt', study: @basic_study,
+                                                   annotation_input: [
+                                                     { name: 'Fizziness', type: 'group', values: %w[high low medium] },
+                                                     { name: 'Buzziness', type: 'group', values: %w[large medium small] }
+                                                   ])
     @basic_study_cluster_file3 = FactoryBot.create(:cluster_file,
                                                    name: 'cluster_3.txt', study: @basic_study,
                                                    annotation_input: [
-                                                     {name: 'Blanks', type: 'group', values: ['foo', 'foo', '']}
+                                                     { name: 'Blanks', type: 'group', values: ['foo', 'foo', ''] }
                                                    ])
     @basic_study_exp_file = FactoryBot.create(:study_file,
-                                                  name: 'dense.txt',
-                                                  file_type: 'Expression Matrix',
-                                                  study: @basic_study)
+                                              name: 'dense.txt',
+                                              file_type: 'Expression Matrix',
+                                              study: @basic_study)
 
     @study_metadata_file = FactoryBot.create(:metadata_file,
                                              name: 'metadata.txt', study: @basic_study,
                                              annotation_input: [
-                                                 {name: 'species', type: 'group', values: ['dog', 'cat', 'dog']},
-                                                 {name: 'disease', type: 'group', values: ['none', 'none', 'measles']}
+                                               { name: 'species', type: 'group', values: %w[dog cat dog] },
+                                               { name: 'disease', type: 'group', values: %w[none none measles] }
                                              ])
-
   end
-
 
   test 'gets the default annotation when no annotation name is specified' do
     annotation = AnnotationVizService.get_selected_annotation(@basic_study)
     assert_equal 'Category', annotation[:name]
-    assert_equal  ['bar', 'baz'], annotation[:values]
+    assert_equal %w[bar baz], annotation[:values]
 
     annotation = AnnotationVizService.get_selected_annotation(@basic_study, annot_scope: 'study')
     assert_equal 'species', annotation[:name]
-    assert_equal  ['dog', 'cat'], annotation[:values]
+    assert_equal %w[dog cat], annotation[:values]
 
     fizz_cluster = @basic_study.cluster_groups.find_by(name: 'cluster_2.txt')
     annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: fizz_cluster)
     assert_equal 'Fizziness', annotation[:name]
-    assert_equal  ['high', 'low', 'medium'], annotation[:values]
+    assert_equal %w[high low medium], annotation[:values]
 
-    @basic_study.update!(default_options: {
-        cluster: 'cluster_1.txt',
-        annotation: 'species--group--study'
-    })
+    @basic_study.update!(default_options: { cluster: 'cluster_1.txt', annotation: 'species--group--study' })
     annotation = AnnotationVizService.get_selected_annotation(@basic_study)
     assert_equal 'species', annotation[:name]
-    assert_equal ['dog', 'cat'], annotation[:values]
+    assert_equal %w[dog cat], annotation[:values]
   end
 
   test 'can get annotations by name and scope' do
     annotation = AnnotationVizService.get_selected_annotation(@basic_study, annot_name: 'disease', annot_type: 'group', annot_scope: 'study')
     assert_equal 'disease', annotation[:name]
-    assert_equal  ['none', 'measles'], annotation[:values]
+    assert_equal %w[none measles], annotation[:values]
 
     cluster = @basic_study.cluster_groups.first
     annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: 'Intensity', annot_type: 'numeric', annot_scope: 'cluster')
     assert_equal 'Intensity', annotation[:name]
-    assert_equal  [1.1, 2.2, 3.3], annotation[:values]
+    assert_equal [1.1, 2.2, 3.3], annotation[:values]
   end
 
   test 'returns first study/cluster annotation if no matching annotation is found' do
@@ -84,20 +79,41 @@ class AnnotationVizServiceTest < ActiveSupport::TestCase
 
   test 'available annotations returns the available annotations' do
     annots = AnnotationVizService.available_annotations(@basic_study)
-    assert_equal ["species", "disease", "Category", "Intensity", "Fizziness", "Buzziness", "Blanks"], annots.map { |a| a[:name] }
-    assert_equal [nil, nil, "cluster_1.txt", "cluster_1.txt", "cluster_2.txt", "cluster_2.txt", "cluster_3.txt"], annots.map { |a| a[:cluster_name] }
+    assert_equal %w[species disease Category Intensity Fizziness Buzziness Blanks], (annots.map { |a| a[:name] })
+    assert_equal [nil, nil, 'cluster_1.txt', 'cluster_1.txt', 'cluster_2.txt', 'cluster_2.txt', 'cluster_3.txt'],
+                 (annots.map { |a| a[:cluster_name] })
 
     # if a cluster is specified, returns the study wide and annotations specific to that cluster
     cluster = @basic_study.cluster_groups.find_by(name: 'cluster_1.txt')
     annots = AnnotationVizService.available_annotations(@basic_study, cluster: cluster)
-    assert_equal ["species", "disease", "Category", "Intensity"], annots.map { |a| a[:name] }
+    assert_equal %w[species disease Category Intensity], (annots.map { |a| a[:name] })
   end
 
   test 'should sanitize blank values from annotation arrays' do
     blank_cluster = @basic_study.cluster_groups.find_by(name: 'cluster_3.txt')
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: blank_cluster, annot_name: 'Blanks',
-                                                          annot_type: 'group', annot_scope: 'cluster')
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study,
+                                                              cluster: blank_cluster, annot_name: 'Blanks',
+                                                              annot_type: 'group', annot_scope: 'cluster')
     assert_equal 'Blanks', annotation[:name]
-    assert_equal  ['foo', AnnotationVizService::MISSING_VALUE_LABEL], annotation[:values]
+    assert_equal ['foo', AnnotationVizService::MISSING_VALUE_LABEL], annotation[:values]
+  end
+
+  test 'should return non-plottable annotations' do
+    study = FactoryBot.create(:detached_study, name_prefix: 'No Valid Viz', test_array: @@studies_to_clean)
+    FactoryBot.create(:cluster_file, name: 'cluster_1.txt', study: study, annotation_input: [
+      { name: 'cluster', type: 'group', values: %w[A A A] }
+    ])
+    FactoryBot.create(:metadata_file, name: 'metadata.txt', study: study, annotation_input: [
+      { name: 'species', type: 'group', values: %w[dog dog dog] }
+    ])
+    annots = AnnotationVizService.available_annotations(study)
+    assert_equal 2, annots.size
+    cluster_annot = annots.detect { |a| a[:name] == 'cluster' }
+    assert cluster_annot.present?
+    assert_equal 'cluster_1.txt', cluster_annot[:cluster_name]
+    assert_equal 'invalid', cluster_annot[:scope]
+    species_annot = annots.detect { |a| a[:name] == 'species' }
+    assert species_annot.present?
+    assert_equal 'invalid', species_annot[:scope]
   end
 end

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -187,7 +187,7 @@ class IngestJobTest < ActiveSupport::TestCase
     job = IngestJob.new(study: @basic_study, study_file: metadata_file, user: @user, action: :ingest_metadata)
     job.set_study_default_options
     @basic_study.reload
-    assert_equal 'species--group--study', @basic_study.default_annotation
+    assert_equal 'species--group--invalid', @basic_study.default_annotation
 
     # reset default annotation, then test cluster file with a single annotation with only one unique value
     @basic_study.cell_metadata.destroy_all
@@ -208,6 +208,6 @@ class IngestJobTest < ActiveSupport::TestCase
     @basic_study.reload
     cluster = @basic_study.cluster_groups.first
     assert_equal cluster, @basic_study.default_cluster
-    assert_equal 'foo--group--cluster', @basic_study.default_annotation
+    assert_equal 'foo--group--invalid', @basic_study.default_annotation
   end
 end


### PR DESCRIPTION
If a user uploads a cluster/metadata file with group-based annotations that are not viewable (i.e. have only 1 unique value, or more than 200), these annotations will not be shown in any select menus dealing with annotations.  This can be confusing to users as it is not immediately obvious why these are omitted, and previously led to errors where no annotations in a study were considered viewable.  This update adds those annotations back in under the "Cannot Display" option group, and does not allow them to be selected when interacting with the Explore tab.  

**NOTE**: As a part of #1093, it is possible for the study owner to set one of these as the default annotation in the case where there are no available valid annotations.  If there are valid annotations, then the first available annotation will be displayed instead, even if the study owner selects an invalid one as the default.

MANUAL TESTING
To test this feature, you will need to add a new cluster file to a study that has only one invalid annotation.  You can use the following data:
```
NAME	X	Y	Z	Category
TYPE	numeric	numeric	numeric	group
CELL_0001	34.472	32.211	60.035	A
CELL_0002	15.975	10.043	21.424	A
CELL_0003	-11.688	-53.645	-58.374	A
CELL_0004	30.04	31.138	33.597	A
CELL_0005	23.862	33.092	26.904	A
CELL_0006	-39.07	-14.64	-44.643	A
CELL_0007	40.039	27.206	55.211	A
CELL_0008	28.755	27.187	34.686	A
CELL_0009	-48.601	-13.512	-51.659	A
CELL_00010	14.653	27.832	28.586	A
CELL_00011	20.603	32.071	45.484	A
CELL_00012	-10.333	-51.733	-26.631	A
CELL_00013	-52.966	-12.484	-60.369	A
CELL_00014	38.513	26.969	63.654	A
CELL_00015	12.838	13.047	17.685	A
```

1. Create a new study, and upload the non-convention metadata file from `test/test_data/metadata_example.txt` (specifying `No` for convention validation).
2. Add a cluster file, using the contents from above.
3. Once both files have ingested, navigate to the explore tab, and note that the `Category` annotation is listed under `Cannot Display (Only one label)` and cannot be selected.
![Screen Shot 2021-07-09 at 1 12 20 PM](https://user-images.githubusercontent.com/729968/125113998-613da900-e0b7-11eb-8781-7b99df195fb4.png)


This PR satisfies SCP-3436.