### PR TITLE
Add tab analytics (SCP-3700)

### DIFF
--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -56,7 +56,7 @@ const SUPPLEMENTAL_STEPS = STEPS.slice(4, 11)
 export function RawUploadWizard({ studyAccession, name }) {
   const routerLocation = useLocation()
   const queryParams = queryString.parse(routerLocation.search)
-  let currentStepIndex = STEPS.findIndex(step => step.name === queryParams.step)
+  let currentStepIndex = STEPS.findIndex(step => step.name === queryParams.tab)
   if (currentStepIndex < 0) {
     currentStepIndex = 0
   }
@@ -77,9 +77,9 @@ export function RawUploadWizard({ studyAccession, name }) {
     })
   }
 
-  /** move the wizard to the given step */
+  /** move the wizard to the given step tab */
   function setCurrentStep(newStep) {
-    navigate(`?step=${newStep.name}`)
+    navigate(`?tab=${newStep.name}`)
     window.scrollTo(0, 0)
   }
 

--- a/app/javascript/components/upload/WizardNavPanel.js
+++ b/app/javascript/components/upload/WizardNavPanel.js
@@ -14,7 +14,7 @@ function RawWizardNavPanel({
   const [othersExpanded, setOthersExpanded] = useState(true)
   const expansionIcon = othersExpanded ? faChevronUp : faChevronDown
   return <div className="position-fixed">
-    <ul className="upload-wizard-steps">
+    <ul className="upload-wizard-steps" role="tablist" data-analytics-name="upload-wizard-primary-steps">
       { mainSteps.map((step, index) =>
         <StepTabHeader key={index}
           step={step}
@@ -24,7 +24,7 @@ function RawWizardNavPanel({
           currentStep={currentStep}
           setCurrentStep={setCurrentStep}/>) }
     </ul>
-    <ul className="upload-wizard-steps">
+    <ul className="upload-wizard-steps" role="tablist" data-analytics-name="upload-wizard-secondary-steps">
       <li className="other-header" onClick={() => setOthersExpanded(!othersExpanded)}>
         <div className="step-number">
           <span className="badge highlight">+</span>

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -335,10 +335,10 @@ function getAnalyticsPageName() {
  * gets the tab name for analytics
  */
 function getTabProperty() {
-  if (window.location.href.match(/\?tab=/)) {
+  if (window.location.href?.match(/\?tab=/)) {
     return window.location.href.split('?tab=')[1]
   } else {
-    return window.location.hash.replace(/#/, '')
+    return window.location.hash?.replace(/#/, '')
   }
 }
 

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -163,6 +163,7 @@ export function logClickLink(target) {
   if (parentTabList.length > 0) {
     // Grab name of tab list and add to props
     props.tabListName = parentTabList[0].attributes['data-analytics-name'].value
+    props.tabDisplayText = target.innerText.trim()
     log('click:tab', props)
   } else {
     log('click:link', props)
@@ -331,6 +332,22 @@ function getAnalyticsPageName() {
 }
 
 /**
+ * gets the tab name for analytics
+ */
+function getTabProperty() {
+  const url = window.location.toString()
+  if (url.includes('step=')) {
+    // if in an upload wizard tab
+    return url.replace(/^(.*?)?step=/, '').trim().replace(/\s/g, '-')
+  } else if (url.includes('#study')) {
+    // if in a study tab
+    return url.replace(/^(.*?)#/, '').trim().replace(/\s/g, '-')
+  } else {
+    return ''
+  }
+}
+
+/**
  * Log metrics to Mixpanel via Bard web service
  *
  * Bard docs:
@@ -339,13 +356,18 @@ function getAnalyticsPageName() {
  * @param {String} name
  * @param {Object} props
  */
-export function log(name, props={}) {
+export function log(name, props = {}) {
   props = Object.assign(props, {
     appId: 'single-cell-portal',
     appPath: getAnalyticsPageName(),
     appFullPath: getAppFullPath(),
     env
   }, getDefaultProperties())
+
+  const tab = getTabProperty()
+  if (tab) {
+    props['tab'] = tab
+  }
 
   props['timeSincePageLoad'] = Math.round(performance.now())
 
@@ -418,7 +440,7 @@ export function log(name, props={}) {
   firing the log event
 */
 export function startPendingEvent(
-  name, props={}, completionTriggerPrefix, fromPageLoad
+  name, props = {}, completionTriggerPrefix, fromPageLoad
 ) {
   const startTime = fromPageLoad ? 0 : performance.now()
   const pendingEvent = {

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -366,7 +366,7 @@ export function log(name, props = {}) {
 
   const tab = getTabProperty()
   if (tab) {
-    props['tab'] = tab
+    props['referringTab'] = tab
   }
 
   props['timeSincePageLoad'] = Math.round(performance.now())

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -335,8 +335,8 @@ function getAnalyticsPageName() {
  * gets the tab name for analytics
  */
 function getTabProperty() {
-  if (window.location.href.match(/\?step=/)) {
-    return window.location.href.split('?step=')[1]
+  if (window.location.href.match(/\?tab=/)) {
+    return window.location.href.split('?tab=')[1]
   } else {
     return window.location.hash.replace(/#/, '')
   }

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -335,15 +335,10 @@ function getAnalyticsPageName() {
  * gets the tab name for analytics
  */
 function getTabProperty() {
-  const url = window.location.toString()
-  if (url.includes('step=')) {
-    // if in an upload wizard tab
-    return url.replace(/^(.*?)?step=/, '').trim().replace(/\s/g, '-')
-  } else if (url.includes('#study')) {
-    // if in a study tab
-    return url.replace(/^(.*?)#/, '').trim().replace(/\s/g, '-')
+  if (window.location.href.match(/\?step=/)) {
+    return window.location.href.split('?step=')[1]
   } else {
-    return ''
+    return window.location.hash.replace(/#/, '')
   }
 }
 
@@ -366,7 +361,7 @@ export function log(name, props = {}) {
 
   const tab = getTabProperty()
   if (tab) {
-    props['referringTab'] = tab
+    props['tab'] = tab
   }
 
   props['timeSincePageLoad'] = Math.round(performance.now())

--- a/test/js/lib/MockRouter.js
+++ b/test/js/lib/MockRouter.js
@@ -13,7 +13,7 @@ export default function MockRouter({ children, initialSearch }) {
   const locationSpy = useRef(jest.spyOn(ReachRouter, 'useLocation'))
   const navigateSpy = useRef(jest.spyOn(ReachRouter, 'navigate'))
 
-  /** simulates a navigation event.  assumes newLocation is just a search string, e.g. '?step=foo' */
+  /** simulates a navigation event.  assumes newLocation is just a search string, e.g. '?tab=foo' */
   function navigate(newLocation) {
     // update the location, which will update the mock useLocation hook on rerender
     setLocation(newLocation)

--- a/test/js/upload-wizard/wizard-navigation.test.js
+++ b/test/js/upload-wizard/wizard-navigation.test.js
@@ -60,7 +60,7 @@ describe('it allows navigating between steps', () => {
 
   it('sets initial tab based on url params', async () => {
     render(
-      <MockRouter initialSearch={'?step=clustering'}>
+      <MockRouter initialSearch={'?tab=clustering'}>
         <RawUploadWizard studyAccession="SCP1" name="Chicken study"/>
       </MockRouter>
     )


### PR DESCRIPTION
Add analytics for tabs
- Add "referringTab" property for events that occur from within a tab i.e. clicking a button while in a tab
- Add "tabDisplayText" property to record the displayed text (different than "text" property as it won't be overwritten by the "data-analytics-name" field)
- Add "tabListName" to the new upload wizard

To test:
Pull the branch and click about the upload wizard and observe the Network tab to see the events and see the new properties being passed in the payload

![Screen Shot 2021-11-02 at 5 14 56 PM](https://user-images.githubusercontent.com/54322292/140072523-bddf4b26-673c-4736-8b16-0dfcfef7e83b.png)

![Screen Shot 2021-11-02 at 5 10 44 PM](https://user-images.githubusercontent.com/54322292/140072499-63211afd-ce67-4364-9ab1-111c7dccfac0.png)
)
