### PR TITLE
softening 'disabled' text on reviewer access (SCP-3574)

### DIFF
--- a/app/views/site/_reviewer_access_fields.html.erb
+++ b/app/views/site/_reviewer_access_fields.html.erb
@@ -28,7 +28,7 @@
       </div>
     </div>
     <div class="col-md-6 left-border-0-5-gray">
-      <h4>Current Access Credentials <a id="copy-reviewer-creds" class="btn btn-default btn-sm btn-copy"
+      <h4>Current Reviewer Access Credentials <a id="copy-reviewer-creds" class="btn btn-default btn-sm btn-copy"
                                              data-toggle="tooltip" title="" data-original-title="Show PIN & copy to clipboard">
                                              <i class="far fa-copy"></i></a>
       </h4>
@@ -40,7 +40,7 @@
           <strong>PIN:</strong>&nbsp;<span id="reviewer-pin"><%= '*' * ReviewerAccess::PIN_LENGTH %></span>
         </p>
       <% else %>
-        <h4 class="text-danger">DISABLED</h4>
+        <span class="detail">none</span>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
SCP-3574
Since most studies will not have (and do not want to have) reviewer access enabled, I think a softer indication that reviewer access is not turned on better communicates the fact that it is not an error to not have reviewer access enabled.  This also changes the label to "Current Reviewer Access Credentails" so it's less likely a quick skim will result in a user thinking "oh no, there are no access credentials for my study, no one will be able to see it"

(before)
![image](https://user-images.githubusercontent.com/2800795/131165375-ff8a78fe-be87-4913-a3ea-ae601cdb0e04.png)

(with this PR)
![image](https://user-images.githubusercontent.com/2800795/131165702-be1d149d-ebc0-4a7a-87ed-52b1a7644471.png)

TO TEST:
0. Load the study settings for a study without reviewer access enabled
1. Confirm the look reasonably communicates that reviewer access is disabled, and that that may be perfectly normal

