### PR TITLE
Removing 'Analyze in cloud' button from study download tab (SCP-3819)

### DIFF
--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -5,7 +5,6 @@
     <h2>Study Files
       <span class="badge"><%= @study_files.count %></span>
       <%= link_to "<i class='fas fa-question-circle'></i> Bulk download".html_safe, '#/', class: "btn btn-default pull-right #{!@allow_downloads ? 'disabled' : nil}", id: 'download-help' %>
-      <%= link_to "Analyze in cloud".html_safe, '#/', class: "btn btn-default pull-right left-margin-icon {!@allow_downloads ? 'disable d' : nil}", id: 'analyze-in-cloud'%>
     </h2>
 
     <% if @allow_downloads %>


### PR DESCRIPTION
This update removes the placeholder "Analyze in cloud" button from the study `Download` tab.  This button was only intended to gather user information for the purposes of a downstream survey, which has been sent and processed.

MANUAL TESTING
1. Boot and sign in
2. Load any study with files, and click into the Download tab
3. Confirm the `Analyze in Cloud` button is no longer present (previously was located next to the `Bulk Download` button)
![Screen Shot 2021-12-13 at 3 14 24 PM](https://user-images.githubusercontent.com/729968/145881740-507282e1-7f53-4f1a-a36a-417b4a66c711.png)

This PR satisfies SCP-3819