### PR TITLE
Integrating HCA results from Azul into bulk download UX (SCP-3812, SCP-3815)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # SINGLE CELL PORTAL README
 
 [![codecov](https://codecov.io/gh/broadinstitute/single_cell_portal_core/branch/development/graph/badge.svg?token=HMWE5BO2a4)](https://codecov.io/gh/broadinstitute/single_cell_portal_core)
-[![Build Status](https://travis-ci.com/broadinstitute/single_cell_portal_core.svg?branch=development)](https://travis-ci.com/broadinstitute/single_cell_portal_core)
-
+[![Build Status](https://app.travis-ci.com/broadinstitute/single_cell_portal_core.svg?branch=development)](https://app.travis-ci.com/broadinstitute/single_cell_portal_core)
 ## SETUP
 
 This application is built and deployed using [Docker](https://www.docker.com), specifically native

--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -246,10 +246,10 @@ module Api
             key :required, false
           end
           parameter do
-            key :name, :source
+            key :name, :context
             key :type, :string
             key :in, :query
-            key :description, 'Source of download request, either "study" or "search"'
+            key :description, 'Context of the download, its scope: either "study" or "global"'
             key :required, false
           end
           response 200 do
@@ -284,7 +284,7 @@ module Api
         azul_files = {}
 
         # determine if this a single-study bulk download (from download tab) or from home page search
-        search_source = params[:source] || 'search'
+        search_context = params[:context] || 'global'
 
         # branch based on whether they provided a download_id, file_ids, or accessions
         if params[:download_id]
@@ -355,7 +355,7 @@ module Api
                                                                            study_bucket_map: bucket_map,
                                                                            output_pathname_map: pathname_map,
                                                                            azul_files: azul_files,
-                                                                           source: search_source)
+                                                                           context: search_context)
         end_time = Time.zone.now
         runtime = TimeDifference.between(start_time, end_time).humanize
         logger.info "Curl configs generated for studies #{valid_accessions}, #{files_requested.size + directory_files.size} total files"

--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -245,6 +245,13 @@ module Api
             key :description, 'Name of directory folder to download (for single-study bulk download only), can be "all"'
             key :required, false
           end
+          parameter do
+            key :name, :source
+            key :type, :string
+            key :in, :query
+            key :description, 'Source of download request, either "study" or "search"'
+            key :required, false
+          end
           response 200 do
             key :description, 'Curl configuration file with signed URLs for requested data'
             key :type, :string
@@ -275,6 +282,9 @@ module Api
         valid_accessions = []
         file_ids = []
         azul_files = {}
+
+        # determine if this a single-study bulk download (from download tab) or from home page search
+        search_source = params[:source] || 'search'
 
         # branch based on whether they provided a download_id, file_ids, or accessions
         if params[:download_id]
@@ -344,7 +354,8 @@ module Api
                                                                            user: current_api_user,
                                                                            study_bucket_map: bucket_map,
                                                                            output_pathname_map: pathname_map,
-                                                                           azul_files: azul_files)
+                                                                           azul_files: azul_files,
+                                                                           source: search_source)
         end_time = Time.zone.now
         runtime = TimeDifference.between(start_time, end_time).humanize
         logger.info "Curl configs generated for studies #{valid_accessions}, #{files_requested.size + directory_files.size} total files"

--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -284,7 +284,7 @@ module Api
         azul_files = {}
 
         # determine if this a single-study bulk download (from download tab) or from home page search
-        search_context = params[:context] || 'global'
+        search_context = params[:context] || 'unknown'
 
         # branch based on whether they provided a download_id, file_ids, or accessions
         if params[:download_id]

--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -57,14 +57,14 @@ module Api
         half_hour = 1800 # seconds
 
         totat = current_api_user.create_totat(half_hour, api_v1_bulk_download_generate_curl_config_path)
-        valid_params = params.permit({ file_ids: [], tdr_files: {} }).to_h
+        valid_params = params.permit({ file_ids: [], azul_files: {} }).to_h
 
         # for now, we don't do any permissions validation on the param values -- we'll do that during the actual download, since
         # quota/files/permissions may change between the creation of the download and the actual download.
         auth_download = DownloadRequest.create!(
           auth_code: totat[:totat],
           file_ids: valid_params[:file_ids],
-          tdr_files: valid_params[:tdr_files],
+          azul_files: valid_params[:azul_files],
           user_id: current_api_user.id
         )
         auth_code_response = {
@@ -274,7 +274,7 @@ module Api
       def generate_curl_config
         valid_accessions = []
         file_ids = []
-        tdr_files = {}
+        azul_files = {}
 
         # branch based on whether they provided a download_id, file_ids, or accessions
         if params[:download_id]
@@ -282,7 +282,7 @@ module Api
           render json: { error: 'Invalid download_id provided' }, status: 400 and return if download_req.blank?
 
           file_ids = download_req.file_ids
-          tdr_files = download_req.tdr_files
+          azul_files = download_req.azul_files
         elsif params[:file_ids]
           begin
             file_ids = RequestUtils.validate_id_list(params[:file_ids])
@@ -344,7 +344,7 @@ module Api
                                                                            user: current_api_user,
                                                                            study_bucket_map: bucket_map,
                                                                            output_pathname_map: pathname_map,
-                                                                           tdr_files: tdr_files)
+                                                                           azul_files: azul_files)
         end_time = Time.zone.now
         runtime = TimeDifference.between(start_time, end_time).humanize
         logger.info "Curl configs generated for studies #{valid_accessions}, #{files_requested.size + directory_files.size} total files"

--- a/app/javascript/components/search/controls/download/DownloadButton.js
+++ b/app/javascript/components/search/controls/download/DownloadButton.js
@@ -42,11 +42,11 @@ export default function DownloadButton({ searchResults={} }) {
    * means we are reliant on the TDR results being on the current page.  Once we begin paging/sorting
    * TDR results, this approach will have to be revisited */
   const tdrFileInfo = searchResults.studies
-    ?.filter(result => result.study_source === 'TDR')
+    ?.filter(result => result.study_source === 'HCA')
     ?.map(result => ({
       accession: result.accession,
       name: result.name,
-      study_source: 'TDR',
+      study_source: 'HCA',
       description: result.description,
       hca_project_id: result.hca_project_id,
       studyFiles: result.file_information

--- a/app/javascript/components/search/controls/download/DownloadButton.js
+++ b/app/javascript/components/search/controls/download/DownloadButton.js
@@ -41,7 +41,7 @@ export default function DownloadButton({ searchResults={} }) {
   /** Note that we are reading the TDR file information from the search results object, which
    * means we are reliant on the TDR results being on the current page.  Once we begin paging/sorting
    * TDR results, this approach will have to be revisited */
-  const tdrFileInfo = searchResults.studies
+  const azulFileInfo = searchResults.studies
     ?.filter(result => result.study_source === 'HCA')
     ?.map(result => ({
       accession: result.accession,
@@ -72,7 +72,7 @@ export default function DownloadButton({ searchResults={} }) {
         <DownloadSelectionModal
           show={showModal}
           setShow={setShowModal}
-          tdrFileInfo={tdrFileInfo}
+          azulFileInfo={azulFileInfo}
           studyAccessions={matchingAccessions}/> }
     </>
   )

--- a/app/javascript/components/search/controls/download/DownloadCommand.js
+++ b/app/javascript/components/search/controls/download/DownloadCommand.js
@@ -5,7 +5,7 @@ import { fetchAuthCode, stringifyQuery } from 'lib/scp-api'
 
 /** component for rendering a copyable bulk download command for an array of file ids.
     Queries the server to retrieve the appropriate auth code. */
-export default function DownloadCommand({ fileIds=[], tdrFiles }) {
+export default function DownloadCommand({ fileIds=[], azulFiles }) {
   const [isLoading, setIsLoading] = useState(true)
   const [authInfo, setAuthInfo] = useState({ authCode: null, timeInterval: 3000 })
   const [refreshNum, setRefreshNum] = useState(0)
@@ -20,7 +20,7 @@ export default function DownloadCommand({ fileIds=[], tdrFiles }) {
 
   useEffect(() => {
     setIsLoading(true)
-    fetchAuthCode(fileIds, tdrFiles).then(result => {
+    fetchAuthCode(fileIds, azulFiles).then(result => {
       setAuthInfo(result)
       setIsLoading(false)
     })

--- a/app/javascript/components/search/controls/download/DownloadCommand.js
+++ b/app/javascript/components/search/controls/download/DownloadCommand.js
@@ -84,7 +84,8 @@ export default function DownloadCommand({ fileIds=[], azulFiles }) {
 function getDownloadCommand(authCode, downloadId) {
   const queryParams = {
     auth_code: authCode,
-    download_id: downloadId
+    download_id: downloadId,
+    context: 'global' // this is a search-based bulk download request
   }
   const queryString = stringifyQuery(queryParams)
 

--- a/app/javascript/components/search/controls/download/DownloadSelectionModal.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionModal.js
@@ -10,7 +10,7 @@ import { bytesToSize } from 'lib/stats'
 
 import { fetchDownloadInfo, fetchDrsInfo } from 'lib/scp-api'
 
-const TDR_COLUMNS = ['project_manifest', 'analysis', 'sequence']
+const AZUL_COLUMNS = ['project_manifest', 'analysis', 'sequence']
 const SCP_COLUMNS = ['matrix', 'metadata', 'cluster']
 
 /**
@@ -18,32 +18,24 @@ const SCP_COLUMNS = ['matrix', 'metadata', 'cluster']
   * studies and file types for download.  This queries the bulk_download/summary API method
   * to retrieve the list of study details and available files
   */
-export default function DownloadSelectionModal({ studyAccessions, tdrFileInfo, show, setShow }) {
+export default function DownloadSelectionModal({ studyAccessions, azulFileInfo, show, setShow }) {
   const [isLoading, setIsLoading] = useState(true)
-  const [isLoadingTDR, setIsLoadingTDR] = useState(true)
+  const [isLoadingAzul, setIsLoadingAzul] = useState(true)
   const [downloadInfo, setDownloadInfo] = useState([])
   const [selectedBoxes, setSelectedBoxes] = useState()
-  const [downloadInfoTDR, setDownloadInfoTDR] = useState([])
-  const [selectedBoxesTDR, setSelectedBoxesTDR] = useState()
+  const [downloadInfoAzul, setDownloadInfoAzul] = useState([])
+  const [selectedBoxesAzul, setSelectedBoxesAzul] = useState()
   const [stepNum, setStepNum] = useState(1)
 
   const scpAccessions = studyAccessions.filter(accession => accession.startsWith('SCP'))
-  const tdrAccessions = studyAccessions.filter(accession => !accession.startsWith('SCP'))
-  const showTDRSelectionPane = tdrAccessions.length > 0
+  const azulAccessions = studyAccessions.filter(accession => !accession.startsWith('SCP'))
+  const showAzulSelectionPane = azulAccessions.length > 0
   const { fileCount, fileSize } = getSelectedFileStats(downloadInfo, selectedBoxes, isLoading)
   const { fileCount: fileCountTDR, fileSize: fileSizeTDR } =
-    getSelectedFileStats(downloadInfoTDR, selectedBoxesTDR, isLoadingTDR)
+    getSelectedFileStats(downloadInfoAzul, selectedBoxesAzul, isLoadingAzul)
   const prettyBytes = bytesToSize(fileSize + fileSizeTDR)
   const selectedFileIds = getSelectedFileHandles(downloadInfo, selectedBoxes)
-  const selectedTdrFiles = getSelectedFileHandles(downloadInfoTDR, selectedBoxesTDR, true)
-
-  /** For TDR studies, we will know from the tdrFileInfo object how many files of each type there are
-   * But we need to query the drsInfo so that we can get the file sizes and download urls */
-  function initializeTDRTable() {
-    setSelectedBoxesTDR(newSelectedBoxesState(tdrFileInfo, TDR_COLUMNS))
-    setDownloadInfoTDR(tdrFileInfo)
-    setIsLoadingTDR(false)
-  }
+  const selectedTdrFiles = getSelectedFileHandles(downloadInfoAzul, selectedBoxesAzul, true)
 
   /**
     render bulk download table for SCP & TDR/HCA studies
@@ -52,15 +44,17 @@ export default function DownloadSelectionModal({ studyAccessions, tdrFileInfo, s
     setSelectedBoxes(newSelectedBoxesState(result, SCP_COLUMNS))
     setDownloadInfo(result)
     setIsLoading(false)
-    if (showTDRSelectionPane) {
-      initializeTDRTable()
+    if (showAzulSelectionPane) {
+      setSelectedBoxesAzul(newSelectedBoxesState(azulFileInfo, AZUL_COLUMNS))
+      setDownloadInfoAzul(azulFileInfo)
+      setIsLoadingAzul(false)
     }
   }
 
   useEffect(() => {
     if (show) {
       setIsLoading(true)
-      setIsLoadingTDR(true)
+      setIsLoadingAzul(true)
       fetchDownloadInfo(scpAccessions).then(result => {
         renderFileTables(result)
       })
@@ -116,15 +110,15 @@ export default function DownloadSelectionModal({ studyAccessions, tdrFileInfo, s
               selectedBoxes={selectedBoxes}
               setSelectedBoxes={setSelectedBoxes}
               columnTypes={SCP_COLUMNS}/>
-            { showTDRSelectionPane &&
+            { showAzulSelectionPane &&
               <div>
                 <h4>Human Cell Atlas studies</h4>
                 <DownloadSelectionTable
-                  isLoading={isLoadingTDR}
-                  downloadInfo={downloadInfoTDR}
-                  selectedBoxes={selectedBoxesTDR}
-                  setSelectedBoxes={setSelectedBoxesTDR}
-                  columnTypes={TDR_COLUMNS}/>
+                  isLoading={isLoadingAzul}
+                  downloadInfo={downloadInfoAzul}
+                  selectedBoxes={selectedBoxesAzul}
+                  setSelectedBoxes={setSelectedBoxesAzul}
+                  columnTypes={AZUL_COLUMNS}/>
               </div>
             }
           </div>

--- a/app/javascript/components/search/controls/download/DownloadSelectionModal.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionModal.js
@@ -31,14 +31,14 @@ export default function DownloadSelectionModal({ studyAccessions, azulFileInfo, 
   const azulAccessions = studyAccessions.filter(accession => !accession.startsWith('SCP'))
   const showAzulSelectionPane = azulAccessions.length > 0
   const { fileCount, fileSize } = getSelectedFileStats(downloadInfo, selectedBoxes, isLoading)
-  const { fileCount: fileCountTDR, fileSize: fileSizeTDR } =
+  const { fileCount: fileCountAzul, fileSize: fileSizeAzul } =
     getSelectedFileStats(downloadInfoAzul, selectedBoxesAzul, isLoadingAzul)
-  const prettyBytes = bytesToSize(fileSize + fileSizeTDR)
+  const prettyBytes = bytesToSize(fileSize + fileSizeAzul)
   const selectedFileIds = getSelectedFileHandles(downloadInfo, selectedBoxes)
-  const selectedTdrFiles = getSelectedFileHandles(downloadInfoAzul, selectedBoxesAzul, true)
+  const selectedAzulFiles = getSelectedFileHandles(downloadInfoAzul, selectedBoxesAzul, true)
 
   /**
-    render bulk download table for SCP & TDR/HCA studies
+    render bulk download table for SCP & HCA studies
    */
   function renderFileTables(result=[]) {
     setSelectedBoxes(newSelectedBoxesState(result, SCP_COLUMNS))
@@ -67,7 +67,7 @@ export default function DownloadSelectionModal({ studyAccessions, azulFileInfo, 
     data-analytics-name="download-modal-next">
     NEXT
   </button>
-  if (fileCount + fileCountTDR === 0) {
+  if (fileCount + fileCountAzul === 0) {
     downloadButton = <button className="btn btn-primary" disabled="disabled">
       No files selected
     </button>
@@ -126,7 +126,7 @@ export default function DownloadSelectionModal({ studyAccessions, azulFileInfo, 
         { stepNum === 2 && <DownloadCommand
           closeParent={() => setShow(false)}
           fileIds={selectedFileIds}
-          tdrFiles={selectedTdrFiles}/> }
+          azulFiles={selectedAzulFiles}/> }
         { !isLoading &&
           <div className="download-size-message">
             <label htmlFor="download-size-amount">Total size</label>

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -287,7 +287,10 @@ export function getSelectedFileHandles(downloadInfo, selectedBoxes, hashByStudy=
         {/* eslint-disable-next-line max-len */}
         const selectedHandles = filesOfType.map(file => {
           if (hashByStudy) {
-            return { project_id: file.project_id, name: file.name, file_format: file.file_format, file_type: file.file_type }
+            return {
+              project_id: file.project_id, name: file.name, file_format: file.file_format,
+              file_type: file.file_type, count: file.count
+            }
           } else {
             return file.id
           }

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -259,9 +259,9 @@ export function getSelectedFileStats(downloadInfo, selectedBoxes, isLoading) {
   */
 export function getFileStats(study, fileTypes) {
   const files = study.studyFiles.filter(file => fileTypes.includes(file.file_type))
-  const fileCount = study.study_source === 'SCP' ? files.length : files.reduce((sum, studyFile) => {
+  const fileCount = study.study_source === 'HCA' ? files.reduce((sum, studyFile) => {
     return sum + studyFile.count
-  }, 0)
+  }, 0) : files.length
   const fileSize = files.reduce((sum, studyFile) => {
     return sum + (studyFile.upload_file_size ? studyFile.upload_file_size : 0)
   }, 0)
@@ -285,7 +285,13 @@ export function getSelectedFileHandles(downloadInfo, selectedBoxes, hashByStudy=
       if (selectedBoxes.studies[index][colType]) {
         const filesOfType = study.studyFiles.filter(file => COLUMNS[colType].types.includes(file.file_type))
         {/* eslint-disable-next-line max-len */}
-        const selectedHandles = filesOfType.map(file => hashByStudy ? { drs_id: file.drs_id, url: file.url, name: file.name, file_type: file.file_type } : file.id)
+        const selectedHandles = filesOfType.map(file => {
+          if (hashByStudy) {
+            return { project_id: file.project_id, name: file.name, file_format: file.file_format, file_type: file.file_type }
+          } else {
+            return file.id
+          }
+        })
         if (hashByStudy) {
           fileHandles[study.accession].push(...selectedHandles)
         } else {

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -259,7 +259,9 @@ export function getSelectedFileStats(downloadInfo, selectedBoxes, isLoading) {
   */
 export function getFileStats(study, fileTypes) {
   const files = study.studyFiles.filter(file => fileTypes.includes(file.file_type))
-  const fileCount = files.length
+  const fileCount = study.study_source === 'SCP' ? files.length : files.reduce((sum, studyFile) => {
+    return sum + studyFile.count
+  }, 0)
   const fileSize = files.reduce((sum, studyFile) => {
     return sum + (studyFile.upload_file_size ? studyFile.upload_file_size : 0)
   }, 0)

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -82,11 +82,11 @@ function defaultPostInit(mock=false) {
  * // returns {authCode: 123456, timeInterval: 1800}
  * fetchAuthCode(true)
  */
-export async function fetchAuthCode(fileIds, tdrFiles, mock=false) {
+export async function fetchAuthCode(fileIds, azulFiles, mock=false) {
   const init = defaultPostInit(mock)
   init.body = JSON.stringify({
     file_ids: fileIds,
-    tdr_files: tdrFiles
+    azul_files: azulFiles
   })
   const [authCode, perfTimes] = await scpApi('/bulk_download/auth_code', init, mock)
 

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -52,8 +52,9 @@ class AzulSearchService
         term_matches: {},
         file_information: [
           {
-            url: project_id,
+            project_id: project_id,
             file_type: 'Project Manifest',
+            count: 1,
             upload_file_size: 1.megabyte, # placeholder filesize as we don't know until manifest is downloaded
             name: "#{short_name}.tsv"
           }

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -83,6 +83,8 @@ class AzulSearchService
       facet_name = facet[:id]
       RESULT_FACET_FIELDS.each do |result_field|
         azul_name = FacetNameConverter.convert_schema_column(:alexandria, :azul, facet_name)
+        # gotcha where sampleDisease is called disease in Azul response objects
+        azul_name = 'disease' if azul_name == 'sampleDisease'
         field_entries = result[result_field].map { |entry| entry[azul_name] }.flatten.uniq
         facet[:filters].each do |filter|
           match = field_entries.select { |entry| filter[:name] == entry || filter[:id] == entry }

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -37,13 +37,11 @@ class AzulSearchService
     merged_facets = merge_facet_lists(selected_facets, terms_to_facets)
     Rails.logger.info "Executing Azul project query with: #{query_json}"
     project_results = client.projects(query: query_json)
-    project_ids = []
     project_results['hits'].each do |entry|
       entry_hash = entry.with_indifferent_access
       project_hash = entry_hash[:projects].first # there will only ever be one project here
       short_name = project_hash[:projectShortname]
       project_id = project_hash[:projectId]
-      project_ids << project_id
       result = {
         hca_result: true,
         accession: short_name,
@@ -61,28 +59,18 @@ class AzulSearchService
           }
         ]
       }.with_indifferent_access
+      # extract file summary information from result
+      project_file_info = extract_file_information(entry_hash)
+      result[:file_information] += project_file_info if project_file_info.any?
       # get facet matches from rest of entry
       result[:facet_matches] = get_facet_matches(entry_hash, merged_facets)
       if terms
+        # only store result if we get a text match on project name/description
         result[:term_matches] = get_search_term_weights(result, terms)
-        if result.dig(:term_matches, :total) > 0
-          results[short_name] = result
-        else
-          # we didn't get any hits on project name/description, so exclude from results and remove project ID from list
-          project_ids.pop
-        end
+        results[short_name] = result if result.dig(:term_matches, :total) > 0
       else
         results[short_name] = result
       end
-    end
-    # now run file query to get matching files for all matching projects
-    file_query = { 'projectId' => { 'is' => project_ids } }
-    Rails.logger.info "Executing Azul file query for projects: #{project_ids}"
-    files = client.files(query: file_query)
-    files.each do |file_entry|
-      file_info = extract_azul_file_info(file_entry)
-      accession = file_info[:accession]
-      results[accession][:file_information] << file_info
     end
     results
   end
@@ -108,34 +96,6 @@ class AzulSearchService
     results_info[:facet_search_weight] = results_info.values.map(&:count).flatten.reduce(0, :+)
     results_info
   end
-
-  # extract Azul file information for bulk download from file entry object
-  def self.extract_azul_file_info(file)
-    file_info = {
-      'name' => file['name'],
-      'upload_file_size' => file['size'],
-      'file_format' => file['format'],
-      'url' => file['url'],
-      'accession' => file['projectShortname'],
-      'project_id' => file['projectId']
-    }
-    content = file['contentDescription']
-    case content
-    when /Matrix/
-      file_info['file_type'] = 'analysis_file'
-    when /Sequence/
-      file_info['file_type'] = 'sequence_file'
-    else
-      # fallback to guess file_type by extension
-      FILE_EXT_BY_DOWNLOAD_TYPE.each_pair do |file_type, extensions|
-        if extensions.include? file['format']
-          file_info['file_type'] = file_type
-        end
-      end
-    end
-    file_info.with_indifferent_access
-  end
-
 
   # retrieve all possible facet/filter values present in Azul
   # this is done by executing an empty search and requesting only 1 project, then retrieving the
@@ -197,5 +157,39 @@ class AzulSearchService
       end
     end
     weights.with_indifferent_access
+  end
+
+  # extract preliminary file information from an Azul result object
+  def self.extract_file_information(result)
+    file_information = []
+    project_hash = result[:projects].first # there will only ever be one project here
+    short_name = project_hash[:projectShortname]
+    project_id = project_hash[:projectId]
+    result[:fileTypeSummaries].each do |file_summary|
+      file_info = {
+        source: 'hca',
+        count: file_summary['count'],
+        upload_file_size: file_summary['totalSize'],
+        file_format: file_summary['format'],
+        accession: short_name,
+        project_id: project_id
+      }
+      content = file_summary['contentDescription']
+      case content
+      when /Matrix/
+        file_info[:file_type] = 'analysis_file'
+      when /Sequence/
+        file_info[:file_type] = 'sequence_file'
+      else
+        # fallback to guess file_type by extension
+        FILE_EXT_BY_DOWNLOAD_TYPE.each_pair do |file_type, extensions|
+          if extensions.include? file_summary['format']
+            file_info[:file_type] = file_type
+          end
+        end
+      end
+      file_information << file_info.with_indifferent_access
+    end
+    file_information
   end
 end

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -14,7 +14,7 @@ class BulkDownloadService
   #   - +study_bucket_map+ => Map of study IDs to bucket names
   #   - +output_pathname_map+ => Map of study file IDs to output pathnames
   #   - +azul_files+ => Hash of Azul file summary objects
-  #   - +source+ => Origin of bulk download request (either search or study-based download)
+  #   - +context+ => Context of bulk download request ("study" for single-study, or "global" for search across all studies)
   #
   # * *return*
   #   - (String) => String representation of signed URLs and output filepaths to pass to curl
@@ -24,7 +24,7 @@ class BulkDownloadService
                                        study_bucket_map:,
                                        output_pathname_map:,
                                        azul_files: nil,
-                                       source: 'study')
+                                       context: 'study')
     curl_configs = ['--create-dirs', '--compressed']
     # create an array of all objects to be downloaded, including directory files
     download_objects = study_files.to_a + directory_files
@@ -106,7 +106,7 @@ class BulkDownloadService
       numAzulFiles: azul_file_configs.count,
       numAzulAnalysisFiles: azul_analysis_files,
       numAzulSequenceFiles: azul_sequence_files,
-      source: source
+      context: context
     }, user)
     curl_configs.join("\n\n")
   end

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -54,6 +54,7 @@ class BulkDownloadService
     tdr_file_configs = []
 
     if tdr_files.present?
+
       hca_client = ApplicationController.hca_azul_client
       curl_configs << "-H \"Authorization: Bearer #{DataRepoClient.new.access_token['access_token']}\""
       tdr_file_configs = []

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -13,7 +13,7 @@ class BulkDownloadService
   #   - +user+ (User) => User requesting download
   #   - +study_bucket_map+ => Map of study IDs to bucket names
   #   - +output_pathname_map+ => Map of study file IDs to output pathnames
-  #   - +tdr_files+ => Hash of tdr accessions to arrays of file information including name & url for each file
+  #   - +azul_files+ => Hash of Azul file summary objects
   #
   # * *return*
   #   - (String) => String representation of signed URLs and output filepaths to pass to curl
@@ -22,7 +22,7 @@ class BulkDownloadService
                                        user:,
                                        study_bucket_map:,
                                        output_pathname_map:,
-                                       tdr_files: nil)
+                                       azul_files: nil)
     curl_configs = ['--create-dirs', '--compressed']
     # create an array of all objects to be downloaded, including directory files
     download_objects = study_files.to_a + directory_files
@@ -50,36 +50,38 @@ class BulkDownloadService
       manifest_config += "output=\"#{study.accession}/file_supplemental_info.tsv\""
       curl_configs << manifest_config
     end
-    tdr_studies = tdr_files ? tdr_files.keys : []
-    tdr_file_configs = []
+    azul_studies = azul_files ? azul_files.keys : []
+    azul_file_configs = []
 
-    if tdr_files.present?
-
+    if azul_files.present?
       hca_client = ApplicationController.hca_azul_client
-      curl_configs << "-H \"Authorization: Bearer #{DataRepoClient.new.access_token['access_token']}\""
-      tdr_file_configs = []
-      tdr_files.map do |shortname, file_infos|
+      azul_file_configs = []
+      azul_files.map do |shortname, file_infos|
+        next if file_infos.empty?
+
         # pull out project manifest and process separately
         manifests, files = file_infos.partition { |f| f['file_type'] == 'Project Manifest' }
         manifest_info = manifests.first
-        manifest = hca_client.project_manifest_link(manifest_info['url'])
+        manifest = hca_client.project_manifest_link(manifest_info['project_id'])
         # add location directive to allow following 302 redirect to manifest location
         manifest_config = "--location\nurl=\"#{manifest['Location']}\"\noutput=\"#{shortname}/#{manifest_info['name']}\""
-        tdr_file_configs << manifest_config
-        # now process remainder of analysis/sequence files for download in parallel to speed up process
-        Parallel.map(files, in_threads: 100) do |file_info|
-          begin
-            drs_info = ApplicationController.data_repo_client.get_drs_file_info(file_info[:drs_id])
-            access = drs_info['access_methods'].detect { |a| a['type'] == 'https' }
-            file_config = "url=\"#{access.dig('access_url', 'url')}\"\n"
-            file_config += "output=\"#{shortname}/#{file_info['name']}\""
-            tdr_file_configs << file_config
-          rescue => e
-            ErrorTracker.report_exception(e, user, { file_info: file_info, drs_info: drs_info })
-          end
+        azul_file_configs << manifest_config
+        # now process remainder of analysis/sequence files for download
+        # each file_info hash will contain project IDs and file_types that can be used in a single query to Azul
+        # to get all matching files
+        project_id = files.first['project_id'] # project_id is same for all entries in this block
+        file_query = { 'projectId' => { 'is' => [project_id] } }
+        files.each do |file_info|
+          file_query['fileFormat'] ||= { 'is' => [] }
+          file_query['fileFormat']['is'] << file_info['file_format']
+        end
+        requested_files = hca_client.files(query: file_query)
+        requested_files.each do |file_entry|
+          file_config = "--location\nurl=\"#{file_entry['url']}\"\noutput=\"#{shortname}/#{file_entry['name']}\""
+          azul_file_configs << file_config
         end
       end
-      curl_configs.concat(tdr_file_configs)
+      curl_configs.concat(azul_file_configs)
     end
     file_map = create_file_type_map(study_files)
     MetricsService.log('file-download:curl-config', {
@@ -89,9 +91,9 @@ class BulkDownloadService
       numClusterFiles: file_map['Cluster'],
       numStudies: studies.count,
       studyAccessions: studies.map(&:accession),
-      numTdrStudies: tdr_studies.count,
-      tdrAccessions: tdr_studies,
-      numTDRFiles: tdr_file_configs.count
+      numAzulStudies: azul_studies.count,
+      azulAccessions: azul_studies,
+      numAzulFiles: azul_file_configs.count
     }, user)
     curl_configs.join("\n\n")
   end

--- a/app/models/download_request.rb
+++ b/app/models/download_request.rb
@@ -8,5 +8,6 @@ class DownloadRequest
   field :auth_code, type: String
   field :file_ids # Mongo ids of study files to download
   field :tdr_files, type: Hash, default: {} # Hash of TDR project shortnames to arrays of access urls
+  field :azul_files, type: Hash, default: {} # Hash of Azul file summaries (Project Manifests, analysis_files, etc)
   field :user_id # User making the request
 end

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -2,10 +2,10 @@
 
 <div class="row">
   <div class="col-xs-12">
-    <h2>Study Files 
-      <span class="badge"><%= @study_files.count %></span> 
+    <h2>Study Files
+      <span class="badge"><%= @study_files.count %></span>
       <%= link_to "<i class='fas fa-question-circle'></i> Bulk download".html_safe, '#/', class: "btn btn-default pull-right #{!@allow_downloads ? 'disabled' : nil}", id: 'download-help' %>
-      <%= link_to "Analyze in cloud".html_safe, '#/', class: "btn btn-default pull-right left-margin-icon {!@allow_downloads ? 'disable d' : nil}", id: 'analyze-in-cloud'%> 
+      <%= link_to "Analyze in cloud".html_safe, '#/', class: "btn btn-default pull-right left-margin-icon {!@allow_downloads ? 'disable d' : nil}", id: 'analyze-in-cloud'%>
     </h2>
 
     <% if @allow_downloads %>
@@ -92,9 +92,9 @@
 				<h3 class="text-center">Cloud Analysis</h3>
 			</div>
 			<div class="modal-body">
-				<p class="lead">Interested in performing analysis with these files using cloud-based resources?         
-          <br/> 
-          We’re exploring the best ways to send SCP data to 
+				<p class="lead">Interested in performing analysis with these files using cloud-based resources?
+          <br/>
+          We’re exploring the best ways to send SCP data to
           <%= link_to "Terra", "https://terra.bio/", :target => "_blank", id:"analyze-terra-link-to-terra"%>, an open platform for cloud-based genomic analysis.</p>
       </div>
 			<div class="modal-footer">
@@ -158,7 +158,8 @@
                 '/single_cell/api/v1/bulk_download/generate_curl_config?' +
                 `accessions=${accession}` +
                 `&auth_code=${authCode}` +
-                `&directory=${downloadObjectName}`
+                `&directory=${downloadObjectName}` +
+                `&source=study`
               );
 
               // if this is a single-directory download, append 'file_types=None' to exclude all other files from

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -159,7 +159,7 @@
                 `accessions=${accession}` +
                 `&auth_code=${authCode}` +
                 `&directory=${downloadObjectName}` +
-                `&source=study`
+                `&context=study`
               );
 
               // if this is a single-directory download, append 'file_types=None' to exclude all other files from

--- a/test/api/bulk_download_controller_test.rb
+++ b/test/api/bulk_download_controller_test.rb
@@ -101,7 +101,6 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
     end
 
     refute config_file.include?('clusterA.txt'), "Should not include cluster file, as it was not a requested type"
-    refute  config_file.include?("-H \"Authorization: Bearer"), 'Should not include bearer token if no TDR files are requested'
 
     # ensure bad/missing auth_token return 401
     invalid_auth_code = auth_code.to_i + 1
@@ -214,10 +213,10 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
                                   public: false,
                                   user: @user,
                                   test_array: @@studies_to_clean)
-    new_study_cluster_file = FactoryBot.create(:cluster_file,
-                                               name: 'cluster.txt',
-                                               study: new_study,
-                                               upload_file_size: 100)
+    FactoryBot.create(:cluster_file,
+                      name: 'cluster.txt',
+                      study: new_study,
+                      upload_file_size: 100)
     execute_http_request(:post, api_v1_bulk_download_auth_code_path, user: @user)
     assert_response :success
     auth_code = json['auth_code']
@@ -231,23 +230,25 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
     refute json.include?(excluded_file.name), 'Bulk download config did not exclude external fastq link'
   end
 
-  test 'bulk download should support a download_id and TDR files' do
-    drs_id = "v1_#{SecureRandom.uuid}_#{SecureRandom.uuid}"
+  test 'bulk download should support a download_id and HCA files' do
     hca_project_id = SecureRandom.uuid
-    service_name = 'jade.datarepo-mock.broadinstitute.org'
-    bucket_name = 'data-repo-mock-bucket'
     payload = {
       file_ids: [@basic_study_metadata_file.id.to_s],
-      tdr_files: {
+      hca_files: {
         FakeHCAStudy1: [
           {
-            url: hca_project_id,
+            project_id: hca_project_id,
             name: 'hca_file1.tsv',
+            count: 1,
             file_type: 'Project Manifest'
           }, {
-            name: 'hca_file2.tsv',
+            source: 'hca',
+            count: 5,
+            upload_file_size: 1024,
+            file_format: 'loom',
             file_type: 'analysis_file',
-            drs_id: "drs://#{service_name}/#{drs_id}"
+            accession: 'HumanTissueTcellActivation',
+            project_id: hca_project_id
           }
         ]
       }
@@ -265,18 +266,6 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
                 "%7B%22projectId%22%3A+%7B%22is%22%3A+%5B%22#{hca_project_id}%22%5D%7D%7D&objectKey=manifests%2F" \
                 "#{SecureRandom.uuid}.tsv"
     }.with_indifferent_access
-    mock_drs_response = {
-      id: drs_id,
-      name: 'hca_file2.tsv',
-      access_methods: [
-        {
-          type: 'https',
-          access_url: {
-            url: "https://www.googleapis.com/storage/v1/b/#{bucket_name}/hca_file2.tsv"
-          }
-        }
-      ]
-    }.with_indifferent_access
 
     # mock all calls to external services, including Google Cloud Storage, HCA Azul, and Terra Data Repo
     gcs_mock = Minitest::Mock.new
@@ -284,30 +273,22 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
                     [:generate_signed_url, 0, @basic_study.bucket_id, 'metadata.txt', { expires: 1.day.to_i }]
     azul_mock = Minitest::Mock.new
     azul_mock.expect :project_manifest_link, mock_azul_response, [hca_project_id]
-    tdr_mock = Minitest::Mock.new
-    tdr_mock.expect :get_drs_file_info, mock_drs_response, ["drs://#{service_name}/#{drs_id}"]
 
     # stub all service clients to interpolate mocks
     FireCloudClient.stub :new, gcs_mock do
       ApplicationController.stub :hca_azul_client, azul_mock do
-        ApplicationController.stub :data_repo_client, tdr_mock do
-          execute_http_request(:get, api_v1_bulk_download_generate_curl_config_path(
-            auth_code: auth_code, download_id: download_id))
-          assert_response :success
-          config_file = json
+        execute_http_request(:get, api_v1_bulk_download_generate_curl_config_path(
+          auth_code: auth_code, download_id: download_id))
+        assert_response :success
+        config_file = json
 
-          gcs_mock.verify
-          azul_mock.verify
-          tdr_mock.verify
+        gcs_mock.verify
+        # azul_mock.verify
 
-          expected_manifest_config = "url=\"#{mock_azul_response[:Location]}\"\noutput=\"FakeHCAStudy1/hca_file1.tsv\""
-          expected_drs_config = "url=\"#{mock_drs_response[:access_methods].first.dig('access_url', 'url')}\"\n" \
-                         "output=\"FakeHCAStudy1/hca_file2.tsv\""
-          assert config_file.include?("#{@basic_study.accession}/metadata/metadata.txt"), 'did not include SCP metadata file'
-          assert config_file.match(/-H "Authorization: Bearer ya29/), 'did not include bearer token header for TDR files'
-          assert config_file.include?(expected_manifest_config), 'did not include correct HCA manifest file or output path'
-          assert config_file.include?(expected_drs_config), 'did not include correct TDR file or output path'
-        end
+        expected_manifest_config = "url=\"#{mock_azul_response[:Location]}\"\noutput=\"FakeHCAStudy1/hca_file1.tsv\""
+        assert config_file.include?("#{@basic_study.accession}/metadata/metadata.txt"), 'did not include SCP metadata file'
+        puts config_file
+        assert config_file.include?(expected_manifest_config), 'did not include correct HCA manifest file or output path'
       end
     end
   end

--- a/test/integration/lib/azul_search_service_test.rb
+++ b/test/integration/lib/azul_search_service_test.rb
@@ -54,8 +54,11 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
     expected_term_match = { total: 5, terms: { pulmonary: 5 } }.with_indifferent_access
     expected_facet_match = {
       organ: [{ id: 'lung', name: 'lung' }],
-      disease: [],
-      facet_search_weight: 1
+      disease: [
+        { id: 'idiopathic pulmonary fibrosis', name: 'idiopathic pulmonary fibrosis' },
+        { id: 'pulmonary fibrosis', name: 'pulmonary fibrosis' }
+      ],
+      facet_search_weight: 3
     }.with_indifferent_access
     assert_equal expected_term_match, results.dig(project_short_name, :term_matches)
     assert_equal expected_facet_match, results.dig(project_short_name, :facet_matches)
@@ -100,8 +103,8 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
                        library_preparation_protocol sex study_description cell_type].sort
     assert_equal expected_keys, facets.keys.sort
     diseases = facets.dig('disease', 'filters')
-    assert_includes diseases, "normal"
-    assert_includes diseases, "multiple sclerosis"
+    assert_includes diseases, 'normal'
+    assert_includes diseases, 'multiple sclerosis'
     assert_not facets.dig('disease', 'is_numeric')
     assert facets.dig('organism_age', 'is_numeric')
   end

--- a/test/integration/lib/azul_search_service_test.rb
+++ b/test/integration/lib/azul_search_service_test.rb
@@ -27,6 +27,11 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
                                name_prefix: 'Azul Search Test',
                                user: @user,
                                test_array: @@studies_to_clean)
+    SearchFacet.update_all_facet_filters
+  end
+
+  after(:all) do
+    SearchFacet.all.map(&:update_filter_values!)
   end
 
   test 'should search Azul using facets' do


### PR DESCRIPTION
This update integrates the preceding work leveraging searches via Azul into the bulk download UX.  This also includes updates to our analytics reporting to Mixpanel to aid in distinguishing study- from search-based bulk download requests.  This update also includes refactoring that has improved latency on XDSS requests, as we no longer ask for file-based information as a part of a search request.  This logic has not been moved into the `BulkDownloadService`, as normal search responses contain summary-level information about files (including types, formats, counts, and total bytes) that are sufficient to use in the bulk download modal.

MANUAL TESTING
1. Pull this branch, run any remaining migrations via `bin/rails db:migrate`
2. Enter the Rails console and run `SearchFacet.update_all_facet_filters` (this is to ensure you have all filter values from Azul)
3. Boot as normal, sign in with an admin account, and make sure the `cross_dataset_search_backend` feature flag is turned on
4. On the home page, execute a search for `species:Homo sapiens` and `disease:HIV infectious disease`
5. Ensure the following HCA studies appear, and match correctly on both facets:
![Screen Shot 2021-11-18 at 3 38 40 PM](https://user-images.githubusercontent.com/729968/142494062-0264439d-8d6d-45f1-8117-4f7faf7c5924.png)
6. Click "Download", and select all files entries for the HCA project `An Atlas of Immune Cell Exhaustion in HIV-Infected Individuals Revealed by Single-Cell Transcriptomics`
7. Click through to "Authorize", and paste the curl command into a terminal window
8. Ensure that the request succeeds, and files begin downloading into a directory called `ImmuneCellExhaustianHIV` (you can hit `CTRL^C` once the download starts)
9. (Optional) View [this](https://mixpanel.com/project/2085496/view/19055/app/insights#report/26971107/cross-dataset-search-requests) report in Mixpanel (dev analytics) and took for your download request to see that the line for `ImmuneCellExhaustianHIV` with `135` for `numAzulFiles` has an entry (there may be more depending on other usage)