### PR TITLE
More test updates for stability (SCP-3061)

### DIFF
--- a/test/api/bulk_download_controller_test.rb
+++ b/test/api/bulk_download_controller_test.rb
@@ -12,7 +12,7 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
     @user = FactoryBot.create(:api_user, test_array: @@users_to_clean)
     @taxon = Taxon.find_or_create_by!(common_name: 'mouse_fake1',
                            scientific_name: 'Mus musculusfake1',
-                           user: User.first,
+                           user: @user,
                            ncbi_taxid: 100901,
                            notes: 'fake mouse taxon 1 for testing')
     @genome_assembly = GenomeAssembly.find_or_create_by!(name: "GRCm38",
@@ -65,6 +65,9 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
 
   teardown do
     OmniAuth.config.mock_auth[:google_oauth2] = nil
+  end
+
+  after(:all) do
     @taxon.destroy
   end
 

--- a/test/api/bulk_download_controller_test.rb
+++ b/test/api/bulk_download_controller_test.rb
@@ -309,7 +309,7 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
     accessions = [@basic_study.accession, 'FakeHCAProject', study.accession, 'AnotherFakeHCAProject']
     scp_accessions = Api::V1::BulkDownloadController.find_matching_accessions(accessions)
     hca_accessions = Api::V1::BulkDownloadController.extract_hca_accessions(accessions)
-    assert_equal [@basic_study.accession, study.accession], scp_accessions
-    assert_equal %w[FakeHCAProject AnotherFakeHCAProject], hca_accessions
+    assert_equal [@basic_study.accession, study.accession].sort, scp_accessions.sort
+    assert_equal %w[FakeHCAProject AnotherFakeHCAProject].sort, hca_accessions.sort
   end
 end

--- a/test/integration/lib/expression_viz_service_test.rb
+++ b/test/integration/lib/expression_viz_service_test.rb
@@ -192,6 +192,8 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
       assert_equal annotation, ideogram_opts[:annotation]
       assert_equal api_url + '?alt=media', ideogram_opts.dig(:ideogram_settings, :annotationsPath)
     end
+    # unset detached to avoid cleanup errors
+    study.update(detached: true)
   end
 
   test 'should load expression axis label' do


### PR DESCRIPTION
This update applies a few more changes to aid in CI stability, as discovered in recent [post-merge builds](https://github.com/broadinstitute/single_cell_portal_core/runs/4791509862?check_suite_focus=true).  This further supports SCP-3061.