### PR TITLE
Update Advanced Search Zendesk Links with better linked article (SCP-3601)

### DIFF
--- a/app/javascript/components/search/controls/SearchPanel.js
+++ b/app/javascript/components/search/controls/SearchPanel.js
@@ -46,7 +46,7 @@ const helpModalContent = (<div>
   <a href="https://singlecell.zendesk.com/hc/en-us/articles/360061006431-Search-Studies"
     target="_blank" rel="noreferrer">documentation
   </a>.  Study authors looking to make their studies more accessible can read our
-  <a href="https://singlecell.zendesk.com/hc/en-us/articles/360060610232-Metadata-File-Overview"
+  <a href="https://singlecell.zendesk.com/hc/en-us/articles/4406379107355-Metadata-powered-Advanced-Search"
     target="_blank" rel="noreferrer"> metadata guide
   </a>.
 </div>)

--- a/app/javascript/components/search/results/ResultsPanel.js
+++ b/app/javascript/components/search/results/ResultsPanel.js
@@ -90,7 +90,7 @@ const FacetResultsFooter = ({ studySearchState }) => {
             target="_blank" rel="noreferrer">documentation
           </a>.  Study authors looking to make their studies more accessible can read our{' '}
           {/* eslint-disable-next-line max-len */}
-          <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#Metadata-powered-Advanced-Search"
+          <a href="https://singlecell.zendesk.com/hc/en-us/articles/4406379107355-Metadata-powered-Advanced-Search"
             target="_blank" rel="noreferrer"> metadata guide
           </a>.
         </div>

--- a/app/javascript/components/search/results/ResultsPanel.js
+++ b/app/javascript/components/search/results/ResultsPanel.js
@@ -90,7 +90,7 @@ const FacetResultsFooter = ({ studySearchState }) => {
             target="_blank" rel="noreferrer">documentation
           </a>.  Study authors looking to make their studies more accessible can read our{' '}
           {/* eslint-disable-next-line max-len */}
-          <a href="https://singlecell.zendesk.com/hc/en-us/articles/360060610232-Metadata-File-Overview"
+          <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#Metadata-powered-Advanced-Search"
             target="_blank" rel="noreferrer"> metadata guide
           </a>.
         </div>

--- a/app/javascript/components/search_xds/controls/SearchPanel.js
+++ b/app/javascript/components/search_xds/controls/SearchPanel.js
@@ -46,7 +46,7 @@ const helpModalContent = (<div>
   </a>.
   <br/>If you are a study creator and would like to provide that metadata for your study to be searchable,
   see our
-  <a href="https://singlecell.zendesk.com/hc/en-us/articles/360060610232-Metadata-File-Overview"
+  <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#Metadata-powered-Advanced-Search"
     target="_blank" rel="noreferrer">metadata guide
   </a>.
 </div>)

--- a/app/javascript/components/search_xds/controls/SearchPanel.js
+++ b/app/javascript/components/search_xds/controls/SearchPanel.js
@@ -46,7 +46,7 @@ const helpModalContent = (<div>
   </a>.
   <br/>If you are a study creator and would like to provide that metadata for your study to be searchable,
   see our
-  <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#Metadata-powered-Advanced-Search"
+  <a href="https://singlecell.zendesk.com/hc/en-us/articles/4406379107355-Metadata-powered-Advanced-Search"
     target="_blank" rel="noreferrer">metadata guide
   </a>.
 </div>)

--- a/app/javascript/components/search_xds/results/ResultsPanel.js
+++ b/app/javascript/components/search_xds/results/ResultsPanel.js
@@ -95,7 +95,7 @@ const FacetResultsFooter = ({ studySearchState }) => {
           </a>.<br/>
           Study authors looking to make their studies more accessible can read our
           {/* eslint-disable-next-line max-len */}
-          <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#Metadata-powered-Advanced-Search"
+          <a href="https://singlecell.zendesk.com/hc/en-us/articles/4406379107355-Metadata-powered-Advanced-Search"
             target="_blank" rel="noreferrer"> metadata guide
           </a>.
         </div>

--- a/app/javascript/components/search_xds/results/ResultsPanel.js
+++ b/app/javascript/components/search_xds/results/ResultsPanel.js
@@ -95,7 +95,7 @@ const FacetResultsFooter = ({ studySearchState }) => {
           </a>.<br/>
           Study authors looking to make their studies more accessible can read our
           {/* eslint-disable-next-line max-len */}
-          <a href="https://singlecell.zendesk.com/hc/en-us/articles/360060610232-Metadata-File-Overview"
+          <a href="https://github.com/broadinstitute/single_cell_portal/wiki/Metadata-File#Metadata-powered-Advanced-Search"
             target="_blank" rel="noreferrer"> metadata guide
           </a>.
         </div>

--- a/app/views/studies/_initialize_metadata_form.html.erb
+++ b/app/views/studies/_initialize_metadata_form.html.erb
@@ -102,7 +102,7 @@
 
     function setMetadataConventionMessage(useMetadataConvention) {
         var message;
-        const advancedUrl = "https://singlecell.zendesk.com/hc/en-us/articles/360060610232-Metadata-File-Overview"
+        const advancedUrl = "https://singlecell.zendesk.com/hc/en-us/articles/4406379107355-Metadata-powered-Advanced-Search"
         const advancedLink = `<a href="${advancedUrl}" target="_blank" rel="noreferrer">advanced search</a>`
         const conventionRequired = <%= convention_required == true %>;
         const helpUrl = 'https://singlecell.zendesk.com/hc/en-us/articles/360061006411-Metadata-Convention'


### PR DESCRIPTION
In this PR: https://github.com/broadinstitute/single_cell_portal_core/pull/1126/files/bb42af7a17aafb2acbcb3ab56b30dba25021085e SCP Github wiki articles were updated to point to Zendesk articles instead. However, the Meta-data Advanced Search article was not split out of the General Meta-data article so that link didn't point at the best spot. This PR updates the Zendesk link to point to the now split out Advanced Search article in all the spots that used to point to the wiki advanced search.