### PR TITLE
Fixing broken COVID-19 view (SCP-3854)

### DIFF
--- a/app/views/site/covid19.html.erb
+++ b/app/views/site/covid19.html.erb
@@ -61,8 +61,6 @@
   </div>
 </div>
 
-<input type="hidden" id="feature-flags" value='<%= current_user.feature_flags_with_defaults.to_json %>'/>
-
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
     $(document).ready(function() {
       var main = $('.home-page-fix');


### PR DESCRIPTION
This update removes obsoleted feature flag code on the special COVID-19 view.  It caused unauthenticated users to not be able to view the COVID-19 collection, and instead saw the generic 500 error page.  This code is no longer used anywhere, and is superseded by [this data](https://github.com/broadinstitute/single_cell_portal_core/blob/development/app/views/layouts/application.html.erb#L236) in the main application layout.

MANUAL TESTING
1. Boot as normal, and click the "Browse Collections" button w/o signing in
2. Select the COVID-19 collection
3. Confirm the page renders and executes the preset search for COVID-19 studies (you may not have any in your local instance, and could see an empty search)

This PR satisfies SCP-3854.
