### PR TITLE
updating branding group image capability (SCP-3685)

### DIFF
--- a/app/controllers/branding_groups_controller.rb
+++ b/app/controllers/branding_groups_controller.rb
@@ -57,7 +57,15 @@ class BrandingGroupsController < ApplicationController
   # PATCH/PUT /branding_groups/1.json
   def update
     respond_to do |format|
-      if @branding_group.update(branding_group_params)
+      clean_params = branding_group_params.to_h
+      ['splash_image', 'banner_image', 'footer_image'].each do |image_name|
+        if clean_params["reset_#{image_name}"] == 'on'
+          clean_params[image_name] = nil
+        end
+        clean_params.delete("reset_#{image_name}")
+      end
+
+      if @branding_group.update(clean_params)
         format.html { redirect_to merge_default_redirect_params(branding_group_path(@branding_group), scpbr: params[:scpbr]),
                                   notice: "Collection '#{@branding_group.name}' was successfully updated." }
         format.json { render :show, status: :ok, location: @branding_group }
@@ -90,6 +98,7 @@ class BrandingGroupsController < ApplicationController
   # Never trust parameters from the scary internet, only allow the permit list through.
   def branding_group_params
     params.require(:branding_group).permit(:name, :tag_line, :public, :background_color, :font_family, :font_color, :user_id,
-                                           :splash_image, :banner_image, :footer_image, :external_link_url, :external_link_description)
+                                           :splash_image, :banner_image, :footer_image, :external_link_url, :external_link_description,
+                                           :reset_splash_image, :reset_footer_image, :reset_banner_image)
   end
 end

--- a/app/controllers/branding_groups_controller.rb
+++ b/app/controllers/branding_groups_controller.rb
@@ -58,10 +58,12 @@ class BrandingGroupsController < ApplicationController
   def update
     respond_to do |format|
       clean_params = branding_group_params.to_h
+      # iterate through each image type to check if the user wants to clear it from the reset checkbox
       ['splash_image', 'banner_image', 'footer_image'].each do |image_name|
         if clean_params["reset_#{image_name}"] == 'on'
           clean_params[image_name] = nil
         end
+        # delete the param since it is not a real model param
         clean_params.delete("reset_#{image_name}")
       end
 

--- a/app/views/branding_groups/_form.html.erb
+++ b/app/views/branding_groups/_form.html.erb
@@ -45,16 +45,27 @@
     <% if @branding_group.banner_image.present? %>
       <p class="help-block">Current file: <%= link_to "<i class='fas fa-download'></i> #{@branding_group.banner_image_file_name} (#{ number_to_human_size @branding_group.banner_image_file_size})".html_safe,
                                                       @branding_group.banner_image.url, download: @branding_group.banner_image_file_name,
-                                                      class: 'btn btn-xs btn-primary' %></p>
+                                                      class: 'btn btn-xs btn-primary' %>
+        <label>
+          Clear/Reset to default
+          <input type="checkbox" name="branding_group[reset_banner_image]"/>
+        </label>
+      </p>
+
     <% end %>
   </div>
   <div class="form-group">
     <%= f.label :splash_image, 'Splash Image (suggested size: 383x89)' %><br/>
     <%= f.file_field :splash_image, class: 'btn btn-default fileinput-button' %>
     <% if @branding_group.splash_image.present? %>
-      <span class="help-block">Current file: <%= link_to "<i class='fas fa-download'></i> #{@branding_group.splash_image_file_name} (#{ number_to_human_size @branding_group.splash_image_file_size})".html_safe,
+      <p class="help-block">Current file: <%= link_to "<i class='fas fa-download'></i> #{@branding_group.splash_image_file_name} (#{ number_to_human_size @branding_group.splash_image_file_size})".html_safe,
                                                       @branding_group.splash_image.url, download: @branding_group.splash_image_file_name,
-                                                      class: 'btn btn-xs btn-primary' %></span>
+                                                      class: 'btn btn-xs btn-primary' %>
+        <label>
+          Clear/Reset to default
+          <input type="checkbox" name="branding_group[reset_splash_image]"/>
+        </label>
+                                                      </p>
     <% end %>
   </div>
   <div class="form-group">
@@ -63,7 +74,12 @@
     <% if @branding_group.footer_image.present? %>
       <p class="help-block">Current file: <%= link_to "<i class='fas fa-download'></i> #{@branding_group.footer_image_file_name} (#{ number_to_human_size @branding_group.footer_image_file_size})".html_safe,
                                                       @branding_group.footer_image.url, download: @branding_group.footer_image_file_name,
-                                                      class: 'btn btn-xs btn-primary' %></p>
+                                                      class: 'btn btn-xs btn-primary' %>
+        <label>
+          &nbsp; Clear/Reset to default
+          <input type="checkbox" name="branding_group[reset_footer_image]"/>
+        </label>
+      </p>
     <% end %>
   </div>
 

--- a/app/views/branding_groups/show.html.erb
+++ b/app/views/branding_groups/show.html.erb
@@ -9,12 +9,30 @@
       <p>Background color: <span id="branding_group_background_color"><%= @branding_group.background_color %></span></p>
     </div>
     <div class="col-md-9">
-      <p>Splash Image: <span id="branding_group_splash_image"><%= @branding_group.splash_image_file_name %></span></p>
-      <%= image_tag @branding_group.splash_image.url, class: 'img-thumbnail' %>
-      <p>Banner Image: <span id="branding_group_banner_image"><%= @branding_group.banner_image_file_name %></span></p>
-      <%= image_tag @branding_group.banner_image.url, class: 'img-thumbnail' %>
-      <p>Footer Image: <span id="branding_group_footer_image"><%= @branding_group.footer_image_file_name %></span></p>
-      <%= image_tag @branding_group.footer_image.url, class: 'img-thumbnail' %>
+      <p>Splash Image:
+        <% if @branding_group.splash_image.present? %>
+          <span id="branding_group_splash_image"><%= @branding_group.splash_image_file_name %></span>
+          <%= image_tag @branding_group.splash_image.url, class: 'img-thumbnail' %>
+        <% else %>
+          <span class="detail"> default</span>
+        <% end %>
+      </p>
+      <p>Banner Image: :
+        <% if @branding_group.banner_image.present? %>
+          <span id="branding_group_banner_image"><%= @branding_group.splash_image_file_name %></span>
+          <%= image_tag @branding_group.banner_image.url, class: 'img-thumbnail' %>
+        <% else %>
+          <span class="detail"> default</span>
+        <% end %>
+      </p>
+      <p>Footer Image:
+        <% if @branding_group.footer_image.present? %>
+          <span id="branding_group_footer_image"><%= @branding_group.splash_image_file_name %></span>
+          <%= image_tag @branding_group.footer_image.url, class: 'img-thumbnail' %>
+        <% else %>
+          <span class="detail"> default</span>
+        <% end %>
+      </p>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
SCP-3685 This adds a checkbox so that users can delete collection images and restore defaults.  I've also double checked in both development and production that images can be changed.  
![image](https://user-images.githubusercontent.com/2800795/134538089-dd60f964-7616-4575-aa6f-24ce881c97ec.png)

This also adds a minor UX enhancement so that if a branding group does not have images specified, the form just shows 'default' on the display
![image](https://user-images.githubusercontent.com/2800795/134538028-d6d31ac9-be2c-4e9e-8886-74664fe83e5a.png)

TO TEST:
1. Go to the 'edit collection' page for a collection that has one or more images
2. If the collection has an existing image, check the 'Clear/Reset to default' checkbox next to the image
3. save the form
4. confirm the image is no longer associated with a branding group
5. add an image to the collection and save
6. change the image and save
7. confirm the change appears