### PR TITLE
Updating admin ingest launch failure email (SCP-3534)

### DIFF
--- a/app/views/single_cell_mailer/notify_admin_parse_launch_fail.html.erb
+++ b/app/views/single_cell_mailer/notify_admin_parse_launch_fail.html.erb
@@ -23,5 +23,6 @@
   study = Study.find_by(accession: '<%= @study.accession %>')
   study_file = study.study_files.detect {|file| file.upload_file_name == '<%= @study_file.upload_file_name %>'}
   user = User.find_by(email: '<%= @user.email %>')
+  study_file.update(parse_status: 'unparsed')
   FileParseService.run_parse_job(study_file, study, user)
 </strong></pre>


### PR DESCRIPTION
This update adds a missing required step to the admin email notification for relaunching an ingest job that failed to initiate.  The goal of the email is to allow a portal administrator to easily launch an ingest job by copying/pasting the email command into the console to re-initiate the job.  Previously, the email missed a required step in resetting the study file's `parse_status` label to `unparsed`.  Failure to do so will result in the `FileParseService` preventing an ingest job from being launched as it assumes the file is already parsing.

While this entire process could potentially be automated, the fact that the automated launch process failed the first time for some reason highlights the potential pitfalls of having an "auto-relaunch" feature.  This manual intervention allows an admin to diagnose new potential regressions/corner cases and take additional corrective action, as necessary.

MANUAL TESTING
Rather than trying to simulate a failed ingest launch, the simplest way of validating this is from the Rails console:
1. Enter the rails console, and load any study that does not already contain the cluster file from `test/test_data/cluster_example.txt`
```
study = Study.find_by(accession: [enter accession here])
user = study.user
```
2. Manually create a new `StudyFile` entry (copying the file contents to `tmp` because of Carrierwave):
```
file_path = 'test/test_data/cluster_example.txt'
new_path = 'tmp/cluster_example.txt'
FileUtils.cp(file_path, new_path)
upload = File.open(new_path)
study_file = study.study_files.build(file_type: 'Cluster', name: 'Test', upload: upload)
study_file.save!
``` 
3. Manually send the ingest launch failure email:
```
error = RuntimeError.new('test')
SingleCellMailer.notify_admin_parse_launch_fail(study, study_file, user, :ingest_cluster, error).deliver_now
```
4. Copy the contents of the email into the Rails console and validate the return of `{status_code: 204}`

This PR satisfies SCP-3534.