### PR TITLE
Addressing UX issues with updates, required asterisk (SCP-3492)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -741,10 +741,10 @@ function setExpressionOverlay(renderOverlay) {
 }
 
 // update all raw counts association dropdowns with new options
-function updateRawCountsAssnSelect(parentForm, currentValues) {
+function updateRawCountsAssnSelect(parentForm, currentValues, isRequired) {
   const rawAssnTarget = $(`${parentForm} .raw_associations_select`)[0]
   const pairedHiddenField = $(`${parentForm} .raw_counts_associations`)[0]
   const matrixOpts = window.SCP.currentStudyFiles.filter(sf => sf?.expression_file_info?.is_raw_counts)
     .map(sf => ({ label: sf.upload_file_name, value: sf['_id']['$oid'] }))
-  window.SCP.renderRawAssociationSelect(rawAssnTarget, currentValues, pairedHiddenField, matrixOpts)
+  window.SCP.renderRawAssociationSelect(rawAssnTarget, currentValues, pairedHiddenField, matrixOpts, isRequired)
 }

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -670,6 +670,8 @@ class StudiesController < ApplicationController
       @study_file.invalidate_cache_by_file_type
     end
 
+    set_expression_form_state
+
     if @study_file.update(study_file_params)
       # if a gene list or cluster got updated, we need to update the associated records
       if study_file_params[:file_type] == 'Gene List'

--- a/app/javascript/components/upload/RawAssociationSelect.js
+++ b/app/javascript/components/upload/RawAssociationSelect.js
@@ -19,8 +19,11 @@ function updateHiddenField(hiddenField, selections) {
  * @param {Object} parentForm parent HTML form DOM object
  * @param {Object} hiddenField hidden HTML form field for tracking associations
  * @param {Array} opts select form options array
+ * @param {Boolean} isRequired indicator that this association is a required field
  */
-export default function RawAssociationSelect({ initialValue, parentForm, hiddenField, opts }) {
+export default function RawAssociationSelect({
+  initialValue, parentForm, hiddenField, opts, isRequired=false
+}) {
   // selected is an array of string for the ids of the associated cluster files
   const [selected, setSelected] = useState(initialValue)
 
@@ -30,10 +33,12 @@ export default function RawAssociationSelect({ initialValue, parentForm, hiddenF
     updateHiddenField(hiddenField, selections, parentForm)
   }
 
+  const requiredLabel = isRequired ? <i className='text-danger'>*</i> : ''
+
   // set minWidth to 100% on label to allow select to expand to fill entire column
   return (
     <label className="min-width-100">
-      Associated raw count file <i className='text-danger'>*</i>
+      Associated raw count file {requiredLabel}
       <Select options={opts}
               value={selected}
               isMulti={true}
@@ -44,7 +49,7 @@ export default function RawAssociationSelect({ initialValue, parentForm, hiddenF
 }
 
 /** convenience method for drawing/updating the component from non-react portions of SCP */
-export function renderRawAssociationSelect(target, initialValue, hiddenField, opts) {
+export function renderRawAssociationSelect(target, initialValue, hiddenField, opts, isRequired=false) {
   const parentForm = $(target).closest('.expression-file-info-fields')[0]
   ReactDOM.unmountComponentAtNode(target)
   ReactDOM.render(
@@ -52,7 +57,8 @@ export function renderRawAssociationSelect(target, initialValue, hiddenField, op
       initialValue={initialValue}
       parentForm={parentForm}
       hiddenField={hiddenField}
-      opts={opts}/>,
+      opts={opts}
+      isRequired={isRequired}/>,
     target
   )
 }

--- a/app/views/studies/_expression_file_fields.html.erb
+++ b/app/views/studies/_expression_file_fields.html.erb
@@ -19,13 +19,13 @@
   <% current_values = f.object.associated_matrix_files(:raw)&.map { |sf| { label: sf.name, value: sf.id.to_s } } %>
 
   // render the raw counts association select; if replace is true, allows swapping out units dropdown in raw counts form
-  updateRawCountsAssnSelect('#study-file-<%= f.object.id.to_s %>', <%= current_values.to_json.html_safe %>)
+  updateRawCountsAssnSelect('#study-file-<%= f.object.id.to_s %>', <%= current_values.to_json.html_safe %>, <%= User.feature_flag_for_instance(current_user, 'raw_counts_required_backend') %>)
 
   $('#study-file-<%= f.object.id.to_s %>').on('updateRawCountsSelect', function() {
-    updateRawCountsAssnSelect('#study-file-<%= f.object.id.to_s %>', <%= current_values.to_json.html_safe %>)
+    updateRawCountsAssnSelect('#study-file-<%= f.object.id.to_s %>', <%= current_values.to_json.html_safe %>, <%= User.feature_flag_for_instance(current_user, 'raw_counts_required_backend') %>)
   })
 
   $('#study-file-<%= f.object.id.to_s %>').on('change', '.is_raw_counts_true, .is_raw_counts_false', function() {
-    updateRawCountsAssnSelect('#study-file-<%= f.object.id.to_s %>', <%= current_values.to_json.html_safe %>)
+    updateRawCountsAssnSelect('#study-file-<%= f.object.id.to_s %>', <%= current_values.to_json.html_safe %>, <%= User.feature_flag_for_instance(current_user, 'raw_counts_required_backend') %>)
   })
 </script>

--- a/app/views/studies/_initialize_expression_form.html.erb
+++ b/app/views/studies/_initialize_expression_form.html.erb
@@ -102,7 +102,8 @@
       function handleRawCountsUpdate() {
         <% current_values = study_file.associated_matrix_files(:raw)&.map { |sf| { label: sf.name, value: sf.id.to_s } } %>
         const currentValues = <%= current_values.to_json.html_safe %>
-        updateRawCountsAssnSelect(expFormId_<%= allow_only %>, currentValues)
+        const isRequired = <%= User.feature_flag_for_instance(current_user, 'raw_counts_required_backend') %>
+        updateRawCountsAssnSelect(expFormId_<%= allow_only %>, currentValues, isRequired)
       }
 
       handleRawCountsUpdate()

--- a/app/views/studies/update_fail.js.erb
+++ b/app/views/studies/update_fail.js.erb
@@ -1,1 +1,1 @@
-$('<%= @selector %>').replaceWith("<%= escape_javascript(render partial: @partial, locals: {study_file: @study_file}) %>");
+$('<%= @selector %>').replaceWith("<%= escape_javascript(render partial: @partial, locals: {study_file: @study_file, allow_only: params[:allow_only] || 'all' }) %>");

--- a/app/views/studies/update_study_file.js.erb
+++ b/app/views/studies/update_study_file.js.erb
@@ -2,7 +2,7 @@
 // calling study.reload avoids caching issues in case files have recently updated
 window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>
 
-$("<%= @selector %>").replaceWith("<%= escape_javascript( render @partial, {study_file: @study_file}) %>");
+$("<%= @selector %>").replaceWith("<%= escape_javascript( render @partial, {study_file: @study_file, allow_only: @allow_only }) %>");
 $("#study-files-notice-target").html("<%= escape_javascript( render partial: 'studies/study_file_notices', locals: {message: @message}) %>");
 
 // get instance of new form as ID has changed


### PR DESCRIPTION
This update fixes small regressions with handling raw count associations when the corresponding feature flags are not enabled.

MANUAL TESTING
1. Turn off the `raw_counts_required_backend` feature flag for your account
2. Load the upload wizard for a study file that has both raw & processed matrix files
3. Confirm the asterisk for "associated raw count file" is gone
4. Confirm that updating the file (like adding a description) does not throw an error in the logs

This PR further satisfies SCP-3492.