### PR TITLE
Adding instrumentation to upload wizard selects (SCP-3678)

### DIFF
--- a/app/javascript/components/upload/ClusteringFileForm.js
+++ b/app/javascript/components/upload/ClusteringFileForm.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import Select from 'react-select'
 
+import Select from 'lib/InstrumentedSelect'
 import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './uploadUtils'
 
@@ -30,12 +30,14 @@ export default function ClusteringFileForm({
         <TextFormField label="Name" fieldName="name" file={file} updateFile={updateFile}/>
         { file.is_spatial &&
           <div className="form-group">
-            <label>Corresponding clusters:</label><br/>
-            <Select options={associatedClusterFileOptions}
-              value={spatialClusterAssocs}
-              isMulti={true}
-              placeholder="None"
-              onChange={val => updateCorrespondingClusters(file, val)}/>
+            <label className="labeled-select">Corresponding clusters
+              <Select options={associatedClusterFileOptions}
+                data-analytics-name="spatial-associated-clusters"
+                value={spatialClusterAssocs}
+                isMulti={true}
+                placeholder="None"
+                onChange={val => updateCorrespondingClusters(file, val)}/>
+            </label>
           </div>
         }
         <div className="form-group">

--- a/app/javascript/components/upload/CoordinateLabelFileForm.js
+++ b/app/javascript/components/upload/CoordinateLabelFileForm.js
@@ -35,10 +35,10 @@ export default function CoordinateLabelForm({
         <div className="form-group">
           <label className="labeled-select">Corresponding clusters / spatial data:
             <Select options={associatedClusterFileOptions}
-              data-analytics-name="label-corresponding-cluster"
+              data-analytics-name="coordinate-labels-corresponding-cluster"
               id={`coordCluster-${file._id}`}
               value={associatedCluster}
-              placeholder="Select one"
+              placeholder="Select one..."
               onChange={val => updateCorrespondingClusters(file, val)}/>
           </label>
         </div>

--- a/app/javascript/components/upload/CoordinateLabelFileForm.js
+++ b/app/javascript/components/upload/CoordinateLabelFileForm.js
@@ -31,7 +31,6 @@ export default function CoordinateLabelForm({
               allowedFileTypes={FileTypeExtensions.plainText}/>
           </div>
         </div>
-        <TextFormField label="Name" fieldName="name" file={file} updateFile={updateFile}/>
         <div className="form-group">
           <label className="labeled-select">Corresponding clusters / spatial data:
             <Select options={associatedClusterFileOptions}

--- a/app/javascript/components/upload/CoordinateLabelFileForm.js
+++ b/app/javascript/components/upload/CoordinateLabelFileForm.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import Select from 'react-select'
 
+import Select from 'lib/InstrumentedSelect'
 import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './uploadUtils'
 
@@ -33,12 +33,14 @@ export default function CoordinateLabelForm({
         </div>
         <TextFormField label="Name" fieldName="name" file={file} updateFile={updateFile}/>
         <div className="form-group">
-          <label htmlFor={`coordCluster-${file._id}`}>Corresponding clusters / spatial data:</label><br/>
-          <Select options={associatedClusterFileOptions}
-            id={`coordCluster-${file._id}`}
-            value={associatedCluster}
-            placeholder="Select one"
-            onChange={val => updateCorrespondingClusters(file, val)}/>
+          <label className="labeled-select">Corresponding clusters / spatial data:
+            <Select options={associatedClusterFileOptions}
+              data-analytics-name="label-corresponding-cluster"
+              id={`coordCluster-${file._id}`}
+              value={associatedCluster}
+              placeholder="Select one"
+              onChange={val => updateCorrespondingClusters(file, val)}/>
+          </label>
         </div>
         <div className="form-group">
           <TextFormField label="Description / Legend (this will be displayed below image)" fieldName="description" file={file} updateFile={updateFile}/>

--- a/app/javascript/components/upload/CoordinateLabelStep.js
+++ b/app/javascript/components/upload/CoordinateLabelStep.js
@@ -26,7 +26,7 @@ function CoordinateLabelForm({
   handleSaveResponse
 }) {
   const coordinateFiles = formState.files.filter(coordinateLabelFileFilter)
-  const associatedClusterFileOptions = formState.files.filter(coordinateLabelFileFilter)
+  const associatedClusterFileOptions = formState.files.filter(f => f.file_type === 'Cluster')
     .map(file => ({ label: file.name, value: file._id }))
 
   /** handle a change in the associated cluster select */

--- a/app/javascript/components/upload/ExpressionFileForm.js
+++ b/app/javascript/components/upload/ExpressionFileForm.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import _kebabCase from 'lodash/kebabCase'
 
 import Select from 'lib/InstrumentedSelect'
 import MTXBundledFilesForm from './MTXBundledFilesForm'
@@ -109,7 +110,7 @@ function ExpressionFileInfoSelect({ label, propertyName, rawOptions, file, updat
   return <div className="form-group">
     <label className="labeled-select">{label}
       <Select options={selectOptions}
-        data-analytics-name={`expression-${propertyName}-select`}
+        data-analytics-name={`expression-select-${_kebabCase(propertyName)}`}
         value={selectedOption}
         placeholder="Select one..."
         onChange={val => {

--- a/app/javascript/components/upload/ExpressionFileForm.js
+++ b/app/javascript/components/upload/ExpressionFileForm.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import Select from 'react-select'
 
+import Select from 'lib/InstrumentedSelect'
 import MTXBundledFilesForm from './MTXBundledFilesForm'
 import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './uploadUtils'
@@ -55,11 +55,13 @@ export default function ExpressionFileForm({
         <TextFormField label="Expression Axis Label" fieldName="y_axis_label" file={file} updateFile={updateFile}/>
 
         <div className="form-group">
-          <label>Species</label><br/>
-          <Select options={speciesOptions}
-            value={selectedSpecies}
-            placeholder="Select one..."
-            onChange={val => updateFile(file._id, { taxon_id: val.value })}/>
+          <label className="labeled-select">Species
+            <Select options={speciesOptions}
+              data-analytics-name="expression-species-select"
+              value={selectedSpecies}
+              placeholder="Select one..."
+              onChange={val => updateFile(file._id, { taxon_id: val.value })}/>
+          </label>
         </div>
 
         { file.expression_file_info.is_raw_counts &&
@@ -105,15 +107,17 @@ function ExpressionFileInfoSelect({ label, propertyName, rawOptions, file, updat
   const selectOptions = rawOptions.map(opt => ({ label: opt, value: opt }))
   const selectedOption = selectOptions.find(opt => opt.value === file.expression_file_info[propertyName])
   return <div className="form-group">
-    <label>{label}</label><br/>
-    <Select options={selectOptions}
-      value={selectedOption}
-      placeholder="Select one..."
-      onChange={val => {
-        const expInfo = {}
-        expInfo[propertyName] = val.value
-        updateFile(file._id, { expression_file_info: expInfo })
-      }}/>
+    <label className="labeled-select">{label}
+      <Select options={selectOptions}
+        data-analytics-name={`expression-${propertyName}-select`}
+        value={selectedOption}
+        placeholder="Select one..."
+        onChange={val => {
+          const expInfo = {}
+          expInfo[propertyName] = val.value
+          updateFile(file._id, { expression_file_info: expInfo })
+        }}/>
+    </label>
   </div>
 }
 

--- a/app/javascript/components/upload/MiscellaneousFileForm.js
+++ b/app/javascript/components/upload/MiscellaneousFileForm.js
@@ -1,0 +1,46 @@
+import React from 'react'
+
+import Select from 'lib/InstrumentedSelect'
+import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
+import { TextFormField, SavingOverlay, SaveDeleteButtons } from './uploadUtils'
+
+/** renders a form for editing/uploading a miscellaneous file */
+export default function MiscellaneousFileForm({
+  file,
+  updateFile,
+  saveFile,
+  deleteFile,
+  handleSaveResponse,
+  miscFileTypes
+}) {
+  return <div className="row top-margin" key={file._id}>
+    <div className="col-md-12">
+      <form id={`misc-file-form-${file._id}`}
+        className="form-terra"
+        acceptCharset="UTF-8">
+        <div className="row">
+          <div className="col-md-12">
+            <FileUploadControl
+              handleSaveResponse={handleSaveResponse}
+              file={file}
+              updateFile={updateFile}/>
+          </div>
+        </div>
+        <div className="form-group">
+          <label className="labeled-select">File type:
+            <Select options={miscFileTypes.map(ft => ({ label: ft, value: ft }))}
+              data-analytics-name="misc-file-type"
+              value={{ label: file.file_type, value: file.file_type }}
+              onChange={val => updateFile(file._id, {file_type: val.value})}/>
+          </label>
+        </div>
+        <div className="form-group">
+          <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
+        </div>
+        <SaveDeleteButtons file={file} updateFile={updateFile} saveFile={saveFile} deleteFile={deleteFile}/>
+      </form>
+
+      <SavingOverlay file={file} updateFile={updateFile}/>
+    </div>
+  </div>
+}

--- a/app/javascript/components/upload/MiscellaneousStep.js
+++ b/app/javascript/components/upload/MiscellaneousStep.js
@@ -1,0 +1,65 @@
+import React, { useEffect } from 'react'
+
+import MiscellaneousFileForm from './MiscellaneousFileForm'
+
+const DEFAULT_NEW_OTHER_FILE = {
+  file_type: 'Documentation',
+  options: {}
+}
+
+const miscFileTypes = ['Other', 'Documentation']
+const miscFileFilter = file => miscFileTypes.includes(file.file_type)
+
+export default {
+  title: 'Miscellaneous / Other',
+  name: 'misc',
+  component: MiscellaneousForm,
+  fileFilter: miscFileFilter
+}
+
+/** Renders a form for uploading one or more miscellaneous files */
+function MiscellaneousForm({
+  formState,
+  addNewFile,
+  updateFile,
+  saveFile,
+  deleteFile,
+  handleSaveResponse
+}) {
+  const miscFiles = formState.files.filter(miscFileFilter)
+
+  useEffect(() => {
+    if (miscFiles.length === 0) {
+      addNewFile(DEFAULT_NEW_OTHER_FILE)
+    }
+  }, [miscFiles.length])
+
+  return <div>
+    <div className="row">
+      <h4 className="col-sm-12">Documentation &amp; Other Files</h4>
+    </div>
+    <div className="row">
+      <div className="col-md-12">
+        <p className="text-center">
+          Any documentation or other support files. These will not be displayed directly, but will be avaialble for users to download.
+        </p>
+      </div>
+    </div>
+
+    { miscFiles.map(file => {
+      return <MiscellaneousFileForm
+        key={file._id}
+        file={file}
+        updateFile={updateFile}
+        saveFile={saveFile}
+        deleteFile={deleteFile}
+        miscFileTypes={miscFileTypes}
+        handleSaveResponse={handleSaveResponse}/>
+    })}
+    <div className="row top-margin">
+      <button className="btn btn-secondary action" onClick={() => addNewFile(DEFAULT_NEW_OTHER_FILE)}>
+        <span className="fas fa-plus"></span> Add File
+      </button>
+    </div>
+  </div>
+}

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -23,10 +23,11 @@ import CoordinateLabelStep from './CoordinateLabelStep'
 import RawCountsStep from './RawCountsStep'
 import ProcessedExpressionStep from './ProcessedExpressionStep'
 import MetadataStep from './MetadataStep'
+import MiscellaneousStep from './MiscellaneousStep'
 import LoadingSpinner from 'lib/LoadingSpinner'
 
 const CHUNK_SIZE = 10000000
-const STEPS = [RawCountsStep, ProcessedExpressionStep, MetadataStep, ClusteringStep, SpatialStep, CoordinateLabelStep, ImageStep]
+const STEPS = [RawCountsStep, ProcessedExpressionStep, MetadataStep, ClusteringStep, SpatialStep, CoordinateLabelStep, ImageStep, MiscellaneousStep]
 
 /** shows the upload wizard */
 export default function UploadWizard({ studyAccession, name }) {
@@ -64,7 +65,11 @@ export default function UploadWizard({ studyAccession, name }) {
     // first update the serverState
     setServerState(prevServerState => {
       const newServerState = _cloneDeep(prevServerState)
-      const fileIndex = newServerState.files.findIndex(f => f.name === updatedFile.name)
+      let fileIndex = newServerState.files.findIndex(f => f.name === updatedFile.name)
+      if (fileIndex < 0) {
+        // this is a new file -- add it to the end of the list
+        fileIndex = newServerState.files.length
+      }
       newServerState.files[fileIndex] = updatedFile
       return newServerState
     })

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -7,11 +7,8 @@
 
 import React, { useState, useEffect } from 'react'
 import ReactDOM from 'react-dom'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faDna } from '@fortawesome/free-solid-svg-icons'
 import _cloneDeep from 'lodash/cloneDeep'
 import _isMatch from 'lodash/isEqual'
-import { Router, navigate, useLocation } from '@reach/router'
 
 import { formatFileFromServer, formatFileForApi, newStudyFileObj } from './uploadUtils'
 import { createStudyFile, updateStudyFile, deleteStudyFile, fetchStudyFileInfo, sendStudyFileChunk } from 'lib/scp-api'
@@ -26,6 +23,7 @@ import CoordinateLabelStep from './CoordinateLabelStep'
 import RawCountsStep from './RawCountsStep'
 import ProcessedExpressionStep from './ProcessedExpressionStep'
 import MetadataStep from './MetadataStep'
+import LoadingSpinner from 'lib/LoadingSpinner'
 
 const CHUNK_SIZE = 10000000
 const STEPS = [RawCountsStep, ProcessedExpressionStep, MetadataStep, ClusteringStep, SpatialStep, CoordinateLabelStep, ImageStep]
@@ -209,7 +207,7 @@ export default function UploadWizard({ studyAccession, name }) {
           </div>
         </div>
         <div className="col-md-9">
-          { !formState && <FontAwesomeIcon icon={faDna} className="gene-load-spinner"/> }
+          { !formState && <LoadingSpinner/> }
           { !!formState && <currentStep.component
             formState={formState}
             serverState={serverState}

--- a/app/javascript/components/upload/uploadUtils.js
+++ b/app/javascript/components/upload/uploadUtils.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faDna } from '@fortawesome/free-solid-svg-icons'
 import _uniqueId from 'lodash/uniqueId'
 import Modal from 'react-bootstrap/lib/Modal'
+
+import LoadingSpinner from 'lib/LoadingSpinner'
 
 /** properties used to track file state on the form, but that should not be sent to the server
  *  this also includes properties that are only modifiable on the server (and so should also
@@ -129,7 +129,7 @@ export function SavingOverlay({ file, updateFile }) {
   return <div className="file-upload-overlay ">
     { (file.isSaving || file.isDeleting) &&
       <div className="file-upload-overlay">
-        { file.isSaving ? 'Saving' : 'Deleting' } <FontAwesomeIcon icon={faDna} className="gene-load-spinner"/>
+        { file.isSaving ? 'Saving' : 'Deleting' } <LoadingSpinner/>
       </div>
     }
     { file.isError &&

--- a/app/javascript/styles/_forms.scss
+++ b/app/javascript/styles/_forms.scss
@@ -148,7 +148,6 @@
   }
   li.active {
     background: lighten($action-color, 40%);
-    padding-left: 1.25em;
   }
   > li {
     cursor: pointer;

--- a/app/views/layouts/_notices.html.erb
+++ b/app/views/layouts/_notices.html.erb
@@ -1,6 +1,6 @@
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
     if (<%= [alert, notice].compact.any? %>) {
-        showMessageModal("<%= notice.present? ? notice.html_safe : nil %>", "<%= alert.present? ? alert.html_safe : nil %>")
+        showMessageModal("<%= notice.present? ? notice.html_safe : nil %>", "<%= alert.present? ? alert.html_safe.gsub('"', '\'') : nil %>")
     } else {
         $('#notice-content').empty();
         $('#alert-content').empty();

--- a/app/views/layouts/session_expired.js.erb
+++ b/app/views/layouts/session_expired.js.erb
@@ -1,1 +1,1 @@
-showMessageModal("<%= @notice.present? ? @notice.html_safe : nil %>", "<%= @alert.present? ? @alert.html_safe : nil %>");
+showMessageModal("<%= @notice.present? ? @notice.html_safe : nil %>", "<%= @alert.present? ? @alert.html_safe.gsub('"', '\'') : nil %>");


### PR DESCRIPTION
This ports over the recent instrumented select and common loading spinner to tis branch,

This also fixes an annoying bug where I would sign in after a session timeout but get stuck on the sign in page due to a script error caused by not escaping the quotes in a `"csrf required"` error

TO TEST:
1. Click through the new upload wizard, observe loading spinners
2. toggle the dropdowns on the cluster, expression and cooridnate label forms, and confirm mixpanel events are sent
3. allow session to timeout, then when prompted, sign back in.  Observe no errors in JS console (this might be tricky to reproduce because it depends on a specific csrf/token/session state