### PR TITLE
Ensure all SCP & HCA query results appear in bulk download modal (SCP-3911)

### DIFF
--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -124,6 +124,8 @@ module Api
       def summary
         # sanitize study accessions
         valid_accessions = self.class.find_matching_accessions(params[:accessions])
+        # extract HCA project names from accession list, if present
+        hca_accessions = self.class.extract_hca_accessions(params[:accessions])
 
         begin
           # only validate accessions, if present.  TDR/HCA-only downloads will not have SCP accessions present
@@ -387,6 +389,12 @@ module Api
         accessions = RequestUtils.split_query_param_on_delim(parameter: raw_accessions)
         sanitized_accessions = StudyAccession.sanitize_accessions(accessions)
         Study.where(:accession.in => sanitized_accessions).pluck(:accession)
+      end
+
+      # extract out HCA "accessions" (project shortnames) by filtering out SCP accessions
+      def self.extract_hca_accessions(raw_accessions)
+        accessions = RequestUtils.split_query_param_on_delim(parameter: raw_accessions)
+        accessions.reject { |accession| accession =~ StudyAccession::ACCESSION_FORMAT }
       end
 
       # find valid bulk download types from query parameters

--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -124,9 +124,10 @@ module Api
       def summary
         # sanitize study accessions
         valid_accessions = self.class.find_matching_accessions(params[:accessions])
+        logger.info "valid_accessions: #{valid_accessions}"
         # extract HCA project names from accession list, if present
         hca_accessions = self.class.extract_hca_accessions(params[:accessions])
-
+        logger.info "hca_accessions: #{hca_accessions}"
         begin
           # only validate accessions, if present.  TDR/HCA-only downloads will not have SCP accessions present
           self.class.check_accession_permissions(valid_accessions, current_api_user) if valid_accessions.any?
@@ -135,6 +136,8 @@ module Api
         end
 
         @study_file_info = ::BulkDownloadService.get_download_info(valid_accessions)
+        hca_file_info = ::AzulSearchService.get_file_summary_info(hca_accessions)
+        @study_file_info += hca_file_info if hca_file_info.any?
 
         render json: @study_file_info
       end

--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -124,10 +124,8 @@ module Api
       def summary
         # sanitize study accessions
         valid_accessions = self.class.find_matching_accessions(params[:accessions])
-        logger.info "valid_accessions: #{valid_accessions}"
         # extract HCA project names from accession list, if present
         hca_accessions = self.class.extract_hca_accessions(params[:accessions])
-        logger.info "hca_accessions: #{hca_accessions}"
         begin
           # only validate accessions, if present.  TDR/HCA-only downloads will not have SCP accessions present
           self.class.check_accession_permissions(valid_accessions, current_api_user) if valid_accessions.any?

--- a/app/javascript/components/search/controls/download/DownloadButton.js
+++ b/app/javascript/components/search/controls/download/DownloadButton.js
@@ -38,20 +38,6 @@ export default function DownloadButton({ searchResults={} }) {
     }
   }
 
-  /** Note that we are reading the TDR file information from the search results object, which
-   * means we are reliant on the TDR results being on the current page.  Once we begin paging/sorting
-   * TDR results, this approach will have to be revisited */
-  const azulFileInfo = searchResults.studies
-    ?.filter(result => result.study_source === 'HCA')
-    ?.map(result => ({
-      accession: result.accession,
-      name: result.name,
-      study_source: 'HCA',
-      description: result.description,
-      hca_project_id: result.hca_project_id,
-      studyFiles: result.file_information
-    }))
-
   return (
     <>
       <OverlayTrigger
@@ -72,7 +58,6 @@ export default function DownloadButton({ searchResults={} }) {
         <DownloadSelectionModal
           show={showModal}
           setShow={setShowModal}
-          azulFileInfo={azulFileInfo}
           studyAccessions={matchingAccessions}/> }
     </>
   )

--- a/app/javascript/components/search/controls/download/DownloadSelectionModal.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionModal.js
@@ -27,7 +27,6 @@ export default function DownloadSelectionModal({ studyAccessions, azulFileInfo, 
   const [selectedBoxesAzul, setSelectedBoxesAzul] = useState()
   const [stepNum, setStepNum] = useState(1)
 
-  const scpAccessions = studyAccessions.filter(accession => accession.startsWith('SCP'))
   const azulAccessions = studyAccessions.filter(accession => !accession.startsWith('SCP'))
   const showAzulSelectionPane = azulAccessions.length > 0
   const { fileCount, fileSize } = getSelectedFileStats(downloadInfo, selectedBoxes, isLoading)
@@ -55,7 +54,7 @@ export default function DownloadSelectionModal({ studyAccessions, azulFileInfo, 
     if (show) {
       setIsLoading(true)
       setIsLoadingAzul(true)
-      fetchDownloadInfo(scpAccessions).then(result => {
+      fetchDownloadInfo(studyAccessions).then(result => {
         renderFileTables(result)
       })
     }

--- a/app/javascript/components/search/controls/download/DownloadSelectionModal.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionModal.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import Modal from 'react-bootstrap/lib/Modal'
-import _cloneDeep from 'lodash/cloneDeep'
-import { partition } from 'lodash'
+import _partition from 'lodash/partition'
 
 import DownloadCommand from './DownloadCommand'
 import DownloadSelectionTable, {
@@ -9,7 +8,7 @@ import DownloadSelectionTable, {
 } from './DownloadSelectionTable'
 import { bytesToSize } from 'lib/stats'
 
-import { fetchDownloadInfo, fetchDrsInfo } from 'lib/scp-api'
+import { fetchDownloadInfo } from 'lib/scp-api'
 
 const AZUL_COLUMNS = ['project_manifest', 'analysis', 'sequence']
 const SCP_COLUMNS = ['matrix', 'metadata', 'cluster']
@@ -41,9 +40,7 @@ export default function DownloadSelectionModal({ studyAccessions, show, setShow 
     render bulk download table for SCP & HCA studies
    */
   function renderFileTables(result=[]) {
-    const partitionedResults = partition(result, ['studySource', 'SCP'])
-    const scpFileInfo = partitionedResults[0]
-    const azulFileInfo = partitionedResults[1]
+    const [scpFileInfo, azulFileInfo] = _partition(result, ['studySource', 'SCP'])
 
     setSelectedBoxes(newSelectedBoxesState(scpFileInfo, SCP_COLUMNS))
     setDownloadInfo(scpFileInfo)

--- a/app/javascript/components/search/controls/download/DownloadSelectionModal.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionModal.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import Modal from 'react-bootstrap/lib/Modal'
 import _cloneDeep from 'lodash/cloneDeep'
+import { partition } from 'lodash'
 
 import DownloadCommand from './DownloadCommand'
 import DownloadSelectionTable, {
@@ -18,7 +19,7 @@ const SCP_COLUMNS = ['matrix', 'metadata', 'cluster']
   * studies and file types for download.  This queries the bulk_download/summary API method
   * to retrieve the list of study details and available files
   */
-export default function DownloadSelectionModal({ studyAccessions, azulFileInfo, show, setShow }) {
+export default function DownloadSelectionModal({ studyAccessions, show, setShow }) {
   const [isLoading, setIsLoading] = useState(true)
   const [isLoadingAzul, setIsLoadingAzul] = useState(true)
   const [downloadInfo, setDownloadInfo] = useState([])
@@ -40,8 +41,12 @@ export default function DownloadSelectionModal({ studyAccessions, azulFileInfo, 
     render bulk download table for SCP & HCA studies
    */
   function renderFileTables(result=[]) {
-    setSelectedBoxes(newSelectedBoxesState(result, SCP_COLUMNS))
-    setDownloadInfo(result)
+    const partitionedResults = partition(result, ['studySource', 'SCP'])
+    const scpFileInfo = partitionedResults[0]
+    const azulFileInfo = partitionedResults[1]
+
+    setSelectedBoxes(newSelectedBoxesState(scpFileInfo, SCP_COLUMNS))
+    setDownloadInfo(scpFileInfo)
     setIsLoading(false)
     if (showAzulSelectionPane) {
       setSelectedBoxesAzul(newSelectedBoxesState(azulFileInfo, AZUL_COLUMNS))

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -205,6 +205,25 @@ class AzulSearchService
   # query Azul with project shortnames and return summary file information
   # this method mirrors interface on BulkDownloadService#study_download_info for use in bulk download modal
   def self.get_file_summary_info(accessions)
-
+    client = ApplicationController.hca_azul_client
+    file_summaries = []
+    file_query = { 'project' => { 'is' => accessions } }
+    results = client.projects(query: file_query)
+    results['hits'].each do |entry|
+      entry_hash = entry.with_indifferent_access
+      project_hash = entry_hash[:projects].first # there will only ever be one project here
+      result = {
+        study_source: 'HCA',
+        hca_result: true,
+        name: project_hash[:projectTitle],
+        accession: project_hash[:projectShortname],
+        description: project_hash[:projectDescription],
+        study_files: []
+      }
+      project_file_info = extract_file_information(entry_hash)
+      result[:study_files] = project_file_info
+      file_summaries << result
+    end
+    file_summaries
   end
 end

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -170,11 +170,10 @@ class AzulSearchService
 
   # extract preliminary file information from an Azul result object
   def self.extract_file_information(result)
-    file_information = []
     project_hash = result[:projects].first # there will only ever be one project here
     short_name = project_hash[:projectShortname]
     project_id = project_hash[:projectId]
-    result[:fileTypeSummaries].each do |file_summary|
+    result[:fileTypeSummaries].map do |file_summary|
       file_info = {
         source: 'hca',
         count: file_summary['count'],
@@ -197,19 +196,17 @@ class AzulSearchService
           end
         end
       end
-      file_information << file_info.with_indifferent_access
+      file_info.with_indifferent_access
     end
-    file_information
   end
 
   # query Azul with project shortnames and return summary file information
   # this method mirrors interface on BulkDownloadService#study_download_info for use in bulk download modal
   def self.get_file_summary_info(accessions)
     client = ApplicationController.hca_azul_client
-    file_summaries = []
     file_query = { 'project' => { 'is' => accessions } }
     results = client.projects(query: file_query)
-    results['hits'].each do |entry|
+    results['hits'].map do |entry|
       entry_hash = entry.with_indifferent_access
       project_hash = entry_hash[:projects].first # there will only ever be one project here
       accession = project_hash[:projectShortname]
@@ -230,8 +227,7 @@ class AzulSearchService
       }.with_indifferent_access
       project_file_info = extract_file_information(entry_hash)
       result[:studyFiles] += project_file_info if project_file_info.any?
-      file_summaries << result
+      result
     end
-    file_summaries
   end
 end

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -201,4 +201,10 @@ class AzulSearchService
     end
     file_information
   end
+
+  # query Azul with project shortnames and return summary file information
+  # this method mirrors interface on BulkDownloadService#study_download_info for use in bulk download modal
+  def self.get_file_summary_info(accessions)
+
+  end
 end

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -212,16 +212,24 @@ class AzulSearchService
     results['hits'].each do |entry|
       entry_hash = entry.with_indifferent_access
       project_hash = entry_hash[:projects].first # there will only ever be one project here
+      accession = project_hash[:projectShortname]
       result = {
         study_source: 'HCA',
-        hca_result: true,
         name: project_hash[:projectTitle],
-        accession: project_hash[:projectShortname],
+        accession: accession,
         description: project_hash[:projectDescription],
-        study_files: []
+        studyFiles: [
+          {
+            project_id: project_hash[:projectId],
+            file_type: 'Project Manifest',
+            count: 1,
+            upload_file_size: 1.megabyte, # placeholder filesize as we don't know until manifest is downloaded
+            name: "#{accession}.tsv"
+          }
+        ]
       }
       project_file_info = extract_file_information(entry_hash)
-      result[:study_files] = project_file_info
+      result[:studyFiles] += project_file_info if project_file_info.any?
       file_summaries << result
     end
     file_summaries

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -4,7 +4,7 @@ class AzulSearchService
   # tar archives are lumped in with analysis_file entries as they could be either
   FILE_EXT_BY_DOWNLOAD_TYPE = {
     'sequence_file' => %w[bam bai fastq].map { |e| [e, e + '.gz'] }.flatten,
-    'analysis_file' => %w[loom csv tsv txt mtx Rdata tar].map { |e| [e, e + '.gz'] }.flatten
+    'analysis_file' => %w[loom csv tsv txt mtx Rdata tar h5ad pdf].map { |e| [e, e + '.gz'] }.flatten
   }.freeze
 
   # list of keys for an individual result entry used for matching facet filter values
@@ -227,7 +227,7 @@ class AzulSearchService
             name: "#{accession}.tsv"
           }
         ]
-      }
+      }.with_indifferent_access
       project_file_info = extract_file_information(entry_hash)
       result[:studyFiles] += project_file_info if project_file_info.any?
       file_summaries << result

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -234,6 +234,7 @@ class BulkDownloadService
       name: study.name,
       accession: study.accession,
       description: study.description,
+      study_source: 'SCP',
       study_files: study.study_files.map { |study_file| BulkDownloadService.study_file_download_info(study_file) }
     }
   end

--- a/test/api/bulk_download_controller_test.rb
+++ b/test/api/bulk_download_controller_test.rb
@@ -304,4 +304,17 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test 'should extract accessions from parameters' do
+    study = FactoryBot.create(:detached_study,
+                              name_prefix: 'Accession Test',
+                              public: true,
+                              user: @user,
+                              test_array: @@studies_to_clean)
+    accessions = [@basic_study.accession, 'FakeHCAProject', study.accession, 'AnotherFakeHCAProject']
+    scp_accessions = Api::V1::BulkDownloadController.find_matching_accessions(accessions)
+    hca_accessions = Api::V1::BulkDownloadController.extract_hca_accessions(accessions)
+    assert_equal [@basic_study.accession, study.accession], scp_accessions
+    assert_equal %w[FakeHCAProject AnotherFakeHCAProject], hca_accessions
+  end
 end

--- a/test/integration/lib/azul_search_service_test.rb
+++ b/test/integration/lib/azul_search_service_test.rb
@@ -143,6 +143,21 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should get summary file information from project shortnames' do
+    projects = %w[HumanTissueTcellActivation KidneySingleCellAtlas Covid19PBMC]
+    summary = AzulSearchService.get_file_summary_info(projects)
+    assert_equal projects.count, summary.count
+    found_projects = summary.map { |project| project[:accession] }
+    assert_equal projects, found_projects
+    manifests = summary.map { |project| project[:studyFiles].detect { |file| file[:file_type] == 'Project Manifest' } }
+    assert_equal 3, manifests.count
+    other_files = summary.map { |project| project[:studyFiles].reject { |file| file[:file_type] == 'Project Manifest' } }
+                         .flatten
+    other_files.each do |file_info|
+      assert_equal %w[source count upload_file_size file_format accession project_id file_type], file_info.keys
+    end
+  end
+
   test 'should match results on facets' do
     matches = AzulSearchService.get_facet_matches(@human_tcell_response['hits'].first, @facets)
     assert_includes matches.keys, 'species'

--- a/test/js/download/download-selection-modal.test.js
+++ b/test/js/download/download-selection-modal.test.js
@@ -11,6 +11,7 @@ const EXAMPLE_HUMAN_SYNTH_STUDY_DOWNLOAD_INFO = [
     'name': 'Human Male Islet cells and Cataracts',
     'accession': 'SCP12',
     'description': 'bleh',
+    'study_source': 'SCP',
     'study_files': [
       {
         'name': 'metadata.tsv',
@@ -24,11 +25,13 @@ const EXAMPLE_HUMAN_SYNTH_STUDY_DOWNLOAD_INFO = [
     'name': 'Human Blood Study with no metadata',
     'accession': 'SCP31',
     'description': 'bleh',
+    'study_source': 'SCP',
     'study_files': []
   },
   {
     'name': 'Human raw counts',
     'accession': 'SCP35',
+    'study_source': 'SCP',
     'description': 'bleh',
     'study_files': [
       {
@@ -80,6 +83,7 @@ const EXAMPLE_HUMAN_SYNTH_STUDY_DOWNLOAD_INFO = [
   {
     'name': 'Tuberculosis in female human lymph',
     'accession': 'SCP42',
+    'study_source': 'SCP',
     'description': 'bleh',
     'study_files': [
       {


### PR DESCRIPTION
Currently, when running a cross-dataset search query that returns more than 1 page of results, there is a bug where only the HCA results shown on the current page will appear in the bulk download modal, regardless of how many total entries were found.  This update addresses that issue by including both SCP & HCA accessions in the `BulkDownloadController#summary` endpoint, and running an additional query on Azul to retrieve summary file info for HCA data.

MANUAL TESTING
1. Boot as normal, sign in with an account that has `cross_dataset_search_backend` enabled
2. Run a faceted search for `species:Homo sapiens, Mus musculus` and `organ:lung, stomach`
3. Confirm that there are more than 1 page of results (there should be at least 16 HCA entries)
4. Click `Download`, and confirm that all HCA entries appear in the table (the screenshot below is not the entire list, but you can see that there are more than 10):
![Screen Shot 2021-12-10 at 10 29 12 AM](https://user-images.githubusercontent.com/729968/145599084-2ddee2f2-4e93-4815-9a2c-f3e59dfb9eea.png)

This PR satisfies SCP-3911.
