### PR TITLE
Ignore email case when checking study shares (SCP-3510)

### DIFF
--- a/test/models/study_test.rb
+++ b/test/models/study_test.rb
@@ -106,4 +106,16 @@ class StudyTest < ActiveSupport::TestCase
                       ])
     assert_equal 'species--group--study', study.default_annotation
   end
+
+  test 'should ignore email case for share checking' do
+    study = FactoryBot.create(:detached_study, name_prefix: 'Share Case Test', test_array: @@studies_to_clean)
+    share_user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    invalid_email = share_user.email.upcase
+    share = study.study_shares.build(permission: 'View', email: invalid_email)
+    share.save!
+    assert share.present?
+    assert_equal invalid_email, share.email
+    refute share.email == share_user.email
+    assert study.can_view?(share_user)
+  end
 end


### PR DESCRIPTION
When sharing studies with other Google accounts, users are asked to enter and email address and select a permission level.  When that other user receives an email notifying them of the share, they can then authenticate into SCP and view that study.  SCP will compare the email address of the current logged in account against the list of "shared" email accounts, and if there is a match, that user can view the study in question.  However, there is a corner case where the string case of the email is entered differently than what Google declares the actual account email to be (Google does not honor case or punctuation in email addresses).  For instance, sharing a study with `JohnDoe@gmail.com` will deliver an email to `johndoe@gmail.com`, but when `johndoe@gmail.com` signs in, they will not be able to view the study in question because `'JohnDoe@gmail' == 'johndoe@gmail.com'` will evaluate to `false`.

This update addresses the problem twofold: first, when comparing email addresses, all emails are downcased prior to comparison.  Secondly, whenever querying for existing shares, a case-insensitive search is run using the `/#{email}/i` regular expression.  While this is slower, the size of the `StudyShare` collection is small enough that no performance impact will be noticed.

MANUAL TESTING
1. Log into with your Broad institute email, and click 'Create a Study'
2. Give the study a name, and set `Public` to `No`
3. At the bottom, click 'Share Study', and enter a different email address (such as a personal Gmail account), but enter the email address in all capitals (e.g. `JOHNDOE@GMAIL.COM`)
4. Click 'Create Study'
5. From the upload wizard, click the "View Study" button at the top right to go to the study overview page
6. Copy the URL for this study, then sign out of your Broad account and log in with the shared user account
7. Paste the URL into the search bar and note that the study loads without error

This PR satisfies SCP-3510.