### PR TITLE
fixing annotated scatter expression plots (SCP-3892)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -257,7 +257,7 @@ export function getPlotlyTraces({
   }
 
   const appliedScatterColor = getScatterColorToApply(dataScatterColor, scatterColor)
-  const isGeneExpressionForColor = genes.length && !isCorrelatedScatter
+  const isGeneExpressionForColor = genes.length && !isCorrelatedScatter && !isAnnotatedScatter
 
   if (annotType === 'group' && !isGeneExpressionForColor) {
     // default cluster scatter plot


### PR DESCRIPTION
Fixes annotated scatter plots for gene searches on numeric annotations
![image](https://user-images.githubusercontent.com/2800795/141860789-2f642b7c-bfd3-43d8-8cec-d178860703ba.png)

TO TEST:
 1. load Male mouse brain study in the explore tab
 2. Choose the 'Intensity' annotation
 3. Do a search for 'Agtr1' gene
 4. Confirm annotated scatter appears as expected