### PR TITLE
update ingest to release 1.12.0

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.11.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.12.0'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
PR to update production to use newly cut docker image for ingest release 1.12.0