### PR TITLE
Backend work to support requiring raw counts matrices (SCP-3535)

### DIFF
--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -14,11 +14,11 @@ class ExpressionFileInfo
 
   # note that species and reference genome/annotation live at the study_file level, not here
 
-  UNITS_VALUES = ['UMI-corrected raw counts', 'raw counts']
-  validates :units, inclusion: {in: UNITS_VALUES}, allow_blank: true
+  UNITS_VALUES = ['UMI-corrected raw counts', 'raw counts'].freeze
+  validates :units, inclusion: { in: UNITS_VALUES }, allow_blank: true
 
-  BIOSAMPLE_INPUT_TYPE_VALUES = ['Whole cell', 'Single nuclei', 'Bulk']
-  validates :biosample_input_type, inclusion: {in: BIOSAMPLE_INPUT_TYPE_VALUES}
+  BIOSAMPLE_INPUT_TYPE_VALUES = ['Whole cell', 'Single nuclei', 'Bulk'].freeze
+  validates :biosample_input_type, inclusion: { in: BIOSAMPLE_INPUT_TYPE_VALUES }
 
   MODALITY_VALUES = [
     'Transcriptomic: unbiased',
@@ -29,14 +29,14 @@ class ExpressionFileInfo
     'Epigenomic: DNA chromatin accessibility',
     'Epigenomic: DNA methylation',
     'Proteomic'
-  ]
-  validates :modality, inclusion: {in: MODALITY_VALUES}
+  ].freeze
+  validates :modality, inclusion: { in: MODALITY_VALUES }
 
-  LIBRARY_PREPARATION_VALUES = ['10x 3\' v1',
-                                '10x 3\' v2',
-                                '10x 3\' v3',
-                                '10x 5\' v2',
-                                '10x 5\' v3',
+  LIBRARY_PREPARATION_VALUES = ["10x 3' v1",
+                                "10x 3' v2",
+                                "10x 3' v3",
+                                "10x 5' v2",
+                                "10x 5' v3",
                                 'CEL-seq2',
                                 'Drop-seq',
                                 'inDrop',
@@ -65,8 +65,8 @@ class ExpressionFileInfo
                                 'smFISH',
                                 'STARmap', # Note WIP for EFO term: https://broadinstitute.zendesk.com/agent/tickets/139334
                                 # single cell ChIP-seq assays
-                                'Drop-ChIP']
-  validates :library_preparation_protocol, inclusion: {in: LIBRARY_PREPARATION_VALUES}
+                                'Drop-ChIP'].freeze
+  validates :library_preparation_protocol, inclusion: { in: LIBRARY_PREPARATION_VALUES }
 
   validate :unset_units_unless_raw_counts
   validate :enforce_units_on_raw_counts
@@ -108,7 +108,7 @@ class ExpressionFileInfo
 
     # next check for exemption
     raw_counts_required = study_file.study.associated_users(permission: 'Edit').map do |user|
-      User.feature_flag_for_instance(user, 'raw_counts_required_backed')
+      User.feature_flag_for_instance(user, 'raw_counts_required_backend')
     end.uniq
     # if any user account returned false for :raw_counts_required_backed, then allow saving of expression matrix
     # otherwise, add validation error for :raw_counts_associations

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -76,7 +76,7 @@ class ExpressionFileInfo
 
   # remove invalid StudyFile ids, as well as nil/empty string values
   def sanitize_raw_counts_associations
-    invalid_ids = raw_counts_associations.map { |study_file_id| StudyFile.find(study_file_id).nil? }
+    invalid_ids = raw_counts_associations.select { |study_file_id| StudyFile.find(study_file_id).nil? }
     raw_counts_associations.reject! { |study_file_id| study_file_id.blank? || invalid_ids.include?(study_file_id) }
   end
 

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -874,7 +874,7 @@ class Study
   def associated_users(permission: nil)
     owner = self.user
     shares = permission.present? ? self.study_shares.where(permission: permission) : self.study_shares
-    share_users = shares.map { |share| User.find_by(email: share.email) }.compact
+    share_users = shares.map { |share| User.find_by(email: /#{share.email}/i) }.compact
     [owner] + share_users
   end
 

--- a/db/migrate/20210802150514_add_raw_counts_required_backend_feature_flag.rb
+++ b/db/migrate/20210802150514_add_raw_counts_required_backend_feature_flag.rb
@@ -1,0 +1,20 @@
+class AddRawCountsRequiredBackendFeatureFlag < Mongoid::Migration
+  # mirror of FeatureFlag.rb, so this migration won't error if that class is renamed/altered
+  class FeatureFlagMigrator
+    include Mongoid::Document
+    store_in collection: 'feature_flags'
+    field :name, type: String
+    field :default_value, type: Boolean, default: false
+    field :description, type: String
+  end
+
+  def self.up
+    FeatureFlagMigrator.create!(name: 'raw_counts_required_backend',
+                                default_value: false,
+                                description: 'require users to add raw expression matrices ahead of processed matrices')
+  end
+
+  def self.down
+    FeatureFlagMigrator.find_by(name: 'raw_counts_required_backend').destroy
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -224,8 +224,11 @@ BrandingGroup.create!(name: 'Test Brand', user_id: api_user.id, font_family: 'He
 # Preset search seeds
 PresetSearch.create!(name: 'Test Search', search_terms: ["Testing Study"],
                      facet_filters: ['species:NCBITaxon_9606', 'disease:MONDO_0000001'], accession_list: %w(SCP1))
+
+# Feature flag seeds
 FeatureFlag.create!(name: 'faceted_search')
 FeatureFlag.create!(name: 'convention_required', default_value: false)
+FeatureFlag.create!(name: 'raw_counts_required_backend', default_value: false)
 
 # seed BQ for search controller test
 begin


### PR DESCRIPTION
This update adds necessary functionality to support requiring raw counts expression matrix files for all users.  Once completed, this new functionality will prompt users to add their raw counts expression matrix files before processed ones.  Functionality included in this update:

1. Feature flag to govern backend behavior for raw counts (`raw_counts_required_backend`)
2. Model field to store associations on processed matrix files pointing back to raw matrix files (`expression_file_info.raw_counts_associations`)
3. Database validations to prevent adding processed matrix files w/o raw associations (`expression_file_info.enforce_raw_counts_associations`)
4. Getters for traversing relationship between expression matrices in a study (`StudyFile#associated_matrix_files`)

Note: none of this new functionality is enabled by default.  Once work commences on SCP-3492, the necessary checks for feature flags can be put into place (to do so now would prevent adding matrix files w/o any way of setting associations, which would block all expression matrix uploads).  As such, this PR is somewhat small, whereas work on SCP-3492 will be much more expansive, and contain backend hooks to check for FFs.

MANUAL TESTING
As none of this functionality is yet hooked into application logic, testing is somewhat difficult.  However, it can be validated in the Rails console using one of the synthetic raw counts studies:

1. Pull this branch, and run all pending database migrations to create the `raw_counts_required_backend` FeatureFlag:
```
./rails_local_setup.rb && source config/secrets/.source_env.bash && bin/rails db:migrate
``` 
2. Enter the Rails console, and set the default value of the FF to `true`:
```
bin/rails c
flag = FeatureFlag.find_by(name: 'raw_counts_required_backend')
flag.update(default_value: true)
```
3. Load either the human or chicken raw counts study, along with both expression matrix files (you may have to ingest one via SyntheticStudyPopulator):
```
study = Study.find_by(name: 'Chicken raw counts')
raw = study.expression_matrix_files.first
processed = study.expression_matrix_files.last
```
4. Add an `expression_file_info` nested document to the processed matrix with the following values:
```
processed.build_expression_file_info(library_preparation_protocol: "Smart-seq2/Fluidigm C1", biosample_input_type: "Single nuclei", modality: "Transcriptomic: targeted", is_raw_counts: false)
```
5. Show that the file is not valid and cannot be saved:
```
processed.valid?
=> false
```
6. Manually add the association, show the file is now valid, and that we can traverse the relationship back to the raw matrix:
```
processed.expression_file_info.raw_counts_associations = [raw.id.to_s]
processed.valid?
=> true
processed.associated_matrix_files(:raw).first.upload_file_name
=> "raw2_chicken_40_cells_4_genes.raw_dense.txt"
```
7. (Optional) Test the FeatureFlag by adding the exemption to the correct account:
```
user = study.user
user.feature_flags['raw_counts_required_backend'] = false
user.save!
```
8. (Optional) Manually unset the association, but show processed file is still valid:
```
processed.expression_file_info.raw_counts_associations = []
processed.valid?
=> true
```
9. (Optional) Clean up:
```
user.feature_flags.delete('raw_counts_required_backend')
user.save!
flag.update(default_value: false)
```

This PR satisfies SCP-3535.