### PR TITLE
Retiring obsolete 'react_explore' feature flag (SCP-3623)

### DIFF
--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -21,4 +21,23 @@ class FeatureFlag
       hash.with_indifferent_access
     end
   end
+
+  # 'retire' a feature flag and remove all per-model flag values to prevent FeatureFlaggable#validate_feature_flags
+  # from throwing an error when trying to update existing feature flags
+  def self.retire_feature_flag(name)
+    feature_flag = FeatureFlag.find_by(name: name)
+    raise NameError, "FeatureFlag: '#{name}' does not exist" if feature_flag.blank?
+
+    # call Rails.application.eager_load! to ensure all classes are loaded in development
+    Rails.application.eager_load! if Rails.env.development?
+
+    # use FeatureFlaggable#remove_flag_from_model to remove all per-model instances of the flag
+    # use Mongoid.models to iterate over all SCP-defined models to see if they include the FeatureFlaggable module
+    Mongoid.models.each do |model|
+      next unless model.include? FeatureFlaggable
+
+      FeatureFlaggable.remove_flag_from_model(model, name)
+    end
+    feature_flag.destroy
+  end
 end

--- a/app/views/site/update_study_settings.js.erb
+++ b/app/views/site/update_study_settings.js.erb
@@ -8,11 +8,7 @@ closeModalSpinner('#update-study-settings-spinner', '#update-study-settings-moda
         $('#study-summary').html("<%= escape_javascript(render partial: 'study_description_view') %>");
         $('#study-download').html("<%= escape_javascript(render partial: 'study_download_data') %>");
         <% if @study.initialized? %>
-          <% if User.feature_flag_for_instance(current_user, 'react_explore')  %>
-            window.SCP.renderExploreView(document.getElementById('study-visualize'), window.SCP.studyAccession)
-          <% else %>
-            $('#study-visualize').html("<%= escape_javascript(render partial: 'study_visualize') %>");
-          <% end %>
+          window.SCP.renderExploreView(document.getElementById('study-visualize'), window.SCP.studyAccession)
         <% end %>
     <% else %>
         showMessageModal("", "An error occurred while saving: <br /><%= @study.errors.full_messages.join(', ').html_safe %>");

--- a/app/views/studies/_initialize_ordinations_form.html.erb
+++ b/app/views/studies/_initialize_ordinations_form.html.erb
@@ -139,13 +139,11 @@
       window.SCP.renderClusterAssociationSelect(clusterAssnTarget, opts, current_values, isNew, pairedHiddenField)
     }
 
-    <% if User.feature_flag_for_instance(current_user, 'react_explore')  %>
-      updateClusterAssnSelect()
+    updateClusterAssnSelect()
 
-      $('form').on('change', '.is_spatial_true , .is_spatial_false', function() {
-        updateClusterAssnSelect()
-      })
-    <% end %>
+    $('form').on('change', '.is_spatial_true , .is_spatial_false', function() {
+      updateClusterAssnSelect()
+    })
 
     $(function() {
 

--- a/db/migrate/20210907141202_remove_react_explore_feature_flag.rb
+++ b/db/migrate/20210907141202_remove_react_explore_feature_flag.rb
@@ -1,0 +1,11 @@
+class RemoveReactExploreFeatureFlag < Mongoid::Migration
+  def self.up
+    FeatureFlag.retire_feature_flag('react_explore')
+  end
+
+  def self.down
+    FeatureFlag.create!(name: 'react_explore',
+                        default_value: false,
+                        description: 'whether the explore tab should use the new React functionality')
+  end
+end

--- a/test/models/feature_flag_test.rb
+++ b/test/models/feature_flag_test.rb
@@ -79,4 +79,16 @@ class FeatureFlagTest < ActiveSupport::TestCase
     exception = assert_raise(Exception) { @user.update!(feature_flags: {'my_feature_flag': 3}) }
     assert_equal 'Invalid feature flag input - value must be boolean', exception.message
   end
+
+  test 'should retire feature flag' do
+    flag_name = :new_flag
+    FeatureFlag.create(name: flag_name.to_s, default_value: false)
+    @user.update(feature_flags: { flag_name => true })
+    @user.reload
+    assert User.feature_flag_for_instance(@user, flag_name)
+    FeatureFlag.retire_feature_flag(flag_name)
+    @user.reload
+    assert_not User.feature_flag_for_instance(@user, flag_name)
+    assert_nil FeatureFlag.find_by(name: flag_name)
+  end
 end


### PR DESCRIPTION
This update removes the obsolete `react_explore` feature flag, and all references to it.  The only places remaining were controlling the state of the spatial association select input, and also handling re-rendering the explore tab when updating study settings.

This update also adds a new class method to `FeatureFlag` to retire old flags from the database.  The `retire_feature_flag` method will delete the flag itself, as well as all model-based instances where this flag has been set.  This will cover _all_ SCP models that implement the `FeatureFlaggable` concern, both now and in the future.

MANUAL TESTING
1. Run `ruby_local_setup.rb && source config/secrets/.source_env.bash && rails db:migrate`
2. Boot portal as normal, including delayed_job, and sign in with an admin account
3. Load any study with visualizations enabled
4. Load the study settings tab, and update any default configuration (like point size, opacity, etc.)
5. Once the update completes, validate the explore tab has re-rendered with the update, and that there are no errors in the JS console
6. Load the Admin Config page, and edit the feature flags for your account
7. Note that the form renders w/o error, and that the `react_explore` entry is gone
8. Optional: in the Rails console, query for any user accounts that still have a value set for `feature_flags.react_explore` and confirm the return is `0`:
```
User.where(:'feature_flags.react_explore'.ne => nil).count
=> 0
```

This PR satisfies SCP-3623.