### PR TITLE
Auto-populate exemption request form fields (SCP-3686)

### DIFF
--- a/app/views/studies/_block_processed_upload_content.html.erb
+++ b/app/views/studies/_block_processed_upload_content.html.erb
@@ -20,7 +20,9 @@
           </div>
           <div class="col-md-3">
             <p><%= link_to "Request Exemption <i class='fas fa-external-link-alt'></i>".html_safe,
-                           'https://singlecell.zendesk.com/hc/en-us/requests/new?ticket_form_id=1260811597230',
+                           'https://singlecell.zendesk.com/hc/en-us/requests/new?ticket_form_id=1260811597230' \
+                           "&tf_1260822624790=#{@study.accession}&tf_anonymous_requester_email=#{current_user.email}" \
+                           "&tf_1900002173444=raw_count_exemption",
                            class: 'btn btn-default btn-lg', 'data-analytics-name' => 'raw-counts-exemption',
                            target: '_blank', rel: 'noopener noreferrer' %>
           </div>

--- a/app/views/studies/_block_processed_upload_content.html.erb
+++ b/app/views/studies/_block_processed_upload_content.html.erb
@@ -22,7 +22,8 @@
             <p><%= link_to "Request Exemption <i class='fas fa-external-link-alt'></i>".html_safe,
                            'https://singlecell.zendesk.com/hc/en-us/requests/new?ticket_form_id=1260811597230' \
                            "&tf_1260822624790=#{@study.accession}&tf_anonymous_requester_email=#{current_user.email}" \
-                           "&tf_1900002173444=raw_count_exemption",
+                           "&tf_1900002173444=raw_count_exemption&tf_subject=" \
+                           "Raw%20Count%20Exemption%20Request%20for%20#{@study.accession}",
                            class: 'btn btn-default btn-lg', 'data-analytics-name' => 'raw-counts-exemption',
                            target: '_blank', rel: 'noopener noreferrer' %>
           </div>


### PR DESCRIPTION
This update automatically populates several fields into the SCP "[Exemption Request](https://singlecell.zendesk.com/hc/en-us/requests/new?ticket_form_id=1260811597230)" form in Zendesk.  Now, instead of requiring the user to obtain their study accession (which isn't actually actually visible anywhere on the page), and manually enter their email address, select the exemption type, and enter an email subject, those values will be automatically set via query string parameters (this is a built-in feature of Zendesk ticket forms).  This will make it easier for users, and reduce the possibility of errors (entering the wrong accession or exemption type, for instance).

MANUAL TESTING

1. Boot as normal and sign in
2. Create a new study, or open the upload wizard for any study w/o raw counts matrices
3. On the "Processed Matrix" tab, click the "Request Exemption" link
4. In the exemption form, confirm that the email, exemption type, subject, and study accession are already populated

This PR satisfies SCP-3686.