### PR TITLE
Frontend cache no longer caches subsampled data (SCP-3803)

### DIFF
--- a/app/javascript/components/explore/plot-data-cache.js
+++ b/app/javascript/components/explore/plot-data-cache.js
@@ -289,7 +289,7 @@ export function createCache() {
     // we don't cache anything for annotated/correlated scatter since the coordinates are different per annotation/gene
 
     if (!isAnnotatedScatter && !isCorrelatedScatter) {
-      if (subsample != 'all') {
+      if (subsample !== 'all') {
         // we also don't cache for subsampled views, since the cells and ordering may be different across annotations
         fields.push('coordinates', 'cells', 'annotation')
         if (genes.length) {

--- a/app/javascript/components/explore/plot-data-cache.js
+++ b/app/javascript/components/explore/plot-data-cache.js
@@ -57,8 +57,7 @@ const Fields = {
       if (cachedCellsAndCoords.then) {
         promises.push(cachedCellsAndCoords)
       } else if (!cachedCellsAndCoords.x) {
-        fields.push('coordinates')
-        fields.push('cells')
+        fields.push('coordinates', 'cells')
       }
     },
     merge: (entry, scatter) => {
@@ -288,12 +287,21 @@ export function createCache() {
     const fields = []
     const promises = [] // API call promises
     // we don't cache anything for annotated/correlated scatter since the coordinates are different per annotation/gene
+
     if (!isAnnotatedScatter && !isCorrelatedScatter) {
-      const cacheEntry = cache._findOrCreateEntry(studyAccession, cluster, subsample)
-      Fields.cellsAndCoords.addFieldsOrPromise(cacheEntry, fields, promises)
-      Fields.annotation.addFieldsOrPromise(cacheEntry, fields, promises, annotation.name, annotation.scope)
-      if (genes.length) {
-        Fields.expression.addFieldsOrPromise(cacheEntry, fields, promises, genes, consensus)
+      if (subsample != 'all') {
+        // we also don't cache for subsampled views, since the cells and ordering may be different across annotations
+        fields.push('coordinates', 'cells', 'annotation')
+        if (genes.length) {
+          fields.push('expression')
+        }
+      } else {
+        const cacheEntry = cache._findOrCreateEntry(studyAccession, cluster, subsample)
+        Fields.cellsAndCoords.addFieldsOrPromise(cacheEntry, fields, promises)
+        Fields.annotation.addFieldsOrPromise(cacheEntry, fields, promises, annotation.name, annotation.scope)
+        if (genes.length) {
+          Fields.expression.addFieldsOrPromise(cacheEntry, fields, promises, genes, consensus)
+        }
       }
     } else {
       fields.push('coordinates')

--- a/test/js/explore/plot-data-cache.test.js
+++ b/test/js/explore/plot-data-cache.test.js
@@ -5,43 +5,43 @@ import { createCache } from 'components/explore/plot-data-cache'
 
 // models a real response from api/v1/visualization/clusters
 const FETCH_CLUSTER_RESPONSE = {
-    data: {
-        annotations: ['foo', 'bar'],
-        cells: ['A', 'B'],
-        x: [11, 14],
-        y: [0, 1],
+  data: {
+    annotations: ['foo', 'bar'],
+    cells: ['A', 'B'],
+    x: [11, 14],
+    y: [0, 1]
+  },
+  pointSize: 3,
+  userSpecifiedRanges: null,
+  showClusterPointBorders: false,
+  description: null,
+  is3D: false,
+  isSubsampled: false,
+  isAnnotatedScatter: false,
+  numPoints: 130,
+  axes: {
+    titles: {
+      x: 'X',
+      y: 'Y',
+      z: 'Z',
+      magnitude: 'Expression'
     },
-    pointSize: 3,
-    userSpecifiedRanges: null,
-    showClusterPointBorders: false,
-    description: null,
-    is3D: false,
-    isSubsampled: false,
-    isAnnotatedScatter: false,
-    numPoints: 130,
-    axes: {
-        titles: {
-            x: 'X',
-            y: 'Y',
-            z: 'Z',
-            magnitude: 'Expression'
-        },
-        aspects: null
-    },
-    hasCoordinateLabels: false,
-    coordinateLabels: [],
-    pointAlpha: 1,
-    cluster: 'cluster.tsv',
-    genes: [],
-    annotParams: {
-        name: 'buzzwords',
-        type: 'group',
-        scope: 'study',
-        values: ['foo', 'bar'],
-        identifier: 'biosample_id--group--study'
-    },
-    subsample: 'all',
-    consensus: null
+    aspects: null
+  },
+  hasCoordinateLabels: false,
+  coordinateLabels: [],
+  pointAlpha: 1,
+  cluster: 'cluster.tsv',
+  genes: [],
+  annotParams: {
+    name: 'buzzwords',
+    type: 'group',
+    scope: 'study',
+    values: ['foo', 'bar'],
+    identifier: 'biosample_id--group--study'
+  },
+  subsample: 'all',
+  consensus: null
 }
 
 const CACHE_PERF_PARAMS = {
@@ -53,19 +53,19 @@ const CACHE_PERF_PARAMS = {
 
 const ANNOTATION_ONLY_RESPONSE = _cloneDeep(FETCH_CLUSTER_RESPONSE)
 ANNOTATION_ONLY_RESPONSE.annotParams = {
-    name: 'species',
-    type: 'group',
-    scope: 'study',
-    values: ['dog', 'cat'],
-    identifier: 'species--group--study'
-  }
+  name: 'species',
+  type: 'group',
+  scope: 'study',
+  values: ['dog', 'cat'],
+  identifier: 'species--group--study'
+}
 ANNOTATION_ONLY_RESPONSE.data = {
   'annotations': ['cat', 'dog']
 }
 
 const EXPRESSION_ONLY_RESPONSE = _cloneDeep(ANNOTATION_ONLY_RESPONSE)
 EXPRESSION_ONLY_RESPONSE.data = {
-  'expression': [0.25, 2.3],
+  'expression': [0.25, 2.3]
 }
 EXPRESSION_ONLY_RESPONSE.genes = ['Apoe']
 
@@ -74,8 +74,8 @@ CLUSTER_AND_EXPRESSION_RESPONSE.data.expression = [0.25, 2.3]
 CLUSTER_AND_EXPRESSION_RESPONSE.genes = ['Apoe']
 
 afterEach(() => {
-  jest.clearAllMocks();
-});
+  jest.clearAllMocks()
+})
 
 describe('Plot data cache', () => {
   it('caches a single cluster call for use when annotation and gene are changed', async () => {
@@ -85,10 +85,11 @@ describe('Plot data cache', () => {
     apiFetch.mockImplementation(() => Promise.resolve([_cloneDeep(FETCH_CLUSTER_RESPONSE), 230]))
 
     // first, check that the repsonse is fetched and returned normally if not in cache
-    const result = cache.fetchCluster({
+    const response = await cache.fetchCluster({
       studyAccession: 'SCP1',
       cluster: '_default',
-      annotation: {}
+      annotation: {},
+      subsample: ''
     })
     const expectedApiParams = {
       annotation: {},
@@ -99,81 +100,78 @@ describe('Plot data cache', () => {
       isAnnotatedScatter: null,
       isCorrelatedScatter: null,
       studyAccession: 'SCP1',
-      subsample: undefined
+      subsample: ''
     }
-
     expect(apiFetch).toHaveBeenLastCalledWith(expectedApiParams)
-    return result.then(response => {
-      expect(response).toEqual([FETCH_CLUSTER_RESPONSE, 230])
+    expect(response).toEqual([FETCH_CLUSTER_RESPONSE, 230])
 
-      // second, check that it only fetches the needed fields when changing annotation
-      apiFetch.mockImplementation(() => Promise.resolve([_cloneDeep(ANNOTATION_ONLY_RESPONSE), 230]))
-      const newAnnotFetch = cache.fetchCluster({
-        studyAccession: 'SCP1',
-        cluster: '_default',
-        annotation: {
-          name: 'species',
-          scope: 'study'
-        }
-      })
-      const expectedNewAnnotParams = {
-        annotation: {name: 'species', scope: 'study'},
-        cluster: '_default',
-        consensus: undefined,
-        fields: ['annotation'],
-        genes: [],
-        isAnnotatedScatter: null,
-        isCorrelatedScatter: null,
-        studyAccession: 'SCP1',
-        subsample: undefined
-      }
-      expect(apiFetch).toHaveBeenLastCalledWith(expectedNewAnnotParams)
-      return newAnnotFetch
-    }).then(response => {
-      // confirm the fields got merged
-      const scatterData = response[0].data
-      expect(scatterData.x).toEqual(FETCH_CLUSTER_RESPONSE.data.x)
-      expect(scatterData.y).toEqual(FETCH_CLUSTER_RESPONSE.data.y)
-      expect(scatterData.cells).toEqual(FETCH_CLUSTER_RESPONSE.data.cells)
-      expect(scatterData.annotations).toEqual(ANNOTATION_ONLY_RESPONSE.data.annotations)
-      expect(response[0].annotParams.name).toEqual('species')
-
-
-      //third, check that the cache works if a gene is then searched
-      apiFetch.mockImplementation(() => Promise.resolve([_cloneDeep(EXPRESSION_ONLY_RESPONSE), 230]))
-      const newGeneFetch = cache.fetchCluster({
-        studyAccession: 'SCP1',
-        cluster: '_default',
-        annotation: {
-          name: 'species',
-          scope: 'study'
-        },
-        genes: ['Apoe']
-      })
-      const expectedNewGeneParams = {
-        annotation: {name: 'species', scope: 'study'},
-        cluster: '_default',
-        consensus: undefined,
-        fields: ['expression'],
-        genes: ['Apoe'],
-        isAnnotatedScatter: null,
-        isCorrelatedScatter: null,
-        studyAccession: 'SCP1',
-        subsample: undefined
-      }
-      expect(apiFetch).toHaveBeenLastCalledWith(expectedNewGeneParams)
-      return newGeneFetch
-    }).then(response => {
-      // confirm the fields got merged
-      const scatterData = response[0].data
-      expect(scatterData.x).toEqual(FETCH_CLUSTER_RESPONSE.data.x)
-      expect(scatterData.y).toEqual(FETCH_CLUSTER_RESPONSE.data.y)
-      expect(scatterData.cells).toEqual(FETCH_CLUSTER_RESPONSE.data.cells)
-      expect(scatterData.annotations).toEqual(ANNOTATION_ONLY_RESPONSE.data.annotations)
-      expect(scatterData.expression).toEqual(EXPRESSION_ONLY_RESPONSE.data.expression)
-      expect(response[0].annotParams.name).toEqual('species')
-      return response
+    // second, check that it only fetches the needed fields when changing annotation
+    apiFetch.mockImplementation(() => Promise.resolve([_cloneDeep(ANNOTATION_ONLY_RESPONSE), 230]))
+    const annotResponse = await cache.fetchCluster({
+      studyAccession: 'SCP1',
+      cluster: 'cluster.tsv',
+      annotation: {
+        name: 'species',
+        scope: 'study'
+      },
+      subsample: 'all'
     })
+    const expectedNewAnnotParams = {
+      annotation: { name: 'species', scope: 'study' },
+      cluster: 'cluster.tsv',
+      consensus: undefined,
+      fields: ['annotation'],
+      genes: [],
+      isAnnotatedScatter: null,
+      isCorrelatedScatter: null,
+      studyAccession: 'SCP1',
+      subsample: 'all'
+    }
+    expect(apiFetch).toHaveBeenLastCalledWith(expectedNewAnnotParams)
+
+
+    // confirm the fields got merged
+    const scatterData = annotResponse[0].data
+    expect(scatterData.x).toEqual(FETCH_CLUSTER_RESPONSE.data.x)
+    expect(scatterData.y).toEqual(FETCH_CLUSTER_RESPONSE.data.y)
+    expect(scatterData.cells).toEqual(FETCH_CLUSTER_RESPONSE.data.cells)
+    expect(scatterData.annotations).toEqual(ANNOTATION_ONLY_RESPONSE.data.annotations)
+    expect(annotResponse[0].annotParams.name).toEqual('species')
+
+
+    // third, check that the cache works if a gene is then searched
+    apiFetch.mockImplementation(() => Promise.resolve([_cloneDeep(EXPRESSION_ONLY_RESPONSE), 230]))
+    const geneResponse = await cache.fetchCluster({
+      studyAccession: 'SCP1',
+      cluster: 'cluster.tsv',
+      annotation: {
+        name: 'species',
+        scope: 'study'
+      },
+      genes: ['Apoe'],
+      subsample: 'all'
+    })
+    const expectedNewGeneParams = {
+      annotation: { name: 'species', scope: 'study' },
+      cluster: 'cluster.tsv',
+      consensus: undefined,
+      fields: ['expression'],
+      genes: ['Apoe'],
+      isAnnotatedScatter: null,
+      isCorrelatedScatter: null,
+      studyAccession: 'SCP1',
+      subsample: 'all'
+    }
+    expect(apiFetch).toHaveBeenLastCalledWith(expectedNewGeneParams)
+
+    // confirm the fields got merged
+    const geneScatterData = geneResponse[0].data
+    expect(geneScatterData.x).toEqual(FETCH_CLUSTER_RESPONSE.data.x)
+    expect(geneScatterData.y).toEqual(FETCH_CLUSTER_RESPONSE.data.y)
+    expect(geneScatterData.cells).toEqual(FETCH_CLUSTER_RESPONSE.data.cells)
+    expect(geneScatterData.annotations).toEqual(ANNOTATION_ONLY_RESPONSE.data.annotations)
+    expect(geneScatterData.expression).toEqual(EXPRESSION_ONLY_RESPONSE.data.expression)
+    expect(geneResponse[0].annotParams.name).toEqual('species')
   })
 
   // same test as above, but  for a case where the user changes the annotation before the original cluster call returns
@@ -182,23 +180,26 @@ describe('Plot data cache', () => {
     const apiFetch = jest.spyOn(ScpApi, 'fetchCluster')
     // pass in a clone of the response since it may get modified by the cache operations
     apiFetch.mockImplementation(() => Promise.resolve([_cloneDeep(FETCH_CLUSTER_RESPONSE), 230]))
-    const result = cache.fetchCluster({
+    // don't use await here, since we need to execute another fetch before this one completes
+    cache.fetchCluster({
       studyAccession: 'SCP1',
       cluster: '_default',
-      annotation: {}
+      annotation: {},
+      subsample: 'all'
     })
 
     apiFetch.mockImplementation(() => Promise.resolve([_cloneDeep(ANNOTATION_ONLY_RESPONSE), 230]))
-    const newAnnotFetch = cache.fetchCluster({
+    const newAnnotResponse = await cache.fetchCluster({
       studyAccession: 'SCP1',
       cluster: '_default',
       annotation: {
         name: 'species',
         scope: 'study'
-      }
+      },
+      subsample: 'all'
     })
 
-     // it should still only fetch the annotation data, even though the cluster data has not yet arrived
+    // it should still only fetch the annotation data, even though the cluster data has not yet arrived
     const expectedNewAnnotParams = {
       annotation: { name: 'species', scope: 'study' },
       cluster: '_default',
@@ -208,21 +209,19 @@ describe('Plot data cache', () => {
       isAnnotatedScatter: null,
       isCorrelatedScatter: null,
       studyAccession: 'SCP1',
-      subsample: undefined
+      subsample: 'all'
     }
 
     expect(apiFetch).toHaveBeenLastCalledWith(expectedNewAnnotParams)
 
-    return newAnnotFetch.then(response => {
-      // check the merge was successful
-      const scatterData = response[0].data
-      expect(scatterData.x).toEqual(FETCH_CLUSTER_RESPONSE.data.x)
-      expect(scatterData.y).toEqual(FETCH_CLUSTER_RESPONSE.data.y)
-      expect(scatterData.cells).toEqual(FETCH_CLUSTER_RESPONSE.data.cells)
-      expect(scatterData.annotations).toEqual(ANNOTATION_ONLY_RESPONSE.data.annotations)
-      expect(response[0].annotParams.name).toEqual('species')
-      return response
-    })
+
+    // check the merge was successful
+    const scatterData = newAnnotResponse[0].data
+    expect(scatterData.x).toEqual(FETCH_CLUSTER_RESPONSE.data.x)
+    expect(scatterData.y).toEqual(FETCH_CLUSTER_RESPONSE.data.y)
+    expect(scatterData.cells).toEqual(FETCH_CLUSTER_RESPONSE.data.cells)
+    expect(scatterData.annotations).toEqual(ANNOTATION_ONLY_RESPONSE.data.annotations)
+    expect(newAnnotResponse[0].annotParams.name).toEqual('species')
   })
 })
 
@@ -234,12 +233,13 @@ describe('cache handles simultaneous gene/cluster plots', () => {
     const apiFetch = jest.spyOn(ScpApi, 'fetchCluster')
     apiFetch.mockImplementation(() => Promise.resolve([_cloneDeep(CLUSTER_AND_EXPRESSION_RESPONSE), 230]))
 
-    // do a request for the full gene plot
+    // do a request for the full gene plot, don't await since we want to send the cluster request before this finishes
     const expressionFetchResult = cache.fetchCluster({
       studyAccession: 'SCP1',
       cluster: '_default',
-      'genes': ['Apoe'],
-      annotation: {}
+      genes: ['Apoe'],
+      annotation: {},
+      subsample: 'all'
     })
     const expectedApiParams = {
       annotation: {},
@@ -250,86 +250,135 @@ describe('cache handles simultaneous gene/cluster plots', () => {
       isAnnotatedScatter: null,
       isCorrelatedScatter: null,
       studyAccession: 'SCP1',
-      subsample: undefined
+      subsample: 'all'
     }
     expect(apiFetch).toHaveBeenLastCalledWith(expectedApiParams)
     // do a request for the cluster plot
     const clusterFetchResult = cache.fetchCluster({
       studyAccession: 'SCP1',
       cluster: '_default',
-      annotation: {}
+      annotation: {},
+      subsample: 'all'
     })
-    //make sure no new request is sent to the server
+    // make sure no new request is sent to the server
     expect(apiFetch).toHaveBeenCalledTimes(1)
 
-    return expressionFetchResult.then(expressionResponse => {
-      expect(expressionResponse).toEqual([CLUSTER_AND_EXPRESSION_RESPONSE, 230])
+    const expressionResponse = await expressionFetchResult
+    expect(expressionResponse).toEqual([CLUSTER_AND_EXPRESSION_RESPONSE, 230])
+    const clusterResponse = await clusterFetchResult
 
-      return clusterFetchResult
-    }).then(clusterResponse => {
-      const expectedResponse = {...FETCH_CLUSTER_RESPONSE, allDataFromCache: true}
-      expect(clusterResponse[0].data).toEqual(FETCH_CLUSTER_RESPONSE.data)
-      expect(clusterResponse[0].annotParams).toEqual(FETCH_CLUSTER_RESPONSE.annotParams)
+    expect(clusterResponse[0].data).toEqual(FETCH_CLUSTER_RESPONSE.data)
+    expect(clusterResponse[0].annotParams).toEqual(FETCH_CLUSTER_RESPONSE.annotParams)
 
-      // now simulate a user changing annotation
-      const mockApiResponse = _cloneDeep(ANNOTATION_ONLY_RESPONSE)
-      mockApiResponse.genes = ['Apoe']
-      apiFetch.mockImplementation(() => Promise.resolve([mockApiResponse, 230]))
-      const expressionFetchResult2 = cache.fetchCluster({
-        studyAccession: 'SCP1',
-        cluster: 'cluster.tsv',
-        genes: ['Apoe'],
-        subsample: 'all',
-        consensus: null,
-        annotation: {
-          name: 'species',
-          scope: 'study'
-        }
-      })
-      const expectedApiParams = {
-        annotation: {
-          name: 'species',
-          scope: 'study'
-        },
-        cluster: 'cluster.tsv',
-        consensus: null,
-        fields: ['annotation'],
-        genes: ['Apoe'],
-        isAnnotatedScatter: null,
-        isCorrelatedScatter: null,
-        studyAccession: 'SCP1',
-        subsample: 'all'
+    // now simulate a user changing annotation
+    const mockApiResponse = _cloneDeep(ANNOTATION_ONLY_RESPONSE)
+    mockApiResponse.genes = ['Apoe']
+    apiFetch.mockImplementation(() => Promise.resolve([mockApiResponse, 230]))
+    const expressionFetchResult2 = cache.fetchCluster({
+      studyAccession: 'SCP1',
+      cluster: 'cluster.tsv',
+      genes: ['Apoe'],
+      subsample: 'all',
+      consensus: null,
+      annotation: {
+        name: 'species',
+        scope: 'study'
       }
-      expect(apiFetch).toHaveBeenLastCalledWith(expectedApiParams)
-
-      const clusterFetchResult2 = cache.fetchCluster({
-        studyAccession: 'SCP1',
-        cluster: 'cluster.tsv',
-        'consensus': null,
-        annotation: {
-          name: 'species',
-          scope: 'study'
-        },
-        subsample: 'all',
-      })
-      // changing annotation should only result in a single call, even with two plots displayed,
-      // so the total number of calls should be 2
-      expect(apiFetch).toHaveBeenCalledTimes(2)
-
-      return expressionFetchResult2.then(response => {
-        const expectedAnnotResponse = _cloneDeep(CLUSTER_AND_EXPRESSION_RESPONSE)
-        expectedAnnotResponse.annotParams = ANNOTATION_ONLY_RESPONSE.annotParams
-        expectedAnnotResponse.data.annotations = ANNOTATION_ONLY_RESPONSE.data.annotations
-        expect(response).toEqual([expectedAnnotResponse, 230])
-        return clusterFetchResult2
-      }).then(response => {
-        const scatterData = response[0].data
-        expect(scatterData.x).toEqual(FETCH_CLUSTER_RESPONSE.data.x)
-        expect(scatterData.y).toEqual(FETCH_CLUSTER_RESPONSE.data.y)
-        expect(scatterData.cells).toEqual(FETCH_CLUSTER_RESPONSE.data.cells)
-        expect(scatterData.annotations).toEqual(ANNOTATION_ONLY_RESPONSE.data.annotations)
-      })
     })
+    const expectedApiParams2 = {
+      annotation: {
+        name: 'species',
+        scope: 'study'
+      },
+      cluster: 'cluster.tsv',
+      consensus: null,
+      fields: ['annotation'],
+      genes: ['Apoe'],
+      isAnnotatedScatter: null,
+      isCorrelatedScatter: null,
+      studyAccession: 'SCP1',
+      subsample: 'all'
+    }
+    expect(apiFetch).toHaveBeenLastCalledWith(expectedApiParams2)
+
+    const clusterFetchResult2 = cache.fetchCluster({
+      'studyAccession': 'SCP1',
+      'cluster': 'cluster.tsv',
+      'consensus': null,
+      'annotation': {
+        name: 'species',
+        scope: 'study'
+      },
+      'subsample': 'all'
+    })
+    // changing annotation should only result in a single call, even with two plots displayed,
+    // so the total number of calls should now be 2
+    expect(apiFetch).toHaveBeenCalledTimes(2)
+
+    const expResponse2 = await expressionFetchResult2
+    const expectedAnnotResponse = _cloneDeep(CLUSTER_AND_EXPRESSION_RESPONSE)
+    expectedAnnotResponse.annotParams = ANNOTATION_ONLY_RESPONSE.annotParams
+    expectedAnnotResponse.data.annotations = ANNOTATION_ONLY_RESPONSE.data.annotations
+    expect(expResponse2).toEqual([expectedAnnotResponse, 230])
+
+    const clusterResponse2 = await clusterFetchResult2
+    const scatterData = clusterResponse2[0].data
+    expect(scatterData.x).toEqual(FETCH_CLUSTER_RESPONSE.data.x)
+    expect(scatterData.y).toEqual(FETCH_CLUSTER_RESPONSE.data.y)
+    expect(scatterData.cells).toEqual(FETCH_CLUSTER_RESPONSE.data.cells)
+    expect(scatterData.annotations).toEqual(ANNOTATION_ONLY_RESPONSE.data.annotations)
+  })
+
+  it('does not attempt to cache subsampled data', async () => {
+    const cache = createCache()
+    const apiFetch = jest.spyOn(ScpApi, 'fetchCluster')
+    // pass in a clone of the response since it may get modified by the cache operations
+    apiFetch.mockImplementation(() => Promise.resolve([_cloneDeep(FETCH_CLUSTER_RESPONSE), 230]))
+
+    // first, check that the repsonse is fetched and returned normally on first load
+    const response = await cache.fetchCluster({
+      studyAccession: 'SCP1',
+      cluster: '_default',
+      subsample: '1000',
+      annotation: {}
+    })
+    const expectedApiParams = {
+      annotation: {},
+      cluster: '_default',
+      consensus: undefined,
+      fields: ['coordinates', 'cells', 'annotation'],
+      genes: [],
+      isAnnotatedScatter: null,
+      isCorrelatedScatter: null,
+      studyAccession: 'SCP1',
+      subsample: '1000'
+    }
+
+    expect(apiFetch).toHaveBeenLastCalledWith(expectedApiParams)
+    expect(response).toEqual([FETCH_CLUSTER_RESPONSE, 230])
+
+    // second, check that it refetches everything
+    cache.fetchCluster({
+      studyAccession: 'SCP1',
+      cluster: '_default',
+      annotation: {
+        name: 'species',
+        scope: 'study'
+      },
+      subsample: '1000'
+    })
+    const expectedNewAnnotParams = {
+      annotation: { name: 'species', scope: 'study' },
+      cluster: '_default',
+      consensus: undefined,
+      fields: ['coordinates', 'cells', 'annotation'],
+      genes: [],
+      isAnnotatedScatter: null,
+      isCorrelatedScatter: null,
+      studyAccession: 'SCP1',
+      subsample: '1000'
+    }
+    expect(apiFetch).toHaveBeenLastCalledWith(expectedNewAnnotParams)
   })
 })
 


### PR DESCRIPTION
(SCP-3803) Because we subsample each annotation separately to ensure feature preservation, this means we cannot use caching on subsampled data -- the cells and cell order may be totally different. 

This means we can only trust the cache where the subsample is explicitly 'all' -- since the default subsample may or may not be 'all'.  Note that that raises the priority of preloading the 'explore_info' data onto the page--that change would enable us to never have to just request the 'default'.  By always knowing exactly what we're requesting, we can then cache more effectively (and eliminate some brutally complex caching scenarios)

TO TEST:
1. load human raw counts synthetic study in explore tab
2. set subsampling to 1000
3. change annotation to 'subcluster'
4. observe the 8 colors are separated 2 per quadrant (without this bugfix, they would be spread across all quadrants)