### PR TITLE
Upload wizard bugfixes (SCP-3758)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -300,6 +300,12 @@ module Api
           end
         end
 
+        # Somewhere in Rails automagic, the upload filename is set as the study file name
+        # We want to have it be the upload_file_name sent by the frontend
+        if safe_file_params[:upload] && safe_file_params[:upload_file_name]
+          safe_file_params[:upload].original_filename = safe_file_params[:upload_file_name]
+        end
+
         # manually check first if species/assembly was supplied by name
         species_name = safe_file_params[:species]
         safe_file_params.delete(:species)
@@ -314,7 +320,7 @@ module Api
 
         # check if the name of the file has changed as we won't be able to tell after we saved
         name_changed = study_file.persisted? && study_file.name != safe_file_params[:name]
-
+        byebug
         study_file.update!(safe_file_params)
 
         # invalidate caches first

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -320,7 +320,7 @@ module Api
 
         # check if the name of the file has changed as we won't be able to tell after we saved
         name_changed = study_file.persisted? && study_file.name != safe_file_params[:name]
-        byebug
+
         study_file.update!(safe_file_params)
 
         # invalidate caches first

--- a/app/javascript/components/upload/FileUploadControl.js
+++ b/app/javascript/components/upload/FileUploadControl.js
@@ -15,6 +15,9 @@ const miscExtensions = ['.txt', '.text', '.tsv', '.csv', '.jpg', '.jpeg', '.png'
 const sequenceExtensions = ['.fq', '.fastq', '.fq.tar.gz', '.fastq.tar.gz', '.fq.gz', '.fastq.gz', '.bam']
 const baiExtensions = ['.bai']
 
+// File types which let the user set a custom name for the file in the UX
+const FILE_TYPES_ALLOWING_SET_NAME = ['Cluster', 'Gene List']
+
 export const FileTypeExtensions = {
   plainText: plainTextExtensions.concat(plainTextExtensions.map(ext => `${ext}.gz`)),
   mtx: mtxExtensions.concat(mtxExtensions.map(ext => `${ext}.gz`)),
@@ -69,7 +72,8 @@ export default function FileUploadControl({
     const selectedFile = e.target.files[0]
     let newName = selectedFile.name
     // for cluster files, don't change an existing specified name
-    if (file.file_type == 'Cluster' && file.name && file.name != file.upload_file_name) {
+
+    if (FILE_TYPES_ALLOWING_SET_NAME.includes(file.file_type) && file.name && file.name != file.upload_file_name) {
       newName = file.name
     }
     setFileValidation({ validating: true, errorMsgs: [], filename: selectedFile.name })
@@ -78,6 +82,7 @@ export default function FileUploadControl({
     if (errorMsgs.length === 0) {
       updateFile(file._id, {
         uploadSelection: selectedFile,
+        upload_file_name: newName,
         name: newName
       })
     }

--- a/app/javascript/components/upload/GeneListFileForm.js
+++ b/app/javascript/components/upload/GeneListFileForm.js
@@ -23,6 +23,7 @@ export default function GeneListFileForm({
     file, allFiles, updateFile, saveFile,
     allowedFileExts, deleteFile, validationMessages, bucketName, isInitiallyExpanded
   }}>
+    <TextFormField label="Name" fieldName="name" file={file} updateFile={updateFile}/>
     <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
   </ExpandableFileForm>
 }

--- a/app/javascript/lib/validation/validate-file-content.js
+++ b/app/javascript/lib/validation/validate-file-content.js
@@ -296,9 +296,9 @@ export function validateGzipEncoding({ fileName, lines, mimeType }) {
   if (fileName.endsWith('.gz') && lines[0][0] !== GZIP_MAGIC_NUMBER) {
     return [['error', 'encoding:invalid-gzip-magic-number',
       'File has a ".gz" suffix but does not seem to be gzipped']]
-  } else if (!fileName.endsWith('.gz') && lines[0][0] === GZIP_MAGIC_NUMBER) {
+  } else if (!fileName.endsWith('.gz') && !fileName.endsWith('.bam') && lines[0][0] === GZIP_MAGIC_NUMBER) {
     return [['error', 'encoding:missing-gz-extension',
-      'File seems to be gzipped but does not have a ".gz" extension']]
+      'File seems to be gzipped but does not have a ".gz" or ".bam" extension']]
   }
   return []
 }


### PR DESCRIPTION
SCP-3758 Fixing bugs found during[ upload wizard testing ](https://docs.google.com/document/d/1o3YEQtYI0J9ifMekUf_ryVeHmoB02imz7A9D2xfMSnQ/edit#)

 A. Custom names are now allowed for Gene List files
 B. Bam files no longer fail validation if they don't have a gzip suffix
 C. Custom cluster names now no longer overwrite the upload_file_name

TO TEST:
1. with react_upload_wizard feature flag on, go to the upload wizard
2. Add a new cluster file, and set the cluster name to something other than the file name
3. hit Save & Upload 
4. Observe the file is saved and the filename is preserved
5. Go to the Sequence Files tab, and attempt to select the `sample1.bam` file from the mouse_brain synthetic study
6. confirm that it allows you to use that file
7. Go to the Precomputed Expression Stats tab
8. Confirm that 'name' is now independently editable outside of the file name
