### PR TITLE
Fix StudySearchResults test regression (SCP3627)

### DIFF
--- a/app/javascript/components/search/results/StudySearchResult.js
+++ b/app/javascript/components/search/results/StudySearchResult.js
@@ -20,13 +20,13 @@ function highlightWords(text, termMatches) {
   let stylizedText = ''
   const words = text.split(' ')
   words.forEach(word => {
-  let stylizedWord = word
-  termMatches.forEach(term => {
-    if (term.toUpperCase() === word.toUpperCase()) {
-      stylizedWord = `<span class='highlight'>${word}</span>`
-    }
-  })
-  stylizedText = `${stylizedText} ${stylizedWord}`
+    let stylizedWord = word
+    termMatches.forEach(term => {
+      if (term.toUpperCase() === word.toUpperCase()) {
+        stylizedWord = `<span class='highlight'>${word}</span>`
+      }
+    })
+    stylizedText = !!stylizedText ? `${stylizedText} ${stylizedWord}` : `${stylizedWord}`
   }
   )
   return stylizedText

--- a/app/javascript/components/search/results/StudySearchResult.js
+++ b/app/javascript/components/search/results/StudySearchResult.js
@@ -95,7 +95,7 @@ export function shortenDescription(textDescription, term) {
     </>
   }
   const displayedStudyDescription = { __html: styledText.slice(0, descriptionCharacterLimit) }
-  if (textDescription.length > descriptionCharacterLimit) {
+  if (styledText.length > descriptionCharacterLimit) {
     return <>
       <span className="studyDescription" dangerouslySetInnerHTML={displayedStudyDescription}></span>{suffixTag}
     </>

--- a/test/js/study.test.js
+++ b/test/js/study.test.js
@@ -48,7 +48,7 @@ note that Release data is not corrected for batch-effects, but is stratified by 
  and showcases HCA single-cell data that wereprocessed with standardized DCP pipelines, further analyzed by\
  Cumulus (LINK), and annotated using published annotations. In this study, you can explore the biological and\
  technical attributes of the analyzed HCA DCP data. Additionally, you can view all HCA Release study pages and\
- search genes across all projects by visiting the'
+ search genes across all projects by visiting t'
     const keywordTerms = ['study']
     const wrapper = mount(shortenDescription(text, keywordTerms))
     // Find span tag with openingText

--- a/test/js/study.test.js
+++ b/test/js/study.test.js
@@ -48,7 +48,7 @@ note that Release data is not corrected for batch-effects, but is stratified by 
  and showcases HCA single-cell data that wereprocessed with standardized DCP pipelines, further analyzed by\
  Cumulus (LINK), and annotated using published annotations. In this study, you can explore the biological and\
  technical attributes of the analyzed HCA DCP data. Additionally, you can view all HCA Release study pages and\
- search genes across all projects by visiting t'
+ search genes across all projects by visiting the Single Cell Portal Release Pag'
     const keywordTerms = ['study']
     const wrapper = mount(shortenDescription(text, keywordTerms))
     // Find span tag with openingText


### PR DESCRIPTION
Had added an extra space at the beginning of study descriptions which the test picked up, so fixed that logic in the code.

Also also it seemed there was a bug in the logic for shortening descriptions for display in the search results.

Previously checking `textDescription.length > descriptionCharacterLimit` for deciding if the description needed truncating was done using the unstylized `textDescription` compared to the character limit. But the display text had been taken from `styledText` which would've included the span syntax which would actually get converted out at display time. So the case could come up where the `textDescription.length` was short enough to skip the truncating and suffixing but the `styledText` was too long so you'd end up with a description that had been shortened without the suffix of "...continued"

As seen here in prod when the study has been searched it gets shortened (with no suffix) but doesn't when just shown in non-searched results:
![Screen Shot 2021-09-01 at 3 06 07 PM](https://user-images.githubusercontent.com/54322292/131730352-486e2b99-a2a9-4248-9431-30c00182fbd3.png)

![Screen Shot 2021-09-01 at 3 06 22 PM](https://user-images.githubusercontent.com/54322292/131729392-3049df90-fa05-48a1-b37d-7cb1904cd214.png)



The change now compares the length of `styledText` to `descriptionCharacterLimit` so that the suffix and truncation are applied to the appropriate text:

Fixed local:
![Screen Shot 2021-09-01 at 3 08 03 PM](https://user-images.githubusercontent.com/54322292/131729574-84e7883d-63b3-424b-aed5-51ad257b2b92.png)

dev on local:
![Screen Shot 2021-09-01 at 3 08 47 PM](https://user-images.githubusercontent.com/54322292/131729637-fd955446-7c3b-4af7-8a72-3e49216abe01.png)


