### PR TITLE
Update matrix file type names (SCP-3665)

### DIFF
--- a/app/javascript/components/upload/ExpressionFileForm.js
+++ b/app/javascript/components/upload/ExpressionFileForm.js
@@ -57,14 +57,14 @@ export default function ExpressionFileForm({
           value="false"
           checked={!isMtxFile}
           onChange={e => updateFile(file._id, { file_type: 'Expression Matrix' })} />
-          &nbsp;Expression Matrix
+          &nbsp;Dense matrix
       </label>
       <label className="sublabel">
         <input type="radio"
           name={`exp-matrix-type-${file._id}`}
           value="true" checked={isMtxFile}
           onChange={e => updateFile(file._id, { file_type: 'MM Coordinate Matrix' })}/>
-          &nbsp;MM Coordinate Matrix
+          &nbsp;Sparse matrix (.mtx)
       </label>
     </div>
 

--- a/app/javascript/components/upload/MTXBundledFilesForm.js
+++ b/app/javascript/components/upload/MTXBundledFilesForm.js
@@ -54,7 +54,7 @@ export default function MTXBundledFilesForm({
   }, [parentFile._id])
 
   if (!barcodesFile || !genesFile) {
-    return <div>After you&apos;ve selected an mtx file, you&apos;ll be prompted for genes and barcodes files</div>
+    return <div>After you&apos;ve selected an mtx file, you&apos;ll be prompted for features and barcodes files</div>
   }
   const barcodesValidationMessages = validateFile({
     file: barcodesFile, allFiles, allowedFileExts: FileTypeExtensions.plainText
@@ -67,7 +67,7 @@ export default function MTXBundledFilesForm({
     <div className="row">
       <div className="col-md-12 ">
         <div className="sub-form">
-          <h5>10x Genes File</h5>
+          <h5>10x Features File</h5>
           <div className="upload-form-header flexbox-align-center expanded">
             <FileUploadControl
               file={genesFile}

--- a/app/javascript/components/upload/RawCountsStep.js
+++ b/app/javascript/components/upload/RawCountsStep.js
@@ -79,17 +79,17 @@ function RawCountsUploadForm({
 export const expressionFileStructureHelp = <>
   <div className="row">
     <div className="col-sm-6 padded">
-      <a href="https://raw.githubusercontent.com/broadinstitute/single_cell_portal/master/demo_data/expression_example.txt" target="_blank" rel="noreferrer noopener">Expression Matrix</a>
+      <a href="https://raw.githubusercontent.com/broadinstitute/single_cell_portal/master/demo_data/expression_example.txt" target="_blank" rel="noreferrer noopener">Dense matrix</a>
       <pre>GENE&#09;CELL_1&#9;CELL_2&#09;CELL_3&#09;...<br/>It2ma&#09;0&#09;0&#09;0&#09;...<br/>Sergef&#09;0&#09;7.092&#09;0&#09;...<br/>Chil5&#09;0&#09;0&#09;0&#09;...<br/>Fgfr3&#09;0&#9;0&#09;0.978&#09;<br/>...</pre>
-      An “Expression Matrix” is a dense matrix (.txt, .tsv, or .csv)** that has a header row containing the value “GENE” in the first column, and single cell names in each successive column.
+      A “Dense matrix” is a file (.txt, .tsv, or .csv)** that has a header row containing the value “GENE” in the first column, and single cell names in each successive column.
     </div>
     <div className="col-sm-6 padded" >
-      <a href="https://github.com/broadinstitute/single_cell_portal_core/blob/master/test/test_data/GRCh38/matrix.mtx" target="_blank" rel="noreferrer noopener">MM Coordinate Matrix file</a>
+      <a href="https://github.com/broadinstitute/single_cell_portal_core/blob/master/test/test_data/GRCh38/matrix.mtx" target="_blank" rel="noreferrer noopener">Sparse matrix (.mtx)</a>
       <pre>%%MatrixMarket matrix coordinate real general<br/>%<br/>17123 31231 124124<br/>1 1241 1.0<br/>1 1552 2.0<br/>...</pre>
-      An “MM Coordinate Matrix” *, as seen in <a href="https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/output/matrices" target="_blank" rel="noreferrer noopener">10x Genomics</a>
-      &nbsp;is a Matrix Market file (.mtx, .mm, or .txt)** that contains a sparse matrix in coordinate form.<br/>
+      A “Sparse matrix,” as seen in <a href="https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/output/matrices" target="_blank" rel="noreferrer noopener">10x Genomics</a>
+      , is a Matrix Market file (.mtx, .mm, or .txt)** that contains a sparse matrix in coordinate form.<br/>
       You&apos;ll be prompted for the&nbsp;
-      <a href="https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices" target="_blank" rel="noreferrer noopener">genes</a> and&nbsp;
+      <a href="https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices" target="_blank" rel="noreferrer noopener">features</a> and&nbsp;
       <a href="https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices" target="_blank" rel="noreferrer noopener">barcodes</a>
       &nbsp;files after selecting this type.
     </div>

--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -188,7 +188,7 @@ export function addObjectPropertyToForm(obj, propertyName, formData, nested) {
   } else {
     // don't set null properties -- those are ones that haven't changed
     // and having them be sent as 'null' or '' can throw off validations
-    if (obj[propertyName] != null) {
+    if (obj[propertyName] != null && typeof obj[propertyName] != 'undefined') {
       formData.append(propString, obj[propertyName])
     }
   }

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -24,13 +24,13 @@ class StudyFile
   # constants, used for statuses and file types
   STUDY_FILE_TYPES = ['Cluster', 'Coordinate Labels' ,'Expression Matrix', 'MM Coordinate Matrix', '10X Genes File',
                       '10X Barcodes File', 'Gene List', 'Metadata', 'Fastq', 'BAM', 'BAM Index', 'Documentation',
-                      'Other', 'Analysis Output', 'Ideogram Annotations', 'Image']
+                      'Other', 'Analysis Output', 'Ideogram Annotations', 'Image'].freeze
   CUSTOM_FILE_TYPE_NAMES = {
     'MM Coordinate Matrix' => 'Sparse matrix (.mtx)',
     'Expression Matrix' => 'Dense matrix',
     '10X Genes File' => '10X Features File'
-  }
-  STUDY_FILE_TYPE_NAME_HASH = STUDY_FILE_TYPES.reduce({}) { |r, t| r[t] = t; r }.merge(CUSTOM_FILE_TYPE_NAMES)
+  }.freeze
+  STUDY_FILE_TYPE_NAME_HASH = STUDY_FILE_TYPES.reduce({}) { |r, t| r[t] = t; r }.merge(CUSTOM_FILE_TYPE_NAMES).freeze
 
 
   PARSEABLE_TYPES = ['Cluster', 'Coordinate Labels', 'Expression Matrix', 'MM Coordinate Matrix', '10X Genes File',

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -25,6 +25,14 @@ class StudyFile
   STUDY_FILE_TYPES = ['Cluster', 'Coordinate Labels' ,'Expression Matrix', 'MM Coordinate Matrix', '10X Genes File',
                       '10X Barcodes File', 'Gene List', 'Metadata', 'Fastq', 'BAM', 'BAM Index', 'Documentation',
                       'Other', 'Analysis Output', 'Ideogram Annotations', 'Image']
+  CUSTOM_FILE_TYPE_NAMES = {
+    'MM Coordinate Matrix' => 'Sparse matrix (.mtx)',
+    'Expression Matrix' => 'Dense matrix',
+    '10X Genes File' => '10X Features File'
+  }
+  STUDY_FILE_TYPE_NAME_HASH = STUDY_FILE_TYPES.reduce({}) { |r, t| r[t] = t; r }.merge(CUSTOM_FILE_TYPE_NAMES)
+
+
   PARSEABLE_TYPES = ['Cluster', 'Coordinate Labels', 'Expression Matrix', 'MM Coordinate Matrix', '10X Genes File',
                      '10X Barcodes File', 'Gene List', 'Metadata', 'Analysis Output']
   DISALLOWED_SYNC_TYPES = ['Fastq']

--- a/app/views/studies/_study_file_form.html.erb
+++ b/app/views/studies/_study_file_form.html.erb
@@ -44,7 +44,7 @@
   <div class="form-group row">
     <div class="col-sm-4">
       <%= f.label :file_type %><br />
-      <%= f.select :file_type, options_for_select(@file_types, study_file.file_type), {include_blank: 'Please select a file type'}, class: 'form-control file-type' %>
+      <%= f.select :file_type, options_for_select(StudyFile::STUDY_FILE_TYPE_NAME_HASH.invert, study_file.file_type), {include_blank: 'Please select a file type'}, class: 'form-control file-type' %>
     </div>
     <div class="col-sm-4 taxon-select-target">
       <% if StudyFile::TAXON_REQUIRED_TYPES.include?(study_file.file_type) || study_file.file_type == 'Analysis Output' %>

--- a/app/views/studies/_synced_study_file_form.html.erb
+++ b/app/views/studies/_synced_study_file_form.html.erb
@@ -39,7 +39,7 @@
       <i class='fas fa-question-circle' data-toggle="tooltip"
          title="You cannot change the file type of synced files.  Please delete and re-sync the file to change this.">
       </i><br />
-      <%= f.select :file_type, options_for_select(@file_types, study_file.file_type), {}, class: 'form-control file-type' %>
+      <%= f.select :file_type, options_for_select(StudyFile::STUDY_FILE_TYPE_NAME_HASH.invert, study_file.file_type), {}, class: 'form-control file-type' %>
     </div>
     <div class="col-sm-2">
       <%= f.label :upload, 'Download' %><br />

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -1,4 +1,4 @@
-<% if !FeatureFlaggable.merged_value_for('react_upload_wizard', current_user)  %>
+<% if FeatureFlaggable.merged_value_for('react_upload_wizard', current_user)  %>
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
     // populate window.SCP.currentStudyFiles with information about all known StudyFiles
     window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>
@@ -60,8 +60,8 @@
             </div>
             </br>
             <div class="row">
-              <p class="col-sm-12">* You will need to upload the <%= link_to 'genes', 'https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices', target: :_blank, rel: 'noopener noreferrer' %> (.csv or .tsv) and
-                <%= link_to 'barcodes', 'https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices', target: :_blank %> (.tsv or .csv) files separately.</p>
+              <p class="col-sm-12">* You will need to upload the <%= link_to '10x features', 'https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices', target: :_blank, rel: 'noopener noreferrer' %> (.csv or .tsv) and
+                <%= link_to '10x barcodes', 'https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices', target: :_blank %> (.tsv or .csv) files separately.</p>
               <p class="col-sm-12">** <%= link_to 'Gzipped', 'https://www.gnu.org/software/gzip/manual/gzip.html', target: :_blank, rel: 'noopener noreferrer' %>  files of this type (e.g. .txt.gz) are accepted as well</p>
             </div>
           </div>
@@ -127,8 +127,8 @@
             </div>
             </br>
             <div class="row">
-              <p class="col-sm-12">* You will need to upload the <%= link_to 'genes', 'https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices', target: :_blank, rel: 'noopener noreferrer' %> (.csv or .tsv) and
-                <%= link_to 'barcodes', 'https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices', target: :_blank, rel: 'noopener noreferrer' %> (.tsv or .csv) files separately.</p>
+              <p class="col-sm-12">* You will need to upload the <%= link_to '10x features', 'https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices', target: :_blank, rel: 'noopener noreferrer' %> (.csv or .tsv) and
+                <%= link_to '10x barcodes', 'https://kb.10xgenomics.com/hc/en-us/articles/115000794686-How-is-the-MEX-format-used-for-the-gene-barcode-matrices', target: :_blank, rel: 'noopener noreferrer' %> (.tsv or .csv) files separately.</p>
               <p class="col-sm-12">** <%= link_to 'Gzipped', 'https://www.gnu.org/software/gzip/manual/gzip.html', target: :_blank, rel: 'noopener noreferrer' %>  files of this type (e.g. .txt.gz) are accepted as well</p>
             </div>
           </div>


### PR DESCRIPTION
SCP-3665. Following Jean's instructions in the comment.

![image](https://user-images.githubusercontent.com/2800795/139731547-97b3d1d9-585e-4e64-88cc-93f65f34f2e7.png)


TO TEST:
1. launch upload wizard with react upload wizard feature flag
2. observe processed and raw counts tabs, that Dense matrix and Sparse matrix (.mtx) appear as the types to choose from
3. Open sync tool
4. Observe the file type names have been updated in the dropdown.

