### PR TITLE
Log errors in CI to `STDOUT` (SCP-3450)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 dist: bionic
 arch: amd64
+env:
+  - RAILS_LOG_TO_STDOUT=true
 rvm:
   - 2.6.6
 install:

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -23,11 +23,12 @@ class MetricsService
       # puts "Posting to Mixpanel.  Params: #{params}"
       RestClient::Request.execute(params)
     rescue RestClient::Exception => e
-      Rails.logger.error "#{Time.zone.now}: Bard error in call to #{params[:url]}: #{e.message}"
+      # log error, unless this is CI, in which case we don't care
+      Rails.logger.error "#{Time.zone.now}: Bard error in call to #{params[:url]}: #{e.message}" unless ENV['CI']
       # Rails.logger.error e.to_yaml
       if e.http_code != 503
         # TODO (SCP-2632): Refine handling of Bard "503 Service Unavailable" errors
-        ErrorTracker.report_exception(e, user, params)
+        ErrorTracker.report_exception(e, user, params) unless ENV['CI']
       end
     end
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -75,6 +75,13 @@ Rails.application.configure do
   # set MongoDB logging level
   Mongoid.logger.level = Logger::INFO
 
+  if ENV["RAILS_LOG_TO_STDOUT"].present? && ENV['CI']
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.log_level = :error
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
+
   config.bard_host_url = 'https://terra-bard-dev.appspot.com'
 
   # Terra Data Repo API base url

--- a/lib/error_tracker.rb
+++ b/lib/error_tracker.rb
@@ -23,7 +23,7 @@ module ErrorTracker
         context[object.class.name.underscore] = object.attributes.to_h
       end
     end
-    context
+    context.with_indifferent_access
   end
 
   def self.extract_user_identifier(user)

--- a/lib/error_tracker.rb
+++ b/lib/error_tracker.rb
@@ -23,7 +23,7 @@ module ErrorTracker
         context[object.class.name.underscore] = object.attributes.to_h
       end
     end
-    context.with_indifferent_access
+    context
   end
 
   def self.extract_user_identifier(user)


### PR DESCRIPTION
Since logs during CI runs are written to files and not persisted anywhere, getting detailed error information is often impossible when an error occurs at the controller level.  Unit-level tests will usually display a stack trace, since an actual method is invoked.  However, for many of our integration-level tests, a simulated HTTP call is being made.  Usually, only the assertion failure will show up in the Travis logs (in the form of calling `assert_response :success`, and seeing the http status code in the `4xx` or `5xx` range instead of `200`).  No other context is available, and the VM and any assets are deleted upon completion of the run.

This update changes the default logging behavior in the `test` environment to log all errors to `STDOUT` if this is a CI run in Travis.  Since `STDOUT` is preserved on all builds, we can get full stack traces of any errors at the controller level.  This will greatly aid developers when attempting to troubleshoot build failures on PRs, reducing the time needed to correctly identify and address regressions, and directly further the goal of increasing CI stability back up to our target goal of 90% pass rates on the "known good" branches of `development` and `master`.

MANUAL TESTING
1. Pull this branch and run `./rails_local_setup.rb && source config/secrets/.source_env.bash` from the project directory
2. Simulate a CI run by setting the following environment variables
```
export RAILS_LOG_TO_STDOUT=true 
export CI=true
```
3. In `app/controllers/api/v1/metadata_schemas_controller.rb`, add the following on line 89:
```
raise 'this should be logged with a stack trace'
```
4. Back in the console, run `rails test test/api/metadata_schemas_controller_test.rb`
5. Confirm that there a single test failure:
```
  1) Failure:
MetadataSchemasControllerTest#test_should_load_requested_schema [/Users/bistline/Documents/Rails/single_cell_portal_core/test/api/metadata_schemas_controller_test.rb:41]:
Did not load requested convention metadata schema: alexandria_convention/1.1.4/alexandria_convention_schema.json.
Expected: 200
  Actual: 500
```
6. Scroll up, and note that there is a stack trace that begins with the following:
```
metadata_schemas_controller_test.rb: test_should_load_all_available_schemas successful!
.metadata_schemas_controller_test.rb: test_should_load_requested_schema
Reporting error analytics to mixpanel for (RuntimeError) this should be logged with a stack trace
Suppressing error reporting to Sentry: RuntimeError:this should be logged with a stack trace, context: {:params=>{"controller"=>"api/v1/metadata_schemas", "action"=>"load_schema", "project_name"=>"alexandria_convention", "version"=>"1.1.4", "schema_format"=>"json", "metadata_schema"=>{}, "format"=>"json"}}
this should be logged with a stack trace
/Users/bistline/Documents/Rails/single_cell_portal_core/app/controllers/api/v1/metadata_schemas_controller.rb:89:in `load_schema'
/Users/bistline/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
/Users/bistline/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/abstract_controller/base.rb:228:in `process_action'
/Users/bistline/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/actionpack-6.1.4.1/lib/action_controller/metal/rendering.rb:30:in `process_action'
...
```

This PR satisfies SCP-3450.