### PR TITLE
Increase scientific precision by increasing default cluster resolution (SCP-3513)

### DIFF
--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -23,12 +23,12 @@ export const UNSPECIFIED_ANNOTATION_NAME = '--Unspecified--'
 export function getDefaultSubsampleForCluster(annotationList, clusterName) {
   const subsampleOptions = annotationList.subsample_thresholds[clusterName]
   if (subsampleOptions?.length) {
-    // find the max subsample less than or equal to 10000
-    const defaultSubsample = Math.max(...subsampleOptions.filter(opt => opt <= 10000))
-    // if it's 10000, that means the study has more than 10000 cells, and so the
-    // default is to show 10000.  otherwise we'll show all cells by default
-    if (defaultSubsample === 10000) {
-      return 10000
+    // find the max subsample less than or equal to 100000
+    const defaultSubsample = Math.max(...subsampleOptions.filter(opt => opt <= 100000))
+    // if it's 100000, that means the study has more than 100000 cells, and so the
+    // default is to show 100000.  otherwise we'll show all cells by default
+    if (defaultSubsample === 100000) {
+      return 100000
     }
   }
   return 'all'

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -102,7 +102,7 @@ export async function fetchAuthCode(fileIds, tdrFiles, mock=false) {
 * @param {String} studyAccession Study accession, e.g. SCP123
 * @param {String} cluster Name of cluster, as defined at upload
 * @param {String} annotation Full annotation name, e.g. "CLUSTER--group--study"
-* @param {String} subsample Subsampling threshold, e.g. 100000
+* @param {String} subsample Subsampling threshold, e.g. 10000
 * @param {String} userAnnotationName Name of new annotation
 * @param {Object} selections User selections for new annotation.
 *    Each selection has a label (`name`) and list of cell names (`values`).
@@ -239,7 +239,7 @@ export async function fetchClusterOptions(studyAccession, mock=false) {
  * @param {String} cluster Name of cluster, as defined at upload
  * @param {String} annotation Full annotation name,
      e.g. "CLUSTER--group--study", or object with name,type, and scope properties
- * @param {String} subsample Subsampling threshold, e.g. 100000
+ * @param {String} subsample Subsampling threshold, e.g. 10000
  * @param {String} consensus Statistic to use for consensus, e.g. "mean"
  * @param {Boolean} isAnnotatedScatter If showing "Annotated scatter" plot.
  *                  Only applies for numeric (not group) annotations.

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -79,10 +79,10 @@ class ClusterVizService
   # will only provide options if subsampling has completed for a cluster
   def self.default_subsampling(cluster)
     num_points = cluster.points
-    if num_points < 10000
+    if num_points < 100000
       return nil
     else
-      ClusterGroup::SUBSAMPLE_THRESHOLDS.select{|val| val <= 10000}.max
+      ClusterGroup::SUBSAMPLE_THRESHOLDS.select{|val| val <= 100000}.max
     end
   end
 


### PR DESCRIPTION
This increases the scientific precision of our leading visualization by increase its default resolution by 10x.  Specifically, this increases the default cluster subsampling threshold from 10K to 100K cells.  If a cluster has < 100K cells, all its cells are shown.

Performance optimizations done last quarter made it trivial to implement this scientific enhancement.

A disadvantage of subsampling is that the number of cells for each subsampled label is equal, while the underlying data can have labels with very unequal numbers of cells.  So subsampling can greatly skew proportions in underlying data, which is a scientific problem.  

Compare the default 10K-subsampled cluster below to its full resolution cluster, as Jean for our U19 stakeholders.  The relatively small subsampling obscures:

* The thick band of grey cells (i.e. annotation-labeled "3").
* The preponderence of red cells (label “0") at bottom and light pink cells (label 2) at top.

Old, low resolution default:
<img width="1680" alt="10K_subsample_old_default_of_spatial_cluster__SCP_2021-07-21" src="https://user-images.githubusercontent.com/1334561/126505477-2f749bd4-72cb-42e1-81a3-02a4fe87b117.png">


New, high resolution default:
<img width="1675" alt="All_cells_for_100K_subsample_new_default_of_spatial_cluster__SCP_2021-07-21" src="https://user-images.githubusercontent.com/1334561/126505504-6c8a30f2-55b5-4cc0-89c0-7365aecf230b.png">

To test:
* Load a study that has a cluster with > 100K cells
* Verify "Subsampling" says "100000", not "10000"
* Switch to "10000"
* Verify it has lower resolution

This satisfies SCP-3513.