### PR TITLE
Update "brand" to "collection" in admin-facing text (SCP-3852)

### DIFF
--- a/app/views/branding_groups/new.html.erb
+++ b/app/views/branding_groups/new.html.erb
@@ -1,4 +1,4 @@
-<h1>New branding group</h1>
+<h1>New Collection</h1>
 
 <%= render 'form' %>
 

--- a/app/views/branding_groups/new.html.erb
+++ b/app/views/branding_groups/new.html.erb
@@ -1,4 +1,4 @@
-<h1>New Collection</h1>
+<h1>New collection</h1>
 
 <%= render 'form' %>
 

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -57,7 +57,7 @@
                               class: 'check-upload', id: 'preset-nav' %></li>
               <li><%= link_to "<span class='fas fa-dna fa-fw'></span> Species".html_safe, taxons_path, class: 'check-upload',
                               id: 'species-nav' %></li>
-              <li><%= scp_link_to "<span class='fas fa-copyright fa-fw'></span> Branding groups".html_safe, branding_groups_path,
+              <li><%= scp_link_to "<span class='fas fa-copyright fa-fw'></span> Collections".html_safe, branding_groups_path,
                                   class: 'check-upload', id: 'branding-groups-nav' %>
               <li><%= scp_link_to "<span class='fas fa-bullhorn fa-fw'></span> Feature announcements".html_safe,
                                   feature_announcements_path, class: 'check-upload', id: 'feature-announcements-nav' %>


### PR DESCRIPTION
Update two admin-facing locations in the UI where we still use "branding group" instead of "collection".
1. Under the admin section of the user menu:
![user_menu](https://user-images.githubusercontent.com/6005195/144631800-0902d7a6-5d3a-4bd1-9fa9-fbf4fdd15c28.png)
2. The title of the new collection page (which currently only admins see):
![new_collection](https://user-images.githubusercontent.com/6005195/144631807-246857df-ece4-45ac-a0f5-7447aa237d50.png)
(The other changes requested in the ticket were addressed in SCP-3867 aka #1265)
This PR supports SCP-3852.
