### PR TITLE
ensuring non-parsable files get bundled as appropriate (SCP-3733)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -399,6 +399,8 @@ module Api
           if study_file.parseable?
             FileParseService.run_parse_job(@study_file, @study, current_api_user)
           else
+            # make sure we bundle non-parseable files if appropriate
+            FileParseService.create_bundle_from_file_options(study_file, @study)
             @study.delay.send_to_firecloud(study_file) # send data to FireCloud if upload was performed
           end
         end


### PR DESCRIPTION
SCP-3733. Bam files uploaded via the new upload wizard were not getting bundled correctly (even though they appeared bundled in the frontend), and therefore were not visualizable.  This fixes that problem

I ran the rails console command `StudyFile.where(file_type: 'BAM').pluck(:id, :study_file_bundle_id).each{|a| puts a.join(', ')}` in staging and production to identify any non-bundled bam files.  there was only one in staging, and none in prod.  I manually fixed the staging study by running `FileParseService.create_bundle_from_file_options(StudyFile.find('61d86f6ab067340ef311dd2c'), StudyFile.find('61d86f6ab067340ef311dd2c').study)`

TO TEST:
 1. Use the new upload wizard to upload a bam and bai file to a study that has no other sequence files
 2. confirm IGV appears successfully in the explore tab after upload 
