### PR TITLE
Fixing query syntax for TDR results (SCP-3544)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -640,7 +640,7 @@ module Api
           if facet_matches.present?
             facet_matches.each do |mapping|
               mapping.each do |key, val|
-                facet_name = FacetNameConverter.convert_to_model(:tim, :alexandria, key)
+                facet_name = FacetNameConverter.convert_schema_column(:tim, :alexandria, key)
                 simple_TDR_result[facet_name] = val
               end
             end
@@ -730,9 +730,9 @@ module Api
       # handle adding to and checking it.
       def self.process_tdr_result_row(row, results, selected_facets:, terms:, added_file_ids:)
         # get column name mappings for assembling results
-        short_name_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :accession)
-        name_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :study_name)
-        description_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :study_description)
+        short_name_field = FacetNameConverter.convert_schema_column(:alexandria, :tim, :accession)
+        name_field = FacetNameConverter.convert_schema_column(:alexandria, :tim, :study_name)
+        description_field = FacetNameConverter.convert_schema_column(:alexandria, :tim, :study_description)
         short_name = row[short_name_field]
         results[short_name] ||= {
           tdr_result: true, # identify this entry as coming from Data Repo
@@ -780,7 +780,7 @@ module Api
 
       # determine facet matches for an individual result row from TDR
       def self.get_facet_match_for_tdr_result(facet, result_row)
-        tdr_name = FacetNameConverter.convert_to_model(:alexandria, :tim, facet[:id])
+        tdr_name = FacetNameConverter.convert_schema_column(:alexandria, :tim, facet[:id])
         if facet[:filters].is_a? Hash
           # this is a numeric facet, so convert to range for match
           # TODO: determine correct unit/datatype and convert
@@ -799,8 +799,8 @@ module Api
 
       # determine term/keyword match for an individual result row from TDR
       def self.get_term_match_for_tdr_result(term, result_row)
-        name_field = FacetNameConverter.convert_to_model(:tim, :alexandria, :study_name)
-        description_field = FacetNameConverter.convert_to_model(:tim, :alexandria, :study_description)
+        name_field = FacetNameConverter.convert_schema_column(:tim, :alexandria, :study_name)
+        description_field = FacetNameConverter.convert_schema_column(:tim, :alexandria, :study_description)
         matches = []
         [name_field, description_field].each do |tdr_name|
           result_row.each_pair do |col, val|

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -298,7 +298,7 @@ module Api
           if @facets.present?
             simple_tdr_results = self.class.simplify_tdr_facet_search_results(@tdr_results, @facets)
             matched_tdr_studies = self.class.match_studies_by_facet(simple_tdr_results, @facets)
-            
+
             if @studies_by_facet.present?
               @studies_by_facet.merge!(matched_tdr_studies)
             else
@@ -638,12 +638,12 @@ module Api
           facet_matches = result[:facet_matches]
           simple_TDR_result[:study_accession] = accession
           if facet_matches.present?
-            facet_matches.each { |mapping| 
-              mapping.each_pair { |key, val| 
-                short_name_field = FacetNameConverter.convert_to_model(:tim, :alex, key, :name)
-                simple_TDR_result[short_name_field] = val
-              }
-            }
+            facet_matches.each do |mapping|
+              mapping.each do |key, val|
+                facet_name = FacetNameConverter.convert_to_model(:tim, :alexandria, key)
+                simple_TDR_result[facet_name] = val
+              end
+            end
           end
           simple_TDR_results << simple_TDR_result
         end
@@ -730,9 +730,9 @@ module Api
       # handle adding to and checking it.
       def self.process_tdr_result_row(row, results, selected_facets:, terms:, added_file_ids:)
         # get column name mappings for assembling results
-        short_name_field = FacetNameConverter.convert_to_model(:tim, :accession, :name)
-        name_field = FacetNameConverter.convert_to_model(:tim, :study_name, :name)
-        description_field = FacetNameConverter.convert_to_model(:tim, :study_description, :name)
+        short_name_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :accession)
+        name_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :study_name)
+        description_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :study_description)
         short_name = row[short_name_field]
         results[short_name] ||= {
           tdr_result: true, # identify this entry as coming from Data Repo
@@ -780,7 +780,7 @@ module Api
 
       # determine facet matches for an individual result row from TDR
       def self.get_facet_match_for_tdr_result(facet, result_row)
-        tdr_name = FacetNameConverter.convert_to_model(:tim, facet[:id], :name)
+        tdr_name = FacetNameConverter.convert_to_model(:alexandria, :tim, facet[:id])
         if facet[:filters].is_a? Hash
           # this is a numeric facet, so convert to range for match
           # TODO: determine correct unit/datatype and convert
@@ -790,7 +790,7 @@ module Api
           matches = []
           facet[:filters].each do |filter|
             matches << result_row.each_pair.select { |col, val| col == tdr_name && (val == filter[:name] || val == filter[:id] ) }
-                                 .flatten                                 
+                                 .flatten
           end
         end
         matches.reject! { |key, value| key.blank? || value.blank? }
@@ -799,8 +799,8 @@ module Api
 
       # determine term/keyword match for an individual result row from TDR
       def self.get_term_match_for_tdr_result(term, result_row)
-        name_field = FacetNameConverter.convert_to_model(:tim, :study_name, :name)
-        description_field = FacetNameConverter.convert_to_model(:tim, :study_description, :name)
+        name_field = FacetNameConverter.convert_to_model(:tim, :alexandria, :study_name)
+        description_field = FacetNameConverter.convert_to_model(:tim, :alexandria, :study_description)
         matches = []
         [name_field, description_field].each do |tdr_name|
           result_row.each_pair do |col, val|

--- a/app/models/data_repo_client.rb
+++ b/app/models/data_repo_client.rb
@@ -270,17 +270,17 @@ class DataRepoClient < Struct.new(:access_token, :api_root, :storage, :expires_a
     selected_facets.each do |search_facet|
       facet_id = search_facet[:id]
       # convert to names used in TDR, or fall back to SCP name if not found
-      tdr_column = FacetNameConverter.convert_to_model(:tim, facet_id, :id) || facet_id
+      tdr_column = FacetNameConverter.convert_to_model(:alexandria, :tim, facet_id) || facet_id
       if search_facet[:filters].is_a? Hash # this is a numeric facet w/ min/max/unit
         # cast to integer for matching; TODO: determine correct unit/datatype and convert
         filters = ["#{search_facet.dig(:filters, :min).to_i}-#{search_facet.dig(:filters, :max).to_i}"]
       else
         filters = search_facet[:filters].map(&:values).flatten
       end
-      elements = filters.map {|filter| "#{tdr_column}:#{filter}" }
-      formatted_elements << "(#{elements.join(' OR ')})"
+      elements = filters.map {|filter| "([#{tdr_column}]:\"#{filter}\")" }
+      formatted_elements << "#{elements.join(' OR ')}"
     end
-    {query_string: {query: formatted_elements.join(' AND ')}}
+    { query_string: { query: formatted_elements.join(' AND ') } }
   end
 
   # generate query json from a list of keywords/terms to search titles/descriptions
@@ -291,15 +291,15 @@ class DataRepoClient < Struct.new(:access_token, :api_root, :storage, :expires_a
   # * *returns*
   #   - (Hash) => Hash representation of query in ElasticSearch query DSL (must be cast to JSON for use in DataRepoClient#query_snapshot_indexes)
   def generate_query_from_keywords(term_list)
-    name_field = FacetNameConverter.convert_to_model(:tim, :study_name, :id)
-    desc_field = FacetNameConverter.convert_to_model(:tim, :study_description, :id)
+    name_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :study_name)
+    desc_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :study_description)
     formatted_elements = []
     [name_field, desc_field].each do |tdr_column|
-      elements = term_list.map {|term| "#{tdr_column}:#{term}"}
+      elements = term_list.map { |term| "[#{tdr_column}]:\"#{term}\"" }
       formatted_elements << "(#{elements.join(' OR ')})"
     end
     # this is a logical OR query as a match in either name or description is valid
-    {query_string: {query: formatted_elements.join(' OR ')}}
+    { query_string: { query: formatted_elements.join(' OR ') } }
   end
 
   # merge two query json objects together, if necessary

--- a/app/models/data_repo_client.rb
+++ b/app/models/data_repo_client.rb
@@ -270,7 +270,7 @@ class DataRepoClient < Struct.new(:access_token, :api_root, :storage, :expires_a
     selected_facets.each do |search_facet|
       facet_id = search_facet[:id]
       # convert to names used in TDR, or fall back to SCP name if not found
-      tdr_column = FacetNameConverter.convert_to_model(:alexandria, :tim, facet_id) || facet_id
+      tdr_column = FacetNameConverter.convert_schema_column(:alexandria, :tim, facet_id) || facet_id
       if search_facet[:filters].is_a? Hash # this is a numeric facet w/ min/max/unit
         # cast to integer for matching; TODO: determine correct unit/datatype and convert
         filters = ["#{search_facet.dig(:filters, :min).to_i}-#{search_facet.dig(:filters, :max).to_i}"]
@@ -291,8 +291,8 @@ class DataRepoClient < Struct.new(:access_token, :api_root, :storage, :expires_a
   # * *returns*
   #   - (Hash) => Hash representation of query in ElasticSearch query DSL (must be cast to JSON for use in DataRepoClient#query_snapshot_indexes)
   def generate_query_from_keywords(term_list)
-    name_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :study_name)
-    desc_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :study_description)
+    name_field = FacetNameConverter.convert_schema_column(:alexandria, :tim, :study_name)
+    desc_field = FacetNameConverter.convert_schema_column(:alexandria, :tim, :study_description)
     formatted_elements = []
     [name_field, desc_field].each do |tdr_column|
       elements = term_list.map { |term| "[#{tdr_column}]:\"#{term}\"" }

--- a/lib/facet_name_converter.rb
+++ b/lib/facet_name_converter.rb
@@ -1,72 +1,54 @@
 # class for converting from Alexandria convention names to HCA or TIM metadata model names (i.e. columns, not individual values)
 # this is currently for PoC work on XDSS - eventually this will be replaced by an onotology server that can handle
 # conversions programmatically
-# entries have a :name (column name in query results for facet matching) and :id (ElasticSearch encoded property name)
 class FacetNameConverter
   # map of Alexandria metadata convention names to HCA 'short' names
   ALEXANDRIA_TO_HCA = {
-    biosample_id: { name: 'biosample_id', id: 'biosample_id' },
-    cell_type: { name: 'cell_type', id: 'cell_type' },
-    donor_id: { name: 'donor_id', id: 'donor_id' },
-    disease: { name: 'disease', id: 'disease' },
-    library_preparation_protocol: {name: 'library_construction_method', id: 'library_construction_method' },
-    organ: { name: 'organ', id: 'organ' },
-    organism_age: { name: 'organism_age', id: 'organism_age' },
-    sex: { name: 'sex', id: 'sex' },
-    species: { name: 'genus_species', id: 'genus_species' },
-    study_name: { name: 'project_title', id: 'project_title' },
-    study_description: { name: 'project_description', id: 'project_description' },
-    accession: {name: 'project_short_name', id: 'project_short_name'}
-  }.freeze
+    'biosample_id' => 'biosample_id',
+    'cell_type' => 'cell_type',
+    'donor_id' => 'donor_id',
+    'disease' => 'disease',
+    'library_preparation_protocol' => 'library_construction_method',
+    'organ' => 'organ',
+    'organism_age' => 'organism_age',
+    'sex' => 'sex',
+    'species' => 'genus_species',
+    'study_name' => 'project_title',
+    'study_description' => 'project_description',
+    'accession' => 'project_short_name'
+  }.with_indifferent_access.freeze
 
   # map of Alexandria metadata convention names to namespace Terra Interoperability Model (TIM) names
   ALEXANDRIA_TO_TIM = {
-    biosample_id: { name: 'dct:identifier', id: 'tim__a__terraa__corec__a__bioa__samplep__dctc__identifier' },
-    donor_id: { name: 'prov:wasDerivedFrom', id: 'tim__a__terraa__corec__a__bioa__sampleprovc__wasa__deriveda__from' },
-    disease: { name: 'TerraCore:hasDisease', id: 'tim__a__terraa__corec__a__bioa__samplea__terraa__corec__c__hasa__disease' },
-    library_preparation_protocol: { name: 'TerraCore:hasLibraryPrep', id: 'tim__a__terraa__corec__a__bioa__samplea__terraa__corec__hasa__librarya__prep' },
-    organ: { name: 'TerraCore:hasAnatomicalSite', id: 'tim__a__terraa__corec__a__bioa__samplea__terraa__corec__hasa__anatomicala__site' },
-    organism_age: { name: 'organism_age', id: 'organism_age' },
-    sex: { name: 'TerraCore:hasSex', id: 'tim__a__terraa__corec__a__donora__terraa__corec__hasa__sex' },
-    species: { name: 'TerraCore:hasOrganismType', id: 'tim__a__terraa__corec__a__donora__terraa__corec__hasa__organisma__type' },
-    study_name: { name: 'dct:title', id: 'tim__dctc__title' },
-    study_description: { name: 'dct:description', id: 'tim__dctc__description' },
-    accession: { name: 'rdfs:label', id: 'tim__rdfsc__label'}
-  }.freeze
+    'biosample_id' => 'dct:identifier',
+    'donor_id' => 'prov:wasDerivedFrom',
+    'disease' => 'TerraCore:hasDisease',
+    'library_preparation_protocol' => 'TerraCore:hasLibraryPrep',
+    'organ' => 'TerraCore:hasAnatomicalSite',
+    'organism_age' => 'organism_age',
+    'sex' => 'TerraCore:hasSex',
+    'species' => 'TerraCore:hasOrganismType',
+    'study_name' => 'dct:title',
+    'study_description' => 'dct:description',
+    'accession' => 'rdfs:label'
+  }.with_indifferent_access.freeze
 
+  # inverted mappings of TIM/HCA to Alexandria
+  TIM_TO_ALEXANDRIA = ALEXANDRIA_TO_TIM.invert.freeze
+  HCA_TO_ALEXANDRIA = ALEXANDRIA_TO_HCA.invert.freeze
 
-  # map of Terra Interoperability Model (TIM) metadata convention names to Alexandria metadata convention names
-  TIM_TO_ALEXANDRIA = {
-    'dct:identifier': { name: 'biosample_id' },
-    'prov:wasDerivedFrom': { name: 'donor_id' },
-    'TerraCore:hasDisease': { name: 'disease'},
-    'TerraCore:hasLibraryPrep': { name: 'library_preparation_protocol'},
-    'TerraCore:hasAnatomicalSite': { name: 'organ'},
-    'organism_age': { name: 'organism_age'},
-    'TerraCore:hasSex': { name: 'sex'},
-    'TerraCore:hasOrganismType': {name: 'species'},
-    'dct:title': { name: 'study_name' },
-    'dct:description': { name: 'study_description'},
-    'rdfs:label': { name: 'accession'}
-  }.freeze
-  
-
-  # convert from SCP metadata names to Terra Interoperability Model or HCA short names
+  # convert column name from one metadata schema to another
   #
   # * *params*
-  #   - +model_name+ (String, Symbol) => Name of schema to convert to (:hca or :tim)
+  #   - +source_model+ (String, Symbol) => Name of schema to convert from (:alexandria, :hca or :tim)
+  #   - +target_name+ (String, Symbol) => Name of schema to convert to (:alexandria, :hca or :tim)
   #   - +column_name+ (String, Symbol) => facet name to convert
-  #   - +property+ (String, Symbol) => property to return (:id or :name only)
   #
   # * *returns*
   #   - (String) => String value of requested column/property
-  def self.convert_to_model(source_model = :alex, target_model, column_name, property)
-    if source_model.to_sym == :tim
-      mappings = TIM_TO_ALEXANDRIA
-    else
-      mappings = target_model.to_sym == :hca ? ALEXANDRIA_TO_HCA : ALEXANDRIA_TO_TIM
-    end
+  def self.convert_to_model(source_model = :alexandria, target_model, column_name)
+    mappings = "FacetNameConverter::#{source_model.upcase}_TO_#{target_model.upcase}".constantize
     # perform lookup, but fall back to provided column name if no match is found
-    mappings[column_name.to_sym]&.dig(property.to_sym) || column_name
+    mappings[column_name.to_sym] || column_name
   end
 end

--- a/lib/facet_name_converter.rb
+++ b/lib/facet_name_converter.rb
@@ -1,4 +1,4 @@
-# class for converting from Alexandria convention names to HCA or TIM metadata model names (i.e. columns, not individual values)
+# class for converting from Alexandria convention names to HCA or TIM metadata model names (i.e. columns, not  values)
 # this is currently for PoC work on XDSS - eventually this will be replaced by an onotology server that can handle
 # conversions programmatically
 class FacetNameConverter
@@ -37,17 +37,18 @@ class FacetNameConverter
   TIM_TO_ALEXANDRIA = ALEXANDRIA_TO_TIM.invert.freeze
   HCA_TO_ALEXANDRIA = ALEXANDRIA_TO_HCA.invert.freeze
 
-  # convert column name from one metadata schema to another
+  # convert a metadata schema column name from one schema to another
+  # e.g. FacetNameConverter.convert_schema_column(:alexandria, :tim, 'species') => 'TerraCore:hasOrganismType'
   #
   # * *params*
-  #   - +source_model+ (String, Symbol) => Name of schema to convert from (:alexandria, :hca or :tim)
-  #   - +target_name+ (String, Symbol) => Name of schema to convert to (:alexandria, :hca or :tim)
-  #   - +column_name+ (String, Symbol) => facet name to convert
+  #   - +source_schema+ (String, Symbol) => Name of schema to convert from (:alexandria, :hca or :tim)
+  #   - +target_schema+ (String, Symbol) => Name of schema to convert to (:alexandria, :hca or :tim)
+  #   - +column_name+ (String, Symbol) => column name to convert from source_schema
   #
   # * *returns*
   #   - (String) => String value of requested column/property
-  def self.convert_to_model(source_model = :alexandria, target_model, column_name)
-    map_name = "FacetNameConverter::#{source_model.upcase}_TO_#{target_model.upcase}"
+  def self.convert_schema_column(source_schema = :alexandria, target_schema, column_name)
+    map_name = "FacetNameConverter::#{source_schema.upcase}_TO_#{target_schema.upcase}"
     if Object.const_defined? map_name
       # perform lookup, but fall back to provided column name if no match is found
       mappings = map_name.constantize

--- a/lib/facet_name_converter.rb
+++ b/lib/facet_name_converter.rb
@@ -2,6 +2,9 @@
 # this is currently for PoC work on XDSS - eventually this will be replaced by an onotology server that can handle
 # conversions programmatically
 class FacetNameConverter
+  # controlled list of metadata schema names
+  SCHEMA_NAMES = %i[alexandria tim hca].freeze
+
   # map of Alexandria metadata convention names to HCA 'short' names
   ALEXANDRIA_TO_HCA = {
     'biosample_id' => 'biosample_id',
@@ -47,7 +50,13 @@ class FacetNameConverter
   #
   # * *returns*
   #   - (String) => String value of requested column/property
+  #
+  # * *raises*
+  #   - (ArgumentError) => if source/target schema do not exist
   def self.convert_schema_column(source_schema = :alexandria, target_schema, column_name)
+    invalid_schemas = [source_schema.to_sym, target_schema.to_sym] - SCHEMA_NAMES
+    raise ArgumentError, "invalid schema conversion: #{invalid_schemas.join(', ')}" if invalid_schemas.any?
+
     map_name = "FacetNameConverter::#{source_schema.upcase}_TO_#{target_schema.upcase}"
     if Object.const_defined? map_name
       # perform lookup, but fall back to provided column name if no match is found

--- a/lib/facet_name_converter.rb
+++ b/lib/facet_name_converter.rb
@@ -47,8 +47,14 @@ class FacetNameConverter
   # * *returns*
   #   - (String) => String value of requested column/property
   def self.convert_to_model(source_model = :alexandria, target_model, column_name)
-    mappings = "FacetNameConverter::#{source_model.upcase}_TO_#{target_model.upcase}".constantize
-    # perform lookup, but fall back to provided column name if no match is found
-    mappings[column_name.to_sym] || column_name
+    map_name = "FacetNameConverter::#{source_model.upcase}_TO_#{target_model.upcase}"
+    if Object.const_defined? map_name
+      # perform lookup, but fall back to provided column name if no match is found
+      mappings = map_name.constantize
+      mappings[column_name] || column_name
+    else
+      # conversion not possible, so fall back on column_name
+      column_name
+    end
   end
 end

--- a/test/integration/data_repo_client_test.rb
+++ b/test/integration/data_repo_client_test.rb
@@ -167,8 +167,8 @@ class DataRepoClientTest < ActiveSupport::TestCase
         ]
       }
     ]
-    species_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :species)
-    disease_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :disease)
+    species_field = FacetNameConverter.convert_schema_column(:alexandria, :tim, :species)
+    disease_field = FacetNameConverter.convert_schema_column(:alexandria, :tim, :disease)
     expected_query = "([#{species_field}]:\"NCBITaxon9609\") OR ([#{species_field}]:\"Homo sapiens\") AND " \
                      "([#{disease_field}]:\"MONDO_0018076\") OR ([#{disease_field}]:\"tuberculosis\") OR " \
                      "([#{disease_field}]:\"MONDO_0005109\") OR ([#{disease_field}]:\"HIV infectious disease\")"
@@ -179,8 +179,8 @@ class DataRepoClientTest < ActiveSupport::TestCase
 
   test 'should generate query JSON from keywords' do
     keywords = %w[pulmonary human lung]
-    name_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :study_name)
-    description_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :study_description)
+    name_field = FacetNameConverter.convert_schema_column(:alexandria, :tim, :study_name)
+    description_field = FacetNameConverter.convert_schema_column(:alexandria, :tim, :study_description)
     expected_query = "([#{name_field}]:\"pulmonary\" OR [#{name_field}]:\"human\" OR [#{name_field}]:\"lung\") OR " \
                      "([#{description_field}]:\"pulmonary\" OR [#{description_field}]:\"human\" OR " \
                      "[#{description_field}]:\"lung\")"
@@ -189,10 +189,10 @@ class DataRepoClientTest < ActiveSupport::TestCase
   end
 
   test 'should merge query JSON for facets and keywords' do
-    name_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :study_name)
-    description_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :study_description)
-    species_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :species)
-    disease_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :disease)
+    name_field = FacetNameConverter.convert_schema_column(:alexandria, :tim, :study_name)
+    description_field = FacetNameConverter.convert_schema_column(:alexandria, :tim, :study_description)
+    species_field = FacetNameConverter.convert_schema_column(:alexandria, :tim, :species)
+    disease_field = FacetNameConverter.convert_schema_column(:alexandria, :tim, :disease)
     selected_facets = [
       { id: :species, filters: [{ id: 'NCBITaxon9609', name: 'Homo sapiens' }] },
       { id: :disease, filters: [
@@ -224,11 +224,11 @@ class DataRepoClientTest < ActiveSupport::TestCase
     original_count = results['result'].count
     assert original_count > 0
     sample_row = results['result'].sample
-    species_field_name = FacetNameConverter.convert_to_model(:alexandria,:tim, :species)
+    species_field_name = FacetNameConverter.convert_schema_column(:alexandria, :tim, :species)
     assert_equal 'Homo sapiens', sample_row[species_field_name]
     expected_project = 'Single-cell RNA-sequencing reveals profibrotic roles of distinct epithelial and mesenchymal ' \
                        'lineages in pulmonary fibrosis'
-    project_title_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :study_name)
+    project_title_field = FacetNameConverter.convert_schema_column(:alexandria, :tim, :study_name)
     assert_equal expected_project, sample_row[project_title_field]
 
     # refine query and re-run

--- a/test/integration/data_repo_client_test.rb
+++ b/test/integration/data_repo_client_test.rb
@@ -169,9 +169,9 @@ class DataRepoClientTest < ActiveSupport::TestCase
     ]
     species_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :species)
     disease_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :disease)
-    expected_query = "(#{species_field}:NCBITaxon9609 OR #{species_field}:Homo sapiens) AND " \
-                     "(#{disease_field}:MONDO_0018076 OR #{disease_field}:tuberculosis OR " \
-                     "#{disease_field}:MONDO_0005109 OR #{disease_field}:HIV infectious disease)"
+    expected_query = "([#{species_field}]:\"NCBITaxon9609\") OR ([#{species_field}]:\"Homo sapiens\") AND " \
+                     "([#{disease_field}]:\"MONDO_0018076\") OR ([#{disease_field}]:\"tuberculosis\") OR " \
+                     "([#{disease_field}]:\"MONDO_0005109\") OR ([#{disease_field}]:\"HIV infectious disease\")"
 
     query_json = @data_repo_client.generate_query_from_facets(selected_facets)
     assert_equal expected_query, query_json.dig(:query_string, :query)
@@ -181,17 +181,18 @@ class DataRepoClientTest < ActiveSupport::TestCase
     keywords = %w[pulmonary human lung]
     name_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :study_name)
     description_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :study_description)
-    expected_query = "(#{name_field}:pulmonary OR #{name_field}:human OR #{name_field}:lung) OR " \
-                     "(#{description_field}:pulmonary OR #{description_field}:human OR #{description_field}:lung)"
+    expected_query = "([#{name_field}]:\"pulmonary\" OR [#{name_field}]:\"human\" OR [#{name_field}]:\"lung\") OR " \
+                     "([#{description_field}]:\"pulmonary\" OR [#{description_field}]:\"human\" OR " \
+                     "[#{description_field}]:\"lung\")"
     query_json = @data_repo_client.generate_query_from_keywords(keywords)
     assert_equal expected_query, query_json.dig(:query_string, :query)
   end
 
   test 'should merge query JSON for facets and keywords' do
-    name_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :study_name)
-    description_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :study_description)
-    species_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :species)
-    disease_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :disease)
+    name_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :study_name)
+    description_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :study_description)
+    species_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :species)
+    disease_field = FacetNameConverter.convert_to_model(:alexandria, :tim, :disease)
     selected_facets = [
       { id: :species, filters: [{ id: 'NCBITaxon9609', name: 'Homo sapiens' }] },
       { id: :disease, filters: [
@@ -200,13 +201,16 @@ class DataRepoClientTest < ActiveSupport::TestCase
       }
     ]
     keywords = %w[pulmonary human lung]
-    expected_query = "((#{species_field}:NCBITaxon9609 OR #{species_field}:Homo sapiens) AND " \
-                     "(#{disease_field}:MONDO_0018076 OR #{disease_field}:tuberculosis OR " \
-                     "#{disease_field}:MONDO_0005109 OR #{disease_field}:HIV infectious disease)) AND " \
-                     "((#{name_field}:pulmonary OR #{name_field}:human OR #{name_field}:lung) OR " \
-                     "(#{description_field}:pulmonary OR #{description_field}:human OR #{description_field}:lung))"
-    merged_query = @data_repo_client.merge_query_json(facet_query: @data_repo_client.generate_query_from_facets(selected_facets),
-                                                      term_query: @data_repo_client.generate_query_from_keywords(keywords))
+    expected_query = "(([#{species_field}]:\"NCBITaxon9609\") OR ([#{species_field}]:\"Homo sapiens\") AND " \
+                     "([#{disease_field}]:\"MONDO_0018076\") OR ([#{disease_field}]:\"tuberculosis\") OR (" \
+                     "[#{disease_field}]:\"MONDO_0005109\") OR ([#{disease_field}]:\"HIV infectious disease\")) AND " \
+                     "(([#{name_field}]:\"pulmonary\" OR [#{name_field}]:\"human\" OR [#{name_field}]:\"lung\") OR " \
+                     "([#{description_field}]:\"pulmonary\" OR [#{description_field}]:\"human\" OR " \
+                     "[#{description_field}]:\"lung\"))"
+    merged_query = @data_repo_client.merge_query_json(
+      facet_query: @data_repo_client.generate_query_from_facets(selected_facets),
+      term_query: @data_repo_client.generate_query_from_keywords(keywords)
+    )
     assert_equal expected_query, merged_query.dig(:query_string, :query)
   end
 

--- a/test/integration/data_repo_client_test.rb
+++ b/test/integration/data_repo_client_test.rb
@@ -167,8 +167,8 @@ class DataRepoClientTest < ActiveSupport::TestCase
         ]
       }
     ]
-    species_field = FacetNameConverter.convert_to_model(:tim, :species, :id)
-    disease_field = FacetNameConverter.convert_to_model(:tim, :disease, :id)
+    species_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :species)
+    disease_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :disease)
     expected_query = "(#{species_field}:NCBITaxon9609 OR #{species_field}:Homo sapiens) AND " \
                      "(#{disease_field}:MONDO_0018076 OR #{disease_field}:tuberculosis OR " \
                      "#{disease_field}:MONDO_0005109 OR #{disease_field}:HIV infectious disease)"
@@ -179,8 +179,8 @@ class DataRepoClientTest < ActiveSupport::TestCase
 
   test 'should generate query JSON from keywords' do
     keywords = %w[pulmonary human lung]
-    name_field = FacetNameConverter.convert_to_model(:tim, :study_name, :id)
-    description_field = FacetNameConverter.convert_to_model(:tim, :study_description, :id)
+    name_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :study_name)
+    description_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :study_description)
     expected_query = "(#{name_field}:pulmonary OR #{name_field}:human OR #{name_field}:lung) OR " \
                      "(#{description_field}:pulmonary OR #{description_field}:human OR #{description_field}:lung)"
     query_json = @data_repo_client.generate_query_from_keywords(keywords)
@@ -188,10 +188,10 @@ class DataRepoClientTest < ActiveSupport::TestCase
   end
 
   test 'should merge query JSON for facets and keywords' do
-    name_field = FacetNameConverter.convert_to_model(:tim, :study_name, :id)
-    description_field = FacetNameConverter.convert_to_model(:tim, :study_description, :id)
-    species_field = FacetNameConverter.convert_to_model(:tim, :species, :id)
-    disease_field = FacetNameConverter.convert_to_model(:tim, :disease, :id)
+    name_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :study_name)
+    description_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :study_description)
+    species_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :species)
+    disease_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :disease)
     selected_facets = [
       { id: :species, filters: [{ id: 'NCBITaxon9609', name: 'Homo sapiens' }] },
       { id: :disease, filters: [
@@ -220,11 +220,11 @@ class DataRepoClientTest < ActiveSupport::TestCase
     original_count = results['result'].count
     assert original_count > 0
     sample_row = results['result'].sample
-    species_field_name = FacetNameConverter.convert_to_model(:tim, :species, :name)
+    species_field_name = FacetNameConverter.convert_to_model(:alexandria,:tim, :species)
     assert_equal 'Homo sapiens', sample_row[species_field_name]
     expected_project = 'Single-cell RNA-sequencing reveals profibrotic roles of distinct epithelial and mesenchymal ' \
                        'lineages in pulmonary fibrosis'
-    project_title_field = FacetNameConverter.convert_to_model(:tim, :study_name, :name)
+    project_title_field = FacetNameConverter.convert_to_model(:alexandria,:tim, :study_name)
     assert_equal expected_project, sample_row[project_title_field]
 
     # refine query and re-run

--- a/test/lib/facet_name_converter_test.rb
+++ b/test/lib/facet_name_converter_test.rb
@@ -7,33 +7,21 @@ class FacetNameConverterTest < ActiveSupport::TestCase
 
   before(:all) do
     @scp_field_names = %i[study_name study_description disease species]
-    @fields = %i[name id]
     @expected_conversions = {
-      hca: {
-        name: %w[project_title project_description disease genus_species],
-        id: %w[project_title project_description disease genus_species]
-      },
-      tim: {
-        name: %w[dct:title dct:description TerraCore:hasDisease TerraCore:hasOrganismType],
-        id: %w[tim__dctc__title tim__dctc__description
-               tim__a__terraa__corec__a__bioa__samplea__terraa__corec__c__hasa__disease
-               tim__a__terraa__corec__a__donora__terraa__corec__hasa__organisma__type
-            ]
-      }
+      hca: %w[project_title project_description disease genus_species],
+      tim: %w[dct:title dct:description TerraCore:hasDisease TerraCore:hasOrganismType]
     }
     @nonexistent_field = :foobar
   end
 
   # iterate through all fields and test conversion
   def compare_all_fields(model_name)
-    @fields.each do |field|
-      @scp_field_names.each_with_index do |scp_name, index|
-        converted_name = FacetNameConverter.convert_to_model(model_name, scp_name, field)
-        assert_equal @expected_conversions[model_name][field][index], converted_name
-      end
-      # test fallback
-      assert_equal @nonexistent_field, FacetNameConverter.convert_to_model(model_name, @nonexistent_field, field)
+    @scp_field_names.each_with_index do |scp_name, index|
+      converted_name = FacetNameConverter.convert_to_model(:alexandria, model_name, scp_name)
+      assert_equal @expected_conversions[model_name][index], converted_name
     end
+    # test fallback
+    assert_equal @nonexistent_field, FacetNameConverter.convert_to_model(:alexandria, model_name, @nonexistent_field)
   end
 
   test 'should convert to HCA names' do

--- a/test/lib/facet_name_converter_test.rb
+++ b/test/lib/facet_name_converter_test.rb
@@ -17,11 +17,11 @@ class FacetNameConverterTest < ActiveSupport::TestCase
   # iterate through all fields and test conversion
   def compare_all_fields(model_name)
     @scp_field_names.each_with_index do |scp_name, index|
-      converted_name = FacetNameConverter.convert_to_model(:alexandria, model_name, scp_name)
+      converted_name = FacetNameConverter.convert_schema_column(:alexandria, model_name, scp_name)
       assert_equal @expected_conversions[model_name][index], converted_name
     end
     # test fallback
-    assert_equal @nonexistent_field, FacetNameConverter.convert_to_model(:alexandria, model_name, @nonexistent_field)
+    assert_equal @nonexistent_field, FacetNameConverter.convert_schema_column(:alexandria, model_name, @nonexistent_field)
   end
 
   test 'should convert to HCA names' do

--- a/test/lib/facet_name_converter_test.rb
+++ b/test/lib/facet_name_converter_test.rb
@@ -31,4 +31,10 @@ class FacetNameConverterTest < ActiveSupport::TestCase
   test 'should convert to TIM names' do
     compare_all_fields(:tim)
   end
+
+  test 'should throw error on invalid conversion' do
+    assert_raise ArgumentError do
+      FacetNameConverter.convert_schema_column(:alexandria, :foo, 'species')
+    end
+  end
 end


### PR DESCRIPTION
This update fixes an issue where search results in TDR are far too lax, resulting in partial matches on filter values that give erroneous results.  For instance, searching for `cataract (disease)` would result in matching on either `cataract` or `disease` anywhere in the entry, and not just within the `disease` field.  The issue was due to incorrect formatting of queries in regards Terra Interoperability Model (TIM) names, and also not quoting values correctly.  

TIM names can be passed in human-readable form (e.g. `TerraCore:hasDisease`), but must be enclosed in brackets `[]` to denote the field.  Also, values must be fully quoted to prevent partial matching.  For instance, a query for `HIV infectious disease` would look like this in ElasticSearch DSL:

```
{:query_string=>{:query=>"([TerraCore:hasDisease]:\"MONDO_0005109\") OR ([TerraCore:hasDisease]:\"HIV infectious disease\")"}}
```

This update also simplifies and hardens the `FacetNameConverter` class.  It is now possible to convert from Alexandria to TIM or HCA names, and back.

MANUAL TESTING
1. Boot portal as normal, and sign in with an account that has `cross_dataset_search_backend` feature flag enabled
2. Use facet for `species: Homo sapiens`, and note both SCP & TDR results
3. Search for `Pulmonary`, and note only TDR results
4. Use facet for `disease: HIV infectious disease` and note only SCP results

This PR satisfies SCP-3544.