### PR TITLE
Adding support for numeric facets in Azul (SCP-3823)

### DIFF
--- a/app/javascript/components/search/results/StudySearchResult.js
+++ b/app/javascript/components/search/results/StudySearchResult.js
@@ -165,7 +165,7 @@ function inferredBadge(study, termMatches) {
 function studyTypeBadge(study) {
   if (study.study_source === 'HCA') {
     // Display a badge indicating this result came from Azul
-    return <span className="badge badge-secondary study-type" data-toggle="tooltip" data-placement="right"
+    return <span className="badge badge-secondary study-type" data-toggle="tooltip"
       title={'Study from Human Cell Atlas'}> Human Cell Atlas </span>
   }
 }
@@ -182,7 +182,8 @@ export default function StudySearchResult({ study }) {
       <div key={study.accession}>
         <label htmlFor={study.name} id="result-title" className="study-label">
           {study.study_source === 'SCP' ? <a href={study.study_url} dangerouslySetInnerHTML={displayStudyTitle} ></a> :
-            <span dangerouslySetInnerHTML={displayStudyTitle} />
+            <a href={`https://data.humancellatlas.org/explore/projects/${study.hca_project_id}`} target="_blank"
+               dangerouslySetInnerHTML={displayStudyTitle} title="View in HCA Data Browser" data-toggle="tooltip"></a>
           }
           {inferredBadge(study, termMatches)}
         </label>

--- a/app/javascript/components/search/results/StudySearchResult.js
+++ b/app/javascript/components/search/results/StudySearchResult.js
@@ -176,15 +176,17 @@ export default function StudySearchResult({ study }) {
   const studyTitle = highlightText(study.name, termMatches).styledText
   const studyDescription = formatDescription(study.description, termMatches)
   const displayStudyTitle = { __html: studyTitle }
-
+  let studyLink = <a href={study.study_url} dangerouslySetInnerHTML={displayStudyTitle} ></a>
+  if (study.study_source !== 'SCP') {
+    studyLink = <a href={`https://data.humancellatlas.org/explore/projects/${study.hca_project_id}`} target="_blank"
+                   dangerouslySetInnerHTML={displayStudyTitle} title="View in HCA Data Browser" data-toggle="tooltip"
+                   rel="noreferrer"></a>
+  }
   return (
     <>
       <div key={study.accession}>
         <label htmlFor={study.name} id="result-title" className="study-label">
-          {study.study_source === 'SCP' ? <a href={study.study_url} dangerouslySetInnerHTML={displayStudyTitle} ></a> :
-            <a href={`https://data.humancellatlas.org/explore/projects/${study.hca_project_id}`} target="_blank"
-               dangerouslySetInnerHTML={displayStudyTitle} title="View in HCA Data Browser" data-toggle="tooltip"></a>
-          }
+          {studyLink}
           {inferredBadge(study, termMatches)}
         </label>
         <div>

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -86,7 +86,7 @@ class AzulSearchService
         # gotcha where sampleDisease is called disease in Azul response objects
         azul_name = 'disease' if azul_name == 'sampleDisease'
         field_entries = result[result_field].map { |entry| entry[azul_name] }.flatten.uniq
-        if facet[:filters].is_a? Hash
+        if facet[:filters].is_a? Hash # this is a numeric facet, and we only have one right now
           results_info[facet_name] = [facet[:filters]]
         else
           facet[:filters].each do |filter|

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -78,7 +78,6 @@ class AzulSearchService
 
   # iterate through the result entries for each project to determine what facets/filters were matched
   def self.get_facet_matches(result, facets)
-    Rails.logger.info "facet matching: #{facets}"
     results_info = {}
     facets.each do |facet|
       facet_name = facet[:id]

--- a/lib/facet_name_converter.rb
+++ b/lib/facet_name_converter.rb
@@ -46,7 +46,7 @@ class FacetNameConverter
     'library_preparation_protocol' => 'libraryConstructionApproach',
     'organ' => 'organ',
     'organ_region' => 'organPart',
-    'organism_age' => 'organismAge',
+    'organism_age' => 'organismAgeRange',
     'preservation_method' => 'preservationMethod',
     'sex' => 'biologicalSex',
     'species' => 'genusSpecies',

--- a/lib/facet_name_converter.rb
+++ b/lib/facet_name_converter.rb
@@ -46,7 +46,7 @@ class FacetNameConverter
     'library_preparation_protocol' => 'libraryConstructionApproach',
     'organ' => 'organ',
     'organ_region' => 'organPart',
-    'organism_age' => 'organismAgeRange',
+    'organism_age' => 'organismAge',
     'preservation_method' => 'preservationMethod',
     'sex' => 'biologicalSex',
     'species' => 'genusSpecies',

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -12,12 +12,12 @@ class HcaAzulClientTest < ActiveSupport::TestCase
       {
         id: 'disease',
         filters: [{ id: 'MONDO_0005109', name: 'HIV infectious disease' }],
-        db_facet: SearchFacet.new(identifier: 'disease', data_type: 'string') # does not need to be persisted
+        db_facet: SearchFacet.find_or_create_by(identifier: 'disease', data_type: 'string')
       },
       {
         id: 'species',
         filters: [{ id: 'NCBITaxon_9606', name: 'Homo sapiens' }],
-        db_facet: SearchFacet.new(identifier: 'species', data_type: 'string')
+        db_facet: SearchFacet.find_or_create_by(identifier: 'species', data_type: 'string')
       }
     ]
     catalogs = @hca_azul_client.catalogs

--- a/test/integration/lib/azul_search_service_test.rb
+++ b/test/integration/lib/azul_search_service_test.rb
@@ -11,13 +11,7 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
     @facets = [
       {
         id: 'species',
-        filters: [{ id: 'NCBITaxon9609', name: 'Homo sapiens' }],
-        db_facet: SearchFacet.new(identifier: 'species', data_type: 'string')
-      },
-      {
-        id: 'organ',
-        filters: [{ id: 'UBERON_0000178', name: 'blood' }],
-        db_facet: SearchFacet.new(identifier: 'organ', data_type: 'string')
+        filters: [{ id: 'NCBITaxon9609', name: 'Homo sapiens' }]
       }
     ]
     @terms = %w[pulmonary]
@@ -29,76 +23,129 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
                                name_prefix: 'Azul Search Test',
                                user: @user,
                                test_array: @@studies_to_clean)
-    SearchFacet.update_all_facet_filters
+    @mock_facet_query = {
+      genusSpecies: {
+        is: ['Homo sapiens']
+      }
+    }.with_indifferent_access
+    @mock_term_query = {
+      sampleDisease: {
+        is: ['chronic obstructive pulmonary disease', 'idiopathic pulmonary fibrosis', 'pulmonary fibrosis']
+      }
+    }.with_indifferent_access
+    @terms_to_facets = [
+      {
+        id: 'disease',
+        filters: [
+          { id: 'chronic obstructive pulmonary disease', name: 'chronic obstructive pulmonary disease' },
+          { id: 'idiopathic pulmonary fibrosis', name: 'idiopathic pulmonary fibrosis' },
+          { id: 'pulmonary fibrosis', name: 'pulmonary fibrosis' }
+        ]
+      }.with_indifferent_access
+    ]
+    tcell_json = File.open(Rails.root.join('test/test_data/azul/human_tcell.json')).read
+    thymus_json = File.open(Rails.root.join('test/test_data/azul/human_thymus.json')).read
+    fibrosis_json = File.open(Rails.root.join('test/test_data/azul/pulmonary_fibrosis.json')).read
+    @human_tcell_response = JSON.parse(tcell_json).with_indifferent_access
+    @human_thymus_response = JSON.parse(thymus_json).with_indifferent_access
+    @fibrosis_response = JSON.parse(fibrosis_json).with_indifferent_access
   end
 
   test 'should search Azul using facets' do
-    results = AzulSearchService.get_results(selected_facets: @facets, terms: nil)
-    assert_includes results.keys, @hca_project_shortname
-    project = results[@hca_project_shortname]
-    # will always be project manifest file
-    manifest = project[:file_information].detect { |f| f[:file_type] == 'Project Manifest' }
-    assert manifest.present?
+    mock = MiniTest::Mock.new
+    mock.expect :format_query_from_facets, @mock_facet_query, [@facets]
+    mock.expect :merge_query_objects, @mock_facet_query, [@mock_facet_query, nil]
+    mock.expect :projects, @human_tcell_response, [{ query: @mock_facet_query }]
+    ApplicationController.stub :hca_azul_client, mock do
+      results = AzulSearchService.get_results(selected_facets: @facets, terms: nil)
+      mock.verify
+      assert_includes results.keys, @hca_project_shortname
+      project = results[@hca_project_shortname]
+      # will always be project manifest file
+      manifest = project[:file_information].detect { |f| f[:file_type] == 'Project Manifest' }
+      assert manifest.present?
+    end
   end
 
   test 'should search Azul using numeric facets' do
-    age_facet = SearchFacet.new(identifier: 'organism_age', data_type: 'number', is_array_based: false, unit: 'years')
     facets = [
       {
-        id: 'organism_age', filters: { min: 1, max: 5, unit: 'years' }, db_facet: age_facet
+        id: 'organism_age', filters: { min: 1, max: 5, unit: 'years' }
       }.with_indifferent_access
     ]
-    results = AzulSearchService.get_results(selected_facets: facets, terms: nil)
-    assert results.keys.any?
-    entry = results.values.sample
-    expected_match = {
-      organism_age: [{ min: 1, max: 5, unit: 'years' }],
-      facet_search_weight: 1
-    }.with_indifferent_access
-    assert_equal expected_match, entry[:facet_matches]
+    mock_age_query = { organismAgeRange: { within: [[31557600, 157788000]] } }
+    mock = MiniTest::Mock.new
+    mock.expect :format_query_from_facets, mock_age_query, [facets]
+    mock.expect :merge_query_objects, mock_age_query, [mock_age_query, nil]
+    mock.expect :projects, @human_thymus_response, [{ query: mock_age_query }]
+    ApplicationController.stub :hca_azul_client, mock do
+      results = AzulSearchService.get_results(selected_facets: facets, terms: nil)
+      mock.verify
+      assert results.keys.any?
+      entry = results.values.sample
+      expected_match = {
+        organism_age: [{ min: 1, max: 5, unit: 'years' }],
+        facet_search_weight: 1
+      }.with_indifferent_access
+      assert_equal expected_match, entry[:facet_matches]
+    end
   end
 
   test 'should search Azul using terms' do
-    results = AzulSearchService.get_results(selected_facets: [], terms: @terms)
-    project_short_name = 'PulmonaryFibrosisGSE135893'
-    assert_includes results.keys, project_short_name
-    expected_term_match = { total: 5, terms: { pulmonary: 5 } }.with_indifferent_access
-    assert_equal expected_term_match, results.dig(project_short_name, :term_matches)
+    mock = MiniTest::Mock.new
+    mock.expect :format_query_from_facets, nil, [[]]
+    mock.expect :format_facet_query_from_keyword, @terms_to_facets, [@terms]
+    mock.expect :format_query_from_facets, @mock_term_query, [@terms_to_facets]
+    mock.expect :merge_query_objects, @mock_term_query, [nil, @mock_term_query]
+    mock.expect :projects, @fibrosis_response, [{ query: @mock_term_query }]
+    ApplicationController.stub :hca_azul_client, mock do
+      results = AzulSearchService.get_results(selected_facets: [], terms: @terms)
+      mock.verify
+      project_short_name = 'PulmonaryFibrosisGSE135893'
+      assert_includes results.keys, project_short_name
+      expected_term_match = { total: 5, terms: { pulmonary: 5 } }.with_indifferent_access
+      assert_equal expected_term_match, results.dig(project_short_name, :term_matches)
+    end
   end
 
   test 'should search Azul using facets and terms' do
     facets = [
       {
         id: 'organ',
-        filters: [{ id: 'lung', name: 'lung' }],
-        db_facet: SearchFacet.new(identifier: 'organ', data_type: 'string')
+        filters: [{ id: 'lung', name: 'lung' }]
       }
     ]
-    results = AzulSearchService.get_results(selected_facets: facets, terms: @terms)
-    project_short_name = 'PulmonaryFibrosisGSE135893'
-    assert_includes results.keys, project_short_name
-    expected_term_match = { total: 5, terms: { pulmonary: 5 } }.with_indifferent_access
-    expected_facet_match = {
-      organ: [{ id: 'lung', name: 'lung' }],
-      disease: [
-        { id: 'idiopathic pulmonary fibrosis', name: 'idiopathic pulmonary fibrosis' },
-        { id: 'pulmonary fibrosis', name: 'pulmonary fibrosis' }
-      ],
-      facet_search_weight: 3
-    }.with_indifferent_access
-    assert_equal expected_term_match, results.dig(project_short_name, :term_matches)
-    assert_equal expected_facet_match, results.dig(project_short_name, :facet_matches)
+    organ_query = { organ: { is: %w[lung] } }
+    merged_query = @mock_term_query.merge(organ_query).with_indifferent_access
+    mock = MiniTest::Mock.new
+    mock.expect :format_query_from_facets, organ_query, [facets]
+    mock.expect :format_facet_query_from_keyword, @terms_to_facets, [@terms]
+    mock.expect :format_query_from_facets, @mock_term_query, [@terms_to_facets]
+    mock.expect :merge_query_objects, merged_query, [organ_query, @mock_term_query]
+    mock.expect :projects, @fibrosis_response, [{ query: merged_query }]
+    ApplicationController.stub :hca_azul_client, mock do
+      results = AzulSearchService.get_results(selected_facets: facets, terms: @terms)
+      mock.verify
+      project_short_name = 'PulmonaryFibrosisGSE135893'
+      assert_includes results.keys, project_short_name
+      expected_term_match = { total: 5, terms: { pulmonary: 5 } }.with_indifferent_access
+      expected_facet_match = {
+        organ: [{ id: 'lung', name: 'lung' }],
+        disease: [
+          { id: 'idiopathic pulmonary fibrosis', name: 'idiopathic pulmonary fibrosis' },
+          { id: 'pulmonary fibrosis', name: 'pulmonary fibrosis' }
+        ],
+        facet_search_weight: 3
+      }.with_indifferent_access
+      assert_equal expected_term_match, results.dig(project_short_name, :term_matches)
+      assert_equal expected_facet_match, results.dig(project_short_name, :facet_matches)
+    end
   end
 
   test 'should match results on facets' do
-    query = { projectId: { is: [@hca_project_id] } }.to_json
-    raw_results = @azul_client.projects(query: query, size: 1)
-    tcell_project = raw_results['hits'].first
-    matches = AzulSearchService.get_facet_matches(tcell_project, @facets)
-    %w[species organ].each do |facet_name|
-      assert_includes matches.keys, facet_name
-    end
-    assert_equal 2, matches[:facet_search_weight]
+    matches = AzulSearchService.get_facet_matches(@human_tcell_response['hits'].first, @facets)
+    assert_includes matches.keys, 'species'
+    assert_equal 1, matches[:facet_search_weight]
   end
 
   test 'should append results to studies/facet map' do
@@ -109,18 +156,27 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
       }
     }.with_indifferent_access
     initial_results = [@study]
-    terms = ['CD8+ T cells']
-    studies, facet_map = AzulSearchService.append_results_to_studies(initial_results,
-                                                                     selected_facets: @facets,
-                                                                     terms: terms, facet_map: facet_map)
-    assert studies.size > 1
-    hca_entry = studies.detect { |study| study.is_a?(Hash) ? study[:accession] == @hca_project_shortname : nil }
-    assert hca_entry.present?
-    hca_facet_entry = facet_map[@hca_project_shortname]
-    assert hca_facet_entry.present?
-    assert_equal 2, hca_facet_entry[:facet_search_weight]
-    assert_equal 1, hca_entry.dig(:term_matches, :total)
-    assert_equal terms, hca_entry.dig(:term_matches, :terms).keys
+    mock = MiniTest::Mock.new
+    mock.expect :format_query_from_facets, @mock_facet_query, [@facets]
+    mock.expect :format_facet_query_from_keyword, @terms_to_facets, [@terms]
+    mock.expect :format_query_from_facets, @mock_term_query, [@terms_to_facets]
+    merged_query = @mock_facet_query.merge(@mock_term_query).with_indifferent_access
+    mock.expect :merge_query_objects, merged_query, [@mock_facet_query, @mock_term_query]
+    mock.expect :projects, @fibrosis_response, [{ query: merged_query }]
+    fibrosis_shortname = 'PulmonaryFibrosisGSE135893'
+    ApplicationController.stub :hca_azul_client, mock do
+      studies, facet_map = AzulSearchService.append_results_to_studies(initial_results,
+                                                                       selected_facets: @facets,
+                                                                       terms: @terms, facet_map: facet_map)
+      assert studies.size > 1
+      hca_entry = studies.detect { |study| study.is_a?(Hash) ? study[:accession] == fibrosis_shortname : nil }
+      assert hca_entry.present?
+      hca_facet_entry = facet_map[fibrosis_shortname]
+      assert hca_facet_entry.present?
+      assert_equal 3, hca_facet_entry[:facet_search_weight]
+      assert_equal 5, hca_entry.dig(:term_matches, :total)
+      assert_equal @terms, hca_entry.dig(:term_matches, :terms).keys
+    end
   end
 
   test 'should retrieve all facets/filters' do
@@ -147,10 +203,6 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
       {
         id: 'species',
         filters: [{ id: 'NCBITaxon9609', name: 'Homo sapiens' }, gallus_filter]
-      },
-      {
-        id: 'organ',
-        filters: [{ id: 'UBERON_0000178', name: 'blood' }]
       }
     ]
     assert_equal expected_facets, AzulSearchService.merge_facet_lists(@facets, extra_facets)

--- a/test/js/download/download-selection-modal.test.js
+++ b/test/js/download/download-selection-modal.test.js
@@ -142,7 +142,7 @@ describe('Download selection modal', () => {
 
     fireEvent.click(screen.getByText('NEXT'))
     await waitForElementToBeRemoved(() => screen.getByTestId('bulk-download-loading-icon'))
-    expect(screen.getByRole('textbox')).toHaveValue('curl "undefined/single_cell/api/v1/bulk_download/generate_curl_config?auth_code=TViAHJmA&download_id=aaaBBB" -o cfg.txt; curl -K cfg.txt && rm cfg.txt')
+    expect(screen.getByRole('textbox')).toHaveValue('curl "undefined/single_cell/api/v1/bulk_download/generate_curl_config?auth_code=TViAHJmA&context=global&download_id=aaaBBB" -o cfg.txt; curl -K cfg.txt && rm cfg.txt')
     expect(fetchAuthCode).toHaveBeenLastCalledWith([
       '60403d30cc7ba03f94477640',
       '60a2cf62cc7ba082358b545f',

--- a/test/test_data/azul/human_tcell.json
+++ b/test/test_data/azul/human_tcell.json
@@ -1,0 +1,331 @@
+{
+  "hits": [
+    {
+      "projects": [
+        {
+          "projectId": "4a95101c-9ffc-4f30-a809-f04518a23803",
+          "projectTitle": "A single-cell reference map of transcriptional states for human blood and tissue T cell activation",
+          "projectShortname": "HumanTissueTcellActivation",
+          "projectDescription": "Human T cells coordinate adaptive immunity in diverse anatomic compartments through production of cytokines and effector molecules, but it is unclear how tissue site influences T cell persistence and function. Here, we use single cell RNA-sequencing (scRNA-seq) to define the heterogeneity of human T cells isolated from lungs, lymph nodes, bone marrow and blood, and their functional responses following stimulation. Through analysis of >50,000 resting and activated T cells, we reveal tissue T cell signatures in mucosal and lymphoid sites, and lineage-specific activation states across all sites including distinct effector states for CD8+ T cells and an interferon-response state for CD4+ T cells. Comparing scRNA-seq profiles of tumor-associated T cells to our dataset reveals predominant activated CD8+ compared to CD4+ T cell states within multiple tumor types. Our results therefore establish a high dimensional reference map of human T cell activation in health for analyzing T cells in disease."
+        }
+      ],
+      "samples": [
+        {
+          "sampleEntityType": [
+            "specimens"
+          ],
+          "effectiveOrgan": [
+            "blood",
+            "hematopoietic system",
+            "lung",
+            "mediastinal lymph node"
+          ],
+          "submissionDate": "2019-09-13T17:52:10.963000Z",
+          "updateDate": "2019-09-13T17:52:15.237000Z",
+          "id": [
+            "PP001",
+            "PP002",
+            "PP003",
+            "PP004",
+            "PP005",
+            "PP006",
+            "PP009",
+            "PP010",
+            "PP011",
+            "PP012",
+            "PP013",
+            "PP014",
+            "PP017",
+            "PP018",
+            "PP019",
+            "PP020"
+          ],
+          "organ": [
+            "blood",
+            "hematopoietic system",
+            "lung",
+            "mediastinal lymph node"
+          ],
+          "organPart": [
+            "Left lateral basal bronchopulmonary segment",
+            "bone marrow",
+            "mediastinal lymph node",
+            "venous blood"
+          ],
+          "disease": [
+            null
+          ],
+          "preservationMethod": [
+            "fresh"
+          ],
+          "source": [
+            "specimen_from_organism"
+          ]
+        }
+      ],
+      "specimens": [
+        {
+          "submissionDate": "2019-09-13T17:52:10.963000Z",
+          "updateDate": "2019-09-13T17:52:15.237000Z",
+          "id": [
+            "PP001",
+            "PP002",
+            "PP003",
+            "PP004",
+            "PP005",
+            "PP006",
+            "PP009",
+            "PP010",
+            "PP011",
+            "PP012",
+            "PP013",
+            "PP014",
+            "PP017",
+            "PP018",
+            "PP019",
+            "PP020"
+          ],
+          "organ": [
+            "blood",
+            "hematopoietic system",
+            "lung",
+            "mediastinal lymph node"
+          ],
+          "organPart": [
+            "Left lateral basal bronchopulmonary segment",
+            "bone marrow",
+            "mediastinal lymph node",
+            "venous blood"
+          ],
+          "disease": [
+            null
+          ],
+          "preservationMethod": [
+            "fresh"
+          ],
+          "source": [
+            "specimen_from_organism"
+          ]
+        }
+      ],
+      "cellLines": [],
+      "donorOrganisms": [
+        {
+          "submissionDate": "2019-09-13T17:52:10.920000Z",
+          "updateDate": "2019-09-13T17:52:15.224000Z",
+          "id": [
+            "Blood_donor_A",
+            "Blood_donor_B",
+            "Tissue_donor_1",
+            "Tissue_donor_2"
+          ],
+          "donorCount": 4,
+          "developmentStage": [
+            "human adult stage"
+          ],
+          "genusSpecies": [
+            "Homo sapiens"
+          ],
+          "organismAge": [
+            {
+              "value": "50-55",
+              "unit": "year"
+            },
+            {
+              "value": "52",
+              "unit": "year"
+            },
+            {
+              "value": "65",
+              "unit": "year"
+            }
+          ],
+          "organismAgeRange": [
+            {
+              "gte": 1639872000,
+              "lte": 1639872000
+            },
+            {
+              "gte": 1576800000,
+              "lte": 1734480000
+            },
+            {
+              "gte": 2049840000,
+              "lte": 2049840000
+            }
+          ],
+          "biologicalSex": [
+            "male"
+          ],
+          "disease": [
+            "hypertension",
+            "normal"
+          ]
+        }
+      ],
+      "organoids": [],
+      "cellSuspensions": [
+        {
+          "submissionDate": "2019-09-13T17:52:11.145000Z",
+          "updateDate": "2019-09-13T17:52:15.235000Z",
+          "organ": [
+            "hematopoietic system"
+          ],
+          "organPart": [
+            "bone marrow"
+          ],
+          "selectedCellType": [
+            "T cell"
+          ],
+          "totalCells": null
+        },
+        {
+          "submissionDate": "2019-09-13T17:52:11.236000Z",
+          "updateDate": "2019-09-13T17:52:15.273000Z",
+          "organ": [
+            "blood"
+          ],
+          "organPart": [
+            "venous blood"
+          ],
+          "selectedCellType": [
+            "T cell"
+          ],
+          "totalCells": null
+        },
+        {
+          "submissionDate": "2019-09-13T17:52:11.128000Z",
+          "updateDate": "2019-09-13T17:52:15.267000Z",
+          "organ": [
+            "lung"
+          ],
+          "organPart": [
+            "Left lateral basal bronchopulmonary segment"
+          ],
+          "selectedCellType": [
+            "T cell"
+          ],
+          "totalCells": null
+        },
+        {
+          "submissionDate": "2019-09-13T17:52:11.163000Z",
+          "updateDate": "2019-09-13T17:52:15.267000Z",
+          "organ": [
+            "mediastinal lymph node"
+          ],
+          "organPart": [
+            "mediastinal lymph node"
+          ],
+          "selectedCellType": [
+            "T cell"
+          ],
+          "totalCells": null
+        }
+      ],
+      "fileTypeSummaries": [
+        {
+          "format": "csv",
+          "fileType": "csv",
+          "fileSource": [
+            "HCA Release"
+          ],
+          "source": [
+            "HCA Release"
+          ],
+          "count": 4,
+          "totalSize": 6959601,
+          "matrixCellCount": null,
+          "isIntermediate": false,
+          "contentDescription": [
+            "Matrix"
+          ]
+        },
+        {
+          "format": "tar",
+          "fileType": "tar",
+          "fileSource": [
+            "GEO"
+          ],
+          "source": [
+            "GEO"
+          ],
+          "count": 1,
+          "totalSize": 116766720,
+          "matrixCellCount": null,
+          "isIntermediate": false,
+          "contentDescription": [
+            "Matrix"
+          ]
+        },
+        {
+          "format": "fastq.gz",
+          "fileType": "fastq.gz",
+          "fileSource": [
+            null
+          ],
+          "source": [
+            null
+          ],
+          "count": 32,
+          "totalSize": 496164231119,
+          "matrixCellCount": null,
+          "isIntermediate": null,
+          "contentDescription": [
+            "DNA sequence (raw)"
+          ]
+        },
+        {
+          "format": "loom",
+          "fileType": "loom",
+          "fileSource": [
+            "DCP/2 Analysis"
+          ],
+          "source": [
+            "DCP/2 Analysis"
+          ],
+          "count": 16,
+          "totalSize": 19776384914,
+          "matrixCellCount": null,
+          "isIntermediate": true,
+          "contentDescription": [
+            "Count Matrix"
+          ]
+        },
+        {
+          "format": "bam",
+          "fileType": "bam",
+          "fileSource": [
+            "DCP/2 Analysis"
+          ],
+          "source": [
+            "DCP/2 Analysis"
+          ],
+          "count": 16,
+          "totalSize": 461550743662,
+          "matrixCellCount": null,
+          "isIntermediate": null,
+          "contentDescription": [
+            null
+          ]
+        },
+        {
+          "format": "loom",
+          "fileType": "loom",
+          "fileSource": [
+            "DCP/2 Analysis"
+          ],
+          "source": [
+            "DCP/2 Analysis"
+          ],
+          "count": 4,
+          "totalSize": 1346139240,
+          "matrixCellCount": null,
+          "isIntermediate": false,
+          "contentDescription": [
+            "Count Matrix"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/test_data/azul/human_thymus.json
+++ b/test/test_data/azul/human_thymus.json
@@ -1,0 +1,396 @@
+{
+  "hits": [
+    {
+      "projects": [
+        {
+          "projectId": "c1810dbc-16d2-45c3-b45e-3e675f88d87b",
+          "projectTitle": "A cell atlas of human thymic development defines T cell repertoire formation",
+          "projectShortname": "HumanThymicDevelopment",
+          "projectDescription": "We performed single-cell RNA-sequencing to create a cell census of the human thymus during development, early childhood and adult life. We sampled 15 embryonic and fetal thymi spanning thymic developmental stages between 7 post-conception weeks (PCW) to 17 PCW, and 9 postnatal thymi from paediatric and adult samples. We compared the cellular composition and T cell differentiation within human and mouse thymus using newly generated and repository mouse datasets. Finally, we investigated the bias in the recombination and selection of human versus mouse TCR repertoires."
+        }
+      ],
+      "samples": [
+        {
+          "sampleEntityType": [
+            "specimens"
+          ],
+          "effectiveOrgan": [
+            "colon",
+            "thymus"
+          ],
+          "submissionDate": "2020-09-14T16:53:22.780000Z",
+          "updateDate": "2020-12-01T17:18:08.743000Z",
+          "id": [
+            "BRC2172_THY",
+            "BRC2194_THY",
+            "BRC2195_THY",
+            "CBTM-337C_THY",
+            "CBTM-464C_THY",
+            "CBTM-470BR_THY",
+            "F21_THY",
+            "F22_THY",
+            "F23_THY",
+            "F29_THY",
+            "F30_THY",
+            "F38_THY",
+            "F41_THY",
+            "F45_THY",
+            "F64_THY",
+            "F67_THY",
+            "F74_COL",
+            "F83_THY",
+            "T03_THY",
+            "T06_THY",
+            "T07_THY",
+            "mouse_1_THY",
+            "mouse_2_THY",
+            "mouse_3_THY"
+          ],
+          "organ": [
+            "colon",
+            "thymus"
+          ],
+          "organPart": [
+            null
+          ],
+          "disease": [
+            "normal"
+          ],
+          "preservationMethod": [
+            null
+          ],
+          "source": [
+            "specimen_from_organism"
+          ]
+        }
+      ],
+      "specimens": [
+        {
+          "submissionDate": "2020-09-14T16:53:22.780000Z",
+          "updateDate": "2020-12-01T17:18:08.743000Z",
+          "id": [
+            "BRC2172_THY",
+            "BRC2194_THY",
+            "BRC2195_THY",
+            "CBTM-337C_THY",
+            "CBTM-464C_THY",
+            "CBTM-470BR_THY",
+            "F21_THY",
+            "F22_THY",
+            "F23_THY",
+            "F29_THY",
+            "F30_THY",
+            "F38_THY",
+            "F41_THY",
+            "F45_THY",
+            "F64_THY",
+            "F67_THY",
+            "F74_COL",
+            "F83_THY",
+            "T03_THY",
+            "T06_THY",
+            "T07_THY",
+            "mouse_1_THY",
+            "mouse_2_THY",
+            "mouse_3_THY"
+          ],
+          "organ": [
+            "colon",
+            "thymus"
+          ],
+          "organPart": [
+            null
+          ],
+          "disease": [
+            "normal"
+          ],
+          "preservationMethod": [
+            null
+          ],
+          "source": [
+            "specimen_from_organism"
+          ]
+        }
+      ],
+      "cellLines": [],
+      "donorOrganisms": [
+        {
+          "submissionDate": "2020-09-14T16:53:22.462000Z",
+          "updateDate": "2021-03-12T11:55:57.371000Z",
+          "id": [
+            "BRC2172",
+            "BRC2194",
+            "BRC2195",
+            "CBTM-337C",
+            "CBTM-464C",
+            "CBTM-470BR",
+            "F21",
+            "F22",
+            "F23",
+            "F29",
+            "F30",
+            "F38",
+            "F41",
+            "F45",
+            "F64",
+            "F67",
+            "F74",
+            "F83",
+            "T03",
+            "T06",
+            "T07",
+            "mouse_1",
+            "mouse_2",
+            "mouse_3"
+          ],
+          "donorCount": 24,
+          "developmentStage": [
+            "10-month-old human stage",
+            "10th week post-fertilization human stage",
+            "11th week post-fertilization human stage",
+            "12th week post-fertilization human stage",
+            "13th week post-fertilization human stage",
+            "14th week post-fertilization human stage",
+            "16th week post-fertilization human stage",
+            "17th week post-fertilization human stage",
+            "2-year-old human stage",
+            "3-month-old human stage",
+            "9th week post-fertilization human stage",
+            "adult",
+            "human adult stage",
+            "juvenile stage",
+            "mature stage",
+            "organogenesis stage"
+          ],
+          "genusSpecies": [
+            "Homo sapiens",
+            "Mus musculus"
+          ],
+          "organismAge": [
+            {
+              "value": "10",
+              "unit": "month"
+            },
+            {
+              "value": "15-20",
+              "unit": "year"
+            },
+            {
+              "value": "20-25",
+              "unit": "year"
+            },
+            {
+              "value": "24",
+              "unit": "week"
+            },
+            {
+              "value": "3",
+              "unit": "month"
+            },
+            {
+              "value": "30",
+              "unit": "month"
+            },
+            {
+              "value": "35-40",
+              "unit": "year"
+            },
+            {
+              "value": "4",
+              "unit": "week"
+            },
+            {
+              "value": "8",
+              "unit": "week"
+            },
+            null
+          ],
+          "organismAgeRange": [
+            {
+              "gte": 2419200,
+              "lte": 2419200
+            },
+            {
+              "gte": 4838400,
+              "lte": 4838400
+            },
+            {
+              "gte": 7884000,
+              "lte": 7884000
+            },
+            {
+              "gte": 14515200,
+              "lte": 14515200
+            },
+            {
+              "gte": 26280000,
+              "lte": 26280000
+            },
+            {
+              "gte": 78840000,
+              "lte": 78840000
+            },
+            {
+              "gte": 473040000,
+              "lte": 630720000
+            },
+            {
+              "gte": 630720000,
+              "lte": 788400000
+            },
+            {
+              "gte": 1103760000,
+              "lte": 1261440000
+            }
+          ],
+          "biologicalSex": [
+            "female",
+            "male"
+          ],
+          "disease": [
+            "normal"
+          ]
+        }
+      ],
+      "organoids": [],
+      "cellSuspensions": [
+        {
+          "submissionDate": "2020-09-14T16:53:23.093000Z",
+          "updateDate": "2020-12-01T17:23:08.754000Z",
+          "organ": [
+            "thymus"
+          ],
+          "organPart": [
+            null
+          ],
+          "selectedCellType": [
+            "T cell",
+            "epithelial cell of thymus",
+            "hematopoietic cell",
+            "somatic cell",
+            null
+          ],
+          "totalCells": 456000
+        },
+        {
+          "submissionDate": "2020-09-14T16:53:23.627000Z",
+          "updateDate": "2020-09-14T16:53:52.137000Z",
+          "organ": [
+            "colon"
+          ],
+          "organPart": [
+            null
+          ],
+          "selectedCellType": [
+            null
+          ],
+          "totalCells": 16000
+        }
+      ],
+      "fileTypeSummaries": [
+        {
+          "format": "fastq.gz",
+          "fileType": "fastq.gz",
+          "fileSource": [
+            null
+          ],
+          "source": [
+            null
+          ],
+          "count": 206,
+          "totalSize": 2908647142469,
+          "matrixCellCount": null,
+          "isIntermediate": null,
+          "contentDescription": [
+            "DNA sequence"
+          ]
+        },
+        {
+          "format": "loom",
+          "fileType": "loom",
+          "fileSource": [
+            "DCP/2 Analysis"
+          ],
+          "source": [
+            "DCP/2 Analysis"
+          ],
+          "count": 28,
+          "totalSize": 44947813666,
+          "matrixCellCount": null,
+          "isIntermediate": true,
+          "contentDescription": [
+            "Count Matrix"
+          ]
+        },
+        {
+          "format": "bam",
+          "fileType": "bam",
+          "fileSource": [
+            "DCP/2 Analysis"
+          ],
+          "source": [
+            "DCP/2 Analysis"
+          ],
+          "count": 28,
+          "totalSize": 879961277870,
+          "matrixCellCount": null,
+          "isIntermediate": null,
+          "contentDescription": [
+            null
+          ]
+        },
+        {
+          "format": "loom",
+          "fileType": "loom",
+          "fileSource": [
+            "DCP/2 Analysis"
+          ],
+          "source": [
+            "DCP/2 Analysis"
+          ],
+          "count": 2,
+          "totalSize": 3975803227,
+          "matrixCellCount": null,
+          "isIntermediate": false,
+          "contentDescription": [
+            "Count Matrix"
+          ]
+        },
+        {
+          "format": "h5ad",
+          "fileType": "h5ad",
+          "fileSource": [
+            "Zenodo"
+          ],
+          "source": [
+            "Zenodo"
+          ],
+          "count": 1,
+          "totalSize": 1571941873,
+          "matrixCellCount": null,
+          "isIntermediate": false,
+          "contentDescription": [
+            "Matrix"
+          ]
+        },
+        {
+          "format": "zip",
+          "fileType": "zip",
+          "fileSource": [
+            "Zenodo"
+          ],
+          "source": [
+            "Zenodo"
+          ],
+          "count": 2,
+          "totalSize": 2964839100,
+          "matrixCellCount": null,
+          "isIntermediate": false,
+          "contentDescription": [
+            "Matrix"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/test_data/azul/pulmonary_fibrosis.json
+++ b/test/test_data/azul/pulmonary_fibrosis.json
@@ -1,0 +1,361 @@
+{
+  "hits": [
+    {
+      "projects": [
+        {
+          "projectId": "c1a9a93d-d9de-4e65-9619-a9cec1052eaa",
+          "projectTitle": "Single-cell RNA-sequencing reveals profibrotic roles of distinct epithelial and mesenchymal lineages in pulmonary fibrosis",
+          "projectShortname": "PulmonaryFibrosisGSE135893",
+          "projectDescription": "Pulmonary fibrosis (PF) is a form of chronic lung disease characterized by progressive destruction of normal alveolar gas-exchange surfaces and accumulation of extracellular matrix (ECM). In order to comprehensively define the cell types, mechanisms and mediators driving ECM deposition and fibrotic remodeling in lungs with pulmonary fibrosis, we performed single-cell RNA-sequencing (scRNA-seq) of single-cell suspensions generated from non-fibrotic control and PF lungs. Analysis of over 114,000 cells from 20 PF and 10 control lungs identified 31 distinct cell types. We identified multiple distinct lineages directly contribute to ECM expansion, including a novel HAS1hi fibroblast subtype and a previously undescribed KRT5-/KRT17+, collagen and ECM-producing epithelial cell population that was highly enriched in PF lungs. Together these data provide high-resolution insights into the basic mechanisms of pulmonary fibrosis, and indicate a direct profibrotic role of the lung epithelium in PF pathogenesis. Overall design: We performed single-cell RNA-sequencing (scRNA-seq) of single-cell suspensions generated from non-fibrotic control and pulmonary fibrosis (PF) lungs"
+        }
+      ],
+      "samples": [
+    {
+      "sampleEntityType": [
+        "specimens"
+      ],
+      "effectiveOrgan": [
+        "lung"
+      ],
+      "submissionDate": "2020-07-15T15:14:32.164000Z",
+      "updateDate": "2020-07-15T15:14:53.363000Z",
+      "id": [
+        "SAMN12587351",
+        "SAMN12587352",
+        "SAMN12587353",
+        "SAMN12587354",
+        "SAMN12587355",
+        "SAMN12587356",
+        "SAMN12587357",
+        "SAMN12587358",
+        "SAMN12587359",
+        "SAMN12587360",
+        "SAMN12587361",
+        "SAMN12587362",
+        "SAMN12587363",
+        "SAMN12587364",
+        "SAMN12587365",
+        "SAMN12587366",
+        "SAMN12587367",
+        "SAMN12587368",
+        "SAMN12587369",
+        "SAMN12587370",
+        "SAMN12587371",
+        "SAMN12587372",
+        "SAMN12587373",
+        "SAMN12587374",
+        "SAMN12587375",
+        "SAMN12587378",
+        "SAMN12587379",
+        "SAMN12587380",
+        "SAMN12587381",
+        "SAMN12587382",
+        "SAMN12587383",
+        "SAMN12587384",
+        "SAMN12587385",
+        "SAMN12587386"
+      ],
+      "organ": [
+        "lung"
+      ],
+      "organPart": [
+        null
+      ],
+      "disease": [
+        "hypersensitivity pneumonitis",
+        "idiopathic pulmonary fibrosis",
+        "interstitial lung disease",
+        "non-specific interstitial pneumonia",
+        "normal",
+        "pulmonary fibrosis",
+        "sarcoidosis"
+      ],
+      "preservationMethod": [
+        null
+      ],
+      "source": [
+        "specimen_from_organism"
+      ]
+    }
+  ],
+      "specimens": [
+    {
+      "submissionDate": "2020-07-15T15:14:32.164000Z",
+      "updateDate": "2020-07-15T15:14:53.363000Z",
+      "id": [
+        "SAMN12587351",
+        "SAMN12587352",
+        "SAMN12587353",
+        "SAMN12587354",
+        "SAMN12587355",
+        "SAMN12587356",
+        "SAMN12587357",
+        "SAMN12587358",
+        "SAMN12587359",
+        "SAMN12587360",
+        "SAMN12587361",
+        "SAMN12587362",
+        "SAMN12587363",
+        "SAMN12587364",
+        "SAMN12587365",
+        "SAMN12587366",
+        "SAMN12587367",
+        "SAMN12587368",
+        "SAMN12587369",
+        "SAMN12587370",
+        "SAMN12587371",
+        "SAMN12587372",
+        "SAMN12587373",
+        "SAMN12587374",
+        "SAMN12587375",
+        "SAMN12587378",
+        "SAMN12587379",
+        "SAMN12587380",
+        "SAMN12587381",
+        "SAMN12587382",
+        "SAMN12587383",
+        "SAMN12587384",
+        "SAMN12587385",
+        "SAMN12587386"
+      ],
+      "organ": [
+        "lung"
+      ],
+      "organPart": [
+        null
+      ],
+      "disease": [
+        "hypersensitivity pneumonitis",
+        "idiopathic pulmonary fibrosis",
+        "interstitial lung disease",
+        "non-specific interstitial pneumonia",
+        "normal",
+        "pulmonary fibrosis",
+        "sarcoidosis"
+      ],
+      "preservationMethod": [
+        null
+      ],
+      "source": [
+        "specimen_from_organism"
+      ]
+    }
+  ],
+      "cellLines": [],
+      "donorOrganisms": [
+    {
+      "submissionDate": "2020-07-15T15:14:31.852000Z",
+      "updateDate": "2020-07-15T15:14:51.774000Z",
+      "id": [
+        "donor_IPF_1",
+        "donor_IPF_10",
+        "donor_IPF_11",
+        "donor_IPF_12",
+        "donor_IPF_2",
+        "donor_IPF_3",
+        "donor_IPF_4",
+        "donor_IPF_5",
+        "donor_IPF_6",
+        "donor_IPF_7",
+        "donor_IPF_8",
+        "donor_IPF_9",
+        "donor_cHP_1",
+        "donor_cHP_2",
+        "donor_ild_1",
+        "donor_nsip_1",
+        "donor_nsip_2",
+        "donor_nsip_3",
+        "donor_sarcoidosis_1",
+        "donor_sarcoidosis_2",
+        "nonfibrotic_control_1",
+        "nonfibrotic_control_10",
+        "nonfibrotic_control_2",
+        "nonfibrotic_control_3",
+        "nonfibrotic_control_4",
+        "nonfibrotic_control_5",
+        "nonfibrotic_control_6",
+        "nonfibrotic_control_7",
+        "nonfibrotic_control_8",
+        "nonfibrotic_control_9"
+      ],
+      "donorCount": 30,
+      "developmentStage": [
+        "human adult stage"
+      ],
+      "genusSpecies": [
+        "Homo sapiens"
+      ],
+      "organismAge": [
+        {
+          "value": "17-59",
+          "unit": "year"
+        },
+        {
+          "value": "46-72",
+          "unit": "year"
+        }
+      ],
+      "organismAgeRange": [
+        {
+          "gte": 536112000,
+          "lte": 1860624000
+        },
+        {
+          "gte": 1450656000,
+          "lte": 2270592000
+        }
+      ],
+      "biologicalSex": [
+        "unknown"
+      ],
+      "disease": [
+        "hypersensitivity pneumonitis",
+        "idiopathic pulmonary fibrosis",
+        "interstitial lung disease",
+        "non-specific interstitial pneumonia",
+        "normal",
+        "sarcoidosis"
+      ]
+    }
+  ],
+      "organoids": [],
+      "cellSuspensions": [
+    {
+      "submissionDate": "2020-07-15T15:14:32.573000Z",
+      "updateDate": "2020-07-15T15:15:06.611000Z",
+      "organ": [
+        "lung"
+      ],
+      "organPart": [
+        null
+      ],
+      "selectedCellType": [
+        null
+      ],
+      "totalCells": 112500
+    }
+  ],
+      "fileTypeSummaries": [
+    {
+      "format": "fastq.gz",
+      "fileType": "fastq.gz",
+      "fileSource": [
+        null
+      ],
+      "source": [
+        null
+      ],
+      "count": 486,
+      "totalSize": 1130860667675,
+      "matrixCellCount": null,
+      "isIntermediate": null,
+      "contentDescription": [
+        "DNA sequence"
+      ]
+    },
+    {
+      "format": "tsv.gz",
+      "fileType": "tsv.gz",
+      "fileSource": [
+        "GEO"
+      ],
+      "source": [
+        "GEO"
+      ],
+      "count": 2,
+      "totalSize": 1066541,
+      "matrixCellCount": null,
+      "isIntermediate": false,
+      "contentDescription": [
+        "Matrix"
+      ]
+    },
+    {
+      "format": "csv.gz",
+      "fileType": "csv.gz",
+      "fileSource": [
+        "GEO"
+      ],
+      "source": [
+        "GEO"
+      ],
+      "count": 1,
+      "totalSize": 3351026,
+      "matrixCellCount": null,
+      "isIntermediate": false,
+      "contentDescription": [
+        "Matrix"
+      ]
+    },
+    {
+      "format": "mtx.gz",
+      "fileType": "mtx.gz",
+      "fileSource": [
+        "GEO"
+      ],
+      "source": [
+        "GEO"
+      ],
+      "count": 1,
+      "totalSize": 1076137992,
+      "matrixCellCount": null,
+      "isIntermediate": false,
+      "contentDescription": [
+        "Matrix"
+      ]
+    },
+    {
+      "format": "loom",
+      "fileType": "loom",
+      "fileSource": [
+        "DCP/2 Analysis"
+      ],
+      "source": [
+        "DCP/2 Analysis"
+      ],
+      "count": 1,
+      "totalSize": 887710199,
+      "matrixCellCount": null,
+      "isIntermediate": true,
+      "contentDescription": [
+        "Count Matrix"
+      ]
+    },
+    {
+      "format": "bam",
+      "fileType": "bam",
+      "fileSource": [
+        "DCP/2 Analysis"
+      ],
+      "source": [
+        "DCP/2 Analysis"
+      ],
+      "count": 1,
+      "totalSize": 30417529465,
+      "matrixCellCount": null,
+      "isIntermediate": null,
+      "contentDescription": [
+        null
+      ]
+    },
+    {
+      "format": "loom",
+      "fileType": "loom",
+      "fileSource": [
+        "DCP/2 Analysis"
+      ],
+      "source": [
+        "DCP/2 Analysis"
+      ],
+      "count": 1,
+      "totalSize": 57332504,
+      "matrixCellCount": null,
+      "isIntermediate": false,
+      "contentDescription": [
+        "Count Matrix"
+      ]
+    }
+  ]
+    }
+  ]
+}


### PR DESCRIPTION
This update adds support for using numeric facets like `organism_age` with XDSS requests against Azul.  This facet can be used by itself, or in conjunction with other facets.  Search requests are converting the age in years into seconds before executing, similar to how BigQuery searches are run.

In addition, this update adds significant mocking to the `AzulSearchServiceTest` and `HcaAzulClientTest` as part of an effort to reduce errors/false negatives during CI runs, usually caused by service interruptions in Azul.  Also, HCA search results now link out directly to the corresponding project in the HCA data browser.

MANUAL TESTING
Note: you may need to run `SearchFacet.update_all_facet_filters` in the Rails console if you have been working on a branch that was based off of versions of `development` before today (Nov. 22)
1. Pull this branch and sign in with an account that has `cross_dataset_search_backend` set to true
2. Run a query for `organism_age:1-5 years` and ensure the following HCA projects are returned
![Screen Shot 2021-11-22 at 3 54 19 PM](https://user-images.githubusercontent.com/729968/142934457-3ee785cb-72b2-4c5b-83e1-2a305fa1a0f6.png)
3. Refine the query to add `organ:Pancreas` and ensure only one match is returned
![Screen Shot 2021-11-22 at 3 55 14 PM](https://user-images.githubusercontent.com/729968/142934517-3483de82-4b6b-4abd-a720-3d9e5c0b7cc9.png)
4. (Optional) Click on the HCA Pancreas project title and ensure it opens on the correct page in the HCA data browser

This PR satisfies SCP-3832.
