### PR TITLE
Adding TDR snapshot IDs configuration for scoping search requests (SCP-3490)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -674,8 +674,9 @@ module Api
           end
           # now we merge the two queries together to perform a single search request
           query_json = ApplicationController.data_repo_client.merge_query_json(facet_query: facet_json, term_query: term_json)
+          logger.info "Executing TDR query with: #{query_json}"
           snapshot_ids = AdminConfiguration.get_tdr_snapshot_ids
-          logger.info "Executing TDR query with: #{query_json} ()"
+          logger.info "Scoping TDR query to snapshots: #{snapshot_ids.join(', ')}" if snapshot_ids.present?
           raw_tdr_results = ApplicationController.data_repo_client.query_snapshot_indexes(query_json,
                                                                                           snapshot_ids: snapshot_ids)
           added_file_ids = {}

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -665,22 +665,29 @@ module Api
       # execute a search in TDR and get back normalized results
       def self.get_tdr_results(selected_facets:, terms:)
         results = {}
-        if selected_facets.present?
-          facet_json = ApplicationController.data_repo_client.generate_query_from_facets(selected_facets)
-        end
-        if terms.present?
-          term_json = ApplicationController.data_repo_client.generate_query_from_keywords(terms)
-        end
-        # now we merge the two queries together to perform a single search request
-        query_json = ApplicationController.data_repo_client.merge_query_json(facet_query: facet_json, term_query: term_json)
-        logger.info "Executing TDR query with: #{query_json}"
-        raw_tdr_results = ApplicationController.data_repo_client.query_snapshot_indexes(query_json)
-        added_file_ids = {}
-        raw_tdr_results['result'].each do |result_row|
-          results = process_tdr_result_row(result_row, results,
-            selected_facets: selected_facets,
-            terms: terms,
-            added_file_ids: added_file_ids)
+        begin
+          if selected_facets.present?
+            facet_json = ApplicationController.data_repo_client.generate_query_from_facets(selected_facets)
+          end
+          if terms.present?
+            term_json = ApplicationController.data_repo_client.generate_query_from_keywords(terms)
+          end
+          # now we merge the two queries together to perform a single search request
+          query_json = ApplicationController.data_repo_client.merge_query_json(facet_query: facet_json, term_query: term_json)
+          snapshot_ids = AdminConfiguration.get_tdr_snapshot_ids
+          logger.info "Executing TDR query with: #{query_json} ()"
+          raw_tdr_results = ApplicationController.data_repo_client.query_snapshot_indexes(query_json,
+                                                                                          snapshot_ids: snapshot_ids)
+          added_file_ids = {}
+          raw_tdr_results['result'].each do |result_row|
+            results = process_tdr_result_row(result_row, results,
+                                             selected_facets: selected_facets,
+                                             terms: terms,
+                                             added_file_ids: added_file_ids)
+          end
+        rescue RestClient::Exception => e
+          Rails.logger.error "Error querying TDR: #{e.class.name} -- #{e.message}"
+          ErrorTracker.report_exception(e, nil, selected_facets, { terms: terms })
         end
         results
       end

--- a/app/models/data_repo_client.rb
+++ b/app/models/data_repo_client.rb
@@ -229,7 +229,7 @@ class DataRepoClient < Struct.new(:access_token, :api_root, :storage, :expires_a
   #
   # * *returns*
   #   - (Array<Hash>) => Array of row-level results, with all columns present in index (there will be a lot of duplication)
-  def query_snapshot_indexes(query_json, limit: 1000, offset: 0, snapshot_ids: [])
+  def query_snapshot_indexes(query_json, limit: 10000, offset: 0, snapshot_ids: [])
     query_opts = merge_query_options({limit: limit, offset: offset})
     path = api_root + '/api/repository/v1/search/query' + query_opts
     payload = {


### PR DESCRIPTION
Since SCP will be enabling cross dataset search via requests to Terra Data Repo (TDR), and will be doing so by connecting to their development instance, there is the possibility that search requests from production SCP could potentially expose data on the development TDR instance that is not intended for public release.  This is because search requests to TDR will query all available snapshots shared with the SCP service account unless we provide a list of snapshots that we want to query.

This update adds an admin configuration option to append a comma-delimited list of snapshot UUIDs to all TDR queries.  This will limit results to only those snapshots, allowing admins to dynamically control what data is returned to users without having to perform a release.  In addition, this update also adds error handling to TDR requests to avoid breaking search requests entirely in case snapshots are redacted.  It also increases the default number of rows returned by TDR from `1000` to `10000` to avoid having to paginate row-level results.

MANUAL TESTING
Since there is currently only 1 snapshot shared with SCP service accounts, the only way to test this is to put in dummy UUIDs for the configuration value, and check the logs to confirm that the query has been limited to those snapshots.

1. Boot portal as normal, sign in, and go to Admin page
2. Click "New Config Option"
3. Select `TDR Snapshot IDs` as the configuration type, and `string` as the value type
4. Paste the following UUIDs into the `value` box: `b5cabf5b-1202-4017-93c6-9537a773f1a3, 7bc2a4d8-95ac-4f5b-9906-92d1f7175eaa` and click "Save"
5. Go back to the home page, and select "Homo sapiens" from the "species" facet
6. Note that normal SCP results are returned
7. In `development.log`, note the following entry:
```
Scoping TDR query to snapshots: b5cabf5b-1202-4017-93c6-9537a773f1a3, 7bc2a4d8-95ac-4f5b-9906-92d1f7175eaa
```
8. Note the `401 Unauthorized` error (since those snapshots do not exist; this proves the error handling works)
9. Back in the admin section, delete the config option for `TDR Snapshot IDs`

This PR satisfies SCP-3490.