### PR TITLE
breaking out separate vendor.js bundle (SCP-3927)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -375,4 +375,13 @@ module ApplicationHelper
   def label_with_asterisk(label_name)
     "#{label_name} <i class='text-danger'>*</i>".html_safe
   end
+
+  # helper for rendering split chunks tags with a nonce
+  # based off of nonced_javascript_pack_tag in secure_headers
+  # see https://github.com/github/secure_headers/blob/main/lib/secure_headers/view_helper.rb
+  def nonced_javascript_pack_with_chunks_tag(*args, &block)
+    opts = extract_options(args).merge(nonce: _content_security_policy_nonce(:script))
+
+    javascript_packs_with_chunks_tag(*args, **opts, &block)
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -90,7 +90,7 @@
     seems resolved
   %>
 
-  <%= nonced_javascript_pack_tag 'application' %>
+  <%= nonced_javascript_pack_with_chunks_tag 'application' %>
   <%= nonced_javascript_include_tag 'application' %>
   <%= nonced_javascript_include_tag "https://cdn.datatables.net/plug-ins/1.10.15/sorting/natural.js" %>
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -5,5 +5,5 @@ process.env.VIEW_ENV = process.env.NODE_ENV
 
 const environment = require('./environment')
 
-
+environment.splitChunks()
 module.exports = environment.toWebpackConfig()


### PR DESCRIPTION
Splitting rarely-updated node module dependencies from application code is a well-known technique for improving site performance for both developers and end users.  See https://rewind.com/blog/optimizing-your-rails-webpacker-compilation/ for the example configuration this is based on.  In local testing on my and Eric's machine, it sped up javascript recompilation time from 2-3sec to 0.4-0.7secs

TO TEST:
1. Stop any existing rails server or webpack dev server
2. Check out branch
2. Restart rails server and webpack dev server
3. load site with chrome debugger active
4. make a change to a JS file
5. observe recompile time in webpack-dev-server is (hopefully) < 1second
6.  in 'view source' note that there is now an `application-[guid].chunk.js` file and a `vendors~application-[guid].chunk.js` file