### PR TITLE
Prevent saving `ReviewerAccess` if `expires_at` is blank (SCP-3908)

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -883,11 +883,13 @@ class SiteController < ApplicationController
 
     if access_settings['reset'] == 'yes'
       logger.info "Rotating credentials for reviewer access in #{study.accession}"
-      study.reviewer_access&.rotate_credentials!
+      study.reviewer_access.rotate_credentials! if study.reviewer_access.present?
     elsif access_settings['enable'] == 'yes' && study.reviewer_access.nil?
+      logger.info "Initializing reviewer access in #{study.accession}"
       study.build_reviewer_access.save!
     elsif access_settings['enable'] == 'no'
-      study.reviewer_access&.destroy
+      logger.info "Disabling reviewer access in #{study.accession}"
+      study.reviewer_access.destroy if study.reviewer_access.present?
     end
   end
 end

--- a/app/models/reviewer_access.rb
+++ b/app/models/reviewer_access.rb
@@ -24,7 +24,7 @@ class ReviewerAccess
   end
 
   before_validation :generate_credentials, on: :create
-  validates :access_code, :pin, presence: true
+  validates :access_code, :pin, :expires_at, presence: true
   validates :study_id, uniqueness: true, presence: true
 
   # determine if user-supplied pin is valid

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -679,6 +679,12 @@ class Study
         errors.add(:base, "Share Error - #{msg}")
       end
     end
+    # get errors for reviewer_access, if any
+    if study.reviewer_access.present? && !study.reviewer_access.valid?
+      study.reviewer_access.errors.full_messages.each do |msg|
+        errors.add(:base, msg)
+      end
+    end
   end
 
   # XSS protection

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -213,24 +213,19 @@ class Study
   has_many :external_resources, as: :resource_links, dependent: :destroy
   accepts_nested_attributes_for :external_resources, allow_destroy: true
 
-  # Anonymous Reviewer Access
-  has_one :reviewer_access, dependent: :delete_all
-  accepts_nested_attributes_for :reviewer_access, allow_destroy: true
+
 
   # DownloadAgreement (extra user terms for downloading data)
   has_one :download_agreement, dependent: :delete_all
   accepts_nested_attributes_for :download_agreement, allow_destroy: true
 
   # Study Detail (full html description)
-  #
-  # NOTE: THIS ASSOCIATION MUST ALWAYS BE DECLARED LAST
-  #
-  # This is due to the after_save :set_study_description_text callback which will cause the parent study
-  # to update itself with the plain-text version of the description
-  # this will clobber any incoming changes to other associations, since the study is always saved first
-  # therefore, put any new associations above :study_detail
   has_one :study_detail, dependent: :delete_all
   accepts_nested_attributes_for :study_detail, allow_destroy: true
+
+  # Anonymous Reviewer Access
+  has_one :reviewer_access, dependent: :delete_all
+  accepts_nested_attributes_for :reviewer_access, allow_destroy: true
 
   # field definitions
   field :name, type: String

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -81,6 +81,7 @@ class Study
       available.reject(&:new_record?)
     end
   end
+  accepts_nested_attributes_for :study_files, allow_destroy: true
 
   has_many :study_file_bundles, dependent: :destroy do
     def by_type(file_type)
@@ -152,6 +153,7 @@ class Study
       end
     end
   end
+  accepts_nested_attributes_for :study_shares, allow_destroy: true, reject_if: proc { |attributes| attributes['email'].blank? }
 
   has_many :cluster_groups do
     def by_name(name)
@@ -209,15 +211,26 @@ class Study
 
   # External Resource links
   has_many :external_resources, as: :resource_links, dependent: :destroy
-
-  # Study Detail (full html description)
-  has_one :study_detail, dependent: :delete_all
-
-  # DownloadAgreement (extra user terms for downloading data)
-  has_one :download_agreement, dependent: :delete_all
+  accepts_nested_attributes_for :external_resources, allow_destroy: true
 
   # Anonymous Reviewer Access
   has_one :reviewer_access, dependent: :delete_all
+  accepts_nested_attributes_for :reviewer_access, allow_destroy: true
+
+  # DownloadAgreement (extra user terms for downloading data)
+  has_one :download_agreement, dependent: :delete_all
+  accepts_nested_attributes_for :download_agreement, allow_destroy: true
+
+  # Study Detail (full html description)
+  #
+  # NOTE: THIS ASSOCIATION MUST ALWAYS BE DECLARED LAST
+  #
+  # This is due to the after_save :set_study_description_text callback which will cause the parent study
+  # to update itself with the plain-text version of the description
+  # this will clobber any incoming changes to other associations, since the study is always saved first
+  # therefore, put any new associations above :study_detail
+  has_one :study_detail, dependent: :delete_all
+  accepts_nested_attributes_for :study_detail, allow_destroy: true
 
   # field definitions
   field :name, type: String
@@ -239,13 +252,6 @@ class Study
   field :view_order, type: Float, default: 100.0
   field :use_existing_workspace, type: Boolean, default: false
   field :default_options, type: Hash, default: {} # extensible hash where we can put arbitrary values as 'defaults'
-
-  accepts_nested_attributes_for :study_files, allow_destroy: true
-  accepts_nested_attributes_for :study_shares, allow_destroy: true, reject_if: proc { |attributes| attributes['email'].blank? }
-  accepts_nested_attributes_for :external_resources, allow_destroy: true
-  accepts_nested_attributes_for :study_detail, allow_destroy: true
-  accepts_nested_attributes_for :download_agreement, allow_destroy: true
-  accepts_nested_attributes_for :reviewer_access, allow_destroy: true
 
   ##
   #

--- a/app/models/study_detail.rb
+++ b/app/models/study_detail.rb
@@ -18,8 +18,7 @@ class StudyDetail
   # study.reload must be called to refresh the state of the association as it may have changed during
   # the course of the callback, otherwise validation failures or infinite recursion can occur
   def set_study_description_text
-    study_object = self.study
-    study_object.reload
+    study_object = Study.find(self.study_id)
     study_object.description = self.plain_text_description
     study_object.save!
   end

--- a/app/views/site/_reviewer_access_fields.html.erb
+++ b/app/views/site/_reviewer_access_fields.html.erb
@@ -2,13 +2,13 @@
   <div class="form-group row">
     <div class="col-md-2">
       <% access_enabled = f.object.persisted? %>
-      <%= label_tag :_destroy, 'Access enabled?' %><br />
+      <%= label_tag :enable, 'Access enabled?' %><br />
       <div class="btn-group btn-toggle" data-toggle="buttons">
         <label class="btn btn-default <%= access_enabled ? 'active' : nil %>">
-          <%= radio_button_tag 'reviewer_access_actions[enable]', :yes, access_enabled, disabled: !access_enabled %> Yes
+          <%= radio_button_tag 'reviewer_access_actions[enable]', :yes, access_enabled %> Yes
         </label>
         <label class="btn btn-default <%= access_enabled ? nil : 'active' %>">
-          <%= radio_button_tag 'reviewer_access_actions[enable]', :no, !access_enabled, disabled: !access_enabled %> No
+          <%= radio_button_tag 'reviewer_access_actions[enable]', :no, !access_enabled %> No
         </label>
       </div>
     </div>

--- a/test/integration/reviewer_access_permission_test.rb
+++ b/test/integration/reviewer_access_permission_test.rb
@@ -51,6 +51,31 @@ class ReviewerAccessPermissionTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'should update expiration date' do
+    access = @study.build_reviewer_access
+    access.save!
+    new_expiration = access.expires_at + 1.month
+    auth_as_user(@user)
+    sign_in @user
+    study_params = {
+      accession: @study.accession, study_name: @study.url_safe_name,
+      study: {
+        reviewer_access_attributes: {
+          expires_at: new_expiration.to_s,
+          id: access.id.to_s
+        }
+      },
+      reviewer_access_actions: {
+        enable: 'yes'
+      }
+    }
+
+    post :update_study_settings, params: study_params, xhr: true
+    assert_response :success
+    access.reload
+    assert_equal new_expiration, access.expires_at
+  end
+
   test 'should create new reviewer access session' do
     access = @study.build_reviewer_access
     access.save!

--- a/test/models/reviewer_access_test.rb
+++ b/test/models/reviewer_access_test.rb
@@ -34,6 +34,20 @@ class ReviewerAccessTest < ActiveSupport::TestCase
     assert_equal expected_cookie_name, @access.cookie_name
   end
 
+  test 'should validate reviewer access' do
+    assert @access.valid?
+    @access.expires_at = nil
+    @access.pin = nil
+    @access.access_code = nil
+    assert_not @access.valid?
+    expected_errors = %i[access_code expires_at pin]
+    expected_errors.each do |attribute|
+      error = @access.errors.find { |e| e.attribute == attribute }
+      assert error.present?
+      assert error.type == :blank
+    end
+  end
+
   test 'should authenticate via pin' do
     pin = @access.pin.dup
     assert @access.authenticate_pin?(pin)


### PR DESCRIPTION
This update addresses a corner case where a user can unset the `expires_at` date for a `ReviewerAccess` object from the "Settings" tab, causing that access object to error out any time a reviewer attempts to view the study after authenticating with the PIN.  Now, if the `expires_at` field is blank, it will prevent saving, and display an appropriate error message.

This update also addresses an issue where any updates to the "Settings" tab would cause a `ReviewerAccess` object to be created, as a necessary parameter was being omitted due to the control being disabled.  Now, objects are only persisted when `enabled` is set to `yes`.  In addition, this update fixes a bug where the `expires_at` timestamp could not be changed, due to the order in which associations were declared.  The `StudyDetail` model has a callback that will go update the parent study on `after_save`, and this callback clobbered any incoming changes to the `ReviewerAccess` object.

MANUAL TESTING
1. Boot as normal and sign in
2. Load any study, and go to the Settings tab
3. Click `Update study settings` w/o changing any values, and ensure that reviewer access has not been enabled
4. Click `Yes` under `Access Enabled?` and ensure reviewer access has been turned on (you will see credentials under `Current reviewer access credentials`)
5. In the `Expiration date` datepicker, clear out the values (the easiest way is to select each date part individually and press `Delete`)
6. Click `Update study settings` and confirm that the following error message is shown, and that the `Expiration date` datepicker is now showing an error state:
![Screen Shot 2021-11-23 at 3 33 53 PM](https://user-images.githubusercontent.com/729968/143104028-0c1f47b9-190c-48df-ad7a-8cfa07c54aa5.png)
![Screen Shot 2021-11-23 at 3 33 58 PM](https://user-images.githubusercontent.com/729968/143104059-38804a03-963a-4c5d-8cfd-6aa31625c314.png)

This PR satisfies SCP-3908.