### PR TITLE
Update metadata ingest emails to indicate large group annotations are not stored (SCP-3881)

### DIFF
--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -628,6 +628,7 @@ class IngestJob
         schema_url = 'https://singlecell.zendesk.com/hc/en-us/articles/360061006411-Metadata-Convention'
         message << "This metadata file was validated against the latest <a href='#{schema_url}'>Metadata Convention</a>"
         message << "Convention version: <strong>#{project_name}/#{current_schema_version}</strong>"
+        message << "Group-type metadata columns with more than 200 unique values are not stored (ie. unavailable for visualization)."
       end
       cell_metadata = CellMetadatum.where(study_id: self.study.id, study_file_id: self.study_file.id)
       message << "Entries created:"

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -628,7 +628,7 @@ class IngestJob
         schema_url = 'https://singlecell.zendesk.com/hc/en-us/articles/360061006411-Metadata-Convention'
         message << "This metadata file was validated against the latest <a href='#{schema_url}'>Metadata Convention</a>"
         message << "Convention version: <strong>#{project_name}/#{current_schema_version}</strong>"
-        message << "Group-type metadata columns with more than 200 unique values are not stored (i.e. unavailable for visualization)."
+        message << "Group-type metadata columns with more than 200 unique values are not made available for visualization."
       end
       cell_metadata = CellMetadatum.where(study_id: self.study.id, study_file_id: self.study_file.id)
       message << "Entries created:"

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -757,7 +757,7 @@ class IngestJob
     case annotation_source.class
     when CellMetadatum
       message = "#{annotation_source.name}: #{annotation_source.annotation_type}"
-      if annotation_source.values.size < max_values || annotation_source.annotation_type == 'numeric'
+      if annotation_source.values.size <= max_values || annotation_source.annotation_type == 'numeric'
         values = annotation_source.values.any? ? ' (' + annotation_source.values.join(', ') + ')' : ''
       else
         values = " (List too large for email -- #{annotation_source.values.size} values present, max is #{max_values})"
@@ -765,7 +765,7 @@ class IngestJob
       message + values
     when ClusterGroup
       message = "#{cell_annotation['name']}: #{cell_annotation['type']}"
-      if cell_annotation['values'].size < max_values || cell_annotation['type'] == 'numeric'
+      if cell_annotation['values'].size <= max_values || cell_annotation['type'] == 'numeric'
         values = cell_annotation['type'] == 'group' ? ' (' + cell_annotation['values'].join(',') + ')' : ''
       else
         values = " (List too large for email -- #{cell_annotation['values'].size} values present, max is #{max_values})"

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -628,7 +628,7 @@ class IngestJob
         schema_url = 'https://singlecell.zendesk.com/hc/en-us/articles/360061006411-Metadata-Convention'
         message << "This metadata file was validated against the latest <a href='#{schema_url}'>Metadata Convention</a>"
         message << "Convention version: <strong>#{project_name}/#{current_schema_version}</strong>"
-        message << "Group-type metadata columns with more than 200 unique values are not stored (ie. unavailable for visualization)."
+        message << "Group-type metadata columns with more than 200 unique values are not stored (i.e. unavailable for visualization)."
       end
       cell_metadata = CellMetadatum.where(study_id: self.study.id, study_file_id: self.study_file.id)
       message << "Entries created:"


### PR DESCRIPTION
Large datasets with unique-per-cell metadata (like barcodes) can fail to store in Mongo due to the size of the dataset (ie. Eran's 3.4M cell metadata file failed to ingest due to a column of barcodes that failed to load into Mongo). Ingest pipeline is being updated to skip the storage of group-type annotations with >200 unique values.

This PR also fixes a fencepost issue where annotations with exactly 200 unique values are not reported fully in the ingest email.

To test, upload any valid metadata file 
The ingest success email notification will have the following statement, following the Convention version declaration:
`Group-type metadata columns with more than 200 unique values are not stored (ie. unavailable for visualization).`

if this metadata file is tested:
https://github.com/broadinstitute/scp-ingest-pipeline/blob/jlc_skip_lg_grp_metadata/tests/data/annotation/metadata/convention/lg_grp_metadata_to_skip.txt

The email should list an array of 200 values for metadata "scale" instead of:
`scale: group (List too large for email -- 200 values present, max is 200)`

This support SCP-3881