### PR TITLE
Update TDR base URL for production (SCP-3559)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -115,7 +115,7 @@ Rails.application.configure do
   config.bard_host_url = 'https://terra-bard-prod.appspot.com'
 
   # Terra Data Repo API base url
-  config.tdr_api_base_url = 'https://jade-terra.datarepo-prod.broadinstitute.org'
+  config.tdr_api_base_url = 'https://jade.datarepo-dev.broadinstitute.org'
 
   # DNS rebinding/host header injection protection
   # CIDR ip ranges from https://cloud.google.com/load-balancing/docs/health-checks#firewall_rules


### PR DESCRIPTION
As per current plans, this update changes the production configuration for SCP to point at the development instance of Terra Data Repo.  This will remain in place until the required search functionality is deployed to the production TDR instance.

This PR satisfies SCP-3559.