### PR TITLE
Requiring raw count matrices in upload wizard, sync UI/UX (SCP-3492, SCP-3585)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -278,15 +278,21 @@ function enableDefaultActions() {
 
     // reset units dropdown based on is_raw_counts?
     $('body').on('click', '.raw-counts-radio', function() {
-        var isRawCount = $(this).val() == '1'
-        var expFileInfoForm = $(this).closest('.expression-file-info-fields')
-        var unitSelect = expFileInfoForm.find('.counts-unit-dropdown');
-        if ( !isRawCount ) {
-            unitSelect.val('');
-            setElementsEnabled(unitSelect, false);
-        } else {
-            setElementsEnabled(unitSelect, true);
-        }
+      let exprFields = $(this).closest('.expression-file-info-fields')
+      let isRawCounts = exprFields.find('.is_raw_counts_true')[0].checked
+      let unitSelect = exprFields.find('.counts-unit-dropdown')
+      let unitsSelectDiv = exprFields.find('.raw-counts-units-select')
+      let assnSelectDiv = exprFields.find('.raw_associations_select')
+      if ( !isRawCounts ) {
+        unitSelect.val('');
+        setElementsEnabled(unitSelect, false);
+        assnSelectDiv.removeClass('hidden')
+        unitsSelectDiv.addClass('hidden')
+      } else {
+        setElementsEnabled(unitSelect, true);
+        unitsSelectDiv.removeClass('hidden')
+        assnSelectDiv.addClass('hidden')
+      }
     });
 
     // when clicking the main study view page tabs, update the current URL so that when you refresh the tab stays open

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -739,3 +739,12 @@ function setExpressionOverlay(renderOverlay) {
     content.removeClass('show-processed-disclaimer').addClass('hide-processed-disclaimer')
   }
 }
+
+// update all raw counts association dropdowns with new options
+function updateRawCountsAssnSelect(parentForm, currentValues) {
+  const rawAssnTarget = $(`${parentForm} .raw_associations_select`)[0]
+  const pairedHiddenField = $(`${parentForm} .raw_counts_associations`)[0]
+  const matrixOpts = window.SCP.currentStudyFiles.filter(sf => sf?.expression_file_info?.is_raw_counts)
+    ?.map(sf => ({ label: sf.upload_file_name, value: sf['_id']['$oid'] }))
+  window.SCP.renderRawAssociationSelect(rawAssnTarget, currentValues, pairedHiddenField, matrixOpts)
+}

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -721,14 +721,15 @@ function setElementsEnabled(selector, enabled= true) {
     selector.attr('disabled', enabled ? false : 'disabled')
 }
 
-function toggleExpressionOverlay(allowUploads) {
+// show/hide overlay div & buttons blocking processed matrix file uploads
+function setExpressionOverlay(renderOverlay) {
   let overlay = $('#block-processed-upload')
-  let disclaimer = $('#block-processed-upload-content')
-  if (allowUploads) {
-    overlay.removeClass('overlay-upload')
-    disclaimer.hide()
-  } else {
+  let content = $('#block-processed-upload-content')
+  if (renderOverlay) {
     overlay.addClass('overlay-upload')
-    disclaimer.show()
+    content.removeClass('hide-processed-disclaimer').addClass('show-processed-disclaimer')
+  } else {
+    overlay.removeClass('overlay-upload')
+    content.removeClass('show-processed-disclaimer').addClass('hide-processed-disclaimer')
   }
 }

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -720,3 +720,15 @@ function setElementsEnabled(selector, enabled= true) {
     selector.css(elementCss).parent().css(parentCss);
     selector.attr('disabled', enabled ? false : 'disabled')
 }
+
+function toggleExpressionOverlay(allowUploads) {
+  let overlay = $('#block-processed-upload')
+  let disclaimer = $('#block-processed-upload-content')
+  if (allowUploads) {
+    overlay.removeClass('overlay-upload')
+    disclaimer.hide()
+  } else {
+    overlay.addClass('overlay-upload')
+    disclaimer.show()
+  }
+}

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -161,7 +161,8 @@ function elementVisible(element) {
 
 // used for keeping track of position in wizard
 var completed = {
-    initialize_expression_form_nav: false,
+    initialize_raw_expression_form_nav: false,
+    initialize_processed_expression_form_nav: false,
     initialize_metadata_form_nav: false,
     initialize_ordinations_form_nav: false,
     initialize_labels_form_nav: false,

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -278,11 +278,11 @@ function enableDefaultActions() {
 
     // reset units dropdown based on is_raw_counts?
     $('body').on('click', '.raw-counts-radio', function() {
-      let exprFields = $(this).closest('.expression-file-info-fields')
-      let isRawCounts = exprFields.find('.is_raw_counts_true')[0].checked
-      let unitSelect = exprFields.find('.counts-unit-dropdown')
-      let unitsSelectDiv = exprFields.find('.raw-counts-units-select')
-      let assnSelectDiv = exprFields.find('.raw_associations_select')
+      const exprFields = $(this).closest('.expression-file-info-fields')
+      const isRawCounts = exprFields.find('.is_raw_counts_true')[0].checked
+      const unitSelect = exprFields.find('.counts-unit-dropdown')
+      const unitsSelectDiv = exprFields.find('.raw-counts-units-select')
+      const assnSelectDiv = exprFields.find('.raw_associations_select')
       if ( !isRawCounts ) {
         unitSelect.val('');
         setElementsEnabled(unitSelect, false);
@@ -629,12 +629,12 @@ function validateCandidateUpload(formId, filename, classSelector) {
         setErrorOnBlank(taxonSelect);
         return false;
     }
-    // enforce units if matrix is raw counts
+    // enforce units if matrix is raw count
     var countsRadio = Array.from(form.find('.raw-counts-radio')).find(radio => radio.checked);
     if ( typeof countsRadio !== 'undefined' && $(countsRadio).val() == '1') {
         var units = form.find('.counts-unit-dropdown');
         if ( $(units).val() == '') {
-            alert('You must specify units for raw counts matrices.');
+            alert('You must specify units for raw count matrices.');
             setErrorOnBlank(units);
             return false;
         }
@@ -729,8 +729,8 @@ function setElementsEnabled(selector, enabled= true) {
 
 // show/hide overlay div & buttons blocking processed matrix file uploads
 function setExpressionOverlay(renderOverlay) {
-  let overlay = $('#block-processed-upload')
-  let content = $('#block-processed-upload-content')
+  const overlay = $('#block-processed-upload')
+  const content = $('#block-processed-upload-content')
   if (renderOverlay) {
     overlay.addClass('overlay-upload')
     content.removeClass('hide-processed-disclaimer').addClass('show-processed-disclaimer')
@@ -745,6 +745,6 @@ function updateRawCountsAssnSelect(parentForm, currentValues) {
   const rawAssnTarget = $(`${parentForm} .raw_associations_select`)[0]
   const pairedHiddenField = $(`${parentForm} .raw_counts_associations`)[0]
   const matrixOpts = window.SCP.currentStudyFiles.filter(sf => sf?.expression_file_info?.is_raw_counts)
-    ?.map(sf => ({ label: sf.upload_file_name, value: sf['_id']['$oid'] }))
+    .map(sf => ({ label: sf.upload_file_name, value: sf['_id']['$oid'] }))
   window.SCP.renderRawAssociationSelect(rawAssnTarget, currentValues, pairedHiddenField, matrixOpts)
 }

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1134,7 +1134,7 @@ class StudiesController < ApplicationController
     @all_expression = @study.study_files.by_type(['Expression Matrix', 'MM Coordinate Matrix'])
     # divide all expression files into raw/processed bins
     @raw_matrix_files, @processed_matrix_files = @all_expression.partition(&:is_raw_counts_file?)
-    @block_processed_upload = @raw_matrix_files.empty? && @processed_matrix_files.empty? &&
+    @block_processed_upload = @raw_matrix_files.empty? &&
                               User.feature_flag_for_instance(current_user, 'raw_counts_required_frontend')
     @metadata_file = @study.metadata_file
     @cluster_ordinations = @study.study_files.by_type('Cluster')

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -609,7 +609,7 @@ class StudiesController < ApplicationController
   def parse
     @study_file = StudyFile.where(study_id: params[:id], upload_file_name: params[:file]).first
     @status = FileParseService.run_parse_job(@study_file, @study, current_user)
-    @allow_only = params[:allow_only]
+    @allow_only = params[:allow_only] || 'all'
     # special handling for coordinate labels
     if @study_file.file_type == 'Coordinate Labels' && @status[:status_code] == 412
       # delete file and inform user of issue as this error is not recoverable

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -483,6 +483,9 @@ class StudiesController < ApplicationController
         study_file.update!(study_file_params)
       rescue => e
         logger.error "#{study_file.errors.full_messages.join(", ")}"
+        if study_file.errors[:expression_file_info].any?
+          logger.info "#{study_file.errors[:expression_file_info]}"
+        end
         existing_file = StudyFile.find(study_file.id)
         if existing_file
           ErrorTracker.report_exception(e, current_user, params)

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -841,7 +841,7 @@ class StudiesController < ApplicationController
     @study_file = @study.build_study_file({file_type: @file_type})
     @allow_only = params[:allow_only] || 'all'
     if @file_type =~ /Matrix/
-      @study_file.build_expression_file_info(is_raw_counts: @allow_only == 'raw' ? true : false)
+      @study_file.build_expression_file_info(is_raw_counts: @allow_only == 'raw')
     end
 
     # logic for rolling back status bar in upload wizard; need to account for raw vs. processed matrix files
@@ -1173,7 +1173,7 @@ class StudiesController < ApplicationController
   end
 
   def set_expression_form_state
-    # if feature flag is enabled, ensure there are raw counts matrix files
+    # if feature flag is enabled, ensure there are raw count matrix files
     if @study.study_files.where(file_type: /Matrix/, queued_for_deletion: false,
                                 'expression_file_info.is_raw_counts' => true).empty? &&
       User.feature_flag_for_instance(current_user, 'raw_counts_required_frontend')

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -145,7 +145,7 @@ const COLUMNS = {
   matrix: {
     title: 'Matrix',
     types: ['Expression Matrix', 'MM Coordinate Matrix', '10X Genes File', '10X Barcodes File'],
-    info: 'Expression matrix files, including processed or raw counts files',
+    info: 'Expression matrix files, including processed or raw count files',
     default: true
   },
   cluster: {
@@ -169,7 +169,7 @@ const COLUMNS = {
   analysis: {
     title: 'Analysis',
     types: ['analysis_file'],
-    info: 'Expression matrix files, including processed or raw counts files',
+    info: 'Expression matrix files, including processed or raw count files',
     default: true
   },
   sequence: {

--- a/app/javascript/components/upload/RawAssociationSelect.js
+++ b/app/javascript/components/upload/RawAssociationSelect.js
@@ -33,7 +33,7 @@ export default function RawAssociationSelect({ initialValue, parentForm, hiddenF
   // set minWidth to 100% on label to allow select to expand to fill entire column
   return (
     <label style={{ minWidth: '100%' }}>
-      Corresponding raw file:
+      Corresponding raw count file:
       <Select options={opts}
               value={selected}
               isMulti={true}

--- a/app/javascript/components/upload/RawAssociationSelect.js
+++ b/app/javascript/components/upload/RawAssociationSelect.js
@@ -49,7 +49,7 @@ export default function RawAssociationSelect({ initialValue, parentForm, hiddenF
 }
 
 /** convenience method for drawing/updating the component from non-react portions of SCP */
-export function renderRawAssociationSelect(target, opts, initialValue, hiddenField) {
+export function renderRawAssociationSelect(target, initialValue, hiddenField, opts ) {
   const parentForm = $(target).closest('.expression-file-info-fields')[0]
   ReactDOM.render(
     <RawAssociationSelect

--- a/app/javascript/components/upload/RawAssociationSelect.js
+++ b/app/javascript/components/upload/RawAssociationSelect.js
@@ -32,8 +32,8 @@ export default function RawAssociationSelect({ initialValue, parentForm, hiddenF
 
   // set minWidth to 100% on label to allow select to expand to fill entire column
   return (
-    <label style={{ minWidth: '100%' }}>
-      Corresponding raw count file:
+    <label className="min-width-100">
+      Associated raw count file <i className='text-danger'>*</i>
       <Select options={opts}
               value={selected}
               isMulti={true}

--- a/app/javascript/components/upload/RawAssociationSelect.js
+++ b/app/javascript/components/upload/RawAssociationSelect.js
@@ -1,0 +1,62 @@
+import React, { useState } from 'react'
+import ReactDOM from 'react-dom'
+import Select from 'react-select'
+
+/** whether or not the given form specifies a raw counts expression form */
+function isInRawForm(parentForm) {
+  return $(parentForm).find('.is_raw_counts_true')[0].checked
+}
+
+/** updates the raw_counts_associations hidden field with the selections, which should be an array of id strings */
+function updateHiddenField(hiddenField, selections) {
+  if (hiddenField) {
+    if (selections) {
+      hiddenField.value = selections.map(selection => selection.value).join(' ')
+    } else {
+      hiddenField.value = ''
+    }
+  }
+}
+
+/** Renders a multiselect for mapping processed matrix to raw matrix files.  Meant to be embedded in
+ the rails _initialize_expression_form */
+export default function RawAssociationSelect({ initialValue, parentForm, hiddenField, opts }) {
+  // selected is an array of string for the ids of the associated cluster files
+  const [selected, setSelected] = useState(initialValue)
+
+  if (isInRawForm(parentForm)) {
+    updateHiddenField(hiddenField, [])
+    return <span className="hidden-raw-association-select"></span>
+  }
+
+  /** handle change events from the multiselect component, and syncing the hidden field */
+  function updateSelection(selections) {
+    setSelected(selections)
+    updateHiddenField(hiddenField, selections, parentForm)
+  }
+
+  // set minWidth to 100% on label to allow select to expand to fill entire column
+  return (
+    <label style={{ minWidth: '100%' }}>
+      Corresponding raw file:
+      <Select options={opts}
+              value={selected}
+              isMulti={true}
+              placeholder="None"
+              onChange={updateSelection}/>
+    </label>
+  )
+}
+
+/** convenience method for drawing/updating the component from non-react portions of SCP */
+export function renderRawAssociationSelect(target, opts, initialValue, hiddenField) {
+  const parentForm = $(target).closest('.expression-file-info-fields')[0]
+  ReactDOM.render(
+    <RawAssociationSelect
+      initialValue={initialValue}
+      parentForm={parentForm}
+      hiddenField={hiddenField}
+      opts={opts}/>,
+    target
+  )
+}

--- a/app/javascript/components/upload/RawAssociationSelect.js
+++ b/app/javascript/components/upload/RawAssociationSelect.js
@@ -2,11 +2,6 @@ import React, { useState } from 'react'
 import ReactDOM from 'react-dom'
 import Select from 'react-select'
 
-/** whether or not the given form specifies a raw counts expression form */
-function isInRawForm(parentForm) {
-  return $(parentForm).find('.is_raw_counts_true')[0].checked
-}
-
 /** updates the raw_counts_associations hidden field with the selections, which should be an array of id strings */
 function updateHiddenField(hiddenField, selections) {
   if (hiddenField) {
@@ -18,16 +13,16 @@ function updateHiddenField(hiddenField, selections) {
   }
 }
 
-/** Renders a multiselect for mapping processed matrix to raw matrix files.  Meant to be embedded in
- the rails _initialize_expression_form */
+/** Renders a multiselect for mapping processed matrix to raw matrix files.
+ *
+ * @param {Object} initialValue current selected value
+ * @param {Object} parentForm parent HTML form DOM object
+ * @param {Object} hiddenField hidden HTML form field for tracking associations
+ * @param {Array} opts select form options array
+ */
 export default function RawAssociationSelect({ initialValue, parentForm, hiddenField, opts }) {
   // selected is an array of string for the ids of the associated cluster files
   const [selected, setSelected] = useState(initialValue)
-
-  if (isInRawForm(parentForm)) {
-    updateHiddenField(hiddenField, [])
-    return <span className="hidden-raw-association-select"></span>
-  }
 
   /** handle change events from the multiselect component, and syncing the hidden field */
   function updateSelection(selections) {
@@ -49,7 +44,7 @@ export default function RawAssociationSelect({ initialValue, parentForm, hiddenF
 }
 
 /** convenience method for drawing/updating the component from non-react portions of SCP */
-export function renderRawAssociationSelect(target, initialValue, hiddenField, opts ) {
+export function renderRawAssociationSelect(target, initialValue, hiddenField, opts) {
   const parentForm = $(target).closest('.expression-file-info-fields')[0]
   ReactDOM.render(
     <RawAssociationSelect

--- a/app/javascript/components/upload/RawAssociationSelect.js
+++ b/app/javascript/components/upload/RawAssociationSelect.js
@@ -46,6 +46,7 @@ export default function RawAssociationSelect({ initialValue, parentForm, hiddenF
 /** convenience method for drawing/updating the component from non-react portions of SCP */
 export function renderRawAssociationSelect(target, initialValue, hiddenField, opts) {
   const parentForm = $(target).closest('.expression-file-info-fields')[0]
+  ReactDOM.unmountComponentAtNode(target)
   ReactDOM.render(
     <RawAssociationSelect
       initialValue={initialValue}

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -62,19 +62,6 @@ function defaultPostInit(mock=false) {
 }
 
 /**
- * Retrieve all study files for a given study
- * Docs: https://singlecell.broadinstitute.org/single_cell/api/v1#/StudyFiles/study_study_files_path
- *
- * @param {String} studyId: BSON ID of study
- * @param {Boolean} mock If using mock data.  Helps development, tests.
- */
-export async function fetchStudyFiles(studyId, mock=false) {
-  const path = `/studies/${studyId}/study_files`
-  const [studyFiles] = await scpApi(path, defaultInit(), mock)
-  return studyFiles
-}
-
-/**
  * Create and return a one-time authorization code for download
  *
  * TODO:

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -62,6 +62,19 @@ function defaultPostInit(mock=false) {
 }
 
 /**
+ * Retrieve all study files for a given study
+ * Docs: https://singlecell.broadinstitute.org/single_cell/api/v1#/StudyFiles/study_study_files_path
+ *
+ * @param {String} studyId: BSON ID of study
+ * @param {Boolean} mock If using mock data.  Helps development, tests.
+ */
+export async function fetchStudyFiles(studyId, mock=false) {
+  const path = `/studies/${studyId}/study_files`
+  const [studyFiles] = await scpApi(path, defaultInit(), mock)
+  return studyFiles
+}
+
+/**
  * Create and return a one-time authorization code for download
  *
  * TODO:

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -55,6 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
   checkMissingAuthToken()
 })
 
+
 window.SCP = window.SCP ? window.SCP : {}
 // SCP expects these variables to be global.
 //

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -30,6 +30,7 @@ import {
 } from 'lib/metrics-api'
 import * as ScpApi from 'lib/scp-api'
 import { renderClusterAssociationSelect } from 'components/upload/ClusterAssociationSelect'
+import { renderRawAssociationSelect } from 'components/upload/RawAssociationSelect'
 import { renderExploreView } from 'components/explore/ExploreView'
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -66,4 +67,5 @@ window.morpheus = morpheus
 window.SCP.log = log
 window.SCP.API = ScpApi
 window.SCP.renderClusterAssociationSelect = renderClusterAssociationSelect
+window.SCP.renderRawAssociationSelect = renderRawAssociationSelect
 window.SCP.renderExploreView = renderExploreView

--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -179,11 +179,16 @@
   background: rgba(244,243,244,0.75);
 }
 
-#block-processed-upload-content {
+.show-processed-disclaimer {
   z-index: 1000;
   display: block;
   position: absolute;
   top: 20%;
   left: 0;
   right: 0;
+}
+
+.hide-processed-disclaimer {
+  display: none;
+  z-index: -1000;
 }

--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -176,7 +176,7 @@
   top: 0;
   left: 0;
   right: 0;
-  background: rgba(244,243,244,0.75);
+  background: rgba(244,243,244,0.85);
 }
 
 .show-processed-disclaimer {

--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -161,3 +161,29 @@
   width: 800px;
   margin: 0px auto;
 }
+
+.overlay-upload {
+  position: relative;
+  background: rgba(244,243,244,1.0);
+}
+
+.overlay-upload:after {
+  content: " ";
+  z-index: 10;
+  display: block;
+  position: absolute;
+  height: 100%;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: rgba(244,243,244,0.75);
+}
+
+#block-processed-upload-content {
+  z-index: 1000;
+  display: block;
+  position: absolute;
+  top: 20%;
+  left: 0;
+  right: 0;
+}

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -783,3 +783,7 @@ figcaption.ck-editor__editable {
 .no-wrap {
   whitespace: no-wrap;
 }
+
+.min-width-100 {
+  min-width: 100%;
+}

--- a/app/models/concerns/feature_flaggable.rb
+++ b/app/models/concerns/feature_flaggable.rb
@@ -68,6 +68,4 @@ module FeatureFlaggable
       instance.save
     end
   end
-
-
 end

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -88,10 +88,10 @@ class ExpressionFileInfo
     end
   end
 
-  # enforce selecting units on raw counts matrices
+  # enforce selecting units on raw count matrices
   def enforce_units_on_raw_counts
     if self.is_raw_counts && self.units.blank?
-      errors.add(:units, ' must have a value for raw counts matrices')
+      errors.add(:units, ' must have a value for raw count matrices')
     end
   end
 
@@ -113,7 +113,7 @@ class ExpressionFileInfo
     # if any user account returned false for :raw_counts_required_backed, then allow saving of expression matrix
     # otherwise, add validation error for :raw_counts_associations
     unless raw_counts_required.include?(false)
-      errors.add(:base, 'You must specify at least one corresponding raw counts file before saving')
+      errors.add(:base, 'You must specify at least one associated raw count file before saving')
     end
   end
 end

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -101,9 +101,7 @@ class ExpressionFileInfo
     # first ensure raw matrix is present
     if raw_counts_associations.any?
       raw_counts_associations.each do |study_file_id|
-        Rails.logger.info "validating presence of #{study_file_id} in enforce_raw_counts_associations"
         raw_matrix = StudyFile.find(study_file_id)
-        Rails.logger.info "file: #{raw_matrix.present?}, raw_counts: #{raw_matrix&.is_raw_counts_file?}"
         return true if raw_matrix&.is_raw_counts_file?
       end
     end
@@ -115,7 +113,7 @@ class ExpressionFileInfo
     # if any user account returned false for :raw_counts_required_backed, then allow saving of expression matrix
     # otherwise, add validation error for :raw_counts_associations
     unless raw_counts_required.include?(false)
-      errors.add(:raw_counts_associations, 'must include at least one raw counts matrix filename before saving')
+      errors.add(:base, 'You must specify at least one corresponding raw counts file before saving')
     end
   end
 end

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -101,7 +101,9 @@ class ExpressionFileInfo
     # first ensure raw matrix is present
     if raw_counts_associations.any?
       raw_counts_associations.each do |study_file_id|
+        Rails.logger.info "validating presence of #{study_file_id} in enforce_raw_counts_associations"
         raw_matrix = StudyFile.find(study_file_id)
+        Rails.logger.info "file: #{raw_matrix.present?}, raw_counts: #{raw_matrix&.is_raw_counts_file?}"
         return true if raw_matrix&.is_raw_counts_file?
       end
     end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -550,7 +550,7 @@ class IngestJob
 
     case file_type
     when /Matrix/
-      # since genes are not ingested for raw counts matrices, report number of cells ingested
+      # since genes are not ingested for raw count matrices, report number of cells ingested
       cells = self.study.expression_matrix_cells(self.study_file)
       cell_count = cells.present? ? cells.count : 0
       job_props.merge!({ numCells: cell_count, is_raw_counts: self.study_file.is_raw_counts_file? })
@@ -612,7 +612,7 @@ class IngestJob
 
     case file_type
     when /Matrix/
-      # since genes are not ingested for raw counts matrices, report number of cells ingested
+      # since genes are not ingested for raw count matrices, report number of cells ingested
       if self.study_file.is_raw_counts_file?
         cells = self.study.expression_matrix_cells(self.study_file).count
         message << "Cells ingested: #{cells}"

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -553,7 +553,7 @@ class IngestJob
       # since genes are not ingested for raw counts matrices, report number of cells ingested
       cells = self.study.expression_matrix_cells(self.study_file)
       cell_count = cells.present? ? cells.count : 0
-      job_props.merge!({:numCells => cell_count})
+      job_props.merge!({ numCells: cell_count, is_raw_counts: self.study_file.is_raw_counts_file? })
       if !self.study_file.is_raw_counts_file?
         genes = Gene.where(study_id: self.study.id, study_file_id: self.study_file.id).count
         job_props.merge!({:numGenes => genes})

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -41,29 +41,35 @@ class Study
   belongs_to :user
   belongs_to :branding_group, optional: true
   has_many :study_files, dependent: :delete_all do
+    # all study files not queued for deletion
+    def available
+      where(queued_for_deletion: false)
+    end
+
     def by_type(file_type)
       if file_type.is_a?(Array)
-        where(queued_for_deletion: false, :file_type.in => file_type).to_a
+        available.where(:file_type.in => file_type).to_a
       else
-        where(queued_for_deletion: false, file_type: file_type).to_a
+        available.where(file_type: file_type).to_a
       end
     end
 
     def non_primary_data
-      where(queued_for_deletion: false).not_in(file_type: StudyFile::PRIMARY_DATA_TYPES).to_a
+      available.not_in(file_type: StudyFile::PRIMARY_DATA_TYPES).to_a
     end
 
     def primary_data
-      where(queued_for_deletion: false).in(file_type: StudyFile::PRIMARY_DATA_TYPES).to_a
+      available.in(file_type: StudyFile::PRIMARY_DATA_TYPES).to_a
     end
 
+    # all files that have been pushed to the bucket (will have the generation tag)
     def valid
-      where(queued_for_deletion: false, :generation.ne => nil).to_a
+      available.where(:generation.ne => nil).to_a
     end
 
     # includes links to external data which do not reside in the workspace bucket
     def downloadable
-      where(queued_for_deletion: false).any_of({:generation.ne => nil}, {:human_fastq_url.ne => nil})
+      available.where.any_of({ :generation.ne => nil }, { :human_fastq_url.ne => nil })
     end
   end
 

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -71,6 +71,11 @@ class Study
     def downloadable
       available.where.any_of({ :generation.ne => nil }, { :human_fastq_url.ne => nil })
     end
+
+    # all files not queued for deletion, ignoring newly built files
+    def persisted
+      available.reject(&:new_record?)
+    end
   end
 
   has_many :study_file_bundles, dependent: :destroy do

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -862,7 +862,7 @@ class StudyFile
       # lazy-load all other expression matrices in study
       process_matrices = StudyFile.where(study_id: study.id, file_type: /Matrix/, queued_for_deletion: false,
                                          :id.ne => id, 'expression_file_info.is_raw_counts' => false)
-      process_matrices.select { |matrix| matrix&.expression_file_info&.raw_counts_associations.include?(id.to_s) }
+      process_matrices.select { |matrix| matrix&.expression_file_info&.raw_counts_associations&.include?(id.to_s) }
     else
       [] # nil-safe return w/ no association type specified
     end

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -63,6 +63,7 @@ class StudyFile
   embeds_one :expression_file_info
 
   accepts_nested_attributes_for :expression_file_info
+  validate :show_exp_file_info_errors
 
   # field definitions
   field :name, type: String
@@ -1339,6 +1340,13 @@ class StudyFile
     # otherwise, add validation error for :use_metadata_convention
     unless convention_required.include?(false)
       errors.add(:use_metadata_convention, 'must be "true" to ensure data complies with the SCP metadata convention')
+    end
+  end
+
+  def show_exp_file_info_errors
+    if self.expression_file_info.present? && !self.expression_file_info.valid?
+      errors.add(:base, self.expression_file_info.errors.full_messages.join(', '))
+      errors.delete(:expression_file_info) # remove "Expression file info is invalid" message
     end
   end
 end

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1066,7 +1066,7 @@ class StudyFile
     when 'Coordinate Labels'
       'initialize_labels_form'
     when 'Expression Matrix'
-      'initialize_expression_form'
+      is_raw_counts_file? ? 'initialize_raw_expression_form' : 'initialize_processed_expression_form'
     when 'MM Coordinate Matrix'
       'initialize_expression_form'
     when '10X Genes File'

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -259,11 +259,11 @@ class StudyFile
       key :description, 'Expression matrix-specific file information'
       property :is_raw_counts do
         key :type, :boolean
-        key :description, 'Indication of whether matrix contains raw counts data'
+        key :description, 'Indication of whether matrix contains raw count data'
       end
       property :units do
         key :type, :string
-        key :description, 'Type of units for raw counts file'
+        key :description, 'Type of units for raw count file'
         key :enum, ExpressionFileInfo::UNITS_VALUES
       end
       property :biosample_input_type do
@@ -404,11 +404,11 @@ class StudyFile
           key :description, 'Expression matrix-specific file information'
           property :is_raw_counts do
             key :type, :boolean
-            key :description, 'Indication of whether matrix contains raw counts data'
+            key :description, 'Indication of whether matrix contains raw count data'
           end
           property :units do
             key :type, :string
-            key :description, 'Type of units for raw counts file'
+            key :description, 'Type of units for raw count file'
             key :enum, ExpressionFileInfo::UNITS_VALUES
           end
           property :biosample_input_type do
@@ -491,11 +491,11 @@ class StudyFile
           key :description, 'Expression matrix-specific file information'
           property :is_raw_counts do
             key :type, :boolean
-            key :description, 'Indication of whether matrix contains raw counts data'
+            key :description, 'Indication of whether matrix contains raw count data'
           end
           property :units do
             key :type, :string
-            key :description, 'Type of units for raw counts file'
+            key :description, 'Type of units for raw count file'
             key :enum, ExpressionFileInfo::UNITS_VALUES
           end
           property :biosample_input_type do
@@ -861,9 +861,9 @@ class StudyFile
       StudyFile.where(:id.in => study_file_ids, queued_for_deletion: false)
     when :processed
       # lazy-load all other expression matrices in study
-      process_matrices = StudyFile.where(study_id: study.id, file_type: /Matrix/, queued_for_deletion: false,
+      processed_matrices = StudyFile.where(study_id: study.id, file_type: /Matrix/, queued_for_deletion: false,
                                          :id.ne => id, 'expression_file_info.is_raw_counts' => false)
-      process_matrices.select { |matrix| matrix&.expression_file_info&.raw_counts_associations&.include?(id.to_s) }
+      processed_matrices.select { |matrix| matrix&.expression_file_info&.raw_counts_associations&.include?(id.to_s) }
     else
       [] # nil-safe return w/ no association type specified
     end
@@ -948,7 +948,7 @@ class StudyFile
     ['Expression Matrix', 'MM Coordinate Matrix'].include? self.file_type
   end
 
-  # helper to identify if matrix is a raw counts file
+  # helper to identify if matrix is a raw count file
   def is_raw_counts_file?
     self.expression_file_info.present? ? self.expression_file_info.is_raw_counts : false
   end

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1066,7 +1066,7 @@ class StudyFile
     when 'Coordinate Labels'
       'initialize_labels_form'
     when 'Expression Matrix'
-      is_raw_counts_file? ? 'initialize_raw_expression_form' : 'initialize_processed_expression_form'
+      'initialize_expression_form'
     when 'MM Coordinate Matrix'
       'initialize_expression_form'
     when '10X Genes File'

--- a/app/views/admin_configurations/edit_user.html.erb
+++ b/app/views/admin_configurations/edit_user.html.erb
@@ -28,29 +28,31 @@
     </div>
   </div>
   <div class="form-group row">
-    <div class="row">
+    <div class="col-md-12">
+      <label>Feature flags</label>
+    </div>
+    <div class="form-group row">
       <div class="col-md-12">
-        <label>Feature flags</label>
+        <% @user.feature_flags_with_defaults.sort_by { |key, _| key }.each do |key, _| %>
+          <% @default_flag =  FeatureFlag.find_by(name: key) %>
+          <div class="row <%= @user.feature_flags.key?(key) ? 'highlight' : '' %>">
+            <div class="col-md-3 text-right">
+              <label><%= key %>:</label>
+            </div>
+            <div class="col-md-2">
+              <select name="feature_flag_<%= key %>" class="form-control">
+                <option value="0" <%= @user.feature_flags[key] == false ? 'selected' : '' %>>False</option>
+                <option value="1" <%= @user.feature_flags[key] == true ? 'selected' : '' %>>True</option>
+                <option value="-" <%= @user.feature_flags.key?(key) ? '' : 'selected' %>>Default (<%= @default_flag.default_value %>)</option>
+              </select>
+            </div>
+            <div class="col-md-6">
+              <%= @default_flag.description %>
+            </div>
+          </div>
+        <% end %>
       </div>
     </div>
-    <% @user.feature_flags_with_defaults.each do |key, value| %>
-      <% @default_flag =  FeatureFlag.find_by(name: key) %>
-      <div class="row <%= @user.feature_flags.key?(key) ? 'highlight' : '' %>">
-        <div class="col-md-3 text-right">
-          <label><%= key %>:</label>
-        </div>
-        <div class="col-md-2">
-          <select name="feature_flag_<%= key %>">
-            <option value="0" <%= @user.feature_flags[key] == false ? 'selected' : '' %>>False</option>
-            <option value="1" <%= @user.feature_flags[key] == true ? 'selected' : '' %>>True</option>
-            <option value="-" <%= @user.feature_flags.key?(key) ? '' : 'selected' %>>Default (<%= @default_flag.default_value %>)</option>
-          </select>
-        </div>
-        <div class="col-md-6">
-          <%= @default_flag.description %>
-        </div>
-      </div>
-     <% end %>
   </div>
   <div class="form-group row">
     <div class="col-md-12">

--- a/app/views/studies/_block_processed_upload.html.erb
+++ b/app/views/studies/_block_processed_upload.html.erb
@@ -1,0 +1,24 @@
+<div id="block-processed-upload-content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12 text-center">
+        <div class="row">
+          <div class="col-md-12 bottom-pad">
+            <h3>Raw count file upload required for access to processed matrix upload</h3>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-offset-4 col-md-2">
+            <p><%= link_to "<i class='fas fa-chevron-circle-left'></i> Upload Raw File".html_safe, '#',
+                           class: 'btn btn-default btn-lg', id: 'upload-raw-counts' %></p>
+          </div>
+          <div class="col-md-2">
+            <p><%= link_to "Request Exemption <i class='fas fa-external-link-alt'></i>".html_safe,
+                           'https://singlecell.zendesk.com/hc/en-us/requests/new?ticket_form_id=1260811597230',
+                           class: 'btn btn-default btn-lg', target: '_blank' %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/studies/_block_processed_upload_content.html.erb
+++ b/app/views/studies/_block_processed_upload_content.html.erb
@@ -14,11 +14,11 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-md-offset-4 col-md-2">
+          <div class="col-md-offset-3 col-md-3">
             <p><%= link_to "<i class='fas fa-chevron-circle-left'></i> Upload Raw Count File".html_safe, '#',
                            class: 'btn btn-default btn-lg', id: 'upload-raw-counts' %></p>
           </div>
-          <div class="col-md-2">
+          <div class="col-md-3">
             <p><%= link_to "Request Exemption <i class='fas fa-external-link-alt'></i>".html_safe,
                            'https://singlecell.zendesk.com/hc/en-us/requests/new?ticket_form_id=1260811597230',
                            class: 'btn btn-default btn-lg', target: '_blank' %>

--- a/app/views/studies/_block_processed_upload_content.html.erb
+++ b/app/views/studies/_block_processed_upload_content.html.erb
@@ -4,12 +4,18 @@
       <div class="col-md-12 text-center">
         <div class="row">
           <div class="col-md-12 bottom-pad">
-            <h3>Raw count file upload required for access to processed matrix upload</h3>
+            <h3>
+              Uploading a raw count matrix is now required in order to access to processed matrix uploads.
+            </h3>
+            <p class="lead">
+              If you are unable or do not wish to upload a raw count matrix, you can request an exemption using the
+              link below.
+            </p>
           </div>
         </div>
         <div class="row">
           <div class="col-md-offset-4 col-md-2">
-            <p><%= link_to "<i class='fas fa-chevron-circle-left'></i> Upload Raw File".html_safe, '#',
+            <p><%= link_to "<i class='fas fa-chevron-circle-left'></i> Upload Raw Count File".html_safe, '#',
                            class: 'btn btn-default btn-lg', id: 'upload-raw-counts' %></p>
           </div>
           <div class="col-md-2">

--- a/app/views/studies/_block_processed_upload_content.html.erb
+++ b/app/views/studies/_block_processed_upload_content.html.erb
@@ -1,4 +1,4 @@
-<div id="block-processed-upload-content">
+<div id="block-processed-upload-content" class="<%= @block_processed_upload ? 'show-processed-disclaimer' : 'hide-processed-disclaimer' %>">
   <div class="container-fluid">
     <div class="row">
       <div class="col-md-12 text-center">

--- a/app/views/studies/_expression_file_fields.html.erb
+++ b/app/views/studies/_expression_file_fields.html.erb
@@ -15,3 +15,25 @@
   end %>
 </div>
 
+<script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+  function updateRawCountsAssnSelect() {
+    const formId = '#study-file-<%= f.object.id.to_s %>'
+    const rawAssnTarget = $(`${formId} .raw_associations_select`)[0]
+    const pairedHiddenField = $(`${formId} .raw_counts_associations`)[0]
+    <% current_values = f.object.associated_matrix_files(:raw)&.map { |sf| { label: sf.name, value: sf.id.to_s } } %>
+    const currentValues = <%= current_values.to_json.html_safe %>
+    const opts = window.SCP.currentStudyFiles.filter(sf => sf?.expression_file_info?.is_raw_counts)
+      ?.map(sf => ({ label: sf.upload_file_name, value: sf['_id']['$oid'] }))
+    window.SCP.renderRawAssociationSelect(rawAssnTarget, currentValues, pairedHiddenField, opts)
+  }
+
+  updateRawCountsAssnSelect()
+
+  $(window).on('updateRawCountsSelect', function() {
+    updateRawCountsAssnSelect()
+  })
+
+  $('form').on('change', '.is_raw_counts_true, .is_raw_counts_false', function() {
+    updateRawCountsAssnSelect()
+  })
+</script>

--- a/app/views/studies/_expression_file_fields.html.erb
+++ b/app/views/studies/_expression_file_fields.html.erb
@@ -5,6 +5,13 @@
   </div>
 </div>
 <div class="form-group">
-  <%= f.fields_for :expression_file_info %>
+  <%= f.fields_for :expression_file_info do |expr_file_info|
+    render partial: 'expression_file_info_fields',
+           locals: {
+             disable_processed: false,
+             disable_raw_counts: false,
+             f: expr_file_info
+           }
+  end %>
 </div>
 

--- a/app/views/studies/_expression_file_fields.html.erb
+++ b/app/views/studies/_expression_file_fields.html.erb
@@ -16,24 +16,16 @@
 </div>
 
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-  function updateRawCountsAssnSelect() {
-    const formId = '#study-file-<%= f.object.id.to_s %>'
-    const rawAssnTarget = $(`${formId} .raw_associations_select`)[0]
-    const pairedHiddenField = $(`${formId} .raw_counts_associations`)[0]
-    <% current_values = f.object.associated_matrix_files(:raw)&.map { |sf| { label: sf.name, value: sf.id.to_s } } %>
-    const currentValues = <%= current_values.to_json.html_safe %>
-    const opts = window.SCP.currentStudyFiles.filter(sf => sf?.expression_file_info?.is_raw_counts)
-      ?.map(sf => ({ label: sf.upload_file_name, value: sf['_id']['$oid'] }))
-    window.SCP.renderRawAssociationSelect(rawAssnTarget, currentValues, pairedHiddenField, opts)
-  }
+  <% current_values = f.object.associated_matrix_files(:raw)&.map { |sf| { label: sf.name, value: sf.id.to_s } } %>
 
-  updateRawCountsAssnSelect()
+  // render the raw counts association select; if replace is true, allows swapping out units dropdown in raw counts form
+  updateRawCountsAssnSelect('#study-file-<%= f.object.id.to_s %>', <%= current_values.to_json.html_safe %>)
 
-  $(window).on('updateRawCountsSelect', function() {
-    updateRawCountsAssnSelect()
+  $('#study-file-<%= f.object.id.to_s %>').on('updateRawCountsSelect', function() {
+    updateRawCountsAssnSelect('#study-file-<%= f.object.id.to_s %>', <%= current_values.to_json.html_safe %>)
   })
 
-  $('form').on('change', '.is_raw_counts_true, .is_raw_counts_false', function() {
-    updateRawCountsAssnSelect()
+  $('#study-file-<%= f.object.id.to_s %>').on('change', '.is_raw_counts_true, .is_raw_counts_false', function() {
+    updateRawCountsAssnSelect('#study-file-<%= f.object.id.to_s %>', <%= current_values.to_json.html_safe %>)
   })
 </script>

--- a/app/views/studies/_expression_file_info_fields.html.erb
+++ b/app/views/studies/_expression_file_info_fields.html.erb
@@ -2,10 +2,12 @@
   <div class="col-lg-2">
     <%= f.label :is_raw_counts, 'Is this a raw counts matrix?' %><br />
     <%= f.radio_button :is_raw_counts, 1,
-                       checked: f.object.is_raw_counts, class: 'raw-counts-radio'  %>
+                       checked: f.object.is_raw_counts, class: 'raw-counts-radio',
+                       disabled: disable_raw_counts %>
     <%= f.label :is_raw_counts, 'Yes', class: 'radio-pad' %>
     <%= f.radio_button :is_raw_counts, 0,
-                       checked: !f.object.is_raw_counts, class: 'raw-counts-radio' %>
+                       checked: !f.object.is_raw_counts, class: 'raw-counts-radio',
+                       disabled: disable_processed %>
     <%= f.label :is_raw_counts, 'No', class: 'radio-pad'  %>
   </div>
   <div class="col-lg-2">

--- a/app/views/studies/_expression_file_info_fields.html.erb
+++ b/app/views/studies/_expression_file_info_fields.html.erb
@@ -4,7 +4,7 @@
       <%= f.label :is_raw_counts, 'Is this a raw counts matrix?' %><br />
       <%= f.radio_button :is_raw_counts, 1,
                          checked: f.object.is_raw_counts, class: 'raw-counts-radio is_raw_counts_true',
-                         disabled: disable_raw_counts %>
+                         disabled: disable_raw_counts%>
       <%= f.label :is_raw_counts, 'Yes', class: 'radio-pad' %>
       <%= f.radio_button :is_raw_counts, 0,
                          checked: !f.object.is_raw_counts, class: 'raw-counts-radio is_raw_counts_false',
@@ -12,20 +12,18 @@
       <%= f.label :is_raw_counts, 'No', class: 'radio-pad'  %>
     </div>
     <div class="col-lg-2 units-or-raw-associations">
-      <div class="raw_associations_select"></div>
-      <% if f.object.is_raw_counts %>
+      <div class="raw_associations_select <%= f.object.is_raw_counts ? 'hidden' : nil %>"></div>
+      <div class="<%= !f.object.is_raw_counts ? 'hidden' : nil %> raw-counts-units-select">
         <%= f.label :units %><br />
         <%= f.select :units, options_for_select(ExpressionFileInfo::UNITS_VALUES, f.object.units),
                      {include_blank: true},
                      class: 'form-control raw-counts-select counts-unit-dropdown', disabled: !f.object.is_raw_counts %>
-      <% else %>
-
-        <%= f.hidden_field :raw_counts_associations,
-                           {
-                             class: "#{f.object.is_raw_counts ? 'hidden' : nil} raw_counts_associations", multiple: true
-                           }
-        %>
-      <% end %>
+      </div>
+      <%= f.hidden_field :raw_counts_associations,
+                         {
+                           class: "raw_counts_associations", multiple: true
+                         }
+      %>
     </div>
     <div class="col-lg-2">
       <%= f.label :biosample_input_type, label_with_asterisk('Biosample Input Type') %><br />
@@ -43,11 +41,6 @@
       <%= f.label :modality, label_with_asterisk('Modality') %><br />
       <%= f.select :modality, options_for_select(ExpressionFileInfo::MODALITY_VALUES, f.object.modality),
                    {}, class: 'form-control' %>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-4">
-
     </div>
   </div>
 </div>

--- a/app/views/studies/_expression_file_info_fields.html.erb
+++ b/app/views/studies/_expression_file_info_fields.html.erb
@@ -14,7 +14,7 @@
     <div class="col-lg-2 units-or-raw-associations">
       <div class="raw_associations_select <%= f.object.is_raw_counts ? 'hidden' : nil %>"></div>
       <div class="<%= !f.object.is_raw_counts ? 'hidden' : nil %> raw-counts-units-select">
-        <%= f.label :units %><br />
+        <%= f.label :units, label_with_asterisk('Units') %><br />
         <%= f.select :units, options_for_select(ExpressionFileInfo::UNITS_VALUES, f.object.units),
                      {include_blank: true},
                      class: 'form-control raw-counts-select counts-unit-dropdown', disabled: !f.object.is_raw_counts %>

--- a/app/views/studies/_expression_file_info_fields.html.erb
+++ b/app/views/studies/_expression_file_info_fields.html.erb
@@ -1,36 +1,53 @@
-<div class="row expression-file-info-fields">
-  <div class="col-lg-2">
-    <%= f.label :is_raw_counts, 'Is this a raw counts matrix?' %><br />
-    <%= f.radio_button :is_raw_counts, 1,
-                       checked: f.object.is_raw_counts, class: 'raw-counts-radio',
-                       disabled: disable_raw_counts %>
-    <%= f.label :is_raw_counts, 'Yes', class: 'radio-pad' %>
-    <%= f.radio_button :is_raw_counts, 0,
-                       checked: !f.object.is_raw_counts, class: 'raw-counts-radio',
-                       disabled: disable_processed %>
-    <%= f.label :is_raw_counts, 'No', class: 'radio-pad'  %>
-  </div>
-  <div class="col-lg-2">
-    <%= f.label :units %><br />
-    <%= f.select :units, options_for_select(ExpressionFileInfo::UNITS_VALUES, f.object.units),
-                 {include_blank: true},
-                 class: 'form-control raw-counts-select counts-unit-dropdown', disabled: !f.object.is_raw_counts %>
-  </div>
-  <div class="col-lg-2">
-    <%= f.label :biosample_input_type, label_with_asterisk('Biosample Input Type') %><br />
-    <%= f.select :biosample_input_type, options_for_select(ExpressionFileInfo::BIOSAMPLE_INPUT_TYPE_VALUES, f.object.biosample_input_type),
-                 {}, class: 'form-control' %>
+<div class="expression-file-info-fields">
+  <div class="row">
+    <div class="col-lg-2">
+      <%= f.label :is_raw_counts, 'Is this a raw counts matrix?' %><br />
+      <%= f.radio_button :is_raw_counts, 1,
+                         checked: f.object.is_raw_counts, class: 'raw-counts-radio is_raw_counts_true',
+                         disabled: disable_raw_counts %>
+      <%= f.label :is_raw_counts, 'Yes', class: 'radio-pad' %>
+      <%= f.radio_button :is_raw_counts, 0,
+                         checked: !f.object.is_raw_counts, class: 'raw-counts-radio is_raw_counts_false',
+                         disabled: disable_processed %>
+      <%= f.label :is_raw_counts, 'No', class: 'radio-pad'  %>
+    </div>
+    <div class="col-lg-2 units-or-raw-associations">
+      <div class="raw_associations_select"></div>
+      <% if f.object.is_raw_counts %>
+        <%= f.label :units %><br />
+        <%= f.select :units, options_for_select(ExpressionFileInfo::UNITS_VALUES, f.object.units),
+                     {include_blank: true},
+                     class: 'form-control raw-counts-select counts-unit-dropdown', disabled: !f.object.is_raw_counts %>
+      <% else %>
 
+        <%= f.hidden_field :raw_counts_associations,
+                           {
+                             class: "#{f.object.is_raw_counts ? 'hidden' : nil} raw_counts_associations", multiple: true
+                           }
+        %>
+      <% end %>
+    </div>
+    <div class="col-lg-2">
+      <%= f.label :biosample_input_type, label_with_asterisk('Biosample Input Type') %><br />
+      <%= f.select :biosample_input_type, options_for_select(ExpressionFileInfo::BIOSAMPLE_INPUT_TYPE_VALUES, f.object.biosample_input_type),
+                   {}, class: 'form-control' %>
+
+    </div>
+    <div class="col-lg-2">
+      <%= f.label :library_preparation_protocol, label_with_asterisk('Library Preparation Protocol') %><br />
+      <%= f.select :library_preparation_protocol,
+                   options_for_select(ExpressionFileInfo::LIBRARY_PREPARATION_VALUES, f.object.library_preparation_protocol),
+                   {}, class: 'form-control' %>
+    </div>
+    <div class="col-lg-4">
+      <%= f.label :modality, label_with_asterisk('Modality') %><br />
+      <%= f.select :modality, options_for_select(ExpressionFileInfo::MODALITY_VALUES, f.object.modality),
+                   {}, class: 'form-control' %>
+    </div>
   </div>
-  <div class="col-lg-2">
-    <%= f.label :library_preparation_protocol, label_with_asterisk('Library Preparation Protocol') %><br />
-    <%= f.select :library_preparation_protocol,
-                 options_for_select(ExpressionFileInfo::LIBRARY_PREPARATION_VALUES, f.object.library_preparation_protocol),
-                 {}, class: 'form-control' %>
-  </div>
-  <div class="col-lg-4">
-    <%= f.label :modality, label_with_asterisk('Modality') %><br />
-    <%= f.select :modality, options_for_select(ExpressionFileInfo::MODALITY_VALUES, f.object.modality),
-                 {}, class: 'form-control' %>
+  <div class="row">
+    <div class="col-md-4">
+
+    </div>
   </div>
 </div>

--- a/app/views/studies/_expression_file_info_fields.html.erb
+++ b/app/views/studies/_expression_file_info_fields.html.erb
@@ -1,7 +1,7 @@
 <div class="expression-file-info-fields">
   <div class="row">
     <div class="col-lg-2">
-      <%= f.label :is_raw_counts, 'Is this a raw counts matrix?' %><br />
+      <%= f.label :is_raw_counts, 'Is this a raw count matrix?' %><br />
       <%= f.radio_button :is_raw_counts, 1,
                          checked: f.object.is_raw_counts, class: 'raw-counts-radio is_raw_counts_true',
                          disabled: disable_raw_counts%>

--- a/app/views/studies/_initialize_expression_form.html.erb
+++ b/app/views/studies/_initialize_expression_form.html.erb
@@ -62,7 +62,7 @@
 			<%= f.label :actions %>
 			<div class="row">
 				<div class="col-xs-6">
-					<%= f.submit 'Save', class: 'btn btn-block btn-success save-study-file', disabled: (study_file.upload_file_name.nil?) %>
+					<%= f.submit 'Save', class: 'btn btn-block btn-success save-study-file save-expression-file', disabled: (study_file.upload_file_name.nil?) %>
 				</div>
 				<div class="col-xs-6">
           <% if study_file.parsing? || study_file.upload_file_name.nil? %>
@@ -96,6 +96,27 @@
           $(expFormId_<%= allow_only %>).find('.initialize-bundle-target').empty();
         }
       });
+
+    function updateRawCountsAssnSelect() {
+      const rawAssnTarget = $(`${expFormId_<%= allow_only %>} .raw_associations_select`)[0]
+      const pairedHiddenField = $(`${expFormId_<%= allow_only %>} .raw_counts_associations`)[0]
+      <% opts =  @study.study_files.where(file_type: /Matrix/, 'expression_file_info.is_raw_counts': true, queued_for_deletion: false)
+                                         .map { |f| { label: f.name, value: f.id.to_s } }
+         current_values = study_file.expression_file_info.raw_counts_associations
+                                   .map {|aid| opts.find {|opt| opt[:value] == aid }} %>
+      const opts = <%= opts.to_json.html_safe %>
+      const current_values = <%= current_values.to_json.html_safe %>
+      window.SCP.renderRawAssociationSelect(rawAssnTarget, opts, current_values, pairedHiddenField)
+    }
+
+    <% if User.feature_flag_for_instance(current_user, 'raw_counts_required_backend')  %>
+      updateRawCountsAssnSelect()
+
+    // update on all form submissions
+    $('body').on('click', '.save-expression-file, .add-expression', function() {
+      updateRawCountsAssnSelect()
+    })
+    <% end %>
 
 		$(function() {
       $(expFormId_<%= allow_only %>).fileupload({

--- a/app/views/studies/_initialize_expression_form.html.erb
+++ b/app/views/studies/_initialize_expression_form.html.erb
@@ -1,4 +1,4 @@
-<%= nested_form_for(study_file, url: update_study_file_study_path(@study._id),
+<%= nested_form_for(study_file, url: update_study_file_study_path(@study._id, allow_only: allow_only || 'all'),
                     html: {multipart: true, id: "expression_form_#{study_file._id}",
                            class: "initialize_expression_form #{study_file.new_record? ? 'new-expression-form' : nil}",
                            data: {remote: true}}) do |f| %>
@@ -97,6 +97,7 @@
         }
       });
 
+    // render the raw counts association select; if replace is true, allows swapping out units dropdown in raw counts form
     function updateRawCountsAssnSelect() {
       const rawAssnTarget = $(`${expFormId_<%= allow_only %>} .raw_associations_select`)[0]
       const pairedHiddenField = $(`${expFormId_<%= allow_only %>} .raw_counts_associations`)[0]
@@ -107,13 +108,15 @@
       window.SCP.renderRawAssociationSelect(rawAssnTarget, currentValues, pairedHiddenField, opts)
     }
 
-    <% if User.feature_flag_for_instance(current_user, 'raw_counts_required_backend')  %>
-      updateRawCountsAssnSelect()
+    updateRawCountsAssnSelect()
 
-      $(window).on('updateRawCountsSelect', function() {
-        updateRawCountsAssnSelect()
-      })
-    <% end %>
+    $(window).on('updateRawCountsSelect', function() {
+      updateRawCountsAssnSelect()
+    })
+
+    $('form').on('change', '.is_raw_counts_true, .is_raw_counts_false', function() {
+      updateRawCountsAssnSelect()
+    })
 
 		$(function() {
       $(expFormId_<%= allow_only %>).fileupload({
@@ -155,8 +158,7 @@
             }
 				},
 				done: function(e, data) {
-          let partial = '<%= allow_only == 'raw' ? 'initialize_raw_expression_form' : 'initialize_processed_expression_form' %>';
-				  let stepName = `${partial}_nav`
+				  let stepName = "initialize_<%= allow_only %>_expression_form_nav"
           completeWizardStep(stepName);
 					var fileName = data.files[0].name.replace(FILENAME_SANITIZER, '_');
 					$.ajax({
@@ -172,7 +174,7 @@
                       data: {
                           file: fileName,
                           modal_target: '#expression-parse-modal',
-                          partial: partial,
+                          partial: 'initialize_expression_form',
                           selector: expFormId_<%= allow_only %>,
                           allow_only: '<%= allow_only %>'
                       },

--- a/app/views/studies/_initialize_expression_form.html.erb
+++ b/app/views/studies/_initialize_expression_form.html.erb
@@ -100,22 +100,19 @@
     function updateRawCountsAssnSelect() {
       const rawAssnTarget = $(`${expFormId_<%= allow_only %>} .raw_associations_select`)[0]
       const pairedHiddenField = $(`${expFormId_<%= allow_only %>} .raw_counts_associations`)[0]
-      <% opts =  @study.study_files.where(file_type: /Matrix/, 'expression_file_info.is_raw_counts': true, queued_for_deletion: false)
-                                         .map { |f| { label: f.name, value: f.id.to_s } }
-         current_values = study_file.expression_file_info.raw_counts_associations
-                                   .map {|aid| opts.find {|opt| opt[:value] == aid }} %>
-      const opts = <%= opts.to_json.html_safe %>
-      const current_values = <%= current_values.to_json.html_safe %>
-      window.SCP.renderRawAssociationSelect(rawAssnTarget, opts, current_values, pairedHiddenField)
+      <% current_values = study_file.associated_matrix_files(:raw)&.map { |sf| { label: sf.name, value: sf.id.to_s } } %>
+      const currentValues = <%= current_values.to_json.html_safe %>
+      const opts = window.SCP.currentStudyFiles.filter(sf => sf?.expression_file_info?.is_raw_counts)
+        ?.map(sf => ({ label: sf.upload_file_name, value: sf['_id']['$oid'] }))
+      window.SCP.renderRawAssociationSelect(rawAssnTarget, currentValues, pairedHiddenField, opts)
     }
 
     <% if User.feature_flag_for_instance(current_user, 'raw_counts_required_backend')  %>
       updateRawCountsAssnSelect()
 
-    // update on all form submissions
-    $('body').on('click', '.save-expression-file, .add-expression', function() {
-      updateRawCountsAssnSelect()
-    })
+      $(window).on('updateRawCountsSelect', function() {
+        updateRawCountsAssnSelect()
+      })
     <% end %>
 
 		$(function() {
@@ -158,7 +155,8 @@
             }
 				},
 				done: function(e, data) {
-				  let stepName = '<%= allow_only == 'raw' ? 'initialize_raw_expression_form_nav' : 'initialize_processed_expression_form_nav' %>';
+          let partial = '<%= allow_only == 'raw' ? 'initialize_raw_expression_form' : 'initialize_processed_expression_form' %>';
+				  let stepName = `${partial}_nav`
           completeWizardStep(stepName);
 					var fileName = data.files[0].name.replace(FILENAME_SANITIZER, '_');
 					$.ajax({
@@ -174,7 +172,7 @@
                       data: {
                           file: fileName,
                           modal_target: '#expression-parse-modal',
-                          partial: 'initialize_expression_form',
+                          partial: partial,
                           selector: expFormId_<%= allow_only %>,
                           allow_only: '<%= allow_only %>'
                       },

--- a/app/views/studies/_initialize_expression_form.html.erb
+++ b/app/views/studies/_initialize_expression_form.html.erb
@@ -97,26 +97,34 @@
         }
       });
 
-    // render the raw counts association select; if replace is true, allows swapping out units dropdown in raw counts form
-    function updateRawCountsAssnSelect() {
-      const rawAssnTarget = $(`${expFormId_<%= allow_only %>} .raw_associations_select`)[0]
-      const pairedHiddenField = $(`${expFormId_<%= allow_only %>} .raw_counts_associations`)[0]
-      <% current_values = study_file.associated_matrix_files(:raw)&.map { |sf| { label: sf.name, value: sf.id.to_s } } %>
-      const currentValues = <%= current_values.to_json.html_safe %>
-      const opts = window.SCP.currentStudyFiles.filter(sf => sf?.expression_file_info?.is_raw_counts)
-        ?.map(sf => ({ label: sf.upload_file_name, value: sf['_id']['$oid'] }))
-      window.SCP.renderRawAssociationSelect(rawAssnTarget, currentValues, pairedHiddenField, opts)
-    }
+      // wrapper to call updateRawCountsAssnSelect() for updating all raw counts association select inputs after
+      // file uploads
+      function handleRawCountsUpdate() {
+        <% current_values = study_file.associated_matrix_files(:raw)&.map { |sf| { label: sf.name, value: sf.id.to_s } } %>
+        const currentValues = <%= current_values.to_json.html_safe %>
+        updateRawCountsAssnSelect(expFormId_<%= allow_only %>, currentValues)
+      }
 
-    updateRawCountsAssnSelect()
+      handleRawCountsUpdate()
 
-    $(window).on('updateRawCountsSelect', function() {
-      updateRawCountsAssnSelect()
-    })
+      $(expFormId_<%= allow_only %>).on('updateRawCountsSelect', function() {
+        handleRawCountsUpdate()
+      })
 
-    $('form').on('change', '.is_raw_counts_true, .is_raw_counts_false', function() {
-      updateRawCountsAssnSelect()
-    })
+      $(expFormId_<%= allow_only %>).on('change', '.is_raw_counts_true, .is_raw_counts_false', function() {
+        handleRawCountsUpdate()
+      })
+
+      // render the raw counts association select; if replace is true, allows swapping out units dropdown in raw counts form
+      updateRawCountsAssnSelect(expFormId_<%= allow_only %>, <%= current_values.to_json.html_safe %>)
+
+      $(expFormId_<%= allow_only %>).on('updateRawCountsSelect', function() {
+        updateRawCountsAssnSelect(expFormId_<%= allow_only %>, <%= current_values.to_json.html_safe %>)
+      })
+
+      $(expFormId_<%= allow_only %>).on('change', '.is_raw_counts_true, .is_raw_counts_false', function() {
+        updateRawCountsAssnSelect(expFormId_<%= allow_only %>, <%= current_values.to_json.html_safe %>)
+      })
 
 		$(function() {
       $(expFormId_<%= allow_only %>).fileupload({

--- a/app/views/studies/_initialize_expression_form.html.erb
+++ b/app/views/studies/_initialize_expression_form.html.erb
@@ -32,7 +32,14 @@
     </div>
   </div>
   <div class="form-group">
-    <%= f.fields_for :expression_file_info %>
+    <%= f.fields_for :expression_file_info do |expr_file_info|
+      render partial: 'expression_file_info_fields',
+                     locals: {
+                       disable_processed: allow_only == 'raw',
+                       disable_raw_counts: allow_only == 'processed',
+                       f: expr_file_info
+                     }
+      end %>
   </div>
 	<div class="form-group row">
 		<div class="col-sm-4">

--- a/app/views/studies/_initialize_expression_form.html.erb
+++ b/app/views/studies/_initialize_expression_form.html.erb
@@ -68,7 +68,7 @@
           <% if study_file.parsing? || study_file.upload_file_name.nil? %>
             <%= link_to 'Delete', '#/', class: 'btn btn-block btn-danger disabled-delete', disabled: 'disabled', title: 'You must wait until the file has finished uploading & parsing before deleting', data: {toggle: 'tooltip'} %>
           <% else %>
-            <%= link_to 'Delete', delete_study_file_study_path(@study._id, study_file._id, target: "#expression_form_#{study_file._id}"), method: :delete, class: 'btn btn-block btn-danger delete-file', data: {remote: true} %>
+            <%= link_to 'Delete', delete_study_file_study_path(@study._id, study_file._id, target: "#expression_form_#{study_file._id}", allow_only: allow_only || 'all'), method: :delete, class: 'btn btn-block btn-danger delete-file', data: {remote: true} %>
           <% end %>
 				</div>
 			</div>
@@ -90,16 +90,15 @@
 
 	<script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
 
-      var expFormId = "#expression_form_<%= study_file._id %>";
-      $(expFormId).find('.file-type').on('change', function() {
-        if ( $(expFormId + ' #study_file_file_type_expression_matrix').prop("checked") ) {
-          $(expFormId).find('.initialize-bundle-target').empty();
+      var expFormId_<%= allow_only %> = "#expression_form_<%= study_file._id %>";
+      $(expFormId_<%= allow_only %>).find('.file-type').on('change', function() {
+        if ( $(expFormId_<%= allow_only %> + ' #study_file_file_type_expression_matrix').prop("checked") ) {
+          $(expFormId_<%= allow_only %>).find('.initialize-bundle-target').empty();
         }
       });
 
 		$(function() {
-
-        $(expFormId).fileupload({
+      $(expFormId_<%= allow_only %>).fileupload({
 				url: "<%= upload_study_path(@study._id) %>",
 				maxChunkSize: 10000000,
 				type: 'PATCH',
@@ -111,10 +110,10 @@
 					// auto-select MM Coordinate Matrix if applicable
           fileExt = fileName.split('.').slice(-1)[0];
           if (fileExt === 'mtx') {
-              $(expFormId + ' #study_file_file_type_mm_coordinate_matrix').prop("checked", true);
+              $(expFormId_<%= allow_only %> + ' #study_file_file_type_mm_coordinate_matrix').prop("checked", true);
           }
-          $(expFormId + ' .filename').val(fileName);
-          var canUpload = validateCandidateUpload(expFormId, fileName, $('.initialize_expression_form .filename'));
+          $(expFormId_<%= allow_only %> + ' .filename').val(fileName);
+          var canUpload = validateCandidateUpload(expFormId_<%= allow_only %>, fileName, $('.initialize_expression_form .filename'));
           if ( canUpload ) {
               $.getJSON("<%= resume_upload_study_path %>", { file: fileName }, function (result) {
                   var file = result.file;
@@ -127,18 +126,19 @@
                   }
               });
           } else {
-              $(expFormId + ' .filename').val('');
+              $(expFormId_<%= allow_only %> + ' .filename').val('');
           }
 				},
 				chunkdone: function(e, data) {
 					var perc = parseInt(data.loaded / data.total * 100, 10);
 					$(data.context).find('h1').html(perc + "% uploaded");
-            if ( $('#<%= study_file.id %>-bundle-btns').length === 0 && $(expFormId + ' #study_file_file_type_mm_coordinate_matrix').prop("checked") ) {
-                $(expFormId).find('.initialize-bundle-target').html("<%= j(render partial: 'study_file_bundle_btns', locals: {study_file_id: study_file.id.to_s, file_type: 'MM Coordinate Matrix'}) %>")
+            if ( $('#<%= study_file.id %>-bundle-btns').length === 0 && $(expFormId_<%= allow_only %> + ' #study_file_file_type_mm_coordinate_matrix').prop("checked") ) {
+                $(expFormId_<%= allow_only %>).find('.initialize-bundle-target').html("<%= j(render partial: 'study_file_bundle_btns', locals: {study_file_id: study_file.id.to_s, file_type: 'MM Coordinate Matrix'}) %>")
             }
 				},
 				done: function(e, data) {
-          completeWizardStep('initialize_expression_form_nav');
+				  let stepName = '<%= allow_only == 'raw' ? 'initialize_raw_expression_form_nav' : 'initialize_processed_expression_form_nav' %>';
+          completeWizardStep(stepName);
 					var fileName = data.files[0].name.replace(FILENAME_SANITIZER, '_');
 					$.ajax({
 						  url: "<%= update_status_study_path %>",
@@ -154,7 +154,8 @@
                           file: fileName,
                           modal_target: '#expression-parse-modal',
                           partial: 'initialize_expression_form',
-                          selector: expFormId
+                          selector: expFormId_<%= allow_only %>,
+                          allow_only: '<%= allow_only %>'
                       },
                       dataType: 'script'
                   });
@@ -172,7 +173,9 @@
             console.log('Aborting upload on study_file: <%= study_file.id %>');
             launchModalSpinner('#delete-modal-spinner','#delete-modal', function() {
                 $.ajax({
-                    url: "<%= delete_study_file_study_path(@study._id, study_file._id, target: "#expression_form_#{study_file._id}") %>",
+                    url: "<%= delete_study_file_study_path(@study._id, study_file._id,
+                              target: "#expression_form_#{study_file._id}",
+                              allow_only: allow_only || 'all') %>",
                     type: 'DELETE',
                     dataType: 'script'
                 });
@@ -181,7 +184,7 @@
 			});
 		});
 
-      $(expFormId).on('nested:fieldAdded', function(event){
+      $(expFormId_<%= allow_only %>).on('nested:fieldAdded', function(event){
           $('#add-expression-file-info').tooltip('destroy')
           $('#add-expression-file-info').remove()
       })

--- a/app/views/studies/_initialize_ordinations_form.html.erb
+++ b/app/views/studies/_initialize_ordinations_form.html.erb
@@ -112,7 +112,6 @@
 		</table>
 	</div>
 	<script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-    console.log("#ordinations_form_<%= study_file._id %>")
     var ordsFormSelector = "#ordinations_form_<%= study_file._id %>"
     $(ordsFormSelector).find('.upload-clusters').click(function() {
         if ($("#ordinations_form_<%= study_file._id %>").find('#study_file_name').val() == '') {

--- a/app/views/studies/_upload_success_modal_content.html.erb
+++ b/app/views/studies/_upload_success_modal_content.html.erb
@@ -13,37 +13,6 @@
         <% elsif !study_file.parseable? && study_file.study_file_bundle.present? && !study_file.study_file_bundle.completed? %>
           <p class="text-danger">This file type requires other associated files in order to be utilized in the portal.  Please use the new forms below to add the necessary files.</p>
         <% end %>
-        <% if study_file.is_expression? %>
-          <% if study_file.is_raw_counts_file? && !@study.has_visualization_matrices? %>
-            <hr />
-            <h4 class="text-center text-success">Thank you for adding your raw counts</h4>
-            <p>
-              Raw counts matrices will not be used for visualization.  Please upload a processed expression matrix to enable
-              gene-expression based visualizations.
-            </p>
-          <% elsif !study_file.is_raw_counts_file? && !@study.has_raw_counts_matrices? %>
-            <hr />
-            <h4 class="text-center text-success">Do you have raw counts?</h4>
-            <p>
-              In addition to uploading your expression matrix for visualization, it is useful to provide raw counts expression
-              data.  This is helpful for other users who would like to incorporate your data into new analyses.
-            </p>
-          <% end %>
-          <% unless @study.has_raw_counts_matrices? && @study.has_visualization_matrices? %>
-            <div class="row">
-              <div class="col-xs-8">
-                <%= link_to "Upload a #{study_file.is_raw_counts_file? ? 'processed' : 'raw counts'} matrix".html_safe,
-                            new_study_file_study_path(study_file.study_id, file_type: 'Expression Matrix', is_raw_counts: !study_file.is_raw_counts_file?,
-                                                      taxon_id: study_file.taxon_id, target: '#expressions-target',
-                                                      form: 'initialize_expression_form'),
-                            class: 'btn btn-lg btn-success', data: {remote: true, dismiss: 'modal'} %>
-              </div>
-              <div class="col-xs-4">
-                <%= link_to 'Skip this time', '#', class: 'btn btn-lg', style: 'vertical-align: center;', data: {dismiss: 'modal'} %>
-              </div>
-            </div>
-          <% end %>
-        <% end %>
       </div>
       <div class="modal-footer">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close" id="parse-modal-dismiss"><span aria-hidden="true">&times;</span></button>

--- a/app/views/studies/delete_study_file.js.erb
+++ b/app/views/studies/delete_study_file.js.erb
@@ -1,4 +1,7 @@
 closeModalSpinner('#delete-modal-spinner', '#delete-modal', function() {
+    // populate window.SCP.currentStudyFiles with information about all known StudyFiles
+    window.SCP.currentStudyFiles = <%= @study.study_files.available.map(&:attributes).to_json.html_safe %>
+
     // replace form with fresh instance if needed
     if (<%= !@message.blank? %>) {
         $("<%= params[:target] %>").replaceWith("<%= escape_javascript( render partial: @partial, locals: {study_file: @study_file, allow_only: @allow_only}) %>");
@@ -28,6 +31,9 @@ closeModalSpinner('#delete-modal-spinner', '#delete-modal', function() {
 
     // show/hide overlay preventing processed uploads, if needed
     setExpressionOverlay(<%= @block_processed_upload %>);
+
+    // emit event to trigger updates to all raw counts select inputs
+    $(window).trigger('updateRawCountsSelect')
 });
 
 

--- a/app/views/studies/delete_study_file.js.erb
+++ b/app/views/studies/delete_study_file.js.erb
@@ -1,6 +1,7 @@
 closeModalSpinner('#delete-modal-spinner', '#delete-modal', function() {
     // populate window.SCP.currentStudyFiles with information about all known StudyFiles
-    window.SCP.currentStudyFiles = <%= @study.study_files.available.map(&:attributes).to_json.html_safe %>
+    // calling study.reload avoids caching issues in case files have recently updated
+    window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
 
     // replace form with fresh instance if needed
     if (<%= !@message.blank? %>) {
@@ -14,8 +15,9 @@ closeModalSpinner('#delete-modal-spinner', '#delete-modal', function() {
     }
     // if status needs to be decremented, reset necessary fields
     if (<%= @reset_status %>) {
-        resetWizardStep('<%= @partial %>_nav');
-        var statusLabel = '<%= @partial %>_completed';
+        var step = '<%= @allow_only.present? ? "initialize_#{@allow_only}_expression_form" : params[:partial] %>';
+        resetWizardStep(`${step}_nav`);
+        var statusLabel = `${step}_completed`;
         $('#' + statusLabel).replaceWith("<small class='initialize-label' id='" + statusLabel + "'><span class='label label-<%= @color %>'><%= @status %></span></small>");
     }
 

--- a/app/views/studies/delete_study_file.js.erb
+++ b/app/views/studies/delete_study_file.js.erb
@@ -1,7 +1,7 @@
 closeModalSpinner('#delete-modal-spinner', '#delete-modal', function() {
     // populate window.SCP.currentStudyFiles with information about all known StudyFiles
     // calling study.reload avoids caching issues in case files have recently updated
-    window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
+    window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>
 
     // replace form with fresh instance if needed
     if (<%= !@message.blank? %>) {

--- a/app/views/studies/delete_study_file.js.erb
+++ b/app/views/studies/delete_study_file.js.erb
@@ -1,7 +1,7 @@
 closeModalSpinner('#delete-modal-spinner', '#delete-modal', function() {
     // replace form with fresh instance if needed
     if (<%= !@message.blank? %>) {
-        $("<%= params[:target] %>").replaceWith("<%= escape_javascript( render partial: @partial, locals: {study_file: @study_file}) %>");
+        $("<%= params[:target] %>").replaceWith("<%= escape_javascript( render partial: @partial, locals: {study_file: @study_file, allow_only: @allow_only}) %>");
         var wizForm = $('.<%= @partial %>').slice(-1)[0];
 
         $(wizForm).find('[data-toggle="tooltip"]').tooltip({container: 'body'});
@@ -25,6 +25,9 @@ closeModalSpinner('#delete-modal-spinner', '#delete-modal', function() {
     if (<%= !@message.blank? %>) {
         $("#study-files-notice-target").html("<%= escape_javascript( render partial: 'studies/study_file_notices', locals: {message: @message}) %>");
     };
+
+    // show/hide overlay preventing processed uploads, if needed
+    toggleExpressionOverlay(<%= @block_processed_upload %>);
 });
 
 

--- a/app/views/studies/delete_study_file.js.erb
+++ b/app/views/studies/delete_study_file.js.erb
@@ -27,7 +27,7 @@ closeModalSpinner('#delete-modal-spinner', '#delete-modal', function() {
     };
 
     // show/hide overlay preventing processed uploads, if needed
-    toggleExpressionOverlay(<%= @block_processed_upload %>);
+    setExpressionOverlay(<%= @block_processed_upload %>);
 });
 
 

--- a/app/views/studies/delete_study_file.js.erb
+++ b/app/views/studies/delete_study_file.js.erb
@@ -34,8 +34,10 @@ closeModalSpinner('#delete-modal-spinner', '#delete-modal', function() {
     // show/hide overlay preventing processed uploads, if needed
     setExpressionOverlay(<%= @block_processed_upload %>);
 
-    // emit event to trigger updates to all raw counts select inputs
-    $(window).trigger('updateRawCountsSelect')
+    $('.expression-file-info-fields').each(function(index, element) {
+      let formId = $(element).closest('form').attr('id')
+      $(`#${formId}`).trigger('updateRawCountsSelect')
+    })
 });
 
 

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -1,6 +1,6 @@
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
   // populate window.SCP.currentStudyFiles with information about all known StudyFiles
-  window.SCP.currentStudyFiles = <%= @study.study_files.available.map(&:attributes).to_json.html_safe %>
+  window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>
 </script>
 
 <div class="row">

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -145,9 +145,9 @@
           </div>
         <% end %>
         <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-          // user clicks the 'Upload Raw Counts' button after seeing disclaimer
+          // user clicks the 'Upload Raw Count' button after seeing disclaimer
           $('#upload-raw-counts').on('click', function() {
-            console.log('Returning to raw counts tab')
+            console.log('Returning to raw count tab')
             $('#initialize_raw_expression_form a').click();
           })
 

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -93,7 +93,9 @@
                      ), class: 'btn btn-sm btn-primary add-expression', 'data-remote' => true %></p>
     </div>
     <div class="tab-pane" id="processed-expression">
-      <div id="processed-expressions-target">
+      <%= render 'block_processed_upload' if @block_processed_upload %>
+        <div id="block-processed-upload" class="<%= @block_processed_upload ? 'overlay-upload' : nil %>">
+        <div id="processed-expressions-target">
         <div class="well well-sm container-fluid upload-wizard">
           <div class="row ">
             <h2 class="col-sm-12">Step 2. Upload Processed Expression File <small class="initialize-label" id="initialize_processed_expression_form_completed"></small></h2>
@@ -124,8 +126,6 @@
             <p class="col-sm-12">** <%= link_to 'Gzipped', 'https://www.gnu.org/software/gzip/manual/gzip.html', target: :_blank %>  files of this type (e.g. .txt.gz) are accepted as well</p>
           </div>
         </div>
-
-
         <% @processed_matrix_files.each do |study_file| %>
           <div class="bs-callout bs-callout-info" id="<%= study_file.form_container_id %>">
             <%= render partial: 'initialize_expression_form',
@@ -140,6 +140,12 @@
           </div>
         <% end %>
         <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+          // user clicks the 'Upload Raw Counts' button after seeing disclaimer
+          $('#upload-raw-counts').on('click', function() {
+            console.log('Returning to raw counts tab')
+            $('#initialize_raw_expression_form a').click();
+          })
+
           if (<%= !@processed_matrix_files.first.new_record? %>) {
             completeWizardStep('initialize_processed_expression_form_nav');
             console.log('incrementing status for expression files upload');
@@ -148,7 +154,7 @@
           }
         </script>
       </div>
-      <p><%= link_to "<span class='fas fa-plus'></span> Add an Processed Matrix File".html_safe,
+        <p><%= link_to "<span class='fas fa-plus'></span> Add an Processed Matrix File".html_safe,
                      new_study_file_study_path(@study._id,
                                                file_type: 'Expression Matrix',
                                                target: '#processed-expressions-target',
@@ -156,6 +162,7 @@
                                                is_raw_counts: false,
                                                allow_only: 'processed'
                      ), class: 'btn btn-sm btn-primary add-expression', 'data-remote' => true %></p>
+        </div>
     </div>
     <div class="tab-pane" id="metadata">
       <div class="well well-sm container-fluid upload-wizard">

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -13,25 +13,27 @@
 
 <div id="rootwizard">
   <ul class="nav wizard">
-    <li role="presentation" class="wizard-nav" id="initialize_expression_form_nav"><a href="#expression" data-toggle="tab">1. Expression Matrix <span id="initialize_expression_form_nav_completed"></span></a></li>
-    <li role="presentation" class="wizard-nav" id="initialize_metadata_form_nav"><a href="#metadata" data-toggle="tab">2. Metadata <span id="initialize_metadata_form_nav_completed"></span></a></li>
-    <li role="presentation" class="wizard-nav" id="initialize_ordinations_form_nav"><a href="#ordinations" data-toggle="tab">3. Clusters / Spatial <span id="initialize_ordinations_form_nav_completed"></span></a></li>
-    <li role="presentation" class="wizard-nav" id="initialize_labels_form_nav"><a href="#labels" data-toggle="tab">4. Coordinate Labels <span id="initialize_labels_form_nav_completed"></span></a></li>
-    <li role="presentation" class="wizard-nav" id="initialize_primary_data_form_nav"><a href="#primary-data" data-toggle="tab">5. Sequence Data <span id="initialize_primary_data_form_nav_completed"></span></a></li>
-    <li role="presentation" class="wizard-nav" id="initialize_marker_genes_form_nav"><a href="#marker-genes" data-toggle="tab">6. Gene Lists <span id="initialize_marker_genes_form_nav_completed"></span></a></li>
-    <li role="presentation" class="wizard-nav" id="initialize_misc_form_nav"><a href="#misc" data-toggle="tab">7. Miscellaneous <span id="initialize_misc_form_nav_completed"></span></a></li>
+    <li role="presentation" class="wizard-nav" id="initialize_raw_expression_form"><a href="#raw-expression" data-toggle="tab">1. Raw Count Matrix <span id="initialize_expression_form_nav_completed"></span></a></li>
+    <li role="presentation" class="wizard-nav" id="initialize_processed_expression_form_nav"><a href="#processed-expression" data-toggle="tab">2. Processed Matrix <span id="initialize_expression_form_nav_completed"></span></a></li>
+    <li role="presentation" class="wizard-nav" id="initialize_metadata_form_nav"><a href="#metadata" data-toggle="tab">3. Metadata <span id="initialize_metadata_form_nav_completed"></span></a></li>
+    <li role="presentation" class="wizard-nav" id="initialize_ordinations_form_nav"><a href="#ordinations" data-toggle="tab">4. Clusters / Spatial <span id="initialize_ordinations_form_nav_completed"></span></a></li>
+    <li role="presentation" class="wizard-nav" id="initialize_labels_form_nav"><a href="#labels" data-toggle="tab">5. Coordinate Labels <span id="initialize_labels_form_nav_completed"></span></a></li>
+    <li role="presentation" class="wizard-nav" id="initialize_primary_data_form_nav"><a href="#primary-data" data-toggle="tab">6. Sequence Data <span id="initialize_primary_data_form_nav_completed"></span></a></li>
+    <li role="presentation" class="wizard-nav" id="initialize_marker_genes_form_nav"><a href="#marker-genes" data-toggle="tab">7. Gene Lists <span id="initialize_marker_genes_form_nav_completed"></span></a></li>
+    <li role="presentation" class="wizard-nav" id="initialize_misc_form_nav"><a href="#misc" data-toggle="tab">8. Miscellaneous <span id="initialize_misc_form_nav_completed"></span></a></li>
   </ul>
 
   <div id="bar" class="progress">
     <div class="progress-bar"><span id="progress-count"></span></div>
   </div>
   <div class="tab-content">
-    <div class="tab-pane" id="expression">
-      <div id="expressions-target">
+    <div class="tab-pane" id="raw-expression">
+      <div id="raw-expressions-target">
         <div class="well well-sm container-fluid upload-wizard">
           <div class="row ">
-            <h2 class="col-sm-12">Step 1. Upload Gene Expression File <small class="initialize-label" id="initialize_expression_form_completed"></small></h2>
-            <p class="col-sm-12">Gene expression scores can be represented either as an:</p>
+            <h2 class="col-sm-12">Step 1. Upload Raw Count Expression File <small class="initialize-label" id="initialize_raw_expression_form_completed"></small></h2>
+            <p class="col-sm-12">Raw count data enables data reuse in new analyses.  Ideal raw count data is unfiltered,
+              without normalization or other processing performed.  Gene expression scores can be represented either as an:</p>
           </div>
           <div class="row">
             <p class="col-sm-3 col-sm-offset-1 text-center"><%= link_to 'Expression Matrix', 'https://raw.githubusercontent.com/broadinstitute/single_cell_portal/master/demo_data/expression_example.txt', target: :_blank %></p>
@@ -39,7 +41,7 @@
           </div>
           <div class="row code-div">
             <div class="col-sm-3 col-sm-offset-1">
-            <pre class="code-example">GENE&#09;CELL_1&#9;CELL_2&#09;CELL_3&#09;...<br/>It2ma&#09;0&#09;0&#09;0&#09;...<br/>Sergef&#09;0&#09;7.092&#09;0&#09;...<br/>Chil5&#09;0&#09;0&#09;0&#09;...<br/>Fgfr3&#09;0&#9;0&#09;0.978&#09;<br/>...</pre>
+              <pre class="code-example">GENE&#09;CELL_1&#9;CELL_2&#09;CELL_3&#09;...<br/>It2ma&#09;0&#09;0&#09;0&#09;...<br/>Sergef&#09;0&#09;7.092&#09;0&#09;...<br/>Chil5&#09;0&#09;0&#09;0&#09;...<br/>Fgfr3&#09;0&#9;0&#09;0.978&#09;<br/>...</pre>
             </div>
             <div class="col-sm-4 col-sm-offset-2" >
               <pre class="code-example">%%MatrixMarket matrix coordinate real general<br/>%<br>17123 31231 124124<br>1 1241 1.0<br/>1 1552 2.0<br/>...</pre>
@@ -59,9 +61,11 @@
         </div>
 
 
-        <% @expression_files.each do |study_file| %>
+        <% @raw_matrix_files.each do |study_file| %>
           <div class="bs-callout bs-callout-info" id="<%= study_file.form_container_id %>">
-            <%= render partial: 'initialize_expression_form', locals: {study_file: study_file} %>
+            <%= render partial: 'initialize_expression_form',
+                       locals: { study_file: study_file, allow_only: 'raw' }
+            %>
             <% if study_file.bundled_files.any? %>
               <h4>Bundled Files</h4>
               <% study_file.bundled_files.each do |bundled_file| %>
@@ -71,20 +75,92 @@
           </div>
         <% end %>
         <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-            if (<%= !@expression_files.first.new_record? %>) {
-                completeWizardStep('initialize_expression_form_nav');
-                console.log('incrementing status for expression files upload');
-                $('#initialize_expression_form_completed').replaceWith("<%= escape_javascript(render partial: 'step_completed', locals: {id: 'initialize_expression_form_completed'}) %>");
-                $('#initialize_expression_form_nav_completed').html("<span class='fas fa-check text-success'></span>");
-            }
+          if (<%= !@raw_matrix_files.first.new_record? %>) {
+            completeWizardStep('initialize_raw_expression_form_nav');
+            console.log('incrementing status for expression files upload');
+            $('#initialize_expression_form_completed').replaceWith("<%= escape_javascript(render partial: 'step_completed', locals: {id: 'initialize_expression_form_completed'}) %>");
+            $('#initialize_expression_form_nav_completed').html("<span class='fas fa-check text-success'></span>");
+          }
         </script>
       </div>
-      <p><%= link_to "<span class='fas fa-plus'></span> Add an Expression Matrix File".html_safe, new_study_file_study_path(@study._id, file_type: 'Expression Matrix', target: '#expressions-target', form: 'initialize_expression_form'), class: 'btn btn-sm btn-primary add-expression', 'data-remote' => true %></p>
+      <p><%= link_to "<span class='fas fa-plus'></span> Add a Raw Count Expression File".html_safe,
+                     new_study_file_study_path(@study._id,
+                                               file_type: 'Expression Matrix',
+                                               target: '#raw-expressions-target',
+                                               form: 'initialize_expression_form',
+                                               is_raw_counts: true,
+                                               allow_only: 'raw'
+                     ), class: 'btn btn-sm btn-primary add-expression', 'data-remote' => true %></p>
+    </div>
+    <div class="tab-pane" id="processed-expression">
+      <div id="processed-expressions-target">
+        <div class="well well-sm container-fluid upload-wizard">
+          <div class="row ">
+            <h2 class="col-sm-12">Step 2. Upload Processed Expression File <small class="initialize-label" id="initialize_processed_expression_form_completed"></small></h2>
+            <p class="col-sm-12">Processed matrix data is used to support gene expression visualizations.  Gene expression
+              scores can be represented either as an:</p>
+          </div>
+          <div class="row">
+            <p class="col-sm-3 col-sm-offset-1 text-center"><%= link_to 'Expression Matrix', 'https://raw.githubusercontent.com/broadinstitute/single_cell_portal/master/demo_data/expression_example.txt', target: :_blank %></p>
+            <p class="text-center col-sm-4 col-sm-offset-2"><%= link_to 'MM Coordinate Matrix file*', 'https://github.com/broadinstitute/single_cell_portal_core/blob/master/test/test_data/GRCh38/matrix.mtx', target: :_blank %></p>
+          </div>
+          <div class="row code-div">
+            <div class="col-sm-3 col-sm-offset-1">
+              <pre class="code-example">GENE&#09;CELL_1&#9;CELL_2&#09;CELL_3&#09;...<br/>It2ma&#09;0&#09;0&#09;0&#09;...<br/>Sergef&#09;0&#09;7.092&#09;0&#09;...<br/>Chil5&#09;0&#09;0&#09;0&#09;...<br/>Fgfr3&#09;0&#9;0&#09;0.978&#09;<br/>...</pre>
+            </div>
+            <div class="col-sm-4 col-sm-offset-2" >
+              <pre class="code-example">%%MatrixMarket matrix coordinate real general<br/>%<br>17123 31231 124124<br>1 1241 1.0<br/>1 1552 2.0<br/>...</pre>
+            </div>
+          </div>
+          <div class="row ">
+            <i class="col-sm-5  text-center">An “Expression Matrix” is a dense matrix (.txt, .tsv, or .csv)** that has a header row containing the value “GENE” in the first column, and single cell names in each successive column.</i>
+            <i class="col-sm-4  col-sm-offset-1 text-center">An “MM Coordinate Matrix” *, as seen in <%= link_to '10x Genomics', 'https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/output/matrices', target: :_blank %>,
+              is a Matrix Market file (.mtx, .mm, or .txt)** that contains a sparse matrix in coordinate form. </i>
+          </div>
+          </br>
+          <div class="row">
+            <p class="col-sm-12">* You will need to upload the <%= link_to 'genes', 'https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices', target: :_blank %> (.csv or .tsv) and
+              <%= link_to 'barcodes', 'https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices', target: :_blank %> (.tsv or .csv) files separately.</p>
+            <p class="col-sm-12">** <%= link_to 'Gzipped', 'https://www.gnu.org/software/gzip/manual/gzip.html', target: :_blank %>  files of this type (e.g. .txt.gz) are accepted as well</p>
+          </div>
+        </div>
+
+
+        <% @processed_matrix_files.each do |study_file| %>
+          <div class="bs-callout bs-callout-info" id="<%= study_file.form_container_id %>">
+            <%= render partial: 'initialize_expression_form',
+                       locals: { study_file: study_file, allow_only: 'processed' }
+            %>
+            <% if study_file.bundled_files.any? %>
+              <h4>Bundled Files</h4>
+              <% study_file.bundled_files.each do |bundled_file| %>
+                <%= render partial: 'initialize_bundled_file_form', locals: {study_file: bundled_file} %>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+        <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+          if (<%= !@processed_matrix_files.first.new_record? %>) {
+            completeWizardStep('initialize_processed_expression_form_nav');
+            console.log('incrementing status for expression files upload');
+            $('#initialize_expression_form_completed').replaceWith("<%= escape_javascript(render partial: 'step_completed', locals: {id: 'initialize_expression_form_completed'}) %>");
+            $('#initialize_expression_form_nav_completed').html("<span class='fas fa-check text-success'></span>");
+          }
+        </script>
+      </div>
+      <p><%= link_to "<span class='fas fa-plus'></span> Add an Processed Matrix File".html_safe,
+                     new_study_file_study_path(@study._id,
+                                               file_type: 'Expression Matrix',
+                                               target: '#processed-expressions-target',
+                                               form: 'initialize_expression_form',
+                                               is_raw_counts: false,
+                                               allow_only: 'processed'
+                     ), class: 'btn btn-sm btn-primary add-expression', 'data-remote' => true %></p>
     </div>
     <div class="tab-pane" id="metadata">
       <div class="well well-sm container-fluid upload-wizard">
         <div class="row">
-          <h2 class="col-sm-12">Step 2. Upload Metadata File <small class="initialize-label" id="initialize_metadata_form_completed"></small></h2>
+          <h2 class="col-sm-12">Step 3. Upload Metadata File <small class="initialize-label" id="initialize_metadata_form_completed"></small></h2>
           <div class="col-sm-12" id="metadata-convention-explainer">
             <%= image_tag "metadata-convention-explainer.jpg" %>
           </div>
@@ -100,7 +176,7 @@
       <div id="ordinations-target">
         <div class="well well-sm upload-wizard">
           <div class="row">
-            <h2 class="col-sm-12">Step 3. Upload Cluster / Spatial Files <small class="initialize-label" id="initialize_ordinations_form_completed"></small></h2>
+            <h2 class="col-sm-12">Step 4. Upload Cluster / Spatial Files <small class="initialize-label" id="initialize_ordinations_form_completed"></small></h2>
             <p class="text-center"><%= link_to 'Cluster File', 'https://github.com/broadinstitute/single_cell_portal/blob/master/demo_data/cluster_example.txt', target: :_blank %></p>
           </div>
           <div class="row">
@@ -159,7 +235,7 @@
     <div class="tab-pane" id="labels">
       <div id="labels-target">
         <div class="well well-sm">
-          <h2>Step 4. Upload Coordinate Labels <small class="initialize-label" id="initialize_labels_form_completed"><span class="label label-info">Optional</span></small></h2>
+          <h2>Step 5. Upload Coordinate Labels <small class="initialize-label" id="initialize_labels_form_completed"><span class="label label-info">Optional</span></small></h2>
           <p class="lead">Upload a tab- or comma-delimited text file containing any 2d or 3d spatial coordinates and labels to display.  <strong class="text-danger">These are not cluster files - they are annotations to overlay on top of a cluster.</strong>
             The file must be a plain text (.txt) file with at least 3 columns and a header row containing the values '<strong>X</strong>', '<strong>Y</strong>', and '<strong>LABELS</strong>'.  The file may have an optional column of '<strong>Z</strong>' (for 3d clusters).
             The last column must contain text labels to display at the specified coordinates.</p>
@@ -185,7 +261,7 @@
     <div class="tab-pane" id="primary-data">
       <div id="primary-data-target">
         <div class="well well-sm">
-          <h2>Step 5. Upload Sequence Data Files <small class="initialize-label" id="initialize_primary_data_form_completed"><span class="label label-info">Optional</span></small></h2>
+          <h2>Step 6. Upload Sequence Data Files <small class="initialize-label" id="initialize_primary_data_form_completed"><span class="label label-info">Optional</span></small></h2>
           <p class="lead"><strong>Primary Human Data</strong>: Primary sequence data derived from humans should be stored in other biological databases and can be linked here by selecting 'Yes' for 'Primary Human Data' and then providing a link in the text field.</p>
           <p class="lead"><strong>Non-human Data</strong>: If you have a few, small (under 2GB) non-human sequence files, they can be uploaded here. For uploading many or larger files, please refer to the instructions <%= link_to 'on our wiki', 'https://github.com/broadinstitute/single_cell_portal/wiki/Uploading-Files-Using-Gsutil-Tool', target: :_blank %>.</p>
           <p class="lead">If you already have <code>gsutil</code> installed you can upload files directly using the following command:</p>
@@ -219,7 +295,7 @@
     <div class="tab-pane" id="marker-genes">
       <div id="marker-genes-target">
         <div class="well well-sm">
-          <h2>Step 6. Upload Gene List File <small class="initialize-label" id="initialize_marker_genes_form_completed"><span class="label label-info">Optional</span></small></h2>
+          <h2>Step 7. Upload Gene List File <small class="initialize-label" id="initialize_marker_genes_form_completed"><span class="label label-info">Optional</span></small></h2>
           <p class="lead">Upload a tab- or comma-delimited text file containing a list of genes and their mean expression values across any clusters.  The file must be a plain text (.txt) with the value 'GENE NAMES' in the first column, and cluster names in each successive column.</p>
           <p><%= link_to "Example Gene List <span class='fas fa-download'></span>".html_safe, 'https://raw.githubusercontent.com/broadinstitute/single_cell_portal/master/demo_data/marker_gene_list_example.txt', class: 'btn btn-default', download: 'marker_gene_list_example.txt' %></p>
         </div>
@@ -243,7 +319,7 @@
     <div class="tab-pane" id="misc">
       <div id="misc-target">
         <div class="well well-sm">
-          <h2>Step 7. Upload Documentation/Other Files <small class="initialize-label" id="initialize_misc_form_completed"><span class="label label-info">Optional</span></small></h2>
+          <h2>Step 8. Upload Documentation/Other Files <small class="initialize-label" id="initialize_misc_form_completed"><span class="label label-info">Optional</span></small></h2>
           <p class="lead">Upload any documentation or other support files you have.</p>
         </div>
         <% @other_files.each do |study_file| %>

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -13,8 +13,8 @@
 
 <div id="rootwizard">
   <ul class="nav wizard">
-    <li role="presentation" class="wizard-nav" id="initialize_raw_expression_form"><a href="#raw-expression" data-toggle="tab">1. Raw Count Matrix <span id="initialize_expression_form_nav_completed"></span></a></li>
-    <li role="presentation" class="wizard-nav" id="initialize_processed_expression_form_nav"><a href="#processed-expression" data-toggle="tab">2. Processed Matrix <span id="initialize_expression_form_nav_completed"></span></a></li>
+    <li role="presentation" class="wizard-nav" id="initialize_raw_expression_form"><a href="#raw-expression" data-toggle="tab">1. Raw Count Matrix <span id="initialize_raw_expression_form_nav_completed"></span></a></li>
+    <li role="presentation" class="wizard-nav" id="initialize_processed_expression_form_nav"><a href="#processed-expression" data-toggle="tab">2. Processed Matrix <span id="initialize_processed_expression_form_nav_completed"></span></a></li>
     <li role="presentation" class="wizard-nav" id="initialize_metadata_form_nav"><a href="#metadata" data-toggle="tab">3. Metadata <span id="initialize_metadata_form_nav_completed"></span></a></li>
     <li role="presentation" class="wizard-nav" id="initialize_ordinations_form_nav"><a href="#ordinations" data-toggle="tab">4. Clusters / Spatial <span id="initialize_ordinations_form_nav_completed"></span></a></li>
     <li role="presentation" class="wizard-nav" id="initialize_labels_form_nav"><a href="#labels" data-toggle="tab">5. Coordinate Labels <span id="initialize_labels_form_nav_completed"></span></a></li>
@@ -77,9 +77,9 @@
         <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
           if (<%= !@raw_matrix_files.first.new_record? %>) {
             completeWizardStep('initialize_raw_expression_form_nav');
-            console.log('incrementing status for expression files upload');
-            $('#initialize_expression_form_completed').replaceWith("<%= escape_javascript(render partial: 'step_completed', locals: {id: 'initialize_expression_form_completed'}) %>");
-            $('#initialize_expression_form_nav_completed').html("<span class='fas fa-check text-success'></span>");
+            console.log('incrementing status for raw expression files upload');
+            $('#initialize_raw_expression_form_completed').replaceWith("<%= escape_javascript(render partial: 'step_completed', locals: {id: 'initialize_expression_form_completed'}) %>");
+            $('#initialize_raw_expression_form_nav_completed').html("<span class='fas fa-check text-success'></span>");
           }
         </script>
       </div>
@@ -93,7 +93,7 @@
                      ), class: 'btn btn-sm btn-primary add-expression', 'data-remote' => true %></p>
     </div>
     <div class="tab-pane" id="processed-expression">
-      <%= render 'block_processed_upload' if @block_processed_upload %>
+      <%= render 'block_processed_upload_content' %>
         <div id="block-processed-upload" class="<%= @block_processed_upload ? 'overlay-upload' : nil %>">
         <div id="processed-expressions-target">
         <div class="well well-sm container-fluid upload-wizard">
@@ -148,9 +148,9 @@
 
           if (<%= !@processed_matrix_files.first.new_record? %>) {
             completeWizardStep('initialize_processed_expression_form_nav');
-            console.log('incrementing status for expression files upload');
-            $('#initialize_expression_form_completed').replaceWith("<%= escape_javascript(render partial: 'step_completed', locals: {id: 'initialize_expression_form_completed'}) %>");
-            $('#initialize_expression_form_nav_completed').html("<span class='fas fa-check text-success'></span>");
+            console.log('incrementing status for processed expression files upload');
+            $('#initialize_processed_expression_form_completed').replaceWith("<%= escape_javascript(render partial: 'step_completed', locals: {id: 'initialize_expression_form_completed'}) %>");
+            $('#initialize_processed_expression_form_nav_completed').html("<span class='fas fa-check text-success'></span>");
           }
         </script>
       </div>

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -1,3 +1,8 @@
+<script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+  // populate window.SCP.currentStudyFiles with information about all known StudyFiles
+  window.SCP.currentStudyFiles = <%= @study.study_files.available.map(&:attributes).to_json.html_safe %>
+</script>
+
 <div class="row">
   <div class="col-sm-10">
     <h1>Upload/Edit Study Data for '<%= @study.name %>' <%= render partial: 'initialize_study_label' %></h1>

--- a/app/views/studies/new_study_file.js.erb
+++ b/app/views/studies/new_study_file.js.erb
@@ -1,4 +1,4 @@
-$('<%= params[:target] %>').append("<div class='bs-callout bs-callout-info' id='<%= @study_file.form_container_id %>'><%= escape_javascript(render partial: params[:form], locals: {study_file: @study_file }) %></div>");
+$('<%= params[:target] %>').append("<div class='bs-callout bs-callout-info' id='<%= @study_file.form_container_id %>'><%= escape_javascript(render partial: params[:form],locals: { study_file: @study_file, allow_only: @allow_only }) %> </div>");
 
 // get instance of new form as ID has changed
 var wizForm = $('.<%= params[:form] %>').slice(-1)[0];

--- a/app/views/studies/parse.js.erb
+++ b/app/views/studies/parse.js.erb
@@ -1,6 +1,6 @@
 // populate window.SCP.currentStudyFiles with information about all known StudyFiles
 // calling study.reload avoids caching issues in case files have recently updated
-window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
+window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>
 
 $('<%= params[:modal_target]%>').modal('hide');
 

--- a/app/views/studies/parse.js.erb
+++ b/app/views/studies/parse.js.erb
@@ -17,7 +17,7 @@ $('<%= params[:modal_target]%>').modal('hide');
 	$('#' + step + '_nav_completed').html("<span class='fas fa-check text-success'></span>");
 <% end %>
 
-// emit event to trigger updates to all raw counts select inputs if this file was a raw counts matrix
+// emit event to trigger updates to all raw count select inputs if this file was a raw counts matrix
 if (<%= @study_file.is_raw_counts_file? %>) {
   $('.expression-file-info-fields').each(function(index, element) {
     let formId = $(element).closest('form').attr('id')

--- a/app/views/studies/parse.js.erb
+++ b/app/views/studies/parse.js.erb
@@ -1,13 +1,16 @@
+// populate window.SCP.currentStudyFiles with information about all known StudyFiles
+// calling study.reload avoids caching issues in case files have recently updated
+window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
+
 $('<%= params[:modal_target]%>').modal('hide');
 
 // when uploading a file that can have multiple instances, only call completeWizardStep the first time
 // also update progress bar
-<% partials = %w(initialize_ordinations_form initialize_labels_form initialize_marker_genes_form
-                 initialize_primary_data_form initialize_misc_form initialize_raw_expression_form
-                 initialize_processed_expression_form) %>
-<% if partials.include?(params[:partial]) && @study.study_files.by_type(@study_file.file_type).count == 1 %>
-	var step = '<%= params[:partial] %>';
-	completeWizardStep(step + '_nav');
+<% if %w(initialize_ordinations_form initialize_labels_form initialize_marker_genes_form initialize_primary_data_form
+         initialize_misc_form initialize_expression_form).
+         include?(params[:partial]) %>
+	var step = '<%= @allow_only.present? ? "initialize_#{@allow_only}_expression_form" : params[:partial] %>';
+	completeWizardStep(`${step}_nav`);
 	var status = getWizardStatus();
 	setWizardProgress(status);
 	console.log('incrementing status for ' + step + ' upload');

--- a/app/views/studies/parse.js.erb
+++ b/app/views/studies/parse.js.erb
@@ -1,5 +1,4 @@
 // populate window.SCP.currentStudyFiles with information about all known StudyFiles
-// calling study.reload avoids caching issues in case files have recently updated
 window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>
 
 $('<%= params[:modal_target]%>').modal('hide');
@@ -18,12 +17,21 @@ $('<%= params[:modal_target]%>').modal('hide');
 	$('#' + step + '_nav_completed').html("<span class='fas fa-check text-success'></span>");
 <% end %>
 
+// emit event to trigger updates to all raw counts select inputs if this file was a raw counts matrix
+if (<%= @study_file.is_raw_counts_file? %>) {
+  $('.expression-file-info-fields').each(function(index, element) {
+    let formId = $(element).closest('form').attr('id')
+    $(`#${formId}`).trigger('updateRawCountsSelect')
+  })
+}
+
 // re-render form upload to get download button and increment completed status
 $.ajax({
     url: "<%= retrieve_wizard_upload_study_path(@study._id) %>",
     data: {
         file: '<%= params[:file] %>',
         selector: '<%= params[:selector] %>',
-        partial: '<%= params[:partial] %>'
+        partial: '<%= params[:partial] %>',
+        allow_only: '<%= @allow_only %>'
     }
 });

--- a/app/views/studies/parse.js.erb
+++ b/app/views/studies/parse.js.erb
@@ -2,7 +2,10 @@ $('<%= params[:modal_target]%>').modal('hide');
 
 // when uploading a file that can have multiple instances, only call completeWizardStep the first time
 // also update progress bar
-<% if %w(initialize_ordinations_form initialize_labels_form initialize_marker_genes_form initialize_primary_data_form initialize_misc_form initialize_expression_form).include?(params[:partial]) && @study.study_files.by_type(@study_file.file_type).count == 1 %>
+<% partials = %w(initialize_ordinations_form initialize_labels_form initialize_marker_genes_form
+                 initialize_primary_data_form initialize_misc_form initialize_raw_expression_form
+                 initialize_processed_expression_form) %>
+<% if partials.include?(params[:partial]) && @study.study_files.by_type(@study_file.file_type).count == 1 %>
 	var step = '<%= params[:partial] %>';
 	completeWizardStep(step + '_nav');
 	var status = getWizardStatus();

--- a/app/views/studies/retrieve_wizard_upload.js.erb
+++ b/app/views/studies/retrieve_wizard_upload.js.erb
@@ -1,5 +1,4 @@
 // populate window.SCP.currentStudyFiles with information about all known StudyFiles
-// calling study.reload avoids caching issues in case files have recently updated
 window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>
 
 // find form, select parent and replace contents with updated values
@@ -44,6 +43,3 @@ setTimeout(function() {
 
 // show/hide overlay preventing processed uploads, if needed
 setExpressionOverlay(<%= @block_processed_upload %>);
-
-// emit event to trigger updates to all raw counts select inputs
-$(window).trigger('updateRawCountsSelect')

--- a/app/views/studies/retrieve_wizard_upload.js.erb
+++ b/app/views/studies/retrieve_wizard_upload.js.erb
@@ -1,3 +1,6 @@
+// populate window.SCP.currentStudyFiles with information about all known StudyFiles
+window.SCP.currentStudyFiles = <%= @study.study_files.available.map(&:attributes).to_json.html_safe %>
+
 // find form, select parent and replace contents with updated values
 $("<%= params[:selector] %>").replaceWith("<%= escape_javascript(render partial: params[:partial], locals: {study_file: @study_file, allow_only: @allow_only }) %>");
 
@@ -40,3 +43,6 @@ setTimeout(function() {
 
 // show/hide overlay preventing processed uploads, if needed
 setExpressionOverlay(<%= @block_processed_upload %>);
+
+// emit event to trigger updates to all raw counts select inputs
+$(window).trigger('updateRawCountsSelect')

--- a/app/views/studies/retrieve_wizard_upload.js.erb
+++ b/app/views/studies/retrieve_wizard_upload.js.erb
@@ -39,4 +39,4 @@ setTimeout(function() {
 }, 500);
 
 // show/hide overlay preventing processed uploads, if needed
-toggleExpressionOverlay(<%= @block_processed_upload %>);
+setExpressionOverlay(<%= @block_processed_upload %>);

--- a/app/views/studies/retrieve_wizard_upload.js.erb
+++ b/app/views/studies/retrieve_wizard_upload.js.erb
@@ -1,5 +1,6 @@
 // populate window.SCP.currentStudyFiles with information about all known StudyFiles
-window.SCP.currentStudyFiles = <%= @study.study_files.available.map(&:attributes).to_json.html_safe %>
+// calling study.reload avoids caching issues in case files have recently updated
+window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
 
 // find form, select parent and replace contents with updated values
 $("<%= params[:selector] %>").replaceWith("<%= escape_javascript(render partial: params[:partial], locals: {study_file: @study_file, allow_only: @allow_only }) %>");
@@ -8,7 +9,7 @@ $("<%= params[:selector] %>").replaceWith("<%= escape_javascript(render partial:
 var wizForm = $('.<%= params[:partial] %>').slice(-1)[0];
 
 // if expression matrix was uploaded & an expression label was provided, then disable all fields for labels
-if ('<%= params[:partial] %>' == 'initialize_expression_form' && <%= !@study_file.y_axis_label.blank? %>) {
+if ('<%= params[:partial] %>'.match(/expression_form/) && <%= !@study_file.y_axis_label.blank? %>) {
     var toolTitle = 'This is displayed as the axis label for box & scatter plots showing expression values.  ' +
         'This label is global to all expression values. Please use the study default options form to update this value.'
     $('.expression-label').val('<%= @study_file.y_axis_label %>')
@@ -20,7 +21,7 @@ if ('<%= params[:partial] %>' == 'initialize_expression_form' && <%= !@study_fil
 $(wizForm).find('[data-toggle="tooltip"]').tooltip({container: 'body'});
 
 // go to next step in wizard
-if ('<%= params[:partial] %>' == 'initialize_metadata_form' && getWizardStatus() <= 2) {
+if ('<%= params[:partial] %>' == 'initialize_metadata_form' && getWizardStatus() <= 3) {
 	$('#next-btn').click();
 }
 

--- a/app/views/studies/retrieve_wizard_upload.js.erb
+++ b/app/views/studies/retrieve_wizard_upload.js.erb
@@ -1,6 +1,6 @@
 // populate window.SCP.currentStudyFiles with information about all known StudyFiles
 // calling study.reload avoids caching issues in case files have recently updated
-window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
+window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>
 
 // find form, select parent and replace contents with updated values
 $("<%= params[:selector] %>").replaceWith("<%= escape_javascript(render partial: params[:partial], locals: {study_file: @study_file, allow_only: @allow_only }) %>");

--- a/app/views/studies/retrieve_wizard_upload.js.erb
+++ b/app/views/studies/retrieve_wizard_upload.js.erb
@@ -1,5 +1,5 @@
 // find form, select parent and replace contents with updated values
-$("<%= params[:selector] %>").replaceWith("<%= escape_javascript( render params[:partial], {study_file: @study_file}) %>");
+$("<%= params[:selector] %>").replaceWith("<%= escape_javascript(render partial: params[:partial], locals: {study_file: @study_file, allow_only: @allow_only }) %>");
 
 // get instance of new form as ID has changed
 var wizForm = $('.<%= params[:partial] %>').slice(-1)[0];
@@ -37,3 +37,6 @@ $('#study-files-notice-target').html("<%= escape_javascript(render partial: 'upl
 setTimeout(function() {
   $('#upload-success-modal').modal('show');
 }, 500);
+
+// show/hide overlay preventing processed uploads, if needed
+toggleExpressionOverlay(<%= @block_processed_upload %>);

--- a/app/views/studies/sync_action_fail.js.erb
+++ b/app/views/studies/sync_action_fail.js.erb
@@ -8,4 +8,7 @@ window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes
   $('<%= @form %>').replaceWith("<%= escape_javascript(render partial: 'directory_listing_form', locals: {directory: @directory}) %>");
 <% end %>
 
-$(window).trigger('updateRawCountsSelect')
+$('.expression-file-info-fields').each(function(index, element) {
+  let formId = $(element).closest('form').attr('id')
+  $(`#${formId}`).trigger('updateRawCountsSelect')
+})

--- a/app/views/studies/sync_action_fail.js.erb
+++ b/app/views/studies/sync_action_fail.js.erb
@@ -1,6 +1,6 @@
 // populate window.SCP.currentStudyFiles with information about all known StudyFiles
 // calling study.reload avoids caching issues in case files have recently updated
-window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
+window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>
 
 <% if !@study_file.nil? %>
   $('<%= @form %>').replaceWith("<%= escape_javascript(render partial: @partial, locals: {study_file: @study_file}) %>");

--- a/app/views/studies/sync_action_fail.js.erb
+++ b/app/views/studies/sync_action_fail.js.erb
@@ -1,5 +1,11 @@
+// populate window.SCP.currentStudyFiles with information about all known StudyFiles
+// calling study.reload avoids caching issues in case files have recently updated
+window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
+
 <% if !@study_file.nil? %>
   $('<%= @form %>').replaceWith("<%= escape_javascript(render partial: @partial, locals: {study_file: @study_file}) %>");
 <% else %>
   $('<%= @form %>').replaceWith("<%= escape_javascript(render partial: 'directory_listing_form', locals: {directory: @directory}) %>");
 <% end %>
+
+$(window).trigger('updateRawCountsSelect')

--- a/app/views/studies/sync_action_success.js.erb
+++ b/app/views/studies/sync_action_success.js.erb
@@ -1,6 +1,6 @@
 // populate window.SCP.currentStudyFiles with information about all known StudyFiles
 // calling study.reload avoids caching issues in case files have recently updated
-window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
+window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>
 
 closeModalSpinner('#delete-modal-spinner', '#delete-modal', function() {
   $('#sync-notices').html("<%= escape_javascript(render partial: 'sync_notice_modal', locals: {message: @message}) %>");

--- a/app/views/studies/sync_action_success.js.erb
+++ b/app/views/studies/sync_action_success.js.erb
@@ -1,15 +1,22 @@
+// populate window.SCP.currentStudyFiles with information about all known StudyFiles
+// calling study.reload avoids caching issues in case files have recently updated
+window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
+
 closeModalSpinner('#delete-modal-spinner', '#delete-modal', function() {
-    $('#sync-notices').html("<%= escape_javascript(render partial: 'sync_notice_modal', locals: {message: @message}) %>");
-    $('#sync-notice-modal').modal('show');
-    $("<%= @form %>").remove();
+  $('#sync-notices').html("<%= escape_javascript(render partial: 'sync_notice_modal', locals: {message: @message}) %>");
+  $('#sync-notice-modal').modal('show');
+  $("<%= @form %>").remove();
 
-// close any empty panels
-    $('.unsynced').each(function() {
-        if ($(this).find('.unsynced-content').html().trim() == "") {
-            $(this).collapse('hide');
-        }
-    });
+  // close any empty panels
+  $('.unsynced').each(function() {
+    if ($(this).find('.unsynced-content').html().trim() == "") {
+      $(this).collapse('hide');
+    }
+  });
 
-    $("#initialized").replaceWith("<%= escape_javascript(render partial: 'initialize_study_label') %>");
-    $('.initialize-label').tooltip({container: 'body'});
+  $("#initialized").replaceWith("<%= escape_javascript(render partial: 'initialize_study_label') %>");
+  $('.initialize-label').tooltip({container: 'body'});
 });
+
+$(window).trigger('updateRawCountsSelect')
+

--- a/app/views/studies/sync_action_success.js.erb
+++ b/app/views/studies/sync_action_success.js.erb
@@ -18,5 +18,7 @@ closeModalSpinner('#delete-modal-spinner', '#delete-modal', function() {
   $('.initialize-label').tooltip({container: 'body'});
 });
 
-$(window).trigger('updateRawCountsSelect')
-
+$('.expression-file-info-fields').each(function(index, element) {
+  let formId = $(element).closest('form').attr('id')
+  $(`#${formId}`).trigger('updateRawCountsSelect')
+})

--- a/app/views/studies/sync_study.html.erb
+++ b/app/views/studies/sync_study.html.erb
@@ -1,5 +1,5 @@
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-  window.SCP.currentStudyFiles = <%= @study.study_files.available.map(&:attributes).to_json.html_safe %>
+  window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>
 </script>
 <div class="row">
   <div class="col-sm-10">

--- a/app/views/studies/sync_study.html.erb
+++ b/app/views/studies/sync_study.html.erb
@@ -1,3 +1,6 @@
+<script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+  window.SCP.currentStudyFiles = <%= @study.study_files.available.map(&:attributes).to_json.html_safe %>
+</script>
 <div class="row">
   <div class="col-sm-10">
     <h1>Sync Study Data for '<%= @study.name %>' <%= render partial: 'initialize_study_label' %></h1>
@@ -145,8 +148,6 @@
 <%= scp_link_to "<i class='fas fa-chevron-left'></i> Back".html_safe, studies_path, class: 'btn btn-warning back-btn' %>
 
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-
-
     // when changing the existing file dropdown, dynamically update the file generation value for the specified form
     $('.existing-file-select').change(function() {
         var selectedFile = $(this).val();

--- a/app/views/studies/sync_study_file.js.erb
+++ b/app/views/studies/sync_study_file.js.erb
@@ -24,6 +24,6 @@ $("#initialized").replaceWith("<%= escape_javascript(render partial: 'initialize
 $('.initialize-label').tooltip({container: 'body'});
 
 $('.expression-file-info-fields').each(function(index, element) {
-  let formId = $(element).closest('form').attr('id')
+  const formId = $(element).closest('form').attr('id')
   $(`#${formId}`).trigger('updateRawCountsSelect')
 })

--- a/app/views/studies/sync_study_file.js.erb
+++ b/app/views/studies/sync_study_file.js.erb
@@ -1,6 +1,6 @@
 // populate window.SCP.currentStudyFiles with information about all known StudyFiles
 // calling study.reload avoids caching issues in case files have recently updated
-window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
+window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>
 
 $('#sync-notices').html("<%= escape_javascript(render partial: 'sync_notice_modal', locals: {message: @message}) %>");
 $('#sync-notice-modal').modal('show');

--- a/app/views/studies/sync_study_file.js.erb
+++ b/app/views/studies/sync_study_file.js.erb
@@ -23,4 +23,7 @@ $('.unsynced').each(function() {
 $("#initialized").replaceWith("<%= escape_javascript(render partial: 'initialize_study_label') %>");
 $('.initialize-label').tooltip({container: 'body'});
 
-$(window).trigger('updateRawCountsSelect')
+$('.expression-file-info-fields').each(function(index, element) {
+  let formId = $(element).closest('form').attr('id')
+  $(`#${formId}`).trigger('updateRawCountsSelect')
+})

--- a/app/views/studies/sync_study_file.js.erb
+++ b/app/views/studies/sync_study_file.js.erb
@@ -1,3 +1,7 @@
+// populate window.SCP.currentStudyFiles with information about all known StudyFiles
+// calling study.reload avoids caching issues in case files have recently updated
+window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
+
 $('#sync-notices').html("<%= escape_javascript(render partial: 'sync_notice_modal', locals: {message: @message}) %>");
 $('#sync-notice-modal').modal('show');
 $("<%= @form %>").remove();
@@ -18,3 +22,5 @@ $('.unsynced').each(function() {
 
 $("#initialized").replaceWith("<%= escape_javascript(render partial: 'initialize_study_label') %>");
 $('.initialize-label').tooltip({container: 'body'});
+
+$(window).trigger('updateRawCountsSelect')

--- a/app/views/studies/update_study_file.js.erb
+++ b/app/views/studies/update_study_file.js.erb
@@ -1,6 +1,6 @@
 // populate window.SCP.currentStudyFiles with information about all known StudyFiles
 // calling study.reload avoids caching issues in case files have recently updated
-window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
+window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>
 
 $("<%= @selector %>").replaceWith("<%= escape_javascript( render @partial, {study_file: @study_file}) %>");
 $("#study-files-notice-target").html("<%= escape_javascript( render partial: 'studies/study_file_notices', locals: {message: @message}) %>");

--- a/app/views/studies/update_study_file.js.erb
+++ b/app/views/studies/update_study_file.js.erb
@@ -10,7 +10,7 @@ var wizForm = $('.<%= params[:partial] %>').slice(-1)[0];
 
 $(wizForm).find('[data-toggle="tooltip"]').tooltip({container: 'body'});
 
-// emit event to trigger updates to all raw counts select inputs if this file was a raw counts matrix
+// emit event to trigger updates to all raw count select inputs if this file was a raw counts matrix
 if (<%= @study_file.is_raw_counts_file? %>) {
   $('.expression-file-info-fields').each(function(index, element) {
     let formId = $(element).closest('form').attr('id')

--- a/app/views/studies/update_study_file.js.erb
+++ b/app/views/studies/update_study_file.js.erb
@@ -10,4 +10,10 @@ var wizForm = $('.<%= params[:partial] %>').slice(-1)[0];
 
 $(wizForm).find('[data-toggle="tooltip"]').tooltip({container: 'body'});
 
-$(window).trigger('updateRawCountsSelect')
+// emit event to trigger updates to all raw counts select inputs if this file was a raw counts matrix
+if (<%= @study_file.is_raw_counts_file? %>) {
+  $('.expression-file-info-fields').each(function(index, element) {
+    let formId = $(element).closest('form').attr('id')
+    $(`#${formId}`).trigger('updateRawCountsSelect')
+  })
+}

--- a/app/views/studies/update_study_file.js.erb
+++ b/app/views/studies/update_study_file.js.erb
@@ -1,3 +1,7 @@
+// populate window.SCP.currentStudyFiles with information about all known StudyFiles
+// calling study.reload avoids caching issues in case files have recently updated
+window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
+
 $("<%= @selector %>").replaceWith("<%= escape_javascript( render @partial, {study_file: @study_file}) %>");
 $("#study-files-notice-target").html("<%= escape_javascript( render partial: 'studies/study_file_notices', locals: {message: @message}) %>");
 
@@ -5,3 +9,5 @@ $("#study-files-notice-target").html("<%= escape_javascript( render partial: 'st
 var wizForm = $('.<%= params[:partial] %>').slice(-1)[0];
 
 $(wizForm).find('[data-toggle="tooltip"]').tooltip({container: 'body'});
+
+$(window).trigger('updateRawCountsSelect')

--- a/app/views/studies/update_study_file_from_sync.js.erb
+++ b/app/views/studies/update_study_file_from_sync.js.erb
@@ -11,4 +11,7 @@ $("<%= @form %>").replaceWith("<%= escape_javascript(render partial: 'synced_stu
 $("#initialized").replaceWith("<%= escape_javascript(render partial: 'initialize_study_label') %>");
 $('.initialize-label').tooltip({container: 'body'});
 
-$(window).trigger('updateRawCountsSelect')
+$('.expression-file-info-fields').each(function(index, element) {
+  let formId = $(element).closest('form').attr('id')
+  $(`#${formId}`).trigger('updateRawCountsSelect')
+})

--- a/app/views/studies/update_study_file_from_sync.js.erb
+++ b/app/views/studies/update_study_file_from_sync.js.erb
@@ -1,6 +1,6 @@
 // populate window.SCP.currentStudyFiles with information about all known StudyFiles
 // calling study.reload avoids caching issues in case files have recently updated
-window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
+window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>
 
 $('#sync-notices').html("<%= escape_javascript(render partial: 'sync_notice_modal', locals: {message: @message}) %>");
 $('#sync-notice-modal').modal('show');

--- a/app/views/studies/update_study_file_from_sync.js.erb
+++ b/app/views/studies/update_study_file_from_sync.js.erb
@@ -1,3 +1,7 @@
+// populate window.SCP.currentStudyFiles with information about all known StudyFiles
+// calling study.reload avoids caching issues in case files have recently updated
+window.SCP.currentStudyFiles = <%= @study.reload.study_files.available.map(&:attributes).to_json.html_safe %>
+
 $('#sync-notices').html("<%= escape_javascript(render partial: 'sync_notice_modal', locals: {message: @message}) %>");
 $('#sync-notice-modal').modal('show');
 
@@ -6,3 +10,5 @@ $("<%= @form %>").replaceWith("<%= escape_javascript(render partial: 'synced_stu
 
 $("#initialized").replaceWith("<%= escape_javascript(render partial: 'initialize_study_label') %>");
 $('.initialize-label').tooltip({container: 'body'});
+
+$(window).trigger('updateRawCountsSelect')

--- a/db/migrate/20210813184203_add_raw_counts_required_frontend_feature_flag.rb
+++ b/db/migrate/20210813184203_add_raw_counts_required_frontend_feature_flag.rb
@@ -1,0 +1,20 @@
+class AddRawCountsRequiredFrontendFeatureFlag < Mongoid::Migration
+  # mirror of FeatureFlag.rb, so this migration won't error if that class is renamed/altered
+  class FeatureFlagMigrator
+    include Mongoid::Document
+    store_in collection: 'feature_flags'
+    field :name, type: String
+    field :default_value, type: Boolean, default: false
+    field :description, type: String
+  end
+
+  def self.up
+    FeatureFlagMigrator.create!(name: 'raw_counts_required_frontend',
+                                default_value: false,
+                                description: 'require users to add raw expression matrices ahead of processed matrices')
+  end
+
+  def self.down
+    FeatureFlagMigrator.find_by(name: 'raw_counts_required_frontend').destroy
+  end
+end

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -111,6 +111,7 @@ class IngestJobTest < ActiveSupport::TestCase
         studyAccession: @basic_study.accession,
         jobStatus: 'success',
         numGenes: @basic_study.genes.count,
+        is_raw_counts: false,
         numCells: num_cells
       }.with_indifferent_access
 

--- a/test/models/study_file_test.rb
+++ b/test/models/study_file_test.rb
@@ -96,7 +96,15 @@ class StudyFileTest < ActiveSupport::TestCase
       )
     )
     assert_equal false, invalid_study_file.valid?
-    assert_equal({expression_file_info: ["is invalid"]}, invalid_study_file.errors.messages)
+    expected_errors = {
+      base: [
+        'Units is not included in the list, ' \
+        'Biosample input type is not included in the list, ' \
+        'Modality is not included in the list, ' \
+        'Library preparation protocol is not included in the list'
+      ]
+    }
+    assert_equal(expected_errors, invalid_study_file.errors.messages)
 
     valid_study_file = StudyFile.new(
       study: Study.new,


### PR DESCRIPTION
This update expands on the backend work for requiring raw count matrices by enforcing the upload/sync of a raw count matrix before allowing a study owner to add a processed expression matrix.  This update also splits out raw & processed matrix files into separate tabs in the upload wizard, and blocks access to the processed tab until a raw counts matrix has been uploaded, or the user requests an exemption.  This update also adds a new field to the expression file info form for mapping the associations between processed matrix files and their "parent" raw count files.

This new UX will display a transparent overlay div with a disclaimer notifying the user that raw counts files are now required.  Successful upload of a raw file will then remove the overlay and allow access to the processed upload forms.  In addition, the radio buttons for "Is this a raw count matrix" are hard-coded in the upload wizard, and cannot be changed (this is not the case on sync forms, which still allow the user to select either value).  Raw count forms will have the `units` select input, and processed forms will instead render the React select component for selecting the corresponding raw count file.  Upon successful upload/sync of any raw count matrix, these select menus will automatically update to include any new raw files.

New overlay blocking processed uploads:
![Screen Shot 2021-08-30 at 11 01 34 AM](https://user-images.githubusercontent.com/729968/131360208-85e010d0-5bef-46bf-88e9-e3439a8ec392.png)

This update also adds raw counts information to Mixpanel reporting at the conclusion of all ingest jobs.

MANUAL TESTING:
1. Pull this branch and run any pending migrations with `./rails_local_setup.rb && source config/secrets/.source_env.bash && rails db:migrate`
2. Boot server as normal, sign in with an admin account, and set the value for the `raw_counts_required_frontend` and `raw_counts_required_backend` feature flags to `true` for that account
3. Create a new study, or use an existing one with no expression matrix files
4. In the upload wizard, confirm that clicking the 2nd tab for "Processed Matrix" displays the disclaimer and does not allow uploading a matrix file
5. Back in the raw matrix tab, upload the matrix from `test/test_files/expression_matrix_example.txt`
6. After the upload succeeds and the confirmation modal loads, confirm you can now upload a processed matrix on the 2nd tab
7. In the processed upload form, confirm that the select menu for `Corresponding raw count file` now contains the entry for `expression_matrix_example.txt`
8. Upload the file from `test/test_files/expression_matrix_example_2.txt` as a processed matrix, setting the association for the raw count matrix
9. In the rails console, load the above study and confirm that the association has been set correctly on the matrix files:
```
study = Study.last # if you used an existing study, load it by id/accession here
raw_matrix = study.expression_matrix_files.first
processed_matrix = study.expression_matrix_files.last
processed_matrix.associated_matrix_files(:raw).first == raw_matrix
=> true
raw_matrix.associated_matrix_files(:processed).first == processed_matrix
=> true
```
10. (optional) Back in the admin console, turn off the raw counts feature flags for your user account
11. (optional) Create a new study, and confirm that the processed matrix tab does not have the overlay/disclaimer present

This PR satisfies SCP-3492 and SCP-3585.