### PR TITLE
fixing numeric annotation expression plots (SCP-3892)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -365,7 +365,7 @@ export function getPlotlyTraces({
       })
     }
   } else {
-    const isGeneExpressionForColor = genes.length && !isCorrelatedScatter
+    const isGeneExpressionForColor = genes.length && !isCorrelatedScatter && !isAnnotatedScatter
     // for non-clustered plots, we pass in a single trace with all the points
     let colors
     if (isGeneExpressionForColor) {


### PR DESCRIPTION
Fixes annotated scatter plots for gene searches on numeric annotations
image

![image](https://user-images.githubusercontent.com/2800795/141872803-0213779e-3c64-4c9b-a57d-34a0d637f490.png)


TO TEST:

1. load Male mouse brain study in the explore tab
2. Choose the 'Intensity' annotation
3. Do a search for 'Agtr1' gene
4. Confirm annotated scatter appears as expected