### PR TITLE
Keyword searching with Azul (SCP-3806)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -274,7 +274,13 @@ module Api
         # determine sort order for pagination; minus sign (-) means a descending search
         case sort_type
         when :keyword
-          @studies = @studies.sort_by { |study| -study.search_weight(@term_list)[:total] }
+          @studies = @studies.sort_by do |study|
+            if study.is_a? Study
+              -study.search_weight(@term_list)[:total]
+            else
+              -(::AzulSearchService.compute_term_search_weight(study, @term_list)[:total])
+            end
+          end
         when :accession
           @studies = @studies.sort_by do |study|
             accession_index = possible_accessions.index(study.accession)

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -254,7 +254,7 @@ module Api
         # perform Azul search, if enabled, and there are facets/terms provided by user
         # run this before inferred search so that they are weighted and sorted correctly
         if api_user_signed_in? && current_api_user.feature_flag_for('cross_dataset_search_backend') &&
-          @facets.present?
+          (@facets.present? || @term_list.present?)
           begin
             @studies, @studies_by_facet = ::AzulSearchService.append_results_to_studies(@studies,
                                                                                         selected_facets: @facets,

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -278,7 +278,7 @@ module Api
             if study.is_a? Study
               -study.search_weight(@term_list)[:total]
             else
-              -(::AzulSearchService.compute_term_search_weight(study, @term_list)[:total])
+              -study[:term_matches][:total]
             end
           end
         when :accession

--- a/app/javascript/components/search/results/StudySearchResult.js
+++ b/app/javascript/components/search/results/StudySearchResult.js
@@ -163,10 +163,10 @@ function inferredBadge(study, termMatches) {
 
 /** Generate a badge to indicate to users the study origin for non-SCP studies */
 function studyTypeBadge(study) {
-  if (study.study_source === 'TDR') {
-    // Once non-HCA studies are added to the TDR search index, we'll want a way to distinguish them
-    return <span className="badge badge-secondary study-type" data-toggle="tooltip"
-      title={'Study from Human Cell Atlas hosted by Terra Data Repo'}> Human Cell Atlas </span>
+  if (study.study_source === 'HCA') {
+    // Display a badge indicating this result came from Azul
+    return <span className="badge badge-secondary study-type" data-toggle="tooltip" data-placement="right"
+      title={'Study from Human Cell Atlas'}> Human Cell Atlas </span>
   }
 }
 

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -159,4 +159,22 @@ class AzulSearchService
   def self.merge_facet_lists(*facets)
     facets.compact.reduce([], :+)
   end
+
+  # compute a term matching weight for a result from Azul
+  # this mirrors Study#search_weight
+  def self.compute_term_search_weight(result, terms)
+    weights = {
+      total: 0,
+      terms: {}
+    }
+    terms.each do |term|
+      text_blob = "#{result['name']} #{result['description']}"
+      score = text_blob.scan(/#{::Regexp.escape(term)}/i).size
+      if score > 0
+        weights[:total] += score
+        weights[:terms][term] = score
+      end
+    end
+    weights
+  end
 end

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -12,6 +12,7 @@ class AzulSearchService
   RESULT_FACET_FIELDS = %w[samples specimens cellLines donorOrganisms organoids cellSuspensions].freeze
 
   def self.append_results_to_studies(existing_studies, selected_facets:, terms:, facet_map: nil)
+    # set facet_map to {}, even if facet_map is explicitly passed in as nil
     facet_map ||= {}
     azul_results = ::AzulSearchService.get_results(selected_facets: selected_facets, terms: terms)
     Rails.logger.info "Found #{azul_results.keys.size} results in Azul"
@@ -27,7 +28,7 @@ class AzulSearchService
     client = ApplicationController.hca_azul_client
     results = {}
     facet_query = client.format_query_from_facets(selected_facets) if selected_facets
-    terms_to_facets = client.convert_keyword_to_facet_query(terms) if terms
+    terms_to_facets = client.format_facet_query_from_keyword(terms) if terms
     term_query = client.format_query_from_facets(terms_to_facets) if terms_to_facets
     query_json = client.merge_query_objects(facet_query, term_query)
     # abort search if no facets/terms result in query to execute

--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -284,7 +284,7 @@ class HcaAzulClient < Struct.new(:api_root)
   #
   # * *returns*
   #   - (Array<Hash>) => Array of facet objects to be fed to :format_query_from_facets
-  def convert_keyword_to_facet_query(term_list = [])
+  def format_facet_query_from_keyword(term_list = [])
     matching_facets = []
     term_list.each do |term|
       facet = SearchFacet.find_facet_from_term(term)

--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -319,17 +319,6 @@ class HcaAzulClient < Struct.new(:api_root)
     end
     merged_query
   end
-  # create a regular expression to use in matching terms against project titles/descriptions or file attributes
-  # returned regular expression is case-insensitive
-  #
-  # * *params*
-  #   - +terms+ (Array<String>) => Array of search terms, can include quoted strings
-  #
-  # * *returns*
-  #   - (Regexp) => regular expression used in matching (case-insensitive)
-  def format_term_regex(terms = [])
-    Regexp.new(terms.map { |t| Regexp.escape(t) }.join('|'), true)
-  end
 
   # take a Hash/JSON object and format as a query string parameter
   #

--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -361,7 +361,7 @@ class SearchFacet
 
   # flatten all filter ids/values into a single array
   def flatten_filters(filter_list = :filters)
-    send(filter_list).map { |filter| [filter[:id], filter[:name]] }.flatten
+    send(filter_list).map { |filter| [filter[:id], filter[:name]] }.flatten.uniq
   end
 
   # retrieve unique values from BigQuery and format an array of hashes with :name and :id values to populate :filters

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -141,13 +141,6 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     assert_equal expected_query, query
   end
 
-  test 'should format regular expression for term matching' do
-    terms = ['foo', 'bar', 'bing baz boo']
-    regex = @hca_azul_client.format_term_regex(terms)
-    expected_regex = /foo|bar|bing\ baz\ boo/i
-    assert_equal expected_regex, regex
-  end
-
   test 'should append HCA catalog name to queries' do
     path = '/index/projects'
     appended_path = @hca_azul_client.append_catalog(path, @default_catalog)

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -151,7 +151,7 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     expected_filters = ['cervical cancer', 'colorectal cancer', 'lower gum cancer', 'lung cancer', 'mandibular cancer',
                        'tongue cancer'].map { |f| { id: f, name: f }.with_indifferent_access }
     expected_facets = [{ id: 'disease', filters: expected_filters }.with_indifferent_access]
-    query = @hca_azul_client.convert_keyword_to_facet_query(terms)
+    query = @hca_azul_client.format_facet_query_from_keyword(terms)
     assert_equal expected_facets, query
   end
 
@@ -166,7 +166,7 @@ class HcaAzulClientTest < ActiveSupport::TestCase
       }
     }.with_indifferent_access
     facet_query = @hca_azul_client.format_query_from_facets(@facets)
-    term_facets = @hca_azul_client.convert_keyword_to_facet_query(%w[cancer])
+    term_facets = @hca_azul_client.format_facet_query_from_keyword(%w[cancer])
     term_query = @hca_azul_client.format_query_from_facets(term_facets)
     merged_query = @hca_azul_client.merge_query_objects(facet_query, term_query)
     assert_equal expected_query, merged_query

--- a/test/integration/lib/azul_search_service_test.rb
+++ b/test/integration/lib/azul_search_service_test.rb
@@ -29,7 +29,7 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
   end
 
   test 'should search Azul using facets' do
-    results = AzulSearchService.get_results(selected_facets: @facets)
+    results = AzulSearchService.get_results(selected_facets: @facets, terms: nil)
     assert_includes results.keys, @hca_project_shortname
     project = results[@hca_project_shortname]
     # will always be project manifest file

--- a/test/integration/lib/azul_search_service_test.rb
+++ b/test/integration/lib/azul_search_service_test.rb
@@ -18,6 +18,7 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
         filters: [{ id: 'UBERON_0000178', name: 'blood' }]
       }
     ]
+    @terms = %w[pulmonary]
     # expected result from Azul
     @hca_project_shortname = 'HumanTissueTcellActivation'
     @hca_project_id = '4a95101c-9ffc-4f30-a809-f04518a23803'
@@ -35,6 +36,29 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
     # will always be project manifest file
     manifest = project[:file_information].detect { |f| f[:file_type] == 'Project Manifest' }
     assert manifest.present?
+  end
+
+  test 'should search Azul using terms' do
+    results = AzulSearchService.get_results(selected_facets: [], terms: @terms)
+    project_short_name = 'PulmonaryFibrosisGSE135893'
+    assert_includes results.keys, project_short_name
+    expected_term_match = { total: 5, terms: { pulmonary: 5 } }.with_indifferent_access
+    assert_equal expected_term_match, results.dig(project_short_name, :term_matches)
+  end
+
+  test 'should search Azul using terms and keywords' do
+    facets = [{ id: 'organ', filters: [{ id: 'lung', name: 'lung' }] }]
+    results = AzulSearchService.get_results(selected_facets: facets, terms: @terms)
+    project_short_name = 'PulmonaryFibrosisGSE135893'
+    assert_includes results.keys, project_short_name
+    expected_term_match = { total: 5, terms: { pulmonary: 5 } }.with_indifferent_access
+    expected_facet_match = {
+      organ: [{ id: 'lung', name: 'lung' }],
+      disease: [],
+      facet_search_weight: 1
+    }.with_indifferent_access
+    assert_equal expected_term_match, results.dig(project_short_name, :term_matches)
+    assert_equal expected_facet_match, results.dig(project_short_name, :facet_matches)
   end
 
   test 'should match results on facets' do
@@ -56,15 +80,18 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
       }
     }.with_indifferent_access
     initial_results = [@study]
+    terms = ['CD8+ T cells']
     studies, facet_map = AzulSearchService.append_results_to_studies(initial_results,
                                                                      selected_facets: @facets,
-                                                                     terms: [], facet_map: facet_map)
+                                                                     terms: terms, facet_map: facet_map)
     assert studies.size > 1
     hca_entry = studies.detect { |study| study.is_a?(Hash) ? study[:accession] == @hca_project_shortname : nil }
     assert hca_entry.present?
     hca_facet_entry = facet_map[@hca_project_shortname]
     assert hca_facet_entry.present?
     assert_equal 2, hca_facet_entry[:facet_search_weight]
+    assert_equal 1, hca_entry.dig(:term_matches, :total)
+    assert_equal terms, hca_entry.dig(:term_matches, :terms).keys
   end
 
   test 'should retrieve all facets/filters' do
@@ -77,5 +104,36 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
     assert_includes diseases, "multiple sclerosis"
     assert_not facets.dig('disease', 'is_numeric')
     assert facets.dig('organism_age', 'is_numeric')
+  end
+
+  test 'should merge facet lists' do
+    gallus_filter = { id: 'NCBITaxon_9031', name: 'Gallus gallus' }
+    extra_facets = [
+      {
+        id: 'species',
+        filters: [gallus_filter]
+      }
+    ]
+    expected_facets = [
+      {
+        id: 'species',
+        filters: [{ id: 'NCBITaxon9609', name: 'Homo sapiens' }, gallus_filter]
+      },
+      {
+        id: 'organ',
+        filters: [{ id: 'UBERON_0000178', name: 'blood' }]
+      }
+    ]
+    assert_equal expected_facets, AzulSearchService.merge_facet_lists(@facets, extra_facets)
+    assert_equal expected_facets, AzulSearchService.merge_facet_lists(@facets, nil, extra_facets)
+  end
+
+  test 'should compute term match weights' do
+    result = {
+      name: 'Fake lung study',
+      description: 'This is a fake study about human lung cancers.'
+    }.with_indifferent_access
+    expected_term_match = { total: 2, terms: { lung: 2 } }.with_indifferent_access
+    assert_equal expected_term_match, AzulSearchService.get_search_term_weights(result, %w[lung])
   end
 end


### PR DESCRIPTION
This update extends keyword-only and keyword + faceted searching to HCA projects in the Azul data service.  Results are weighted/highlighted as normal using existing functionality.  Since Azul does not natively support keyword searching at the current time, keywords are "converted" into a faceted search by leveraging the work done in #1231. As we now have a complete list of all possible facet/filters from Azul, we can take any user-supplied keyword and attempt to map it to a known filter in Azul.  If a partial match is found, all possible filter values are taken and then used as the search criteria.  Results are then filtered to include only those where the supplied keyword is present in the project name/description.  This is to maintain parity with SCP-based keyword search functionality, and avoid confusion for users who would not expect to get a keyword match on an entry that does not contain the value in the name/description.  Downstream work will be done in SCP-3815 to log these "misses" to Mixpanel to inform us if these should be included in future download results.

MANUAL TESTING
1. Pull this branch, and run the following command in the Rails console to ensure that all results from Azul are stored in your local instance, as work on other branches may have cleared these values out.  This is not an issue for deployed environments as previous migrations have already seeded the data:
```
SearchFacet.update_all_facet_filters
```
2. Boot as normal, and sign in with an admin account that has `cross_dataset_search_backend` enabled
3. Enter `pulmonary` as a search term, and validate the following 3 HCA projects are returned
![Screen Shot 2021-11-10 at 12 23 24 PM](https://user-images.githubusercontent.com/729968/141164612-f152268d-6299-4df1-b05b-50d5eb403ac5.png)
4. Select `10X 5' v2 sequencing` from `library_preparation_protocol` (note the case of capital `X` and `sequencing` at the end) and ensure only one HCA project is returned:
![Screen Shot 2021-11-10 at 12 28 36 PM](https://user-images.githubusercontent.com/729968/141164915-f28ba880-b463-44d9-b6b7-c0257a61ebc9.png)
 
This PR satisfies SCP-3806