### PR TITLE
Refactoring TDR integration for v2 snapshot query (SCP-3677)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -697,7 +697,7 @@ module Api
       # execute a search in TDR and get back normalized results
       # will actually issue 2 search requests, first to extract unique project_ids that match the query,
       # and a second to retrieve all result rows for those projects
-      # this is to address issues in sparsity of ES index with regards to some data (like species, disease, etc)
+      # this is to address issues in sparsity of Elasticsearch index with regards to some data (like species, disease, etc)
       def self.get_tdr_results(selected_facets:, terms:)
         client = ApplicationController.data_repo_client
         results = {}

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -307,7 +307,6 @@ module Api
           end
           # just log for now
           logger.info "Found #{@tdr_results.keys.size} results in Terra Data Repo"
-          logger.info "#{@tdr_results.map {|name, info| { name => info['facet_matches']}}}"
           @tdr_results.each do |_, tdr_result|
             @studies << tdr_result
           end

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -296,9 +296,8 @@ module Api
           @tdr_results = self.class.get_tdr_results(selected_facets: @facets, terms: @term_list)
 
           if @facets.present?
-            simple_tdr_results = self.class.simplify_tdr_facet_search_results(@tdr_results, @facets)
+            simple_tdr_results = self.class.simplify_tdr_facet_search_results(@tdr_results)
             matched_tdr_studies = self.class.match_studies_by_facet(simple_tdr_results, @facets)
-
             if @studies_by_facet.present?
               @studies_by_facet.merge!(matched_tdr_studies)
             else
@@ -630,23 +629,22 @@ module Api
       end
 
       # Simplify TDR results to be mappable for the UI badges for faceted search
-      def self.simplify_tdr_facet_search_results(query_results, search_facets)
-        simple_TDR_result = {}
-        simple_TDR_results = []
+      def self.simplify_tdr_facet_search_results(query_results)
+        tdr_results = []
         query_results.each_pair do |accession, result|
           facet_matches = result[:facet_matches]
-          simple_TDR_result[:study_accession] = accession
           if facet_matches.present?
+            simple_result = { study_accession: accession }
             facet_matches.each do |mapping|
               mapping.each do |key, val|
                 facet_name = FacetNameConverter.convert_schema_column(:tim, :alexandria, key)
-                simple_TDR_result[facet_name] = val
+                simple_result[facet_name] = val
               end
             end
           end
-          simple_TDR_results << simple_TDR_result
+          tdr_results << simple_result
         end
-        simple_TDR_results
+        tdr_results
       end
 
 

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -5,6 +5,9 @@ module Api
       include Swagger::Blocks
       include StudySearchResultsObjects
 
+      # regex to match on 'sequence_file' and 'analysis_file' entries from TDR
+      TDR_FILE_OUTPUT_TYPE_MATCH = /_file/.freeze
+
       before_action :set_current_api_user!
       before_action :authenticate_api_user!, only: [:create_auth_code]
       before_action :set_search_facet, only: :facet_filters
@@ -776,7 +779,7 @@ module Api
           end
         end
         # gather file information for sequence_file and analysis_file entries
-        if row['output_type'] =~ /_file/
+        if row['output_type'] =~ TDR_FILE_OUTPUT_TYPE_MATCH
           file_info = extract_file_information(row)
           drs_id = file_info[:drs_id]
           unless added_file_ids[drs_id]
@@ -824,7 +827,7 @@ module Api
       # extract file information from row-level TDR results for sequence_file and analysis_file entries
       def self.extract_file_information(result_row)
         safe_entry = result_row.with_indifferent_access
-        output_type = safe_entry['output_type']
+        output_type = safe_entry[:output_type]
         case output_type
         when 'sequence_file'
           filename = safe_entry[:sequence_file_name]
@@ -837,7 +840,7 @@ module Api
             'upload_file_size' => safe_entry[:sequence_file_size].to_i,
             'file_type' => output_type,
             'file_format' => safe_entry[:file_type] || file_format,
-            'drs_id' => safe_entry['output_id']
+            'drs_id' => safe_entry[:output_id]
           }.with_indifferent_access
         when 'analysis_file'
           {
@@ -845,7 +848,7 @@ module Api
             'upload_file_size' => safe_entry[:analysis_file_size].to_i,
             'file_type' => output_type,
             'file_format' => safe_entry[:analysis_format],
-            'drs_id' => safe_entry['drs_id']
+            'drs_id' => safe_entry[:drs_id]
           }.with_indifferent_access
         end
       end

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -307,8 +307,8 @@ module Api
           end
           # just log for now
           logger.info "Found #{@tdr_results.keys.size} results in Terra Data Repo"
-          logger.info pp @tdr_results if @tdr_results.any?
-          @tdr_results.each do |short_name, tdr_result|
+          logger.info "#{@tdr_results.map {|name, info| { name => info['facet_matches']}}}"
+          @tdr_results.each do |_, tdr_result|
             @studies << tdr_result
           end
         end
@@ -837,7 +837,7 @@ module Api
           file_format = format_parts.last == 'gz' ? format_parts.slice(-2) : format_parts.last
           {
             'name' => filename,
-            'upload_file_size' => safe_entry[:sequence_file_size],
+            'upload_file_size' => safe_entry[:sequence_file_size].to_i,
             'file_type' => output_type,
             'file_format' => safe_entry[:file_type] || file_format,
             'drs_id' => safe_entry['output_id']
@@ -845,13 +845,12 @@ module Api
         when 'analysis_file'
           {
             'name' => safe_entry[:analysis_file_name],
-            'upload_file_size' => safe_entry[:analysis_file_size],
+            'upload_file_size' => safe_entry[:analysis_file_size].to_i,
             'file_type' => output_type,
             'file_format' => safe_entry[:analysis_format],
             'drs_id' => safe_entry['drs_id']
           }.with_indifferent_access
         end
-
       end
     end
   end

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -699,23 +699,25 @@ module Api
       # and a second to retrieve all result rows for those projects
       # this is to address issues in sparsity of ES index with regards to some data (like species, disease, etc)
       def self.get_tdr_results(selected_facets:, terms:)
+        client = ApplicationController.data_repo_client
         results = {}
         begin
           if selected_facets.present?
-            facet_json = ApplicationController.data_repo_client.generate_query_from_facets(selected_facets)
+            facet_json = client.generate_query_from_facets(selected_facets)
           end
           if terms.present?
-            term_json = ApplicationController.data_repo_client.generate_query_from_keywords(terms)
+            term_json = client.generate_query_from_keywords(terms)
           end
           # now we merge the two queries together to perform a single search request
-          query_json = ApplicationController.data_repo_client.merge_query_json(facet_query: facet_json, term_query: term_json)
+          query_json = client.merge_query_json(facet_query: facet_json, term_query: term_json)
           logger.info "Executing TDR query with: #{query_json}"
           snapshot_ids = AdminConfiguration.get_tdr_snapshot_ids
           logger.info "Scoping TDR query to snapshots: #{snapshot_ids.join(', ')}" if snapshot_ids.present?
           # first request is to only retrieve project IDs, then the second is for actual row-level results
-          projects = ApplicationController.data_repo_client.query_snapshot_indexes(query_json,
-                                                                                   snapshot_ids: snapshot_ids)
+          projects = client.query_snapshot_indexes(query_json, snapshot_ids: snapshot_ids)['result']
           project_ids = projects.map { |row| row['project_id'] }.uniq.compact
+          project_query = client.generate_query_for_projects(project_ids)
+          raw_tdr_results = client.query_snapshot_indexes(project_query, snapshot_ids: snapshot_ids)
           added_file_ids = {}
           raw_tdr_results['result'].each do |result_row|
             results = process_tdr_result_row(result_row, results,
@@ -776,14 +778,12 @@ module Api
             end
           end
         end
-        # if the output_id is a drs_id, add it and the output_type to the file_information array,
-        if row['output_id']&.starts_with?('drs')
-          drs_id = row['output_id']
-          if !added_file_ids[drs_id]
-            result[:file_information] << {
-              drs_id: drs_id,
-              file_type: row['output_type']
-            }
+        # gather file information for sequence_file and analysis_file entries
+        if row['output_type'] =~ /_file/
+          file_info = extract_file_information(row)
+          drs_id = file_info[:drs_id]
+          unless added_file_ids[drs_id]
+            result[:file_information] << file_info
             added_file_ids[drs_id] = true
           end
         end
@@ -822,6 +822,36 @@ module Api
           end
         end
         matches
+      end
+
+      # extract file information from row-level TDR results for sequence_file and analysis_file entries
+      def self.extract_file_information(result_row)
+        safe_entry = result_row.with_indifferent_access
+        output_type = safe_entry['output_type']
+        case output_type
+        when 'sequence_file'
+          filename = safe_entry[:sequence_file_name]
+          format_parts = filename.split('.')
+          # make a guess at the file format, controlling for gzipped files
+          # this is a fallback if file_type hasn't been set in the row
+          file_format = format_parts.last == 'gz' ? format_parts.slice(-2) : format_parts.last
+          {
+            'name' => filename,
+            'upload_file_size' => safe_entry[:sequence_file_size],
+            'file_type' => output_type,
+            'file_format' => safe_entry[:file_type] || file_format,
+            'drs_id' => safe_entry['output_id']
+          }.with_indifferent_access
+        when 'analysis_file'
+          {
+            'name' => safe_entry[:analysis_file_name],
+            'upload_file_size' => safe_entry[:analysis_file_size],
+            'file_type' => output_type,
+            'file_format' => safe_entry[:analysis_format],
+            'drs_id' => safe_entry['drs_id']
+          }.with_indifferent_access
+        end
+
       end
     end
   end

--- a/app/javascript/components/search/controls/download/DownloadButton.js
+++ b/app/javascript/components/search/controls/download/DownloadButton.js
@@ -9,11 +9,8 @@ import { UserContext } from 'providers/UserProvider'
 
 /**
  * Component for "Download" button which shows a Bulk Download modal on click.
- * showDemoFiles is included which will limit the number of TDR files queried, and make sure
- * analysis files are seeded as well.  Ordinarily, we wouldn't merge demo code, but this feature may be in demo-only
-  * state for a long time, and need lots of demos
  */
-export default function DownloadButton({ searchResults={}, showDemoFiles=false }) {
+export default function DownloadButton({ searchResults={} }) {
   const userContext = useContext(UserContext)
 
   const [showModal, setShowModal] = useState(false)
@@ -52,7 +49,7 @@ export default function DownloadButton({ searchResults={}, showDemoFiles=false }
       study_source: 'TDR',
       description: result.description,
       hca_project_id: result.hca_project_id,
-      studyFiles: showDemoFiles ? enableDemoResults(result.file_information) : result.file_information
+      studyFiles: result.file_information
     }))
 
   return (
@@ -80,18 +77,3 @@ export default function DownloadButton({ searchResults={}, showDemoFiles=false }
     </>
   )
 }
-
-/** limit the files returned to 10, and add two fake analysis files
-  */
-function enableDemoResults(fileInfomation) {
-  return fileInfomation.slice(0, 10).concat(DEMO_ONLY_ANALYSIS_FILES)
-}
-
-/** these are real (sequence file) DRS ids */
-const DEMO_ONLY_ANALYSIS_FILES = [{
-  drs_id: 'drs://jade.datarepo-dev.broadinstitute.org/v1_257c5646-689a-4f25-8396-2500c849cb4f_7e3fb399-325f-42a5-bca1-3b8659f2c287', // eslint-disable-line max-len
-  file_type: 'analysis_file'
-}, {
-  drs_id: 'drs://jade.datarepo-dev.broadinstitute.org/v1_257c5646-689a-4f25-8396-2500c849cb4f_8326615b-d61f-420a-b22c-ef637e79e551', // eslint-disable-line max-len
-  file_type: 'analysis_file'
-}]

--- a/app/javascript/components/search/controls/download/DownloadSelectionModal.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionModal.js
@@ -42,31 +42,6 @@ export default function DownloadSelectionModal({ studyAccessions, tdrFileInfo, s
     setSelectedBoxesTDR(newSelectedBoxesState(tdrFileInfo, TDR_COLUMNS))
     setDownloadInfoTDR(tdrFileInfo)
     setIsLoadingTDR(false)
-    // pull the drs ids out of each study and put them in a single array
-    // calling filter at end removes metadata file that does not have a DRS id
-    const drsIds = tdrFileInfo.map(study => study.studyFiles.map(sfile => sfile.drs_id))
-      .reduce((acc, val) => acc.concat(val), []).filter(e => e !== null)
-    fetchDrsInfo(drsIds).then(result => {
-      const fullTdrFileInfo = _cloneDeep(tdrFileInfo)
-      // now iterate through the file info and add file sizes, urls, and file names.
-      // the names and urls will be used for making the download request later
-      fullTdrFileInfo.forEach(study => {
-        study.studyFiles.forEach(studyFile => {
-          if (studyFile.drs_id) {
-            const fileId = studyFile.drs_id.split('/').slice(-1)[0]
-            const matchFile = result.find(file => file.id === fileId)
-            if (matchFile) {
-              studyFile.upload_file_size = matchFile.size
-              // we add the url and name to each file info so that they can be sent along with the download
-              // request, this allows us to avoid having to query the DRS service again
-              studyFile.url = matchFile.accessMethods.find(method => method.type === 'https').access_url.url
-              studyFile.name = matchFile.name
-            }
-          }
-        })
-      })
-      setDownloadInfoTDR(fullTdrFileInfo)
-    })
   }
 
   /**

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -175,7 +175,7 @@ const COLUMNS = {
   sequence: {
     title: 'Sequence',
     types: ['sequence_file'],
-    info: 'Sequence files, such as Fastq, BAM or BAI files',
+    info: 'Sequence files, such as FASTQ, BAM or BAI files',
     default: false
   }
 }

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -175,7 +175,7 @@ const COLUMNS = {
   sequence: {
     title: 'Sequence',
     types: ['sequence_file'],
-    info: 'Sequence files, such as BAM or BAI files',
+    info: 'Sequence files, such as Fastq, BAM or BAI files',
     default: false
   }
 }
@@ -286,7 +286,7 @@ export function getSelectedFileHandles(downloadInfo, selectedBoxes, hashByStudy=
       if (selectedBoxes.studies[index][colType]) {
         const filesOfType = study.studyFiles.filter(file => COLUMNS[colType].types.includes(file.file_type))
         {/* eslint-disable-next-line max-len */}
-        const selectedHandles = filesOfType.map(file => file.url ? { url: file.url, name: file.name, file_type: file.file_type } : file.id)
+        const selectedHandles = filesOfType.map(file => hashByStudy ? { drs_id: file.drs_id, url: file.url, name: file.name, file_type: file.file_type } : file.id)
         if (hashByStudy) {
           fileHandles[study.accession].push(...selectedHandles)
         } else {

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -57,22 +57,36 @@ class BulkDownloadService
       hca_client = ApplicationController.hca_azul_client
       default_catalog = hca_client.default_catalog
       curl_configs << "-H \"Authorization: Bearer #{DataRepoClient.new.access_token['access_token']}\""
-      tdr_file_configs = tdr_files.map do |shortname, file_infos|
-        file_infos.map do |file_info|
-          if file_info['file_type'] == 'Project Manifest'
-            # generate manifest link using HCA project UUID from :url property
-            manifest = hca_client.get_project_manifest_link(default_catalog, file_info['url'])
-            file_config = "--location\n" # add location directive to allow following 302 redirect to manifest location
-            file_config += "url=\"#{manifest['Location']}\"\n"
-          else
-            file_config = "url=\"#{file_info['url']}\"\n"
+      tdr_file_configs = []
+      tdr_files.map do |shortname, file_infos|
+        # pull out project manifest and process separately
+        manifests, files = file_infos.partition { |f| f['file_type'] == 'Project Manifest' }
+        manifest_info = manifests.first
+        manifest = hca_client.get_project_manifest_link(default_catalog, manifest_info['url'])
+        manifest_config = "--location\n" # add location directive to allow following 302 redirect to manifest location
+        manifest_config += "url=\"#{manifest['Location']}\"\n"
+        manifest_config += "output=\"#{shortname}/#{manifest_info['name']}\""
+        tdr_file_configs << manifest_config
+        # now process remainder of analysis/sequence files for download in parallel to speed up process
+        Parallel.map(files, in_threads: 100) do |file_info|
+          begin
+            drs_info = ApplicationController.data_repo_client.get_drs_file_info(file_info[:drs_id])
+            access = drs_info['access_methods'].detect { |a| a['type'] == 'https' }
+            file_config = "url=\"#{access.dig('access_url', 'url')}\"\n"
             file_config += "output=\"#{shortname}/#{file_info['name']}\""
+            tdr_file_configs << file_config
+          rescue RestClient::Exception => e
+            # DataRepoClient only emits RestClient::Exception errors, and the error will have already been reported
+            # to Sentry, so also report to Mixpanel
+            MetricsService.report_error(e, request, current_api_user)
+            {
+              drs_id: drs_id,
+              error: e.message
+            }
           end
-          file_config += "output=\"#{shortname}/#{file_info['name']}\""
-          file_config
         end
       end
-      curl_configs.concat(tdr_file_configs.flatten)
+      curl_configs.concat(tdr_file_configs)
     end
     file_map = create_file_type_map(study_files)
     MetricsService.log('file-download:curl-config', {

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -75,14 +75,8 @@ class BulkDownloadService
             file_config = "url=\"#{access.dig('access_url', 'url')}\"\n"
             file_config += "output=\"#{shortname}/#{file_info['name']}\""
             tdr_file_configs << file_config
-          rescue RestClient::Exception => e
-            # DataRepoClient only emits RestClient::Exception errors, and the error will have already been reported
-            # to Sentry, so also report to Mixpanel
-            MetricsService.report_error(e, request, current_api_user)
-            {
-              drs_id: drs_id,
-              error: e.message
-            }
+          rescue => e
+            ErrorTracker.report_exception(e, user, { file_info: file_info, drs_info: drs_info })
           end
         end
       end

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -63,9 +63,8 @@ class BulkDownloadService
         manifests, files = file_infos.partition { |f| f['file_type'] == 'Project Manifest' }
         manifest_info = manifests.first
         manifest = hca_client.get_project_manifest_link(default_catalog, manifest_info['url'])
-        manifest_config = "--location\n" # add location directive to allow following 302 redirect to manifest location
-        manifest_config += "url=\"#{manifest['Location']}\"\n"
-        manifest_config += "output=\"#{shortname}/#{manifest_info['name']}\""
+        # add location directive to allow following 302 redirect to manifest location
+        manifest_config = "--location\nurl=\"#{manifest['Location']}\"\noutput=\"#{shortname}/#{manifest_info['name']}\""
         tdr_file_configs << manifest_config
         # now process remainder of analysis/sequence files for download in parallel to speed up process
         Parallel.map(files, in_threads: 100) do |file_info|

--- a/test/integration/data_repo_client_test.rb
+++ b/test/integration/data_repo_client_test.rb
@@ -6,12 +6,12 @@ class DataRepoClientTest < ActiveSupport::TestCase
 
   before(:all) do
     @data_repo_client = ApplicationController.data_repo_client
-    @dataset_id = 'd918e6f2-e63b-4d9c-82a6-f0d44c6bcc0d' # dataset for snapshot, we don't actually have access to this
-    @snapshot_id = '257c5646-689a-4f25-8396-2500c849cb4f' # dev PulmonaryFibrosisGSE135893 snapshot
-    @file_id = '5009a1f8-c2ee-4ceb-8ddb-40c3ddee5472' # ID of sequence file in PulmonaryFibrosisGSE135893 snapshot
-    @filename = 'IPF_VUILD54_1_LU_Whole_C1_X5SCR_F00207_HMWLCBGX7_ATTTGCTA_L001_R1_001.fastq.gz' # name of above file
+    @dataset_id = '5813840c-46e4-47ab-89fe-d4da28834698' # dataset for snapshot, we don't actually have access to this
+    @snapshot_id = '25740be5-b493-4185-84b0-bebf425c5072' # dev PulmonaryFibrosisGSE135893 snapshot
+    @file_id = '1c36ad71-755d-4623-8a5c-c336ecf80073' # ID of loom file in PulmonaryFibrosisGSE135893 snapshot
+    @filename = 'pulmonary-fibrosis-human-lung-10XV2.loom' # name of above file
     @drs_file_id = "drs://#{DataRepoClient::REPOSITORY_HOSTNAME}/v1_#{@snapshot_id}_#{@file_id}" # computed DRS id
-    bucket_id = 'broad-jade-dev-data-bucket'
+    bucket_id = 'datarepo-dev-54946186-bucket'
     @gs_url = "gs://#{bucket_id}/#{@dataset_id}/#{@file_id}/#{@filename}" # computed GS url
     @https_url = "https://www.googleapis.com/storage/v1/b/#{bucket_id}/o/#{@dataset_id}%2F#{@file_id}%2F#{@filename}?alt=media"
   end
@@ -185,6 +185,14 @@ class DataRepoClientTest < ActiveSupport::TestCase
                      "([#{description_field}]:\"pulmonary\" OR [#{description_field}]:\"human\" OR " \
                      "[#{description_field}]:\"lung\")"
     query_json = @data_repo_client.generate_query_from_keywords(keywords)
+    assert_equal expected_query, query_json.dig(:query_string, :query)
+  end
+
+  test 'should generate query JSON from HCA project IDs' do
+    project_id = '2c1a9a93d-d9de-4e65-9619-a9cec1052eaa'
+    project_ids = [project_id]
+    query_json = @data_repo_client.generate_query_for_projects(project_ids)
+    expected_query = "(project_id: #{project_id})"
     assert_equal expected_query, query_json.dig(:query_string, :query)
   end
 

--- a/test/integration/data_repo_client_test.rb
+++ b/test/integration/data_repo_client_test.rb
@@ -224,8 +224,10 @@ class DataRepoClientTest < ActiveSupport::TestCase
 
   test 'should query snapshot index' do
     skip_if_api_down
+    hca_project_id = 'c1a9a93d-d9de-4e65-9619-a9cec1052eaa'
     selected_facets = [
-      { id: :species, filters: [{ id: 'NCBITaxon9609', name: 'Homo sapiens' }] }
+      { id: :species, filters: [{ id: 'NCBITaxon9609', name: 'Homo sapiens' }] },
+      { id: :project_id, filters: [{ name: hca_project_id, id: hca_project_id }] }
     ]
     query_json = @data_repo_client.generate_query_from_facets(selected_facets)
     results = @data_repo_client.query_snapshot_indexes(query_json, snapshot_ids: [@snapshot_id])
@@ -240,10 +242,7 @@ class DataRepoClientTest < ActiveSupport::TestCase
     assert_equal expected_project, sample_row[project_title_field]
 
     # refine query and re-run
-    selected_facets = [
-      { id: :species, filters: [{ id: 'NCBITaxon9609', name: 'Homo sapiens' }] },
-      { id: :organism_age, filters: { min: 46, max: 72, unit: 'years' } }
-    ]
+    selected_facets << { id: :organism_age, filters: { min: 46, max: 72, unit: 'years' } }
     query_json = @data_repo_client.generate_query_from_facets(selected_facets)
     results = @data_repo_client.query_snapshot_indexes(query_json, snapshot_ids: [@snapshot_id])
     new_count = results['result'].count


### PR DESCRIPTION
This update handles necessary refactoring to deal with the new [result structure](https://github.com/broadinstitute/single_cell_portal_core/blob/development/lib/assets/sql/tdr_indexes/query_w_analysis_file.sql) for TDR queries.  This includes the following:

* Performing "double queries" to first find all projects that match the initial query, and then a second query to find all files that are included in the project.  This is to address sparsity in the ElasticSearch index for certain kinds of metadata due to the complexity of the HCA metadata graph model (like species, disease, organ, etc)
* Moving retrieving `drs_info` objects to `BulkDownloadService#generate_curl_config` as we will already have file type/size information
* Removing obsolete code

This update also addresses a previously undiscovered issue with `BulkDownloadControllerTest#test_bulk_download_should_support_a_download_id_and_TDR_files` where multiple calls were being executed to external services which subsequently failed, and those errors were suppressed.  This test has been refactored to correctly mock the external service calls, as well as handle the newly introduced functionality from this update.

MANUAL TESTING
1. Boot portal as normal and log in w/ admin account
2. Go to admin console, and create/edit configuration for `TDR Snapshot IDs` to use the new snapshot: `25740be5-b493-4185-84b0-bebf425c5072` (if creating, set the `value_type` to `string`)
3. Ensure that the `cross_dataset_search_backend` feature flag is turned on for your account
4. Back on the home page, run a search for `species: Homo sapiens` using facets
5. Scroll to the end of the results, and ensure that the following HCA studies are present and have a facet match: 
  * **A single-cell reference map of transcriptional states for human blood and tissue T cell activation**
  * **Single-cell RNA-sequencing reveals profibrotic roles of distinct epithelial and mesenchymal lineages in pulmonary fibrosis**
6. Click the "Download" button, and confirm that the file counts for both studies are as follows:
![hca_results](https://user-images.githubusercontent.com/729968/133673132-da6d718d-134e-4c9d-be7f-4f4473ee1bca.png)
7. (Optional): Click through to generate the `curl` command and paste into the terminal to ensure that downloads begin (there will be a longer delay than usual as we now generate access URLs for TDR files when creating the curl command).  You can hit `^C` once the download begins as there is > 2TB of data if you select everything.

This PR satisfies SCP-3677.
