### PR TITLE
Add support note to in-app validation (SCP-3636)

### DIFF
--- a/app/javascript/components/validation/ValidationAlert.js
+++ b/app/javascript/components/validation/ValidationAlert.js
@@ -1,6 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
+import { supportEmailLink } from 'lib/error-utils'
+
+const supportMessage = <div>
+  If you need help, let us know at {supportEmailLink}.
+  Please include the above errors, your file, and study accession.
+</div>
+
 /** Renders a report of file validation errors for upload UI */
 export default function ValidationAlert({ summary, errors, fileType }) {
   return (
@@ -13,6 +20,8 @@ export default function ValidationAlert({ summary, errors, fileType }) {
         return <li key={i}>{columns[2]}</li>
       })}
       </ul>
+      <br/>
+      {supportMessage}
     </div>
   )
 }


### PR DESCRIPTION
This explains how to get support when trouble persists in client-side file validation (#1154).  Thanks to @jlchang for the suggestion in demo today!

<img width="1125" alt="Support_message_for_in-app_validation__SCP_2021-09-15" src="https://user-images.githubusercontent.com/1334561/133528052-db797f2a-351e-4da5-a73c-8a6ccdea7b87.png">

This relates to SCP-3636.