### PR TITLE
Upload wizard gene list form (SCP-3723)

### DIFF
--- a/app/javascript/components/upload/ClusteringFileForm.js
+++ b/app/javascript/components/upload/ClusteringFileForm.js
@@ -41,9 +41,8 @@ export default function ClusteringFileForm({
             </label>
           </div>
         }
-        <div className="form-group">
-          <TextFormField label="Description / Figure Legend (this will be displayed below cluster)" fieldName="description" file={file} updateFile={updateFile}/>
-        </div>
+        <TextFormField label="Description / Figure Legend (this will be displayed below cluster)" fieldName="description" file={file} updateFile={updateFile}/>
+
         <div className="row">
           <div className="col-md-4">
             <TextFormField label="X Axis Label" fieldName="x_axis_label" file={file} updateFile={updateFile}/>

--- a/app/javascript/components/upload/CoordinateLabelFileForm.js
+++ b/app/javascript/components/upload/CoordinateLabelFileForm.js
@@ -42,9 +42,7 @@ export default function CoordinateLabelForm({
               onChange={val => updateCorrespondingClusters(file, val)}/>
           </label>
         </div>
-        <div className="form-group">
-          <TextFormField label="Description / Legend (this will be displayed below image)" fieldName="description" file={file} updateFile={updateFile}/>
-        </div>
+        <TextFormField label="Description / Legend (this will be displayed below image)" fieldName="description" file={file} updateFile={updateFile}/>
         <SaveDeleteButtons file={file} updateFile={updateFile} saveFile={saveFile} deleteFile={deleteFile}/>
       </form>
 

--- a/app/javascript/components/upload/GeneListFileForm.js
+++ b/app/javascript/components/upload/GeneListFileForm.js
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import FileUploadControl from './FileUploadControl'
+import { TextFormField, SavingOverlay, SaveDeleteButtons } from './form-components'
+
+/** renders a form for editing/uploading a miscellaneous file */
+export default function GeneListFileForm({
+  file,
+  updateFile,
+  saveFile,
+  deleteFile,
+  handleSaveResponse,
+  miscFileTypes
+}) {
+  return <div className="row top-margin" key={file._id}>
+    <div className="col-md-12">
+      <form id={`misc-file-form-${file._id}`}
+        className="form-terra"
+        onSubmit={e => e.preventDefault()}
+        acceptCharset="UTF-8">
+        <div className="row">
+          <div className="col-md-12">
+            <FileUploadControl
+              handleSaveResponse={handleSaveResponse}
+              file={file}
+              updateFile={updateFile}/>
+          </div>
+        </div>
+        <div className="form-group">
+          <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
+        </div>
+        <SaveDeleteButtons file={file} updateFile={updateFile} saveFile={saveFile} deleteFile={deleteFile}/>
+      </form>
+
+      <SavingOverlay file={file} updateFile={updateFile}/>
+    </div>
+  </div>
+}

--- a/app/javascript/components/upload/GeneListFileForm.js
+++ b/app/javascript/components/upload/GeneListFileForm.js
@@ -26,9 +26,9 @@ export default function GeneListFileForm({
               updateFile={updateFile}/>
           </div>
         </div>
-        <div className="form-group">
-          <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
-        </div>
+
+        <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
+
         <SaveDeleteButtons file={file} updateFile={updateFile} saveFile={saveFile} deleteFile={deleteFile}/>
       </form>
 

--- a/app/javascript/components/upload/GeneListFileForm.js
+++ b/app/javascript/components/upload/GeneListFileForm.js
@@ -14,7 +14,7 @@ export default function GeneListFileForm({
 }) {
   return <div className="row top-margin" key={file._id}>
     <div className="col-md-12">
-      <form id={`misc-file-form-${file._id}`}
+      <form id={`gene-list-form-${file._id}`}
         className="form-terra"
         onSubmit={e => e.preventDefault()}
         acceptCharset="UTF-8">

--- a/app/javascript/components/upload/GeneListStep.js
+++ b/app/javascript/components/upload/GeneListStep.js
@@ -1,0 +1,71 @@
+import React, { useEffect } from 'react'
+
+import GeneListFileForm from './GeneListFileForm'
+import { AddFileButton } from './form-components'
+
+const DEFAULT_NEW_GENE_LIST_FILE = {
+  file_type: 'Gene List',
+  options: {}
+}
+
+const geneListFileFilter = file => file.file_type === 'Gene List'
+
+export default {
+  title: 'Mean Expression Lists',
+  name: 'geneLists',
+  component: GeneListForm,
+  fileFilter: geneListFileFilter
+}
+
+/** Renders a form for uploading one or more miscellaneous files */
+function GeneListForm({
+  formState,
+  addNewFile,
+  updateFile,
+  saveFile,
+  deleteFile,
+  handleSaveResponse
+}) {
+  const geneListFiles = formState.files.filter(geneListFileFilter)
+
+  useEffect(() => {
+    if (geneListFiles.length === 0) {
+      addNewFile(DEFAULT_NEW_GENE_LIST_FILE)
+    }
+  }, [geneListFiles.length])
+
+  return <div>
+    <div className="row">
+      <h4 className="col-sm-12">Mean Expression Lists</h4>
+    </div>
+    <div className="row">
+      <div className="col-md-12">
+        <div className="form-terra">
+          <p>
+            A list of genes and their mean expression values across any clusters.
+          </p>
+          <pre>
+            GENE NAMES&#9;Cluster1&#9;Cluster2<br/>Grm2&#9;6.39&#9;1.96<br/>C1ql3&#9;6.66&#9;2.05
+          </pre>
+          <p>
+            The file must be tab- or comma-delimited plain text (.txt) with the value &quot;GENE NAMES&quot; in the first column, and cluster names in each successive column.
+            <br/>
+            <a href="https://raw.githubusercontent.com/broadinstitute/single_cell_portal/master/demo_data/marker_gene_list_example.txt" target="_blank" rel="noreferrer noopener">
+              Example file
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+    { geneListFiles.map(file => {
+      return <GeneListFileForm
+        key={file._id}
+        file={file}
+        updateFile={updateFile}
+        saveFile={saveFile}
+        deleteFile={deleteFile}
+        handleSaveResponse={handleSaveResponse}/>
+    })}
+    <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_GENE_LIST_FILE}/>
+  </div>
+}

--- a/app/javascript/components/upload/ImageFileForm.js
+++ b/app/javascript/components/upload/ImageFileForm.js
@@ -54,9 +54,7 @@ export default function ImageFileForm({
               onChange={val => updateCorrespondingClusters(file, val)}/>
           </label>
         </div>
-        <div className="form-group">
-          <TextFormField label="Description / Legend (this will be displayed below image)" fieldName="description" file={file} updateFile={updateFile}/>
-        </div>
+        <TextFormField label="Description / Legend (this will be displayed below image)" fieldName="description" file={file} updateFile={updateFile}/>
         <SaveDeleteButtons file={file} updateFile={updateFile} saveFile={saveFile} deleteFile={deleteFile}/>
       </form>
       <SavingOverlay file={file} updateFile={updateFile}/>

--- a/app/javascript/components/upload/MetadataStep.js
+++ b/app/javascript/components/upload/MetadataStep.js
@@ -121,9 +121,8 @@ function MetadataForm({
                 rel="noopener noreferrer">how to convert your file.</a><br/>
               If the file fails metadata convention validation, you will be emailed messages to help correct it.
             </div>
-            <div className="form-group">
-              <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
-            </div>
+            <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
+
             <SaveDeleteButtons file={file} updateFile={updateFile} saveFile={saveFile} deleteFile={deleteFile}/>
           </form>
           <SavingOverlay file={file} updateFile={updateFile}/>

--- a/app/javascript/components/upload/MiscellaneousFileForm.js
+++ b/app/javascript/components/upload/MiscellaneousFileForm.js
@@ -35,9 +35,9 @@ export default function MiscellaneousFileForm({
               onChange={val => updateFile(file._id, {file_type: val.value})}/>
           </label>
         </div>
-        <div className="form-group">
-          <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
-        </div>
+
+        <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
+
         <SaveDeleteButtons file={file} updateFile={updateFile} saveFile={saveFile} deleteFile={deleteFile}/>
       </form>
 

--- a/app/javascript/components/upload/SequenceFileForm.js
+++ b/app/javascript/components/upload/SequenceFileForm.js
@@ -102,9 +102,8 @@ export default function SequenceFileForm({
             </label>
           </div>
         }
-        <div className="form-group">
-          <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
-        </div>
+        <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
+
         <SaveDeleteButtons file={file} updateFile={updateFile} saveFile={saveFile} deleteFile={deleteFile}/>
         { (file.file_type === 'BAM' || associatedBaiFile) &&
           <BamIndexFileForm parentFile={file}

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -25,10 +25,22 @@ import ProcessedExpressionStep from './ProcessedExpressionStep'
 import MetadataStep from './MetadataStep'
 import MiscellaneousStep from './MiscellaneousStep'
 import SequenceFileStep from './SequenceFileStep'
+import GeneListStep from './GeneListStep'
 import LoadingSpinner from 'lib/LoadingSpinner'
 
 const CHUNK_SIZE = 10000000
-const STEPS = [RawCountsStep, ProcessedExpressionStep, MetadataStep, ClusteringStep, SpatialStep, CoordinateLabelStep, ImageStep, SequenceFileStep, MiscellaneousStep]
+const STEPS = [
+  RawCountsStep,
+  ProcessedExpressionStep,
+  MetadataStep,
+  ClusteringStep,
+  SpatialStep,
+  CoordinateLabelStep,
+  ImageStep,
+  SequenceFileStep,
+  GeneListStep,
+  MiscellaneousStep
+]
 
 /** shows the upload wizard */
 export default function UploadWizard({ studyAccession, name }) {

--- a/test/js/explore/scatter-tab.test.js
+++ b/test/js/explore/scatter-tab.test.js
@@ -75,7 +75,8 @@ const MOCK_EXPLORE_RESPONSE = {
   inferCNVIdeogramFiles: null,
   spatialGroups: [],
   taxonNames: ['Gallus gallus'],
-  uniqueGenes: ['Foo', 'Bar']
+  uniqueGenes: ['Foo', 'Bar'],
+  imageFiles: []
 }
 
 beforeAll(() => {


### PR DESCRIPTION
SCP-3723.  Adding a gene list form to the new react wizard.  I'm curious to get some feedback here and at demo of renaming 'Gene Lists' externally to 'Mean Expression Lists' or something similarly more descriptive and less easily confused with 10x gene lists.  Maybe something even more generic like "Analysis tables"?

![image](https://user-images.githubusercontent.com/2800795/135464867-7143d88d-7709-4be7-bb49-a1040de3c790.png)

 Nothing much to see here technically--very similar to the other forms.  At this stage, I'm very much erring on the side of making the forms easy to independently edit and change rather than DRYing them out.  As the UX crystallizes we can start factoring out more common UX (e.g. the form heading styles).  

This PR also cleans out some redundant divs.  TextFormField is already wrapped in a 'form-group' div

