### PR TITLE
Fix spatial multi-gene layout (SCP-3550)

### DIFF
--- a/app/javascript/components/explore/ScatterTab.js
+++ b/app/javascript/components/explore/ScatterTab.js
@@ -39,7 +39,7 @@ export default function ScatterTab({
         const isTwoColRow = isTwoColumn && !(index === 0 && firstRowSingleCol)
         const key = getKeyFromScatterParams(params)
         let rowDivider = <span key={`d${index}`}></span>
-        if (index % 2 === 1) {
+        if (index % 2 === 1 && !isMultiGene) {
           // Use a full-width empty column to make sure plots align into rows, even if they are unequal height
           rowDivider = <div className="col-md-12" key={`d${index}`}></div>
         }


### PR DESCRIPTION
This fixes a bug with spatial expression scatter plots for 2 or more genes.  It extends a fix for 1-gene layout (#1075).

Previously, when the user selected a spatial cluster and searched >= 2 genes, each expression plot would be in its own row.  Now, screen real estate is economized by aligning two expression plots per row.

Here's how it looks:

https://user-images.githubusercontent.com/1334561/130252793-367765bf-1117-4226-8f6a-400b99699a5d.mov

I've also added a "[Spatial: Multi-gene](https://docs.google.com/document/d/1rKcOQPtkbhZCbTqxTnaT-4E29VLzkJrm0kAoWjLx3QA/edit#heading=h.nbi2il6tkmg9)" section to manual tests for release engineer.

To test:
* Reproduce realistic spatial study https://singlecell-staging.broadinstitute.org/single_cell/study/SCP215 in your local SCP
* Go to its Explore tab
* Search "Mapk1 Mapk3 Mbp Stat3"
* Verify there are 3 rows of plots, as shown in above video:
  * Reference cluster for XYCoords
  * Expression plots for Mapk1 and Mapk3
  * Expression plots for Mbp and Stat3

This satisfies SCP-3550.