### PR TITLE
Upload wizard UX update (SCP-3657)

### DIFF
--- a/app/javascript/components/upload/ClusteringStep.js
+++ b/app/javascript/components/upload/ClusteringStep.js
@@ -85,9 +85,6 @@ export function ClusteringUploadForm({
             </p>
           </div>
           <div className="row">
-            <p className="col-sm-12"><a href="https://en.wikipedia.org/wiki/Spatial_transcriptomics" target="_blank" rel="noreferrer">Spatial transcriptomics</a> data can also be uploaded with this file format.  The x, y, and z coordinates then represent actual spatial coordinates, as opposed to clustering output.</p>
-          </div>
-          <div className="row">
             <p className="col-sm-12">* Group values are treated as literal strings, and numerics as floating-point numbers.</p>
           </div>
         </div>

--- a/app/javascript/components/upload/CoordinateLabelStep.js
+++ b/app/javascript/components/upload/CoordinateLabelStep.js
@@ -50,28 +50,31 @@ function CoordinateLabelForm({
     <div className="row">
       <div className="col-md-12">
         <p className="text-center">
-          <a href="https://raw.githubusercontent.com/broadinstitute/single_cell_portal/master/demo_data/coordinate_labels_example.txt" target="_blank" rel="noopener noreferrer">Coordinate Label File</a>
+
         </p>
       </div>
     </div>
 
     <div className="row">
       <div className="col-md-12">
-        <pre className="code-example col-sm-5 col-sm-offset-4">
-          X&#09;Y&#09;Z&#09;LABELS<br/>
-          35.47&#09;33.21&#09;61.03&#09;Region 1<br/>
-          -10.68&#09;-52.64&#09;-57.34&#09;Region 2<br/>
-          ...
-        </pre>
-      </div>
-    </div>
-    <div className="row">
-      <div className="col-md-12">
-        <p>A tab- or comma-delimited text file containing labels to display at specified coordinates of a cluster. <br/>
-          <strong className="text-danger">These are not cluster files - they are annotations to overlay on top of a cluster.</strong><br/>
+        <div className="form-terra">
+          <p>
+            A <a href="https://raw.githubusercontent.com/broadinstitute/single_cell_portal/master/demo_data/coordinate_labels_example.txt" target="_blank" rel="noopener noreferrer">Coordinate Label File</a>
+            &nbsp;specifies labels to display at specified coordinates of a cluster.
+          </p>
+          <pre>
+            X&#09;Y&#09;Z&#09;LABELS<br/>
+            35.47&#09;33.21&#09;61.03&#09;Region 1<br/>
+            -10.68&#09;-52.64&#09;-57.34&#09;Region 2<br/>
+            ...
+          </pre>
+        <p>
+          <strong>These are not cluster files</strong> - they are annotations to overlay on top of a cluster.<br/>
           The file must be a plain text (.txt) file with at least 3 columns and a header row containing the values <strong>X</strong>, <strong>Y</strong>, and <strong>LABELS</strong>.  The file may have an optional column of <strong>Z</strong> (for 3d clusters).
-          The last column must contain text labels to display at the specified coordinates.</p>
+          The last column must contain text labels to display at the specified coordinates.
+        </p>
         <p><i className="fas fa-fw fa-exclamation-triangle text-warning"></i> The coordinates of the labels must fall inside the ranges of the cluster they are associated with for them to render.</p>
+        </div>
       </div>
     </div>
 

--- a/app/javascript/components/upload/ImageStep.js
+++ b/app/javascript/components/upload/ImageStep.js
@@ -46,12 +46,17 @@ export function ImageForm({
 
   return <div>
     <div className="row">
-      <h4 className="col-sm-12">5. Reference Images</h4>
+      <div className="col-md-12">
+       <h4>Reference Images</h4>
+      </div>
     </div>
     <div className="row">
-      <br/>
-      <p className="col-sm-12 text-center">An image file is a static image (.png, .jpeg) that is intended for view alongside cluster and/or expression data.  For example, an anatomical reference image to be dispalyed alongside spatial transcriptomics data</p>
-      <p className="col-sm-12 text-center">Note also that if you want images to appear within your study <i>description</i> you can edit your description and use the toolbar to upload images inline</p>
+      <div className="col-md-12">
+        <div className="form-terra">
+          <p>An image file is a static image (.png, .jpeg) that is intended for view alongside cluster and/or expression data.  For example, an anatomical reference image to be dispalyed alongside spatial transcriptomics data</p>
+          <p>Note also that if you want images to appear within your study <i>description</i> you can edit your description and use the toolbar to upload images inline</p>
+        </div>
+      </div>
     </div>
 
     { imageFiles.map(file => {

--- a/app/javascript/components/upload/MetadataStep.js
+++ b/app/javascript/components/upload/MetadataStep.js
@@ -45,29 +45,36 @@ function MetadataForm({
 
   return <div>
     <div className="row">
-      <h4 className="col-sm-12">3. Metadata</h4>
+      <div className="col-md-12">
+        <h4>Metadata</h4>
+      </div>
     </div>
     <div className="row">
-      <div className="col-md-12" id="metadata-convention-explainer">
-        <img src={metadataExplainerImage}/>
-
-      </div>
       <div className="col-md-12">
-        <a id="metadata-convention-example-link"
-          href="https://singlecell.zendesk.com/hc/en-us/articles/360060609852-Required-Metadata"
-          target="_blank" rel="noopener noreferrer">
-          View required conventional metadata
-        </a>
+        <div className="form-terra">
+          <div className="row">
+            <div className="col-md-12" id="metadata-convention-explainer">
+              A <b>metadata file</b> lists all cells in the study
+              <img src={metadataExplainerImage}/>
+            </div>
+            <div className="col-md-12">
+              <a id="metadata-convention-example-link"
+                href="https://singlecell.zendesk.com/hc/en-us/articles/360060609852-Required-Metadata"
+                target="_blank" rel="noopener noreferrer">
+                View required conventional metadata
+              </a>
+            </div>
+          </div>
+        </div>
       </div>
-
     </div>
+
     { file &&
       <div className="row top-margin" key={file._id}>
-        <div className="col-md-12">
+        <div className="col-md-12 ">
           <form id={`metadataForm-${file._id}`}
             className="form-terra"
-            acceptCharset="UTF-8"
-            onSubmit={() => { console.log('submitting'); return false}}>
+            acceptCharset="UTF-8">
             <div className="row">
               <div className="col-md-12">
                 <FileUploadControl

--- a/app/javascript/components/upload/MetadataStep.js
+++ b/app/javascript/components/upload/MetadataStep.js
@@ -57,6 +57,8 @@ function MetadataForm({
               A <b>metadata file</b> lists all cells in the study
               <img src={metadataExplainerImage}/>
             </div>
+          </div>
+          <div className="row">
             <div className="col-md-12">
               <a id="metadata-convention-example-link"
                 href="https://singlecell.zendesk.com/hc/en-us/articles/360060609852-Required-Metadata"

--- a/app/javascript/components/upload/SpatialStep.js
+++ b/app/javascript/components/upload/SpatialStep.js
@@ -1,25 +1,26 @@
 import React, { useEffect } from 'react'
 
 import ClusteringFileForm from './ClusteringFileForm'
+import { clusterFileFilter } from './ClusteringStep'
 
 
-const DEFAULT_NEW_CLUSTER_FILE = {
-  is_spatial: false,
+const DEFAULT_NEW_SPATIAL_FILE = {
+  is_spatial: true,
   file_type: 'Cluster'
 }
 
-export const clusterFileFilter = file => file.file_type === 'Cluster' && !file.is_spatial
+export const spatialFileFilter = file => file.file_type === 'Cluster' && file.is_spatial
 
 export default {
-  title: 'Clustering',
-  name: 'clustering',
-  component: ClusteringUploadForm,
-  fileFilter: clusterFileFilter
+  title: 'Spatial Transcriptomics',
+  name: 'spatial',
+  component: SpatialUploadForm,
+  fileFilter: spatialFileFilter
 }
 
 
 /** Renders a form for uploading one or more cluster/spatial files */
-export function ClusteringUploadForm({
+export function SpatialUploadForm({
   formState,
   addNewFile,
   updateFile,
@@ -27,26 +28,38 @@ export function ClusteringUploadForm({
   deleteFile,
   handleSaveResponse
 }) {
-  const clusterFiles = formState.files.filter(clusterFileFilter)
+  const spatialFiles = formState.files.filter(spatialFileFilter)
+  const associatedClusterFileOptions = formState.files.filter(clusterFileFilter)
+    .map(file => ({ label: file.name, value: file._id }))
+
+  /** handle a change in the associated cluster select */
+  function updateCorrespondingClusters(file, val) {
+    let newVal = []
+    if (val) {
+      newVal = val.map(opt => opt.value)
+    }
+    updateFile(file._id, { spatial_cluster_associations: newVal })
+  }
 
   useEffect(() => {
-    if (clusterFiles.length === 0) {
-      addNewFile(DEFAULT_NEW_CLUSTER_FILE)
+    if (spatialFiles.length === 0) {
+      addNewFile(DEFAULT_NEW_SPATIAL_FILE)
     }
-  }, [clusterFiles.length])
+  }, [spatialFiles.length])
 
   return <div>
     <div className="row">
-      <div className="col-md-12">
-         <h4>Clustering files</h4>
-      </div>
+      <h4 className="col-sm-12">Spatial transcriptomics coordinate files</h4>
     </div>
     <div className="row">
       <div className="col-md-12">
         <div className="form-terra">
           <div className="row">
             <div className="col-md-12">
-              <p>A <a href="https://github.com/broadinstitute/single_cell_portal/blob/master/demo_data/cluster_example.txt" target="_blank" rel="noreferrer">cluster file</a> (.txt or .txt.gz) contains any cluster ordinations and optional cluster-specific metadata.</p>
+              <p>
+                A <a href="https://github.com/broadinstitute/single_cell_portal/blob/master/demo_data/cluster_example.txt" target="_blank" rel="noreferrer">spatial file</a>
+                &nbsp;(.txt or .txt.gz) contains <a href="https://en.wikipedia.org/wiki/Spatial_transcriptomics" target="_blank" rel="noreferrer">spatial transcriptomics</a> cell coordinates and optional metadata.
+              </p>
             </div>
           </div>
           <div className="row">
@@ -56,7 +69,7 @@ export function ClusteringUploadForm({
           </div>
           <div className="row">
             <div className="col-md-6">
-              <p><strong>At minimum </strong> a cluster file has:</p>
+              <p><strong>At minimum </strong> a spatial file has:</p>
             </div>
           </div>
           <div className="row">
@@ -77,15 +90,11 @@ export function ClusteringUploadForm({
                 </ul>
               </ul>
             </div>
-          </div>
-          <div className="row">
-            <p className="col-sm-12 text-center">Once your cluster file has been successfully ingested, additional representative
+
+            <p className="col-sm-12 text-center">Once your spatial file has been successfully ingested, additional representative
               subsamples of the full resolution data will be stored as well.
               <a href="https://singlecell.zendesk.com/hc/en-us/articles/360060610032-Cluster-File-Subsampling" target="_blank" rel="noreferrer"> Learn More <i className='fas fa-question-circle'></i></a>
             </p>
-          </div>
-          <div className="row">
-            <p className="col-sm-12"><a href="https://en.wikipedia.org/wiki/Spatial_transcriptomics" target="_blank" rel="noreferrer">Spatial transcriptomics</a> data can also be uploaded with this file format.  The x, y, and z coordinates then represent actual spatial coordinates, as opposed to clustering output.</p>
           </div>
           <div className="row">
             <p className="col-sm-12">* Group values are treated as literal strings, and numerics as floating-point numbers.</p>
@@ -93,18 +102,19 @@ export function ClusteringUploadForm({
         </div>
       </div>
     </div>
-
-    { clusterFiles.map(file => {
+    { spatialFiles.map(file => {
       return <ClusteringFileForm
         key={file._id}
         file={file}
         updateFile={updateFile}
         saveFile={saveFile}
         deleteFile={deleteFile}
-        handleSaveResponse={handleSaveResponse}/>
+        handleSaveResponse={handleSaveResponse}
+        associatedClusterFileOptions={associatedClusterFileOptions}
+        updateCorrespondingClusters={updateCorrespondingClusters}/>
     })}
     <div className="row top-margin">
-      <button className="btn btn-secondary action" onClick={() => addNewFile(DEFAULT_NEW_CLUSTER_FILE)}><span className="fas fa-plus"></span> Add File</button>
+      <button className="btn btn-secondary action" onClick={() => addNewFile(DEFAULT_NEW_SPATIAL_FILE)}><span className="fas fa-plus"></span> Add File</button>
     </div>
   </div>
 }

--- a/app/javascript/components/upload/SpatialStep.js
+++ b/app/javascript/components/upload/SpatialStep.js
@@ -49,7 +49,7 @@ export function SpatialUploadForm({
 
   return <div>
     <div className="row">
-      <h4 className="col-sm-12">Spatial transcriptomics coordinate files</h4>
+      <h4 className="col-sm-12">Spatial files</h4>
     </div>
     <div className="row">
       <div className="col-md-12">
@@ -57,7 +57,7 @@ export function SpatialUploadForm({
           <div className="row">
             <div className="col-md-12">
               <p>
-                A <a href="https://github.com/broadinstitute/single_cell_portal/blob/master/demo_data/cluster_example.txt" target="_blank" rel="noreferrer">spatial file</a>
+                A <a href="https://github.com/broadinstitute/single_cell_portal/blob/master/demo_data/spatial_example.txt" target="_blank" rel="noreferrer">spatial file</a>
                 &nbsp;(.txt or .txt.gz) contains <a href="https://en.wikipedia.org/wiki/Spatial_transcriptomics" target="_blank" rel="noreferrer">spatial transcriptomics</a> cell coordinates and optional metadata.
               </p>
             </div>

--- a/app/javascript/components/upload/StepTabHeader.js
+++ b/app/javascript/components/upload/StepTabHeader.js
@@ -8,15 +8,16 @@ export default function StepTitle({ step, index, currentStep, setCurrentStep, se
   }
   const className = step.name === currentStep.name ? 'active' : ''
   return <li className={className} onClick={() => setCurrentStep(step)}>
-    <div className="stepNumber">
+    <div>
       <span className="badge">{index + 1}</span>
     </div>
-    <div className="stepContent">
+    <div>
       <a className="action link">
         {step.title}
       </a>
       <ul className="file-list">
         { stepFiles.map(file => {
+          // show different style depending on whether file is locally modified
           return <li key={file.name}>
             <span className={file.isDirty ? 'dirty' : ''}>{file.name}</span>
           </li>

--- a/app/javascript/components/upload/StepTabHeader.js
+++ b/app/javascript/components/upload/StepTabHeader.js
@@ -8,17 +8,21 @@ export default function StepTitle({ step, index, currentStep, setCurrentStep, se
   }
   const className = step.name === currentStep.name ? 'active' : ''
   return <li className={className} onClick={() => setCurrentStep(step)}>
-    <span className="badge">{index + 1}</span>
-    <a className="action link">
-      {step.title}
-    </a>
-    <ul className="fileList">
-      { stepFiles.map(file => {
-        return <li key={file.name}>
-          <span className={file.isDirty ? 'dirty' : ''}>{file.name}</span>
-        </li>
-      })
-      }
-    </ul>
+    <div className="stepNumber">
+      <span className="badge">{index + 1}</span>
+    </div>
+    <div className="stepContent">
+      <a className="action link">
+        {step.title}
+      </a>
+      <ul className="file-list">
+        { stepFiles.map(file => {
+          return <li key={file.name}>
+            <span className={file.isDirty ? 'dirty' : ''}>{file.name}</span>
+          </li>
+        })
+        }
+      </ul>
+    </div>
   </li>
 }

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -19,6 +19,7 @@ import UserProvider from 'providers/UserProvider'
 
 import StepTabHeader from './StepTabHeader'
 import ClusteringStep from './ClusteringStep'
+import SpatialStep from './SpatialStep'
 import ImageStep from './ImageStep'
 import CoordinateLabelStep from './CoordinateLabelStep'
 import RawCountsStep from './RawCountsStep'
@@ -26,7 +27,7 @@ import ProcessedExpressionStep from './ProcessedExpressionStep'
 import MetadataStep from './MetadataStep'
 
 const CHUNK_SIZE = 10000000
-const STEPS = [RawCountsStep, ProcessedExpressionStep, MetadataStep, ClusteringStep, CoordinateLabelStep, ImageStep]
+const STEPS = [RawCountsStep, ProcessedExpressionStep, MetadataStep, ClusteringStep, SpatialStep, CoordinateLabelStep, ImageStep]
 
 /** shows the upload wizard */
 export default function UploadWizard({ studyAccession, name }) {
@@ -182,27 +183,24 @@ export default function UploadWizard({ studyAccession, name }) {
   }, [studyAccession])
 
   return <UserProvider>
-    <div className="">
-      <div className="row padded">
-        <div className="col-md-10">
-          <h4>{studyAccession}: {name}</h4>
-        </div>
-        <div className="col-md-2">
-          <a href={`/single_cell/study/${studyAccession}`}>View Study</a>
-        </div>
-      </div>
+    <div className="upload-wizard-react">
       <div className="row">
         <div className="col-md-3">
-          <ul className="upload-wizard-steps">
-            { STEPS.map((step, index) =>
-              <StepTabHeader key={index}
-                step={step}
-                index={index}
-                formState={formState}
-                serverState={serverState}
-                currentStep={currentStep}
-                setCurrentStep={setCurrentStep}/>) }
-          </ul>
+          <div className="position-fixed">
+            <div className="padded">
+              <h5><a href={`/single_cell/study/${studyAccession}`}>{studyAccession}</a>: {name}</h5>
+            </div>
+            <ul className="upload-wizard-steps">
+              { STEPS.map((step, index) =>
+                <StepTabHeader key={index}
+                  step={step}
+                  index={index}
+                  formState={formState}
+                  serverState={serverState}
+                  currentStep={currentStep}
+                  setCurrentStep={setCurrentStep}/>) }
+            </ul>
+          </div>
         </div>
         <div className="col-md-9">
           { !formState && <FontAwesomeIcon icon={faDna} className="gene-load-spinner"/> }

--- a/app/javascript/styles/_forms.scss
+++ b/app/javascript/styles/_forms.scss
@@ -83,6 +83,9 @@
   background: #fff;
   padding: 1em;
   border-radius: 5px;
+  #metadata-convention-example img {
+    border: 2px solid #888;
+  }
 }
 
 .padded {
@@ -102,27 +105,49 @@
   font-weight: normal;
 }
 
-.upload-wizard-steps {
-  list-style: none;
+.position-fixed {
   width: 24%;
   position: fixed;
+}
+
+.upload-wizard-react {
+  h4 {
+    margin-top: 1em;
+  }
+}
+
+.upload-wizard-steps {
+  list-style: none;
+  width: 100%;
   padding-left: 0;
   .dirty {
     font-style: italic;
   }
   .badge {
-    background: $action-color;
+    background: #fff;
+    color: $action-color;
     margin-right: 1em;
+    border-radius: 1em;
+    padding: 0.5em 0.75em;
   }
   li.active {
-    background: #fff
+    background: lighten($action-color, 40%);
+    padding-left: 1.25em;
   }
   > li {
     cursor: pointer;
     width: 100%;
     padding: 0.5em;
-    border-bottom: 1px solid #666;
+    border-radius: 5px;
     overflow-x: hidden;
+    display: flex;
+  }
+  .file-list {
+    padding-inline-start: 0px;
+    font-size: 0.9em;
+    li {
+      padding: 0.1em 0em;
+    }
   }
   ul {
     list-style: none;


### PR DESCRIPTION
Updates to in-progress designs from Jerome.

![image](https://user-images.githubusercontent.com/2800795/134237700-62f3545d-a58b-4cd7-a850-effe2fe5e182.png)


Most notably splitting 'clustering' and 'spatial' into two separate steps.  those two steps currently share a lot of descriptions, but Jerome and I expect that to diverge as the descriptions for each step are tweaked, so it is not factored out.

TO TEST:
1. ensure react_upload_wizard feature flag is on
2. go to upload wizard
3. click around the various file types and observe the UX