### PR TITLE
Refining generation of `window.SCP.readOnlyToken` (SCP-3661)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -349,8 +349,8 @@ module ApplicationHelper
   def get_read_access_token(study, user)
     if study.present? && study.public? && ApplicationController.read_only_firecloud_client.present?
       ApplicationController.read_only_firecloud_client.valid_access_token["access_token"]
-    elsif user.present? && user.registered_for_firecloud
-      user.token_for_storage_object
+    elsif user.present? && user.registered_for_firecloud && study.present?
+      user.token_for_storage_object(study)
     else
       nil # there is no 'safe' token that will work as user has no Terra profile
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -90,8 +90,10 @@ class UserTest < ActiveSupport::TestCase
 
     # user does not actually have a Terra profile which will throw an error
     # RuntimeError should be handled and not raised here
+    study = FactoryBot.create(:detached_study,
+                              name_prefix: 'Pet Service Account Token Test', user: @user, test_array: @@studies_to_clean)
     assert_nothing_raised do
-      token = @user.token_for_storage_object('single-cell-portal')
+      token = @user.token_for_storage_object(study)
       assert_nil token
     end
   end


### PR DESCRIPTION
This update changes the process and narrows the scope in which `window.SCP.readOnlyToken` is generated.  These tokens for the most part are generated from the "read-only service account", which has read access to all public studies in SCP.  However, for private studies, a user's credentials will be used instead.  This work will be necessary for upcoming changes to the Terra ecosystem, where every Terra workspace will now live in a separate GCP project, instead of one GCP project per Terra billing project.

The changes are as follows:

1. `window.SCP.readOnlyToken` is only populated when there is a `Study` object present (will not be populated on search requests, or when a user is performing profile-centric actions, like managing email preferences, or looking a billing projects/collections).
2. In the case of private studies, the GCP project is sourced from the `googleProject` attribute in the associated workspace JSON, with the fallback value of the default SCP project.

MANUAL TESTING
1. Boot portal as normal
2. In the Dev Tools > Console panel, enter `window.SCP.readOnlyToken` and confirm an empty string is returned
3. Sign in with a user account that is registered for Terra
4. Back in the JS console, re-enter `window.SCP.readOnlyToken` and confirm it is still unset
5. Load any study
6. Back in the JS console, re-enter `window.SCP.readOnlyToken` and confirm an OAuth token is returned:
```
> window.SCP.readOnlyToken
< 'ya29.c.KqE.......'
```

This PR satisfies SCP-3661.