### PR TITLE
Align legend point text in all viewport widths (SCP-3895)

### DIFF
--- a/app/javascript/styles/_scatterPlot.scss
+++ b/app/javascript/styles/_scatterPlot.scss
@@ -65,19 +65,20 @@
 
 .scatter-legend-entry {
   position: relative;
+  display: flex;
   top: 5px;
   white-space: pre;
 
   .legend-label {
     display: inline-block;
-    width: 160px;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    margin-right: 5px;
   }
 
   .num-points {
-    float: right;
+    margin-left: auto;
     margin-right: 5px;
   }
 }


### PR DESCRIPTION
This fixes a bug in which the text reporting number of points in the custom scatter legend misaligned in some narrow widths.  It also gives more space for label text.

In the videos below, watch the numbers ("10") at right in the legend.

Old bug:

https://user-images.githubusercontent.com/1334561/142062605-ed2cf451-ab8a-4b1d-ab5e-d498d18667af.mov

New fix:

https://user-images.githubusercontent.com/1334561/142062629-1560b1ae-57b9-4757-98db-0794851dcd43.mov

This also removes a hard-coded width, which had previously (naively) accounted for the space occupied by large numbers (e.g. 1,000,000).  Using `display: flex;` fixed the alignment, and `margin-left: auto;` more flexibly accounts for text width of big numbers.

To test:
* Go to a study with visualizations
* Search a gene
* Narrow window width to just before scatter plots readjust to two lines
* Note how point text always vertically aligns with label text in custom scatter plot legend

This satisfies SCP-3895.