### PR TITLE
Allow scrolling of dropdown nav menu (SCP-3600)

### DIFF
--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -15,6 +15,11 @@
   }
 }
 
+.dropdown_scroll {
+  overflow: auto;
+  max-height: 80vh;
+}
+
 @media screen and (max-width: 768px) {
   ul.nav.navbar-nav.pull-right {
     margin-top: -7.5px;

--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -15,7 +15,7 @@
   }
 }
 
-.dropdown_scroll {
+.dropdown-scroll {
   overflow: auto;
   max-height: 80vh;
 }

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -34,7 +34,7 @@
       </li>
       <% if user_signed_in? %>
         <li class="dropdown"><%= scp_link_to "<span class='fas fa-user'></span> #{current_user.email.split('@').first} <span class='caret'></span>".html_safe, "#", class: "dropdown-toggle left-border-0-5", "data-toggle" => "dropdown", id: 'profile-nav' %>
-          <ul class="dropdown-menu dropdown-menu-right dropdown_scroll">
+          <ul class="dropdown-menu dropdown-menu-right dropdown-scroll">
             <% if current_user.admin? %>
               <li><%= link_to "<span class='fas fa-lock fa-fw'></span> Admin Config".html_safe, admin_configurations_path, class: 'check-upload', id: 'admin-nav' %></li>
               <li><%= link_to "<span class='fas fa-flask fa-fw'></span> Analyses".html_safe, analysis_configurations_path, class: 'check-upload', id: 'analysis-nav' %></li>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -34,7 +34,7 @@
       </li>
       <% if user_signed_in? %>
         <li class="dropdown"><%= scp_link_to "<span class='fas fa-user'></span> #{current_user.email.split('@').first} <span class='caret'></span>".html_safe, "#", class: "dropdown-toggle left-border-0-5", "data-toggle" => "dropdown", id: 'profile-nav' %>
-          <ul class="dropdown-menu dropdown-menu-right">
+          <ul class="dropdown-menu dropdown-menu-right dropdown_scroll">
             <% if current_user.admin? %>
               <li><%= link_to "<span class='fas fa-lock fa-fw'></span> Admin Config".html_safe, admin_configurations_path, class: 'check-upload', id: 'admin-nav' %></li>
               <li><%= link_to "<span class='fas fa-flask fa-fw'></span> Analyses".html_safe, analysis_configurations_path, class: 'check-upload', id: 'analysis-nav' %></li>


### PR DESCRIPTION
It was mentioned at standup or on slack(?) when discussing the Branded Collections and the idea of adding more stuff to the drop down menu how if it gets too long you can't see the rest of the list. Figured it'd be a good time to add scrolling to the menu. No ticket just a quick fix for most use cases.

Only weird quirky-ness is if you make the window super tiny (both vertically and horizontally) you can get 3 scroll bars. Not sure how folks feel about that, just wanted to call it out though, so there will still be that bug but figured this would help out the more general case at least.

Video shows current on Left and new on Right. First half shows how this is an improvement. Second half shows how the scenario when things are very tiny still isn't great but other than the extra scroll bar in that scenario functionality hasn't decreased.

https://user-images.githubusercontent.com/54322292/130662389-49056503-5a9e-4d30-b2b1-25b6dccf72fa.mov


