### PR TITLE
Analytics for basic in-app file validation (SCP-3547)

### DIFF
--- a/app/javascript/components/validation/ValidationAlert.js
+++ b/app/javascript/components/validation/ValidationAlert.js
@@ -1,38 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-import { log } from 'lib/metrics-api'
-
 /** Renders a report of file validation errors for upload UI */
-export default function ValidationAlert({ errors, file, fileType }) {
-  const numErrors = errors.length
-  const errorsTerm = (numErrors === 1) ? 'error' : 'errors'
-
-  const summary = `Your ${fileType} file had ${numErrors} ${errorsTerm}`
-
-  console.log('file', file)
-
-  // TODO (SCP-3608): Improve observability of in-app validation analytics
-  // We'll extend and/or refine this logging to handle multiple different
-  // types of validation errors (e.g. format, ontology, etc.) in a way that
-  // eases reporting for various use cases.
-  log('error:file-validation', {
-    fileType,
-    summary,
-    numErrors,
-    'file:name': file.name,
-    'file:size': file.size,
-    'file:mimeType': file.type,
-    'errors': errors.map(columns => columns[2])
-  })
-
-  const testId = `${fileType}-validation-alert`
-
+export default function ValidationAlert({ summary, errors, fileType }) {
   return (
-    <div className="alert alert-danger" data-testid={testId}>
-      <p>
-      Your {fileType} file had {numErrors} {errorsTerm}:
-      </p>
+    <div
+      className="alert alert-danger"
+      data-testid={`${fileType}-validation-alert`}
+    >
+      <p>{summary}:</p>
       <ul>{errors.map((columns, i) => {
         return <li key={i}>{columns[2]}</li>
       })}
@@ -42,10 +18,14 @@ export default function ValidationAlert({ errors, file, fileType }) {
 }
 
 /** Convenience function to render this in a non-React part of the app */
-export function renderValidationAlert(target, errors, file, fileType) {
+export function renderValidationAlert(target, summary, errors, fileType) {
   ReactDOM.unmountComponentAtNode(target)
   ReactDOM.render(
-    <ValidationAlert errors={errors} file={file} fileType={fileType}/>,
+    <ValidationAlert
+      summary={summary}
+      errors={errors}
+      fileType={fileType}
+    />,
     target
   )
 }

--- a/app/javascript/lib/validation/io.js
+++ b/app/javascript/lib/validation/io.js
@@ -19,8 +19,8 @@ export async function readLinesAndType(file, numLines) {
       const enc = new TextDecoder('utf-8')
       const rawString = enc.decode(bufferSlice)
       const lines = rawString.split(/\r?\n/).slice(0, numLines)
-      const fileType = file.type
-      resolve({ lines, fileType })
+      const mimeType = file.type
+      resolve({ lines, mimeType })
     }
 
     reader.onerror = reject

--- a/app/views/studies/_initialize_metadata_form.html.erb
+++ b/app/views/studies/_initialize_metadata_form.html.erb
@@ -155,16 +155,20 @@
           const containerId = `${fileType}-metadata-container`
 
           let validationErrors = []
+          let summary = ''
           <% if User.feature_flag_for_instance(current_user, 'clientside_validation') %>
             $('#metadata-errors').remove() // Remove any prior notice
             $('#metadata_form').append(`<div id="${containerId}"></div>`)
             // Run client-side metadata file validation
-            validationErrors = await window.SCP.validateFile(file, fileType)
+            const results = await window.SCP.validateFile(file, fileType)
+            validationErrors = results.errors
+            summary = results.summary
           <% end %>
 
           const numErrors = validationErrors.length
 
           if (numErrors === 0) {
+            var fileName = file.name.replace(FILENAME_SANITIZER, '_');
             $('#metadata_form .filename').val(fileName);
             $.getJSON("<%= resume_upload_study_path %>", { file: fileName }, function (result) {
             	var file = result.file;
@@ -179,7 +183,7 @@
           } else {
             const target = document.querySelector(`#${containerId}`)
             window.SCP.renderValidationAlert(
-              target, validationErrors, file, fileType
+              target, summary, validationErrors, fileType,
             )
           }
 				},


### PR DESCRIPTION
This instruments Mixpanel logging for client-side file validation.  It enables product insight on which general errors users encounter and how frequently, as well as engineering insight by providing granular data about the invalid file and specifically why it failed validation.

After we capture different types of errors, e.g. ontology errors (SCP-3584), this basic analytics implementation will be extended in SCP-3608.  Having more error types to deal with will let us refine the logging design to ease triage, while also coherently integration with existing Mixpanel logging for ingests as done by Rails.

This satisfies SCP-3547.