### PR TITLE
Restore local SCP speed via Sprockets 4, fix Dockerized segfault (SCP-3531)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,7 +457,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.3)
-    sprockets (3.7.2)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.2)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,7 +14,7 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 Rails.application.config.assets.precompile += %w(manifest.js *.svg *.eot *.woff *.ttf)
 
 # Fixes error thrown when calling `assets:precompile` in Dockerized environment
-# See https://broadworkbench.atlassian.net/browse/SCP-3531.
+# See https://github.com/broadinstitute/single_cell_portal_core/pull/1109.
 Rails.application.config.assets.configure do |env|
   env.export_concurrent = false
 end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,3 +12,9 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 Rails.application.config.assets.precompile += %w(manifest.js *.svg *.eot *.woff *.ttf)
+
+# Fixes error thrown when calling `assets:precompile` in Dockerized environment
+# See https://broadworkbench.atlassian.net/browse/SCP-3531.
+Rails.application.config.assets.configure do |env|
+  env.export_concurrent = false
+end


### PR DESCRIPTION
This fixes very long iteration times in local SCP instances, which affect almost all SCP engineers.  Local page load times are now back to 3-5 seconds, down from 30-180 seconds.  

### Background
In a first, [Mixpanel performance tracking for development](https://mixpanel.com/s/1o1xwL) helped diagnose this productivity bug.  `git bisect` was used to isolate the causal commit.  That commit downgraded from Sprockets 4 to Sprockets 3.7.2 to fix segfault errors on Ubuntu.  The problematic change fixed the segfault when running `assets:precompile` \[1] on Dockerized environments -- CI, staging, and production -- but caused severe slowness for  non-Dockerized environments, i.e. development.  Oddly, the slowness affected all engineers except one, who had made the change.  An affected engineer verified they shared the same Ruby environment and general local setup as the unaffected engineer.

### Changes
These changes restore local speed while avoiding segfaults in Dockerized environments.  The fix was copied from anecdotal solutions noted in the [upstream issue](https://github.com/rails/sprockets/issues/633), specifically [here](https://github.com/spree/spree/commit/d2792e820fe23e79e5e619f5139783dcdcc29853).  The mechanism is unclear but seems effective.  Over 5 runs of the triggering command (leveraging ways to rapid test [here](https://github.com/broadinstitute/single_cell_portal_core/pull/1109/commits/b5e3df0d4fc8ce114560d474dc48f9d7c1feca81) and [here](https://github.com/broadinstitute/single_cell_portal_core/pull/1109/commits/30982129c6148194be7b35d4265b92696bdd6d0e)) have been successful.

The original segfault only occurred on 10-15% of deployments.  So it's possible that these changes do not fix the segfault.  If that proves so, then team chats have decided that the cost of very slow development outweighs the cost of an extra occasional few minutes of downtime and need to manually run the full command \[1] in the production VM.

This satisfies SCP-3531.

---

1.  Full command that had triggered segfault: 
`sudo -E -u app -H bundle exec rake NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV SECRET_KEY_BASE=$SECRET_KEY_BASE assets:precompile`