### PR TITLE
Download HCA Project manifests via bulk download (SCP-3505)

### DIFF
--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -31,10 +31,10 @@ module Api
             key :required, true
           end
           parameter do
-            key :name, :hca_project_id
-            key :type, :string
+            key :name, :hca_projects
+            key :type, :object
             key :in, :body
-            key :description, 'HCA project UUID, if specified'
+            key :description, 'Hash of HCA project short names to UUIDs, if specified'
             key :required, false
           end
           response 200 do
@@ -67,7 +67,7 @@ module Api
         half_hour = 1800 # seconds
 
         totat = current_api_user.create_totat(half_hour, api_v1_bulk_download_generate_curl_config_path)
-        valid_params = params.permit({file_ids: [], tdr_files: {}, hca_project_id: ''}).to_h
+        valid_params = params.permit({file_ids: [], tdr_files: {}, hca_project_ids: {}}).to_h
 
         # for now, we don't do any permissions validation on the param values -- we'll do that during the actual download, since
         # quota/files/permissions may change between the creation of the download and the actual download.
@@ -75,7 +75,7 @@ module Api
           auth_code: totat[:totat],
           file_ids: valid_params[:file_ids],
           tdr_files: valid_params[:tdr_files],
-          hca_project_id: valid_params[:hca_project_id],
+          hca_projects: valid_params[:hca_projects],
           user_id: current_api_user.id)
         auth_code_response = {
           auth_code: totat[:totat],

--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -30,13 +30,6 @@ module Api
             key :description, 'Hash of file arrays to download from TDR, keyed by accession. Each file should specify URL and name'
             key :required, true
           end
-          parameter do
-            key :name, :hca_projects
-            key :type, :object
-            key :in, :body
-            key :description, 'Hash of HCA project short names to UUIDs, if specified'
-            key :required, false
-          end
           response 200 do
             key :description, 'One-time auth code and time interval, in seconds'
             schema do

--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -356,8 +356,7 @@ module Api
                                                                            user: current_api_user,
                                                                            study_bucket_map: bucket_map,
                                                                            output_pathname_map: pathname_map,
-                                                                           tdr_files: tdr_files,
-                                                                           hca_project_id: download_req&.hca_project_id)
+                                                                           tdr_files: tdr_files)
         end_time = Time.zone.now
         runtime = TimeDifference.between(start_time, end_time).humanize
         logger.info "Curl configs generated for studies #{valid_accessions}, #{files_requested.size + directory_files.size} total files"

--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -334,7 +334,7 @@ module Api
 
         # create maps to avoid Mongo timeouts when generating curl commands in parallel processes
         bucket_map = ::BulkDownloadService.generate_study_bucket_map(valid_accessions) if valid_accessions.any?
-        pathname_map = ::BulkDownloadService.generate_output_path_map(files_requested, directories) if files_requested.present?
+        pathname_map = ::BulkDownloadService.generate_output_path_map(files_requested, directories) if files_requested.any?
 
         # generate curl config file
         logger.info "Beginning creation of curl configuration for user_id, auth token: #{current_api_user.id}"

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -656,9 +656,9 @@ module Api
         if db_facet.is_numeric?
           match = matching_facet[:filters].dup
           match.delete(:name)
-          return match
+          match
         else
-          return matching_facet[:filters].detect { |filter| filter[:id] == search_result[result_key] }
+          matching_facet[:filters].detect { |filter| filter[:id] == search_result[result_key] }
         end
       end
 
@@ -678,9 +678,9 @@ module Api
         added_file_ids = {}
         raw_tdr_results['result'].each do |result_row|
           results = process_tdr_result_row(result_row, results,
-            selected_facets: selected_facets,
-            terms: terms,
-            added_file_ids: added_file_ids)
+                                           selected_facets: selected_facets,
+                                           terms: terms,
+                                           added_file_ids: added_file_ids)
         end
         results
       end
@@ -705,7 +705,7 @@ module Api
           file_information: [
             {
               url: row['project_id'],
-              file_type: 'Metadata',
+              file_type: 'Project Manifest',
               upload_file_size: 1.megabyte, # placeholder filesize as we don't know until manifest is downloaded
               name: "#{short_name}.tsv"
             }

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -706,7 +706,7 @@ module Api
             {
               url: row['project_id'],
               file_type: 'Metadata',
-              upload_file_size: 10.kilobytes,
+              upload_file_size: 1.megabyte, # placeholder filesize as we don't know until manifest is downloaded
               name: "#{short_name}.tsv"
             }
           ]

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -702,7 +702,14 @@ module Api
           hca_project_id: row['project_id'],
           facet_matches: [],
           term_matches: [],
-          file_information: []
+          file_information: [
+            {
+              url: row['project_id'],
+              file_type: 'Metadata',
+              upload_file_size: 10.kilobytes,
+              name: "#{short_name}.tsv"
+            }
+          ]
         }.with_indifferent_access
         result = results[short_name]
         # determine facet filter matches

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -699,7 +699,7 @@ module Api
           accession: short_name,
           name: row[name_field],
           description: row[description_field],
-          project_id: row['project_id'],
+          hca_project_id: row['project_id'],
           facet_matches: [],
           term_matches: [],
           file_information: []

--- a/app/controllers/api/v1/study_search_results_objects.rb
+++ b/app/controllers/api/v1/study_search_results_objects.rb
@@ -68,6 +68,7 @@ module Api
             description: study[:description],
             public: true,
             detached: false,
+            hca_project_id: study[:hca_project_id],
             cell_count: 0,
             gene_count: 0,
             study_url: '#',

--- a/app/javascript/components/search/controls/download/DownloadButton.js
+++ b/app/javascript/components/search/controls/download/DownloadButton.js
@@ -49,7 +49,9 @@ export default function DownloadButton({ searchResults={}, showDemoFiles=false }
     ?.map(result => ({
       accession: result.accession,
       name: result.name,
+      study_source: 'TDR',
       description: result.description,
+      hca_project_id: result.hca_project_id,
       studyFiles: showDemoFiles ? enableDemoResults(result.file_information) : result.file_information
     }))
 

--- a/app/javascript/components/search/controls/download/DownloadSelectionModal.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionModal.js
@@ -45,22 +45,22 @@ export default function DownloadSelectionModal({ studyAccessions, tdrFileInfo, s
     // pull the drs ids out of each study and put them in a single array
     // calling filter at end removes metadata file that does not have a DRS id
     const drsIds = tdrFileInfo.map(study => study.studyFiles.map(sfile => sfile.drs_id))
-      .reduce((acc, val) => acc.concat(val), []).filter(e => e != null)
+      .reduce((acc, val) => acc.concat(val), []).filter(e => e !== null)
     fetchDrsInfo(drsIds).then(result => {
       const fullTdrFileInfo = _cloneDeep(tdrFileInfo)
       // now iterate through the file info and add file sizes, urls, and file names.
       // the names and urls will be used for making the download request later
       fullTdrFileInfo.forEach(study => {
-        study.studyFiles.forEach(sfile => {
-          if (sfile.drs_id) {
-            const fileId = sfile.drs_id.split('/').slice(-1)[0]
+        study.studyFiles.forEach(studyFile => {
+          if (studyFile.drs_id) {
+            const fileId = studyFile.drs_id.split('/').slice(-1)[0]
             const matchFile = result.find(file => file.id === fileId)
             if (matchFile) {
-              sfile.upload_file_size = matchFile.size
+              studyFile.upload_file_size = matchFile.size
               // we add the url and name to each file info so that they can be sent along with the download
               // request, this allows us to avoid having to query the DRS service again
-              sfile.url = matchFile.accessMethods.find(method => method.type === 'https').access_url.url
-              sfile.name = matchFile.name
+              studyFile.url = matchFile.accessMethods.find(method => method.type === 'https').access_url.url
+              studyFile.name = matchFile.name
             }
           }
         })

--- a/app/javascript/components/search/controls/download/DownloadSelectionModal.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionModal.js
@@ -9,7 +9,7 @@ import DownloadSelectionTable, {
 
 import { fetchDownloadInfo, fetchDrsInfo } from 'lib/scp-api'
 
-const TDR_COLUMNS = ['analysis', 'sequence']
+const TDR_COLUMNS = ['metadata', 'analysis', 'sequence']
 const SCP_COLUMNS = ['matrix', 'metadata', 'cluster']
 
 /**

--- a/app/javascript/components/search/controls/download/DownloadSelectionModal.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionModal.js
@@ -43,22 +43,25 @@ export default function DownloadSelectionModal({ studyAccessions, tdrFileInfo, s
     setDownloadInfoTDR(tdrFileInfo)
     setIsLoadingTDR(false)
     // pull the drs ids out of each study and put them in a single array
+    // calling filter at end removes metadata file that does not have a DRS id
     const drsIds = tdrFileInfo.map(study => study.studyFiles.map(sfile => sfile.drs_id))
-      .reduce((acc, val) => acc.concat(val), [])
+      .reduce((acc, val) => acc.concat(val), []).filter(e => e != null)
     fetchDrsInfo(drsIds).then(result => {
       const fullTdrFileInfo = _cloneDeep(tdrFileInfo)
       // now iterate through the file info and add file sizes, urls, and file names.
       // the names and urls will be used for making the download request later
       fullTdrFileInfo.forEach(study => {
         study.studyFiles.forEach(sfile => {
-          const fileId = sfile.drs_id.split('/').slice(-1)[0]
-          const matchFile = result.find(file => file.id === fileId)
-          if (matchFile) {
-            sfile.upload_file_size = matchFile.size
-            // we add the url and name to each file info so that they can be sent along with the download
-            // request, this allows us to avoid having to query the DRS service again
-            sfile.url = matchFile.accessMethods.find(method => method.type === 'https').access_url.url
-            sfile.name = matchFile.name
+          if (sfile.drs_id) {
+            const fileId = sfile.drs_id.split('/').slice(-1)[0]
+            const matchFile = result.find(file => file.id === fileId)
+            if (matchFile) {
+              sfile.upload_file_size = matchFile.size
+              // we add the url and name to each file info so that they can be sent along with the download
+              // request, this allows us to avoid having to query the DRS service again
+              sfile.url = matchFile.accessMethods.find(method => method.type === 'https').access_url.url
+              sfile.name = matchFile.name
+            }
           }
         })
       })

--- a/app/javascript/components/search/controls/download/DownloadSelectionModal.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionModal.js
@@ -9,7 +9,7 @@ import DownloadSelectionTable, {
 
 import { fetchDownloadInfo, fetchDrsInfo } from 'lib/scp-api'
 
-const TDR_COLUMNS = ['metadata', 'analysis', 'sequence']
+const TDR_COLUMNS = ['project_manifest', 'analysis', 'sequence']
 const SCP_COLUMNS = ['matrix', 'metadata', 'cluster']
 
 /**
@@ -69,18 +69,25 @@ export default function DownloadSelectionModal({ studyAccessions, tdrFileInfo, s
     })
   }
 
+  /**
+    render bulk download table for SCP & TDR/HCA studies
+   */
+  function renderFileTables(result=[]) {
+    setSelectedBoxes(newSelectedBoxesState(result, SCP_COLUMNS))
+    setDownloadInfo(result)
+    setIsLoading(false)
+    if (showTDRSelectionPane) {
+      initializeTDRTable()
+    }
+  }
+
   useEffect(() => {
     if (show) {
       setIsLoading(true)
       setIsLoadingTDR(true)
       fetchDownloadInfo(scpAccessions).then(result => {
-        setSelectedBoxes(newSelectedBoxesState(result, SCP_COLUMNS))
-        setDownloadInfo(result)
-        setIsLoading(false)
+        renderFileTables(result)
       })
-      if (showTDRSelectionPane) {
-        initializeTDRTable()
-      }
     }
   }, [show, studyAccessions.join(',')])
 

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -180,17 +180,7 @@ const COLUMNS = {
   */
 function StudyFileCheckbox({ study, studyIndex, selectedBoxes, colType, updateSelection }) {
   const { fileCount, fileSize } = getFileStats(study, COLUMNS[colType].types)
-  if (colType === 'metadata' && study.study_source === 'TDR') {
-    return <label>
-      <input type="checkbox"
-             data-analytics-name="download-modal-checkbox"
-             onChange={e => updateSelection(e.target.checked, false, colType, studyIndex)}
-             checked={selectedBoxes.studies[studyIndex][colType]}>
-      </input>
-      &nbsp;
-      1 file (size TBD until download)
-    </label>
-  } else if (fileCount === 0) {
+  if (fileCount === 0) {
     return <span className="detail">none</span>
   }
   let sizeIndicator = null

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -68,7 +68,8 @@ export default function DownloadSelectionTable({
         </div>
       }
       {
-        !isLoading &&
+        // only render table if there are results to show
+        !isLoading && Object.keys(downloadInfo).length > 0 &&
         <table className="table table-terra">
           <thead>
             <tr>
@@ -98,6 +99,7 @@ export default function DownloadSelectionTable({
                   &nbsp;
                   <FontAwesomeIcon data-analytics-name="download-modal-column-info"
                     data-toggle="tooltip"
+                    data-container="terra-table"
                     data-original-title={COLUMNS[colType].info}
                     className="action log-click help-icon"
                     icon={faInfoCircle} />
@@ -156,6 +158,12 @@ const COLUMNS = {
     title: 'Metadata',
     types: ['Metadata'],
     info: 'The listing of all cells in the study, along with associated metadata such as species, cell type, etc.',
+    default: true
+  },
+  project_manifest: {
+    title: 'Project Manifest',
+    types: ['Project Manifest'],
+    info: 'List of available project files and associated project-level metadata.',
     default: true
   },
   analysis: {

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -180,7 +180,17 @@ const COLUMNS = {
   */
 function StudyFileCheckbox({ study, studyIndex, selectedBoxes, colType, updateSelection }) {
   const { fileCount, fileSize } = getFileStats(study, COLUMNS[colType].types)
-  if (fileCount === 0) {
+  if (colType === 'metadata' && study.study_source === 'TDR') {
+    return <label>
+      <input type="checkbox"
+             data-analytics-name="download-modal-checkbox"
+             onChange={e => updateSelection(e.target.checked, false, colType, studyIndex)}
+             checked={selectedBoxes.studies[studyIndex][colType]}>
+      </input>
+      &nbsp;
+      1 file (size TBD until download)
+    </label>
+  } else if (fileCount === 0) {
     return <span className="detail">none</span>
   }
   let sizeIndicator = null

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -270,12 +270,17 @@ export function getSelectedFileHandles(downloadInfo, selectedBoxes, hashByStudy=
   }
   const fileTypeKeys = Object.keys(selectedBoxes.all).filter(key => key !== 'all')
   downloadInfo.forEach((study, index) => {
+    if (hashByStudy) {
+      // initialize empty array for storing file handles by study accession
+      fileHandles[study.accession] = []
+    }
     fileTypeKeys.forEach(colType => {
       if (selectedBoxes.studies[index][colType]) {
         const filesOfType = study.studyFiles.filter(file => COLUMNS[colType].types.includes(file.file_type))
-        const selectedHandles = filesOfType.map(file => file.url ? { url: file.url, name: file.name } : file.id)
+        {/* eslint-disable-next-line max-len */}
+        const selectedHandles = filesOfType.map(file => file.url ? { url: file.url, name: file.name, file_type: file.file_type } : file.id)
         if (hashByStudy) {
-          fileHandles[study.accession] = selectedHandles
+          fileHandles[study.accession].push(...selectedHandles)
         } else {
           fileHandles.push(...selectedHandles)
         }

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -66,12 +66,20 @@ class BulkDownloadService
       curl_configs.concat(tdr_file_configs.flatten)
     end
     if hca_project_id.present?
-
+      hca_azul_client = ApplicationController.hca_azul_client
+      default_catalog = hca_azul_client.default_catalog
+      # get project short name to use as filename
+      hca_project = hca_azul_client.get_project(default_catalog, hca_project_id)
+      short_name = hca_project['projects'].first['projectShortname'] || hca_project_id
+      manifest_info = hca_azul_client.get_project_manifest_link(default_catalog, hca_project_id)
+      metadata_config = "url=\"#{manifest_info['Location']}\"\n"
+      metadata_config += "output=\"#{short_name}.tsv\""
+      curl_configs << metadata_config
     end
     MetricsService.log('file-download:curl-config', {
       numFiles: study_files.count,
       numStudies: studies.count,
-      studyAccesions: studies.map(&:accession),
+      studyAccessions: studies.map(&:accession),
       numTdrStudies: tdr_studies.count,
       tdrAccessions: tdr_studies,
       numTDRFiles: tdr_file_configs.count

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -22,8 +22,7 @@ class BulkDownloadService
                                        user:,
                                        study_bucket_map:,
                                        output_pathname_map:,
-                                       tdr_files: nil,
-                                       hca_project_id: nil)
+                                       tdr_files: nil)
     curl_configs = ['--create-dirs', '--compressed']
     # create an array of all objects to be downloaded, including directory files
     download_objects = study_files.to_a + directory_files
@@ -64,17 +63,6 @@ class BulkDownloadService
         end
       end
       curl_configs.concat(tdr_file_configs.flatten)
-    end
-    if hca_project_id.present?
-      hca_azul_client = ApplicationController.hca_azul_client
-      default_catalog = hca_azul_client.default_catalog
-      # get project short name to use as filename
-      hca_project = hca_azul_client.get_project(default_catalog, hca_project_id)
-      short_name = hca_project['projects'].first['projectShortname'] || hca_project_id
-      manifest_info = hca_azul_client.get_project_manifest_link(default_catalog, hca_project_id)
-      metadata_config = "url=\"#{manifest_info['Location']}\"\n"
-      metadata_config += "output=\"#{short_name}.tsv\""
-      curl_configs << metadata_config
     end
     MetricsService.log('file-download:curl-config', {
       numFiles: study_files.count,

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -59,7 +59,7 @@ class BulkDownloadService
       curl_configs << "-H \"Authorization: Bearer #{DataRepoClient.new.access_token['access_token']}\""
       tdr_file_configs = tdr_files.map do |shortname, file_infos|
         file_infos.map do |file_info|
-          if file_info['file_type'] == 'Metadata'
+          if file_info['file_type'] == 'Project Manifest'
             # generate manifest link using HCA project UUID from :url property
             manifest = hca_client.get_project_manifest_link(default_catalog, file_info['url'])
             file_config = "--location\n" # add location directive to allow following 302 redirect to manifest location
@@ -95,7 +95,7 @@ class BulkDownloadService
   #
   # * *raises*
   #   - (RuntimeError) => User download quota exceeded
-  def self.update_user_download_quota(user:, files: [], directories: [])
+  def self.update_user_download_quota(user:, files:, directories: [])
     download_quota = ApplicationController.get_download_quota
     file_bytes_requested = files.map(&:upload_file_size).compact.reduce(0, :+)
     dir_bytes_requested = directories.map(&:total_bytes).reduce(0, :+)

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -14,7 +14,7 @@ class BulkDownloadService
   #   - +study_bucket_map+ => Map of study IDs to bucket names
   #   - +output_pathname_map+ => Map of study file IDs to output pathnames
   #   - +tdr_files+ => Hash of tdr accessions to arrays of file information including name & url for each file
-  #   - +hca_project_id+ => UUID of HCA project, for generating metadata manifest (optional)
+  #
   # * *return*
   #   - (String) => String representation of signed URLs and output filepaths to pass to curl
   def self.generate_curl_configuration(study_files:,

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -62,9 +62,11 @@ class BulkDownloadService
           if file_info['file_type'] == 'Metadata'
             # generate manifest link using HCA project UUID from :url property
             manifest = hca_client.get_project_manifest_link(default_catalog, file_info['url'])
-            file_config = "url=\"#{manifest['Location']}\"\n"
+            file_config = "--location\n" # add location directive to allow following 302 redirect to manifest location
+            file_config += "url=\"#{manifest['Location']}\"\n"
           else
             file_config = "url=\"#{file_info['url']}\"\n"
+            file_config += "output=\"#{shortname}/#{file_info['name']}\""
           end
           file_config += "output=\"#{shortname}/#{file_info['name']}\""
           file_config

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -14,6 +14,7 @@ class BulkDownloadService
   #   - +study_bucket_map+ => Map of study IDs to bucket names
   #   - +output_pathname_map+ => Map of study file IDs to output pathnames
   #   - +tdr_files+ => Hash of tdr accessions to arrays of file information including name & url for each file
+  #   - +hca_project_id+ => UUID of HCA project, for generating metadata manifest (optional)
   # * *return*
   #   - (String) => String representation of signed URLs and output filepaths to pass to curl
   def self.generate_curl_configuration(study_files:,
@@ -21,7 +22,8 @@ class BulkDownloadService
                                        user:,
                                        study_bucket_map:,
                                        output_pathname_map:,
-                                       tdr_files: nil)
+                                       tdr_files: nil,
+                                       hca_project_id: nil)
     curl_configs = ['--create-dirs', '--compressed']
     # create an array of all objects to be downloaded, including directory files
     download_objects = study_files.to_a + directory_files
@@ -62,6 +64,9 @@ class BulkDownloadService
         end
       end
       curl_configs.concat(tdr_file_configs.flatten)
+    end
+    if hca_project_id.present?
+
     end
     MetricsService.log('file-download:curl-config', {
       numFiles: study_files.count,

--- a/app/models/download_request.rb
+++ b/app/models/download_request.rb
@@ -8,7 +8,5 @@ class DownloadRequest
   field :auth_code, type: String
   field :file_ids # Mongo ids of study files to download
   field :tdr_files, type: Hash, default: {} # Hash of TDR project shortnames to arrays of access urls
-  # Hash of HCA project shortnames to UUIDs of HCA projects for requesting metadata manifests
-  field :hca_projects, type: Hash, default: {}
   field :user_id # User making the request
 end

--- a/app/models/download_request.rb
+++ b/app/models/download_request.rb
@@ -8,5 +8,6 @@ class DownloadRequest
   field :auth_code, type: String
   field :file_ids # Mongo ids of study files to download
   field :tdr_files, type: Hash, default: {} # Hash of TDR project shortnames to arrays of access urls
+  field :hca_project_id, type: String # UUID of HCA project, for requesting metadata manifest file
   field :user_id # User making the request
 end

--- a/app/models/download_request.rb
+++ b/app/models/download_request.rb
@@ -8,6 +8,7 @@ class DownloadRequest
   field :auth_code, type: String
   field :file_ids # Mongo ids of study files to download
   field :tdr_files, type: Hash, default: {} # Hash of TDR project shortnames to arrays of access urls
-  field :hca_project_id, type: String # UUID of HCA project, for requesting metadata manifest file
+  # Hash of HCA project shortnames to UUIDs of HCA projects for requesting metadata manifests
+  field :hca_projects, type: Hash, default: {}
   field :user_id # User making the request
 end

--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -1,6 +1,6 @@
 # Query Human Cell Atlas Azul service for metadata associated with both experimental and analysis data
 # No ServiceAccountManager or GoogleServiceClient includes as all requests are unauthenticated for public data
-class HcaAzulClient < Struct.new(:api_root)
+class HcaAzulClient < Struct.new(:api_root, :default_catalog)
   include ApiHelpers
 
   GOOGLE_SCOPES = %w[openid email profile].freeze
@@ -25,6 +25,8 @@ class HcaAzulClient < Struct.new(:api_root)
   #   - +HcaAzulClient+ object
   def initialize
     self.api_root = BASE_URL
+    catalogs = get_catalogs
+    self.default_catalog = catalogs['default_catalog']
   end
 
   ##

--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -189,13 +189,21 @@ class HcaAzulClient < Struct.new(:api_root, :default_catalog)
       # fall back to HCA_CATALOGS
       is_valid = HCA_CATALOGS.include? catalog
     end
-    raise ArgumentError, "#{catalog} is not a valid catalog: #{HCA_CATALOGS.join(',')}" unless is_valid
+    unless is_valid
+      error = ArgumentError.new("#{catalog} is not a valid catalog: #{HCA_CATALOGS.join(',')}")
+      api_method = caller_locations.first.label
+      ErrorTracker.report_exception(error, nil, { catalog: catalog, method: api_method })
+      raise error
+    end
   end
 
   # validate requested format is valid
   def validate_manifest_format(format)
     unless MANIFEST_FORMATS.include?(format)
-      raise ArgumentError, "#{format} is not a valid format: #{MANIFEST_FORMATS.join(',')}"
+      error = ArgumentError.new("#{format} is not a valid format: #{MANIFEST_FORMATS.join(',')}")
+      api_method = caller_locations.first.label
+      ErrorTracker.report_exception(error, nil, { format: format, method: api_method })
+      raise error
     end
   end
 end

--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -9,8 +9,8 @@ class HcaAzulClient < Struct.new(:api_root)
   # maximum wait time for manifest generation
   MAX_MANIFEST_TIMEOUT = 30.seconds.freeze
 
-  # list of available HCA catalogs
-  HCA_CATALOGS = %w[dcp1 dcp7 it1 it7 it0lungmap lungmap].freeze
+  # list of available public HCA catalogs (used as fallback)
+  HCA_CATALOGS = %w[dcp1 dcp7 lungmap].freeze
 
   # List of accepted formats for manifest files
   MANIFEST_FORMATS = %w[compact full terra.bdbag terra.pfb curl].freeze
@@ -101,7 +101,40 @@ class HcaAzulClient < Struct.new(:api_root)
   # * *returns*
   #   - (Hash) => Available catalogs, including :default_catalog
   def get_catalogs
-    path = self.api_root + '/index/catalogs'
+    path = "#{api_root}/index/catalogs"
+    process_api_request(:get, path)
+  end
+
+  # get a list of all available projects
+  #
+  # * *params*
+  #   - +catalog+ (String) => HCA catalog name, from HCA_CATALOGS
+  #
+  # * *returns*
+  #   - (Hash) => Available projects
+  #
+  # * *raises*
+  #   - (ArgumentError) => if catalog is not in HCA_CATALOGS or format is not in MANIFEST_FORMATS
+  def get_projects(catalog)
+    validate_catalog_name(catalog)
+    path = "#{api_root}/index/projects"
+    process_api_request(:get, path)
+  end
+
+  # get a list of all available catalogs
+  #
+  # * *params*
+  #   - +catalog+ (String) => HCA catalog name, from HCA_CATALOGS
+  #   - +project_id+ (String) => UUID of HCA project
+  #
+  # * *returns*
+  #   - (Hash) => Available catalogs, including :default_catalog
+  #
+  # * *raises*
+  #   - (ArgumentError) => if catalog is not in HCA_CATALOGS
+  def get_project(catalog, project_id)
+    validate_catalog_name(catalog)
+    path = "#{api_root}/index/projects/#{project_id}?catalog=#{catalog}"
     process_api_request(:get, path)
   end
 
@@ -118,14 +151,10 @@ class HcaAzulClient < Struct.new(:api_root)
   # * *raises*
   #   - (ArgumentError) => if catalog is not in HCA_CATALOGS or format is not in MANIFEST_FORMATS
   def get_project_manifest_link(catalog, project_id, format = 'compact')
-    unless HCA_CATALOGS.include?(catalog)
-      raise ArgumentError, "#{catalog} is not a valid catalog: #{HCA_CATALOGS.join(',')}"
-    end
-    unless MANIFEST_FORMATS.include?(format)
-      raise ArgumentError, "#{format} is not a valid format: #{MANIFEST_FORMATS.join(',')}"
-    end
+    validate_catalog_name(catalog)
+    validate_manifest_format(format)
 
-    path = self.api_root + "/fetch/manifest/files?catalog=#{catalog}"
+    path = "#{api_root}/fetch/manifest/files?catalog=#{catalog}"
     project_filter = { 'projectId' => { 'is' => [project_id] } }
     filter_query = format_hash_as_query_string(project_filter)
     path += "&filters=#{filter_query}&format=#{format}"
@@ -143,5 +172,28 @@ class HcaAzulClient < Struct.new(:api_root)
       manifest_info = process_api_request(:get, path)
     end
     manifest_info
+  end
+
+  private
+
+  # validate that a catalog exists by checking the list of available public catalogs
+  def validate_catalog_name(catalog)
+    is_valid = true
+    begin
+      all_catalogs = get_catalogs['catalogs']
+      public_catalogs = all_catalogs.reject { |_, catalog_detail| catalog_detail['internal'] }.keys
+      is_valid = public_catalogs.include? catalog
+    rescue RestClient::Exception
+      # fall back to HCA_CATALOGS
+      is_valid = HCA_CATALOGS.include? catalog
+    end
+    raise ArgumentError, "#{catalog} is not a valid catalog: #{HCA_CATALOGS.join(',')}" unless is_valid
+  end
+
+  # validate requested format is valid
+  def validate_manifest_format(format)
+    unless MANIFEST_FORMATS.include?(format)
+      raise ArgumentError, "#{format} is not a valid format: #{MANIFEST_FORMATS.join(',')}"
+    end
   end
 end

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -19,8 +19,8 @@ class HcaAzulClientTest < ActiveSupport::TestCase
   test 'should get catalogs' do
     catalogs = @hca_azul_client.get_catalogs
     default_catalog = catalogs['default_catalog']
-    all_catalogs = catalogs['catalogs'].keys
-    assert_equal HcaAzulClient::HCA_CATALOGS.sort, all_catalogs.sort
+    public_catalogs = catalogs['catalogs'].reject { |_, catalog| catalog['internal'] }.keys
+    assert_equal HcaAzulClient::HCA_CATALOGS.sort, public_catalogs.sort
     assert HcaAzulClient::HCA_CATALOGS.include? default_catalog
   end
 
@@ -32,7 +32,7 @@ class HcaAzulClientTest < ActiveSupport::TestCase
 
   test 'should get one project' do
     project = @hca_azul_client.get_project(@default_catalog, @project_id)
-    assert_equal @project_id, project['projectId']
+    assert_equal @project_id, project['entryId']
     project_detail = project['projects'].first
     assert_equal @project_short_name, project_detail['projectShortname']
   end

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -14,8 +14,16 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     assert_equal HcaAzulClient::BASE_URL, client.api_root
   end
 
+  test 'should get catalogs' do
+    catalogs = @hca_azul_client.get_catalogs
+    default_catalog = catalogs['default_catalog']
+    all_catalogs = catalogs['catalogs'].keys
+    assert_equal HcaAzulClient::HCA_CATALOGS.sort, all_catalogs.sort
+    assert HcaAzulClient::HCA_CATALOGS.include? default_catalog
+  end
+
   test 'should get HCA metadata tsv link' do
-    manifest_info = @hca_azul_client.get_project_manifest_link('dcp6', @project_id)
+    manifest_info = @hca_azul_client.get_project_manifest_link('dcp7', @project_id)
     assert manifest_info.present?
     assert_equal 302, manifest_info['Status']
     # make GET on manifest URL and assert contents are HCA metadata

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -7,6 +7,8 @@ class HcaAzulClientTest < ActiveSupport::TestCase
   before(:all) do
     @hca_azul_client = ApplicationController.hca_azul_client
     @project_id = 'c1a9a93d-d9de-4e65-9619-a9cec1052eaa'
+    @project_short_name = 'PulmonaryFibrosisGSE135893'
+    @default_catalog = @hca_azul_client.get_catalogs['default_catalog'] || 'dcp7'
   end
 
   test 'should instantiate client' do
@@ -22,8 +24,21 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     assert HcaAzulClient::HCA_CATALOGS.include? default_catalog
   end
 
+  test 'should get projects' do
+    projects = @hca_azul_client.get_projects(@default_catalog)
+    assert projects.keys.sort == %w[hits pagination termFacets]
+    assert projects['hits'].any?
+  end
+
+  test 'should get one project' do
+    project = @hca_azul_client.get_project(@default_catalog, @project_id)
+    assert_equal @project_id, project['projectId']
+    project_detail = project['projects'].first
+    assert_equal @project_short_name, project_detail['projectShortname']
+  end
+
   test 'should get HCA metadata tsv link' do
-    manifest_info = @hca_azul_client.get_project_manifest_link('dcp7', @project_id)
+    manifest_info = @hca_azul_client.get_project_manifest_link(@default_catalog, @project_id)
     assert manifest_info.present?
     assert_equal 302, manifest_info['Status']
     # make GET on manifest URL and assert contents are HCA metadata


### PR DESCRIPTION
This update allows downloading of project manifest files from the HCA Azul service during bulk download requests.  These files manifests contain project-level metadata about all analysis/sequence/supplemental files associated with a given HCA project, including file provenance and access methods.  Since these are all public HCA files, the access URLs contained in the file manifest are all valid, and can be pasted into any browser to download the files directly (in case the user does not already download them through the bulk download UX).

This update also fixes an issue in the `BulkDownloadServiceTest` where the test `should get requested file sizes by query` was not asserting anything other than the expected outputs being declared.  The test has been rewritten to perform a strict equality comparison of method outputs against a known good structure.

MANUAL TESTING

1. Boot the portal and sign in with an account that has the `cross_dataset_search_backend` feature flag to `true`
2. Execute a keyword search for `pulmonary`
3. Once the Pulmonary Fibrosis study loads, click the "Download" button
4. Click "Next" (or optionally, wait for the "Sequence" column to finish updating and select all sequence files to download)
5. Click the copy icon once the `curl` command loads
6. Paste the `curl` command into a terminal window to download the data
7. Once the download completes, open the `PulmonaryFibrosisGSE135893.tsv` file and validate that it has project data in it

This PR satisfies SCP-3505.