### PR TITLE
Adding pre-populated metadata convention exemption form links (SCP-3686)

### DIFF
--- a/app/views/studies/_initialize_metadata_form.html.erb
+++ b/app/views/studies/_initialize_metadata_form.html.erb
@@ -41,7 +41,7 @@
         <% if convention_required %>
 
           <a href="#/" style="color:#999" id="convention-decline-label-<%= f.object.id.to_s %>"
-             data-content="Using the convention is now required.  If this presents a particular issue for your study, please use this <a href='<%= exemption_form %>'>contact form</a> so we can assist you with your metadata."
+             data-content="The convention is required.  If this is a problem for your study, please <a data-analytics-name='exemption-contact-us-link' href='<%= exemption_form %>'>contact us</a>."
              data-toggle="popover"
              data-analytics-name="convention-decline-label">
             <%= f.radio_button :use_metadata_convention, false, checked: false, disabled: true %>
@@ -55,7 +55,7 @@
       <% end %>
       &nbsp; &nbsp; <a href="#/" id="convention-decline-helplink-<%= f.object.id.to_s %>"
         data-toggle="popover"
-        data-content="Please use this <a href='<%= exemption_form %>'>contact form</a> so we can assist you with your metadata."
+        data-content="Please use this <a data-analytics-name='exemption-contact-us-link' href='<%= exemption_form %>'>contact form</a> so we can assist you with your metadata."
         data-analytics-name="convention-decline-helplink">
         Using conventional names is an issue for my study
       </a>

--- a/app/views/studies/_initialize_metadata_form.html.erb
+++ b/app/views/studies/_initialize_metadata_form.html.erb
@@ -27,6 +27,10 @@
         Do you use SCP conventional names for required metadata column headers?
         <%= render partial: 'metadata_convention_help_popover', locals: {id: f.object.id.to_s} %>
       <% end %>
+      <% exemption_form = 'https://singlecell.zendesk.com/hc/en-us/requests/new?ticket_form_id=1260811597230' \
+                              "&tf_1260822624790=#{@study.accession}&tf_anonymous_requester_email=#{current_user.email}" \
+                              "&tf_1900002173444=metadata_convention_exemption&tf_subject=" \
+                              "Metadata%20Convention%20Exemption%20Request%20for%20#{@study.accession}" %>
       <br />
       <%= f.label :use_metadata_convention_true, 'data-analytics-name': 'metadata-convention-optin' do %>
         <%= f.radio_button :use_metadata_convention, true, checked: true, disabled: !study_file.new_record?%>
@@ -35,8 +39,9 @@
       &nbsp;
       <%= f.label :use_metadata_convention_false, 'data-analytics-name': 'metadata-convention-optout' do %>
         <% if convention_required %>
+
           <a href="#/" style="color:#999" id="convention-decline-label-<%= f.object.id.to_s %>"
-             data-content="Using the convention is now required.  If this presents a particular issue for your study, please contact us at <a href='mailto:scp-support@broadinstitute.zendesk.com'>scp-support@broadinstitute.zendesk.com</a> so we can help or make any updates to the convention."
+             data-content="Using the convention is now required.  If this presents a particular issue for your study, please use this <a href='<%= exemption_form %>'>contact form</a> so we can assist you with your metadata."
              data-toggle="popover"
              data-analytics-name="convention-decline-label">
             <%= f.radio_button :use_metadata_convention, false, checked: false, disabled: true %>
@@ -50,7 +55,7 @@
       <% end %>
       &nbsp; &nbsp; <a href="#/" id="convention-decline-helplink-<%= f.object.id.to_s %>"
         data-toggle="popover"
-        data-content="Please contact us at <a href='mailto:scp-support@broadinstitute.zendesk.com'>scp-support@broadinstitute.zendesk.com</a> so we can help or make any needed updates to the convention."
+        data-content="Please use this <a href='<%= exemption_form %>'>contact form</a> so we can assist you with your metadata."
         data-analytics-name="convention-decline-helplink">
         Using conventional names is an issue for my study
       </a>

--- a/app/views/studies/_metadata_file_fields.html.erb
+++ b/app/views/studies/_metadata_file_fields.html.erb
@@ -18,7 +18,7 @@
     <%= f.label :use_metadata_convention_false, 'data-analytics-name': 'metadata-convention-optout' do %>
       <% if convention_required %>
         <a href="#/" style="color:#999" id="convention-decline-label-<%= f.object.id.to_s %>"
-           data-content="Using the convention is now required.  If this presents a particular issue for your study, please use this <a href='<%= exemption_form %>'>contact form</a> so we can assist you with your metadata."
+           data-content="The convention is required.  If this is a problem for your study, please <a data-analytics-name='exemption-contact-us-link' href='<%= exemption_form %>'>contact us</a>."
            data-toggle="popover"
            data-analytics-name="convention-decline-label">
           <%= f.radio_button :use_metadata_convention, false, checked: false, disabled: true %>
@@ -32,7 +32,7 @@
     <% end %>
     &nbsp; &nbsp; <a href="#/" id="convention-decline-helplink-<%= f.object.id.to_s %>"
                      data-toggle="popover"
-                     data-content="Please use this <a href='<%= exemption_form %>'>contact form</a> so we can assist you with your metadata."
+                     data-content="Please use this <a data-analytics-name='exemption-contact-us-link' href='<%= exemption_form %>'>contact form</a> so we can assist you with your metadata."
                      data-analytics-name="convention-decline-helplink">
     Using conventional names is an issue for my study
   </a>

--- a/app/views/studies/_metadata_file_fields.html.erb
+++ b/app/views/studies/_metadata_file_fields.html.erb
@@ -1,6 +1,10 @@
 <div class="form-group row">
   <div class="col-sm-4">
     <% convention_required = User.feature_flag_for_instance(current_user, 'convention_required') %>
+    <% exemption_form = 'https://singlecell.zendesk.com/hc/en-us/requests/new?ticket_form_id=1260811597230' \
+                              "&tf_1260822624790=#{@study.accession}&tf_anonymous_requester_email=#{current_user.email}" \
+                              "&tf_1900002173444=metadata_convention_exemption&tf_subject=" \
+                              "Metadata%20Convention%20Exemption%20Request%20for%20#{@study.accession}" %>
     <%= f.label :use_metadata_convention do %>
       Do you use SCP conventional names for required metadata column headers?
       <%= render partial: 'metadata_convention_help_popover', locals: {id: f.object.id.to_s} %>
@@ -14,7 +18,7 @@
     <%= f.label :use_metadata_convention_false, 'data-analytics-name': 'metadata-convention-optout' do %>
       <% if convention_required %>
         <a href="#/" style="color:#999" id="convention-decline-label-<%= f.object.id.to_s %>"
-           data-content="Using the convention is now required.  If this presents a particular issue for your study, please contact us at <a href='mailto:scp-support@broadinstitute.zendesk.com'>scp-support@broadinstitute.zendesk.com</a> so we can help or make any updates to the convention."
+           data-content="Using the convention is now required.  If this presents a particular issue for your study, please use this <a href='<%= exemption_form %>'>contact form</a> so we can assist you with your metadata."
            data-toggle="popover"
            data-analytics-name="convention-decline-label">
           <%= f.radio_button :use_metadata_convention, false, checked: false, disabled: true %>
@@ -28,7 +32,7 @@
     <% end %>
     &nbsp; &nbsp; <a href="#/" id="convention-decline-helplink-<%= f.object.id.to_s %>"
                      data-toggle="popover"
-                     data-content="Please contact us at <a href='mailto:scp-support@broadinstitute.zendesk.com'>scp-support@broadinstitute.zendesk.com</a> so we can help or make any needed updates to the convention."
+                     data-content="Please use this <a href='<%= exemption_form %>'>contact form</a> so we can assist you with your metadata."
                      data-analytics-name="convention-decline-helplink">
     Using conventional names is an issue for my study
   </a>


### PR DESCRIPTION
This update expands on #1168 to add pre-populated metadata convention exemption request form links to the metadata upload/sync forms.  This will make it simpler for users to request an exemption, and make it more streamlined for user liaisons to process those requests.

New popover content:
![Screen Shot 2021-09-24 at 12 03 21 PM](https://user-images.githubusercontent.com/729968/134706576-cbdd56df-229f-4253-af1f-b46055dd0eca.png)


MANUAL TESTING
1. Boot portal as normal and sign in with an admin account
2. Ensure that the `convention_required` feature flag is turned on for your account
3. Load the upload wizard for any new/existing study
4. In the metadata tab, hover over either the `Using conventional names is an issue for my study` link, or the `No` radio button for the `use_metadata_convention` field.
5. Confirm the text contains the phrase `Please use this contact form so we can assist you with your metadata`
6. Click the link for `contact form`, and confirm that the email, subject, exemption type, and study accession fields are all pre-populated
7. (Optional) Load the sync page for any existing study with a metadata file, and check steps 4-6 on the form for the metadata file

This PR supports SCP-3686.