### PR TITLE
fixing UX papercuts from file id changes (SCP-3760)

### DIFF
--- a/app/javascript/components/upload/ClusteringStep.js
+++ b/app/javascript/components/upload/ClusteringStep.js
@@ -91,7 +91,7 @@ export function ClusteringUploadForm({
     { clusterFiles.length > 1 && <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_CLUSTER_FILE}/> }
     { clusterFiles.map(file => {
       return <ClusteringFileForm
-        key={file._id}
+        key={file.oldId ? file.oldId : file._id}
         file={file}
         allFiles={formState.files}
         updateFile={updateFile}

--- a/app/javascript/components/upload/CoordinateLabelStep.js
+++ b/app/javascript/components/upload/CoordinateLabelStep.js
@@ -74,7 +74,7 @@ function CoordinateLabelForm({
     { coordinateFiles.length > 1 && <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_LABEL_FILE}/> }
     { coordinateFiles.map(file => {
       return <CoordinateLabelFileForm
-        key={file._id}
+        key={file.oldId ? file.oldId : file._id}
         file={file}
         allFiles={formState.files}
         updateFile={updateFile}

--- a/app/javascript/components/upload/GeneListStep.js
+++ b/app/javascript/components/upload/GeneListStep.js
@@ -57,7 +57,7 @@ function GeneListForm({
     { geneListFiles.length > 1 && <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_GENE_LIST_FILE}/> }
     { geneListFiles.map(file => {
       return <GeneListFileForm
-        key={file._id}
+        key={file.oldId ? file.oldId : file._id}
         file={file}
         allFiles={formState.files}
         updateFile={updateFile}

--- a/app/javascript/components/upload/ImageStep.js
+++ b/app/javascript/components/upload/ImageStep.js
@@ -58,7 +58,7 @@ export function ImageForm({
     { imageFiles.length > 1 && <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_IMAGE_FILE}/> }
     { imageFiles.map(file => {
       return <ImageFileForm
-        key={file._id}
+        key={file.oldId ? file.oldId : file._id}
         file={file}
         allFiles={formState.files}
         updateFile={updateFile}

--- a/app/javascript/components/upload/MiscellaneousStep.js
+++ b/app/javascript/components/upload/MiscellaneousStep.js
@@ -45,7 +45,7 @@ function MiscellaneousForm({
     </div>
     { miscFiles.map(file => {
       return <MiscellaneousFileForm
-        key={file._id}
+        key={file.oldId ? file.oldId : file._id}
         file={file}
         allFiles={formState.files}
         updateFile={updateFile}

--- a/app/javascript/components/upload/ProcessedExpressionStep.js
+++ b/app/javascript/components/upload/ProcessedExpressionStep.js
@@ -99,7 +99,7 @@ function ProcessedUploadForm({
         { processedParentFiles.length > 1 && <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_PROCESSED_FILE}/> }
         { processedParentFiles.map(file => {
           return <ExpressionFileForm
-            key={file._id}
+            key={file.oldId ? file.oldId : file._id}
             file={file}
             allFiles={formState.files}
             updateFile={updateFile}

--- a/app/javascript/components/upload/RawCountsStep.js
+++ b/app/javascript/components/upload/RawCountsStep.js
@@ -61,7 +61,7 @@ function RawCountsUploadForm({
     { rawParentFiles.length > 1 && <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_RAW_COUNTS_FILE}/> }
     { rawParentFiles.map(file => {
       return <ExpressionFileForm
-        key={file._id}
+        key={file.oldId ? file.oldId : file._id}
         file={file}
         allFiles={formState.files}
         updateFile={updateFile}

--- a/app/javascript/components/upload/SequenceFileStep.js
+++ b/app/javascript/components/upload/SequenceFileStep.js
@@ -68,7 +68,7 @@ function SequenceForm({
     { sequenceFiles.map(file => {
       const associatedBaiFile = findBundleChildren(file, formState.files)[0]
       return <SequenceFileForm
-        key={file._id}
+        key={file.oldId ? file.oldId : file._id}
         file={file}
         allFiles={formState.files}
         updateFile={updateFile}

--- a/app/javascript/components/upload/SpatialStep.js
+++ b/app/javascript/components/upload/SpatialStep.js
@@ -105,7 +105,7 @@ export function SpatialUploadForm({
     { spatialFiles.length > 1 && <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_SPATIAL_FILE}/> }
     { spatialFiles.map(file => {
       return <ClusteringFileForm
-        key={file._id}
+        key={file.oldId ? file.oldId : file._id}
         file={file}
         allFiles={formState.files}
         updateFile={updateFile}


### PR DESCRIPTION
This fixes a bug Jon found in the cancel button, where the cancel dialog would close of its own accord if it was open during the time the first chunk upload completed.  This also fixes a related bug where if a user was uploading a new file other than the first file in the list, after the upload completed, that file would be shown as collapsed.

TO TEST:
 1. Open a study with the new upload wizard
 2. go to the Miscellaneous / other tab
 3. upload a file
 4. upload another file
 5. Confirm that after the second file upload completes, the panel of the uploaded file does not spontaneously collapse.