### PR TITLE
Allow updating study description w/o reviewer access settings changes (SCP-3680)

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -883,7 +883,7 @@ class SiteController < ApplicationController
 
     if access_settings['reset'] == 'yes'
       logger.info "Rotating credentials for reviewer access in #{study.accession}"
-      @study.reviewer_access&.rotate_credentials!
+      study.reviewer_access&.rotate_credentials!
     elsif access_settings['enable'] == 'yes' && study.reviewer_access.nil?
       study.build_reviewer_access.save!
     elsif access_settings['enable'] == 'no'

--- a/test/integration/reviewer_access_permission_test.rb
+++ b/test/integration/reviewer_access_permission_test.rb
@@ -161,4 +161,24 @@ class ReviewerAccessPermissionTest < ActionController::TestCase
     get :reviewer_access, params: { access_code: access.access_code }
     assert_response :success
   end
+
+  # handles regression found in SCP-3680
+  test 'should update study description w/o reviewer access settings' do
+    auth_as_user(@user)
+    sign_in @user
+    new_description = "<p>This is the updated description</p>"
+    study_params = {
+      accession: @study.accession, study_name: @study.url_safe_name,
+      study: {
+        study_detail_attributes: {
+          full_description: new_description,
+          id: @study.study_detail.id.to_s
+        }
+      }
+    }
+    post :update_study_settings, params: study_params, xhr: true
+    assert_response :success
+    @study.reload
+    assert_equal @study.full_description, new_description
+  end
 end


### PR DESCRIPTION
This update fixes a regression which prevented re-rendering the study description after a user updated it through the "Edit Description" button in the "Summary" tab.  The issue was checking for `reviewer_access_actions` parameters, which will only be present when using the "Study Settings" form, and are not present when updating only the description (both updates use the same controller method.

MANUAL TESTING
1. Boot as normal and sign in
2. Load any study, and click "Edit Description"
3. Make any update, then click "Update Description"
4. Confirm update completes and re-renders the description with the update
5. (Optional): Turn on reviewer access for this study in the "Study Settings" tab using instructions from #1120 

This PR satisfies SCP-3680.