### PR TITLE
Bugfixes for test regressions from recent merges (SCP-3934)

### DIFF
--- a/test/api/studies_controller_test.rb
+++ b/test/api/studies_controller_test.rb
@@ -73,8 +73,12 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
     }
     execute_http_request(:patch, api_v1_study_path(id: study_id), request_payload: update_attributes)
     assert_response :success
+    # since callback to update plain-text description no longer uses the same study reference, we must load it from
+    # the database as the response will not have the updated description
+    # see StudyDetail#set_study_description_text
+    study = Study.find(study_id)
     plain_text_description = ActionController::Base.helpers.strip_tags update_attributes[:study][:study_detail_attributes][:full_description]
-    assert json['description'] == plain_text_description, "Did not set description correctly, expected #{plain_text_description} but found #{json['description']}"
+    assert study.description == plain_text_description, "Did not set description correctly, expected #{plain_text_description} but found #{json['description']}"
     # delete study, passing ?workspace=persist to skip FireCloud workspace deletion
     execute_http_request(:delete, api_v1_study_path(id: study_id))
     assert_response 204, "Did not successfully delete study, expected response of 204 but found #{@response.response_code}"

--- a/test/integration/lib/bulk_download_service_test.rb
+++ b/test/integration/lib/bulk_download_service_test.rb
@@ -53,6 +53,7 @@ class BulkDownloadServiceTest < ActiveSupport::TestCase
         name: @study.name,
         accession: @study.accession,
         description: @study.description,
+        study_source: 'SCP',
         study_files: @study.study_files.map do |f|
           { name: f.name, id: f.id.to_s, file_type: f.file_type, upload_file_size: f.upload_file_size }
         end

--- a/test/test_data/azul/human_tcell.json
+++ b/test/test_data/azul/human_tcell.json
@@ -1,6 +1,35 @@
 {
   "hits": [
     {
+      "protocols": [
+        {
+          "submissionDate": "2021-06-17T23:44:59.385000Z",
+          "updateDate": "2021-09-10T22:51:36.434000Z",
+          "workflow": [
+            "analysis_protocol_1"
+          ]
+        },
+        {
+          "submissionDate": "2021-06-17T23:44:59.366000Z",
+          "updateDate": "2021-06-17T23:45:07.150000Z",
+          "libraryConstructionApproach": [
+            "10X 3' V2 sequencing"
+          ],
+          "nucleicAcidSource": [
+            "single cell"
+          ]
+        },
+        {
+          "submissionDate": "2021-06-17T23:44:59.375000Z",
+          "updateDate": "2021-06-17T23:45:07.264000Z",
+          "instrumentManufacturerModel": [
+            "Illumina NextSeq 500"
+          ],
+          "pairedEnd": [
+            false
+          ]
+        }
+      ],
       "projects": [
         {
           "projectId": "4a95101c-9ffc-4f30-a809-f04518a23803",

--- a/test/test_data/azul/human_thymus.json
+++ b/test/test_data/azul/human_thymus.json
@@ -1,6 +1,35 @@
 {
   "hits": [
     {
+      "protocols": [
+        {
+          "submissionDate": "2021-06-17T23:44:59.385000Z",
+          "updateDate": "2021-09-10T22:51:36.434000Z",
+          "workflow": [
+            "analysis_protocol_1"
+          ]
+        },
+        {
+          "submissionDate": "2021-06-17T23:44:59.366000Z",
+          "updateDate": "2021-06-17T23:45:07.150000Z",
+          "libraryConstructionApproach": [
+            "10X 3' V2 sequencing"
+          ],
+          "nucleicAcidSource": [
+            "single cell"
+          ]
+        },
+        {
+          "submissionDate": "2021-06-17T23:44:59.375000Z",
+          "updateDate": "2021-06-17T23:45:07.264000Z",
+          "instrumentManufacturerModel": [
+            "Illumina NextSeq 500"
+          ],
+          "pairedEnd": [
+            false
+          ]
+        }
+      ],
       "projects": [
         {
           "projectId": "c1810dbc-16d2-45c3-b45e-3e675f88d87b",

--- a/test/test_data/azul/pulmonary_fibrosis.json
+++ b/test/test_data/azul/pulmonary_fibrosis.json
@@ -1,6 +1,35 @@
 {
   "hits": [
     {
+      "protocols": [
+        {
+          "submissionDate": "2021-06-17T23:44:59.385000Z",
+          "updateDate": "2021-09-10T22:51:36.434000Z",
+          "workflow": [
+            "analysis_protocol_1"
+          ]
+        },
+        {
+          "submissionDate": "2021-06-17T23:44:59.366000Z",
+          "updateDate": "2021-06-17T23:45:07.150000Z",
+          "libraryConstructionApproach": [
+            "10X 3' V2 sequencing"
+          ],
+          "nucleicAcidSource": [
+            "single cell"
+          ]
+        },
+        {
+          "submissionDate": "2021-06-17T23:44:59.375000Z",
+          "updateDate": "2021-06-17T23:45:07.264000Z",
+          "instrumentManufacturerModel": [
+            "Illumina NextSeq 500"
+          ],
+          "pairedEnd": [
+            false
+          ]
+        }
+      ],
       "projects": [
         {
           "projectId": "c1a9a93d-d9de-4e65-9619-a9cec1052eaa",


### PR DESCRIPTION
This fixes several test regressions detected recently due to the absence of functional CI.  Since SCP-3934 was supposed to have migrated us over to GitHub actions by now, the only way we can validate builds is to run them locally.  This update addresses issues found in `AzulSearchServiceTest`, `BulkDownloadServiceTest`, and `StudiesControllerTest`.

MANUAL TESTING
The easiest way to validate this is to check out this branch, and run `bin/run_tests.sh -l` from your project root directory.  However, be advised this can take ~40m to complete, depending on network speed.  To run these 3 suites directly:
1. Run `./rails_local_setup.rb && source config/secrets/.source_env.bash`
2. Run `bin/rails test test/integration/lib/bulk_download_service_test.rb` to cover `BulkDownloadServiceTest`
3. Run `bin/rails test test/integration/lib/azul_search_service_test.rb` to cover `AzulSearchServiceTest`
4. Run `bin/run_tests.sh -l -t test/api/studies_controller_test.rb` to run the final `StudiesControllerTest` suite and perform cleanups