### PR TITLE
Ensure better test cleanup/stability for study objects (SCP-3978)

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1677,7 +1677,7 @@ class Study
     end
     Rails.logger.info "Removing workspace #{firecloud_project}/#{firecloud_workspace} in #{Rails.env} environment"
     begin
-      ApplicationController.firecloud_client.delete_workspace(firecloud_project, firecloud_workspace)
+      ApplicationController.firecloud_client.delete_workspace(firecloud_project, firecloud_workspace) unless self.detached
       DeleteQueueJob.new(self.metadata_file).delay.perform if self.metadata_file.present?
       destroy
     rescue => e

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1677,13 +1677,14 @@ class Study
     end
     Rails.logger.info "Removing workspace #{firecloud_project}/#{firecloud_workspace} in #{Rails.env} environment"
     begin
-      ApplicationController.firecloud_client.delete_workspace(firecloud_project, firecloud_workspace) unless self.detached
+      ApplicationController.firecloud_client.delete_workspace(firecloud_project, firecloud_workspace) unless detached
       DeleteQueueJob.new(self.metadata_file).delay.perform if self.metadata_file.present?
       destroy
     rescue => e
       Rails.logger.error "Error in removing #{firecloud_project}/#{firecloud_workspace}"
       Rails.logger.error "#{e.class.name}:"
       Rails.logger.error "#{e.message}"
+      destroy # ensure deletion of study, even if workspace is orphaned
     end
     Rails.logger.info "Workspace #{firecloud_project}/#{firecloud_workspace} successfully removed."
   end

--- a/app/views/studies/index.html.erb
+++ b/app/views/studies/index.html.erb
@@ -19,19 +19,19 @@
 					<% @studies.each do |study| %>
 						<tr class="study-entry">
               <td class="study-name"><%= scp_link_to study.name, view_study_path(accession: study.accession, study_name: study.url_safe_name), title: 'View Live', data: {toggle: 'tooltip', placement: 'right'}, id: "#{study.url_safe_name}-view-live-link" %></td>
-              <td><%= study.user.email %></td>
-							<td><%= study.description.truncate_words(10, omission: '...') %></td>
+              <td><%= study.user&.email %></td>
+							<td><%= study.description&.truncate_words(10, omission: '...') %></td>
 							<td><%= study.visibility %></td>
               <td id="<%= study.url_safe_name %>-study-file-count"><%= study.total_file_count %></td>
 							<td>
                 <% if study.can_edit?(current_user) %>
-                  <%= scp_link_to "<span class='fas fa-info-circle'></span> Show details".html_safe, study_path(study), 
+                  <%= scp_link_to "<span class='fas fa-info-circle'></span> Show details".html_safe, study_path(study),
                     class: "btn btn-xs btn-info #{study.url_safe_name}-show", title: 'View/Edit your study description' , data: {toggle: 'tooltip', placement: 'top'} %>
-                  <%= scp_link_to "<span class='fas fa-upload'></span> Upload/Edit data".html_safe, initialize_study_path(study), 
+                  <%= scp_link_to "<span class='fas fa-upload'></span> Upload/Edit data".html_safe, initialize_study_path(study),
                   class: "btn btn-xs btn-success #{study.url_safe_name}-upload", title: 'Add new files to your study' , data: {toggle: 'tooltip', placement: 'top'}  %>
-                  <%= scp_link_to "<span class='fas fa-sync-alt'></span> Sync workspace".html_safe, sync_study_path(study), 
+                  <%= scp_link_to "<span class='fas fa-sync-alt'></span> Sync workspace".html_safe, sync_study_path(study),
                   class: "btn btn-xs btn-warning #{study.url_safe_name}-sync sync-button", title: 'Sync files from your workspace to your study' , data: {toggle: 'tooltip', placement: 'top'} %>
-                  <%= scp_link_to "<span class='fas fa-edit'></span> Edit study".html_safe, edit_study_path(study), 
+                  <%= scp_link_to "<span class='fas fa-edit'></span> Edit study".html_safe, edit_study_path(study),
                   class: "btn btn-xs btn-primary #{study.url_safe_name}-edit", title: 'View/Update the settings for your study' , data: {toggle: 'tooltip', placement: 'top'} %>
                   <% if study.can_delete?(current_user) %>
                     <%= scp_link_to "<span class='fas fa-trash'></span> Delete study & workspace".html_safe, study_path(study),

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -15,6 +15,9 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   FILTER_DELIM = Api::V1::SearchController::FILTER_DELIMITER
 
   before(:all) do
+    # make sure all studies/users have been removed as dangling references can sometimes cause false negatives/failures
+    StudyCleanupTools.destroy_all_studies_and_workspaces
+    User.destroy_all
     @random_seed = SecureRandom.uuid
     @user = FactoryBot.create(:admin_user, test_array: @@users_to_clean)
     @other_user = FactoryBot.create(:api_user, test_array: @@users_to_clean)
@@ -339,7 +342,6 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should log out user after inactivity' do
-    @user = User.first
     # save access token to prevent breaking downstream tests
     valid_token = @user.api_access_token.dup
     # mark study as false to show if a user is signed in or not

--- a/test/api/studies_controller_test.rb
+++ b/test/api/studies_controller_test.rb
@@ -13,7 +13,12 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
                                user: @user,
                                public: true,
                                test_array: @@studies_to_clean)
+    @random_seed = SecureRandom.uuid
     sign_in_and_update @user
+  end
+
+  after(:all) do
+    Study.where(name: /#{@random_seed}/).map(&:destroy_and_remove_workspace)
   end
 
   teardown do
@@ -51,7 +56,7 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
     # create study
     study_attributes = {
         study: {
-            name: "New Study #{SecureRandom.uuid}"
+            name: "New Study #{@random_seed}"
         }
     }
     execute_http_request(:post, api_v1_studies_path, request_payload: study_attributes)
@@ -100,7 +105,7 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
   # then call sync_study API method
   test 'should create and then sync study' do
     # create study by calling FireCloud API manually
-    study_name = "Sync Study #{SecureRandom.uuid}"
+    study_name = "Sync Study #{@random_seed}"
     workspace_name = study_name.downcase.gsub(/[^a-zA-Z0-9]+/, '-').chomp('-')
     study_attributes = {
         study: {

--- a/test/api/visualization/annotations_controller_test.rb
+++ b/test/api/visualization/annotations_controller_test.rb
@@ -81,7 +81,10 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'index should return list of annotations' do
-    empty_study = FactoryBot.create(:detached_study, name_prefix: 'Empty Annotation Study', test_array: @@studies_to_clean)
+    empty_study = FactoryBot.create(:detached_study,
+                                    user: @user,
+                                    name_prefix: 'Empty Annotation Study',
+                                    test_array: @@studies_to_clean)
     sign_in_and_update @user
     execute_http_request(:get, api_v1_study_annotations_path(@basic_study))
     assert_equal 3, json.length

--- a/test/api/visualization/clusters_controller_test.rb
+++ b/test/api/visualization/clusters_controller_test.rb
@@ -60,6 +60,7 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
 
     empty_study = FactoryBot.create(:detached_study,
                                     name_prefix: 'Empty Cluster Study',
+                                    user: @user,
                                     test_array: @@studies_to_clean)
     execute_http_request(:get, api_v1_study_clusters_path(empty_study))
     assert_equal [], json
@@ -106,6 +107,7 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
   test 'should load clusters with slashes in name' do
     slash_study = FactoryBot.create(:detached_study,
                                     name_prefix: 'Cluster Slash Study',
+                                    user: @user,
                                     test_array: @@studies_to_clean)
     cluster_with_slash = FactoryBot.create(:cluster_file,
                                            name: 'data/cluster_with_slash.txt',
@@ -143,6 +145,7 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
   test 'should set aspect ratio and domains when provided' do
     study = FactoryBot.create(:detached_study,
                               name_prefix: 'Domain Range Study',
+                              user: @user,
                               test_array: @@studies_to_clean)
     cluster_name = 'cluster_domains.txt'
     cluster_file = FactoryBot.create(:cluster_file,

--- a/test/api/visualization/explore_controller_test.rb
+++ b/test/api/visualization/explore_controller_test.rb
@@ -25,6 +25,7 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
 
     @empty_study = FactoryBot.create(:detached_study,
                                      name_prefix: 'Empty study',
+                                     user: @user,
                                      test_array: @@studies_to_clean)
   end
 

--- a/test/integration/cache_management_test.rb
+++ b/test/integration/cache_management_test.rb
@@ -5,7 +5,10 @@ class CacheManagementTest < ActionDispatch::IntegrationTest
 
   before(:all) do
     @user = FactoryBot.create(:user, test_array: @@users_to_clean)
-    @study = FactoryBot.create(:detached_study, name_prefix: 'Cache Test', test_array: @@studies_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                               name_prefix: 'Cache Test',
+                               user: @user,
+                               test_array: @@studies_to_clean)
     @study_cluster_file = FactoryBot.create(:cluster_file,
                                             name: 'cluster 1', study: @study,
                                             cell_input: {

--- a/test/integration/lib/annotation_viz_service_test.rb
+++ b/test/integration/lib/annotation_viz_service_test.rb
@@ -4,7 +4,10 @@ class AnnotationVizServiceTest < ActiveSupport::TestCase
 
   before(:all) do
     @user = FactoryBot.create(:user, test_array: @@users_to_clean)
-    @basic_study = FactoryBot.create(:detached_study, name_prefix: 'Basic Viz', test_array: @@studies_to_clean)
+    @basic_study = FactoryBot.create(:detached_study,
+                                     name_prefix: 'Basic Viz',
+                                     user: @user,
+                                     test_array: @@studies_to_clean)
     @basic_study_cluster_file = FactoryBot.create(:cluster_file,
                                                   name: 'cluster_1.txt', study: @basic_study,
                                                   annotation_input: [
@@ -96,7 +99,10 @@ class AnnotationVizServiceTest < ActiveSupport::TestCase
   end
 
   test 'should return non-plottable annotations' do
-    study = FactoryBot.create(:detached_study, name_prefix: 'No Valid Viz', test_array: @@studies_to_clean)
+    study = FactoryBot.create(:detached_study,
+                              name_prefix: 'No Valid Viz',
+                              user: @user,
+                              test_array: @@studies_to_clean)
     FactoryBot.create(:cluster_file, name: 'cluster_1.txt', study: study, annotation_input: [
       { name: 'cluster', type: 'group', values: %w[A A A] }
     ])

--- a/test/integration/lib/bulk_download_service_test.rb
+++ b/test/integration/lib/bulk_download_service_test.rb
@@ -181,7 +181,9 @@ class BulkDownloadServiceTest < ActiveSupport::TestCase
   end
 
   test 'should generate study manifest file' do
-    study = FactoryBot.create(:detached_study, name_prefix: "#{self.method_name}")
+    study = FactoryBot.create(:detached_study,
+                              user: @user,
+                              name_prefix: "#{self.method_name}")
     FactoryBot.create(:study_file,
                       study: study, file_type: 'Expression Matrix', name: 'test_exp_validate.tsv', taxon_id: Taxon.new.id,
                       expression_file_info: ExpressionFileInfo.new(

--- a/test/integration/lib/bulk_download_service_test.rb
+++ b/test/integration/lib/bulk_download_service_test.rb
@@ -183,7 +183,8 @@ class BulkDownloadServiceTest < ActiveSupport::TestCase
   test 'should generate study manifest file' do
     study = FactoryBot.create(:detached_study,
                               user: @user,
-                              name_prefix: "#{self.method_name}")
+                              name_prefix: 'Study Manifest Test',
+                              test_array: @@studies_to_clean,)
     FactoryBot.create(:study_file,
                       study: study, file_type: 'Expression Matrix', name: 'test_exp_validate.tsv', taxon_id: Taxon.new.id,
                       expression_file_info: ExpressionFileInfo.new(
@@ -207,8 +208,6 @@ class BulkDownloadServiceTest < ActiveSupport::TestCase
     assert_equal 2, rows.count
     raw_count_row = rows.find {|r| r['filename'] == 'test_exp_validate.tsv'}
     assert_equal 'true', raw_count_row['is_raw_counts']
-
-    study.destroy!
   end
 
   test 'should create map of study file types to counts' do

--- a/test/integration/lib/cluster_cache_service_test.rb
+++ b/test/integration/lib/cluster_cache_service_test.rb
@@ -4,7 +4,10 @@ class ClusterCacheServiceTest < ActiveSupport::TestCase
 
   before(:all) do
     @user = FactoryBot.create(:admin_user, test_array: @@users_to_clean)
-    @study = FactoryBot.create(:detached_study, name_prefix: 'Test Cache Study', test_array: @@studies_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                               name_prefix: 'Test Cache Study',
+                               user: @user,
+                               test_array: @@studies_to_clean)
     @study_cluster_file_1 = FactoryBot.create(:cluster_file,
                                               name: 'cluster_1.txt', study: @study,
                                               cell_input: {

--- a/test/integration/lib/cluster_viz_service_test.rb
+++ b/test/integration/lib/cluster_viz_service_test.rb
@@ -4,7 +4,10 @@ class ClusterVizServiceTest < ActiveSupport::TestCase
 
   before(:all) do
     @user = FactoryBot.create(:admin_user, test_array: @@users_to_clean)
-    @study = FactoryBot.create(:detached_study, name_prefix: 'Test Cluster Study', test_array: @@studies_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                               name_prefix: 'Test Cluster Study',
+                               user: @user,
+                               test_array: @@studies_to_clean)
     @study_cluster_file_1 = FactoryBot.create(:cluster_file,
                                               name: 'cluster_1.txt', study: @study,
                                               cell_input: {

--- a/test/integration/lib/expression_viz_service_test.rb
+++ b/test/integration/lib/expression_viz_service_test.rb
@@ -4,7 +4,10 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
 
   before(:all) do
     @user = FactoryBot.create(:user, test_array: @@users_to_clean)
-    @basic_study = FactoryBot.create(:detached_study, name_prefix: 'Basic Viz', test_array: @@studies_to_clean)
+    @basic_study = FactoryBot.create(:detached_study,
+                                     name_prefix: 'Basic Viz',
+                                     user: @user,
+                                     test_array: @@studies_to_clean)
     @basic_study_cluster_file = FactoryBot.create(:cluster_file,
                                               name: 'cluster_1.txt', study: @basic_study,
                                               cell_input: {
@@ -150,7 +153,10 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
 
   test 'should load ideogram outputs' do
     # we need a non-detached study, so create one
-    study = FactoryBot.create(:detached_study, name: "Ideogram Study #{SecureRandom.uuid}", test_array: @@studies_to_clean)
+    study = FactoryBot.create(:detached_study,
+                              name: "Ideogram Study #{SecureRandom.uuid}",
+                              user: @user,
+                              test_array: @@studies_to_clean)
 
     cluster_file = FactoryBot.create(:cluster_file,
                                      name: 'cluster_1.txt', study: study,

--- a/test/integration/lib/summary_stats_utils_test.rb
+++ b/test/integration/lib/summary_stats_utils_test.rb
@@ -96,14 +96,20 @@ class SummaryStatsUtilsTest < ActiveSupport::TestCase
   end
 
   test 'should get Study creation stats' do
-    new_study = FactoryBot.create(:detached_study, name_prefix: 'creation history stats', test_array: @@studies_to_clean)
+    new_study = FactoryBot.create(:detached_study,
+                                  name_prefix: 'creation history stats',
+                                  user: @user,
+                                  test_array: @@studies_to_clean)
     created_studies_info = SummaryStatsUtils.created_studies_info
     created_titles = created_studies_info.map{|creation| creation[:title]}
     assert created_titles.include?(new_study.name)
   end
 
   test 'should get Study deletion stats' do
-    new_study = FactoryBot.create(:detached_study, name_prefix: 'deletion history stats', test_array: @@studies_to_clean)
+    new_study = FactoryBot.create(:detached_study,
+                                  name_prefix: 'deletion history stats',
+                                  user: @user,
+                                  test_array: @@studies_to_clean)
     new_study.destroy
     deleted_studies_info = SummaryStatsUtils.deleted_studies_info
     titles = deleted_studies_info.map{|deletion| deletion[:title]}
@@ -111,7 +117,11 @@ class SummaryStatsUtilsTest < ActiveSupport::TestCase
   end
 
   test 'should get Study update stats' do
-    new_study = FactoryBot.create(:detached_study, name_prefix: 'update history stats', public: false, test_array: @@studies_to_clean)
+    new_study = FactoryBot.create(:detached_study,
+                                  name_prefix: 'update history stats',
+                                  public: false,
+                                  user: @user,
+                                  test_array: @@studies_to_clean)
     new_study.update(public: true)
     cluster_file = FactoryBot.create(:cluster_file, name: 'clusterA.txt', study: new_study)
     cluster_file.update(description: 'test cluster file')
@@ -132,7 +142,10 @@ class SummaryStatsUtilsTest < ActiveSupport::TestCase
     assert_equal studies.count, stats[:all]
     assert_equal existing_public, stats[:public]
     assert_equal existing_compliant, stats[:compliant]
-    new_study = FactoryBot.create(:detached_study, name_prefix: 'public compliant stats', test_array: @@studies_to_clean)
+    new_study = FactoryBot.create(:detached_study,
+                                  name_prefix: 'public compliant stats',
+                                  user: @user,
+                                  test_array: @@studies_to_clean)
     FactoryBot.create(:metadata_file, name: 'compliant.txt', study: new_study, use_metadata_convention: true)
     updated_stats = SummaryStatsUtils.study_counts
     updated_studies = studies.count

--- a/test/integration/study_validation_test.rb
+++ b/test/integration/study_validation_test.rb
@@ -34,7 +34,7 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
   end
 
   after(:all) do
-    Study.where(name: /#{@random_seed}/).each(&:destroy_and_remove_workspace)
+    Study.where(name: /#{@random_seed}/).map(&:destroy_and_remove_workspace)
   end
 
   # check that file header/format checks still function properly

--- a/test/integration/study_validation_test.rb
+++ b/test/integration/study_validation_test.rb
@@ -8,6 +8,9 @@ require 'includes_helper'
 class StudyValidationTest < ActionDispatch::IntegrationTest
 
   before(:all) do
+    # make sure all studies/users have been removed as dangling references can sometimes cause false negatives/failures
+    StudyCleanupTools.destroy_all_studies_and_workspaces
+    User.destroy_all
     @user = FactoryBot.create(:admin_user, test_array: @@users_to_clean)
     @sharing_user = FactoryBot.create(:user, test_array: @@users_to_clean)
     @random_seed = SecureRandom.uuid

--- a/test/lib/delayed_job_accessor_test.rb
+++ b/test/lib/delayed_job_accessor_test.rb
@@ -4,7 +4,10 @@ class DelayedJobAccessorTest < ActiveSupport::TestCase
 
   before(:all) do
     @user = FactoryBot.create(:user, test_array: @@users_to_clean)
-    @study = FactoryBot.create(:detached_study, name_prefix: 'DelayedJobAccessor Study', test_array: @@studies_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                               name_prefix: 'DelayedJobAccessor Study',
+                               user: @user,
+                               test_array: @@studies_to_clean)
     @study_file = FactoryBot.create(:study_file, name: 'dense.txt', file_type: 'Expression Matrix', study: @study)
   end
 

--- a/test/lib/generic_profiler_test.rb
+++ b/test/lib/generic_profiler_test.rb
@@ -4,7 +4,10 @@ class GenericProfilerTest < ActiveSupport::TestCase
 
   before(:all) do
     @user = FactoryBot.create(:user, test_array: @@users_to_clean)
-    @basic_study = FactoryBot.create(:detached_study, name_prefix: 'Profiler Test', test_array: @@studies_to_clean)
+    @basic_study = FactoryBot.create(:detached_study,
+                                     name_prefix: 'Profiler Test',
+                                     user: @user,
+                                     test_array: @@studies_to_clean)
     @basic_study_cluster_file = FactoryBot.create(:cluster_file,
                                                   name: 'cluster_1.txt', study: @basic_study,
                                                   cell_input: {

--- a/test/lib/study_cleanup_tools_test.rb
+++ b/test/lib/study_cleanup_tools_test.rb
@@ -6,7 +6,10 @@ class StudyCleanupToolsTest < ActiveSupport::TestCase
 
   before(:all) do
     @user = FactoryBot.create(:user, test_array: @@users_to_clean)
-    @basic_study = FactoryBot.create(:study, name_prefix: 'Cleanup Security Checks', test_array: @@studies_to_clean)
+    @basic_study = FactoryBot.create(:study,
+                                     name_prefix: 'Cleanup Security Checks',
+                                     user: @user,
+                                     test_array: @@studies_to_clean)
   end
 
   test 'should validate hostname' do

--- a/test/models/cluster_group_test.rb
+++ b/test/models/cluster_group_test.rb
@@ -4,7 +4,10 @@ class ClusterGroupTest < ActiveSupport::TestCase
 
   before(:all) do
     @user = FactoryBot.create(:user, test_array: @@users_to_clean)
-    @study = FactoryBot.create(:detached_study, name_prefix: 'Basic Viz', test_array: @@studies_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                               name_prefix: 'Basic Viz',
+                               user: @user,
+                               test_array: @@studies_to_clean)
     @cluster_file = FactoryBot.create(:cluster_file,
                                                   name: 'cluster_1.txt', study: @study,
                                                   cell_input: {

--- a/test/models/data_array_test.rb
+++ b/test/models/data_array_test.rb
@@ -4,7 +4,10 @@ class DataArrayTest < ActiveSupport::TestCase
 
   before(:all) do
     @user = FactoryBot.create(:user, test_array: @@users_to_clean)
-    @study = FactoryBot.create(:detached_study, name_prefix: 'Concatenation Test', test_array: @@studies_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                               name_prefix: 'Concatenation Test',
+                               user: @user,
+                               test_array: @@studies_to_clean)
     @cluster_file = FactoryBot.create(:cluster_file,
                                       name: 'cluster_1.txt', study: @study,
                                       annotation_input: [])

--- a/test/models/delete_queue_job_test.rb
+++ b/test/models/delete_queue_job_test.rb
@@ -4,7 +4,10 @@ class DeleteQueueJobTest < ActiveSupport::TestCase
 
   before(:all) do
     @user = FactoryBot.create(:user, test_array: @@users_to_clean)
-    @basic_study = FactoryBot.create(:detached_study, name_prefix: 'DeleteQueue Test', test_array: @@studies_to_clean)
+    @basic_study = FactoryBot.create(:detached_study,
+                                     name_prefix: 'DeleteQueue Test',
+                                     user: @user,
+                                     test_array: @@studies_to_clean)
 
     @basic_study_exp_file = FactoryBot.create(:study_file,
                                               name: 'dense.txt',

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -9,6 +9,7 @@ class IngestJobTest < ActiveSupport::TestCase
     @basic_study_exp_file = FactoryBot.create(:study_file,
                                               name: 'dense.txt',
                                               file_type: 'Expression Matrix',
+                                              user: @user,
                                               study: @basic_study)
 
     @pten_gene = FactoryBot.create(:gene_with_expression,

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -4,12 +4,14 @@ class IngestJobTest < ActiveSupport::TestCase
 
   before(:all) do
     @user = FactoryBot.create(:user, test_array: @@users_to_clean)
-    @basic_study = FactoryBot.create(:detached_study, name_prefix: 'IngestJob Test', test_array: @@studies_to_clean)
+    @basic_study = FactoryBot.create(:detached_study,
+                                     name_prefix: 'IngestJob Test',
+                                     user: @user,
+                                     test_array: @@studies_to_clean)
 
     @basic_study_exp_file = FactoryBot.create(:study_file,
                                               name: 'dense.txt',
                                               file_type: 'Expression Matrix',
-                                              user: @user,
                                               study: @basic_study)
 
     @pten_gene = FactoryBot.create(:gene_with_expression,

--- a/test/models/reviewer_access_session_test.rb
+++ b/test/models/reviewer_access_session_test.rb
@@ -7,6 +7,7 @@ class ReviewerAccessSessionTest < ActiveSupport::TestCase
     @study = FactoryBot.create(:detached_study,
                                name_prefix: 'Reviewer Access Session Test',
                                public: false,
+                               user: @user,
                                test_array: @@studies_to_clean)
     @access = @study.build_reviewer_access
     @access.save!

--- a/test/models/reviewer_access_test.rb
+++ b/test/models/reviewer_access_test.rb
@@ -7,6 +7,7 @@ class ReviewerAccessTest < ActiveSupport::TestCase
     @study = FactoryBot.create(:detached_study,
                                name_prefix: 'Reviewer Access Test',
                                public: false,
+                               user: @user,
                                test_array: @@studies_to_clean)
   end
 

--- a/test/models/study_file_test.rb
+++ b/test/models/study_file_test.rb
@@ -4,7 +4,10 @@ class StudyFileTest < ActiveSupport::TestCase
 
   before(:all) do
     @user = FactoryBot.create(:user, test_array: @@users_to_clean)
-    @study = FactoryBot.create(:detached_study, name_prefix: 'Study File Test', test_array: @@studies_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                               name_prefix: 'Study File Test',
+                               user: @user,
+                               test_array: @@studies_to_clean)
 
     @expression_matrix = FactoryBot.create(:study_file, name: 'dense.txt', file_type: 'Expression Matrix', study: @study)
 

--- a/test/models/study_test.rb
+++ b/test/models/study_test.rb
@@ -98,7 +98,10 @@ class StudyTest < ActiveSupport::TestCase
 
   test 'should default to first available annotation' do
     user = FactoryBot.create(:user, test_array: @@users_to_clean)
-    study = FactoryBot.create(:detached_study, name_prefix: 'Default Annotation Test', test_array: @@studies_to_clean)
+    study = FactoryBot.create(:detached_study,
+                              name_prefix: 'Default Annotation Test',
+                              user: user,
+                              test_array: @@studies_to_clean)
     assert study.default_annotation.nil?
     FactoryBot.create(:metadata_file,
                       name: 'metadata.txt',
@@ -111,7 +114,10 @@ class StudyTest < ActiveSupport::TestCase
   end
 
   test 'should ignore email case for share checking' do
-    study = FactoryBot.create(:detached_study, name_prefix: 'Share Case Test', test_array: @@studies_to_clean)
+    study = FactoryBot.create(:detached_study,
+                              name_prefix: 'Share Case Test',
+                              user: @user,
+                              test_array: @@studies_to_clean)
     share_user = FactoryBot.create(:user, test_array: @@users_to_clean)
     invalid_email = share_user.email.upcase
     share = study.study_shares.build(permission: 'View', email: invalid_email)
@@ -124,7 +130,10 @@ class StudyTest < ActiveSupport::TestCase
 
   # ensure that user-specified data embargoes expire on the date given
   test 'should lift embargo on date specified' do
-    study = FactoryBot.create(:detached_study, name_prefix: 'Embargo Test', test_array: @@studies_to_clean)
+    study = FactoryBot.create(:detached_study,
+                              name_prefix: 'Embargo Test',
+                              user: @user,
+                              test_array: @@studies_to_clean)
     user = FactoryBot.create(:user, test_array: @@users_to_clean)
     assert_not study.embargo_active?
     assert_not study.embargoed?(user)


### PR DESCRIPTION
This update addresses stability issues during CI relating to `Study` and `User` cleanup, where (depending on test execution order) a study can have the associated user deleted w/o removing the study as well.  In addition, this update ensures better cleanup in test suites where `FactoryBot` is not being leveraged (such as some integration tests that a `POST` to create a study).  Lastly, the "My Studies" table has had methods nil-safed to avoid the [actual error](https://github.com/broadinstitute/single_cell_portal_core/runs/4763654601?check_suite_focus=true#step:4:4121) that was causing some tests to fail erroneously.

MANUAL TESTING
Since the bug seems to only be isolated to CI runs, testing manually is neither very feasible or particularly worthwhile.  Instead, this PR should have a green build, and the workflow should be able to be re-run w/o incurring the particular error highlighted. 

This PR satisfies SCP-3978.