### PR TITLE
Removing reference to non-existent archived_feature_announcements_path (SCP-3833)

### DIFF
--- a/app/views/feature_announcements/view_announcement.html.erb
+++ b/app/views/feature_announcements/view_announcement.html.erb
@@ -1,5 +1,5 @@
 <h2>
-  <%= scp_link_to '<<', @feature_announcement.archived? ? archived_feature_announcements_path : latest_feature_announcements_path %>
+  <%= scp_link_to '<<', latest_feature_announcements_path %>
   <%= @feature_announcement.title %>
   <% if @feature_announcement.doc_link.present? %>
     <%= link_to "More Info <i class='fas fa-external-link-alt'></i>".html_safe, @feature_announcement.doc_link,


### PR DESCRIPTION
This fixes a bug with archived `FeatureAnnouncement` entries where a reference to a now-obsolete path threw an error.

MANUAL TESTING
1. Boot as normal, sign in as an admin
2. Select "Feature Announcements" from the top-right menu
3. Click "New Announcement", give it a name, enter some text in the editor, and check "Archived?" at the top right
4. Save the announcement, and then click the title for the announcement you just created
5. Ensure the page loads without error, and the `<<` link at the top right takes you back to the "Latest Features" page

This PR satisfies SCP-3833.