### PR TITLE
Conditionally show Link out in feature announcement (SCP-3822)

### DIFF
--- a/app/views/feature_announcements/view_announcement.html.erb
+++ b/app/views/feature_announcements/view_announcement.html.erb
@@ -1,7 +1,7 @@
 <h2>
   <%= scp_link_to '<<', @feature_announcement.archived? ? archived_feature_announcements_path : latest_feature_announcements_path %>
   <%= @feature_announcement.title %>
-  <% unless @feature_announcement.doc_link.empty? %>
+  <% if @feature_announcement.doc_link.present? %>
     <%= link_to "More Info <i class='fas fa-external-link-alt'></i>".html_safe, @feature_announcement.doc_link,
       class: 'btn btn-default pull-right', target: :_blank, rel: 'noopener noreferrer' %>
   <% end %>


### PR DESCRIPTION
Don't show the "More Info" link if there is no link.

To test create a feature announcement with a link and observe that there is a link. Then edit the announcement and remove the link and save. Then observe that the "More Info" link is no longer shown.

<img width="1120" alt="Screen Shot 2021-10-25 at 12 26 47 PM" src="https://user-images.githubusercontent.com/54322292/138734594-6a788220-947b-4f90-b142-51a1f87212ba.png">
