### PR TITLE
Flip the color scale (SCP-2945)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -328,6 +328,7 @@ export function getPlotlyTraces({
       Object.assign(trace.marker, {
         showscale: true,
         colorscale: appliedScatterColor,
+        reversescale: true,
         color: colors,
         colorbar: { title, titleside: 'right' }
       })

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -234,10 +234,10 @@ function getLegendEntries(data, pointSize, labelCorrelations) {
 }
 
 
-  // Reverse the continous colorscale as appropriate for high contrast color to correspond to high expression
-  function shouldReverseScale(scatterColor) {
-    return scatterColor === 'Reds' ? false : true
-  }
+/** Reverse the continuous colorscale so high contrast color corresponds to high expression */
+function shouldReverseScale(scatterColor) {
+  return scatterColor !== 'Reds'
+}
 
 /** get the array of plotly traces for plotting */
 export function getPlotlyTraces({

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -127,7 +127,7 @@ function RawScatterPlot({
   useUpdateEffect(() => {
     // Don't try to update the color if the graph hasn't loaded yet
     if (scatterData && !isLoading) {
-      const dataUpdate = { 'marker.colorscale': scatterColor }
+      const dataUpdate = { 'marker.colorscale': scatterColor, 'marker.reversescale': shouldReverseScale(scatterColor) }
       Plotly.update(graphElementId, dataUpdate)
     }
   }, [scatterColor])
@@ -233,6 +233,12 @@ function getLegendEntries(data, pointSize, labelCorrelations) {
   return legendEntries
 }
 
+
+  // Reverse the continous colorscale as appropriate for high contrast color to correspond to high expression
+  function shouldReverseScale(scatterColor) {
+    return scatterColor === 'Reds' ? false : true
+  }
+
 /** get the array of plotly traces for plotting */
 export function getPlotlyTraces({
   axes,
@@ -328,7 +334,7 @@ export function getPlotlyTraces({
       Object.assign(trace.marker, {
         showscale: true,
         colorscale: appliedScatterColor,
-        reversescale: true,
+        reversescale: shouldReverseScale(appliedScatterColor),
         color: colors,
         colorbar: { title, titleside: 'right' }
       })


### PR DESCRIPTION
This flips the colorscale so that the high expression values are the more high contrast colors and the lower expression values are lower contrast colors. This improves visual signal for the plots.

To test pull this branch and view a study with a Scatter plots for “numeric” annotations and Scatter plots for gene expression.

Be sure to look at "Reds" and also any other colorscale.

Before:
<img width="874" alt="Screen Shot 2021-11-15 at 3 02 48 PM" src="https://user-images.githubusercontent.com/54322292/141850895-731e4e6d-866a-4f95-8e1a-c00b74aaff36.png">
After:
<img width="882" alt="Screen Shot 2021-11-15 at 3 03 46 PM" src="https://user-images.githubusercontent.com/54322292/141850899-bcc0a216-2a58-4609-8d3b-e209766855a7.png">

Before:
<img width="1149" alt="Screen Shot 2021-11-15 at 3 37 21 PM" src="https://user-images.githubusercontent.com/54322292/141850903-baa0b049-c86b-4dc6-a09e-ba4fdc312078.png">
After:
<img width="1116" alt="Screen Shot 2021-11-15 at 3 38 57 PM" src="https://user-images.githubusercontent.com/54322292/141850909-e1ef1f7f-fdf9-4873-ad59-4783274dcaa1.png">
