### PR TITLE
Scatter plot legend analytics

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -236,12 +236,8 @@ function RawScatterPlot({
   useEffect(() => {
     const jqScatterGraph = $(`#${graphElementId}`)
     jqScatterGraph.on('plotly_selected', plotPointsSelected)
-    jqScatterGraph.on('plotly_legendclick', logLegendClick)
-    jqScatterGraph.on('plotly_legenddoubleclick', logLegendDoubleClick)
     return () => {
       jqScatterGraph.off('plotly_selected')
-      jqScatterGraph.off('plotly_legendclick')
-      jqScatterGraph.off('plotly_legenddoubleclick')
       Plotly.purge(graphElementId)
     }
   }, [])
@@ -597,22 +593,4 @@ export function get3DScatterProps({
 /** get the appropriate plotly dragmode option string */
 function getDragMode(isCellSelecting) {
   return isCellSelecting ? 'lasso' : 'lasso, select'
-}
-
-let currentClickCall = null
-
-/** we don't want to fire two single click events for a double click, so
- * we wait until we've confirmed a click isn't a double click before logging it.
- * Unfortunately (despite the docs indicating otherwise), there doesn't seem to be
- * a way of getting the text of the clicked annotation
- */
-function logLegendClick(event) {
-  clearTimeout(currentClickCall)
-  currentClickCall = setTimeout(() => log('click:scatterlegend:single'), 300)
-}
-
-/** log a double-click on a plotly graph legend */
-function logLegendDoubleClick(event) {
-  clearTimeout(currentClickCall)
-  log('click:scatterlegend:double')
 }

--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.js
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.js
@@ -91,7 +91,7 @@ function LegendEntry({
     updateShownTraces(label, wasShown, numLabels)
 
     const legendEntry = {
-      label, numPoints, numLabels, wasShown, shownTraces, iconColor,
+      label, numPoints, numLabels, wasShown, iconColor,
       hasCorrelations
     }
     log('click:scatterlegend:single', legendEntry)

--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.js
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { log } from 'lib/metrics-api'
 
 import { UNSPECIFIED_ANNOTATION_NAME } from 'lib/cluster-utils'
 import { getColorBrewerColor, scatterLabelLegendWidth } from 'lib/plot'
@@ -70,6 +71,8 @@ function LegendEntry({
   numLabels, shownTraces, updateShownTraces
 }) {
   let entry = label
+
+  const hasCorrelations = correlations !== null
   if (correlations) {
     const correlation = Math.round(correlations[label] * 100) / 100
 
@@ -84,14 +87,20 @@ function LegendEntry({
 
   /** Toggle state of this legend filter, and accordingly upstream */
   function toggleSelection() {
-    const state = !isShown
-    updateShownTraces(label, state, numLabels)
+    const wasShown = !isShown
+    updateShownTraces(label, wasShown, numLabels)
+
+    const legendEntry = {
+      label, numPoints, numLabels, wasShown, shownTraces, iconColor,
+      hasCorrelations
+    }
+    log('click:scatterlegend:single', legendEntry)
   }
 
   return (
     <div
       className={`scatter-legend-row ${shownClass}`}
-      onClick={() => toggleSelection()}
+      onClick={event => toggleSelection(event)}
     >
       <div className="scatter-legend-icon" style={iconStyle}></div>
       <div className="scatter-legend-entry">
@@ -100,6 +109,20 @@ function LegendEntry({
       </div>
     </div>
   )
+}
+
+/** Handle click on "Show all" or "Hide all" button */
+function showHideAll(showOrHide, labels, updateShownTraces) {
+  if (showOrHide === 'show') {
+    updateShownTraces(labels, false, null, true)
+  } else {
+    updateShownTraces(labels, true, null, true)
+  }
+
+  const numLabels = labels.length
+  log(`click:scatterlegend:${showOrHide}-all-labels`, {
+    labels, numLabels
+  })
 }
 
 /** Component for custom legend for scatter plots */
@@ -144,14 +167,14 @@ export default function ScatterPlotLegend({
             data-analytics-name='legend-show-all'
             className={`stateful-link ${getActivity(showIsActive)}`}
             disabled={!showIsActive}
-            onClick={() => {updateShownTraces(labels, false, null, true)}}
+            onClick={() => {showHideAll('show', labels, updateShownTraces)}}
           >Show all</a>
           <a
             role="button"
             data-analytics-name='legend-hide-all'
             className={`stateful-link pull-right ${getActivity(hideIsActive)}`}
             disabled={!hideIsActive}
-            onClick={() => {updateShownTraces(labels, true, null, true)}}
+            onClick={() => {showHideAll('hide', labels, updateShownTraces)}}
           >Hide all</a>
         </div>
       </div>

--- a/test/test_data/mock_responses/scatter-plot.test-data.js
+++ b/test/test_data/mock_responses/scatter-plot.test-data.js
@@ -6,7 +6,7 @@
  */
 
 export const MANY_LABELS_MOCKS = {
-  'EXPLORE_RESPONSE': {
+  EXPLORE_RESPONSE: {
     cluster: {
       numPoints: 130,
       isSubsampled: false
@@ -218,10 +218,12 @@ export const MANY_LABELS_MOCKS = {
       'cluster_many_long_odd_labels.tsv', 'cluster.tsv'
     ],
     spatialGroups: [],
-    clusterPointAlpha: 1.0,
-    colorProfile: null
+    imageFiles: [],
+    clusterPointAlpha: 1,
+    colorProfile: null,
+    bucketId: 'fc-968ec9be-fdba-49a1-ba2e-af49281c4a1d'
   },
-  'CLUSTER_RESPONSE': {
+  CLUSTER_RESPONSE: {
     data: {
       annotations: [
         'A.Rather.Long.Label.With.Several.Periods',


### PR DESCRIPTION
This adds analytics for the new custom legend for reference group scatter plots.  Clicks on legend entries indicate the user is gaining scientific insight, especially so in spatial transcriptomics.  [Tracking these clicks](https://mixpanel.com/s/4E3GG3) is essential to know if our redesigned UX achieves our expected outcomes.

Here's an example showing these analytics:

https://user-images.githubusercontent.com/1334561/141139596-aa946425-7e37-4ad7-bbe1-b63cf88ffe92.mov

To test:
* Open study that has a cluster group plot
* Go to Network panel in DevTools
* In "Filter" box, enter "bard method:POST"
* Click a label in the legend
* Verify that an event named `click:scatterlegend:single` is posted
* Verify that event includes properties `label`, `numPoints`, `numLabels`, `wasShown`, `iconColor`, and `hasCorrelations`

This helps satisfy SCP-3712.