### PR TITLE
Fixing broken variable references (SCP-3485, SCP-3499)

### DIFF
--- a/app/controllers/api/v1/user_annotations_controller.rb
+++ b/app/controllers/api/v1/user_annotations_controller.rb
@@ -101,7 +101,7 @@ module Api
           ErrorTracker.report_exception(e, current_user, @study, log_params)
           render json: {error: e.message}, status: 400 # Bad request
         rescue => e
-          ErrorTracker.report_exception(e, current_user, error_context)
+          ErrorTracker.report_exception(e, current_user, @study, log_params)
           message = 'An unexpected error prevented the annotation from being saved: ' + e.message
           render json: {error: message}, status: 500 # Server error
         end

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -248,7 +248,7 @@ class ExpressionVizService
     annotation_array = ClusterVizService.get_annotation_values_array(study, cluster, annotation, cells, subsample_annotation, subsample_threshold)
 
     cells.each_with_index do |cell, index|
-      annotation_value = annotation[:scope] == 'cluster' ? annotation_array[index] : annotation_hash[cell]
+      annotation_value = annotation_array[index]
       if !annotation_value.nil?
         case consensus
         when 'mean'


### PR DESCRIPTION
This fixes a pair of regressions that occurred during recent refactoring that left two undefined variables, both of which cause errors that were identified during Sentry triage.  They are merged into one PR for brevity's sake.