### PR TITLE
Fixing bundle display for some existing studies (SCP-3907)

### DIFF
--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -61,6 +61,9 @@ export function formatFileFromServer(file) {
   if (file.genome_assembly_id) {
     file.genome_assembly_id = file.genome_assembly_id.$oid
   }
+  if (file.study_file_bundle_id) {
+    file.study_file_bundle_id = file.study_file_bundle_id.$oid
+  }
   if (file.expression_file_info) {
     delete file.expression_file_info._id
   }
@@ -77,8 +80,17 @@ export function formatFileFromServer(file) {
 /** find the bundle children of 'file', if any, in the given 'files' list */
 export function findBundleChildren(file, files) {
   return files.filter(f => {
-    const parentFields = [f.options?.matrix_id, f.options?.bam_id, f.options?.cluster_file_id]
-    return parentFields.includes(file._id) || (file.oldId && parentFields.includes(file.oldId))
+    // check if the file is either explicity listed as a parent in the child's 'options' field,
+    // or if the child and the parent are in the same study_file_bundle
+    const parentFields = [
+      f.options?.matrix_id,
+      f.options?.bam_id,
+      f.options?.cluster_file_id,
+      f.study_file_bundle_id
+    ]
+    return parentFields.includes(file._id) ||
+      (file.oldId && parentFields.includes(file.oldId)) ||
+      file.study_file_bundle_id && parentFields.includes(file.study_file_bundle_id)
   })
 }
 

--- a/test/js/upload-wizard/upload-expression-data.test.js
+++ b/test/js/upload-wizard/upload-expression-data.test.js
@@ -6,7 +6,7 @@ import selectEvent from 'react-select-event'
 import * as ScpApi from 'lib/scp-api'
 
 import {
-  RAW_COUNTS_MTX_FILE, BARCODES_FILE, FEATURES_FILE
+  RAW_COUNTS_MTX_FILE, BARCODES_FILE, FEATURES_FILE, EMPTY_STUDY, RAW_COUNTS_FILE
 } from './file-info-responses'
 
 import { fireFileSelectionEvent } from '../lib/file-mock-utils'
@@ -109,6 +109,43 @@ describe('it allows uploading of expression matrices', () => {
     fireEvent.click(subForms[0].querySelector('button[data-testid="file-save"]'))
     await waitForElementToBeRemoved(() => screen.getByTestId('file-save-spinner'))
 
+    // confirm all the filenames and headers are correct
+    const headerList = screen.getAllByRole('heading', { level: 5 }).map(h => h.textContent)
+    expect(headerList).toEqual([
+      'raw_counts.mtx',
+      '10x Features File',
+      'features.txt',
+      '10x Barcodes File',
+      'barcodes.txt'
+    ])
+  })
+
+  it('correctly displays a previously uploaded mtx file bundle', async () => {
+    // When files are uploaded via the new or legacy wizard, their bundle parent is indicated
+    // via the study file options hash.  However, for some sync studies, the parent will only
+    // be indicated via the bundle.  So check that we handle that case appropriately
+    const bundleId = '6191fb48771a5b0d8b5a0a98'
+    const studyInfo = {
+      ...EMPTY_STUDY,
+      files: [
+        {
+          ...RAW_COUNTS_MTX_FILE,
+          options: {},
+          study_file_bundle_id: { $oid: bundleId }
+        },
+        {
+          ...FEATURES_FILE,
+          options: {},
+          study_file_bundle_id: { $oid: bundleId }
+        },
+        {
+          ...BARCODES_FILE,
+          options: {},
+          study_file_bundle_id: { $oid: bundleId }
+        }
+      ]
+    }
+    await renderWizardWithStudy({ studyInfo })
     // confirm all the filenames and headers are correct
     const headerList = screen.getAllByRole('heading', { level: 5 }).map(h => h.textContent)
     expect(headerList).toEqual([


### PR DESCRIPTION
Fixes a bug where some barcodes and feature files do not have their parent specified via file options.  I thought I had checked that that would always be the case, but apparently there are ways that files can get into the portal and bundled without--maybe sync tool or manage-study?  In any case, now we find bundles by either file options or the presence of a StudyFileBundle.

TO TEST:
  1. Create a new study 
  2. Use the new upload wizard to upload a raw counts sparse matrix and associated features & barcodes. 
  2. confirm it displays correctly after upload and a page refresh
  3. in the rails console, run `Study.find_by(accession: <<accession>>).study_files.update_all(options: {})`
  4. reload the upload wizard and confirm the files still display correctly 