### PR TITLE
Sort the annotations AlphaNumerically [SCP-3466]

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -67,6 +67,9 @@ function RawScatterPlot({
       is3D: scatter.is3D
     })
 
+    // sort the annotations array alphanumerically - this will determine order of legend in graph
+    plotlyTraces[0].transforms[0].groups.sort(sortAlphaNumerically)
+
     const startTime = performance.now()
     Plotly.react(graphElementId, plotlyTraces, layout)
 
@@ -237,7 +240,6 @@ function getPlotlyTraces({
           target: val,
           value: {
             name: `${val} (${traceCounts[val]} points)`,
-            legendrank: index,
             marker: {
               color: getColorBrewerColor(index),
               size: pointSize
@@ -296,6 +298,11 @@ function traceNameSort(a, b) {
   if (a === UNSPECIFIED_ANNOTATION_NAME) {return 1}
   if (b === UNSPECIFIED_ANNOTATION_NAME) {return -1}
   return a.localeCompare(b)
+}
+
+/** sort alphanumerically */
+function sortAlphaNumerically(a, b) {
+  return a.localeCompare(b, 'en', { numeric: true })
 }
 
 /** makes the data trace attributes (cells, trace name) available via hover text */


### PR DESCRIPTION
Sort the annotations for scatterplot Alphanumerically.

Remove "legendrank" as that was not actually setting the order in the legend, it is coming from the annotation groups order.
Sorting the groups even with the million cell study added only about 3 ms so it seemed reasonable to continue with this approach.

Before:
<img width="475" alt="Screen Shot 2021-07-19 at 4 10 11 PM" src="https://user-images.githubusercontent.com/54322292/126221167-432e9b3c-d400-4ed3-aa9e-dd5ffd492045.png">
After:
<img width="666" alt="Screen Shot 2021-07-19 at 4 07 03 PM" src="https://user-images.githubusercontent.com/54322292/126221186-050d7c03-082f-4c12-85d3-6aaacc9d2456.png">

Another example of how the annotation groups will be sorted now:
<img width="188" alt="Screen Shot 2021-07-19 at 3 11 55 PM" src="https://user-images.githubusercontent.com/54322292/126221217-f0bab68c-c757-4de2-a7c1-356a8beb8569.png">

Sorts just numbers logically too:
<img width="409" alt="Screen Shot 2021-07-19 at 4 54 35 PM" src="https://user-images.githubusercontent.com/54322292/126226509-8e7fc009-a369-4ff5-a837-8983d6b2956b.png">

