### PR TITLE
add file encoding check (SCP-3668)

### DIFF
--- a/app/javascript/lib/validation/validate-file-content.js
+++ b/app/javascript/lib/validation/validate-file-content.js
@@ -289,13 +289,13 @@ function getLogProps(fileObj, fileType, errorObj) {
 
 /** confirm that the presence/absence of a .gz suffix matches the lead byte of the file */
 export function validateGzipEncoding({ fileName, lines, mimeType }) {
-  const GZIP_LEAD_CHAR = '\x1F'
+  const GZIP_MAGIC_NUMBER = '\x1F'
   if (fileName.endsWith('.gz') && lines[0][0] !== GZIP_LEAD_CHAR) {
-    return [['error', 'file:encoding:invalid-gzip-lead-char',
-      'File has a \'.gz\' suffix but does not appear to be gzipped']]
-  } else if (!fileName.endsWith('.gz') && lines[0][0] === GZIP_LEAD_CHAR) {
-    return [['error', 'file:encoding:missing-gz-suffix',
-      'File appears to be gzipped but does not have a \'.gz\' suffix']]
+    return [['error', 'encoding:invalid-gzip-magic-number',
+      'File has a ".gz" suffix but does not seem to be gzipped']]
+  } else if (!fileName.endsWith('.gz') && lines[0][0] === GZIP_MAGIC_NUMBER) {
+    return [['error', 'encoding:missing-gz-extension',
+      'File seems to be gzipped but does not have a ".gz" extension']]
   }
   return []
 }

--- a/test/js/lib/validate-file-content.test.js
+++ b/test/js/lib/validate-file-content.test.js
@@ -75,18 +75,18 @@ describe('Client-side file validation', () => {
     mockReadLinesAndType({ content: '\x1F\x2E3lkjf3' })
     const { errors } = await validateFileContent({ name: 'c.txt' }, 'Cluster')
     expect(errors).toHaveLength(1)
-    expect(errors[0][1]).toEqual('file:encoding:missing-gz-suffix')
+    expect(errors[0][1]).toEqual('encoding:missing-gz-suffix')
   })
 
   it('catches text file with .gz suffix', async () => {
     mockReadLinesAndType({ content: 'CELL\tX\tY' })
     const { errors } = await validateFileContent({ name: 'c.txt.gz' }, 'Cluster')
     expect(errors).toHaveLength(1)
-    expect(errors[0][1]).toEqual('file:encoding:invalid-gzip-lead-char')
+    expect(errors[0][1]).toEqual('encoding:invalid-gzip-magic-number')
   })
 
   it('passes valid gzip file', async () => {
-    // Confirms no false positive due to comma-separated values
+    // Confirms no false positive due to gzip-related content
     mockReadLinesAndType({ content: '\x1F\x2E3lkjf3' })
     const { errors } = await validateFileContent({ name: 'c.txt.gz' }, 'Cluster')
     expect(errors).toHaveLength(0)


### PR DESCRIPTION
Checks that the file suffix matches the lead character of the actual content by looking for the gzip 'magic character'.  

TO TEST:
1. go to upload wizard with upload wizard react feature flag on
2. go to 'Clustering' tab
3. Click "+ Add File"
4. Click "Choose file"
5. select a valid cluster text file (e.g. cluster.tsv from mouse_brain)
6. confirm it is able to be selected
7. in terminal `db/seed/synthetic_studies/mouse_brain` directory, run `cp cluster.tsv cluster.tsv.gz`
8. Now click 'Replace' and pick `cluster.tsv.gz`
9. Confirm error message shows 'file has gz suffix but is not gzipped'
10. in terminal run `gzip cluster.tsv; mv cluster.tsv.gz cluster_new.tsv`
11. Now click 'Replace' and pick `cluster_new.tsv`
12. confirm error message shows 'file appears to be gzipped but does not have a .gz suffix'