### PR TITLE
fixing graph resizing (SCP-3897)

### DIFF
--- a/app/javascript/components/explore/plot-data-cache.js
+++ b/app/javascript/components/explore/plot-data-cache.js
@@ -86,7 +86,9 @@ const Fields = {
     },
     addFieldsOrPromise: (entry, fields, promises, annotationName, annotationScope) => {
       const cachedAnnotation = Fields.annotation.getFromEntry(entry, annotationName, annotationScope)
-      if (!cachedAnnotation) {
+      if (!cachedAnnotation || annotationScope === 'user') {
+        // because the requested name (the guid) for user annotations won't match the returned name
+        // (the annotation's actual name), we don't cache user annotation values
         fields.push('annotation')
       } else if (cachedAnnotation.then && !promises.includes(cachedAnnotation)) {
         promises.push(cachedAnnotation)

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -25,19 +25,6 @@ export const SCATTER_COLOR_OPTIONS = [
 export const defaultScatterColor = 'Reds'
 window.Plotly = Plotly
 
-/** Get width and height for scatter plot dimensions */
-export function getScatterDimensions(scatter, dimensionProps) {
-  const isRefGroup = getIsRefGroup(scatter)
-
-  dimensionProps = Object.assign({
-    hasLabelLegend: isRefGroup,
-    hasTitle: true
-  }, dimensionProps)
-
-  return getPlotDimensions(dimensionProps)
-}
-
-
 /** Renders the appropriate scatter plot for the given study and params
   * @param studyAccession {string} e.g. 'SCP213'
   * @param cluster {string} the name of the cluster, or blank/null for the study's default
@@ -203,6 +190,7 @@ function RawScatterPlot({
     })
   }, [cluster, annotation.name, subsample, consensus, genes.join(','), isAnnotatedScatter])
 
+  const widthAndHeight = getScatterDimensions(scatterData, dimensionProps, genes)
   // Handles custom scatter legend updates and window resizing
   useUpdateEffect(() => {
     // Don't update if graph hasn't loaded
@@ -211,7 +199,7 @@ function RawScatterPlot({
     }
     // look for updates of individual properties, so that we don't rerender if the containing array
     // happens to be a different instance
-  }, [shownTraces.join(','), dimensionProps.height, dimensionProps.width])
+  }, [shownTraces.join(','), widthAndHeight.height, widthAndHeight.width])
 
   // Handles Plotly `data` updates, e.g. changes in color profile
   useUpdateEffect(() => {
@@ -305,6 +293,20 @@ function getIsRefGroup(scatter) {
   const isGeneExpressionForColor = genes.length && !isCorrelatedScatter
 
   return annotType === 'group' && !isGeneExpressionForColor
+}
+
+/** Get width and height for scatter plot dimensions */
+function getScatterDimensions(scatter, dimensionProps, genes) {
+  // if we don't have a server response yet so we don't know the annotation type,
+  // guess based on the number of genes
+  const isRefGroup = scatter ? getIsRefGroup(scatter) : (genes.length === 0)
+
+  dimensionProps = Object.assign({
+    hasLabelLegend: isRefGroup,
+    hasTitle: true
+  }, dimensionProps)
+
+  return getPlotDimensions(dimensionProps)
 }
 
 


### PR DESCRIPTION
This fixes a bug introduced by the fix of the create annotations capability.  We weren't passing the actual width and height to the resize useEffect -- the reason resizing was working before was that we were redrawing the graph on every rerender.

This also fixes a bug with user annotation caching on expression plots

TO TEST:
1. Open a study in the explore tab
2. view a cluster
3. resize your browser
4. confirm the plot redraws
5. sign in, and click 'create annotation'
6. confirm that you can select points for a labelled annotation
__________
1. Open a study with a user annotation
2. go to explore tab
3. search for a gene
4. confirm the expression plot renders