### PR TITLE
Add "Analyze on Terra" button (SCP-3735)

### DIFF
--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -5,7 +5,7 @@
     <h2>Study Files 
       <span class="badge"><%= @study_files.count %></span> 
       <%= link_to "<i class='fas fa-question-circle'></i> Bulk Download".html_safe, '#/', class: "btn btn-default pull-right #{!@allow_downloads ? 'disabled' : nil}", id: 'download-help' %>
-      <%= link_to "Analyze on Terra".html_safe, '#/', class: "btn btn-default pull-right left-margin-icon {!@allow_downloads ? 'disable d' : nil}", id: 'analyze-on-terra' data-analytics-name="analyze-on-terra"%> 
+      <%= link_to "Analyze in Cloud".html_safe, '#/', class: "btn btn-default pull-right left-margin-icon {!@allow_downloads ? 'disable d' : nil}", id: 'analyze-in-cloud'%> 
     </h2>
 
     <% if @allow_downloads %>
@@ -84,20 +84,23 @@
         </div>
       </div>
     </div>
-    <div class="modal fade" id="analyze-on-terra-modal" role="dialog" aria-labelledby="required-modal-label" aria-hidden="true">
+    <div class="modal fade" id="analyze-in-cloud-modal" role="dialog" aria-labelledby="required-modal-label" aria-hidden="true">
 	<div class="modal-dialog">
 		<div class="modal-content">
 			<div class="modal-header">
-				<h3 class="text-center">Analyze on Terra?</h3>
+        <button class="close" data-dismiss="modal">×</button>
+				<h3 class="text-center">Cloud Analysis</h3>
 			</div>
 			<div class="modal-body">
-				<p class="lead">Interested in performing analysis with these files? We’re exploring the best ways to send SCP data to 
+				<p class="lead">Interested in performing analysis with these files using cloud-based resources?         
+          <br/> 
+          We’re exploring the best ways to send SCP data to 
           <%= link_to "Terra", "https://terra.bio/", :target => "_blank", id:"analyze-terra-link-to-terra"%>, an open platform for cloud-based genomic analysis.</p>
-        <p class="lead"><%= link_to "Tell us more", "https://singlecell.zendesk.com/hc/en-us/requests/new", :target => "_blank", id:"analyze-terra-form" %>
-          about what you need for analyzing your data!</p>
       </div>
 			<div class="modal-footer">
-				<button class="btn btn-success" data-dismiss="modal" id="accept-skip-required">OK</button>
+      <p class="lead"> Want to tell us more about how you want to analyze this data?</p>
+				<%= link_to "YES", "https://singlecell.zendesk.com/hc/en-us/requests/new", :target => "_blank", id:"analyze-terra-form", class:"btn btn-success" %>
+        <button class="btn btn-danger" href="https://singlecell.zendesk.com/hc/en-us/requests/new" data-dismiss="modal" id="accept-skip-required">NO</button>
 			</div>
 		</div>
 	</div>
@@ -108,8 +111,8 @@
             $('#download-help-modal').modal('show');
         });
 
-        $('#analyze-on-terra').click(function() {
-          $('#analyze-on-terra-modal').modal('show');
+        $('#analyze-in-cloud').click(function() {
+          $('#analyze-in-cloud-modal').modal('show');
       });
         // Enables copying to clipboard upon clicking a "clipboard" icon,
         // like on GitHub.  https://clipboardjs.com.


### PR DESCRIPTION
Add a button to the Study download tab page next to the "Bulk Download" button. This will open a modal which contains links to Terra info page and Zendesk form. Currently it's just the generic Zendesk help submit section, I think we might want to add a specific form about this if that's where we want to be linking?

The analytics will be on mixpanel for clicking this button and for clicking either link in the modal.

To test go to a study and click to the download tab.

Feedback on language is definitely encouraged!

<img width="1169" alt="Screen Shot 2021-10-07 at 5 09 28 PM" src="https://user-images.githubusercontent.com/54322292/136466191-43b3e644-3a19-44ef-928e-7333cf47d7dc.png">
<img width="1021" alt="Screen Shot 2021-10-07 at 5 09 21 PM" src="https://user-images.githubusercontent.com/54322292/136466208-385a7804-be91-401f-b749-7e45b4437e68.png">
