### PR TITLE
Adding progress bar to uploads (SCP-3716)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -361,13 +361,13 @@ module Api
         content_range = RequestUtils.parse_content_range_header(request.headers)
         if content_range.present?
           if content_range[:first_byte] == 0
-            render json: {errors: 'create/update should be used for uploading the first chunk'}, status: :unprocessable_entity
+            render json: {errors: 'create/update should be used for uploading the first chunk'}, status: :unprocessable_entity and return
           end
           if content_range[:first_byte] != @study_file.upload_file_size
-            render json: {errors: "Incorrect chunk sent: expected bytes starting with #{@study_file.upload_file_size}, received #{content_range[:first_byte]}" }, status: :unprocessable_entity
+            render json: {errors: "Incorrect chunk sent: expected bytes starting with #{@study_file.upload_file_size}, received #{content_range[:first_byte]}" }, status: :unprocessable_entity and return
           end
         else
-          render json: {errors: 'Missing Content-Range header'}, status: :unprocessable_entity
+          render json: {errors: 'Missing Content-Range header'}, status: :unprocessable_entity and return
         end
 
         File.open(@study_file.upload.path, "ab") do |f|
@@ -382,6 +382,7 @@ module Api
           # this was the last chunk
           complete_upload_process(@study_file, safe_file_params[:parse_on_upload])
         end
+        render :show
       end
 
       def complete_upload_process(study_file, parse_on_upload)

--- a/app/javascript/components/upload/MiscellaneousFileForm.js
+++ b/app/javascript/components/upload/MiscellaneousFileForm.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import Select from 'lib/InstrumentedSelect'
-import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
+import FileUploadControl from './FileUploadControl'
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './uploadUtils'
 
 /** renders a form for editing/uploading a miscellaneous file */
@@ -17,6 +17,7 @@ export default function MiscellaneousFileForm({
     <div className="col-md-12">
       <form id={`miscFileForm-${file._id}`}
         className="form-terra"
+        onSubmit={e => e.preventDefault()}
         acceptCharset="UTF-8">
         <div className="row">
           <div className="col-md-12">

--- a/app/javascript/components/upload/uploadUtils.js
+++ b/app/javascript/components/upload/uploadUtils.js
@@ -11,6 +11,7 @@ const PROPERTIES_NOT_TO_SEND = [
   'selectedFile',
   'uploadSelection',
   'submitData',
+  'saveProgress',
   'isDirty',
   'isSaving',
   'isDeleting',
@@ -130,6 +131,10 @@ export function SavingOverlay({ file, updateFile }) {
     { (file.isSaving || file.isDeleting) &&
       <div className="file-upload-overlay">
         { file.isSaving ? 'Saving' : 'Deleting' } <LoadingSpinner/>
+        <br/>
+        { file.saveProgress &&
+          <progress value={file.saveProgress} max="100">{file.saveProgress}%</progress>
+        }
       </div>
     }
     { file.isError &&

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -59,7 +59,7 @@ class ClusterVizService
     # now return an array of objects with names and associated cluster names
     spatial_file_info.map do |cluster|
       associated_cluster_names = cluster[1].map{ |id| associated_clusters[id] }
-      { name: cluster[0], associated_clusters: associated_cluster_names, bucket_file_name: cluster[2] }
+      { name: cluster[0], associated_clusters: associated_cluster_names }
     end
   end
 


### PR DESCRIPTION
Adds a progress bar to uploads.  This required converting the api calls to XMLHttpRequests as 'fetch' doesn't support progress notifications

![image](https://user-images.githubusercontent.com/2800795/135196042-8182c8b2-d514-4722-9bb9-b46c5099000f.png)

I'm sure there's a lot of refinement that could be done with the display, but this is intended to be a 'good-enough-for-now' bar

TO TEST:
1. load the upload wizard with react_upload_wizard feature flag on
2. upload a large file
3. observe that the progress bar displays