### PR TITLE
adding miscellaneous file upload (SCP-3722)

### DIFF
--- a/app/javascript/components/upload/MiscellaneousFileForm.js
+++ b/app/javascript/components/upload/MiscellaneousFileForm.js
@@ -15,7 +15,7 @@ export default function MiscellaneousFileForm({
 }) {
   return <div className="row top-margin" key={file._id}>
     <div className="col-md-12">
-      <form id={`miscFileForm-${file._id}`}
+      <form id={`misc-file-form-${file._id}`}
         className="form-terra"
         acceptCharset="UTF-8">
         <div className="row">

--- a/app/javascript/components/upload/MiscellaneousFileForm.js
+++ b/app/javascript/components/upload/MiscellaneousFileForm.js
@@ -4,22 +4,18 @@ import Select from 'lib/InstrumentedSelect'
 import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './uploadUtils'
 
-/** renders a form for editing/uploading an image file */
-export default function CoordinateLabelForm({
+/** renders a form for editing/uploading a miscellaneous file */
+export default function MiscellaneousFileForm({
   file,
   updateFile,
   saveFile,
   deleteFile,
   handleSaveResponse,
-  associatedClusterFileOptions,
-  updateCorrespondingClusters
+  miscFileTypes
 }) {
-
-  const associatedCluster = associatedClusterFileOptions.find(opt => opt.value === file.options.cluster_file_id)
-
   return <div className="row top-margin" key={file._id}>
     <div className="col-md-12">
-      <form id={`labelForm-${file._id}`}
+      <form id={`miscFileForm-${file._id}`}
         className="form-terra"
         acceptCharset="UTF-8">
         <div className="row">
@@ -27,22 +23,19 @@ export default function CoordinateLabelForm({
             <FileUploadControl
               handleSaveResponse={handleSaveResponse}
               file={file}
-              updateFile={updateFile}
-              allowedFileTypes={FileTypeExtensions.plainText}/>
+              updateFile={updateFile}/>
           </div>
         </div>
         <div className="form-group">
-          <label className="labeled-select">Corresponding clusters / spatial data:
-            <Select options={associatedClusterFileOptions}
-              data-analytics-name="label-corresponding-cluster"
-              id={`coordCluster-${file._id}`}
-              value={associatedCluster}
-              placeholder="Select one"
-              onChange={val => updateCorrespondingClusters(file, val)}/>
+          <label className="labeled-select">File type:
+            <Select options={miscFileTypes.map(ft => ({ label: ft, value: ft }))}
+              data-analytics-name="misc-file-type"
+              value={{ label: file.file_type, value: file.file_type }}
+              onChange={val => updateFile(file._id, {file_type: val.value})}/>
           </label>
         </div>
         <div className="form-group">
-          <TextFormField label="Description / Legend (this will be displayed below image)" fieldName="description" file={file} updateFile={updateFile}/>
+          <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
         </div>
         <SaveDeleteButtons file={file} updateFile={updateFile} saveFile={saveFile} deleteFile={deleteFile}/>
       </form>

--- a/app/javascript/components/upload/MiscellaneousStep.js
+++ b/app/javascript/components/upload/MiscellaneousStep.js
@@ -1,0 +1,63 @@
+import React, { useEffect } from 'react'
+
+import MiscellaneousFileForm from './MiscellaneousFileForm'
+
+const DEFAULT_NEW_OTHER_FILE = {
+  file_type: 'Documentation',
+  options: {}
+}
+
+const miscFileTypes = ['Other', 'Documentation']
+const miscFileFilter = file => miscFileTypes.includes(file.file_type)
+
+export default {
+  title: 'Miscellaneous / Other',
+  name: 'misc',
+  component: MiscellaneousForm,
+  fileFilter: miscFileFilter
+}
+
+/** Renders a form for uploading one or more miscellaneous files */
+function MiscellaneousForm({
+  formState,
+  addNewFile,
+  updateFile,
+  saveFile,
+  deleteFile,
+  handleSaveResponse
+}) {
+  const miscFiles = formState.files.filter(miscFileFilter)
+
+  useEffect(() => {
+    if (miscFiles.length === 0) {
+      addNewFile(DEFAULT_NEW_OTHER_FILE)
+    }
+  }, [miscFiles.length])
+
+  return <div>
+    <div className="row">
+      <h4 className="col-sm-12">Documentation &amp; Other files</h4>
+    </div>
+    <div className="row">
+      <div className="col-md-12">
+        <p className="text-center">
+          Any documentation or other support files. These will not be displayed directly, but will be avaialble for users to download
+        </p>
+      </div>
+    </div>
+
+    { miscFiles.map(file => {
+      return <MiscellaneousFileForm
+        key={file._id}
+        file={file}
+        updateFile={updateFile}
+        saveFile={saveFile}
+        deleteFile={deleteFile}
+        miscFileTypes={miscFileTypes}
+        handleSaveResponse={handleSaveResponse}/>
+    })}
+    <div className="row top-margin">
+      <button className="btn btn-secondary action" onClick={() => addNewFile(DEFAULT_NEW_OTHER_FILE)}><span className="fas fa-plus"></span> Add File</button>
+    </div>
+  </div>
+}

--- a/app/javascript/components/upload/MiscellaneousStep.js
+++ b/app/javascript/components/upload/MiscellaneousStep.js
@@ -36,12 +36,12 @@ function MiscellaneousForm({
 
   return <div>
     <div className="row">
-      <h4 className="col-sm-12">Documentation &amp; Other files</h4>
+      <h4 className="col-sm-12">Documentation &amp; Other Files</h4>
     </div>
     <div className="row">
       <div className="col-md-12">
         <p className="text-center">
-          Any documentation or other support files. These will not be displayed directly, but will be avaialble for users to download
+          Any documentation or other support files. These will not be displayed directly, but will be avaialble for users to download.
         </p>
       </div>
     </div>
@@ -57,7 +57,9 @@ function MiscellaneousForm({
         handleSaveResponse={handleSaveResponse}/>
     })}
     <div className="row top-margin">
-      <button className="btn btn-secondary action" onClick={() => addNewFile(DEFAULT_NEW_OTHER_FILE)}><span className="fas fa-plus"></span> Add File</button>
+      <button className="btn btn-secondary action" onClick={() => addNewFile(DEFAULT_NEW_OTHER_FILE)}>
+        <span className="fas fa-plus"></span> Add File
+      </button>
     </div>
   </div>
 }

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -23,10 +23,11 @@ import CoordinateLabelStep from './CoordinateLabelStep'
 import RawCountsStep from './RawCountsStep'
 import ProcessedExpressionStep from './ProcessedExpressionStep'
 import MetadataStep from './MetadataStep'
+import MiscellaneousStep from './MiscellaneousStep'
 import LoadingSpinner from 'lib/LoadingSpinner'
 
 const CHUNK_SIZE = 10000000
-const STEPS = [RawCountsStep, ProcessedExpressionStep, MetadataStep, ClusteringStep, SpatialStep, CoordinateLabelStep, ImageStep]
+const STEPS = [RawCountsStep, ProcessedExpressionStep, MetadataStep, ClusteringStep, SpatialStep, CoordinateLabelStep, ImageStep, MiscellaneousStep]
 
 /** shows the upload wizard */
 export default function UploadWizard({ studyAccession, name }) {
@@ -64,7 +65,11 @@ export default function UploadWizard({ studyAccession, name }) {
     // first update the serverState
     setServerState(prevServerState => {
       const newServerState = _cloneDeep(prevServerState)
-      const fileIndex = newServerState.files.findIndex(f => f.name === updatedFile.name)
+      let fileIndex = newServerState.files.findIndex(f => f.name === updatedFile.name)
+      if (fileIndex < 0) {
+        // this is a new file -- add it to the end of the list
+        fileIndex = newServerState.files.length
+      }
       newServerState.files[fileIndex] = updatedFile
       return newServerState
     })

--- a/app/javascript/styles/_forms.scss
+++ b/app/javascript/styles/_forms.scss
@@ -148,7 +148,6 @@
   }
   li.active {
     background: lighten($action-color, 40%);
-    padding-left: 1.25em;
   }
   > li {
     cursor: pointer;


### PR DESCRIPTION
SCP-3722 - adding miscellaneous file upload capability
![image](https://user-images.githubusercontent.com/2800795/135183306-6b992b83-7034-45bd-a6a6-aad37910db99.png)

This also does some minor cleaning of other forms, and reverts the left-menu indention for active items per feedback from Jerome

TO TEST:
1. go to upload wizard (make sure react upload wizard feature flag is on)
2. upload/modify/delete miscellaneous files
3. confirm upload/delete behaves as expected