### PR TITLE
Fixing bulk download of "root" DirectoryListing objects (SCP-3682)

### DIFF
--- a/app/models/directory_listing.rb
+++ b/app/models/directory_listing.rb
@@ -164,12 +164,9 @@ class DirectoryListing
   end
 
   # helper for setting DOM attributes that are URL-encoded
+  # include file type as well to disambiguate directories with the same name/path
   def url_safe_name
-    if self.name == '/'
-      'root-dir'
-    else
-      self.name
-    end
+    name == '/' ? "root-dir--#{file_type}" : "#{name}--#{file_type}"
   end
 
   # guess at a possible sample name based on filename

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -50,11 +50,13 @@
                   <thead>
                     <tr>
                       <th>Folder</th>
+                      <th>File Type</th>
                       <th>Download command</th>
                     </tr>
                     <% @directories.each do |directory| %>
                       <tr>
                         <td><%= directory.name %></td>
+                        <td><%= directory.file_type %></td>
                         <td class="command-container" id="command-container-<%= directory.url_safe_name %>">
                           <%= link_to "<i class='fas fa-download'></i> Get download command".html_safe, '#/',
                                       class: 'btn btn-default get-download-command', id: "get-download-command__#{directory.url_safe_name}",
@@ -117,7 +119,8 @@
               var expiresMinutes = timeInterval / 60;
               const accession = "<%= @study.accession %>"
               const curlSecureFlag = "<%= Rails.env.development? ? '-k' : '' %>"
-              const downloadObjectName = downloadObject == 'root-dir' ? '%2F' : downloadObject
+              const matcher = /root-dir/
+              const downloadObjectName = downloadObject.match(matcher) ? downloadObject.replace(matcher, '%2F') : downloadObject
               // Gets a curl configuration ("cfg.txt") containing signed
               // URLs and output names for all files in the download object.
               var url = (


### PR DESCRIPTION
This update fixes a bug where directories at the root level of a GCP bucket could not download via bulk download.  Users could select "all data", which works, but any requests to download individual directories fail and do not return any files.  The issue was that we were not generating the output map of accessions/files to folders on the host machine.

This update also addresses a newly discovered issue where multiple directories at the same path, but with different file types, cannot be downloaded discretely.  This update now appends the `file_type` value to directory-based bulk download requests to disambiguate which directory is being requested.

MANUAL TESTING 
1. Before starting, download either of the folders from [here](https://console.cloud.google.com/storage/browser/broad-singlecellportal-staging-testing-data/directory_listing_data?project=broad-singlecellportal-staging) to your local machine
2. Boot and log in as normal
3. Create a new study, but don't upload any files
4. Go back to "My Studies", and click on "Show Details" for the new study
5. On the study detail page, click "View Google Bucket"
6. Upload either of the folders downloaded earlier to the bucket at the root level
7. Back in the portal, return to "My Studies", and click "Sync Workspace"
8. Sync the directory you uploaded before
9. Sign out, and sign in with a different user account, and load the study
10. Click "Bulk Download", and then use the download link for the directory at the bottom

This PR satisfies SCP-3682.