### PR TITLE
Update handling of term match text highlighting (SCP-2877)

### DIFF
--- a/app/javascript/components/search/results/StudySearchResult.js
+++ b/app/javascript/components/search/results/StudySearchResult.js
@@ -15,15 +15,26 @@ export function formatDescription(rawDescription, term) {
   return shortenDescription(textDescription, term)
 }
 
+// add highlighted style around matched words keeping original capitalization of text
+function highlightWords(text, term) {
+  const words = text.split(' ')
+  words.forEach(word => {
+    if (term.toUpperCase() === word.toUpperCase()) {
+      text = text.replace(word, `<span class='highlight'>${word}</span>`)
+    }
+  }
+  )
+  return text
+}
+
 export function highlightText(text, termMatches) {
   let matchedIndices = []
   if (termMatches) {
     matchedIndices = termMatches.map(term => text.indexOf(term))
   }
   if (matchedIndices.length > 0) {
-    termMatches.forEach((term, index) => {
-      const regex = RegExp(term, 'gi')
-      text = text.replace(regex, `<span class='highlight'>${term}</span>`)
+    termMatches.forEach(term => {
+      text = highlightWords(text, term)
     })
   }
   return { styledText: text, matchedIndices }

--- a/app/javascript/components/search/results/StudySearchResult.js
+++ b/app/javascript/components/search/results/StudySearchResult.js
@@ -16,15 +16,23 @@ export function formatDescription(rawDescription, term) {
 }
 
 // add highlighted style around matched words keeping original capitalization of text
-function highlightWords(text, term) {
+function highlightWords(text, termMatches) {
+  let stylizedText = ''
   const words = text.split(' ')
   words.forEach(word => {
-    if (term.toUpperCase() === word.toUpperCase()) {
-      text = text.replace(word, `<span class='highlight'>${word}</span>`)
+    let alreadyMatched = false
+    termMatches.forEach(term => {
+      if (term.toUpperCase() === word.toUpperCase()) {
+        stylizedText = `${stylizedText} <span class='highlight'>${word}</span>`
+        alreadyMatched = true
+      }
+    })
+    if (!alreadyMatched) {
+      stylizedText = `${stylizedText} ${word}`
     }
   }
   )
-  return text
+  return stylizedText
 }
 
 export function highlightText(text, termMatches) {
@@ -33,9 +41,7 @@ export function highlightText(text, termMatches) {
     matchedIndices = termMatches.map(term => text.indexOf(term))
   }
   if (matchedIndices.length > 0) {
-    termMatches.forEach(term => {
-      text = highlightWords(text, term)
-    })
+    text = highlightWords(text, termMatches)
   }
   return { styledText: text, matchedIndices }
 }

--- a/app/javascript/components/search/results/StudySearchResult.js
+++ b/app/javascript/components/search/results/StudySearchResult.js
@@ -20,16 +20,13 @@ function highlightWords(text, termMatches) {
   let stylizedText = ''
   const words = text.split(' ')
   words.forEach(word => {
-    let alreadyMatched = false
-    termMatches.forEach(term => {
-      if (term.toUpperCase() === word.toUpperCase()) {
-        stylizedText = `${stylizedText} <span class='highlight'>${word}</span>`
-        alreadyMatched = true
-      }
-    })
-    if (!alreadyMatched) {
-      stylizedText = `${stylizedText} ${word}`
+  let stylizedWord = word
+  termMatches.forEach(term => {
+    if (term.toUpperCase() === word.toUpperCase()) {
+      stylizedWord = `<span class='highlight'>${word}</span>`
     }
+  })
+  stylizedText = `${stylizedText} ${stylizedWord}`
   }
   )
   return stylizedText

--- a/app/javascript/components/search/results/StudySearchResult.js
+++ b/app/javascript/components/search/results/StudySearchResult.js
@@ -15,7 +15,7 @@ export function formatDescription(rawDescription, term) {
   return shortenDescription(textDescription, term)
 }
 
-// add highlighted style around matched words keeping original capitalization of text
+/** Highlight matched words, keeping original capitalization of text */
 function highlightWords(text, termMatches) {
   let stylizedText = ''
   const words = text.split(' ')

--- a/test/js/study.test.js
+++ b/test/js/study.test.js
@@ -6,7 +6,7 @@ describe('highlightText', () => {
   const text = 'Study: Single nucleus RNA-seq of cell diversity in the adult mouse hippocampus (sNuc-Seq)'
   const expectedHighlightedText = 'Study: Single <span class=\'highlight\'>nucleus</span> RNA-seq of cell <span class=\'highlight\'>diversity</span> in the adult mouse hippocampus (sNuc-Seq)'
   const unMatchedTerms = ['tuberculosis', 'population']
-  const matchedTerms = ['nucleus', 'and', 'diversity']
+  const matchedTerms = ['nUcLEus', 'and', 'diVERsity']
 
   it('returns unaltered text when there are no matches', () => {
     const unhighlightedText = highlightText(text, unMatchedTerms).styledText


### PR DESCRIPTION
Previously a keyword search would replace the words in the text of the study with the exact search word for highlighting purposes. So if a user searched for "mOuSe" then in the study the word "mouse" would be replaced with the highlighted text "mOuSe".

This fixes the search so that the formatting/capitalization of the text in a study remains regardless of how the user typed the word.

This also removes partial word matching so if a user searches on "to" only the word "to" will result in a match not words like "on**_to_**logy" which would have previously matched. 

New keyword search respects study description/title capitalization:
![Screen Shot 2021-08-30 at 2 21 07 PM](https://user-images.githubusercontent.com/54322292/131386119-72d29560-b2bf-4f7c-9241-34cf8cff6b64.png)

Old Style:
<img width="974" alt="Screen Shot 2021-08-28 at 11 05 26 PM" src="https://user-images.githubusercontent.com/54322292/131237197-62d25ec5-1232-4a4e-a2af-f238960f2d6c.png">

New style doesn't partial match:
![Screen Shot 2021-08-30 at 2 22 35 PM](https://user-images.githubusercontent.com/54322292/131386239-1233c91a-9203-4d49-987d-3c5a9c29ebe4.png)

Old matched partial:
<img width="782" alt="Screen Shot 2021-08-28 at 11 19 33 PM" src="https://user-images.githubusercontent.com/54322292/131237227-8dab206a-691a-47a5-9a1a-697a4256417f.png">

