### PR TITLE
reference image upload tests and UX polish (SCP-3758)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.js
+++ b/app/javascript/components/explore/ExploreDisplayTabs.js
@@ -390,7 +390,7 @@ export default function ExploreDisplayTabs({
                 <ImageTab
                   studyAccession={studyAccession}
                   imageFiles={exploreInfo.imageFiles}
-                  bucketName={exploreInfo.bucket_id}
+                  bucketName={exploreInfo.bucketId}
                   isCellSelecting={isCellSelecting}
                   isVisible={shownTab === 'images'}
                   getPlotDimensions={getPlotDimensions}

--- a/app/javascript/components/explore/ImageTab.js
+++ b/app/javascript/components/explore/ImageTab.js
@@ -58,7 +58,7 @@ export default function ImageTab({
       return <div className="row" key={file.name}>
         <div className={imageColClass}>
           <h5 className="plot-title">{file.name}</h5>
-          <BucketImage fileName={file.upload_file_name} bucketName={bucketName}/>
+          <BucketImage fileName={file.bucket_file_name} bucketName={bucketName}/>
           <p className="help-block">
             { file.description &&
               <span>{file.description}</span>

--- a/app/javascript/components/explore/ScatterTab.js
+++ b/app/javascript/components/explore/ScatterTab.js
@@ -47,7 +47,11 @@ export default function ScatterTab({
   return <div className="row">
     {
       scatterParams.map((params, index) => {
-        const associatedImages = imagesForClusters[params.cluster] ? imagesForClusters[params.cluster] : []
+        let associatedImages = []
+        if (imagesForClusters[params.cluster] && params.genes.length === 0) {
+          // only show the reference image under the cluster plot, not the expression plot
+          associatedImages = imagesForClusters[params.cluster]
+        }
         const isTwoColRow = isTwoColumn && !(index === 0 && firstRowSingleCol)
         const key = getKeyFromScatterParams(params)
         let rowDivider = <span key={`d${index}`}></span>

--- a/app/javascript/components/upload/FileUploadControl.js
+++ b/app/javascript/components/upload/FileUploadControl.js
@@ -16,7 +16,7 @@ const sequenceExtensions = ['.fq', '.fastq', '.fq.tar.gz', '.fastq.tar.gz', '.fq
 const baiExtensions = ['.bai']
 
 // File types which let the user set a custom name for the file in the UX
-const FILE_TYPES_ALLOWING_SET_NAME = ['Cluster', 'Gene List']
+const FILE_TYPES_ALLOWING_SET_NAME = ['Cluster', 'Gene List', 'Image']
 
 export const FileTypeExtensions = {
   plainText: plainTextExtensions.concat(plainTextExtensions.map(ext => `${ext}.gz`)),
@@ -71,8 +71,8 @@ export default function FileUploadControl({
   async function handleFileSelection(e) {
     const selectedFile = e.target.files[0]
     let newName = selectedFile.name
-    // for cluster files, don't change an existing specified name
 
+    // for cluster files, don't change an existing specified name
     if (FILE_TYPES_ALLOWING_SET_NAME.includes(file.file_type) && file.name && file.name != file.upload_file_name) {
       newName = file.name
     }

--- a/app/javascript/components/upload/FileUploadControl.js
+++ b/app/javascript/components/upload/FileUploadControl.js
@@ -73,7 +73,7 @@ export default function FileUploadControl({
     let newName = selectedFile.name
 
     // for cluster files, don't change an existing specified name
-    if (FILE_TYPES_ALLOWING_SET_NAME.includes(file.file_type) && file.name && file.name != file.upload_file_name) {
+    if (FILE_TYPES_ALLOWING_SET_NAME.includes(file.file_type) && file.name && file.name !== file.upload_file_name) {
       newName = file.name
     }
     setFileValidation({ validating: true, errorMsgs: [], filename: selectedFile.name })

--- a/app/javascript/components/upload/ImageFileForm.js
+++ b/app/javascript/components/upload/ImageFileForm.js
@@ -32,11 +32,13 @@ export default function ImageFileForm({
     file, allFiles, updateFile, saveFile,
     allowedFileExts, deleteFile, validationMessages, bucketName, isInitiallyExpanded
   }}>
-    <div className="col-md-6">
-      { file.uploadSelection && <img className="preview-image" src={imagePreviewUrl} alt={file.uploadSelection.name} /> }
-      { file.status == 'uploaded' && <BucketImage fileName={file.upload_file_name} bucketName={bucketName}/> }
+    <div className="row">
+      <div className="col-md-6">
+        { file.uploadSelection && <img className="preview-image" src={imagePreviewUrl} alt={file.uploadSelection.name} /> }
+        { file.generation && <BucketImage fileName={file.upload_file_name} bucketName={bucketName}/> }
+      </div>
     </div>
-    <br/>
+
     <TextFormField label="Name" fieldName="name" file={file} updateFile={updateFile}/>
     <div className="form-group">
       <label className="labeled-select">Corresponding clusters / spatial data:

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -78,7 +78,7 @@ class ClusterVizService
     image_file_info.map do |file|
       associated_cluster_names = file[:spatial_cluster_associations].map{ |id| associated_clusters[id] }
       { name: file[:name],
-        associated_clusters: associated_cluster_names,
+        associated_clusters: associated_cluster_names.compact,
         bucket_file_name: file[:upload_file_name],
         description: file[:description] }
     end

--- a/test/js/upload-wizard/file-info-responses.js
+++ b/test/js/upload-wizard/file-info-responses.js
@@ -429,6 +429,34 @@ export const FEATURES_FILE = {
   _id: { $oid: '618bd61acc7ba038ac22334' }
 }
 
+export const IMAGE_FILE = {
+  created_at: '2021-11-15T18:31:41.598Z',
+  data_dir: '71e1a89e5c5d9300aabd0e757d1b569eb66644872b40bcbb720e2b39bc7e3822',
+  description: '',
+  file_type: 'Image',
+  human_data: false,
+  is_spatial: false,
+  name: 'chicken.jpeg',
+  options: {},
+  parse_status: 'unparsed',
+  queued_for_deletion: false,
+  remote_location: '',
+  spatial_cluster_associations: [''],
+  status: 'uploaded',
+  study_id: { $oid: '61797543cc7ba05f3e3be552' },
+  upload: { 'url': 'fake/app/original/chicken1.jpeg' },
+  updated_at: '2021-11-15T18:31:41.772Z',
+  upload_content_type: 'image/jpeg',
+  upload_file_name: 'chicken.jpeg',
+  upload_file_size: 6644,
+  use_metadata_convention: false,
+  version: 1,
+  x_axis_label: '',
+  y_axis_label: '',
+  z_axis_label: '',
+  _id: { $oid: '6192a78dcc7ba06aada9badb' }
+}
+
 export const BASIC_MENU_OPTIONS = {
   'fonts': ['Helvetica Neue', 'Arial'],
   'species': [{

--- a/test/js/upload-wizard/upload-images.test.js
+++ b/test/js/upload-wizard/upload-images.test.js
@@ -4,17 +4,12 @@ import _cloneDeep from 'lodash/cloneDeep'
 import selectEvent from 'react-select-event'
 
 import * as ScpApi from 'lib/scp-api'
-
-import {
-  IMAGE_FILE
-} from './file-info-responses'
-
+import { IMAGE_FILE } from './file-info-responses'
 import { fireFileSelectionEvent } from '../lib/file-mock-utils'
-
 import { renderWizardWithStudy, getSelectByLabelText, saveButton } from './upload-wizard-test-utils'
 
-describe('it allows uploading of reference images', () => {
-  it('uploads a raw counts mtx file', async () => {
+describe('Upload wizard supports reference images', () => {
+  it('validates bad file names, starts upload of JPEG file', async () => {
     const createFileSpy = jest.spyOn(ScpApi, 'createStudyFile')
     await renderWizardWithStudy({})
 

--- a/test/js/upload-wizard/upload-images.test.js
+++ b/test/js/upload-wizard/upload-images.test.js
@@ -1,0 +1,64 @@
+import { screen, fireEvent, waitForElementToBeRemoved } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import _cloneDeep from 'lodash/cloneDeep'
+import selectEvent from 'react-select-event'
+
+import * as ScpApi from 'lib/scp-api'
+
+import {
+  IMAGE_FILE
+} from './file-info-responses'
+
+import { fireFileSelectionEvent } from '../lib/file-mock-utils'
+
+import { renderWizardWithStudy, getSelectByLabelText, saveButton } from './upload-wizard-test-utils'
+
+describe('it allows uploading of reference images', () => {
+  it('uploads a raw counts mtx file', async () => {
+    const createFileSpy = jest.spyOn(ScpApi, 'createStudyFile')
+    await renderWizardWithStudy({})
+
+    const formData = new FormData()
+
+    createFileSpy.mockImplementation(() => _cloneDeep(IMAGE_FILE))
+
+    fireEvent.click(screen.getByText('Reference images'))
+
+    expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent('Reference images')
+
+    expect(saveButton()).toBeDisabled()
+    fireEvent.mouseOver(saveButton())
+    expect(screen.getByRole('tooltip')).toHaveTextContent('You must select a file')
+
+    const badFileName = 'raw_counts.wrong'
+    fireFileSelectionEvent(screen.getByTestId('file-input'), {
+      fileName: badFileName,
+      content: 'crap\n'
+    })
+    await waitForElementToBeRemoved(() => screen.getByTestId('file-validation-spinner'))
+    expect(screen.getByTestId('file-content-validation')).toHaveTextContent(`Could not use ${badFileName}`)
+
+    const imageFileName = 'chicken.jpeg'
+    fireFileSelectionEvent(screen.getByTestId('file-input'), {
+      fileName: imageFileName,
+      content: 'binarystuff' // we'll want to update this if we ever add client-side image file format checks
+    })
+    await waitForElementToBeRemoved(() => screen.getByTestId('file-validation-spinner'))
+
+    expect(screen.getByTestId('file-selection-name')).toHaveTextContent(imageFileName)
+    expect(saveButton()).not.toBeDisabled()
+
+    fireEvent.click(saveButton())
+    await waitForElementToBeRemoved(() => screen.getByTestId('file-save-spinner'))
+
+    expect(createFileSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+      chunkEnd: 11,
+      chunkStart: 0,
+      fileSize: 11,
+      isChunked: false,
+      studyAccession: 'SCP1',
+      studyFileData: formData
+    }))
+    expect(screen.getByTestId('images-status-badge')).toHaveClass('complete')
+  })
+})


### PR DESCRIPTION
This fixes a couple UX papercuts in reference image upload, and adds a test

TO TEST:
 1. open a study in the new upload wizard, and go to the reference image tab
 2. select an image to upload
 3. confirm the 'name' text field displays correctly, and is prepopulated with the filename
 4. upload the image
 5. confirm that a broken image tag does not appear while the file is in 'waiting for remote image' state.
 6. once the image is sent to firecloud, confirm the image is shown