### PR TITLE
Avoid sometimes-incorrect direction of interaction in related genes ideogram (SCP-3962) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
-    "ideogram": "1.33.0",
+    "ideogram": "1.32.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.13.0",
     "morpheus-app": "1.0.18",


### PR DESCRIPTION
While refining language for the direction of interactions, I noticed that Ideogram sometimes reports an incorrect direction in the improvements from #1301.  For example, sometimes it reports "gene A inhibits gene B" when the pathway diagram shows gene A _is inhibited by_ gene B.

So, for now, this reverts to the prior version.  That reports more general interactions -- without indicating direction.

This relates to SCP-3962.