### PR TITLE
Making single-study bulk download include all files (SCP-3699)

### DIFF
--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -38,6 +38,9 @@
                 <%= link_to "<i class='fas fa-download'></i> Get download command for all study data".html_safe,
                             '#/', class: 'btn btn-default get-download-command', id: 'get-download-command__all' %></p>
               <% if @directories.any? %>
+                <p class="lead command-container" id="command-container-nodirs">
+                  <%= link_to "<i class='fas fa-download'></i> Get download command for study files only (no folders)".html_safe,
+                              '#/', class: 'btn btn-default get-download-command', id: 'get-download-command__nodirs' %></p>
                 <p class="lead">To download all data files in a specific folder, use the following commands:</p>
                 <table class="table table-condensed table-striped">
                   <thead>
@@ -58,6 +61,7 @@
                   </thead>
                 </table>
               <% end %>
+
             <% else %>
               <%# The user is trying to download a public study that is currently embargoed. %>
               <p class="lead">No downloads are available to you for this study yet</p>

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -34,13 +34,17 @@
               Then <%= link_to "click here".html_safe, "#{generate_manifest_study_url(@study)}" %> for the file_supplemental_info.tsv containing file supplementary information (units, protocols, etc...)
             <% elsif @study.public? && !@user_embargoed || current_user.admin? %>
               <p class="lead">To download all files using <code>curl</code>, click the button below to get the download command:</p>
-              <p class="lead command-container" id="command-container-all">
-                <%= link_to "<i class='fas fa-download'></i> Get download command for all study data".html_safe,
+              <p class="lead command-container text-center" id="command-container-all">
+                <%= link_to "<i class='fas fa-download'></i> Download all study data".html_safe,
                             '#/', class: 'btn btn-default get-download-command', id: 'get-download-command__all' %></p>
+
               <% if @directories.any? %>
-                <p class="lead command-container" id="command-container-nodirs">
-                  <%= link_to "<i class='fas fa-download'></i> Get download command for study files only (no folders)".html_safe,
+                <p class="lead command-container text-center" id="command-container-nodirs">
+                  <%= link_to "<i class='fas fa-download'></i> Download main study files only".html_safe,
                               '#/', class: 'btn btn-default get-download-command', id: 'get-download-command__nodirs' %></p>
+              <% end %>
+
+              <% if @directories.any? %>
                 <p class="lead">To download all data files in a specific folder, use the following commands:</p>
                 <table class="table table-condensed table-striped">
                   <thead>


### PR DESCRIPTION
This update changes the behavior of single-study bulk download to match the language in the UI.  Currently, while the UI says "download all files", what in fact happens is that only expression, clustering, and metadata files are returned, along with all `DirectoryListing` objects as well.  For studies that have uploaded supplementary data as "Other" or "Documentation", these files are ignored, as are Gene Lists, Analysis Outputs, Ideogram Annotations, and any individual sequence (BAM, FASTQ) files that the study owner has uploaded.  While the reusability of some of these file types might be questionable, there are [some studies](https://singlecell.broadinstitute.org/single_cell/study/SCP354/slide-seq-study#/) in SCP that have uploaded important data as "Other" that cannot be downloaded via bulk download.  This is both inconsistent with the UI, and a bad UX for users as they have to individually click potentially dozens or hundreds of individual download links.

This update changes that behavior so that when a user clicks the link to get the download command for "all files", _all_ `StudyFile` and `DirectoryListing` objects are included, regardless of type.  Also, in addition to the individual `DirectoryListing` download commands, this adds another button to get all `StudyFile` entries, but ignore `DirectoryListing` objects (called "download main study files").  This is especially useful if a study has a lot of sequence data in `DirectoryListing` objects that will exhaust a user's download quota, thus preventing the use of bulk download in that study (SCP354 is a good example).

New UI for bulk download:
![Screen Shot 2021-09-24 at 11 40 04 AM](https://user-images.githubusercontent.com/729968/134702989-021f6b88-5f61-456a-9cf7-9711fceca4aa.png)

MANUAL TESTING
1. Boot portal as normal (including delayed_job) and sign in with your Broad credentials
2. Create a new study, and upload the following files:
  a. `test/test_data/fixed_neurons_6days_2000_possorted_genome_bam_test_data.bam` as `BAM` in `Sequence Data`
  b. `test/test_data/fixed_neurons_6days_2000_possorted_genome_bam_test_data.bam.bai` as `BAM Index` (bundled file)
  c. `test/test_data/table_1.xlsx` as `Other` in `Miscellaneous`
3. Once uploaded, sign out, and sign in with a different, non-admin account
4. Load the above study and click "Bulk Download" > "Get download command for all study data"
5. Paste `curl` command into the terminal and confirm all 3 files are downloaded
6. (Optional) Add at least 10 files of the same extension (not .txt) to the study bucket, and sync to create a `DirectoryListing` object
7. (Optional) Back in the download tab, click "Get download command for study files only (no folders)" and confirm the same 3 files are downloaded, minus the `DirectoryListing` files

This PR satisfies SCP-3699.
