### PR TITLE
Enforcing metadata convention rules when syncing files (SCP-3514)

### DIFF
--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -172,16 +172,4 @@ class FileParseService
       ErrorTracker.report_exception(e, nil, study)
     end
   end
-
-  # helper to determine if a metadata file can be ingested (must either conform to convention, or user has exemption)
-  # if no exemption is present, will fall back to opposite of the default value
-  def self.can_ingest_metadata?(study_file, user)
-    if study_file.use_metadata_convention || study_file.file_type != 'Metadata'
-      # file is compliant, or not metadata
-      true
-    else
-      # return opposite as convention_required: true here means the file cannot be ingested
-      !User.feature_flag_for_instance(user, 'convention_required')
-    end
-  end
 end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -869,6 +869,15 @@ class Study
     [self.user.email, self.study_shares.can_edit, User.where(admin: true).pluck(:email)].flatten.uniq
   end
 
+  # array of user accounts associated with this study (study owner + shares); can scope by permission, if provided
+  # differs from study.admins as it does not include portal admins
+  def associated_users(permission: nil)
+    owner = self.user
+    shares = permission.present? ? self.study_shares.where(permission: permission) : self.study_shares
+    share_users = shares.map { |share| User.find_by(email: share.email) }.compact
+    [owner] + share_users
+  end
+
   # check if study is still under embargo or whether given user can bypass embargo
   def embargoed?(user)
     if user.nil?

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -580,11 +580,11 @@ class StudyFile
   before_validation   :set_file_name_and_data_dir, on: :create
   before_save         :sanitize_name
   after_save          :set_cluster_group_ranges, :set_options_by_file_type
-  validates_uniqueness_of :upload_file_name, scope: :study_id, unless: Proc.new {|f| f.human_data?}
+  validates_uniqueness_of :upload_file_name, scope: :study_id, unless: Proc.new { |f| f.human_data? }
   validates_presence_of :name
-  validates_presence_of :human_fastq_url, if: proc {|f| f.human_data}
+  validates_presence_of :human_fastq_url, if: proc { |f| f.human_data }
   validates_format_of :human_fastq_url, with: URI.regexp,
-                      message: 'is not a valid URL', if: proc {|f| f.human_data}
+                      message: 'is not a valid URL', if: proc { |f| f.human_data }
   validate :validate_name_by_file_type
 
   validates_format_of :description, with: ValidationTools::NO_SCRIPT_TAGS,
@@ -600,13 +600,14 @@ class StudyFile
                       message: ValidationTools::NO_SCRIPT_TAGS_ERROR,
                       allow_blank: true
 
-  validates_format_of :generation, with: /\A\d+\z/, if: proc {|f| f.generation.present?}
+  validates_format_of :generation, with: /\A\d+\z/, if: proc { |f| f.generation.present? }
 
-  validates_inclusion_of :file_type, in: STUDY_FILE_TYPES, unless: proc {|f| f.file_type == 'DELETE'}
+  validates_inclusion_of :file_type, in: STUDY_FILE_TYPES, unless: proc { |f| f.file_type == 'DELETE' }
 
   validate :check_taxon, on: :create
   validate :check_assembly, on: :create
-  validate :ensure_metadata_singleton, if: proc {|f| f.file_type == 'Metadata'}
+  validate :ensure_metadata_singleton, if: proc { |f| f.file_type == 'Metadata' }
+  validate :ensure_metadata_convention, if: proc { |f| f.file_type == 'Metadata' }
 
   ###
   #
@@ -1308,6 +1309,14 @@ class StudyFile
   def ensure_metadata_singleton
     if StudyFile.where(file_type: 'Metadata', study_id: self.study_id, queued_for_deletion: false, :id.ne => self.id).exists?
       errors.add(:file_type, 'You may only add one metadata file per study')
+    end
+  end
+
+  # ensure that metadata file adheres to convention acceptance criteria, if turned on
+  # will check for exemption from any users associated with given study
+  def ensure_metadata_convention
+    unless use_metadata_convention
+
     end
   end
 end

--- a/app/views/studies/_metadata_file_fields.html.erb
+++ b/app/views/studies/_metadata_file_fields.html.erb
@@ -1,6 +1,46 @@
 <div class="form-group row">
   <div class="col-sm-4">
-    <%= f.label :use_metadata_convention, "Use Metadata Convention?" %> <%= render partial: 'metadata_convention_help_popover', locals: {id: f.object.id.to_s} %><br />
-    <%= f.select :use_metadata_convention, options_for_select([['Yes', true],['No', false]], f.object.use_metadata_convention), {}, class: 'form-control use-metadata-convention', disabled: !f.object.new_record? %>
+    <% convention_required = User.feature_flag_for_instance(current_user, 'convention_required') %>
+    <%= f.label :use_metadata_convention do %>
+      Do you use SCP conventional names for required metadata column headers?
+      <%= render partial: 'metadata_convention_help_popover', locals: {id: f.object.id.to_s} %>
+    <% end %>
+    <br />
+    <%= f.label :use_metadata_convention_true, 'data-analytics-name': 'metadata-convention-optin' do %>
+      <%= f.radio_button :use_metadata_convention, true, checked: true, disabled: !f.object.new_record?%>
+      Yes
+    <% end %>
+    &nbsp;
+    <%= f.label :use_metadata_convention_false, 'data-analytics-name': 'metadata-convention-optout' do %>
+      <% if convention_required %>
+        <a href="#/" style="color:#999" id="convention-decline-label-<%= f.object.id.to_s %>"
+           data-content="Using the convention is now required.  If this presents a particular issue for your study, please contact us at <a href='mailto:scp-support@broadinstitute.zendesk.com'>scp-support@broadinstitute.zendesk.com</a> so we can help or make any updates to the convention."
+           data-toggle="popover"
+           data-analytics-name="convention-decline-label">
+          <%= f.radio_button :use_metadata_convention, false, checked: false, disabled: true %>
+          No
+        </a>
+
+      <% else %>
+        <%= f.radio_button :use_metadata_convention, false, checked: false, disabled: !f.object.new_record? %>
+        No
+      <% end %>
+    <% end %>
+    &nbsp; &nbsp; <a href="#/" id="convention-decline-helplink-<%= f.object.id.to_s %>"
+                     data-toggle="popover"
+                     data-content="Please contact us at <a href='mailto:scp-support@broadinstitute.zendesk.com'>scp-support@broadinstitute.zendesk.com</a> so we can help or make any needed updates to the convention."
+                     data-analytics-name="convention-decline-helplink">
+    Using conventional names is an issue for my study
+  </a>
+    <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+      ['#convention-decline-label-', '#convention-decline-helplink-'].forEach(function(idString) {
+        var popoverTarget = idString + '<%= f.object.id.to_s %>'
+        $(popoverTarget).on('click', function() {
+          window.SCP.log('file-upload:metadata:optout-attempt', {studyAccession: '<%= @study.accession %>'})
+        })
+        enableHoverPopovers(popoverTarget);
+      })
+    </script>
+    <div id="use-metadata-convention-message"></div>
   </div>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -225,6 +225,7 @@ BrandingGroup.create!(name: 'Test Brand', user_id: api_user.id, font_family: 'He
 PresetSearch.create!(name: 'Test Search', search_terms: ["Testing Study"],
                      facet_filters: ['species:NCBITaxon_9606', 'disease:MONDO_0000001'], accession_list: %w(SCP1))
 FeatureFlag.create!(name: 'faceted_search')
+FeatureFlag.create!(name: 'convention_required', default_value: false)
 
 # seed BQ for search controller test
 begin


### PR DESCRIPTION
Currently, there is a gap in functionality concerning the SCP metadata convention when a user is syncing study files, rather than uploading them.  There is only a yes/no select menu, and all of the acceptance logic displayed in the metadata upload form is omitted.  This can lead to a corner case where a user can select "No" for the metadata convention while syncing, which will then throw an error in production (as it is required), leading to the file being "synced" but not ingested.

This update applies the same UI/UX for the metadata convention to sync forms.  In addition, a server-side validation has been put in place to honor the value of the `convention_required` feature flag.  If set to `true`, it will reject saving any metadata files that do not conform to the metadata convention unless that user (or any other user associated with the current study) has obtained an exemption from SCP admins.  This is handled through a new `associated_users` method on studies that will return an array of all users that have access to the study in question.  

This will be useful as well for upcoming work regarding requiring raw count expression matrices, as that will also attempt to enforce acceptance via a validation which will also be governed by a feature flag.

MANUAL TESTING
To test, you will first need to create a new Terra workspace in your developer-specific project, and upload the non-convention metadata file from `test/test_data/metadata_example.txt` to the workspace bucket.  In addition, you will want to set the default value for `convention_required` to `true`:

```
./rails_local_setup.rb
source config/secrets/.source_env.bash && bin/rails c
irb(main):001:0> flag = FeatureFlag.find_by(name: 'convention_required')
=> #<FeatureFlag _id: 6033f69ee241391a2371c242, name: "convention_required", default_value: false, description: "whether metadata convention compliant files are required">
irb(main):002:0> flag.update(default_value: true)
=> true
```

1. Boot the portal as normal, sign in, and click "Create a study"
2. Set `use_existing_workspace` to `true` and put in the name of the above workspace
3. Click "Create" to go to the sync page
4. For the one unsynced file, select the file type of 'Metadata' and confirm that "No" is greyed out for the `use_metadata_convention` field
![Screen Shot 2021-07-20 at 12 30 17 PM](https://user-images.githubusercontent.com/729968/126366088-b05c4f5c-c701-4ad0-930c-5d5239fadcc6.png)
5. Go to the Admin page, load your user account, and set the `convention_required` feature flag to `false`
6. Reload the sync page, and confirm that you can now specify "No" for `use_metadata_convention`
7. Select "No", save the file, and note in `development.log` that an ingest job has launched:
```
Remote found for metadata_example.txt:60f7037794ec8f7f4c8d9b5e, launching Ingest job
Request object sent to Google Pipelines API (PAPI), excluding 'environment' parameters:
---
:actions:
  :commands:
  - python
  - ingest_pipeline.py
  - "--study-id"
  - 60ef404d94ec8f6c291f59d8
  - "--study-file-id"
  - 60f7037794ec8f7f4c8d9b5e
  - "--user-metrics-uuid"
  - ab2abaf4-4322-48c2-b886-9bb111bef757
  - ingest_cell_metadata
  - "--cell-metadata-file"
  - gs://fc-19feb94f-9d21-4f93-8aeb-ef0c5e014fbe/metadata_example.txt
  ...

```
8. (Optional) Back in the Rails console, set the `default_value` to `false` for the `convention_required` feature flag.

This PR satisfies SCP-3514.