### PR TITLE
fixing plot caching for expression annotations (SCP-3894)

### DIFF
--- a/app/javascript/components/explore/plot-data-cache.js
+++ b/app/javascript/components/explore/plot-data-cache.js
@@ -215,7 +215,7 @@ export function createCache() {
     return Promise.all(promises).then(resultArray => {
       let mergedResult = null
       resultArray.forEach(result => {
-        mergedResult = cache._mergeClusterResponse(studyAccession, result, cluster, subsample)
+        mergedResult = cache._mergeClusterResponse(studyAccession, result, cluster, annotation, subsample)
       })
       return mergedResult
     }).catch(error => {
@@ -232,7 +232,7 @@ export function createCache() {
 
 
   /** adds the data for a given study/clusterName, overwriting any previous entry */
-  cache._mergeClusterResponse = (accession, clusterResponse, requestedCluster, requestedSubsample) => {
+  cache._mergeClusterResponse = (accession, clusterResponse, requestedCluster, requestedAnnotation, requestedSubsample) => {
     const scatter = clusterResponse[0]
     const cacheEntry = cache._findOrCreateEntry(accession, scatter.cluster, scatter.subsample)
 
@@ -250,7 +250,11 @@ export function createCache() {
     }
     Fields.clusterProps.merge(cacheEntry, scatter)
     Fields.cellsAndCoords.merge(cacheEntry, scatter)
-    Fields.annotation.merge(cacheEntry, scatter)
+    // only merge in annotation values if the annotation matches (or the default was requested, so
+    // we can then assume the response matches)
+    if (!requestedAnnotation.name || scatter.annotParams.name === requestedAnnotation.name) {
+      Fields.annotation.merge(cacheEntry, scatter)
+    }
     if (scatter.genes.length) {
       Fields.expression.merge(cacheEntry, scatter)
     }


### PR DESCRIPTION
Wow, this bug has been in production since frontend caching started.  But the recent expression sorting code just turned it from a hard-to-notice missing data problem to a full-stop error.  (and if we weren't using `for` loops for performance, the bug might have stayed hidden forever :-P)
To reproduce in production,
1. go to https://singlecell.broadinstitute.org/single_cell/study/SCP738.
2. Change the cluster to "Synovial fibroblasts"
3. Change the annotation to "biosample_id"
4. Do a gene search for AGAP1
5. Hover over a point in the expression graph, and observe that `%{meta}` appears where the annotation value should be.

TO TEST: (you need a study with >=2 clusters, and >=2 annotations)
1. populate the synthetic study 'human_lymph_node'
2. open the study in the explore tab
3. change the cluster
4. change the annotation to disease_ontology_label
5. do a gene search for AGPAT2
6. observe the expression graph renders, and hovering over points shows the annotation for each cell.
