### PR TITLE
Properly escape single quotes when using Azul filters in BigQuery (SCP-3951)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -589,7 +589,7 @@ module Api
           filter_arr_name = "#{facet_id}_filters"
           filter_val_name = "#{facet_id}_value"
           filter_where_val = "#{facet_id}_val"
-          filter_values = facet_obj[:filters].map {|filter| filter[:id]}
+          filter_values = facet_obj[:filters].map { |filter| sanitize_filter_value(filter[:id]) }
           query_elements[:with] = "#{filter_arr_name} AS (SELECT#{filter_values} as #{filter_val_name})"
           query_elements[:from] = "#{filter_arr_name}, UNNEST(#{filter_arr_name}.#{filter_val_name}) AS #{filter_where_val}"
           query_elements[:where] = "(#{filter_where_val} IN UNNEST(#{column_name}))"
@@ -610,7 +610,7 @@ module Api
         else
           query_elements[:select] = "#{column_name}"
           # for non-array columns we can pass an array of quoted values and call IN directly
-          filter_values = facet_obj[:filters].map {|filter| filter[:id]}
+          filter_values = facet_obj[:filters].map { |filter| sanitize_filter_value(filter[:id]) }
           query_elements[:where] = "#{column_name} IN ('#{filter_values.join('\',\'')}')"
         end
         query_elements
@@ -697,6 +697,11 @@ module Api
         else
           matching_facet[:filters].detect { |filter| filter[:id] == search_result[result_key] || filter[:name] == search_result[result_key]}
         end
+      end
+
+      # properly escape any single quotes in a filter value (double quotes are correctly handled already)
+      def self.sanitize_filter_value(filter)
+        filter.gsub(/'/) { "\\'" }
       end
     end
   end

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -90,7 +90,6 @@ class AzulSearchService
           results_info[facet_name] = [facet[:filters]]
         else
           facet[:filters].each do |filter|
-            puts "trying to match on #{filter}"
             match = field_entries.select { |entry| filter[:name] == entry || filter[:id] == entry }
             results_info[facet_name] ||= []
             if match.any? && !results_info[facet_name].include?(filter)

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -9,7 +9,7 @@ class AzulSearchService
 
   # list of keys for an individual result entry used for matching facet filter values
   # each Azul result entry under 'hits' will have these keys, whether project- or file-based
-  RESULT_FACET_FIELDS = %w[samples specimens cellLines donorOrganisms organoids cellSuspensions].freeze
+  RESULT_FACET_FIELDS = %w[protocols samples specimens cellLines donorOrganisms organoids cellSuspensions].freeze
 
   def self.append_results_to_studies(existing_studies, selected_facets:, terms:, facet_map: nil)
     # set facet_map to {}, even if facet_map is explicitly passed in as nil
@@ -90,6 +90,7 @@ class AzulSearchService
           results_info[facet_name] = [facet[:filters]]
         else
           facet[:filters].each do |filter|
+            puts "trying to match on #{filter}"
             match = field_entries.select { |entry| filter[:name] == entry || filter[:id] == entry }
             results_info[facet_name] ||= []
             if match.any? && !results_info[facet_name].include?(filter)

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -355,4 +355,11 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     api_test_study.update(public: true)
     @user.update(api_access_token: valid_token)
   end
+
+
+  test 'should escape quotes in facet filter values' do
+    sanitized_filter = Api::V1::SearchController.sanitize_filter_value("10X 3' v3")
+    expected_value = "10X 3\\' v3"
+    assert_equal expected_value, sanitized_filter
+  end
 end


### PR DESCRIPTION
This update fixes a bug where running searches in BigQuery will throw an error if an Azul search filter value contains a single quote (`'`).  In addition, this also fixes a bug where values in `library_preparation_protocol` were not displaying facet match badges correctly.

MANUAL TESTING
1. Boot as normal, sign in with an account that has `cross_dataset_search_backend` enabled
2. Run a faceted search using `library_preparation_protocol:10X 3' V2 sequencing` 
3. Confirm the first result is `Single Cell RNA-Seq profiling human embryonic kidney cortex cells`, and the badge match for `10X 3' V2 sequencing` is shown:
![Screen Shot 2021-12-10 at 1 31 27 PM](https://user-images.githubusercontent.com/729968/145624049-aef1894d-e070-4e5e-85c6-414516b2aaf8.png)

This PR satisfies SCP-3951.