### PR TITLE
Log whether scatter plot is for spatial data (SCP-3599)

### DIFF
--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -247,6 +247,7 @@ module Api
             "isSubsampled": cluster.subsampled?,
             "isAnnotatedScatter": is_annotated_scatter,
             "isCorrelatedScatter": is_correlated_scatter,
+            "isSpatial": cluster.study_file.is_spatial,
             "numPoints": cluster.points,
             "axes": axes_full,
             "hasCoordinateLabels": cluster.has_coordinate_labels?,

--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -160,6 +160,7 @@ export function logScatterPlot(
     'annotScope': scatter.annotParams.scope,
     'isCorrelatedScatter': scatter.isCorrelatedScatter,
     'isAnnotatedScatter': scatter.isAnnotatedScatter,
+    'isSpatial': scatter.isSpatial,
     perfTimes
   }
 

--- a/test/api/visualization/clusters_controller_test.rb
+++ b/test/api/visualization/clusters_controller_test.rb
@@ -88,6 +88,7 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
       "isSubsampled"=>false,
       "isAnnotatedScatter"=>false,
       "isCorrelatedScatter"=>false,
+      "isSpatial"=>false,
       "numPoints"=>3,
       "axes"=>{"titles"=>{"x"=>"X", "y"=>"Y", "z"=>"Z", "magnitude" => "Expression"}, "aspects"=>nil},
       "hasCoordinateLabels"=>false,


### PR DESCRIPTION
This adds an `isSpatial` property to Mixpanel analytics logging for the `plot:scatter` event.  This enables robustly analyzing scatter plots for spatial clusters, e.g. to assess performance relevant to spatial transcriptomics.

Previously, we shoehorned this metrics functionality by [querying whether `spatial?` was contained in a `perfTime:url` property](https://mixpanel.com/s/3D2R5X).  That proved brittle.  Making this parameter explicit allows us to resolve that.  We should be able to stitch together queries to get continuous historical performance metrics, perhaps minus a gap from late July to September.

<img width="1679" alt="isSpatial_property_for_scatter_plot_log_to_Mixpanel__SCP_2021-09-08" src="https://user-images.githubusercontent.com/1334561/132778142-7e8130e5-1d05-4204-9f91-f7c9c01130dd.png">

To test:
1.  Go to Explore tab for a study with spatial data
2. Select a spatial cluster
3. Open Network panel in Chrome DevTools
4. Filter requests to `bard method:POST`
5. In log requests for `scatter:plot`, verify presence of one log with `isSpatial: true` and one with `isSpatial: false`

This satisfies SCP-3599.
