### PR TITLE
Support matching on `__ontology_label` columns when using Azul filter values (SCP-3952)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -594,6 +594,19 @@ module Api
           query_elements[:from] = "#{filter_arr_name}, UNNEST(#{filter_arr_name}.#{filter_val_name}) AS #{filter_where_val}"
           query_elements[:where] = "(#{filter_where_val} IN UNNEST(#{column_name}))"
           query_elements[:select] = "#{filter_where_val}"
+          # to maximize XDSS queries, also check __ontology_label columns since Azul doesn't support IDs
+          if search_facet.is_ontology_based? && search_facet.big_query_name_column.present?
+            label_values = facet_obj[:filters].map { |filter| filter[:name] }
+            label_column = search_facet.big_query_name_column
+            label_filter_arr_name = "#{facet_id}_label_filters"
+            label_filter_val_name = "#{facet_id}_label_value"
+            label_filter_where_val = "#{facet_id}_label_val"
+            query_elements[:with] += ", #{label_filter_arr_name} AS (SELECT#{label_values} as #{label_filter_val_name})"
+            query_elements[:from] += ", #{label_filter_arr_name}, UNNEST(#{label_filter_arr_name}.#{label_filter_val_name}) AS #{label_filter_where_val}"
+            # reconstitute where clause to use OR to match on either ID or label
+            query_elements[:where] = "((#{filter_where_val} IN UNNEST(#{column_name})) OR (#{label_filter_where_val} IN UNNEST(#{label_column})))"
+            query_elements[:select] += ", #{label_filter_where_val}"
+          end
         elsif search_facet.is_numeric?
           # run a range query (e.g. WHERE organism_age BETWEEN 20 and 60)
           query_elements[:select] = "#{column_name}"
@@ -611,7 +624,14 @@ module Api
           query_elements[:select] = "#{column_name}"
           # for non-array columns we can pass an array of quoted values and call IN directly
           filter_values = facet_obj[:filters].map {|filter| filter[:id]}
-          query_elements[:where] = "#{column_name} IN ('#{filter_values.join('\',\'')}')"
+          main_query = "#{column_name} IN ('#{filter_values.join('\',\'')}')"
+          query_elements[:where] = main_query
+          # to maximize XDSS queries, also check __ontology_label columns since Azul doesn't support IDs
+          if search_facet.is_ontology_based? && search_facet.big_query_name_column.present?
+            label_values = facet_obj[:filters].map { |filter| filter[:name] }
+            extra_query = "#{search_facet.big_query_name_column} IN ('#{label_values.join('\',\'')}')"
+            query_elements[:where] = "(#{main_query} OR #{extra_query})"
+          end
         end
         query_elements
       end
@@ -641,6 +661,8 @@ module Api
           matches[accession] ||= {facet_search_weight: 0}
           result.keys.keep_if { |key| key != :study_accession }.each do |key|
             facet_name = key.to_s.chomp('_val')
+            next if facet_name.ends_with?('_label') # ignore __ontology_label queries as we'll match on the main one
+
             matching_filter = match_results_by_filter(search_result: result, result_key: key, facets: search_facets)
             # there may not be a matching filter if the facet was OR'ed
             if matching_filter
@@ -677,7 +699,7 @@ module Api
         else
           filters_list = facet.filters_with_external.any? ? facet.filters_with_external : facet.filters
           filters_list.each do |filter|
-            if filter_values.include?(filter[:id])
+            if filter_values.include?(filter[:id]) || filter_values.include?(filter[:name])
               matching_filters << filter
             end
           end

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -355,4 +355,41 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     api_test_study.update(public: true)
     @user.update(api_access_token: valid_token)
   end
+
+  test "should construct query elements for facets" do
+    non_array_facet = {
+      id: 'species',
+      filters: [
+        { id: 'NCBITaxon_9606', name: 'Homo sapiens' },
+        { id: 'Gallus gallus', name: 'Gallus gallus' }
+      ],
+      db_facet: SearchFacet.find_by(identifier: 'species')
+    }
+    expected_where = "(species IN ('NCBITaxon_9606','Gallus gallus') OR" \
+                     " species__ontology_label IN ('Homo sapiens','Gallus gallus'))"
+    query_elements = Api::V1::SearchController.get_query_elements_for_facet(non_array_facet)
+    assert_equal expected_where, query_elements[:where]
+    array_facet = {
+      id: 'disease',
+      filters: [
+        { id: 'MONDO_0005109', name: 'HIV infectious disease' },
+        { id: 'Alzheimer disease', name: 'Alzheimer disease' }
+      ],
+      db_facet: SearchFacet.find_by(identifier: 'disease')
+    }
+    # assemble expected query elements
+    # both disease and disease__ontology_label should have corresponding with/from/where clauses using UNNEST
+    array_with = 'disease_filters AS (SELECT["MONDO_0005109", "Alzheimer disease"] as disease_value), ' \
+                 'disease_label_filters AS (SELECT["HIV infectious disease", "Alzheimer disease"] ' \
+                 'as disease_label_value)'
+    array_from = 'disease_filters, UNNEST(disease_filters.disease_value) AS disease_val, disease_label_filters, ' \
+                 'UNNEST(disease_label_filters.disease_label_value) AS disease_label_val'
+    array_where = '((disease_val IN UNNEST(disease)) OR (disease_label_val IN UNNEST(disease__ontology_label)))'
+    array_select = 'disease_val, disease_label_val'
+    array_query_elements = Api::V1::SearchController.get_query_elements_for_facet(array_facet)
+    assert_equal array_with, array_query_elements[:with]
+    assert_equal array_from, array_query_elements[:from]
+    assert_equal array_where, array_query_elements[:where]
+    assert_equal array_select, array_query_elements[:select]
+  end
 end


### PR DESCRIPTION
Currently, when running a search request that uses an ontology ID (e.g. `NCBITaxon_9606` for `Homo sapiens`), SCP will convert that into a query that can be run in Azul using the label value, rather than the name.  However, going the opposite direction is not supported - using a plain text filter value sourced from Azul, and searching for SCP studies in BigQuery.  This update extends search functionality to additionally run searches on the `__ontology_label` columns in BigQuery, so that cross-dataset searches can be as agnostic as possible regarding where filter values are sourced from.  These additional queries are appended as `OR` inside parentheses to allow for matching on either the ID or the label.

MANUAL TESTING
Given how data is sourced/persisted for search facets in the UI, the easiest way to manually test this update is to use the API directly via Swagger:
1. Boot portal as normal, and select `REST API documentation` from the `Help & Resources` menu
2. On the Swagger page, click `Authorize` at the top right, and sign in with an account that has `cross_dataset_search_backend` enabled
3. Go down to the entry for `/search` under the `Search` section (or use [this](https://localhost:3000/single_cell/api/v1#/Search/search_studies) link)
4. Enter `species:Homo sapiens` for the `facets` value and execute the search
5. Confirm the `matching_accessions` entry contains both HCA project short names, as well as SCP accessions:
```
matching_accessions": [
    "SCP15",
    "SCP18",
    "SCP58",
    "ProstateCellAtlas",
    "PRJNA640427_human_neutrophils",
    "HumanMousePancreas",
    "AtlasOfHumanIntervertebralDisc",
    "HumanThymicDevelopment",
    ...
```

This PR satisfies SCP-3952.