### PR TITLE
fixing expression info saving bugs (SCP-3758)

### DIFF
--- a/app/javascript/components/upload/ExpressionFileForm.js
+++ b/app/javascript/components/upload/ExpressionFileForm.js
@@ -136,7 +136,12 @@ export default function ExpressionFileForm({
 /** render a dropdown for an expression file info property */
 function ExpressionFileInfoSelect({ label, propertyName, rawOptions, file, updateFile }) {
   const selectOptions = rawOptions.map(opt => ({ label: opt, value: opt }))
-  const selectedOption = selectOptions.find(opt => opt.value === file.expression_file_info[propertyName])
+  let selectedOption = selectOptions.find(opt => opt.value === file.expression_file_info[propertyName])
+  // if the value is undefined, sometimes react-select will not rerender
+  // this can happen if the server returns different data than was submitted by the user
+  if (!selectedOption) {
+    selectedOption = null
+  }
   return <div className="form-group">
     <label className="labeled-select" data-testid={`expression-select-${_kebabCase(propertyName)}`}>{label}
       <Select options={selectOptions}

--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -4,6 +4,8 @@ import _get from 'lodash/get'
 export const PARSEABLE_TYPES = ['Cluster', 'Coordinate Labels', 'Expression Matrix', 'MM Coordinate Matrix',
   '10X Genes File', '10X Barcodes File', 'Gene List', 'Metadata', 'Analysis Output']
 
+const EXPRESSION_INFO_TYPES = ['Expression Matrix', 'MM Coordinate Matrix']
+
 /** properties used to track file state on the form, but that should not be sent to the server
  *  this also includes properties that are only modifiable on the server (and so should also
  * be ignored server side, but for best hygiene are also just not sent ) */
@@ -61,6 +63,13 @@ export function formatFileFromServer(file) {
   }
   if (file.expression_file_info) {
     delete file.expression_file_info._id
+  }
+  if (EXPRESSION_INFO_TYPES.includes(file.file_type) && !file.expression_file_info) {
+    // some legacy studies will not have supplemental expression file info
+    file.expression_file_info = {
+      is_raw_counts: false,
+      raw_counts_associations: []
+    }
   }
   return file
 }

--- a/app/views/api/v1/study_files/_study_file.json.jbuilder
+++ b/app/views/api/v1/study_files/_study_file.json.jbuilder
@@ -3,3 +3,5 @@ study_file.attributes.each do |name, value|
     json.set! name, value
   end
 end
+
+json.set! 'expression_file_info', study_file.expression_file_info


### PR DESCRIPTION
SCP-3758 Fixes the display of legacy expression files that do not have expression_file_info on them.

This also fixes two bugs that had for the most part canceled each other out in the past.  First is that we weren't sending expression_file_info back from the server after saving a file.  And we didn't notice it because react-select apparently preserves the previous value if you pass 'undefined' as a new value, so the forms looked fine after the save, even though the underlying object was lacking the info.  

TO TEST:
 1.  Delete the expression_file_info object for an existing expression matrix. e.g. `Study.find_by(accession: 'SCP__').study_files.find_by(file_type: 'Expression Matrix').update(expression_file_info: nil)`
 2. View the study in the new upload wizard
 3. click on the Processed matrices tab
 4. observe that the file appears, but the dropdowns are not populated (except species)
 5. fill in the dropdowns, and observe the save button become enabled.
 6. Click save
 7. confirm the file remains intact with the values populated after the save is complete.
 8. update the file description, and confirm you can save again
 9. reload the page, and confirm the file appears with all saved info. 