### PR TITLE
SCP-3536 Hide Expression Axis Label in Sync when file is raw count matrix

### DIFF
--- a/app/views/studies/_expression_file_fields.html.erb
+++ b/app/views/studies/_expression_file_fields.html.erb
@@ -1,8 +1,10 @@
 <div class="form-group row">
   <div class="col-sm-12">
+  <% if !@study.has_raw_counts_matrices? %>
     <%= f.label :y_axis_label, 'Expression Axis Label' %>&nbsp;<span class="fas fa-question-circle" data-toggle="tooltip" data-placement="right" title="This is displayed as the axis label for box & scatter plots showing expression values.  This label is global to all expression values.<%= @study.has_expression_label? ? ' Please use the study default options form to update this value.' : '' %>"></span> <br />
     <%= f.text_field :y_axis_label, value: @study.has_expression_label? ? @study.default_expression_label : f.object.y_axis_label, placeholder: @study.default_expression_label, class: 'form-control', disabled: @study.has_expression_label? %>
-  </div>
+  <% end %>
+    </div>
 </div>
 <div class="form-group">
   <%= f.fields_for :expression_file_info %>

--- a/app/views/studies/_expression_file_fields.html.erb
+++ b/app/views/studies/_expression_file_fields.html.erb
@@ -1,11 +1,15 @@
 <div class="form-group row">
   <div class="col-sm-12">
-  <% if !@study.has_raw_counts_matrices? %>
+  
+    <% if !study_file.is_raw_counts_file? %>
+
     <%= f.label :y_axis_label, 'Expression Axis Label' %>&nbsp;<span class="fas fa-question-circle" data-toggle="tooltip" data-placement="right" title="This is displayed as the axis label for box & scatter plots showing expression values.  This label is global to all expression values.<%= @study.has_expression_label? ? ' Please use the study default options form to update this value.' : '' %>"></span> <br />
     <%= f.text_field :y_axis_label, value: @study.has_expression_label? ? @study.default_expression_label : f.object.y_axis_label, placeholder: @study.default_expression_label, class: 'form-control', disabled: @study.has_expression_label? %>
-  <% end %>
+
+    <% end %>
     </div>
-</div>
+
+    </div>
 <div class="form-group">
   <%= f.fields_for :expression_file_info %>
 </div>

--- a/app/views/studies/_expression_file_fields.html.erb
+++ b/app/views/studies/_expression_file_fields.html.erb
@@ -7,9 +7,8 @@
     <%= f.text_field :y_axis_label, value: @study.has_expression_label? ? @study.default_expression_label : f.object.y_axis_label, placeholder: @study.default_expression_label, class: 'form-control', disabled: @study.has_expression_label? %>
 
     <% end %>
-    </div>
-
-    </div>
+  </div>
+</div>
 <div class="form-group">
   <%= f.fields_for :expression_file_info %>
 </div>

--- a/app/views/studies/_orphaned_study_file_form.html.erb
+++ b/app/views/studies/_orphaned_study_file_form.html.erb
@@ -38,7 +38,7 @@
     <% elsif study_file.file_type == 'Metadata' %>
       <%= render partial: 'metadata_file_fields', locals: {f: f.dup} %>
     <% elsif study_file.file_type == 'Expression Matrix' || study_file.file_type == 'MM Coordinate Matrix' %>
-      <%= render partial: 'expression_file_fields', locals: {f: f.dup} %>
+      <%= render partial: 'expression_file_fields', locals: {study_file: study_file, f: f.dup} %>
     <% end %>
   </div>
   <div class="form-group row">

--- a/app/views/studies/_shared_sync_functions.js.erb
+++ b/app/views/studies/_shared_sync_functions.js.erb
@@ -18,7 +18,7 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', function() {
         nameField.val(fileName);
         nameField.attr('readonly', 'readonly');
     } else if (fileType === 'Expression Matrix' || fileType === 'MM Coordinate Matrix') {
-        extraInfo.html("<%= j(render partial: 'expression_file_fields', locals: {f: f.dup}) %>");
+        extraInfo.html("<%= j(render partial: 'expression_file_fields', locals: {study_file: study_file, f: f.dup}) %>");
         taxonTarget.html("<%= j(render partial: 'taxon_fields', locals: {f: f.dup}) %>");
         nameField.val(fileName);
         nameField.attr('readonly', 'readonly');

--- a/app/views/studies/_study_file_form.html.erb
+++ b/app/views/studies/_study_file_form.html.erb
@@ -34,7 +34,7 @@
     <% elsif study_file.file_type == 'Metadata' %>
       <%= render partial: 'metadata_file_fields', locals: {f: f.dup} %>
     <% elsif study_file.file_type == 'Expression Matrix' || study_file.file_type == 'MM Coordinate Matrix' %>
-      <%= render partial: 'expression_file_fields', locals: {f: f.dup} %>
+      <%= render partial: 'expression_file_fields', locals: {study_file: study_file, f: f.dup} %>
     <% elsif study_file.file_type == '10X Genes File' || study_file.file_type == '10X Barcodes File' %>
       <%= render partial: 'mm_coordinate_association_fields', locals: {f: f.dup} %>
     <% elsif study_file.file_type == 'BAM Index' %>

--- a/app/views/studies/_synced_bundled_study_file_form.html.erb
+++ b/app/views/studies/_synced_bundled_study_file_form.html.erb
@@ -26,7 +26,7 @@
     <% if study_file.file_type == 'Cluster'  %>
       <%= render partial: 'cluster_axis_fields', locals: {f: f.dup} %>
     <% elsif study_file.file_type == 'Expression Matrix' || study_file.file_type == 'MM Coordinate Matrix' %>
-      <%= render partial: 'expression_file_fields', locals: {f: f.dup} %>
+      <%= render partial: 'expression_file_fields',locals: {study_file: study_file, f: f.dup} %>
     <% end %>
   </div>
   <div class="form-group row">

--- a/app/views/studies/_synced_bundled_study_file_form.html.erb
+++ b/app/views/studies/_synced_bundled_study_file_form.html.erb
@@ -26,7 +26,7 @@
     <% if study_file.file_type == 'Cluster'  %>
       <%= render partial: 'cluster_axis_fields', locals: {f: f.dup} %>
     <% elsif study_file.file_type == 'Expression Matrix' || study_file.file_type == 'MM Coordinate Matrix' %>
-      <%= render partial: 'expression_file_fields',locals: {study_file: study_file, f: f.dup} %>
+      <%= render partial: 'expression_file_fields', locals: {study_file: study_file, f: f.dup} %>
     <% end %>
   </div>
   <div class="form-group row">

--- a/app/views/studies/_synced_study_file_form.html.erb
+++ b/app/views/studies/_synced_study_file_form.html.erb
@@ -45,7 +45,7 @@
       <%= f.label :upload, 'Download' %><br />
       <%= render partial: 'layouts/download_link', locals: {study_file: study_file} %>
     </div>
-    <div class="col-sm-4 taxon-select-target">
+    <div class="col-sm-3 taxon-select-target">
       <% if StudyFile::TAXON_REQUIRED_TYPES.include?(study_file.file_type) || study_file.file_type == 'Analysis Output' %>
         <%= render partial: 'taxon_fields', locals: {f: f.dup} %>
       <% end %>
@@ -54,13 +54,13 @@
       <%= label_tag :reparse, 'Reparse File?' %><br/>
       <%= select_tag :reparse, options_for_select(%w(Yes No), 'No'), {class: 'form-control'} %>
     </div>
-    <div class="col-sm-2">
+    <div class="col-sm-3">
       <%= f.label :actions %>
       <div class="row">
-        <div class="col-xs-6">
+        <div class="col-xs-6 col-sm-12 col-md-6" style="margin-bottom: 8px">
           <%= f.submit 'Update', class: 'btn btn-block btn-success save-study-file', id: "sync-study-file-#{study_file.id}" %>
         </div>
-        <div class="col-xs-6">
+        <div class="col-xs-6 col-sm-12 col-md-6">
           <% if study_file.parsing? %>
             <%= link_to 'Delete', '#/', class: 'btn btn-block btn-danger disabled-delete', disabled: 'disabled', title: 'You must wait until the file has finished parsing before deleting', data: {toggle: 'tooltip'} %>
           <% else %>

--- a/app/views/studies/_synced_study_file_form.html.erb
+++ b/app/views/studies/_synced_study_file_form.html.erb
@@ -30,7 +30,7 @@
     <% elsif study_file.file_type == 'Metadata' %>
       <%= render partial: 'metadata_file_fields', locals: {f: f.dup} %>
     <% elsif study_file.file_type == 'Expression Matrix' || study_file.file_type == 'MM Coordinate Matrix' %>
-      <%= render partial: 'expression_file_fields', locals: {f: f.dup} %>
+      <%= render partial: 'expression_file_fields', locals: {study_file: study_file, f: f.dup} %>
     <% end %>
   </div>
   <div class="form-group row">

--- a/app/views/studies/_taxon_fields.html.erb
+++ b/app/views/studies/_taxon_fields.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-xs-6">
+  <div class="col-xs-12">
     <%= f.label :taxon_id, 'Species' %> <%= render partial: 'taxon_help_popover', locals: {id: f.object.id.to_s} %><br />
     <%= f.select :taxon_id, options_from_collection_for_select(Taxon.sorted, :id, :display_name, f.object.taxon_id.present? ? f.object.taxon_id.to_s : nil),
                  {include_blank: 'None selected...'}, {class: 'form-control taxon-select'} %>


### PR DESCRIPTION
Don't show the Expression Axis form field when a synced file is raw counts.
Also cleaned up the button sizing for this particular form.

Steps to Reproduce:
1. Make a new study in SCP
2. In the Terra workspace for this study add these 2 files 

[RAW.raw_dense.txt](https://github.com/broadinstitute/single_cell_portal_core/files/7023178/RAW.raw_dense.txt)

[NOTRAW.processed_dense.txt](https://github.com/broadinstitute/single_cell_portal_core/files/7023180/NOTRAW.processed_dense.txt)

3. Go to the new study in SCP and go to "sync study"
4. Sync the files (the 2 files you added to your Terra workspace should appear in SCP), making sure to indicate for the file titled "RAW" that you indicate it is a raw-count matrix and for "NOTRAW" that is not.
5. Look at the synced files and see that the raw-count file does not show the expression axis label but the not raw-count file does




Now - see that the one that is raw counts doesn't have the field while the one that isn't raw counts still does:
![Screen Shot 2021-08-20 at 10 01 46 AM](https://user-images.githubusercontent.com/54322292/130266151-f1964c14-6df6-4384-b99d-72d9349171d5.png)

![Screen Shot 2021-08-20 at 10 03 34 AM](https://user-images.githubusercontent.com/54322292/130266173-2f869790-17a8-4989-95ec-bb9f93d6e0a7.png)

Note the fixed buttons - when the screensize gets too small to support both buttons side by side it will swing one down :
![Screen Shot 2021-08-20 at 10 01 37 AM](https://user-images.githubusercontent.com/54322292/130266266-953b9dd7-e9f7-43e2-9524-7090d8097109.png)



Before (note the button text is messed up) and even though this is raw counts it has the Expression Axis Label field
<img width="1014" alt="Screen Shot 2021-08-20 at 12 49 28 PM" src="https://user-images.githubusercontent.com/54322292/130267130-4084cb6d-96dc-4e4f-8864-65ad5b26003b.png">


![Screen Shot 2021-08-20 at 9 54 23 AM](https://user-images.githubusercontent.com/54322292/130266232-5023b80e-6306-4f9c-ae53-8195c00d9baa.png)

