### PR TITLE
Eh strip quotes from gene search

### DIFF
--- a/app/javascript/components/search/genes/GeneKeyword.js
+++ b/app/javascript/components/search/genes/GeneKeyword.js
@@ -72,6 +72,26 @@ export default function GeneKeyword({ placeholder, helpTextContent }) {
     }
   }
 
+  /** handle a user pressing the 'x' to clear the field */
+  function handleClear() {
+    setGeneArray([])
+    setInputText('')
+    geneSearchState.updateSearch(
+      { genes: '' },
+      studySearchState
+    )
+  }
+
+  /** handles the change event corresponding a a user adding or clearing one or more genes */
+  function handleSelectChange(value, event) {
+    if (event.action === 'clear') {
+      handleClear()
+    } else {
+      const newValue = value ? value : []
+      setGeneArray(newValue)
+    }
+  }
+
   return (
     <form className="gene-keyword-search form-horizontal" onSubmit={handleSubmit}>
       <div className="input-group">
@@ -80,10 +100,10 @@ export default function GeneKeyword({ placeholder, helpTextContent }) {
           inputValue={inputText}
           value={geneArray}
           className="gene-keyword-search-input"
-          isClearable
           isMulti
+          isClearable
           menuIsOpen={false}
-          onChange={value => setGeneArray(value ? value : [])}
+          onChange={handleSelectChange}
           onInputChange={inputValue => setInputText(inputValue)}
           onKeyDown={handleKeyDown}
           // the default blur behavior removes any entered free text,

--- a/app/javascript/components/search/genes/GeneKeyword.js
+++ b/app/javascript/components/search/genes/GeneKeyword.js
@@ -2,7 +2,6 @@ import React, { useContext, useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSearch } from '@fortawesome/free-solid-svg-icons'
 import Button from 'react-bootstrap/lib/Button'
-import Modal from 'react-bootstrap/lib/Modal'
 import CreatableSelect from 'react-select/creatable'
 
 import { GeneSearchContext } from 'providers/GeneSearchProvider'
@@ -29,7 +28,7 @@ export default function GeneKeyword({ placeholder, helpTextContent }) {
   const [geneArray, setGeneArray] = useState(geneParamAsArray)
   const [inputText, setInputText] = useState('')
 
-  const [showEmptySearchModal, setShowEmptySearchModal] = useState(false)
+  // const [showEmptySearchModal, setShowEmptySearchModal] = useState(false)
 
   /** handles a user submitting a gene search */
   function handleSubmit(event) {
@@ -42,7 +41,10 @@ export default function GeneKeyword({ placeholder, helpTextContent }) {
         studySearchState
       )
     } else {
-      setShowEmptySearchModal(true)
+      geneSearchState.updateSearch(
+        { genes: '' },
+        studySearchState
+      )
     }
   }
 
@@ -72,26 +74,6 @@ export default function GeneKeyword({ placeholder, helpTextContent }) {
     }
   }
 
-  /** handle a user pressing the 'x' to clear the field */
-  function handleClear() {
-    setGeneArray([])
-    setInputText('')
-    geneSearchState.updateSearch(
-      { genes: '' },
-      studySearchState
-    )
-  }
-
-  /** handles the change event corresponding a a user adding or clearing one or more genes */
-  function handleSelectChange(value, event) {
-    if (event.action === 'clear') {
-      handleClear()
-    } else {
-      const newValue = value ? value : []
-      setGeneArray(newValue)
-    }
-  }
-
   return (
     <form className="gene-keyword-search form-horizontal" onSubmit={handleSubmit}>
       <div className="input-group">
@@ -103,7 +85,7 @@ export default function GeneKeyword({ placeholder, helpTextContent }) {
           isMulti
           isClearable
           menuIsOpen={false}
-          onChange={handleSelectChange}
+          onChange={value => setGeneArray(value ? value : [])}
           onInputChange={inputValue => setInputText(inputValue)}
           onKeyDown={handleKeyDown}
           // the default blur behavior removes any entered free text,
@@ -117,16 +99,6 @@ export default function GeneKeyword({ placeholder, helpTextContent }) {
           </Button>
         </div>
       </div>
-
-      <Modal
-        show={showEmptySearchModal}
-        onHide={() => {setShowEmptySearchModal(false)}}
-        animation={false}
-        bsSize='small'>
-        <Modal.Body className="text-center">
-          You must enter at least one gene to search
-        </Modal.Body>
-      </Modal>
     </form>
   )
 }

--- a/app/javascript/components/search/genes/GeneKeyword.js
+++ b/app/javascript/components/search/genes/GeneKeyword.js
@@ -28,8 +28,6 @@ export default function GeneKeyword({ placeholder, helpTextContent }) {
   const [geneArray, setGeneArray] = useState(geneParamAsArray)
   const [inputText, setInputText] = useState('')
 
-  // const [showEmptySearchModal, setShowEmptySearchModal] = useState(false)
-
   /** handles a user submitting a gene search */
   function handleSubmit(event) {
     event.preventDefault()

--- a/app/javascript/providers/GeneSearchProvider.js
+++ b/app/javascript/providers/GeneSearchProvider.js
@@ -118,10 +118,28 @@ export function PropsGeneSearchProvider(props) {
 /** returns an object built from the query params and defaults */
 export function buildParamsFromQuery(query, preset) {
   const queryParams = queryString.parse(query)
+  const cleanGeneParams = sanitizeGeneParams(queryParams)
   return {
     page: queryParams.genePage ? parseInt(queryParams.genePage) : 1,
-    genes: queryParams.genes ? queryParams.genes : '',
+    genes: cleanGeneParams,
     preset: preset ? preset : queryString.preset_search
+  }
+}
+
+/** strip any begining or end quotes from a gene param*/
+function stripOffQuotes(geneParam) {
+  const cleanedWord = geneParam.replace(/"\B/, '').replace(/\B"/, '').trim()
+  return cleanedWord
+}
+
+/** sanitize gene params */
+function sanitizeGeneParams(queryParams) {
+  if (!queryParams.genes) {
+    return ''
+  } else {
+    const geneParamArray = queryParams.genes.split(' ')
+    const sanitizedGeneParams = geneParamArray.map(stripOffQuotes)
+    return sanitizedGeneParams.join(' ')
   }
 }
 

--- a/test/js/search/gene-keyword.test.js
+++ b/test/js/search/gene-keyword.test.js
@@ -1,0 +1,83 @@
+import React from 'react'
+
+import { mount } from 'enzyme'
+
+import { PropsStudySearchProvider } from 'providers/StudySearchProvider'
+import GeneKeyword from 'components/search/genes/GeneKeyword'
+import { GeneSearchContext } from 'providers/GeneSearchProvider'
+
+
+describe('Search query display text', () => {
+  it('shows blank search form with place holder text present', async () => {
+    const wrapper = mount((
+      <GeneKeyword placeholder={'I am a place holder'} />
+    ))
+    expect(wrapper.find('.gene-keyword-search').text().trim()).toEqual('I am a place holder')
+  })
+
+  it('shows study result matches search param', async () => {
+    const searchState = {
+      params: {
+        genes: 'PTEN',
+        genePage: 1
+      },
+      results: [],
+      isLoading: false,
+      isLoaded: false,
+      isError: false
+    }
+    const wrapper = mount((
+      <PropsStudySearchProvider searchParams={{ terms: 'PTEN', page: 1 }}>
+        <GeneSearchContext.Provider value={searchState}>
+          <GeneKeyword placeholder={'I am a place holder'} />
+        </GeneSearchContext.Provider>
+      </PropsStudySearchProvider>
+    ))
+    expect(wrapper.find('.gene-keyword-search').text().trim()).toEqual('PTEN')
+  })
+
+  it('show matching multiple params and strips off surronding quotes on search params', async () => {
+    const searchState = {
+      params: {
+        genes: 'PTEN, NA',
+        genePage: 1
+      },
+      results: [],
+      isLoading: false,
+      isLoaded: false,
+      isError: false
+    }
+    const wrapper = mount((
+      <PropsStudySearchProvider searchParams={{ terms: '"PTEN", NA', page: 1 }}>
+        <GeneSearchContext.Provider value={searchState}>
+          <GeneKeyword placeholder={'I am a place holder'} />
+        </GeneSearchContext.Provider>
+      </PropsStudySearchProvider>
+    ))
+    expect(wrapper.find('.gene-keyword-search').text().trim()).toEqual('PTEN,NA')
+  })
+
+  it('show that searching on no entered genes provides the generic results ', async () => {
+    const searchState = {
+      params: {
+        genes: '',
+        genePage: 1
+      },
+      results: [],
+      isLoading: false,
+      isLoaded: false,
+      isError: false
+    }
+    const wrapper = mount((
+      <PropsStudySearchProvider searchParams={{ terms: '', page: 1 }}>
+        <GeneSearchContext.Provider value={searchState}>
+          <GeneKeyword placeholder={'I am a place holder'} />
+        </GeneSearchContext.Provider>
+      </PropsStudySearchProvider>
+    ))
+    expect(wrapper.find('.gene-keyword-search').text().trim()).toEqual('I am a place holder')
+    wrapper.find('.input-group-append').simulate('click')
+    expect(wrapper.find('.gene-keyword-search').text().trim()).toEqual('I am a place holder')
+  })
+})
+


### PR DESCRIPTION
- Strip off the beginning and ending quotes from a gene search. 
- Allow searching on no genes as a means to clear out the form.

To Test:
1. Go to SCP home page and click to the Gene Search tab. Enter a gene with beginning and/or quotations like "PTEN" and search. Observe that this will return the same results as searching on just PTEN (no quotes).
2. After searching a gene in the Gene Search tab clear out the gene params by clicking the 'X' in the search. Then search on the empty gene params. Observe that the page loads the default set of studies not filtered by any genes. 


Left side shows current situation where a gene with ""s won't match even though that gene is in a study. Right side shows the new way that will show the search result for such genes.
![Screen Shot 2021-09-16 at 1 15 57 PM](https://user-images.githubusercontent.com/54322292/133850548-082dc5e1-fa10-4467-953b-4b66c3da027c.png)

Previously there was no way for a user to get the gene search form back to the default state shown on the left. Right side shows the page as it's reloading after clicking search with no genes entered
![Screen Shot 2021-09-17 at 4 38 42 PM](https://user-images.githubusercontent.com/54322292/133850875-7d0c84bd-5474-42e8-91f4-39fa0cab7d76.png)




