### PR TITLE
Adding HCA Azul service API client (SCP-3503)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -699,6 +699,7 @@ module Api
           accession: short_name,
           name: row[name_field],
           description: row[description_field],
+          project_id: row['project_id'],
           facet_matches: [],
           term_matches: [],
           file_information: []

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,6 +49,10 @@ class ApplicationController < ActionController::Base
     @@data_repo_client ||= DataRepoClient.new
   end
 
+  def self.hca_azul_client
+    @@hca_azul_client ||= HcaAzulClient.new
+  end
+
   # method to renew firecloud client (forces new access token for API and reinitializes storage driver)
   def self.refresh_firecloud_client
     begin

--- a/app/models/data_repo_client.rb
+++ b/app/models/data_repo_client.rb
@@ -52,6 +52,18 @@ class DataRepoClient < Struct.new(:access_token, :api_root, :storage, :expires_a
   ##
 
   # submit a request to TDR API
+  #
+  # * *params*
+  #   - +http_method+ (String, Symbol) => HTTP method, e.g. :get, :post
+  #   - +path+ (String) => Relative URL path for API request being made
+  #   - +payload+ (Hash) => Hash representation of request body
+  #   - +retry_count+ (Integer) => Counter for tracking request retries
+  #
+  # * *returns*
+  #   - (Hash) => Parsed response body, if present
+  #
+  # * *raises*
+  #   - (RestClient::Exception) => if HTTP request fails for any reason  def process_api_request(http_method, path, payload: nil, retry_count: 0)
   def process_api_request(http_method, path, payload: nil, retry_count: 0)
     # Log API call for auditing/tracking purposes
     Rails.logger.info "Terra Data Repo API request (#{http_method.to_s.upcase}) #{path}"

--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -1,0 +1,122 @@
+# Query Human Cell Atlas Azul service for metadata associated with both experimental and analysis data
+# No ServiceAccountManager or GoogleServiceClient includes as all requests are unauthenticated for public data
+class HcaAzulClient < Struct.new(:api_root)
+  include ApiHelpers
+
+  GOOGLE_SCOPES = %w[openid email profile].freeze
+  BASE_URL = 'https://service.azul.data.humancellatlas.org'.freeze
+
+  # list of available HCA catalogs
+  HCA_CATALOGS = %w[dcp1 dcp6 dcp7 it1 it6 it7 it0lungmap lungmap].freeze
+
+  # List of accepted formats for manifest files
+  MANIFEST_FORMATS = %w[compact full terra.bdbag terra.pfb curl].freeze
+
+  ##
+  # Constructors & token management methods
+  ##
+
+  # base constructor
+  #
+  # * *return*
+  #   - +HcaAzulClient+ object
+  def initialize
+    self.api_root = BASE_URL
+  end
+
+  ##
+  # Abstract request handlers/heplers
+  ##
+
+  # submit a request to HCA Azul Service API
+  #
+  # * *params*
+  #   - +http_method+ (String, Symbol) => HTTP method, e.g. :get, :post
+  #   - +path+ (String) => Relative URL path for API request being made
+  #   - +payload+ (Hash) => Hash representation of request body
+  #   - +retry_count+ (Integer) => Counter for tracking request retries
+  #
+  # * *returns*
+  #   - (Hash) => Parsed response body, if present
+  #
+  # * *raises*
+  #   - (RestClient::Exception) => if HTTP request fails for any reason
+  def process_api_request(http_method, path, payload: nil, retry_count: 0)
+    # Log API call for auditing/tracking purposes
+    Rails.logger.info "HCA Azul API request (#{http_method.to_s.upcase}) #{path}"
+    # process request
+    begin
+      headers = {
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json',
+        'x-app-id' => 'single-cell-portal',
+        'x-domain-id' => "#{ENV['HOSTNAME']}"
+      }
+      response = RestClient::Request.execute(method: http_method, url: path, payload: payload, headers: headers)
+      # handle response using helper
+      handle_response(response)
+    rescue RestClient::Exception => e
+      current_retry = retry_count + 1
+      context = " encountered when requesting '#{path}', attempt ##{current_retry}"
+      log_message = "#{e.message}: #{e.http_body}; #{context}"
+      Rails.logger.error log_message
+      retry_time = retry_count * ApiHelpers::RETRY_INTERVAL
+      sleep(retry_time)
+      # only retry if status code indicates a possible temporary error, and we are under the retry limit and
+      # not calling a method that is blocked from retries
+      if should_retry?(e.http_code) && retry_count < ApiHelpers::MAX_RETRY_COUNT
+        process_api_request(http_method, path, payload: payload, retry_count: current_retry)
+      else
+        # we have reached our retry limit or the response code indicates we should not retry
+        ErrorTracker.report_exception(e, nil, {
+          method: http_method, url: path, payload: payload, retry_count: retry_count
+        })
+        error_message = parse_response_body(e.message)
+        Rails.logger.error "Retry count exceeded when requesting '#{path}' - #{error_message}"
+        raise e
+      end
+    end
+  end
+
+  # take a Hash/JSON object and format as a query string parameter
+  #
+  # * *params*
+  #   - +query_params+ (Hash) => Hash of query parameters
+  #
+  # * *returns*
+  #   - (String) => URL-encoded string version of query parameters
+  def format_hash_as_query_string(query_params)
+    # replace Ruby => assignment operators with JSON standard colons (:)
+    sanitized_params = query_params.to_s.gsub(/=>/, ':')
+    CGI.escape(sanitized_params)
+  end
+
+  # API endpoint bindings
+
+  # get a metadata TSV file for a given HCA project UUID
+  #
+  # * *params*
+  #   - +catalog+ (String) => HCA catalog name, from HCA_CATALOGS
+  #   - +project_id+ (UUID) => HCA project UUID
+  #   - +format+ (string) => manifest file format, from MANIFEST_FORMATS
+  #
+  # * *returns*
+  #   - (Hash) => Hash response including an HTTP status code and a location to download
+  #
+  # * *raises*
+  #   - (ArgumentError) => if catalog is not in HCA_CATALOGS or format is not in MANIFEST_FORMATS
+  def get_project_manifest_link(catalog, project_id, format = 'compact')
+    unless HCA_CATALOGS.include?(catalog)
+      raise ArgumentError, "#{catalog} is not a valid catalog: #{HCA_CATALOGS.join(',')}"
+    end
+    unless MANIFEST_FORMATS.include?(format)
+      raise ArgumentError, "#{format} is not a valid format: #{MANIFEST_FORMATS.join(',')}"
+    end
+
+    path = self.api_root + "/fetch/manifest/files?catalog=#{catalog}"
+    project_filter = { 'projectId' => { 'is' => [project_id] } }
+    filter_query = format_hash_as_query_string(project_filter)
+    path += "&filters=#{filter_query}&format=#{format}"
+    process_api_request(:get, path)
+  end
+end

--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -10,7 +10,7 @@ class HcaAzulClient < Struct.new(:api_root)
   MAX_MANIFEST_TIMEOUT = 30.seconds.freeze
 
   # list of available HCA catalogs
-  HCA_CATALOGS = %w[dcp1 dcp6 dcp7 it1 it6 it7 it0lungmap lungmap].freeze
+  HCA_CATALOGS = %w[dcp1 dcp7 it1 it7 it0lungmap lungmap].freeze
 
   # List of accepted formats for manifest files
   MANIFEST_FORMATS = %w[compact full terra.bdbag terra.pfb curl].freeze
@@ -95,6 +95,15 @@ class HcaAzulClient < Struct.new(:api_root)
   end
 
   # API endpoint bindings
+
+  # get a list of all available catalogs
+  #
+  # * *returns*
+  #   - (Hash) => Available catalogs, including :default_catalog
+  def get_catalogs
+    path = self.api_root + '/index/catalogs'
+    process_api_request(:get, path)
+  end
 
   # get a metadata TSV file for a given HCA project UUID
   #

--- a/lib/service_account_manager.rb
+++ b/lib/service_account_manager.rb
@@ -14,13 +14,24 @@ module ServiceAccountManager
   #     - +expires_in+ (Integer) => duration of token, in seconds
   #     - +token_type+ (String) => type of access token (e.g. 'Bearer')
   def generate_access_token(service_account)
-    creds_attr = {scope: self::GOOGLE_SCOPES}
-    if !service_account.blank?
-      creds_attr.merge!(json_key_io: File.open(service_account))
-    end
-    creds = Google::Auth::ServiceAccountCredentials.make_creds(creds_attr)
-    token = creds.fetch_access_token!
-    token
+    creds = load_service_account_creds(service_account)
+    creds.fetch_access_token!
+  end
+
+  # create a Google ServiceAccountCredentials instance for issuing access tokens, parsing service account attributes
+  #
+  # * *params*
+  #   - +service_account+ (Pathname) => path to service account JSON keyfile
+  #
+  # * *returns*
+  #   - (Google::Auth::ServiceAccountCredentials) => ServiceAccountCredentials instance
+  def load_service_account_creds(service_account)
+    Google::Auth::ServiceAccountCredentials.make_creds(
+      {
+        scope: self::GOOGLE_SCOPES,
+        json_key_io: File.open(service_account)
+      }
+    )
   end
 
   # return the GCP project this instance is running in

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -14,8 +14,16 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     assert_equal HcaAzulClient::BASE_URL, client.api_root
   end
 
+  test 'should get catalogs' do
+    catalogs = @hca_azul_client.get_catalogs
+    default_catalog = catalogs['default_catalog']
+    all_catalogs = catalogs['catalogs'].keys
+    assert_equal HcaAzulClient::HCA_CATALOGS.sort, all_catalogs.sort
+    assert HcaAzulClient::HCA_CATALOGS.include? default_catalog
+  end
+
   test 'should get HCA metadata tsv link' do
-    manifest_info = @hca_azul_client.get_project_manifest_link('dcp6', @project_id)
+    manifest_info = @hca_azul_client.get_project_manifest_link('dcp7', @project_id)
     assert manifest_info.present?
     assert_equal 302, manifest_info['Status']
     # make GET on manifest URL and assert contents are HCA metadata

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class HcaAzulClientTest < ActiveSupport::TestCase
+  include Minitest::Hooks
+  include TestInstrumentor
+
+  before(:all) do
+    @hca_azul_client = ApplicationController.hca_azul_client
+    @project_id = 'c1a9a93d-d9de-4e65-9619-a9cec1052eaa'
+  end
+
+  test 'should instantiate client' do
+    client = HcaAzulClient.new
+    assert_equal HcaAzulClient::BASE_URL, client.api_root
+  end
+
+  test 'should get HCA metadata tsv link' do
+    manifest_info = @hca_azul_client.get_project_manifest_link('dcp6', @project_id)
+    assert manifest_info.present?
+    assert_equal 302, manifest_info['Status']
+    # make GET on manifest URL and assert contents are HCA metadata
+    manifest_response = RestClient.get manifest_info['Location']
+    assert_equal 200, manifest_response.code
+    raw_manifest = manifest_response.body.split("\r\n")
+    headers = raw_manifest.first.split("\t")
+    project_id_header = 'project.provenance.document_id'
+    assert headers.include? project_id_header
+    project_idx = headers.index(project_id_header)
+    data_row = raw_manifest.sample.split("\t")
+    assert_equal @project_id, data_row[project_idx]
+  end
+
+  test 'should format object for query string' do
+    query_object = { 'foo' => { 'bar' => 'baz' } }
+    expected_response = '%7B%22foo%22%3A%7B%22bar%22%3A%22baz%22%7D%7D'
+    formatted_query = @hca_azul_client.format_hash_as_query_string(query_object)
+    assert_equal expected_response, formatted_query
+    # assert we can get back to original object, but as JSON
+    query_as_json = CGI.unescape(formatted_query)
+    assert_equal query_object.to_json, query_as_json
+  end
+end


### PR DESCRIPTION
This update adds a minimal API client for interacting with the Human Cell Atlas [Azul service](https://service.azul.data.humancellatlas.org).  Currently, the only API endpoint integration is for generating file manifests for available files in Azul.  These manifests can also contain experimental metadata (if requesting the `full` manifest), though mostly they contain information about files from various catalogs/projects.  This will allow SCP to export metadata pertaining to HCA catalogs that exist in TDR as a part of bulk download requests.

MANUAL TESTING
As this is not wired into advanced search or bulk download yet, the only way to test is manually through the Rails console:

1. Pull this branch, run local setup, and enter the Rails console:
```
./rails_local_setup.rb && source config/secrets/.source_env.bash && bin/rails c
```
2. Set up variables for making Azul requests:
```
pulmonary_project = 'c1a9a93d-d9de-4e65-9619-a9cec1052eaa'
tcell_act_project = '4a95101c-9ffc-4f30-a809-f04518a23803'
catalog = 'dcp7'
azul_client = ApplicationController.hca_azul_client
```
3. Get a link to the standard manifest for the Pulmonary Fibrosis HCA project:
```
pulmonary_manifest = azul_client.get_project_manifest_link(catalog, pulmonary_project)
```
4. Open the `Location` URL in a browser tab to download the manifest
5. Get a link to the `full` manifest for the Human Tissue Tcell Activation project:
```
tcell_manifest = azul_client.get_project_manifest_link(catalog, tcell_act_project, 'full')
```
6. Open the `Location` URL in a browser tab to download the full manifest
7. (Optional) Generate a curl manifest to download all files from the Tcell project:
```
tcell_curl = azul_client.get_project_manifest_link(catalog, tcell_act_project, 'curl')
```
8. (Optional) Copy the `CommandLine` > `bash` curl config into a terminal window to execute file downloads (you may want to quit after a while as there is quite a lot of data).

This PR satisfies SCP-3503.