### PR TITLE
Enhance caching of report runs (SCP-3790)

### DIFF
--- a/app/models/report_time_point.rb
+++ b/app/models/report_time_point.rb
@@ -9,19 +9,63 @@ class ReportTimePoint
   include Mongoid::Document
   include Mongoid::Timestamps
 
+  ## Names of defined reports
+  STUDY_COUNTS = {
+    name: 'study_counts',
+    proc: Proc.new { SummaryStatsUtils.study_counts }
+  }
+  WEEKLY_RETURNING_USERS = {
+    name: 'Weekly Returning Users',
+    proc: Proc.new { SummaryStatsUtils.weekly_returning_users }
+  }
+
   field :name, type: String
-  field :date, type: Date
+  field :date, type: DateTime
   field :value, type: Hash
 
   validates_presence_of :name, :date, :value
 
-  ## Custom Reporting Methods
+  after_save :do_record_change_update
+  after_destroy :do_record_change_update
 
-  # get a weekly count of users that have logged into the portal
-  def self.weekly_returning_users
-    today = Date.today
-    one_week_ago = today - 1.weeks
-    user_count = User.all.select {|user| (user.last_sign_in_at >= one_week_ago || user.current_sign_in_at >= one_week_ago) && (user.last_sign_in_at < today || user.current_sign_in_at < today) }.size
-    self.create!(name: 'Weekly Returning Users', date: today, value: {count: user_count, description: "Count of returning users from #{one_week_ago} to #{today}"})
+  index({name: 1})
+
+  @@latest_reports = {}
+
+  # when a ReportTimePoint changes, refresh the latest_reports cache for that report name
+  def do_record_change_update
+    ReportTimePoint.update_latest_report(self.name)
+  end
+
+  # updates the latest_reports hash by doing a fresh query for the report of the given name
+  def self.update_latest_report(report_name)
+    @@latest_reports[report_name] = ReportTimePoint.where(name: report_name).order(date: 'DESC').first
+  end
+
+  # attempts to get the most recent report of the given name from a cache, before fetching it fresh from the DB, or regenerating it
+  # example: ReportTimePoint.get_latest_report(ReportTimePoint::STUDY_COUNTS, 2.days)
+  # will look for the most recent study_counts report that is less than 2 days old.  If it isn't found,
+  # it will generate a new report
+  def self.get_latest_report(report, max_age=1.day, create_if_absent=true)
+    report_name = report[:name]
+    cutoff_time = Time.zone.now - max_age
+    if !@@latest_reports[report_name] || @@latest_reports[report_name].date < cutoff_time
+      # if it's not cached, refetch it from the DB
+      update_latest_report(report_name)
+      if (!@@latest_reports[report_name] || @@latest_reports[report_name].date < cutoff_time) &&
+        create_if_absent
+        # if it's not in the DB, create a new report time point
+        # note that the after_save hook will take care of updating latest_reports
+        ReportTimePoint.create_point(report)
+      end
+    end
+    @@latest_reports[report_name]
+  end
+
+  # Convenience method for creating a ReportTimePoint for one of the predefined reports above
+  # e.g. ReportTimePoint.create_report(ReportTimePoint::STUDY_COUNTS)
+  def self.create_point(report)
+    result = report[:proc].call
+    ReportTimePoint.create!(name: report[:name], date: Time.zone.now, value: result)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,7 +59,7 @@
       var userId = window.SCP.userId;
 
       // stats for search UI
-      window.SCP.studyStats = <%= SummaryStatsUtils.study_counts.to_json.html_safe %>;
+      window.SCP.studyStats = <%= ReportTimePoint.get_latest_report(ReportTimePoint::STUDY_COUNTS).value.to_json.html_safe %>;
 
       window.ga=window.ga||function() {(ga.q=ga.q||[]).push(arguments)}; ga.l=+new Date
       ga('create', window.SCP.gaTrackingId, 'auto')

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -137,4 +137,8 @@ Rails.application.configure do
 
   # Enable profiling and flamegraphs via rack-mini-profiler
   config.profile_performance = false
+
+  # show mongo logs in the console
+  Mongoid.logger = Logger.new($stdout)
+  Mongo::Logger.logger = Logger.new($stdout)
 end

--- a/test/models/report_time_point_test.rb
+++ b/test/models/report_time_point_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class ReportTimePointTest < ActiveSupport::TestCase
+  include Minitest::Hooks
+  include SelfCleaningSuite
+  include TestInstrumentor
+
+  def setup
+    ReportTimePoint.destroy_all
+  end
+
+  test 'ReportTimePoints cache correctly' do
+    test_report = ReportTimePoint::STUDY_COUNTS
+    report_name = test_report[:name]
+    # confirm nothing is found if create_if_absent is false
+    assert_equal 0, ReportTimePoint.where(name: report_name).count
+    assert_nil ReportTimePoint.get_latest_report(test_report, 1.day, false)
+
+    # confirm the report is created if it doesn't exist and create_if_absent is true
+    created_report = ReportTimePoint.get_latest_report(test_report)
+    assert_equal 1, ReportTimePoint.where(name: report_name).count
+    assert_equal created_report, ReportTimePoint.where(name: report_name).first
+
+    # confirm if it is called again, the report is fetched from the cache, and not recreated
+    next_result = ReportTimePoint.get_latest_report(test_report)
+    assert_equal 1, ReportTimePoint.where(name: report_name).count
+    assert_equal created_report, next_result
+
+    # if the report is too old, confirm it is rerun
+    ReportTimePoint.where(name: report_name).first.update!(date: 4.days.ago)
+    new_result = ReportTimePoint.get_latest_report(test_report)
+    assert_equal 2, ReportTimePoint.where(name: report_name).count
+    assert_not_equal new_result, created_report
+  end
+end


### PR DESCRIPTION
This updates ReportTimePoint with a cache, so that summary stats can be cached and retrieved without database calls when they are relatively fresh. 

This also refines the query in SummaryStatsUtils.study_counts.  Previously, we were loading all public studies into memory, and then running a separate DB query for each study to pull its metadata file, which explains the production slowdown we observed.

This also adds mongo logs to standard out in development.  this can definitely be chatty, but is great for seeing cases like the above where we are running more queries than necessary, and so will be helpful as we tackle more performance issues.

TO TEST:
1. prior to checking out this branch, load the homepage in your local instance
2. click the (?) next to the More Facets button, and note the `(X of Y) public studies` 
3. check out this branch
4. restart your rails server, and load the homepage
5. confirm the `(X of Y)` public studies numbers are the same
6. in your server console, confirm you can see mongo query start/stop log messages like ```MONGODB | 104.155.132.18:27017 req:130 conn:1:1 sconn:4243 | single_cell_portal_development.find | STARTED | {"find"=>"studies", "filter"=>{"queued_for_deletion"=>false, "public"=>true}, "$db"=>"single_cell_portal_development", "lsid"=>{"id"=><BSON::Binary:0x70169748647360 type=uuid data=0x569ba5b4777c4865...>}}```
and
``` MONGODB | 104.155.132.18:27017 req:129 | single_cell_portal_development.find | SUCCEEDED | 0.096s```