### PR TITLE
Add the badges for TDR results for facet matching (SCP-3473)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -294,9 +294,9 @@ module Api
         # perform TDR search, if enabled, and there are facets/terms provided by user
         if User.feature_flag_for_instance(current_api_user, 'cross_dataset_search_backend') && (@facets.present? || @term_list.present?)
           @tdr_results = self.class.get_tdr_results(selected_facets: @facets, terms: @term_list)
-          
+
           if @facets.present?
-            simple_tdr_results = self.class.simplify_TDR_facet_search_results(@tdr_results, @facets)
+            simple_tdr_results = self.class.simplify_tdr_facet_search_results(@tdr_results, @facets)
             matched_tdr_studies = self.class.match_studies_by_facet(simple_tdr_results, @facets)
             
             if @studies_by_facet.present?
@@ -309,9 +309,7 @@ module Api
           logger.info "Found #{@tdr_results.keys.size} results in Terra Data Repo"
           logger.info pp @tdr_results if @tdr_results.any?
           @tdr_results.each do |short_name, tdr_result|
-              if tdr_result[:accession] != nil
-                @studies << tdr_result
-              end
+              @studies << tdr_result
           end
         end
 
@@ -636,20 +634,18 @@ module Api
       def self.simplify_tdr_facet_search_results(query_results, search_facets)
         simple_TDR_result = {}
         simple_TDR_results = []
-        query_results.each do |result|
-          unless result[0].nil?
-            result_details = result[1]
-            accession = result_details[:accession]
-            facet_matches = result_details[:facet_matches]
-            simple_TDR_result[:study_accession] = accession
-            if facet_matches.present?
-              facet_matches[0].each_pair { |key, val| 
-              short_name_field = FacetNameConverter.convert_to_scp(key, :name)
-              simple_TDR_result[short_name_field] = val
+        query_results.each_pair do |accession, result|
+          facet_matches = result[:facet_matches]
+          simple_TDR_result[:study_accession] = accession
+          if facet_matches.present?
+            facet_matches.each { |mapping| 
+              mapping.each_pair { |key, val| 
+                short_name_field = FacetNameConverter.convert_to_model(:tim, :alex, key, :name)
+                simple_TDR_result[short_name_field] = val
               }
-            end
+            }
           end
-          simple_TDR_results.append(simple_TDR_result)
+          simple_TDR_results << simple_TDR_result
         end
         simple_TDR_results
       end
@@ -793,9 +789,8 @@ module Api
         else
           matches = []
           facet[:filters].each do |filter|
-            # look for match on the column name, and see which filter value also matched (ontology label or id)
-            matches << result_row.each_pair.select { |col, val| col == tdr_name && (val == filter[:name] || filter[:id]) }
-                                 .flatten
+            matches << result_row.each_pair.select { |col, val| col == tdr_name && (val == filter[:name] || val == filter[:id] ) }
+                                 .flatten                                 
           end
         end
         matches

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -630,7 +630,7 @@ module Api
         matches
       end
 
-      # Simplify TDR results to be mappable for the UI badges for facet search
+      # Simplify TDR results to be mappable for the UI badges for faceted search
       def self.simplify_tdr_facet_search_results(query_results, search_facets)
         simple_TDR_result = {}
         simple_TDR_results = []

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -296,7 +296,7 @@ module Api
           @tdr_results = self.class.get_tdr_results(selected_facets: @facets, terms: @term_list)
           
           if (@facets.present?)
-            simple_tdr_results = self.class.simplify_TDR_facet_search_results(@tdr_results, @facets)
+            simple_tdr_results = self.class.simplify_tdr_facet_search_results(@tdr_results, @facets)
             matched_tdr_studies = self.class.match_studies_by_facet(simple_tdr_results, @facets)
             
             if @studies_by_facet.present?
@@ -633,7 +633,7 @@ module Api
       end
 
       # Simplify TDR results to be mappable for the UI badges for facet search
-      def self.simplify_TDR_facet_search_results(query_results, search_facets)
+      def self.simplify_tdr_facet_search_results(query_results, search_facets)
         simple_TDR_result = {}
         simple_TDR_results = []
         query_results.each do |result|

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -638,9 +638,9 @@ module Api
         simple_TDR_results = []
         query_results.each do |result|
           unless result[0].nil?
-            result_for_real = result[1]
-            accession = result_for_real[:accession]
-            facet_matches = result_for_real[:facet_matches]
+            result_details = result[1]
+            accession = result_details[:accession]
+            facet_matches = result_details[:facet_matches]
             simple_TDR_result[:study_accession] = accession
             if facet_matches.present?
               facet_matches[0].each_pair { |key, val| 

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -309,7 +309,7 @@ module Api
           logger.info "Found #{@tdr_results.keys.size} results in Terra Data Repo"
           logger.info pp @tdr_results if @tdr_results.any?
           @tdr_results.each do |short_name, tdr_result|
-              @studies << tdr_result
+            @studies << tdr_result
           end
         end
 
@@ -793,6 +793,7 @@ module Api
                                  .flatten                                 
           end
         end
+        matches.reject! { |key, value| key.blank? || value.blank? }
         matches
       end
 

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -213,22 +213,6 @@ module Api
           @studies = @viewable
         end
 
-        #prune out nil studies
-        # @studies.each do |study|
-        #   puts "study: #{study}"
-        # end
-
-        # @studies = @studies.where.not(accession: nil)
-        # stt = @studies.where.not(:accession.in => [nil])
-
-        # puts "studi styyt: #{@studies}" 
-
-        # puts "styyt: #{stt}"
-
-        # suttu = @studies.select { |k,v| k == :accession && v == nil}
-         
-        # puts "Studies fter filter: #{suttu}"
-
         # only call BigQuery if list of possible studies is larger than 0 and we have matching facets to use
         if @studies.count > 0 && @facets.any?
           # puts "studies at begining of the facet matching: #{@studies}"
@@ -238,16 +222,8 @@ module Api
           logger.info "Searching BigQuery using facet-based query: #{@big_query_search}"
           query_results = ApplicationController.big_query_client.dataset(CellMetadatum::BIGQUERY_DATASET).query @big_query_search
           job_id = query_results.job_gapi.job_reference.job_id
-          # build up map of study matches by facet & filter value (for adding labels in UI)
-
-          # first need to do the re-map here before passing results to be matched
-          # @temp_studies_by_facet = 
-
-
           @studies_by_facet = self.class.match_studies_by_facet(query_results, @facets)
-          puts "HERE: #{@studies_by_facet}" 
-          # result: {:study_accession=>"SCP14", :species=>"NCBITaxon_9606"}
-          #   "facet_matches"=>[{"TerraCore:hasOrganismType"=>"Homo sapiens"}],
+
           # uniquify result list as one study may match multiple facets/filters
           @convention_accessions = query_results.map {|match| match[:study_accession]}.uniq
           logger.info "Found #{@convention_accessions.count} matching studies from BQ job #{job_id}: #{@convention_accessions}"
@@ -319,34 +295,26 @@ module Api
         # perform TDR search, if enabled, and there are facets/terms provided by user
         if User.feature_flag_for_instance(current_api_user, 'cross_dataset_search_backend') && (@facets.present? || @term_list.present?)
           @tdr_results = self.class.get_tdr_results(selected_facets: @facets, terms: @term_list)
-          puts "@facets.present? : #{@facets.present?}"
-          facets_studies = @studies_by_facet
-
+          
           if (@facets.present?)
-            # puts "perform the TDR sarch: #{@tdr_results}"
-
             simple_tdr_results = self.class.simplify_TDR_facet_search_results(@tdr_results, @facets)
-
-            # puts "@simple_tdr_results: #{@simple_tdr_results}"
-            studys_frim_tdr = self.class.match_studies_by_facet(simple_tdr_results, @facets)
-            # puts "studys_frim_tdr: #{@studys_frim_tdr}"
-            @studies_by_facet = facets_studies.merge(studys_frim_tdr)
-            # puts "HERE2: #{@studies_by_facet}" 
+            studys_from_tdr = self.class.match_studies_by_facet(simple_tdr_results, @facets)
+            
+            // TODO
+            if @studies_by_facet.present?
+              @studies_by_facet = @studies_by_facet.merge(studys_from_tdr)
+            else
+              @studies_by_facet = studys_from_tdr
+            end
           end
-
-          # result: ["PulmonaryFibrosisGSE135893", {"tdr_result"=>true, "accession"=>"PulmonaryFibrosisGSE135893", "name"=>"Single-cell RNA-sequencing reveals profibrotic roles of distinct epithelial and mesenchymal lineages in pulmonary fibrosis", "description"=>"Pulmonary fibrosis (PF) is a form of chronic lung disease characterized by progressive destruction of normal alveolar gas-exchange surfaces and accumulation of extracellular matrix (ECM). In order to comprehensively define the cell types, mechanisms and mediators driving ECM deposition and fibrotic remodeling in lungs with pulmonary fibrosis, we performed single-cell RNA-sequencing (scRNA-seq) of single-cell suspensions generated from non-fibrotic control and PF lungs. Analysis of over 114,000 cells from 20 PF and 10 control lungs identified 31 distinct cell types. We identified multiple distinct lineages directly contribute to ECM expansion, including a novel HAS1hi fibroblast subtype and a previously undescribed KRT5-/KRT17+, collagen and ECM-producing epithelial cell population that was highly enriched in PF lungs. Together these data provide high-resolution insights into the basic mechanisms of pulmonary fibrosis, and indicate a direct profibrotic role of the lung epithelium in PF pathogenesis. Overall design: We performed single-cell RNA-sequencing (scRNA-seq) of single-cell suspensions generated from non-fibrotic control and pulmonary fibrosis (PF) lungs", "facet_matches"=>[{"TerraCore:hasOrganismType"=>"Homo sapiens"}], "term_matches"=>[], "file_information"=>[]}]
-          #   "facet_matches"=>[{"TerraCore:hasOrganismType"=>"Homo sapiens"}],
           # just log for now
           logger.info "Found #{@tdr_results.keys.size} results in Terra Data Repo"
           logger.info pp @tdr_results if @tdr_results.any?
           @tdr_results.each do |short_name, tdr_result|
-            # puts "tdr_result in do : #{tdr_result}"
-            # puts "short_name in do : #{tdr_result}"
               if tdr_result[:accession] != nil
                 @studies << tdr_result
               end
           end
-          # puts "studies after supposed to add TDR results #{@studies}" 
         end
 
         @matching_accessions = @studies.map {|study| study.is_a?(Study) ? study.accession : study[:accession]}
@@ -650,19 +618,14 @@ module Api
 
       # build a match of studies to facets/filters used in search (for labeling studies in UI with matches)
       def self.match_studies_by_facet(query_results, search_facets)
-        # puts "Queryresults: #{query_results}"
-        # puts "search_facets: #{search_facets}"
         matches = {}
         query_results.each do |result|
-          # puts "result: #{result}"
           accession = result[:study_accession]
-          # puts "accession: #{accession}"
           matches[accession] ||= {facet_search_weight: 0}
           result.keys.keep_if { |key| key != :study_accession }.each do |key|
             facet_name = key.to_s.chomp('_val')
             matching_filter = match_results_by_filter(search_result: result, result_key: key, facets: search_facets)
             # there may not be a matching filter if the facet was OR'ed
-            # puts "matching_filter: #{matching_filter}"
             if matching_filter
               matches[accession][facet_name] ||= []
               if !matches[accession][facet_name].include?(matching_filter)
@@ -672,39 +635,23 @@ module Api
             end
           end
         end
-        # puts "matches:' #{matches}"
         matches
       end
 
       # Simplify TDR results to be mappable for the UI badges for facet search
       def self.simplify_TDR_facet_search_results(query_results, search_facets)
-        # puts "Queryresults: #{query_results}"
-        # puts "search_facets: #{search_facets}"
         simple_TDR_result = {}
         simple_TDR_results = []
         query_results.each do |result|
           unless result[0].nil?
-            # puts "result: #{result}"
             result_for_real = result[1]
-            # puts "result_for_real, #{result_for_real}"
             accession = result_for_real[:accession]
-            # puts "accession: #{accession}"
             facet_matches = result_for_real[:facet_matches]
-            # puts "facet_mathces: #{facet_matches}"
             simple_TDR_result[:study_accession] = accession
-            # simple_TDR_result[study_accession] = accession
-
             if facet_matches.present?
               facet_matches[0].each_pair {|key, val| 
-                puts "key : #{key}" 
-                puts "val : #{val}" 
-
               short_name_field = FacetNameConverter.convert_to_scp(key, :name)
-                # puts "short_name_field #{short_name_field}"
               simple_TDR_result[short_name_field] = val
-              #  puts "simple_TDR_result: #{simple_TDR_result}"
-              #result: {:study_accession=>"SCP14", :species=>"NCBITaxon_9606"}
-              #  simple_TDR_result: {:study_accession=>"PulmonaryFibrosisGSE135893", :short_name_field=>"Homo sapiens"}
               }
             end
           end
@@ -746,20 +693,13 @@ module Api
       # build a map of facet filter matches to studies for computing simplistic weights for scoring
       def self.match_results_by_filter(search_result:, result_key:, facets:)
         facet_name = result_key.to_s.chomp('_val')
-        # puts "inside match_results_by_filter facet_name: , #{facet_name}"
-        # puts "facets: #{facets}"
         matching_facet = facets.detect { |facet| facet[:id] == facet_name }
-        # puts "inside match_results_by_filter matching_facet: , #{matching_facet}"
         db_facet = matching_facet[:db_facet]
-        # puts "inside match_results_by_filter db_facet: , #{db_facet}"
         if db_facet.is_numeric?
           match = matching_facet[:filters].dup
           match.delete(:name)
           return match
         else
-          # puts "matching_facet[:filters] #{matching_facet[:filters]}"
-          # puts "filter[:id]: #{filter[:id]}"
-          # puts "earch_result[result_key]: #{search_result[result_key]}"
           return matching_facet[:filters].detect { |filter| filter[:id] == search_result[result_key] || filter[:name] == search_result[result_key]}
         end
       end
@@ -799,22 +739,9 @@ module Api
       # added_file_ids is a hash to ensure the same file is not added multiple times -- this method will
       # handle adding to and checking it.
       def self.process_tdr_result_row(row, results, selected_facets:, terms:, added_file_ids:)
-        # get column name mappings for assembling results
-        # console.log('tim:', :tim)
-        # console.log('accession:', :accession)
-        # console.log('name:', :name)
-        
         short_name_field = FacetNameConverter.convert_to_model(:tim, :accession, :name)
-        # console.log('result is a shortname field:', short_name_field)
         name_field = FacetNameConverter.convert_to_model(:tim, :study_name, :name)
-        # console.log('study_name:', :study_name)
-        # console.log('result is a name_field field:', name_field)
-        
-
         description_field = FacetNameConverter.convert_to_model(:tim, :study_description, :name)
-        # console.log('study_description:', :study_description)
-        # console.log('result is a description_field field:', description_field)
-
         short_name = row[short_name_field]
         results[short_name] ||= {
           tdr_result: true, # identify this entry as coming from Data Repo
@@ -863,18 +790,12 @@ module Api
 
       # determine facet matches for an individual result row from TDR
       def self.get_facet_match_for_tdr_result(facet, result_row)
-        # puts "tdrtim: #{:tim}"
-        # puts "tdrid: #{facet[:id]}"
-        # puts "tdrnamebefore: #{:name}"
-
         tdr_name = FacetNameConverter.convert_to_model(:tim, facet[:id], :name)
-        puts "tdrname final: #{tdr_name}"
         if facet[:filters].is_a? Hash
           # this is a numeric facet, so convert to range for match
           # TODO: determine correct unit/datatype and convert
           filter_value = "#{facet.dig(:filters, :min).to_i}-#{facet.dig(:filters, :max).to_i}"
           matches = result_row.each_pair.select { |col, val| col == tdr_name && val == filter_value }
-          puts "matches in if: #{matches}"
         else
           matches = []
           facet[:filters].each do |filter|
@@ -882,7 +803,6 @@ module Api
             matches << result_row.each_pair.select { |col, val| col == tdr_name && (val == filter[:name] || filter[:id]) }
                                  .flatten
           end
-          puts "matches in else: #{matches}"
         end
         matches
       end

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -299,7 +299,6 @@ module Api
             simple_tdr_results = self.class.simplify_TDR_facet_search_results(@tdr_results, @facets)
             studys_from_tdr = self.class.match_studies_by_facet(simple_tdr_results, @facets)
             
-            // TODO
             if @studies_by_facet.present?
               @studies_by_facet = @studies_by_facet.merge(studys_from_tdr)
             else

--- a/app/controllers/api/v1/study_search_results_objects.rb
+++ b/app/controllers/api/v1/study_search_results_objects.rb
@@ -40,7 +40,6 @@ module Api
           if @studies_by_facet.present?
             # faceted search was run, so append filter matches
             puts "studies_by_facet: #{@studies_by_facet}"
-              #studies_by_facet: {"SCP14"=>{:facet_search_weight=>1, "species"=>[{"id"=>"NCBITaxon_9606", "name"=>"Homo sapiens"}]}}
             study_obj[:facet_matches] = @studies_by_facet[study.accession]
           end
           if params[:terms].present?
@@ -63,8 +62,6 @@ module Api
             study_obj[:can_visualize_clusters] = study.can_visualize_clusters?
           end
         else
-          # puts "studies_by_facet in else: #{@studies_by_facet}"
-          # puts "@studies_by_facet[:accession]: #{study[:accession]}"
           study_obj = {
             study_source: 'TDR',
             accession: study[:accession],
@@ -77,14 +74,12 @@ module Api
             study_url: '#',
             file_information: study[:file_information],
             term_matches: @term_list,
-            # facet_matches: @studies_by_facet[study[:accession]]
           }
           if @studies_by_facet.present?
             # faceted search was run, so append filter matches
             study_obj[:facet_matches] = @studies_by_facet[study[:accession]]
           end
         end
-        # puts "study_obj: #{study_obj}"
         study_obj
       end
     end

--- a/app/controllers/api/v1/study_search_results_objects.rb
+++ b/app/controllers/api/v1/study_search_results_objects.rb
@@ -39,7 +39,6 @@ module Api
           }
           if @studies_by_facet.present?
             # faceted search was run, so append filter matches
-            puts "studies_by_facet: #{@studies_by_facet}"
             study_obj[:facet_matches] = @studies_by_facet[study.accession]
           end
           if params[:terms].present?
@@ -73,7 +72,7 @@ module Api
             gene_count: 0,
             study_url: '#',
             file_information: study[:file_information],
-            term_matches: @term_list,
+            term_matches: @term_list
           }
           if @studies_by_facet.present?
             # faceted search was run, so append filter matches

--- a/app/controllers/api/v1/study_search_results_objects.rb
+++ b/app/controllers/api/v1/study_search_results_objects.rb
@@ -39,6 +39,8 @@ module Api
           }
           if @studies_by_facet.present?
             # faceted search was run, so append filter matches
+            puts "studies_by_facet: #{@studies_by_facet}"
+              #studies_by_facet: {"SCP14"=>{:facet_search_weight=>1, "species"=>[{"id"=>"NCBITaxon_9606", "name"=>"Homo sapiens"}]}}
             study_obj[:facet_matches] = @studies_by_facet[study.accession]
           end
           if params[:terms].present?
@@ -61,6 +63,8 @@ module Api
             study_obj[:can_visualize_clusters] = study.can_visualize_clusters?
           end
         else
+          # puts "studies_by_facet in else: #{@studies_by_facet}"
+          # puts "@studies_by_facet[:accession]: #{study[:accession]}"
           study_obj = {
             study_source: 'TDR',
             accession: study[:accession],
@@ -72,9 +76,15 @@ module Api
             gene_count: 0,
             study_url: '#',
             file_information: study[:file_information],
-            term_matches: @term_list
+            term_matches: @term_list,
+            # facet_matches: @studies_by_facet[study[:accession]]
           }
+          if @studies_by_facet.present?
+            # faceted search was run, so append filter matches
+            study_obj[:facet_matches] = @studies_by_facet[study[:accession]]
+          end
         end
+        # puts "study_obj: #{study_obj}"
         study_obj
       end
     end

--- a/app/javascript/components/search/results/StudySearchResult.js
+++ b/app/javascript/components/search/results/StudySearchResult.js
@@ -102,7 +102,6 @@ export function stripTags(rawString) {
 /* generate a badge for each matched facet, containing the filter names */
 function facetMatchBadges(study) {
   const matches = study.facet_matches
-
   if (!matches) {
     return <></>
   }
@@ -164,26 +163,22 @@ export default function StudySearchResult({ study }) {
   const studyDescription = formatDescription(study.description, termMatches)
   const displayStudyTitle = { __html: studyTitle }
 
-  if (!study.accession) {
-    return
-  } else {
-    return (
-      <>
-        <div key={study.accession}>
-          <label htmlFor={study.name} id="result-title" className="study-label">
-            {study.study_source === 'SCP' ? <a href={study.study_url} dangerouslySetInnerHTML={displayStudyTitle} ></a> :
-              <span dangerouslySetInnerHTML={displayStudyTitle} />
-            }
-            {inferredBadge(study, termMatches)}
-          </label>
-          <div>
-            {cellCountBadge(study)}
-            {studyTypeBadge(study)}
-            {facetMatchBadges(study)}
-          </div>
-          {studyDescription}
+  return (
+    <>
+      <div key={study.accession}>
+        <label htmlFor={study.name} id="result-title" className="study-label">
+          {study.study_source === 'SCP' ? <a href={study.study_url} dangerouslySetInnerHTML={displayStudyTitle} ></a> :
+            <span dangerouslySetInnerHTML={displayStudyTitle} />
+          }
+          {inferredBadge(study, termMatches)}
+        </label>
+        <div>
+          {cellCountBadge(study)}
+          {studyTypeBadge(study)}
+          {facetMatchBadges(study)}
         </div>
-      </>
-    )
-  }
+        {studyDescription}
+      </div>
+    </>
+  )
 }

--- a/app/javascript/components/search/results/StudySearchResult.js
+++ b/app/javascript/components/search/results/StudySearchResult.js
@@ -101,7 +101,10 @@ export function stripTags(rawString) {
 
 /* generate a badge for each matched facet, containing the filter names */
 function facetMatchBadges(study) {
+  console.log('inside the facetbade match:', study)
   const matches = study.facet_matches
+  console.log('matches:', matches)
+
   if (!matches) {
     return <></>
   }
@@ -163,22 +166,29 @@ export default function StudySearchResult({ study }) {
   const studyDescription = formatDescription(study.description, termMatches)
   const displayStudyTitle = { __html: studyTitle }
 
-  return (
-    <>
-      <div key={study.accession}>
-        <label htmlFor={study.name} id="result-title" className="study-label">
-          {study.study_source === 'SCP' ? <a href={study.study_url} dangerouslySetInnerHTML={displayStudyTitle} ></a> :
-            <span dangerouslySetInnerHTML={displayStudyTitle} />
-          }
-          {inferredBadge(study, termMatches)}
-        </label>
-        <div>
-          {cellCountBadge(study)}
-          {facetMatchBadges(study)}
-          {studyTypeBadge(study)}
+  console.log('study:', study)
+
+  if (!study.accession) {
+    console.log("accession was: ", study.accession)
+    return
+  } else {
+    return (
+      <>
+        <div key={study.accession}>
+          <label htmlFor={study.name} id="result-title" className="study-label">
+            {study.study_source === 'SCP' ? <a href={study.study_url} dangerouslySetInnerHTML={displayStudyTitle} ></a> :
+              <span dangerouslySetInnerHTML={displayStudyTitle} />
+            }
+            {inferredBadge(study, termMatches)}
+          </label>
+          <div>
+            {cellCountBadge(study)}
+            {studyTypeBadge(study)}
+            {facetMatchBadges(study)}
+          </div>
+          {studyDescription}
         </div>
-        {studyDescription}
-      </div>
-    </>
-  )
+      </>
+    )
+  }
 }

--- a/app/javascript/components/search/results/StudySearchResult.js
+++ b/app/javascript/components/search/results/StudySearchResult.js
@@ -101,9 +101,7 @@ export function stripTags(rawString) {
 
 /* generate a badge for each matched facet, containing the filter names */
 function facetMatchBadges(study) {
-  console.log('inside the facetbade match:', study)
   const matches = study.facet_matches
-  console.log('matches:', matches)
 
   if (!matches) {
     return <></>
@@ -166,10 +164,7 @@ export default function StudySearchResult({ study }) {
   const studyDescription = formatDescription(study.description, termMatches)
   const displayStudyTitle = { __html: studyTitle }
 
-  console.log('study:', study)
-
   if (!study.accession) {
-    console.log("accession was: ", study.accession)
     return
   } else {
     return (

--- a/app/javascript/styles/_resultsPanel.scss
+++ b/app/javascript/styles/_resultsPanel.scss
@@ -135,6 +135,7 @@
   color: #777;
   min-width: 44px;
   height: 20px;
+  margin-right: 0.5em;
 }
 
 .study-label {

--- a/lib/facet_name_converter.rb
+++ b/lib/facet_name_converter.rb
@@ -1,9 +1,9 @@
-# class for converting from alexandria convention names to HCA or TIM metadata model names (i.e. columns, not individual values)
+# class for converting from Alexandria convention names to HCA or TIM metadata model names (i.e. columns, not individual values)
 # this is currently for PoC work on XDSS - eventually this will be replaced by an onotology server that can handle
 # conversions programmatically
 # entries have a :name (column name in query results for facet matching) and :id (ElasticSearch encoded property name)
 class FacetNameConverter
-  # map of alexandria metadata convention names to HCA 'short' names
+  # map of Alexandria metadata convention names to HCA 'short' names
   ALEXANDRIA_TO_HCA = {
     biosample_id: { name: 'biosample_id', id: 'biosample_id' },
     cell_type: { name: 'cell_type', id: 'cell_type' },
@@ -19,7 +19,7 @@ class FacetNameConverter
     accession: {name: 'project_short_name', id: 'project_short_name'}
   }.freeze
 
-  # map of alexandria metadata convention names to namespace Terra Interoperability Model (TIM) names
+  # map of Alexandria metadata convention names to namespace Terra Interoperability Model (TIM) names
   ALEXANDRIA_TO_TIM = {
     biosample_id: { name: 'dct:identifier', id: 'tim__a__terraa__corec__a__bioa__samplep__dctc__identifier' },
     donor_id: { name: 'prov:wasDerivedFrom', id: 'tim__a__terraa__corec__a__bioa__sampleprovc__wasa__deriveda__from' },
@@ -34,6 +34,17 @@ class FacetNameConverter
     accession: { name: 'rdfs:label', id: 'tim__rdfsc__label'}
   }.freeze
 
+
+  # map of Terra Interoperability Model (TIM) metadata convention names to Alexandria metadata convention names
+  TIM_TO_ALEXANDRIA = {
+    'TerraCore:hasOrganismType': {name: 'species'},
+    'dct:title': { name: 'study_name' },
+    'dct:description': { name: 'study_description'},
+    'rdfs:label': { name: 'accession'}
+  }.freeze
+  
+  # matches in else: [["TerraCore:hasOrganismType", "Homo sapiens"]]
+
   # convert from SCP metadata names to Terra Interoperability Model or HCA short names
   #
   # * *params*
@@ -45,6 +56,24 @@ class FacetNameConverter
   #   - (String) => String value of requested column/property
   def self.convert_to_model(model_name, column_name, property)
     mappings = model_name.to_sym == :hca ? ALEXANDRIA_TO_HCA : ALEXANDRIA_TO_TIM
+    # perform lookup, but fall back to provided column name if no match is found
+    mappings[column_name.to_sym]&.dig(property.to_sym) || column_name
+  end
+
+
+
+    # convert from SCP metadata names to Terra Interoperability Model or HCA short names
+  #
+  # * *params*
+  #   - +model_name+ (String, Symbol) => Name of schema to convert to (:hca or :tim)
+  #   - +column_name+ (String, Symbol) => facet name to convert
+  #   - +property+ (String, Symbol) => property to return (:id or :name only)
+  #
+  # * *returns*
+  #   - (String) => String value of requested column/property
+  def self.convert_to_scp(column_name, property)
+    mappings = TIM_TO_ALEXANDRIA
+    puts "column_name: #{column_name}"
     # perform lookup, but fall back to provided column name if no match is found
     mappings[column_name.to_sym]&.dig(property.to_sym) || column_name
   end

--- a/lib/facet_name_converter.rb
+++ b/lib/facet_name_converter.rb
@@ -37,13 +37,19 @@ class FacetNameConverter
 
   # map of Terra Interoperability Model (TIM) metadata convention names to Alexandria metadata convention names
   TIM_TO_ALEXANDRIA = {
+    'dct:identifier': { name: 'biosample_id' },
+    'prov:wasDerivedFrom': { name: 'donor_id' },
+    'TerraCore:hasDisease': { name: 'disease'},
+    'TerraCore:hasLibraryPrep': { name: 'library_preparation_protocol'},
+    'TerraCore:hasAnatomicalSite': { name: 'organ'},
+    'organism_age': { name: 'organism_age'},
+    'TerraCore:hasSex': { name: 'sex'},
     'TerraCore:hasOrganismType': {name: 'species'},
     'dct:title': { name: 'study_name' },
     'dct:description': { name: 'study_description'},
     'rdfs:label': { name: 'accession'}
   }.freeze
   
-  # matches in else: [["TerraCore:hasOrganismType", "Homo sapiens"]]
 
   # convert from SCP metadata names to Terra Interoperability Model or HCA short names
   #
@@ -62,10 +68,9 @@ class FacetNameConverter
 
 
 
-    # convert from SCP metadata names to Terra Interoperability Model or HCA short names
+  # convert from Terra Interoperability Model to SCP metadata names 
   #
   # * *params*
-  #   - +model_name+ (String, Symbol) => Name of schema to convert to (:hca or :tim)
   #   - +column_name+ (String, Symbol) => facet name to convert
   #   - +property+ (String, Symbol) => property to return (:id or :name only)
   #
@@ -73,8 +78,6 @@ class FacetNameConverter
   #   - (String) => String value of requested column/property
   def self.convert_to_scp(column_name, property)
     mappings = TIM_TO_ALEXANDRIA
-    puts "column_name: #{column_name}"
-    # perform lookup, but fall back to provided column name if no match is found
     mappings[column_name.to_sym]&.dig(property.to_sym) || column_name
   end
 end

--- a/lib/facet_name_converter.rb
+++ b/lib/facet_name_converter.rb
@@ -60,24 +60,13 @@ class FacetNameConverter
   #
   # * *returns*
   #   - (String) => String value of requested column/property
-  def self.convert_to_model(model_name, column_name, property)
-    mappings = model_name.to_sym == :hca ? ALEXANDRIA_TO_HCA : ALEXANDRIA_TO_TIM
+  def self.convert_to_model(source_model = :alex, target_model, column_name, property)
+    if source_model.to_sym == :tim
+      mappings = TIM_TO_ALEXANDRIA
+    else
+      mappings = target_model.to_sym == :hca ? ALEXANDRIA_TO_HCA : ALEXANDRIA_TO_TIM
+    end
     # perform lookup, but fall back to provided column name if no match is found
-    mappings[column_name.to_sym]&.dig(property.to_sym) || column_name
-  end
-
-
-
-  # convert from Terra Interoperability Model to SCP metadata names 
-  #
-  # * *params*
-  #   - +column_name+ (String, Symbol) => facet name to convert
-  #   - +property+ (String, Symbol) => property to return (:id or :name only)
-  #
-  # * *returns*
-  #   - (String) => String value of requested column/property
-  def self.convert_to_scp(column_name, property)
-    mappings = TIM_TO_ALEXANDRIA
     mappings[column_name.to_sym]&.dig(property.to_sym) || column_name
   end
 end


### PR DESCRIPTION
This adds the facet matching badge for TDR results in the study search.

To Test locally:
Try searching for a study using the facet "homo sapien" and you should see the TDR result with the badge same as any SCP study 

Search on both keyword and facet matching:
<img width="1191" alt="Screen Shot 2021-07-30 at 12 30 49 PM" src="https://user-images.githubusercontent.com/54322292/127872863-9fd43d1e-c04b-4c50-afa9-4ab6c1a6f719.png">

Hovering tooltip on TDR:
<img width="311" alt="Screen Shot 2021-07-30 at 12 30 56 PM" src="https://user-images.githubusercontent.com/54322292/127872864-8351fed7-0ed3-461f-ba81-751b8039c400.png">

Just Facet match:
<img width="804" alt="Screen Shot 2021-07-30 at 12 31 08 PM" src="https://user-images.githubusercontent.com/54322292/127872865-5d16b03d-8810-4ee9-9428-25804d3e019f.png">

Just keyword match still works as usual
<img width="911" alt="Screen Shot 2021-07-30 at 12 31 22 PM" src="https://user-images.githubusercontent.com/54322292/127872866-4935f6a0-7ea6-46a6-a089-80d2d6a2dd90.png">
