### PR TITLE
Adding public_filters to SearchFacet for anonymous searches (SCP-3471)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -390,7 +390,8 @@ module Api
         # sanitize query string for regexp matching
         @query_string = params[:query]
         query_matcher = /#{Regexp.escape(@query_string)}/i
-        @matching_filters = @search_facet.filters.select {|filter| filter[:name] =~ query_matcher}
+        filter_list = user_signed_in? ? @search_facet.filters : @search_facet.public_filters
+        @matching_filters = filter_list.select { |filter| filter[:name] =~ query_matcher }
       end
 
       private

--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -166,7 +166,7 @@ class SearchFacet
     end
     property :filters do
       key :type, :array
-      key :description, 'Array of filter values for facet (will default to public_filters if no user is signed in)'
+      key :description, 'Array of filter values for facet (will default to public_filters if user is not signed in)'
       items type: :object do
         key :title, 'FacetFilter'
         key :required, %i[name id]

--- a/app/views/api/v1/search/_search_facet_config.json.jbuilder
+++ b/app/views/api/v1/search/_search_facet_config.json.jbuilder
@@ -9,7 +9,7 @@ else
 end
 json.set! :id, search_facet_config.identifier
 json.set! :links, search_facet_config.ontology_urls
-json.set! :filters, search_facet_config.filters
+json.set! :filters, user_signed_in? ? search_facet_config.filters : search_facet_config.public_filters
 if search_facet_config.is_numeric?
   json.set! :unit, search_facet_config.unit
   json.set! :max, search_facet_config.max

--- a/db/migrate/20210712154710_update_public_facet_filters.rb
+++ b/db/migrate/20210712154710_update_public_facet_filters.rb
@@ -1,0 +1,8 @@
+class UpdatePublicFacetFilters < Mongoid::Migration
+  def self.up
+    SearchFacet.update_all_facet_filters
+  end
+
+  def self.down
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,7 @@ end
 user_access_token = {access_token: 'test-api-token', expires_in: 3600, expires_at: Time.zone.now + 1.hour}
 user_2_access_token = {access_token: 'test-api-token-2', expires_in: 3600, expires_at: Time.zone.now + 1.hour}
 user = User.find_or_initialize_by(email:'testing.user@gmail.com')
-user.update!(password:'password', admin: true, uid: '12345', metrics_uuid: SecureRandom.uuid, 
+user.update!(password:'password', admin: true, uid: '12345', metrics_uuid: SecureRandom.uuid,
              api_access_token: user_access_token, access_token: user_access_token, registered_for_firecloud: true)
 user_2 = User.find_or_initialize_by(email: 'sharing.user@gmail.com')
 user_2.update!(password: 'password', uid: '67890',
@@ -62,21 +62,21 @@ study.reload
 expression_file = study.expression_matrix_files.first
 cluster_file = study.cluster_ordinations_files.first
 metadata_file = study.metadata_file
-cluster = ClusterGroup.create!(name: 'Test Cluster', study_id: study.id, study_file_id: cluster_file.id, cluster_type: '3d', cell_annotations: [
-    {
-        name: 'Category',
-        type: 'group',
-        values: %w(a b c d)
-    },
-    {
-        name: 'Intensity',
-        type: 'numeric',
-        values: []
-    }
-])
+cluster = ClusterGroup.create!(name: 'Test Cluster', study_id: study.id, study_file_id: cluster_file.id, cluster_type: '3d',
+                               cell_annotations: [
+                                 {
+                                   name: 'Category',
+                                   type: 'group',
+                                   values: %w(a b c d)
+                                 },
+                                 {
+                                   name: 'Intensity',
+                                   type: 'numeric',
+                                   values: []
+                                 }])
 # create raw arrays of values to use in DataArrays and StudyMetadatum
-category_array = ['a', 'b', 'c', 'd'].repeated_combination(18).to_a.flatten
-metadata_label_array = ['E', 'F', 'G', 'H'].repeated_combination(18).to_a.flatten
+category_array = %w[a b c d].repeated_combination(18).to_a.flatten
+metadata_label_array = %w[E F G H].repeated_combination(18).to_a.flatten
 point_array = 0.upto(category_array.size - 1).to_a
 cluster_cell_array = point_array.map {|p| "cell_#{p}"}
 all_cell_array = 0.upto(metadata_label_array.size - 1).map {|c| "cell_#{c}"}
@@ -95,13 +95,15 @@ z_array = cluster.data_arrays.build(name: 'z', cluster_name: cluster.name, array
                                     study_id: study.id, values: point_array, study_file_id: cluster_file.id)
 z_array.save!
 cluster_txt = cluster.data_arrays.build(name: 'text', cluster_name: cluster.name, array_type: 'cells', array_index: 1,
-                                    study_id: study.id, values: cluster_cell_array, study_file_id: cluster_file.id)
+                                        study_id: study.id, values: cluster_cell_array, study_file_id: cluster_file.id)
 cluster_txt.save!
-cluster_cat_array = cluster.data_arrays.build(name: 'Category', cluster_name: cluster.name, array_type: 'annotations', array_index: 1,
-                                    study_id: study.id, values: category_array, study_file_id: cluster_file.id)
+cluster_cat_array = cluster.data_arrays.build(name: 'Category', cluster_name: cluster.name, array_type: 'annotations',
+                                              array_index: 1, study_id: study.id, values: category_array,
+                                              study_file_id: cluster_file.id)
 cluster_cat_array.save!
-cluster_int_array = cluster.data_arrays.build(name: 'Intensity', cluster_name: cluster.name, array_type: 'annotations', array_index: 1,
-                                    study_id: study.id, values: intensity_array, study_file_id: cluster_file.id)
+cluster_int_array = cluster.data_arrays.build(name: 'Intensity', cluster_name: cluster.name, array_type: 'annotations',
+                                              array_index: 1, study_id: study.id, values: intensity_array,
+                                              study_file_id: cluster_file.id)
 cluster_int_array.save!
 # set point count on cluster after arrays are saved
 cluster.set_point_count!
@@ -119,26 +121,28 @@ meta2_vals.save!
 gene_1 = Gene.create!(name: 'Gene_1', searchable_name: 'gene_1', study_id: study.id, study_file_id: expression_file.id)
 gene_2 = Gene.create!(name: 'Gene_2', searchable_name: 'gene_2', study_id: study.id, study_file_id: expression_file.id)
 gene1_vals = gene_1.data_arrays.build(name: gene_1.score_key, array_type: 'expression', cluster_name: expression_file.name,
-                                      array_index: 1, study_id: study.id, study_file_id: expression_file.id, values: metadata_score_array)
+                                      array_index: 1, study_id: study.id, study_file_id: expression_file.id,
+                                      values: metadata_score_array)
 gene1_vals.save!
 gene1_cells = gene_1.data_arrays.build(name: gene_1.cell_key, array_type: 'cells', cluster_name: expression_file.name,
-                                      array_index: 1, study_id: study.id, study_file_id: expression_file.id, values: all_cell_array)
+                                      array_index: 1, study_id: study.id, study_file_id: expression_file.id,
+                                       values: all_cell_array)
 gene1_cells.save!
 gene2_vals = gene_2.data_arrays.build(name: gene_2.score_key, array_type: 'expression', cluster_name: expression_file.name,
-                                      array_index: 1, study_id: study.id, study_file_id: expression_file.id, values: metadata_score_array)
+                                      array_index: 1, study_id: study.id, study_file_id: expression_file.id,
+                                      values: metadata_score_array)
 gene2_vals.save!
 gene2_cells = gene_2.data_arrays.build(name: gene_2.cell_key, array_type: 'cells', cluster_name: expression_file.name,
-                                       array_index: 1, study_id: study.id, study_file_id: expression_file.id, values: all_cell_array)
+                                       array_index: 1, study_id: study.id, study_file_id: expression_file.id,
+                                       values: all_cell_array)
 gene2_cells.save!
 DirectoryListing.create!(name: 'fastq', file_type: 'fastq',
                          files: [
-                           {name: '1_L1_001.fastq', size: 100, generation: '12345'},
-                           {name: '1_R1_001.fastq', size: 100, generation: '12345'},
-                           {name: '2_L1_001.fastq', size: 100, generation: '12345'},
-                           {name: '2_R1_001.fastq', size: 100, generation: '12345'},
+                           { name: '1_L1_001.fastq', size: 100, generation: '12345' },
+                           { name: '1_R1_001.fastq', size: 100, generation: '12345' },
+                           { name: '2_L1_001.fastq', size: 100, generation: '12345' },
+                           { name: '2_R1_001.fastq', size: 100, generation: '12345' },
                          ], sync_status: true, study_id: study.id)
-
-
 # API TEST SEEDS
 api_study = Study.create!(name: "API Test Study #{@random_seed}", data_dir: 'api_test_study', user_id: user.id,
                           firecloud_project: ENV['PORTAL_NAMESPACE'])
@@ -153,14 +157,16 @@ StudyFile.create(study_id: api_study.id, name: 'SRA Study for housing fastq data
                  file_type: 'Fastq', status: 'uploaded', human_fastq_url: 'https://www.ncbi.nlm.nih.gov/sra/ERX4159348[accn]')
 DirectoryListing.create!(name: 'csvs', file_type: 'csv', files: [{name: 'foo.csv', size: 100, generation: '12345'}],
                          sync_status: true, study_id: api_study.id)
-StudyFileBundle.create!(bundle_type: 'BAM', original_file_list: [{'name' => 'sample_1.bam', 'file_type' => 'BAM'},
-                                                                 {'name' => 'sample_1.bam.bai', 'file_type' => 'BAM Index'}],
+StudyFileBundle.create!(bundle_type: 'BAM',
+                        original_file_list: [
+                          { 'name' => 'sample_1.bam', 'file_type' => 'BAM' },
+                          { 'name' => 'sample_1.bam.bai', 'file_type' => 'BAM Index' }],
                         study_id: api_study.id)
 resource = api_study.external_resources.build(url: 'https://singlecell.broadinstitute.org', title: 'SCP',
                                               description: 'Link to Single Cell Portal')
 resource.save!
 api_user = User.create!(email:'testing.user.2@gmail.com', password:'someotherpassword', metrics_uuid: SecureRandom.uuid,
-             api_access_token: {access_token: 'test-api-token-2', expires_in: 3600, expires_at: Time.zone.now + 1.hour})
+             api_access_token: { access_token: 'test-api-token-2', expires_in: 3600, expires_at: Time.zone.now + 1.hour })
 
 # Analysis Configuration seeds
 AnalysisConfiguration.create!(namespace: 'single-cell-portal', name: 'split-cluster', snapshot: 1, user_id: user.id,
@@ -169,29 +175,51 @@ AnalysisConfiguration.create!(namespace: 'single-cell-portal', name: 'split-clus
 
 # SearchFacet seeds
 # These facets represent 3 of the main types: String-based (both for array- and non-array columns), and numeric
-SearchFacet.create!(name: 'Species', identifier: 'species', filters: [{id: 'NCBITaxon_9606', name: 'Homo sapiens'}],
-                   ontology_urls: [{name: 'NCBI organismal classification',
-                                    url: 'https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon',
-                                    browser_url: nil}],
-                   data_type: 'string', is_ontology_based: true, is_array_based: false, big_query_id_column: 'species',
-                   big_query_name_column: 'species__ontology_label', convention_name: 'Alexandria Metadata Convention',
-                   convention_version: '2.2.0')
-SearchFacet.create!(name: 'Disease', identifier: 'disease', filters: [{id: 'MONDO_0000001', name: 'disease or disorder'}],
-                   ontology_urls: [{name: 'Monarch Disease Ontology',
-                                    url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo',
-                                    browser_url: nil},
-                                   {name: 'Phenotype And Trait Ontology',
-                                    url: 'https://www.ebi.ac.uk/ols/ontologies/pato',
-                                    browser_url: nil}],
-                   data_type: 'string', is_ontology_based: true, is_array_based: true, big_query_id_column: 'disease',
-                   big_query_name_column: 'disease__ontology_label', convention_name: 'Alexandria Metadata Convention',
-                   convention_version: '2.2.0')
-SearchFacet.create!(name: 'Organism Age', identifier: 'organism_age', big_query_id_column: 'organism_age', big_query_name_column: 'organism_age',
-                   big_query_conversion_column: 'organism_age__seconds', is_ontology_based: false, data_type: 'number',
-                   is_array_based: false, convention_name: 'Alexandria Metadata Convention', convention_version: '2.2.0',
-                   unit: 'years')
+SearchFacet.create!(name: 'Species', identifier: 'species',
+                    filters: [
+                      { id: 'NCBITaxon_9606', name: 'Homo sapiens' }
+                    ],
+                    public_filters: [
+                      { id: 'NCBITaxon_9606', name: 'Homo sapiens' }
+                    ],
+                    ontology_urls: [
+                      {
+                        name: 'NCBI organismal classification',
+                        url: 'https://www.ebi.ac.uk/ols/api/ontologies/ncbitaxon',
+                        browser_url: nil
+                      }
+                    ],
+                    data_type: 'string', is_ontology_based: true, is_array_based: false, big_query_id_column: 'species',
+                    big_query_name_column: 'species__ontology_label', convention_name: 'Alexandria Metadata Convention',
+                    convention_version: '2.2.0')
+SearchFacet.create!(name: 'Disease', identifier: 'disease',
+                    filters: [
+                      { id: 'MONDO_0000001', name: 'disease or disorder' }
+                    ],
+                    public_filters: [
+                      { id: 'MONDO_0000001', name: 'disease or disorder' }
+                    ],
+                    ontology_urls: [
+                      {
+                        name: 'Monarch Disease Ontology',
+                        url: 'https://www.ebi.ac.uk/ols/api/ontologies/mondo',
+                        browser_url: nil
+                      }, {
+                        name: 'Phenotype And Trait Ontology',
+                        url: 'https://www.ebi.ac.uk/ols/ontologies/pato',
+                        browser_url: nil
+                      }
+                    ],
+                    data_type: 'string', is_ontology_based: true, is_array_based: true, big_query_id_column: 'disease',
+                    big_query_name_column: 'disease__ontology_label', convention_name: 'Alexandria Metadata Convention',
+                    convention_version: '2.2.0')
+SearchFacet.create!(name: 'Organism Age', identifier: 'organism_age', big_query_id_column: 'organism_age',
+                    big_query_name_column: 'organism_age', big_query_conversion_column: 'organism_age__seconds',
+                    is_ontology_based: false, data_type: 'number', is_array_based: false,
+                    convention_name: 'Alexandria Metadata Convention', convention_version: '2.2.0', unit: 'years')
 
-BrandingGroup.create!(name: 'Test Brand', user_id: api_user.id, font_family: 'Helvetica Neue, sans-serif', background_color: '#FFFFFF')
+BrandingGroup.create!(name: 'Test Brand', user_id: api_user.id, font_family: 'Helvetica Neue, sans-serif',
+                      background_color: '#FFFFFF')
 
 # Preset search seeds
 PresetSearch.create!(name: 'Test Search', search_terms: ["Testing Study"],

--- a/test/models/search_facet_test.rb
+++ b/test/models/search_facet_test.rb
@@ -10,8 +10,8 @@ class SearchFacetTest < ActiveSupport::TestCase
 
     # filter_results to return from mock call to BigQuery
     @filter_results = [
-        {id: 'NCBITaxon_9606', name: 'Homo sapiens'},
-        {id: 'NCBITaxon_10090', name: 'Mus musculus'}
+        { id: 'NCBITaxon_9606', name: 'Homo sapiens' },
+        { id: 'NCBITaxon_10090', name: 'Mus musculus' }
     ]
 
     # mock schema for number_of_reads column in BigQuery


### PR DESCRIPTION
Currently, when viewing the SCP home page before logging in, the filter values displayed when clicking on a search facet can contain values that only reside in private studies that the user may not be able to view, once logged in.  This can lead to confusing situations where a user selects one of those filter values, runs a search, and gets no results (due to correct permission filtering on studies).

This update adds the `public_filters` attribute to `SearchFacet`, where only filter values from public studies are shown.  This way, when an anonymous user selects a filter value, they are guaranteed to see at least one result.  Once logged in, the former scenario still applies, but solving that issue is out of scope for this PR.  In addition, this update applies general linting format updates to files updated in this PR.

MANUAL TESTING
Since waiting for an ingest of a convention-compliant metadata file in a private study will take several minutes, the easiest way to test this feature is to manually update the `public_filters` value on a search facet.  Also, you will need to set the default value for the "faceted_search" `FeatureFlag` to `true` in order to have advanced search show up when not logged in.

1. From the project root, after running `rails_local_setup.rb`, run all queued migrations:
```
bin/rails db:migrate
```
2. Enter the rails console, and find the 'faceted_search' `FeatureFlag`:
```
feature_flag = FeatureFlag.find_by(name: 'faceted_search')
```
3. Set the `default_value` to true:
```
feature_flag.update(default_value: true)
```
4. Load the `SearchFacet` for 'species'
```
facet = SearchFacet.find_by(name: 'species')
```
5. Update the `public_filters` to be only the first two filters:
```
facet.update(public_filters: facet.filters.take(2))
```
6. In another terminal window, boot the portal as normal, and click on the "species" facet, confirming there are only 2 values:
![Screen Shot 2021-07-12 at 3 14 49 PM](https://user-images.githubusercontent.com/729968/125343296-e927eb00-e323-11eb-940f-4f09f0615d9c.png)
7. Sign in, and confirm that all values for species are now shown:
![Screen Shot 2021-07-12 at 3 15 42 PM](https://user-images.githubusercontent.com/729968/125343416-0957aa00-e324-11eb-849a-0360c3b08fdf.png)
8. (Optional): Back in the rails console, reset the 'species' facet:
```
facet.update_filter_values!
```

This PR satisfies SCP-3471