### PR TITLE
Complete adding download links (SCP-3719)

### DIFF
--- a/app/javascript/components/download/FileDownloadControl.js
+++ b/app/javascript/components/download/FileDownloadControl.js
@@ -27,11 +27,11 @@ export default function FileDownloadControl({ file, bucketName }) {
     } else {
       return <p>
         <br></br>
-        {!file.generation ? <span className="label label-warning no-download-available" data-toggle="tooltip"
+        {!file.generation ? <span style={{ marginLeft: '5px' }} className="label label-warning no-download-available" data-toggle="tooltip"
           title='You can download this file once it has been fully uploaded. Check back soon.'>
           {<span className="fas fa-ban"></span> } Awaiting remote file
         </span> :
-          <a onClick={() => handleDownloadClick()} className="btn action">
+          <a onClick={() => handleDownloadClick()} className="btn action" style={{ marginLeft: '5px' }} >
             {<span className="fas fa-download"></span> } {bytesToSize(file.upload_file_size)}
           </a>
         }

--- a/app/javascript/components/download/FileDownloadControl.js
+++ b/app/javascript/components/download/FileDownloadControl.js
@@ -18,23 +18,18 @@ export default function FileDownloadControl({ file, bucketName }) {
     return URL.createObjectURL(fileBlob)
   }
 
-  if (!file.upload_file_name) {
+  if (!file.upload_file_name || file.human_data) {
     return null
   } else {
-    if (!file.upload_file_name && file.human_data) {
-      return null
-    // TODO (SCP-3719): Once the Sequence Data tab is added update this section for handling external human data files
-    } else {
-      return <p style={{ display: 'inline' }} >
-        {!file.generation ? <span style={{ display: '5px' }} className="label label-warning no-download-available" data-toggle="tooltip"
-          title='You can download this file once it has been fully uploaded. Check back soon.'>
-          {<span className="fas fa-ban"></span> } Awaiting remote file
-        </span> :
-          <a onClick={() => handleDownloadClick()} className="btn action" style={{ marginLeft: '5px' }} >
-            {<span className="fas fa-download"></span> } {bytesToSize(file.upload_file_size)}
-          </a>
-        }
-      </p>
-    }
+    return <p style={{ display: 'inline' }} >
+      {!file.generation ? <span style={{ marginLeft: '5px' }} className="label label-warning no-download-available" data-toggle="tooltip"
+        title='You can download this file once it has been fully uploaded. Check back soon.'>
+        {<span className="fas fa-ban"></span> } Awaiting remote file
+      </span> :
+        <a onClick={() => handleDownloadClick()} className="btn action" style={{ marginLeft: '5px' }} >
+          {<span className="fas fa-download"></span> } {bytesToSize(file.upload_file_size)}
+        </a>
+      }
+    </p>
   }
 }

--- a/app/javascript/components/download/FileDownloadControl.js
+++ b/app/javascript/components/download/FileDownloadControl.js
@@ -25,9 +25,8 @@ export default function FileDownloadControl({ file, bucketName }) {
       return null
     // TODO (SCP-3719): Once the Sequence Data tab is added update this section for handling external human data files
     } else {
-      return <p>
-        <br></br>
-        {!file.generation ? <span style={{ marginLeft: '5px' }} className="label label-warning no-download-available" data-toggle="tooltip"
+      return <p style={{ display: 'inline' }} >
+        {!file.generation ? <span style={{ display: '5px' }} className="label label-warning no-download-available" data-toggle="tooltip"
           title='You can download this file once it has been fully uploaded. Check back soon.'>
           {<span className="fas fa-ban"></span> } Awaiting remote file
         </span> :

--- a/app/javascript/components/upload/ClusteringFileForm.js
+++ b/app/javascript/components/upload/ClusteringFileForm.js
@@ -2,7 +2,6 @@ import React from 'react'
 
 import Select from 'lib/InstrumentedSelect'
 import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
-import FileDownloadControl from 'components/download/FileDownloadControl'
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './form-components'
 
 
@@ -24,17 +23,12 @@ export default function ClusteringFileForm({
         className="form-terra"
         onSubmit={e => e.preventDefault()}
         acceptCharset="UTF-8">
-        <div className="flexbox-align-center">
-          <FileUploadControl
-            handleSaveResponse={handleSaveResponse}
-            file={file}
-            updateFile={updateFile}
-            allowedFileTypes={FileTypeExtensions.plainText}/>
-          <FileDownloadControl
-            file={file}
-            bucketName={bucketName}
-          />
-        </div>
+        <FileUploadControl
+          handleSaveResponse={handleSaveResponse}
+          file={file}
+          updateFile={updateFile}
+          allowedFileTypes={FileTypeExtensions.plainText}
+          bucketName={bucketName}/>
         <TextFormField label="Name" fieldName="name" file={file} updateFile={updateFile}/>
         { file.is_spatial &&
           <div className="form-group">

--- a/app/javascript/components/upload/CoordinateLabelFileForm.js
+++ b/app/javascript/components/upload/CoordinateLabelFileForm.js
@@ -2,6 +2,7 @@ import React from 'react'
 
 import Select from 'lib/InstrumentedSelect'
 import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
+import FileDownloadControl from 'components/download/FileDownloadControl'
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './form-components'
 
 /** renders a form for editing/uploading an image file */
@@ -12,7 +13,8 @@ export default function CoordinateLabelForm({
   deleteFile,
   handleSaveResponse,
   associatedClusterFileOptions,
-  updateCorrespondingClusters
+  updateCorrespondingClusters,
+  bucketName
 }) {
 
   const associatedCluster = associatedClusterFileOptions.find(opt => opt.value === file.options.cluster_file_id)
@@ -24,12 +26,16 @@ export default function CoordinateLabelForm({
         onSubmit={e => e.preventDefault()}
         acceptCharset="UTF-8">
         <div className="row">
-          <div className="col-md-12">
+          <div className="col-md-12 flexbox-align-center">
             <FileUploadControl
               handleSaveResponse={handleSaveResponse}
               file={file}
               updateFile={updateFile}
               allowedFileTypes={FileTypeExtensions.plainText}/>
+            <FileDownloadControl
+              file={file}
+              bucketName={bucketName}
+            />
           </div>
         </div>
         <div className="form-group">

--- a/app/javascript/components/upload/CoordinateLabelFileForm.js
+++ b/app/javascript/components/upload/CoordinateLabelFileForm.js
@@ -2,7 +2,6 @@ import React from 'react'
 
 import Select from 'lib/InstrumentedSelect'
 import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
-import FileDownloadControl from 'components/download/FileDownloadControl'
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './form-components'
 
 /** renders a form for editing/uploading an image file */
@@ -26,16 +25,13 @@ export default function CoordinateLabelForm({
         onSubmit={e => e.preventDefault()}
         acceptCharset="UTF-8">
         <div className="row">
-          <div className="col-md-12 flexbox-align-center">
+          <div className="col-md-12">
             <FileUploadControl
               handleSaveResponse={handleSaveResponse}
               file={file}
               updateFile={updateFile}
-              allowedFileTypes={FileTypeExtensions.plainText}/>
-            <FileDownloadControl
-              file={file}
-              bucketName={bucketName}
-            />
+              allowedFileTypes={FileTypeExtensions.plainText}
+              bucketName={bucketName}/>
           </div>
         </div>
         <div className="form-group">

--- a/app/javascript/components/upload/CoordinateLabelStep.js
+++ b/app/javascript/components/upload/CoordinateLabelStep.js
@@ -88,7 +88,9 @@ function CoordinateLabelForm({
         deleteFile={deleteFile}
         handleSaveResponse={handleSaveResponse}
         associatedClusterFileOptions={associatedClusterFileOptions}
-        updateCorrespondingClusters={updateCorrespondingClusters}/>
+        updateCorrespondingClusters={updateCorrespondingClusters}
+        bucketName={formState.study.bucket_id}
+        />
     })}
     <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_LABEL_FILE}/>
   </div>

--- a/app/javascript/components/upload/ExpressionFileForm.js
+++ b/app/javascript/components/upload/ExpressionFileForm.js
@@ -4,6 +4,8 @@ import _kebabCase from 'lodash/kebabCase'
 import Select from 'lib/InstrumentedSelect'
 import MTXBundledFilesForm from './MTXBundledFilesForm'
 import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
+import FileDownloadControl from 'components/download/FileDownloadControl'
+
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './form-components'
 
 /** renders a form for editing/uploading an expression file (raw or processed) and any bundle children */
@@ -15,7 +17,8 @@ export default function ExpressionFileForm({
   addNewFile,
   handleSaveResponse,
   fileMenuOptions,
-  associatedChildren
+  associatedChildren,
+  bucketName
 }) {
 
   const speciesOptions = fileMenuOptions.species.map(spec => ({ label: spec.common_name, value: spec.id }))
@@ -28,12 +31,17 @@ export default function ExpressionFileForm({
         className="form-terra"
         onSubmit={e => e.preventDefault()}
         acceptCharset="UTF-8">
-
-        <FileUploadControl
-          handleSaveResponse={handleSaveResponse}
-          file={file}
-          updateFile={updateFile}
-          allowedFileTypes={isMtxFile ? FileTypeExtensions.mtx : FileTypeExtensions.plainText}/>
+        <div className='flexbox-align-center'>
+          <FileUploadControl
+            handleSaveResponse={handleSaveResponse}
+            file={file}
+            updateFile={updateFile}
+            allowedFileTypes={isMtxFile ? FileTypeExtensions.mtx : FileTypeExtensions.plainText}/>
+          <FileDownloadControl
+            file={file}
+            bucketName={bucketName}
+          />
+        </div>
         <div className="form-group">
           <label>Matrix file type:</label><br/>
           <label className="sublabel">

--- a/app/javascript/components/upload/ExpressionFileForm.js
+++ b/app/javascript/components/upload/ExpressionFileForm.js
@@ -4,7 +4,6 @@ import _kebabCase from 'lodash/kebabCase'
 import Select from 'lib/InstrumentedSelect'
 import MTXBundledFilesForm from './MTXBundledFilesForm'
 import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
-import FileDownloadControl from 'components/download/FileDownloadControl'
 
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './form-components'
 
@@ -31,17 +30,12 @@ export default function ExpressionFileForm({
         className="form-terra"
         onSubmit={e => e.preventDefault()}
         acceptCharset="UTF-8">
-        <div className='flexbox-align-center'>
-          <FileUploadControl
-            handleSaveResponse={handleSaveResponse}
-            file={file}
-            updateFile={updateFile}
-            allowedFileTypes={isMtxFile ? FileTypeExtensions.mtx : FileTypeExtensions.plainText}/>
-          <FileDownloadControl
-            file={file}
-            bucketName={bucketName}
-          />
-        </div>
+        <FileUploadControl
+          handleSaveResponse={handleSaveResponse}
+          file={file}
+          updateFile={updateFile}
+          allowedFileTypes={isMtxFile ? FileTypeExtensions.mtx : FileTypeExtensions.plainText}
+          bucketName={bucketName}/>
         <div className="form-group">
           <label>Matrix file type:</label><br/>
           <label className="sublabel">
@@ -102,7 +96,7 @@ export default function ExpressionFileForm({
 
         <SaveDeleteButtons file={file} updateFile={updateFile} saveFile={saveFile} deleteFile={deleteFile}/>
         { isMtxFile &&
-          <MTXBundledFilesForm {...{ parentFile: file, updateFile, saveFile, deleteFile, handleSaveResponse, addNewFile, associatedChildren }}/>
+          <MTXBundledFilesForm {...{ parentFile: file, updateFile, saveFile, deleteFile, handleSaveResponse, addNewFile, associatedChildren, bucketName }}/>
         }
 
       </form>

--- a/app/javascript/components/upload/FileUploadControl.js
+++ b/app/javascript/components/upload/FileUploadControl.js
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { bytesToSize } from 'lib/stats'
+import FileDownloadControl from 'components/download/FileDownloadControl'
 
 const plainTextExtensions = ['.txt', '.tsv', '.text', '.csv']
 const mtxExtensions = ['.mtx', '.mm', '.txt', '.text']
@@ -13,7 +14,7 @@ export const FileTypeExtensions = {
 }
 
 /** renders a file upload control for the given file object */
-export default function FileUploadControl({ file, updateFile, handleSaveResponse, allowedFileTypes=['*'] }) {
+export default function FileUploadControl({ file, updateFile, handleSaveResponse, allowedFileTypes=['*'], bucketName }) {
   const inputId = `fileInput-${file._id}`
 
   /** handle user interaction with the file input */
@@ -27,6 +28,10 @@ export default function FileUploadControl({ file, updateFile, handleSaveResponse
 
   return <div className="form-group">
     <label>File{ file.status !== 'new' && <span>: {file.upload_file_name}</span> }</label>
+    <FileDownloadControl
+      file={file}
+      bucketName={bucketName}
+    />
     <br/>
     <button className="fileinput-button btn btn-secondary" id={`fileButton-${file._id}`}>
       { file.upload_file_name ? 'Change file' : 'Choose file' }

--- a/app/javascript/components/upload/GeneListFileForm.js
+++ b/app/javascript/components/upload/GeneListFileForm.js
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import FileUploadControl from './FileUploadControl'
-import FileDownloadControl from 'components/download/FileDownloadControl'
 
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './form-components'
 
@@ -22,15 +21,12 @@ export default function GeneListFileForm({
         onSubmit={e => e.preventDefault()}
         acceptCharset="UTF-8">
         <div className="row">
-          <div className="col-md-12 flexbox-align-center">
+          <div className="col-md-12">
             <FileUploadControl
               handleSaveResponse={handleSaveResponse}
               file={file}
-              updateFile={updateFile}/>
-            <FileDownloadControl
-              file={file}
-              bucketName={bucketName}
-            />
+              updateFile={updateFile}
+              bucketName={bucketName}/>
           </div>
         </div>
 

--- a/app/javascript/components/upload/GeneListFileForm.js
+++ b/app/javascript/components/upload/GeneListFileForm.js
@@ -1,6 +1,8 @@
 import React from 'react'
 
 import FileUploadControl from './FileUploadControl'
+import FileDownloadControl from 'components/download/FileDownloadControl'
+
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './form-components'
 
 /** renders a form for editing/uploading a miscellaneous file */
@@ -10,7 +12,8 @@ export default function GeneListFileForm({
   saveFile,
   deleteFile,
   handleSaveResponse,
-  miscFileTypes
+  miscFileTypes,
+  bucketName
 }) {
   return <div className="row top-margin" key={file._id}>
     <div className="col-md-12">
@@ -19,11 +22,15 @@ export default function GeneListFileForm({
         onSubmit={e => e.preventDefault()}
         acceptCharset="UTF-8">
         <div className="row">
-          <div className="col-md-12">
+          <div className="col-md-12 flexbox-align-center">
             <FileUploadControl
               handleSaveResponse={handleSaveResponse}
               file={file}
               updateFile={updateFile}/>
+            <FileDownloadControl
+              file={file}
+              bucketName={bucketName}
+            />
           </div>
         </div>
 

--- a/app/javascript/components/upload/GeneListStep.js
+++ b/app/javascript/components/upload/GeneListStep.js
@@ -64,7 +64,9 @@ function GeneListForm({
         updateFile={updateFile}
         saveFile={saveFile}
         deleteFile={deleteFile}
-        handleSaveResponse={handleSaveResponse}/>
+        handleSaveResponse={handleSaveResponse}
+        bucketName={formState.study.bucket_id}
+        />
     })}
     <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_GENE_LIST_FILE}/>
   </div>

--- a/app/javascript/components/upload/ImageFileForm.js
+++ b/app/javascript/components/upload/ImageFileForm.js
@@ -4,7 +4,6 @@ import Select from 'lib/InstrumentedSelect'
 import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './form-components'
 import BucketImage from 'components/visualization/BucketImage'
-import FileDownloadControl from 'components/download/FileDownloadControl'
 
 /** renders a form for editing/uploading an image file */
 export default function ImageFileForm({
@@ -31,16 +30,13 @@ export default function ImageFileForm({
         onSubmit={e => e.preventDefault()}
         acceptCharset="UTF-8">
         <div className="row">
-          <div className="col-md-6 flexbox-align-center">
+          <div className="col-md-6">
             <FileUploadControl
               handleSaveResponse={handleSaveResponse}
               file={file}
               updateFile={updateFile}
-              allowedFileTypes={FileTypeExtensions.image}/>
-            <FileDownloadControl
-              file={file}
-              bucketName={bucketName}
-            />
+              allowedFileTypes={FileTypeExtensions.image}
+              bucketName={bucketName}/>
           </div>
           <div className="col-md-6">
             { file.uploadSelection && <img className="preview-image" src={imagePreviewUrl} alt={file.uploadSelection.name} /> }

--- a/app/javascript/components/upload/MTXBundledFilesForm.js
+++ b/app/javascript/components/upload/MTXBundledFilesForm.js
@@ -32,7 +32,8 @@ export default function MTXBundledFilesForm({
   deleteFile,
   addNewFile,
   handleSaveResponse,
-  associatedChildren
+  associatedChildren,
+  bucketName
 }) {
   const barcodesFile = associatedChildren.find(f => f.file_type === '10X Barcodes File')
   const genesFile = associatedChildren.find(f => f.file_type === '10X Genes File')
@@ -72,7 +73,8 @@ export default function MTXBundledFilesForm({
             handleSaveResponse={handleSaveResponse}
             file={genesFile}
             updateFile={updateFile}
-            allowedFileTypes={FileTypeExtensions.plainText}/>
+            allowedFileTypes={FileTypeExtensions.plainText}
+            bucketName={bucketName}/>
           <TextFormField label="Description" fieldName="description" file={genesFile} updateFile={updateFile}/>
           <SaveDeleteButtons
             file={genesFile}
@@ -93,7 +95,8 @@ export default function MTXBundledFilesForm({
             handleSaveResponse={handleSaveResponse}
             file={barcodesFile}
             updateFile={updateFile}
-            allowedFileTypes={FileTypeExtensions.plainText}/>
+            allowedFileTypes={FileTypeExtensions.plainText}
+            bucketName={bucketName}/>
           <TextFormField label="Description" fieldName="description" file={barcodesFile} updateFile={updateFile}/>
           <SaveDeleteButtons
             file={barcodesFile}

--- a/app/javascript/components/upload/MetadataStep.js
+++ b/app/javascript/components/upload/MetadataStep.js
@@ -3,7 +3,6 @@ import metadataExplainerImage from 'images/metadata-convention-explainer.jpg'
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Popover, OverlayTrigger } from 'react-bootstrap'
-import FileDownloadControl from 'components/download/FileDownloadControl'
 
 
 import { UserContext } from 'providers/UserProvider'
@@ -81,16 +80,13 @@ function MetadataForm({
             acceptCharset="UTF-8"
             onSubmit={() => {return false}}>
             <div className="row">
-              <div className="col-md-12 flexbox-align-center">
+              <div className="col-md-12">
                 <FileUploadControl
                   handleSaveResponse={handleSaveResponse}
                   file={file}
                   updateFile={updateFile}
-                  allowedFileTypes={FileTypeExtensions.plainText}/>
-                <FileDownloadControl
-                  file={file}
-                  bucketName={formState.study.bucket_id}
-                />
+                  allowedFileTypes={FileTypeExtensions.plainText}
+                  bucketName={formState.study.bucket_id}/>
               </div>
             </div>
             <div className="form-group">

--- a/app/javascript/components/upload/MetadataStep.js
+++ b/app/javascript/components/upload/MetadataStep.js
@@ -73,7 +73,6 @@ function MetadataForm({
         </div>
       </div>
     </div>
-
     { file &&
       <div className="row top-margin" key={file._id}>
         <div className="col-md-12 ">

--- a/app/javascript/components/upload/MiscellaneousFileForm.js
+++ b/app/javascript/components/upload/MiscellaneousFileForm.js
@@ -2,7 +2,6 @@ import React from 'react'
 
 import Select from 'lib/InstrumentedSelect'
 import FileUploadControl from './FileUploadControl'
-import FileDownloadControl from 'components/download/FileDownloadControl'
 
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './form-components'
 
@@ -23,15 +22,12 @@ export default function MiscellaneousFileForm({
         onSubmit={e => e.preventDefault()}
         acceptCharset="UTF-8">
         <div className="row">
-          <div className="col-md-12 flexbox-align-center">
+          <div className="col-md-12">
             <FileUploadControl
               handleSaveResponse={handleSaveResponse}
               file={file}
-              updateFile={updateFile}/>
-            <FileDownloadControl
-              file={file}
-              bucketName={bucketName}
-            />
+              updateFile={updateFile}
+              bucketName={bucketName}/>
           </div>
         </div>
         <div className="form-group">

--- a/app/javascript/components/upload/MiscellaneousFileForm.js
+++ b/app/javascript/components/upload/MiscellaneousFileForm.js
@@ -2,6 +2,8 @@ import React from 'react'
 
 import Select from 'lib/InstrumentedSelect'
 import FileUploadControl from './FileUploadControl'
+import FileDownloadControl from 'components/download/FileDownloadControl'
+
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './form-components'
 
 /** renders a form for editing/uploading a miscellaneous file */
@@ -11,7 +13,8 @@ export default function MiscellaneousFileForm({
   saveFile,
   deleteFile,
   handleSaveResponse,
-  miscFileTypes
+  miscFileTypes,
+  bucketName
 }) {
   return <div className="row top-margin" key={file._id}>
     <div className="col-md-12">
@@ -20,11 +23,15 @@ export default function MiscellaneousFileForm({
         onSubmit={e => e.preventDefault()}
         acceptCharset="UTF-8">
         <div className="row">
-          <div className="col-md-12">
+          <div className="col-md-12 flexbox-align-center">
             <FileUploadControl
               handleSaveResponse={handleSaveResponse}
               file={file}
               updateFile={updateFile}/>
+            <FileDownloadControl
+              file={file}
+              bucketName={bucketName}
+            />
           </div>
         </div>
         <div className="form-group">

--- a/app/javascript/components/upload/MiscellaneousStep.js
+++ b/app/javascript/components/upload/MiscellaneousStep.js
@@ -54,7 +54,9 @@ function MiscellaneousForm({
         saveFile={saveFile}
         deleteFile={deleteFile}
         miscFileTypes={miscFileTypes}
-        handleSaveResponse={handleSaveResponse}/>
+        handleSaveResponse={handleSaveResponse}
+        bucketName={formState.study.bucket_id}
+        />
     })}
     <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_OTHER_FILE}/>
   </div>

--- a/app/javascript/components/upload/ProcessedExpressionStep.js
+++ b/app/javascript/components/upload/ProcessedExpressionStep.js
@@ -109,7 +109,8 @@ function ProcessedUploadForm({
           addNewFile={addNewFile}
           handleSaveResponse={handleSaveResponse}
           fileMenuOptions={fileMenuOptions}
-          associatedChildren={associatedChildren}/>
+          associatedChildren={associatedChildren}
+          bucketName={formState.study.bucket_id}/>
       })}
       <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_PROCESSED_FILE}/>
     </> }

--- a/app/javascript/components/upload/RawCountsStep.js
+++ b/app/javascript/components/upload/RawCountsStep.js
@@ -69,7 +69,8 @@ function RawCountsUploadForm({
         addNewFile={addNewFile}
         handleSaveResponse={handleSaveResponse}
         fileMenuOptions={fileMenuOptions}
-        associatedChildren={associatedChildren}/>
+        associatedChildren={associatedChildren}
+        bucketName={formState.study.bucket_id}/>
     })}
     <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_RAW_COUNTS_FILE}/>
   </div>

--- a/app/javascript/components/upload/SequenceFileForm.js
+++ b/app/javascript/components/upload/SequenceFileForm.js
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react'
 
 import Select from 'lib/InstrumentedSelect'
 import FileUploadControl from './FileUploadControl'
-import FileDownloadControl from 'components/download/FileDownloadControl'
 
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './form-components'
 
@@ -56,15 +55,12 @@ export default function SequenceFileForm({
         </div>
         { !file.human_data && <>
           <div className="row">
-            <div className="col-md-12 flexbox-align-center">
+            <div className="col-md-12">
               <FileUploadControl
                 handleSaveResponse={handleSaveResponse}
                 file={file}
-                updateFile={updateFile}/>
-              <FileDownloadControl
-                file={file}
-                bucketName={bucketName}
-              />
+                updateFile={updateFile}
+                bucketName={bucketName}/>
             </div>
           </div>
           <div className="form-group">
@@ -174,16 +170,11 @@ function BamIndexFileForm({
     <div className="col-md-12 ">
       <div className="sub-form">
         <h5>BAM Index File</h5>
-        <div className='flexbox-align-center'>
-          <FileUploadControl
-            handleSaveResponse={handleSaveResponse}
-            file={file}
-            updateFile={updateFile}/>
-          <FileDownloadControl
-            file={file}
-            bucketName={bucketName}
-          />
-        </div>
+        <FileUploadControl
+          handleSaveResponse={handleSaveResponse}
+          file={file}
+          updateFile={updateFile}
+          bucketName={bucketName}/>
         <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
         <SaveDeleteButtons
           file={file}

--- a/app/javascript/components/upload/SequenceFileForm.js
+++ b/app/javascript/components/upload/SequenceFileForm.js
@@ -2,6 +2,8 @@ import React, { useEffect } from 'react'
 
 import Select from 'lib/InstrumentedSelect'
 import FileUploadControl from './FileUploadControl'
+import FileDownloadControl from 'components/download/FileDownloadControl'
+
 import { TextFormField, SavingOverlay, SaveDeleteButtons } from './form-components'
 
 /** renders a form for editing/uploading a sequence file and any assoicated bundle files */
@@ -14,7 +16,8 @@ export default function SequenceFileForm({
   handleSaveResponse,
   sequenceFileTypes,
   fileMenuOptions,
-  associatedBaiFile
+  associatedBaiFile,
+  bucketName
 }) {
   const speciesOptions = fileMenuOptions.species.map(spec => ({ label: spec.common_name, value: spec.id }))
   const selectedSpecies = speciesOptions.find(opt => opt.value === file.taxon_id)
@@ -53,11 +56,15 @@ export default function SequenceFileForm({
         </div>
         { !file.human_data && <>
           <div className="row">
-            <div className="col-md-12">
+            <div className="col-md-12 flexbox-align-center">
               <FileUploadControl
                 handleSaveResponse={handleSaveResponse}
                 file={file}
                 updateFile={updateFile}/>
+              <FileDownloadControl
+                file={file}
+                bucketName={bucketName}
+              />
             </div>
           </div>
           <div className="form-group">
@@ -112,7 +119,8 @@ export default function SequenceFileForm({
             saveFile={saveFile}
             deleteFile={deleteFile}
             handleSaveResponse={handleSaveResponse}
-            addNewFile={addNewFile}/>
+            addNewFile={addNewFile}
+            bucketName={bucketName}/>
         }
 
       </form>
@@ -130,7 +138,8 @@ function BamIndexFileForm({
   saveFile,
   deleteFile,
   addNewFile,
-  handleSaveResponse
+  handleSaveResponse,
+  bucketName
 }) {
   let validationMessage = ''
   // don't allow saving until parent file is saved
@@ -165,10 +174,16 @@ function BamIndexFileForm({
     <div className="col-md-12 ">
       <div className="sub-form">
         <h5>BAM Index File</h5>
-        <FileUploadControl
-          handleSaveResponse={handleSaveResponse}
-          file={file}
-          updateFile={updateFile}/>
+        <div className='flexbox-align-center'>
+          <FileUploadControl
+            handleSaveResponse={handleSaveResponse}
+            file={file}
+            updateFile={updateFile}/>
+          <FileDownloadControl
+            file={file}
+            bucketName={bucketName}
+          />
+        </div>
         <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
         <SaveDeleteButtons
           file={file}

--- a/app/javascript/components/upload/SequenceFileStep.js
+++ b/app/javascript/components/upload/SequenceFileStep.js
@@ -79,7 +79,8 @@ function SequenceForm({
         sequenceFileTypes={sequenceFileTypes}
         fileMenuOptions={serverState.menu_options}
         handleSaveResponse={handleSaveResponse}
-        associatedBaiFile={associatedBaiFile}/>
+        associatedBaiFile={associatedBaiFile}
+        bucketName={formState.study.bucket_id}/>
     })}
     <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_SEQUENCE_FILE}/>
   </div>


### PR DESCRIPTION
Add download links to the remaining new file types and update the style to be ready for file validation.

To test: flip on the feature flag for upload wizard and all the file types should have a download (other than human data sequence files which just have their url as is seen today in the wizard)

Human Data:
<img width="700" alt="Screen Shot 2021-10-05 at 3 38 24 PM" src="https://user-images.githubusercontent.com/54322292/136091706-5292be17-da3f-4d6a-b751-da79adb1c6be.png">

Not Human Data:
<img width="443" alt="Screen Shot 2021-10-05 at 3 37 00 PM" src="https://user-images.githubusercontent.com/54322292/136091741-214d8c99-c785-42c7-aad3-f991a780c43a.png">

Coordinate Labels that is still uploading:
<img width="361" alt="Screen Shot 2021-10-05 at 3 35 52 PM" src="https://user-images.githubusercontent.com/54322292/136091814-05cfd122-5293-4b32-9ac9-19f65727ebe4.png">

Reference image:
<img width="821" alt="Screen Shot 2021-10-05 at 3 20 04 PM" src="https://user-images.githubusercontent.com/54322292/136092076-3332dc4c-976e-4a17-93e0-7c60f2dd7143.png">

