### PR TITLE
Clarifying study embargo language & functionality (SCP-3630)

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -885,16 +885,16 @@ class Study
   # check if study is still under embargo or whether given user can bypass embargo
   def embargoed?(user)
     if user.nil?
-      self.check_embargo?
+      embargo_active?
     else
       # must not be viewable by current user & embargoed to be true
-      !self.can_view?(user) && self.check_embargo?
+      !can_view?(user) && embargo_active?
     end
   end
 
   # helper method to check embargo status
-  def check_embargo?
-    self.embargo.nil? || self.embargo.blank? ? false : Date.today <= self.embargo
+  def embargo_active?
+    embargo.blank? ? false : Time.zone.today < embargo
   end
 
   def has_download_agreement?

--- a/app/views/layouts/_download_link.html.erb
+++ b/app/views/layouts/_download_link.html.erb
@@ -1,5 +1,5 @@
 <% if @user_embargoed %>
-    <span class="label label-warning embargoed-file"><i class="fas fa-ban"></i> Data embargo expires on <%= @study.embargo.to_s(:long) %></span>
+    <span class="label label-warning embargoed-file"><i class="fas fa-ban"></i> Data Release Date: <%= @study.embargo.to_s(:long) %></span>
 <% else %>
   <% if study_file.upload_file_name.nil? && study_file.human_data %>
       <%= link_to "<span class='fas fa-cloud-download'></span> External".html_safe, study_file.download_path, class: 'btn btn-primary', target: :_blank, data: {"analytics-name": 'file-download:study-single:external'} %>

--- a/app/views/layouts/_download_link.html.erb
+++ b/app/views/layouts/_download_link.html.erb
@@ -1,5 +1,5 @@
 <% if @user_embargoed %>
-    <span class="label label-warning embargoed-file"><i class="fas fa-ban"></i> Not available until <%= @study.embargo.to_s(:long) %></span>
+    <span class="label label-warning embargoed-file"><i class="fas fa-ban"></i> Data embargo expires on <%= @study.embargo.to_s(:long) %></span>
 <% else %>
   <% if study_file.upload_file_name.nil? && study_file.human_data %>
       <%= link_to "<span class='fas fa-cloud-download'></span> External".html_safe, study_file.download_path, class: 'btn btn-primary', target: :_blank, data: {"analytics-name": 'file-download:study-single:external'} %>

--- a/app/views/site/_study_settings_form.html.erb
+++ b/app/views/site/_study_settings_form.html.erb
@@ -19,7 +19,7 @@
   </div>
   <div class="form-group row">
     <div class="col-md-4">
-      <%= f.label :embargo, 'Data Embargo Date' %>&nbsp;<span class='fas fa-question-circle' data-toggle='tooltip' title='Downloads will be prevented for everyone except study owners & shared users.  The embargo will expire on the date specified (leave blank to allow downloads)' data-placement='right'></span><br />
+      <%= f.label :embargo, 'Data Release Date' %>&nbsp;<span class='fas fa-question-circle' data-toggle='tooltip' title='Setting a Data Release Date will prevent downloads for everyone except study owners & shared users, and will expire at 12AM on the date specified (leave blank to allow downloads)' data-placement='right'></span><br />
       <%= f.text_field :embargo, class: 'form-control datepicker' %>
     </div>
     <div class="col-md-4">

--- a/app/views/site/_study_settings_form.html.erb
+++ b/app/views/site/_study_settings_form.html.erb
@@ -19,7 +19,7 @@
   </div>
   <div class="form-group row">
     <div class="col-md-4">
-      <%= f.label :embargo, 'No Data Download Until?' %>&nbsp;<span class='fas fa-question-circle' data-toggle='tooltip' title='Prevent data file downloads until date specified below (leave blank to allow downloads)' data-placement='right'></span><br />
+      <%= f.label :embargo, 'Data Embargo Date' %>&nbsp;<span class='fas fa-question-circle' data-toggle='tooltip' title='Downloads will be prevented for everyone except study owners & shared users.  The embargo will expire on the date specified (leave blank to allow downloads)' data-placement='right'></span><br />
       <%= f.text_field :embargo, class: 'form-control datepicker' %>
     </div>
     <div class="col-md-4">

--- a/app/views/studies/_form.html.erb
+++ b/app/views/studies/_form.html.erb
@@ -30,7 +30,7 @@
   </div>
   <div class="form-group row">
 		<div class="col-md-3">
-			<%= f.label :embargo, 'Data Embargo Date' %>&nbsp;<span class='fas fa-question-circle' data-toggle='tooltip' title='Downloads will be prevented for everyone except study owners & shared users.  The embargo will expire on the date specified (leave blank to allow downloads)' data-placement='right'></span><br />
+      <%= f.label :embargo, 'Data Release Date' %>&nbsp;<span class='fas fa-question-circle' data-toggle='tooltip' title='Setting a Data Release Date will prevent downloads for everyone except study owners & shared users, and will expire at 12AM on the date specified (leave blank to allow downloads)' data-placement='right'></span><br />
 			<%= f.text_field :embargo, class: 'form-control datepicker' %>
 		</div>
 		<div class="col-md-2">

--- a/app/views/studies/_form.html.erb
+++ b/app/views/studies/_form.html.erb
@@ -30,7 +30,7 @@
   </div>
   <div class="form-group row">
 		<div class="col-md-3">
-			<%= f.label :embargo, 'No Data Download Until?' %>&nbsp;<span class='fas fa-question-circle' data-toggle='tooltip' title='Prevent data file downloads until date specified below (leave blank to allow downloads)' data-placement='right'></span><br />
+			<%= f.label :embargo, 'Data Embargo Date' %>&nbsp;<span class='fas fa-question-circle' data-toggle='tooltip' title='Downloads will be prevented for everyone except study owners & shared users.  The embargo will expire on the date specified (leave blank to allow downloads)' data-placement='right'></span><br />
 			<%= f.text_field :embargo, class: 'form-control datepicker' %>
 		</div>
 		<div class="col-md-2">

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -4,8 +4,8 @@
 </h1>
 <p class="lead">Accession: <span id="study-accession"><%= @study.accession %></span></p>
 </p>
-<% if @study.check_embargo? %>
-  <p class="lead text-danger">Embargoed until: <%= @study.embargo.to_s(:long) %></p>
+<% if @study.embargo_active? %>
+  <p class="lead text-danger">Embargoed expires on: <%= @study.embargo.to_s(:long) %></p>
 <% end %>
 
 <%= @study.description.html_safe %>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -5,7 +5,7 @@
 <p class="lead">Accession: <span id="study-accession"><%= @study.accession %></span></p>
 </p>
 <% if @study.embargo_active? %>
-  <p class="lead text-danger">Embargoed expires on: <%= @study.embargo.to_s(:long) %></p>
+  <p class="lead text-danger">Embargo expires on: <%= @study.embargo.to_s(:long) %></p>
 <% end %>
 
 <%= @study.description.html_safe %>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -5,7 +5,7 @@
 <p class="lead">Accession: <span id="study-accession"><%= @study.accession %></span></p>
 </p>
 <% if @study.embargo_active? %>
-  <p class="lead text-danger">Embargo expires on: <%= @study.embargo.to_s(:long) %></p>
+  <p class="lead text-danger">Data Release Date: <%= @study.embargo.to_s(:long) %></p>
 <% end %>
 
 <%= @study.description.html_safe %>

--- a/test/models/study_test.rb
+++ b/test/models/study_test.rb
@@ -118,4 +118,22 @@ class StudyTest < ActiveSupport::TestCase
     refute share.email == share_user.email
     assert study.can_view?(share_user)
   end
+
+  # ensure that user-specified data embargoes expire on the date given
+  test 'should lift embargo on date specified' do
+    study = FactoryBot.create(:detached_study, name_prefix: 'Embargo Test', test_array: @@studies_to_clean)
+    user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    assert_not study.embargo_active?
+    assert_not study.embargoed?(user)
+    today = Time.zone.today
+    study.update(embargo: today + 1.week)
+    assert study.embargo_active?
+    assert study.embargoed?(user)
+    # ensure users with direct access are still not embargoed
+    assert_not study.embargoed?(study.user)
+    # ensure embargo lifts on specified date
+    study.update(embargo: today)
+    assert_not study.embargo_active?
+    assert_not study.embargoed?(user)
+  end
 end


### PR DESCRIPTION
A study can have an "embargo" date, which will prevent any authenticated users from downloading data from that study unless they have direct access to said study (either as the owner, or a share) until a specified date.  This is often used for a study that has a corresponding publication, and the journal does not want the data to become accessible until the article has been published.  A recent support ticket highlighted a discontinuity between the displayed language and the actual functionality - the messaging for this feature states that files are "Not available until [date]".  However, the logic for checking the whether the embargo was active is date-inclusive, meaning that the displayed date was the _last day of the emabargo_, rather than the first day of availability.

This update changes that logic to match the expected functionality.  Embargoes set by study owners will expire on the specified date.  Furthermore, messaging for this feature has been updated to use "on" (which is specific), rather than "until" (which is ambiguous).  Also, the field is now displayed in forms as "Data Release Date", rather than "No Data Download Until?", and the help tooltip specifies that the data will be made available starting at 12AM on the provided date.

MANUAL TESTING
1. Sign in as an admin and go to the study settings tab on any public study
2. Set the embargo date to today and save
3. Sign out, and sign in as a non-admin user (that doesn't have a share with the above study)
4. Load the study download tab, and validate that the embargo is not in effect, and files can be downloaded

This PR satisfies SCP-3630.