### PR TITLE
Enabling metadata upload in react refactor (SCP-3667)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -194,8 +194,6 @@ module Api
           render :show
         rescue ArgumentError => e
           render json: {errors: e.message}, status: :unprocessable_entity
-        rescue => e
-          render json: {errors: e.message}, status: 500
         end
       end
 
@@ -263,8 +261,6 @@ module Api
           render :show
         rescue Mongoid::Errors::Validations => e
           render json: {errors: e.message}, status: :unprocessable_entity
-        rescue => e
-          render json: {errors: e.message}, status: 500
         end
       end
 
@@ -310,10 +306,6 @@ module Api
 
         # invalidate caches first
         study_file.delay.invalidate_cache_by_file_type
-
-        if ['Cluster', 'Coordinate Labels', 'Gene List'].include?(study_file.file_type) && study_file.valid?
-          study_file.invalidate_cache_by_file_type
-        end
 
         # if a gene list or cluster got updated, we need to update the associated records
         if safe_file_params[:file_type] == 'Gene List' && name_changed

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -390,7 +390,7 @@ module Api
 
       def complete_upload_process(study_file, parse_on_upload)
         @study.delay.send_to_firecloud(study_file) # send data to FireCloud if upload was performed
-        study_file.update(status: 'uploaded') # set status to uploaded on full create
+        study_file.update(status: 'uploaded', parse_status: 'unparsed') # set status to uploaded on full create
 
         if (parse_on_upload && study_file.parseable? && !study_file.parsing? && study_file.parse_status == 'unparsed')
           FileParseService.run_parse_job(@study_file, @study, current_api_user)

--- a/app/controllers/api/v1/visualization/explore_controller.rb
+++ b/app/controllers/api/v1/visualization/explore_controller.rb
@@ -87,7 +87,7 @@ module Api
             imageFiles: image_options,
             clusterPointAlpha: @study.default_cluster_point_alpha,
             colorProfile: @study.default_color_profile,
-            bucket_id: @study.bucket_id
+            bucketId: @study.bucket_id
           }
 
           render json: explore_props

--- a/app/javascript/components/explore/ImageTab.js
+++ b/app/javascript/components/explore/ImageTab.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import BucketImage from 'components/visualization/BucketImage'
 import ScatterPlot from 'components/visualization/ScatterPlot'
 
-/** Component for displaying IGV for any BAM/BAI files provided with the study */
+/** Display reference images (e.g. tissue stains) beside spatial scatter plots */
 export default function ImageTab({
   studyAccession,
   exploreParams,

--- a/app/javascript/components/explore/ImageTab.js
+++ b/app/javascript/components/explore/ImageTab.js
@@ -58,7 +58,7 @@ export default function ImageTab({
       return <div className="row" key={file.name}>
         <div className={imageColClass}>
           <h5 className="plot-title">{file.name}</h5>
-          <BucketImage fileName={file.bucket_file_name} bucketName={bucketName}/>
+          <BucketImage fileName={file.upload_file_name} bucketName={bucketName}/>
           <p className="help-block">
             { file.description &&
               <span>{file.description}</span>

--- a/app/javascript/components/upload/CoordinateLabelFileForm.js
+++ b/app/javascript/components/upload/CoordinateLabelFileForm.js
@@ -19,7 +19,7 @@ export default function CoordinateLabelForm({
 
   return <div className="row top-margin" key={file._id}>
     <div className="col-md-12">
-      <form id={`clusterForm-${file._id}`}
+      <form id={`labelForm-${file._id}`}
         className="form-terra"
         acceptCharset="UTF-8">
         <div className="row">

--- a/app/javascript/components/upload/ImageFileForm.js
+++ b/app/javascript/components/upload/ImageFileForm.js
@@ -26,7 +26,7 @@ export default function ImageFileForm({
 
   return <div className="row top-margin" key={file._id}>
     <div className="col-md-12">
-      <form id={`clusterForm-${file._id}`}
+      <form id={`imageForm-${file._id}`}
         className="form-terra"
         acceptCharset="UTF-8">
         <div className="row">
@@ -35,7 +35,7 @@ export default function ImageFileForm({
               handleSaveResponse={handleSaveResponse}
               file={file}
               updateFile={updateFile}
-              allowedFileTypes={["*"]}/>
+              allowedFileTypes={FileTypeExtensions.image}/>
           </div>
           <div className="col-md-6">
             { file.uploadSelection && <img className="preview-image" src={imagePreviewUrl} alt={file.uploadSelection.name} /> }

--- a/app/javascript/components/upload/MetadataStep.js
+++ b/app/javascript/components/upload/MetadataStep.js
@@ -1,0 +1,49 @@
+import React, { useEffect } from 'react'
+import metadataExplainerImage from 'images/metadata-convention-explainer.jpg'
+
+const DEFAULT_NEW_METADATA_FILE = {
+  file_type: 'Metadata'
+}
+
+const metadataFileFilter = file => file.file_type === 'Metadata'
+
+export default {
+  title: 'Metadata',
+  name: 'metadata',
+  component: MetadataForm,
+  fileFilter: metadataFileFilter
+}
+
+/** Renders a form for uploading one or more cluster/spatial files */
+function MetadataForm({
+  formState,
+  addNewFile,
+  updateFile,
+  saveFile,
+  deleteFile,
+  handleSaveResponse
+}) {
+  const metadataFile = formState.files.find(metadataFileFilter)
+
+  useEffect(() => {
+    if (!metadataFile) {
+      addNewFile(DEFAULT_NEW_METADATA_FILE)
+    }
+  }, [metadataFile?._id])
+
+  return <div>
+    <div className="row">
+      <h4 className="col-sm-12">3. Metadata</h4>
+    </div>
+    <div className="row">
+      <div className="col-md-12" id="metadata-convention-explainer">
+        <img src={metadataExplainerImage}/>
+        <a id="metadata-convention-example-link"
+          href="https://singlecell.zendesk.com/hc/en-us/articles/360060609852-Required-Metadata"
+          target="_blank" rel="noopener noreferrer">
+          View required conventional metadata
+        </a>
+      </div>
+    </div>
+  </div>
+}

--- a/app/javascript/components/upload/MetadataStep.js
+++ b/app/javascript/components/upload/MetadataStep.js
@@ -24,6 +24,7 @@ export default {
 
 /** Renders a form for uploading one or more cluster/spatial files */
 function MetadataForm({
+  serverState,
   formState,
   addNewFile,
   updateFile,
@@ -99,7 +100,10 @@ function MetadataForm({
                   checked={!file.use_metadata_convention}
                   onChange={e => updateFile(file._id, { use_metadata_convention: false })} /> No
               </label> &nbsp; &nbsp;
-              <OverlayTrigger trigger="click" rootClose placement="top" overlay={conventionIssuePopover}>
+              <OverlayTrigger trigger="click"
+                rootClose
+                placement="top"
+                overlay={<ConventionIssuePopover studyAccession={serverState.study.accession} email={userState.email}/>}>
                 <span className="action log-click"> Using conventional names is an issue for my study</span>
               </OverlayTrigger><br/>
               Learn <a href="https://singlecell.zendesk.com/hc/en-us/articles/360061006411-Metadata-Convention"
@@ -131,11 +135,18 @@ const whyConventionPopover = (
   </Popover>
 )
 
-const conventionIssuePopover = (
-  <Popover id="convention-issues">
+
+/** Popover with the zendesk form url so that the user's info is prepopulated */
+function ConventionIssuePopover({ email, studyAccession, ...props }) {
+  /** return the zendesk form url so that the user's info is prepopulated */
+  const formUrl= `https://singlecell.zendesk.com/hc/en-us/requests/new?ticket_form_id=1260811597230
+&tf_1260822624790=${studyAccession}&tf_anonymous_requester_email=${email}
+&tf_1900002173444=metadata_convention_exemption&tf_subject=
+Metadata%20Convention%20Exemption%20Request%20for%20${studyAccession}`
+  return <Popover id="convention-issues" {...props}>
     Using the convention is now required.  If this presents a particular issue for your study,
-    please contact us at <a href='mailto:scp-support@broadinstitute.zendesk.com'>scp-support@broadinstitute.zendesk.com</a>
-    so we can help or make any updates to the convention.
+    please use this <a href={formUrl} target="_blank" rel="noopener noreferrer">contact form </a>
+    so we can assist you with your metadata.
   </Popover>
-)
+}
 

--- a/app/javascript/components/upload/MetadataStep.js
+++ b/app/javascript/components/upload/MetadataStep.js
@@ -61,61 +61,64 @@ function MetadataForm({
       </div>
 
     </div>
-    <div className="row top-margin" key={file._id}>
-      <div className="col-md-12">
-        <form id={`metadataForm-${file._id}`}
-          className="form-terra"
-          acceptCharset="UTF-8">
-          <div className="row">
-            <div className="col-md-12">
-              <FileUploadControl
-                handleSaveResponse={handleSaveResponse}
-                file={file}
-                updateFile={updateFile}
-                allowedFileTypes={FileTypeExtensions.plainText}/>
+    { file &&
+      <div className="row top-margin" key={file._id}>
+        <div className="col-md-12">
+          <form id={`metadataForm-${file._id}`}
+            className="form-terra"
+            acceptCharset="UTF-8"
+            onSubmit={() => { console.log('submitting'); return false}}>
+            <div className="row">
+              <div className="col-md-12">
+                <FileUploadControl
+                  handleSaveResponse={handleSaveResponse}
+                  file={file}
+                  updateFile={updateFile}
+                  allowedFileTypes={FileTypeExtensions.plainText}/>
+              </div>
             </div>
-          </div>
-          <div className="form-group">
-            <label>Do you use SCP conventional names for required metadata column headers? </label>
-            <OverlayTrigger trigger="click" rootClose placement="top" overlay={whyConventionPopover}>
-              <span> <FontAwesomeIcon data-analytics-name="metadata-convention-popover"
-                className="action log-click help-icon" icon={faInfoCircle}/></span>
-            </OverlayTrigger><br/>
-            <label className="sublabel">
-              <input type="radio"
-                name={`metadataFormYes-${file._id}`}
-                value="true"
-                disabled={conventionRequired}
-                checked={file.use_metadata_convention}
-                onChange={e => updateFile(file._id, { use_metadata_convention: true })} /> Yes
-            </label>
-            <label className="sublabel">
-              <input type="radio"
-                name={`metadataFormNo-${file._id}`}
-                value="false"
-                disabled={conventionRequired}
-                checked={!file.use_metadata_convention}
-                onChange={e => updateFile(file._id, { use_metadata_convention: false })} /> No
-            </label> &nbsp; &nbsp;
-            <OverlayTrigger trigger="click" rootClose placement="top" overlay={conventionIssuePopover}>
-              <span className="action log-click"> Using conventional names is an issue for my study</span>
-            </OverlayTrigger><br/>
-            Learn <a href="https://singlecell.zendesk.com/hc/en-us/articles/360061006411-Metadata-Convention"
-              target="_blank"
-              rel="noopener noreferrer">how to convert your file.</a><br/>
-            If the file fails metadata convention validation, you will be emailed messages to help correct it.
-          </div>
-          <div className="form-group">
-            <TextFormField label="Name" fieldName="name" file={file} updateFile={updateFile}/>
-          </div>
-          <div className="form-group">
-            <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
-          </div>
-          <SaveDeleteButtons file={file} updateFile={updateFile} saveFile={saveFile} deleteFile={deleteFile}/>
-        </form>
-        <SavingOverlay file={file} updateFile={updateFile}/>
+            <div className="form-group">
+              <label>Do you use SCP conventional names for required metadata column headers? </label>
+              <OverlayTrigger trigger="click" rootClose placement="top" overlay={whyConventionPopover}>
+                <span> <FontAwesomeIcon data-analytics-name="metadata-convention-popover"
+                  className="action log-click help-icon" icon={faInfoCircle}/></span>
+              </OverlayTrigger><br/>
+              <label className="sublabel">
+                <input type="radio"
+                  name={`metadataFormYes-${file._id}`}
+                  value="true"
+                  disabled={conventionRequired}
+                  checked={file.use_metadata_convention}
+                  onChange={e => updateFile(file._id, { use_metadata_convention: true })} /> Yes
+              </label>
+              <label className="sublabel">
+                <input type="radio"
+                  name={`metadataFormNo-${file._id}`}
+                  value="false"
+                  disabled={conventionRequired}
+                  checked={!file.use_metadata_convention}
+                  onChange={e => updateFile(file._id, { use_metadata_convention: false })} /> No
+              </label> &nbsp; &nbsp;
+              <OverlayTrigger trigger="click" rootClose placement="top" overlay={conventionIssuePopover}>
+                <span className="action log-click"> Using conventional names is an issue for my study</span>
+              </OverlayTrigger><br/>
+              Learn <a href="https://singlecell.zendesk.com/hc/en-us/articles/360061006411-Metadata-Convention"
+                target="_blank"
+                rel="noopener noreferrer">how to convert your file.</a><br/>
+              If the file fails metadata convention validation, you will be emailed messages to help correct it.
+            </div>
+            <div className="form-group">
+              <TextFormField label="Name" fieldName="name" file={file} updateFile={updateFile}/>
+            </div>
+            <div className="form-group">
+              <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
+            </div>
+            <SaveDeleteButtons file={file} updateFile={updateFile} saveFile={saveFile} deleteFile={deleteFile}/>
+          </form>
+          <SavingOverlay file={file} updateFile={updateFile}/>
+        </div>
       </div>
-    </div>
+    }
   </div>
 }
 

--- a/app/javascript/components/upload/MetadataStep.js
+++ b/app/javascript/components/upload/MetadataStep.js
@@ -68,7 +68,7 @@ function MetadataForm({
           <form id={`metadataForm-${file._id}`}
             className="form-terra"
             acceptCharset="UTF-8"
-            onSubmit={() => { console.log('submitting'); return false}}>
+            onSubmit={() => { return false }}>
             <div className="row">
               <div className="col-md-12">
                 <FileUploadControl
@@ -146,7 +146,7 @@ Metadata%20Convention%20Exemption%20Request%20for%20${studyAccession}`
   return <Popover id="convention-issues" {...props}>
     Using the convention is now required.  If this presents a particular issue for your study,
     please use this <a href={formUrl} target="_blank" rel="noopener noreferrer">contact form </a>
-    so we can assist you with your metadata.
+    &nbsp;so we can assist you with your metadata.
   </Popover>
 }
 

--- a/app/javascript/components/upload/MetadataStep.js
+++ b/app/javascript/components/upload/MetadataStep.js
@@ -1,8 +1,16 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useContext } from 'react'
 import metadataExplainerImage from 'images/metadata-convention-explainer.jpg'
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { Popover, OverlayTrigger } from 'react-bootstrap'
+
+import { UserContext } from 'providers/UserProvider'
+import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
+import { TextFormField, SavingOverlay, SaveDeleteButtons } from './uploadUtils'
 
 const DEFAULT_NEW_METADATA_FILE = {
-  file_type: 'Metadata'
+  file_type: 'Metadata',
+  use_metadata_convention: true
 }
 
 const metadataFileFilter = file => file.file_type === 'Metadata'
@@ -23,13 +31,17 @@ function MetadataForm({
   deleteFile,
   handleSaveResponse
 }) {
-  const metadataFile = formState.files.find(metadataFileFilter)
+  const userState = useContext(UserContext)
+  const featureFlagState = userState.featureFlagsWithDefaults
+  const conventionRequired = featureFlagState && featureFlagState.convention_required
+
+  const file = formState.files.find(metadataFileFilter)
 
   useEffect(() => {
-    if (!metadataFile) {
+    if (!file) {
       addNewFile(DEFAULT_NEW_METADATA_FILE)
     }
-  }, [metadataFile?._id])
+  }, [file?._id])
 
   return <div>
     <div className="row">
@@ -38,12 +50,89 @@ function MetadataForm({
     <div className="row">
       <div className="col-md-12" id="metadata-convention-explainer">
         <img src={metadataExplainerImage}/>
+
+      </div>
+      <div className="col-md-12">
         <a id="metadata-convention-example-link"
           href="https://singlecell.zendesk.com/hc/en-us/articles/360060609852-Required-Metadata"
           target="_blank" rel="noopener noreferrer">
           View required conventional metadata
         </a>
       </div>
+
+    </div>
+    <div className="row top-margin" key={file._id}>
+      <div className="col-md-12">
+        <form id={`metadataForm-${file._id}`}
+          className="form-terra"
+          acceptCharset="UTF-8">
+          <div className="row">
+            <div className="col-md-12">
+              <FileUploadControl
+                handleSaveResponse={handleSaveResponse}
+                file={file}
+                updateFile={updateFile}
+                allowedFileTypes={FileTypeExtensions.plainText}/>
+            </div>
+          </div>
+          <div className="form-group">
+            <label>Do you use SCP conventional names for required metadata column headers? </label>
+            <OverlayTrigger trigger="click" rootClose placement="top" overlay={whyConventionPopover}>
+              <span> <FontAwesomeIcon data-analytics-name="metadata-convention-popover"
+                className="action log-click help-icon" icon={faInfoCircle}/></span>
+            </OverlayTrigger><br/>
+            <label className="sublabel">
+              <input type="radio"
+                name={`metadataFormYes-${file._id}`}
+                value="true"
+                disabled={conventionRequired}
+                checked={file.use_metadata_convention}
+                onChange={e => updateFile(file._id, { use_metadata_convention: true })} /> Yes
+            </label>
+            <label className="sublabel">
+              <input type="radio"
+                name={`metadataFormNo-${file._id}`}
+                value="false"
+                disabled={conventionRequired}
+                checked={!file.use_metadata_convention}
+                onChange={e => updateFile(file._id, { use_metadata_convention: false })} /> No
+            </label> &nbsp; &nbsp;
+            <OverlayTrigger trigger="click" rootClose placement="top" overlay={conventionIssuePopover}>
+              <span className="action log-click"> Using conventional names is an issue for my study</span>
+            </OverlayTrigger><br/>
+            Learn <a href="https://singlecell.zendesk.com/hc/en-us/articles/360061006411-Metadata-Convention"
+              target="_blank"
+              rel="noopener noreferrer">how to convert your file.</a><br/>
+            If the file fails metadata convention validation, you will be emailed messages to help correct it.
+          </div>
+          <div className="form-group">
+            <TextFormField label="Name" fieldName="name" file={file} updateFile={updateFile}/>
+          </div>
+          <div className="form-group">
+            <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
+          </div>
+          <SaveDeleteButtons file={file} updateFile={updateFile} saveFile={saveFile} deleteFile={deleteFile}/>
+        </form>
+        <SavingOverlay file={file} updateFile={updateFile}/>
+      </div>
     </div>
   </div>
 }
+
+const whyConventionPopover = (
+  <Popover id="why-use-convention">
+    Why use the metadata convention?<br/>
+    Using the metadata convention will enable your data to be discovered through our faceted search interface.
+    Using the convention means extra validation will be applied to ensure your metadata conforms to standard vocabularies.<br/>
+    <a href='https://singlecell.zendesk.com/hc/en-us/articles/360061006411-Metadata-Convention' target='_blank' rel="noopener noreferrer">Learn more</a>.
+  </Popover>
+)
+
+const conventionIssuePopover = (
+  <Popover id="convention-issues">
+    Using the convention is now required.  If this presents a particular issue for your study,
+    please contact us at <a href='mailto:scp-support@broadinstitute.zendesk.com'>scp-support@broadinstitute.zendesk.com</a>
+    so we can help or make any updates to the convention.
+  </Popover>
+)
+

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -15,6 +15,7 @@ import _isMatch from 'lodash/isEqual'
 import { formatFileFromServer, formatFileForApi, newStudyFileObj } from './uploadUtils'
 import { createStudyFile, updateStudyFile, deleteStudyFile, fetchStudyFileInfo, sendStudyFileChunk } from 'lib/scp-api'
 import MessageModal from 'lib/MessageModal'
+import UserProvider from 'providers/UserProvider'
 
 import StepTabHeader from './StepTabHeader'
 import ClusteringStep from './ClusteringStep'
@@ -180,43 +181,45 @@ export default function UploadWizard({ studyAccession, name }) {
     })
   }, [studyAccession])
 
-  return <div className="">
-    <div className="row padded">
-      <div className="col-md-10">
-        <h4>{studyAccession}: {name}</h4>
+  return <UserProvider>
+    <div className="">
+      <div className="row padded">
+        <div className="col-md-10">
+          <h4>{studyAccession}: {name}</h4>
+        </div>
+        <div className="col-md-2">
+          <a href={`/single_cell/study/${studyAccession}`}>View Study</a>
+        </div>
       </div>
-      <div className="col-md-2">
-        <a href={`/single_cell/study/${studyAccession}`}>View Study</a>
+      <div className="row">
+        <div className="col-md-3">
+          <ul className="upload-wizard-steps">
+            { STEPS.map((step, index) =>
+              <StepTabHeader key={index}
+                step={step}
+                index={index}
+                formState={formState}
+                serverState={serverState}
+                currentStep={currentStep}
+                setCurrentStep={setCurrentStep}/>) }
+          </ul>
+        </div>
+        <div className="col-md-9">
+          { !formState && <FontAwesomeIcon icon={faDna} className="gene-load-spinner"/> }
+          { !!formState && <currentStep.component
+            formState={formState}
+            serverState={serverState}
+            deleteFile={deleteFile}
+            updateFile={updateFile}
+            saveFile={saveFile}
+            addNewFile={addNewFile}
+            handleSaveResponse={handleSaveResponse}
+          /> }
+        </div>
       </div>
+      <MessageModal/>
     </div>
-    <div className="row">
-      <div className="col-md-3">
-        <ul className="upload-wizard-steps">
-          { STEPS.map((step, index) =>
-            <StepTabHeader key={index}
-              step={step}
-              index={index}
-              formState={formState}
-              serverState={serverState}
-              currentStep={currentStep}
-              setCurrentStep={setCurrentStep}/>) }
-        </ul>
-      </div>
-      <div className="col-md-9">
-        { !formState && <FontAwesomeIcon icon={faDna} className="gene-load-spinner"/> }
-        { !!formState && <currentStep.component
-          formState={formState}
-          serverState={serverState}
-          deleteFile={deleteFile}
-          updateFile={updateFile}
-          saveFile={saveFile}
-          addNewFile={addNewFile}
-          handleSaveResponse={handleSaveResponse}
-        /> }
-      </div>
-    </div>
-    <MessageModal/>
-  </div>
+  </UserProvider>
 }
 
 /** convenience method for drawing/updating the component from non-react portions of SCP */

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -22,9 +22,10 @@ import ImageStep from './ImageStep'
 import CoordinateLabelStep from './CoordinateLabelStep'
 import RawCountsStep from './RawCountsStep'
 import ProcessedExpressionStep from './ProcessedExpressionStep'
+import MetadataStep from './MetadataStep'
 
 const CHUNK_SIZE = 10000000
-const STEPS = [RawCountsStep, ProcessedExpressionStep, ClusteringStep, CoordinateLabelStep, ImageStep]
+const STEPS = [RawCountsStep, ProcessedExpressionStep, MetadataStep, ClusteringStep, CoordinateLabelStep, ImageStep]
 
 /** shows the upload wizard */
 export default function UploadWizard({ studyAccession, name }) {

--- a/app/javascript/components/visualization/BucketImage.js
+++ b/app/javascript/components/visualization/BucketImage.js
@@ -8,7 +8,6 @@ export default function BucketImage({ bucketName, fileName }) {
 
   /** If there is a remote file, try to load it and render it on the page */
   useEffect(() => {
-    console.log('useEffect!!!')
     setRemoteImageUrl(null)
     getBucketImageLocalUrl(bucketName, fileName).then(setRemoteImageUrl)
   }, [bucketName, fileName])
@@ -16,7 +15,6 @@ export default function BucketImage({ bucketName, fileName }) {
   if (!remoteImageUrl) {
     return <></>
   }
-  console.log(`remote url: ${remoteImageUrl}`)
   return <img src={remoteImageUrl} alt={fileName}/>
 }
 

--- a/app/javascript/providers/UserProvider.js
+++ b/app/javascript/providers/UserProvider.js
@@ -49,7 +49,6 @@ export function getURLSafeAccessToken() {
 /** Returns the feature flags with defaults for the current user */
 export function getFeatureFlagsWithDefaults() {
   const flags = readUserInfoFromPage().featureFlags
-  console.log(flags)
   return flags
 }
 

--- a/app/javascript/providers/UserProvider.js
+++ b/app/javascript/providers/UserProvider.js
@@ -48,19 +48,26 @@ export function getURLSafeAccessToken() {
 
 /** Returns the feature flags with defaults for the current user */
 export function getFeatureFlagsWithDefaults() {
-  // for now, read it off the home page.  Eventually, this will want to be an API call
-  let flags = {}
-  const pageFlagElement = $('#feature-flags')
-  if (pageFlagElement.length) {
-    flags = JSON.parse(pageFlagElement.attr('value'))
-  }
+  const flags = readUserInfoFromPage().featureFlags
+  console.log(flags)
   return flags
+}
+
+/** for now, read it off the home page.  Eventually, this will want to be an API call */
+function readUserInfoFromPage() {
+  let userInfo = {}
+  const userElement = document.getElementById('user-provider-info')
+  if (userElement) {
+    userInfo = JSON.parse(userElement.value)
+  }
+  return userInfo
 }
 
 const defaultUserState = {
   accessToken: null,
   isAnonymous: true,
   featureFlagsWithDefaults: null,
+  email: null,
   updateFlags: () => {
     throw new Error(
       'You are trying to use this context outside of a Provider container'
@@ -78,13 +85,11 @@ export const UserContext = React.createContext(defaultUserState)
   * e.g. in metrics-api
   */
 export default function UserProvider({ user, children }) {
-  const [userState, setUserState] = useState(user ? user : defaultUserState)
+  const [userState, setUserState] = useState(user ? user : readUserInfoFromPage())
 
   userState.updateFeatureFlags = updateFeatureFlags
   userState.accessToken = getAccessToken()
   userState.isAnonymous = !userState.accessToken
-  userState.featureFlagsWithDefaults = userState.featureFlagsWithDefaults ?
-    userState.featureFlagsWithDefaults : getFeatureFlagsWithDefaults()
 
   /** update the user's feature flags on the server */
   async function updateFeatureFlags(updatedFlags) {

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -701,7 +701,6 @@ ul.pager li.dimmed {
 
 #metadata-convention-explainer {
   overflow-x: scroll;
-  margin-left: -7px;
 }
 
 #metadata-convention-example-link {

--- a/app/lib/active_record_utils.rb
+++ b/app/lib/active_record_utils.rb
@@ -1,0 +1,6 @@
+class ActiveRecordUtils
+  # plucks the given attrs from the query, and returns a hash of attr=>value
+  def self.pluck_to_hash(query, attrs)
+    query.pluck(*attrs).map { |p| attrs.zip(p).to_h }
+  end
+end

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -65,21 +65,22 @@ class ClusterVizService
 
   def self.load_image_options(study)
     # grab all the image files for this study
-    image_file_info = StudyFile.where(study: study, file_type: 'Image')
-                                 .pluck(:name, :spatial_cluster_associations, :upload_file_name, :description)
+    attrs = [:name, :spatial_cluster_associations, :upload_file_name, :description]
+    image_file_info = ActiveRecordUtils.pluck_to_hash(StudyFile.where(study: study, file_type: 'Image'), attrs)
 
+    associated_cluster_ids = image_file_info.map{ |si| si[:spatial_cluster_associations] }.flatten.uniq
     # now grab any non spatial cluster files for the study that had ids specified in the image files above
     # and put them in an id=>name hash
-    associated_clusters = StudyFile.where(study: study, :id.in => image_file_info.map{ |si| si[1] }.flatten.uniq)
+    associated_clusters = StudyFile.where(study: study, :id.in => associated_cluster_ids)
                                    .pluck(:id, :name)
                                    .map{ |a| [a[0].to_s, a[1]] }.to_h
     # now return an array of objects with names and associated cluster names
     image_file_info.map do |file|
-      associated_cluster_names = file[1].map{ |id| associated_clusters[id] }
-      { name: file[0],
+      associated_cluster_names = file[:spatial_cluster_associations].map{ |id| associated_clusters[id] }
+      { name: file[:name],
         associated_clusters: associated_cluster_names,
-        upload_file_name: file[2],
-        description: file[3] }
+        upload_file_name: file[:upload_file_name],
+        description: file[:description] }
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -226,6 +226,10 @@
     });
 </script>
 
-<input type="hidden" id="feature-flags" value='<%= FeatureFlaggable.feature_flags_for_instances(@selected_branding_group, current_user).to_json %>'/>
+<input type="hidden" id="user-provider-info" value='<%=
+  {
+    email: current_user&.email,
+    featureFlags: FeatureFlaggable.feature_flags_for_instances(@selected_branding_group, current_user)
+  }.to_json %>'/>
 </body>
 </html>

--- a/app/views/site/covid19.html.erb
+++ b/app/views/site/covid19.html.erb
@@ -60,7 +60,11 @@
     </div>
   </div>
 </div>
-<input type="hidden" id="feature-flags" value='<%= User.feature_flags_for_instance(current_user).to_json %>'/>
+<input type="hidden" id="user-provider-info" value='<%=
+  {
+    email: current_user&.email,
+    feature_flags: FeatureFlaggable.feature_flags_for_instances(@selected_branding_group, current_user)
+  }.to_json %>'/>
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
     $(document).ready(function() {
       var main = $('.home-page-fix');


### PR DESCRIPTION
SCP-3667   More-or-less a direct UX port of the existing metadata upload page

![image](https://user-images.githubusercontent.com/2800795/134222550-68c5eeab-9217-478c-924f-5c09d9cfdd64.png)

TO TEST:
1. make sure react-upload-wizard feature flag is on
2. go to upload wizard, and select Metadata step
3. confirm page more-or-less matches current production UX
4. toggle the 'convention_required' feature flag
5. confirm UX works to upload and parse a file

