### PR TITLE
cancel upload button (SCP-3760)

### DIFF
--- a/app/controllers/api/v1/concerns/fire_cloud_status.rb
+++ b/app/controllers/api/v1/concerns/fire_cloud_status.rb
@@ -5,7 +5,7 @@ module Api
         extend ActiveSupport::Concern
 
         included do
-          before_action :check_firecloud_status!, unless: proc {action_name == :index || action_name == :show}
+          before_action :check_firecloud_status!, unless: proc {firecloud_independent_methods.include?(action_name.to_sym)}
         end
 
         # check on FireCloud API status and respond accordingly
@@ -14,6 +14,11 @@ module Api
             alert = 'Study workspaces are temporarily unavailable, so we cannot complete your request.  Please try again later.'
             render json: {error: alert}, status: 503
           end
+        end
+
+        # methods to exclude from the required status check
+        def firecloud_independent_methods
+          [:index, :show]
         end
       end
     end

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -195,7 +195,6 @@ module Api
 
       # PATCH /single_cell/api/v1/studies/:id
       def update
-        byebug
         if @study.update(study_params)
           if @study.previous_changes.keys.include?('name')
             # if user renames a study, invalidate all visualization caches and repopulate default cache

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -3,6 +3,11 @@ module Api
     class StudiesController < ApiBaseController
       include Concerns::FireCloudStatus
 
+      def firecloud_independent_methods
+        # add file_info is essentially a more extensive 'show' method
+        [:index, :show, :file_info]
+      end
+
       before_action :authenticate_api_user!
       before_action :set_study, except: [:index, :create]
       before_action :check_study_permission, except: [:index, :create, :generate_manifest]
@@ -190,6 +195,7 @@ module Api
 
       # PATCH /single_cell/api/v1/studies/:id
       def update
+        byebug
         if @study.update(study_params)
           if @study.previous_changes.keys.include?('name')
             # if user renames a study, invalidate all visualization caches and repopulate default cache

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1221,15 +1221,15 @@ class StudiesController < ApplicationController
 
   # check on FireCloud API status and respond accordingly
   def check_firecloud_status
-    unless ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE, FireCloudClient::RAWLS_SERVICE)
-      alert = "Study workspaces are temporarily unavailable, so we cannot complete your request.  Please try again later.  #{SCP_SUPPORT_EMAIL}"
-      respond_to do |format|
-        format.js {render js: "$('.modal').modal('hide'); alert('#{alert}')" and return}
-        format.html {redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
-                                 alert: alert and return}
-        format.json {head 503}
-      end
-    end
+    # unless ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE, FireCloudClient::RAWLS_SERVICE)
+    #   alert = "Study workspaces are temporarily unavailable, so we cannot complete your request.  Please try again later.  #{SCP_SUPPORT_EMAIL}"
+    #   respond_to do |format|
+    #     format.js {render js: "$('.modal').modal('hide'); alert('#{alert}')" and return}
+    #     format.html {redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
+    #                              alert: alert and return}
+    #     format.json {head 503}
+    #   end
+    # end
   end
 
   # check if a study is 'detached' and handle accordingly

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1221,15 +1221,15 @@ class StudiesController < ApplicationController
 
   # check on FireCloud API status and respond accordingly
   def check_firecloud_status
-    # unless ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE, FireCloudClient::RAWLS_SERVICE)
-    #   alert = "Study workspaces are temporarily unavailable, so we cannot complete your request.  Please try again later.  #{SCP_SUPPORT_EMAIL}"
-    #   respond_to do |format|
-    #     format.js {render js: "$('.modal').modal('hide'); alert('#{alert}')" and return}
-    #     format.html {redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
-    #                              alert: alert and return}
-    #     format.json {head 503}
-    #   end
-    # end
+    unless ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE, FireCloudClient::RAWLS_SERVICE)
+      alert = "Study workspaces are temporarily unavailable, so we cannot complete your request.  Please try again later.  #{SCP_SUPPORT_EMAIL}"
+      respond_to do |format|
+        format.js {render js: "$('.modal').modal('hide'); alert('#{alert}')" and return}
+        format.html {redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
+                                 alert: alert and return}
+        format.json {head 503}
+      end
+    end
   end
 
   # check if a study is 'detached' and handle accordingly

--- a/app/javascript/components/upload/FileUploadControl.js
+++ b/app/javascript/components/upload/FileUploadControl.js
@@ -111,7 +111,7 @@ export default function FileUploadControl({
       bucketName={bucketName}
     />
     &nbsp;
-    <button className={buttonClass} id={`fileButton-${file._id}`}>
+    <button className={buttonClass} id={`fileButton-${file._id}`} data-testid="file-input-btn">
       { buttonText }
       <input className="file-upload-input" data-testid="file-input"
         type="file"

--- a/app/javascript/components/upload/MTXBundledFilesForm.js
+++ b/app/javascript/components/upload/MTXBundledFilesForm.js
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react'
 
 import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
-import { TextFormField, SaveDeleteButtons, SavingOverlay } from './form-components'
+import { SavingOverlay } from './ExpandableFileForm'
+import { TextFormField, SaveDeleteButtons } from './form-components'
 import { validateFile } from './upload-utils'
 
 /** return a blank barcodes file associated with the parent */

--- a/app/javascript/components/upload/MiscellaneousStep.js
+++ b/app/javascript/components/upload/MiscellaneousStep.js
@@ -13,7 +13,7 @@ const miscFileFilter = file => miscFileTypes.includes(file.file_type)
 
 export default {
   title: 'Miscellaneous / Other',
-  header: 'Documentation &amp; Other Files',
+  header: 'Documentation & Other Files',
   name: 'misc',
   component: MiscellaneousForm,
   fileFilter: miscFileFilter

--- a/app/javascript/components/upload/MiscellaneousStep.js
+++ b/app/javascript/components/upload/MiscellaneousStep.js
@@ -13,7 +13,7 @@ const miscFileFilter = file => miscFileTypes.includes(file.file_type)
 
 export default {
   title: 'Miscellaneous / Other',
-  header: 'Documentation & Other Files',
+  header: 'Documentation & other files',
   name: 'misc',
   component: MiscellaneousForm,
   fileFilter: miscFileFilter

--- a/app/javascript/components/upload/SequenceFileForm.js
+++ b/app/javascript/components/upload/SequenceFileForm.js
@@ -2,7 +2,8 @@ import React, { useEffect } from 'react'
 
 import Select from 'lib/InstrumentedSelect'
 import FileUploadControl, { FileTypeExtensions } from './FileUploadControl'
-import { TextFormField, SavingOverlay, SaveDeleteButtons } from './form-components'
+import { TextFormField, SaveDeleteButtons } from './form-components'
+import { SavingOverlay } from './ExpandableFileForm'
 import { validateFile } from './upload-utils'
 
 const REQUIRED_FIELDS = [{ label: 'species', propertyName: 'taxon_id' }]

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -16,7 +16,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheckCircle, faExclamationTriangle, faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons'
 
 import { formatFileFromServer, formatFileForApi, newStudyFileObj } from './upload-utils'
-import { createStudyFile, updateStudyFile, deleteStudyFile, fetchStudyFileInfo, sendStudyFileChunk } from 'lib/scp-api'
+import { createStudyFile, updateStudyFile, deleteStudyFile, fetchStudyFileInfo, sendStudyFileChunk, RequestCanceller } from 'lib/scp-api'
 import MessageModal from 'lib/MessageModal'
 import UserProvider from 'providers/UserProvider'
 import ErrorBoundary from 'lib/ErrorBoundary'
@@ -101,7 +101,12 @@ export function RawUploadWizard({ studyAccession, name }) {
   }
 
   /** handle response from server after an upload by updating the serverState with the updated file response */
-  function handleSaveResponse(response, oldFileId, uploadingMoreChunks) {
+  function handleSaveResponse(response, oldFileId, uploadingMoreChunks, requestCanceller) {
+    if (requestCanceller.wasCancelled) {
+      store.addNotification(failureNotification(`${updatedFile.name} save cancelled`))
+      updateFile(oldFileId, { isSaving: false, requestCanceller: null })
+      return
+    }
     const updatedFile = formatFileFromServer(response)
     // first update the serverState
     setServerState(prevServerState => {
@@ -121,8 +126,10 @@ export function RawUploadWizard({ studyAccession, name }) {
       const formFile = _cloneDeep(updatedFile)
       if (uploadingMoreChunks) {
         // copy over the previous files saving states
+        const oldFormFile = newFormState.files[fileIndex]
         formFile.isSaving = true
-        formFile.saveProgress = newFormState.files[fileIndex].saveProgress
+        formFile.saveProgress = oldFormFile.saveProgress
+        formFile.cancelUpload = oldFormFile.cancelUpload
       }
       if (oldFileId != updatedFile._id) { // we saved a new file and got back a fresh id
         formFile.oldId = oldFileId
@@ -171,10 +178,24 @@ export function RawUploadWizard({ studyAccession, name }) {
     updateFile(fileId, { saveProgress: overallCompletePercent })
   }
 
+  /** cancels the pending upload and deletes the file */
+  async function cancelUpload(requestCanceller) {
+    requestCanceller.cancel()
+    const fileId = requestCanceller.fileId
+
+    deleteFileFromForm(fileId)
+    // wait a brief amount of time to minimize the timing edge case where the user hits 'cancel' while the request
+    // completed.  In that case the file will have been saved, but we won't have the new id yet.  We need to wait until
+    // the id comes back so we can address the delete request properly
+    // We also don't await the delete since if it errors, it is likely because the file never got created or
+    // got deleted for other reasons (e.g. invalid form data) in the meantime
+    setTimeout(() => deleteFileFromServer(requestCanceller.fileId), 500)
+  }
+
   /** save the given file and perform an upload if a selected file is present */
   async function saveFile(file) {
     let studyFileId = file._id
-    updateFile(studyFileId, { isSaving: true })
+
     const fileSize = file.uploadSelection?.size
     const isChunked = fileSize > CHUNK_SIZE
     let chunkStart = 0
@@ -183,36 +204,66 @@ export function RawUploadWizard({ studyAccession, name }) {
     const studyFileData = formatFileForApi(file, chunkStart, chunkEnd)
     try {
       let response
+      const requestCanceller = new RequestCanceller(studyFileId)
+      if (fileSize) {
+        updateFile(studyFileId, { isSaving: true, cancelUpload: () => cancelUpload(requestCanceller) })
+      } else {
+        // if there isn't an associated file upload, don't allow the user to cancel the request
+        updateFile(studyFileId, { isSaving: true })
+      }
+
       if (file.status === 'new') {
         response = await createStudyFile({
-          studyAccession, studyFileData, isChunked, chunkStart, chunkEnd, fileSize,
+          studyAccession, studyFileData, isChunked, chunkStart, chunkEnd, fileSize, requestCanceller,
           onProgress: e => handleSaveProgress(e, studyFileId, fileSize, chunkStart)
         })
       } else {
         response = await updateStudyFile({
-          studyAccession, studyFileId, studyFileData, isChunked, chunkStart, chunkEnd, fileSize,
+          studyAccession, studyFileId, studyFileData, isChunked, chunkStart, chunkEnd, fileSize, requestCanceller,
           onProgress: e => handleSaveProgress(e, studyFileId, fileSize, chunkStart)
         })
       }
-      handleSaveResponse(response, studyFileId, isChunked)
+      handleSaveResponse(response, studyFileId, isChunked, requestCanceller)
+      // copy over the new id from the server
       studyFileId = response._id
-      if (isChunked) {
-        while (chunkEnd < fileSize) {
+      requestCanceller.fileId = studyFileId
+      if (isChunked && !requestCanceller.wasCancelled) {
+        while (chunkEnd < fileSize && !requestCanceller.wasCancelled) {
           chunkStart += CHUNK_SIZE
           chunkEnd = Math.min(chunkEnd + CHUNK_SIZE, fileSize)
           const chunkApiData = formatFileForApi(file, chunkStart, chunkEnd)
           response = await sendStudyFileChunk({
-            studyAccession, studyFileId, studyFileData: chunkApiData, chunkStart, chunkEnd, fileSize,
+            studyAccession, studyFileId, studyFileData: chunkApiData, chunkStart, chunkEnd, fileSize, requestCanceller,
             onProgress: e => handleSaveProgress(e, studyFileId, fileSize, chunkStart)
           })
         }
-        handleSaveResponse(response, studyFileId, false)
+        handleSaveResponse(response, studyFileId, false, requestCanceller)
       }
     } catch (error) {
       store.addNotification(failureNotification(<span>{file.name} failed to save<br/>{error}</span>))
       updateFile(studyFileId, {
         isSaving: false
       })
+    }
+  }
+
+  /** delete the file from the form, and also the server if it exists there */
+  async function deleteFile(file) {
+    const fileId = file._id
+    if (file.status === 'new') {
+      deleteFileFromForm(fileId)
+    } else {
+      updateFile(fileId, { isDeleting: true })
+      try {
+        await deleteFileFromServer(fileId)
+        deleteFileFromForm(fileId)
+        store.addNotification(successNotification(`${file.name} deleted successfully`))
+      } catch (error) {
+        store.addNotification(failureNotification(<span>{file.name} failed to delete<br/>{error.message}</span>))
+        updateFile(fileId, {
+          isDeleting: false
+        })
+      }
     }
   }
 
@@ -225,28 +276,14 @@ export function RawUploadWizard({ studyAccession, name }) {
     })
   }
 
-  /** delete the file from the form, and also the server if it exists there */
-  async function deleteFile(file) {
-    if (file.status === 'new') {
-      deleteFileFromForm(file._id)
-    } else {
-      updateFile(file._id, { isDeleting: true })
-      try {
-        await deleteStudyFile(studyAccession, file._id)
-        setServerState(prevServerState => {
-          const newServerState = _cloneDeep(prevServerState)
-          newServerState.files = newServerState.files.filter(f => f._id != file._id)
-          return newServerState
-        })
-        deleteFileFromForm(file._id)
-        store.addNotification(successNotification(`${file.name} deleted successfully`))
-      } catch (error) {
-        store.addNotification(failureNotification(<span>{file.name} failed to delete<br/>{error}</span>))
-        updateFile(file._id, {
-          isDeleting: false
-        })
-      }
-    }
+  /** deletes the file from the server */
+  async function deleteFileFromServer(fileId) {
+    await deleteStudyFile(studyAccession, fileId)
+    setServerState(prevServerState => {
+      const newServerState = _cloneDeep(prevServerState)
+      newServerState.files = newServerState.files.filter(f => f._id != fileId)
+      return newServerState
+    })
   }
 
   // on initial load, load all the details of the study and study files

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -281,7 +281,7 @@ export function RawUploadWizard({ studyAccession, name }) {
     await deleteStudyFile(studyAccession, fileId)
     setServerState(prevServerState => {
       const newServerState = _cloneDeep(prevServerState)
-      newServerState.files = newServerState.files.filter(f => f._id != fileId)
+      newServerState.files = newServerState.files.filter(f => f._id !== fileId)
       return newServerState
     })
   }

--- a/app/javascript/components/upload/form-components.js
+++ b/app/javascript/components/upload/form-components.js
@@ -32,15 +32,6 @@ export function TextFormField({ label, fieldName, file, updateFile }) {
   </div>
 }
 
-/** renders an overlay if the file is saving, and also displays server error messages */
-export function SavingOverlay({ file, updateFile }) {
-  const showOverlay = file.isSaving || file.isDeleting
-  if (!showOverlay) {
-    return <></>
-  }
-  return <div className="file-upload-overlay"></div>
-}
-
 /** renders save and delete buttons for a given file */
 export function SaveDeleteButtons({ file, updateFile, saveFile, deleteFile, validationMessages={} }) {
   const [showConfirmDeleteModal, setShowConfirmDeleteModal] = useState(false)

--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -27,7 +27,8 @@ const PROPERTIES_NOT_TO_SEND = [
   'version',
   'status',
   'upload',
-  'parse_status'
+  'parse_status',
+  'requestCanceller'
 ]
 
 /** gets an object representing a new, empty study file.  Does not communicate to server */

--- a/app/javascript/lib/validation/validate-file-content.js
+++ b/app/javascript/lib/validation/validate-file-content.js
@@ -317,14 +317,14 @@ async function parseFile(file, fileType) {
   }
 
   if (!file.name.endsWith('.gz')) {
-    if (lines.length < 2) {
-      return { table, delimiter, issues: [['error', 'cap:format:no-newlines', 'File does not contain newlines to separate rows']] }
-    }
-    // if there are no encoding issues, and this isn't a gzipped file, validate content
-    delimiter = sniffDelimiter(lines, mimeType)
-    table = lines.map(line => line.split(delimiter))
-
     if (['Cluster', 'Metadata'].includes(fileType)) {
+      if (lines.length < 2) {
+        return { table, delimiter, issues: [['error', 'cap:format:no-newlines', 'File does not contain newlines to separate rows']] }
+      }
+      // if there are no encoding issues, and this isn't a gzipped file, validate content
+      delimiter = sniffDelimiter(lines, mimeType)
+      table = lines.map(line => line.split(delimiter))
+
       issues = await validateCapFormat(table, fileType)
     }
   }

--- a/app/javascript/styles/_uploadWizard.scss
+++ b/app/javascript/styles/_uploadWizard.scss
@@ -100,11 +100,15 @@
   width: 100%;
   height: 100%;
   background: rgba(255, 255, 255, .6);
-  text-align: center;
-  padding-top: 3em;
+  text-align: right;
+  padding-top: 0.6em;
   font-size: 1.5em;
   color: #888;
   margin-left: 15px;
+}
+
+.upload-cancel-btn {
+  margin-right: 3em;
 }
 
 .preview-image {

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -1,4 +1,4 @@
-<% if FeatureFlaggable.merged_value_for('react_upload_wizard', current_user)  %>
+<% if !FeatureFlaggable.merged_value_for('react_upload_wizard', current_user)  %>
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
     // populate window.SCP.currentStudyFiles with information about all known StudyFiles
     window.SCP.currentStudyFiles = <%= @study.study_files.persisted.map(&:attributes).to_json.html_safe %>

--- a/test/js/upload-wizard/file-info-responses.js
+++ b/test/js/upload-wizard/file-info-responses.js
@@ -166,6 +166,48 @@ export const METADATA_FILE = {
   }
 }
 
+export const CLUSTER_FILE = {
+  created_at: '2021-11-02T13:51:11.522-04:00',
+  data_dir: '621131cf45939570efc4210174e6ac87e73472f6ed6b6bef2f65c292ab5a1a0a',
+  description: '',
+  file_type: 'Cluster',
+  generation: '1635875474894538',
+  genome_annotation_id: null,
+  genome_assembly_id: null,
+  human_data: false,
+  human_fastq_url: null,
+  is_spatial: false,
+  name: 'cluster.txt',
+  options: {},
+  parse_status: 'parsed',
+  queued_for_deletion: false,
+  remote_location: '',
+  spatial_cluster_associations: [''],
+  status: 'uploaded',
+  study_file_bundle_id: null,
+  study_id: { $oid: '60a2b9f4cc7ba082358b5448' },
+  taxon_id: null,
+  updated_at: '2021-11-02T13:53:25.520-04:00',
+  upload: {
+    url: 'fake/app/original/cluster1.txt'
+  },
+  upload_content_type: 'text/plain',
+  upload_file_name: 'cluster1.txt',
+  upload_file_size: 348,
+  use_metadata_convention: false,
+  version: 1,
+  x_axis_label: '',
+  x_axis_max: null,
+  x_axis_min: null,
+  y_axis_label: '',
+  y_axis_max: null,
+  y_axis_min: null,
+  z_axis_label: '',
+  z_axis_max: null,
+  z_axis_min: null,
+  _id: { '$oid': '61817a7bcc7ba07a266dcc56' }
+}
+
 export const BASIC_MENU_OPTIONS = {
   'fonts': ['Helvetica Neue', 'Arial'],
   'species': [{

--- a/test/js/upload-wizard/file-upload-cancel.test.js
+++ b/test/js/upload-wizard/file-upload-cancel.test.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import { render, screen, waitForElementToBeRemoved, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import _cloneDeep from 'lodash/cloneDeep'
+import ReactNotification from 'react-notifications-component'
+
+import { RawUploadWizard } from 'components/upload/UploadWizard'
+import MockRouter from '../lib/MockRouter'
+import { fireFileSelectionEvent } from '../lib/file-mock-utils'
+import * as ScpApi from 'lib/scp-api'
+import { EMPTY_STUDY } from './file-info-responses'
+
+describe('cancels a study file upload', () => {
+  it('shows the cancel button for in-progress uploads', async () => {
+    const studyInfoSpy = jest.spyOn(ScpApi, 'fetchStudyFileInfo')
+    // pass in a clone of the response since it may get modified by the cache operations
+    studyInfoSpy.mockImplementation(params => {
+      const response = _cloneDeep(EMPTY_STUDY)
+      return Promise.resolve(response)
+    })
+
+    const createFileSpy = jest.spyOn(ScpApi, 'createStudyFile')
+    // create promise that will not resolve
+    createFileSpy.mockImplementation(() => new Promise(() => {}))
+    const deleteFileSpy = jest.spyOn(ScpApi, 'deleteStudyFile')
+    deleteFileSpy.mockImplementation(() => new Promise(() => {}))
+    render(<>
+      <ReactNotification/>
+      <MockRouter>
+        <RawUploadWizard studyAccession="SCP1" name="Chicken study"/>
+      </MockRouter>
+    </>)
+    const saveButton = () => screen.getByTestId('file-save')
+    await waitForElementToBeRemoved(() => screen.getByTestId('upload-wizard-spinner'))
+    fireEvent.click(screen.getByText('Miscellaneous / Other'))
+    const fileName = 'miscText.txt'
+    fireFileSelectionEvent(screen.getByTestId('file-input'), {
+      fileName,
+      content: 'Stuff and things\n'
+    })
+    await waitForElementToBeRemoved(() => screen.getByTestId('file-validation-spinner'))
+    expect(screen.getByTestId('file-selection-name')).toHaveTextContent(fileName)
+    expect(saveButton()).not.toBeDisabled()
+
+    expect(screen.queryByTestId('upload-cancel-btn')).toBeNull()
+    fireEvent.click(saveButton())
+    expect(screen.getByTestId('upload-cancel-btn')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('upload-cancel-btn'))
+
+    fireEvent.click(screen.getByTestId('upload-cancel-yes-btn'))
+
+    // should delete the file from the form and call the delete method
+    expect(screen.getByTestId('file-input-btn')).toHaveTextContent('Choose file')
+    expect(screen.queryByTestId('file-selection-name')).toBeNull()
+    expect(deleteFileSpy).toHaveBeenCalledTimes(0)
+    // the delete is only called after a delay
+    await new Promise(r => setTimeout(r, 600))
+    expect(deleteFileSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/js/upload-wizard/upload-new-study.test.js
+++ b/test/js/upload-wizard/upload-new-study.test.js
@@ -9,7 +9,10 @@ import { RawUploadWizard } from 'components/upload/UploadWizard'
 import MockRouter from '../lib/MockRouter'
 import { fireFileSelectionEvent } from '../lib/file-mock-utils'
 import * as ScpApi from 'lib/scp-api'
-import { EMPTY_STUDY, RAW_COUNTS_FILE, PROCESSED_MATRIX_FILE, METADATA_FILE } from './file-info-responses'
+import {
+  EMPTY_STUDY, RAW_COUNTS_FILE, PROCESSED_MATRIX_FILE, METADATA_FILE,
+  CLUSTER_FILE
+} from './file-info-responses'
 import { UserContext } from 'providers/UserProvider'
 
 /** gets a pointer to the react-select node based on label text
@@ -46,12 +49,13 @@ describe('creation of study files', () => {
     await testRawCountsUpload({ createFileSpy, saveButton })
     await testProcessedUpload({ createFileSpy, saveButton })
     await testMetadataUpload({ createFileSpy, saveButton })
+    await testClusterUpload({ createFileSpy, saveButton })
   })
 })
 
 /** Uploads a raw count file and checks the field requirements */
 async function testRawCountsUpload({ createFileSpy, saveButton }) {
-  const formDataRaw = new FormData()
+  const formData = new FormData()
 
   createFileSpy.mockImplementation(() => _cloneDeep(RAW_COUNTS_FILE))
   expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent('Raw Count Expression Files')
@@ -93,7 +97,7 @@ async function testRawCountsUpload({ createFileSpy, saveButton }) {
     fileSize: 26,
     isChunked: false,
     studyAccession: 'SCP1',
-    studyFileData: formDataRaw
+    studyFileData: formData
   }))
   expect(screen.getByTestId('rawCounts-status-badge')).toHaveClass('complete')
   expect(screen.getByTestId('processed-status-badge')).not.toHaveTextContent('1')
@@ -102,7 +106,7 @@ async function testRawCountsUpload({ createFileSpy, saveButton }) {
 
 /** Uploads a processed expression file and checks the field requirements */
 async function testProcessedUpload({ createFileSpy, saveButton }) {
-  const formDataProcessed = new FormData()
+  const formData = new FormData()
 
   createFileSpy.mockImplementation(() => _cloneDeep(PROCESSED_MATRIX_FILE))
 
@@ -143,7 +147,7 @@ async function testProcessedUpload({ createFileSpy, saveButton }) {
     fileSize: 32,
     isChunked: false,
     studyAccession: 'SCP1',
-    studyFileData: formDataProcessed
+    studyFileData: formData
   }))
   expect(screen.getByTestId('processed-status-badge')).not.toHaveTextContent('2')
   expect(screen.getByTestId('processed-status-badge')).toHaveClass('complete')
@@ -151,7 +155,7 @@ async function testProcessedUpload({ createFileSpy, saveButton }) {
 
 /** Uploads a metadata file and checks the field requirements */
 async function testMetadataUpload({ createFileSpy, saveButton }) {
-  const formDataMetadata = new FormData()
+  const formData = new FormData()
 
   createFileSpy.mockImplementation(() => _cloneDeep(METADATA_FILE))
 
@@ -162,25 +166,25 @@ async function testMetadataUpload({ createFileSpy, saveButton }) {
   fireEvent.mouseOver(saveButton())
   expect(screen.getByRole('tooltip')).toHaveTextContent('You must select a file')
 
-  const badMetadataFileName = 'metadata-bad.txt'
+  const badFileName = 'metadata-bad.txt'
   fireFileSelectionEvent(screen.getByTestId('file-input'), {
-    fileName: badMetadataFileName,
+    fileName: badFileName,
     content: 'garbage'
   })
   await waitForElementToBeRemoved(() => screen.getByTestId('file-validation-spinner'))
   expect(screen.queryByTestId('file-selection-name')).toBeFalsy()
-  expect(screen.getByTestId('file-content-validation')).toHaveTextContent(`Could not use ${badMetadataFileName}`)
+  expect(screen.getByTestId('file-content-validation')).toHaveTextContent(`Could not use ${badFileName}`)
   fireEvent.mouseOver(saveButton())
   expect(screen.getByRole('tooltip')).toHaveTextContent('You must select a file')
 
 
-  const goodMetadataFileName = 'metadata-good.txt'
+  const goodFileName = 'metadata-good.txt'
   fireFileSelectionEvent(screen.getByTestId('file-input'), {
-    fileName: goodMetadataFileName,
+    fileName: goodFileName,
     content: 'NAME,cell_type,cell_type__ontology_label,organism_age,disease,disease__ontology_label,species,species__ontology_label,geographical_region,geographical_region__ontology_label,library_preparation_protocol,library_preparation_protocol__ontology_label,organ,organ__ontology_label,sex,is_living,organism_age__unit,organism_age__unit_label,ethnicity__ontology_label,ethnicity,race,race__ontology_label,sample_type,donor_id,biosample_id,biosample_type,preservation_method\nTYPE,group,group,numeric,group,group,group,group,group,group,group,group,group,group,group,group,group,group,group,group,group,group,group,group,group,group,group'
   })
   await waitForElementToBeRemoved(() => screen.getByTestId('file-validation-spinner'))
-  expect(screen.getByTestId('file-selection-name')).toHaveTextContent(goodMetadataFileName)
+  expect(screen.getByTestId('file-selection-name')).toHaveTextContent(goodFileName)
   expect(saveButton()).not.toBeDisabled()
 
   fireEvent.click(saveButton())
@@ -192,8 +196,57 @@ async function testMetadataUpload({ createFileSpy, saveButton }) {
     fileSize: 627,
     isChunked: false,
     studyAccession: 'SCP1',
-    studyFileData: formDataMetadata
+    studyFileData: formData
   }))
   expect(screen.getByTestId('metadata-status-badge')).not.toHaveTextContent('3')
   expect(screen.getByTestId('metadata-status-badge')).toHaveClass('complete')
 }
+
+/** Uploads a metadata file and checks the field requirements */
+async function testClusterUpload({ createFileSpy, saveButton }) {
+  const formData = new FormData()
+
+  createFileSpy.mockImplementation(() => _cloneDeep(CLUSTER_FILE))
+
+  fireEvent.click(screen.getByText('Clustering'))
+  expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent('Clustering')
+  expect(screen.getByTestId('clustering-status-badge')).toHaveTextContent('4')
+  expect(saveButton()).toBeDisabled()
+  fireEvent.mouseOver(saveButton())
+  expect(screen.getByRole('tooltip')).toHaveTextContent('You must select a file')
+
+  const badFileName = 'cluster-bad.txt'
+  fireFileSelectionEvent(screen.getByTestId('file-input'), {
+    fileName: badFileName,
+    content: 'garbage'
+  })
+  await waitForElementToBeRemoved(() => screen.getByTestId('file-validation-spinner'))
+  expect(screen.queryByTestId('file-selection-name')).toBeFalsy()
+  expect(screen.getByTestId('file-content-validation')).toHaveTextContent(`Could not use ${badFileName}`)
+  fireEvent.mouseOver(saveButton())
+  expect(screen.getByRole('tooltip')).toHaveTextContent('You must select a file')
+
+  const goodFileName = 'cluster-good.txt'
+  fireFileSelectionEvent(screen.getByTestId('file-input'), {
+    fileName: goodFileName,
+    content: 'NAME,X,Y\nTYPE,numeric,numeric\nCell1,1,0\n'
+  })
+  await waitForElementToBeRemoved(() => screen.getByTestId('file-validation-spinner'))
+  expect(screen.getByTestId('file-selection-name')).toHaveTextContent(goodFileName)
+  expect(saveButton()).not.toBeDisabled()
+
+  fireEvent.click(saveButton())
+  await waitForElementToBeRemoved(() => screen.getByTestId('file-save-spinner'))
+
+  expect(createFileSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+    chunkEnd: 40,
+    chunkStart: 0,
+    fileSize: 40,
+    isChunked: false,
+    studyAccession: 'SCP1',
+    studyFileData: formData
+  }))
+  expect(screen.getByTestId('clustering-status-badge')).not.toHaveTextContent('3')
+  expect(screen.getByTestId('clustering-status-badge')).toHaveClass('complete')
+}
+


### PR DESCRIPTION
As shown in demo, this puts a 'cancel' button where the 'delete' button was when you are uploading a file. (it does not appear if you are just saving a file).  

![image](https://user-images.githubusercontent.com/2800795/140812865-96b101c6-87ea-4582-aa5b-69f18f47ce5b.png)

On clicking the button, a confirm dialog appears

![image](https://user-images.githubusercontent.com/2800795/140812933-4fd3b596-c020-4667-85b6-afae309db81e.png)

This also fixes some bugs, most notably a missing negative in the feature flag branch, but also a bug where non-text, non-gzipped files could not be uploaded as they would fail validation

TO TEST:
1. Open upload wizard with the `react_upload_wizard` flag set to true
2. Go to the Miscellaneous/Other tab and select a very large file (you can create one with `mkfile -n 10g temp_10GB_file` in the terminal)
3. press "Save & Upload"
4. Observe cancel button appears in place of 'Delete'
5. Press 'Cancel' 
5. Observe confirmation dialog appears
6. Press 'Yes'
7. Observe upload stops, and file form is cleared

