### PR TITLE
Fixing bug w/ rendering upload wizard (SCP-3642)

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -95,7 +95,7 @@ class StudiesController < ApplicationController
     # load any existing files if user restarted for some reason (unlikely)
     initialize_wizard_files
     # check if study has been properly initialized yet, set to true if not
-    if !@cluster_ordinations.last.new_record? && !@all_expression.last.new_record? && !@metadata_file.new_record? && !@study.initialized?
+    if !@cluster_ordinations.last.new_record? && !@processed_matrix_files.last.new_record? && !@metadata_file.new_record? && !@study.initialized?
       @study.update_attributes(initialized: true)
     end
   end

--- a/test/integration/upload_wizard_test.rb
+++ b/test/integration/upload_wizard_test.rb
@@ -1,0 +1,78 @@
+require 'integration_test_helper'
+require 'test_helper'
+
+class UploadWizardTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+  include Minitest::Hooks
+  include SelfCleaningSuite
+  include TestInstrumentor
+
+  before(:all) do
+    @user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                               name_prefix: 'Upload Wizard Test',
+                               public: false,
+                               user: @user,
+                               test_array: @@studies_to_clean)
+    @study.update(detached: false) # workaround to get test to run faster & allow rendering of upload wizard
+    TosAcceptance.create!(email: @user.email)
+  end
+
+  # ensures the upload wizard will render, regardless of the state of the study in terms of how many files have
+  # already been uploaded.  used as a smoke test for changes to the upload wizard state logic
+  test 'can render upload wizard' do
+    sign_in @user
+    auth_as_user @user
+    # empty study
+    get initialize_study_path(@study.id)
+    assert_response :success
+
+    FactoryBot.create(:metadata_file,
+                      name: 'metadata.txt', study: @study,
+                      cell_input: %w[A B C],
+                      annotation_input: [
+                        { name: 'species', type: 'group', values: %w[dog cat dog] },
+                        { name: 'disease', type: 'group', values: %w[none none measles] }
+                      ])
+    @study.reload
+    assert @study.metadata_file.present?
+    get initialize_study_path(@study.id)
+    assert_response :success
+
+    FactoryBot.create(:cluster_file,
+                      name: 'cluster_1.txt', study: @study,
+                      cell_input: {
+                        x: [1, 4, 6],
+                        y: [7, 5, 3],
+                        cells: %w[A B C]
+                      },
+                      cluster_type: '2d')
+    @study.reload
+    assert @study.cluster_ordinations_files.any?
+    get initialize_study_path(@study.id)
+    assert_response :success
+
+    raw_matrix = FactoryBot.create(:study_file, name: 'raw.txt', file_type: 'Expression Matrix', study: @study)
+    raw_matrix.build_expression_file_info(is_raw_counts: true, units: 'raw counts',
+                                          library_preparation_protocol: 'MARS-seq',
+                                          modality: 'Transcriptomic: unbiased',
+                                          biosample_input_type: 'Whole cell')
+    raw_matrix.save
+    @study.reload
+    assert @study.expression_matrix_files.any?
+    get initialize_study_path(@study.id)
+    assert_response :success
+
+    processed_matrix = FactoryBot.create(:study_file, name: 'proccessed.txt', file_type: 'Expression Matrix', study: @study)
+    processed_matrix.build_expression_file_info(is_raw_counts: false, raw_counts_associations: [raw_matrix.id.to_s],
+                                                library_preparation_protocol: 'MARS-seq',
+                                                modality: 'Transcriptomic: unbiased',
+                                                biosample_input_type: 'Whole cell')
+    processed_matrix.save
+    @study.reload
+    assert @study.expression_matrix_files.count == 2
+    get initialize_study_path(@study.id)
+    assert_response :success
+
+  end
+end

--- a/test/integration/upload_wizard_test.rb
+++ b/test/integration/upload_wizard_test.rb
@@ -9,12 +9,11 @@ class UploadWizardTest < ActionDispatch::IntegrationTest
 
   before(:all) do
     @user = FactoryBot.create(:user, test_array: @@users_to_clean)
-    @study = FactoryBot.create(:detached_study,
+    @study = FactoryBot.create(:study,
                                name_prefix: 'Upload Wizard Test',
                                public: false,
                                user: @user,
                                test_array: @@studies_to_clean)
-    @study.update(detached: false) # workaround to get test to run faster & allow rendering of upload wizard
     TosAcceptance.create!(email: @user.email)
   end
 


### PR DESCRIPTION
Fixes an issue where upload wizard cannot render if a study has clustering/metadata files, but no expression matrix files yet uploaded.  This is due to a regression from the "raw counts required" UX work that split raw/processed matrix files into separate containers, and we were checking for the presence of a matrix file in the wrong place when attempting to set `@study.initialized`.

MANUAL TESTING
1. Sign in and create a new study
2. Upload a cluster file
3. Navigate back to "My Studies", and then go back to the upload wizard for the new study
4. Confirm page renders and expression files can be uploaded

This PR satisfies SCP-3642