### PR TITLE
fixing create annotations bug (SCP-3897)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -209,7 +209,9 @@ function RawScatterPlot({
     if (scatterData && !isLoading) {
       processScatterPlot()
     }
-  }, [shownTraces, dimensionProps])
+    // look for updates of individual properties, so that we don't rerender if the containing array
+    // happens to be a different instance
+  }, [shownTraces.join(','), dimensionProps.height, dimensionProps.width])
 
   // Handles Plotly `data` updates, e.g. changes in color profile
   useUpdateEffect(() => {


### PR DESCRIPTION
this fixes create annotations so that cell selections are possible.  Previously, processScatterPlot was being called again after the cellselection event, which would then pass plotly new traces, which would obliterate the current selection.

The underlying technical note is that React useEffect only does a superficial compare of objects passed in the second argument array to see if they've changed.  So, e.g. if  `['foo', [2,3]]` is passed in, the 'foo' string will be compared as expected.  But the array `[2,3]` will have to be the exact same instance as the previous call, or else the property will be treated as changed.  So best practice is to always pass simple properties to useEffect, unless the shallow compare is what you want.


TO TEST:
1. Load a cluster plot in the explore tab
2. click create annotation
3. Select some cells
4. observe the cells remain selected, and then name the given group
5. select some more cells, and name the group
6. name your new annotation, and click 'create'
7. Observe the annotation is saved and displayed