### PR TITLE
reverting dependabot PR re: datepicker bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "core-js": "^3.6.4",
     "ideogram": "1.30.0",
     "jquery": "3.5.1",
-    "jquery-ui": "1.13.0",
+    "jquery-ui": "1.12.1",
     "morpheus-app": "1.0.18",
     "plotly.js-dist": "2.2.0",
     "pluralize": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8505,12 +8505,10 @@ jest@^26.0.1:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
-jquery-ui@1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.13.0.tgz#ab5ac65f37ca093c51b3478c4097f55bbc008f36"
-  integrity sha512-Osf7ECXNTYHtKBkn9xzbIf9kifNrBhfywFEKxOeB/OVctVmLlouV9mfc2qXCp6uyO4Pn72PXKOnj09qXetopCw==
-  dependencies:
-    jquery ">=1.8.0 <4.0.0"
+jquery-ui@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.12.1.tgz#bcb4045c8dd0539c134bc1488cdd3e768a7a9e51"
+  integrity sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE=
 
 jquery@3.5.1:
   version "3.5.1"


### PR DESCRIPTION
This reverts the dependabot PR #1217 that introduced a bug with `datepicker` that was causing various client-side issues with `jquery-ui`.  This backdates `jquery-ui` to `1.12.1`, and downstream work will be done to determine the root cause of the `datepicker` issue before running the update again.

MANUAL TESTING
1. Pull this branch, and run `yarn install`
2. Boot as normal, and ensure the tooltip loads on the "Browse Collections" button:
![Screen Shot 2021-10-27 at 4 23 12 PM](https://user-images.githubusercontent.com/729968/139141368-10e8ecdf-5b4f-4621-9cca-737b94d209fe.png)

