### PR TITLE
Updating to latest base image (SCP-3698)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:1.3.0
+FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:1.3.1
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-2.6.6'


### PR DESCRIPTION
This updates to the latest version of `scp-rails-baseimage:1.3.1` to apply security patches to the underlying `ubuntu1804:latest` image.

This PR satisfies SCP-3698.