### PR TITLE
Legend Fixes SCP-3572 & SCP-3466

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -295,7 +295,7 @@ function countOccurences(array) {
 function traceNameSort(a, b) {
   if (a === UNSPECIFIED_ANNOTATION_NAME) {return 1}
   if (b === UNSPECIFIED_ANNOTATION_NAME) {return -1}
-  return a.localeCompare(b)
+  return a.localeCompare(b, 'en', { numeric: true, ignorePunctuation: true })
 }
 
 /** makes the data trace attributes (cells, trace name) available via hover text */
@@ -366,7 +366,8 @@ function getPlotlyLayout({ width, height }={}, {
   if (!genes.length && annotParams && annotParams.name) {
     layout.legend = {
       itemsizing: 'constant',
-      title: { text: annotParams.name }
+      title: { text: annotParams.name },
+      y: 0.94
     }
   }
   layout.width = width

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -364,6 +364,7 @@ function getPlotlyLayout({ width, height }={}, {
     Object.assign(layout, props2d)
   }
   if (!genes.length && annotParams && annotParams.name) {
+  if (annotParams && annotParams.name) {
     layout.legend = {
       itemsizing: 'constant',
       title: { text: annotParams.name },

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -363,7 +363,6 @@ function getPlotlyLayout({ width, height }={}, {
     })
     Object.assign(layout, props2d)
   }
-  if (!genes.length && annotParams && annotParams.name) {
   if (annotParams && annotParams.name) {
     layout.legend = {
       itemsizing: 'constant',

--- a/app/javascript/components/visualization/StudyViolinPlot.js
+++ b/app/javascript/components/visualization/StudyViolinPlot.js
@@ -187,7 +187,7 @@ function getViolinTraces(
   resultValues, showPoints='none', plotType='violin'
 ) {
   const data = Object.entries(resultValues)
-    .sort((a, b) => a[0].localeCompare(b[0]))
+    .sort((a, b) => a[0].localeCompare(b[0], 'en', { numeric: true, ignorePunctuation: true }))
     .map(([traceName, traceData], index) => {
     // Plotly violin trace creation, adding to main array
     // get inputs for plotly violin creation


### PR DESCRIPTION
- Sort Legend annotations "Naturally"
- Add space so that legend does not overlap Plotly tool menu
- Add title to legend for gene-gene correlation

I think I've ended up being able to fix this using Plotly legends for now. (I must have missed something small earlier and super overcomplicated things..). 

Note: The colors are slightly different with this implementation as it appears the colors stay in a certain order no matter the annotation order. However they match to the graph and I checked with Jean and it seems to be alright. 


Before:
<img width="937" alt="Screen Shot 2021-08-08 at 3 06 11 PM" src="https://user-images.githubusercontent.com/54322292/128735196-5bb898c6-6016-4faf-b18e-0e90603a37af.png">

After:
![Screen Shot 2021-08-09 at 10 46 19 AM](https://user-images.githubusercontent.com/54322292/128735245-40565121-d25f-4f83-9556-4b186dd1232a.png)

![Screen Shot 2021-08-09 at 10 46 31 AM](https://user-images.githubusercontent.com/54322292/128735784-b5f64c47-4b37-4bea-b742-ff9278e62f2e.png)


Overlap Before:
![Screen Shot 2021-08-09 at 10 07 37 AM](https://user-images.githubusercontent.com/54322292/128735304-d0570f32-ffbc-48e5-afa5-03f5a59065fe.png)

Overlap Fixed:
![Screen Shot 2021-08-09 at 10 19 38 AM](https://user-images.githubusercontent.com/54322292/128735366-54379718-8e20-4890-a67c-4a82a307cff3.png)

Before Gene-Gene correlation:
![Screen Shot 2021-08-09 at 11 50 54 AM](https://user-images.githubusercontent.com/54322292/128735524-09ab5e5c-6404-4472-91e0-21e5ae932571.png)

AFter:
![Screen Shot 2021-08-09 at 11 51 55 AM](https://user-images.githubusercontent.com/54322292/128735686-ae643562-f9ff-454e-8948-1f187c21df2f.png)

