### PR TITLE
Updating to scp-ingest-pipeline:1.12.4 (SCP-3031, SCP-3876, SCP-3575, SCP-3899)

### DIFF
--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -629,7 +629,7 @@ class IngestJob
         message << "This metadata file was validated against the latest <a href='#{schema_url}'>Metadata Convention</a>"
         message << "Convention version: <strong>#{project_name}/#{current_schema_version}</strong>"
         ingest_image_attributes = AdminConfiguration.get_ingest_docker_image_attributes
-        message << "Docker version: #{ingest_image_attributes[:tag]}"
+        message << "Ingest Pipeline Docker image version: #{ingest_image_attributes[:tag]}"
         message << "Group-type metadata columns with more than 200 unique values are not made available for visualization."
       end
       cell_metadata = CellMetadatum.where(study_id: self.study.id, study_file_id: self.study_file.id)
@@ -734,7 +734,7 @@ class IngestJob
     message_body += "<p>Ingest Run ID: <strong>#{self.pipeline_name}</strong></p>"
     message_body += "<p>Command Line: <strong>#{self.command_line}</strong></p>"
     ingest_image_attributes = AdminConfiguration.get_ingest_docker_image_attributes
-    message_body << "<p>Docker version: <strong>#{ingest_image_attributes[:tag]}</strong></p>"
+    message_body << "<p>Ingest Pipeline Docker image version: <strong>#{ingest_image_attributes[:tag]}</strong></p>"
     message_body
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.12.3'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.12.4'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
### Add docker image tag to notifier emails
This update adds docker image tag info to metadata validation notifier emails. This change makes it easier to confirm the docker image used during testing or when troubleshooting Zendesk upload issues.

For the first three tests of ingest below (error notifications), look for the following near the bottom of the error notifications, under the Command Line in the Job Details section:
`Docker version: 1.12.4`

For the last test of ingest below (success notification), look for the following nearer the top of the email, under Convention version:
`Docker version: 1.12.4`

### Update ingest pipeline to 1.12.4
This update of ingest pipeline includes several bugfixes for the ingest process. If testing locally, set your local instance "Ingest Pipeline Docker Image" configuration to use:
`gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.12.4`
- Handle "Excel drag" ontology ID user error in Ingest Pipeline validation (SCP-3031) 
  - upload the metadata file found at:
  `https://raw.githubusercontent.com/broadinstitute/scp-ingest-pipeline/development/tests/data/annotation/metadata/convention/invalid_excel_drag.txt`

  - Look for the following errors in the ingest failure email:
  > *** ontology error list:
  > disease: Long stretch of contiguously incrementing ontology ID values suggest cut and paste issue - exiting validation, ontology content not validated against ontology server.
  > Please confirm ontology IDs are correct and resubmit.
  > Check for mismatches between ontology ID and provided ontology label(s) ['absent', 'disease or disorder']
  > 
  > species: Long stretch of contiguously incrementing ontology ID values suggest cut and paste issue - exiting validation, ontology content not validated against ontology server.
  > Please confirm ontology IDs are correct and resubmit.
  > Check for mismatches between ontology ID and provided ontology label(s) ['Homo sapiens', 'Mus musculus']
  > 
  > race: Long stretch of contiguously incrementing ontology ID values suggest cut and paste issue - exiting validation, ontology content not validated against ontology server.
  > Please confirm ontology IDs are correct and resubmit.

- Validate nonconventional numeric metadata values are numeric (SCP-3876) 
  - upload metadata file:
  `https://raw.githubusercontent.com/broadinstitute/scp-ingest-pipeline/development/tests/data/annotation/metadata/convention/invalid_nonconventional_numeric_v2.2.0.txt`

  - Look for the following error message the ingest failure email:
  > *** type error list:
  > percent_mt: supplied value 07.juil is not numeric [ Error count: 1 ]

- Reject cluster file if coordinate value of NaN detected in a coordinate column (SCP-3575) 
  - upload cluster file below:
  `https://raw.githubusercontent.com/broadinstitute/scp-ingest-pipeline/development/tests/data/cluster_bad_space_delimited.txt`
  - with this feedback in the ingest failure email:
  > *** format error list:
  > Missing coordinate values in x column
  > Missing coordinate values in y column
  > Cluster file format invalid

- Restore storage of numeric array-based metadata annotation values (SCP-3899) 
  - upload the metadata file found at:
`https://raw.githubusercontent.com/broadinstitute/scp-ingest-pipeline/development/tests/data/annotation/metadata/convention/valid_array_v2.1.2.txt`
  - in the Single Cell Portal Notifier email for the metadata file, you should see
  > disease__time_since_onset: group (12|2, 1, 24|2, 36|3|1, 0)
  > and not a bare entry with no values:
  > disease__time_since_onset: group

This PR supports SCP-3031, SCP-3876, SCP-3575, SCP-3899