### PR TITLE
fixing colorscale behavior when Reds are default (SCP-2945)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -312,7 +312,8 @@ function getScatterDimensions(scatter, dimensionProps, genes) {
 
 /** Reverse the continuous colorscale so high contrast color corresponds to high expression */
 function shouldReverseScale(scatterColor) {
-  return scatterColor !== 'Reds'
+  // don't reverse the Reds scale, and check whether it is the default
+  return (scatterColor && scatterColor !== 'Reds') || (!scatterColor && defaultScatterColor !== 'Reds')
 }
 
 /** get the array of plotly traces for plotting */

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -313,7 +313,8 @@ function getScatterDimensions(scatter, dimensionProps, genes) {
 /** Reverse the continuous colorscale so high contrast color corresponds to high expression */
 function shouldReverseScale(scatterColor) {
   // don't reverse the Reds scale, and check whether it is the default
-  return (scatterColor && scatterColor !== 'Reds') || (!scatterColor && defaultScatterColor !== 'Reds')
+  const shownColor = scatterColor ? scatterColor : defaultScatterColor
+  return shownColor !== 'Reds'
 }
 
 /** get the array of plotly traces for plotting */


### PR DESCRIPTION
Prior to this fix, The 'Reds' colorscale would be inverted when it was rendered as the default colorscale, but not inverted if it was explicitly selected.  See e.g. https://singlecell-staging.broadinstitute.org/single_cell/study/SCP1/breast-milk-alexandria-staging#study-visualize.  

TO TEST:
1. Load a study and go to the explore tab
2. do a single gene search
3. observe the Reds scale is not inverted

