### PR TITLE
Updating to scp-ingest-pipeline:1.12.3 (SCP-3889)

### DIFF
--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -40,7 +40,7 @@ module StudiesHelper
   def get_annotation_bounds(values:, annotation_type:)
     case annotation_type.to_sym
     when :group
-      values.size
+      values.any? ? values.size : '> 200'
     when :numeric
       RequestUtils.get_minmax(values).join(', ')
     end
@@ -55,7 +55,7 @@ module StudiesHelper
         Naturally.sort(values).join(', ')
       else
         label = "<big><span class='label label-warning' data-toggle='tooltip' " + \
-        "title='Group-based annotations with over 100 groups are not visualized for performance reasons'>" + \
+        "title='Group-based annotations with over 200 groups are not visualized for performance reasons'>" + \
         "<i class='fas fa-exclamation-triangle'></i> List too long, will not visualize</span></big>"
         label.html_safe
       end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.12.2'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.12.3'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
This updates to the latest version of `scp-ingest-pipeline`, which is currently `1.12.3`.  This update handles the corner case of group-based annotations that have many unique values (> 200), which in some very large annotations can cause ingest failures as the MongoDB documents exceed the 16MB document size constraint.  Also, this refines the UX on the "Study Details" page to indicate when an annotation has > 200 unique values.

It should be noted that it is still possible to visualize these annotations - a study owner can select one of the "Cannot Visualize" annotations as the default, which will allow it to be shown.  This does not cause any errors, although the legend for said plots is mostly unusable, and for very large annotations, the browser could time out/crash.  Given that this is an extreme corner case that would require direct intervention on the part of a study owner to set, I don't view this as something we need to guard against.

MANUAL TESTING
1. Download the metadata file from https://github.com/broadinstitute/scp-ingest-pipeline/blob/master/tests/data/annotation/metadata/convention/large_group_metadata_to_skip.txt and ingest as normal into any study w/o a metadata file
2. Once completed, go back to "My Studies" and click "Show Details" for this study
3. Confirm the following entry for `barcodekey` under `Cell Metadata & Cluster Annotations`
![Screen Shot 2021-11-15 at 4 12 32 PM](https://user-images.githubusercontent.com/729968/141854509-1c80317f-9ff9-4ca1-9e6a-a368ab2fc4ef.png)

If you want to demo the front-end component of this PR, you can upload this [simulated cluster file](https://github.com/broadinstitute/single_cell_portal_core/files/7541703/cluster_demo_for_large_metadata.txt) and then follow these steps:
1. Load the explore tab for this study, and confirm that `barcodekey` is listed under "Cannot Visualize", and gives the reason of "Too many labels"
![Screen Shot 2021-11-15 at 4 14 51 PM](https://user-images.githubusercontent.com/729968/141854770-be5118ac-ae9f-4de8-b411-b0c7ed6f98ca.png)
2. (Optional) In the "Study Settings" tab, set the default annotation to `barcodekey` and ensure that the plot renders without error (you may need to refresh the page)

This PR satisfies SCP-3889.