### PR TITLE
SCP-3595 Collections demo UX fixups

### DIFF
--- a/app/controllers/branding_groups_controller.rb
+++ b/app/controllers/branding_groups_controller.rb
@@ -44,7 +44,7 @@ class BrandingGroupsController < ApplicationController
         # push all branding assets to remote to ensure consistency
         UserAssetService.delay.push_assets_to_remote(asset_type: :branding_images)
         format.html { redirect_to merge_default_redirect_params(branding_group_path(@branding_group), scpbr: params[:scpbr]),
-                                  notice: "Branding group '#{@branding_group.name}' was successfully created." }
+                                  notice: "Collection '#{@branding_group.name}' was successfully created." }
         format.json { render :show, status: :created, location: @branding_group }
       else
         format.html { render :new }
@@ -59,7 +59,7 @@ class BrandingGroupsController < ApplicationController
     respond_to do |format|
       if @branding_group.update(branding_group_params)
         format.html { redirect_to merge_default_redirect_params(branding_group_path(@branding_group), scpbr: params[:scpbr]),
-                                  notice: "Branding group '#{@branding_group.name}' was successfully updated." }
+                                  notice: "Collection '#{@branding_group.name}' was successfully updated." }
         format.json { render :show, status: :ok, location: @branding_group }
       else
         format.html { render :edit }
@@ -75,7 +75,7 @@ class BrandingGroupsController < ApplicationController
     @branding_group.destroy
     respond_to do |format|
       format.html { redirect_to merge_default_redirect_params(branding_groups_path, scpbr: params[:scpbr]),
-                                notice: "Branding group '#{name}' was successfully destroyed." }
+                                notice: "Collection '#{name}' was successfully destroyed." }
       format.json { head :no_content }
     end
   end

--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -205,18 +205,30 @@
   z-index: -1000;
 }
 
-.collections-list li {
-  display: flex;
-  padding: 1em 0em 1em 0em;
-  border-bottom: 1px solid #ccc;
-  .collections-logo {
-    width: 180px;
-    img {
-      max-width: 180px;
+.collections-list {
+  background: #fff;
+  padding: 0em 1em;
+  margin-top: 0.5em;
+  border-radius: 5px;
+  li {
+    display: flex;
+    padding: 1em 0em 1em 0em;
+    border-bottom: 1px solid #ccc;
+    .collections-logo {
+      width: 180px;
+      img {
+        max-width: 180px;
+      }
     }
-  }
-  .collections-name {
-    text-align: left;
-    padding-left: 2em;
+    .collections-name {
+      text-align: left;
+      padding-left: 2em;
+    }
+    .collections-actions {
+      margin-left: auto;
+    }
+    &:last-of-type {
+      border-bottom: none;
+    }
   }
 }

--- a/app/views/branding_groups/_form.html.erb
+++ b/app/views/branding_groups/_form.html.erb
@@ -86,6 +86,6 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit nil, class: 'btn btn-lg btn-success', id: 'save-branding-group' %>
+    <%= f.submit 'Update Collection', class: 'btn btn-lg btn-success', id: 'save-branding-group' %>
   </div>
 <% end %>

--- a/app/views/branding_groups/index.html.erb
+++ b/app/views/branding_groups/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Branding Groups</h1>
+<h1>Collections</h1>
 <div class="row">
   <div class="col-md-12">
     <div class="table-responsive">
@@ -31,7 +31,7 @@
         </table>
       </div>
     </div>
-    <p><%= scp_link_to "<i class='fas fa-plus'></i> New Branding Group".html_safe, new_branding_group_path, class: 'btn btn-lg btn-success', id: 'new-branding-group' %></p>
+    <p><%= scp_link_to "<i class='fas fa-plus'></i> New Collection".html_safe, new_branding_group_path, class: 'btn btn-lg btn-success', id: 'new-branding-group' %></p>
   </div>
 </div>
 

--- a/app/views/branding_groups/list_navigate.html.erb
+++ b/app/views/branding_groups/list_navigate.html.erb
@@ -1,12 +1,12 @@
 <h2 class="text-center">Collections</h2>
-
+<span>Collections are curated groups of studies which share a common research theme. If your organization is interested in creating a collection within SCP, contact us at <%= mail_to 'scp-support@broadinstitute.zendesk.com', 'scp-support@broadinstitute.zendesk.com' %></span>
 <div class="row">
   <div class="col-md-12">
     <ul class="collections-list">
       <% @branding_groups.each do |branding_group| %>
         <li id="<%= branding_group.name_as_id %>">
           <div class="collections-logo">
-            <% if branding_group.splash_image.url.present? %>
+            <% if branding_group.splash_image.filename.present? %>
               <%= link_to image_tag(branding_group.splash_image.url), site_path(scpbr: branding_group.name_as_id) %>
             <% end %>
           </div>
@@ -19,7 +19,7 @@
               <%= link_to branding_group.external_link_description.html_safe + " <span class='fas fa-fw fa-external-link-alt'></span> ".html_safe , branding_group.external_link_url, target: '_blank'%>
             <% end %>
           </div>
-          <div>
+          <div class="collections-actions">
             <% if @editable_branding_groups.include?(branding_group) %>
               <%= scp_link_to "<i class='fas fa-search'></i> Info".html_safe, branding_group_path(branding_group), class: "btn btn-xs btn-info #{branding_group.name_as_id}-show" %>
               <%= scp_link_to "<i class='fas fa-edit'></i> Edit".html_safe, edit_branding_group_path(branding_group), class: "btn btn-xs btn-primary #{branding_group.name_as_id}-edit" %>
@@ -41,4 +41,3 @@
     </ul>
   </div>
 </div>
-<span>Collections are curated groups of studies which share a common research theme. If your organization is interested in creating a collection within SCP, contact us at <%= mail_to 'scp-support@broadinstitute.zendesk.com', 'scp-support@broadinstitute.zendesk.com' %></span>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -40,7 +40,7 @@
               <li><%= link_to "<span class='fas fa-flask fa-fw'></span> Analyses".html_safe, analysis_configurations_path, class: 'check-upload', id: 'analysis-nav' %></li>
               <li><%= link_to "<span class='fas fa-search fa-fw'></span> Preset Searches".html_safe, preset_searches_path, class: 'check-upload', id: 'preset-nav' %></li>
               <li><%= link_to "<span class='fas fa-dna fa-fw'></span> Species".html_safe, taxons_path, class: 'check-upload', id: 'species-nav' %></li>
-              <li><%= scp_link_to "<span class='fas fa-copyright fa-fw'></span> Branding Groups".html_safe, branding_groups_path, class: 'check-upload', id: 'branding-groups-nav' %>
+              <li><%= scp_link_to "<span class='fas fa-copyright fa-fw'></span> Collections".html_safe, branding_groups_path, class: 'check-upload', id: 'branding-groups-nav' %>
             <% end %>
             <% if current_user.acts_like_reporter? %>
               <li><%= link_to "<span class='fas fa-chart-area fa-fw'></span> Reports".html_safe, reports_path, class: 'check-upload', id: 'reports-nav' %></li>
@@ -53,7 +53,7 @@
             <li><%= scp_link_to "<span class='fas fa-plus fa-fw'></span> Create a Study".html_safe, new_study_path, class: 'check-upload' %></li>
             <% if current_user.available_branding_groups.any? %>
               <li role="separator" class="divider"></li>
-              <li class="dropdown-header">My Brands</li>
+              <li class="dropdown-header">My Collections</li>
               <% current_user.available_branding_groups.each do |branding_group| %>
                 <li id="<%= branding_group.name_as_id %>-nav"><%= link_to "<i class='fas fa-copyright fa-fw'></i> #{branding_group.name}".html_safe, site_path(scpbr: branding_group.name_as_id) %></li>
               <% end %>


### PR DESCRIPTION
SCP-3595 - this addresses the comments from demo, notably around the collections list UX, moving text to top, aligning buttons, and getting rid of broken image tags.  This also does a more thorough job of replacing branding group with collection throught the UI

![image](https://user-images.githubusercontent.com/2800795/132573224-f12993d3-2788-40c0-9397-00d745067f4b.png)

TO TEST:
0. from the home page, click 'browse collections'
1. confirm the collections browser appears as desired
2. As admin, click around the collections UX, and confirm no stray 'branding group' references remain