### PR TITLE
Enable more realistic metrics for first plot time (SCP-3836)

### DIFF
--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -8,7 +8,7 @@ import {
 import { log } from './metrics-api'
 
 // See note in logSearch
-let numSearchesSincePageLoad = 0
+let searchNumber = 0
 
 const filterNamesById = {}
 
@@ -75,8 +75,8 @@ function getFriendlyFilterListByFacet(facets) {
  * Log global study search metrics, one type of search done on home page
  */
 export function logSearch(type, searchParams, perfTimes) {
-  numSearchesSincePageLoad += 1
-  if (numSearchesSincePageLoad < 3) {
+  searchNumber += 1
+  if (searchNumber < 3) {
     // This prevents over-reporting searches.
     //
     // Loading home page triggers 2 searches, which is a side-effect / artifact
@@ -106,7 +106,7 @@ export function logSearch(type, searchParams, perfTimes) {
   const simpleProps = {
     terms, numTerms, genes, numGenes, page, preset,
     facetList, numFacets, numFilters,
-    perfTimes, numSearchesSincePageLoad,
+    perfTimes,
     type, context: 'global'
   }
   const props = Object.assign(simpleProps, filterListByFacet)

--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -8,7 +8,7 @@ import {
 import { log } from './metrics-api'
 
 // See note in logSearch
-let searchNumber = 0
+let numSearchesSincePageLoad = 0
 
 const filterNamesById = {}
 
@@ -75,8 +75,8 @@ function getFriendlyFilterListByFacet(facets) {
  * Log global study search metrics, one type of search done on home page
  */
 export function logSearch(type, searchParams, perfTimes) {
-  searchNumber += 1
-  if (searchNumber < 3) {
+  numSearchesSincePageLoad += 1
+  if (numSearchesSincePageLoad < 3) {
     // This prevents over-reporting searches.
     //
     // Loading home page triggers 2 searches, which is a side-effect / artifact
@@ -106,7 +106,7 @@ export function logSearch(type, searchParams, perfTimes) {
   const simpleProps = {
     terms, numTerms, genes, numGenes, page, preset,
     facetList, numFacets, numFilters,
-    perfTimes,
+    perfTimes, numSearchesSincePageLoad,
     type, context: 'global'
   }
   const props = Object.assign(simpleProps, filterListByFacet)
@@ -139,11 +139,13 @@ export function logViolinPlot(
   log('plot:violin', props)
 }
 
+let numScatterPlotsSincePageLoad = 0
 /** Logs scatter plot metrics */
 export function logScatterPlot(
   { scatter, genes },
   perfTimes
 ) {
+  numScatterPlotsSincePageLoad += 1
   const props = {
     'numPoints': scatter.numPoints, // How many cells are we plotting?
     genes,
@@ -161,7 +163,8 @@ export function logScatterPlot(
     'isCorrelatedScatter': scatter.isCorrelatedScatter,
     'isAnnotatedScatter': scatter.isAnnotatedScatter,
     'isSpatial': scatter.isSpatial,
-    perfTimes
+    perfTimes,
+    numScatterPlotsSincePageLoad
   }
 
   log('plot:scatter', props)


### PR DESCRIPTION
This logs the number of scatter plots since page load.  Combined with `perfTime` metrics, it lets us more accurately measure the user-perceived time it takes to load the first scatter plot, e.g. [in this Mixpanel report](https://mixpanel.com/s/23U5VP).

That's especially helpful as an objective yardstick to measure improvements in engineering iteration time for certain tasks.  It can also help better measure performance improvements for that particular user journey.

To test:
* Open DevTools
* Go to a study overview page that has visualizations
* In Network panel in DevTools, find `scatter:plot` event
* Verify that `numScatterPlotsSincePageLoad` is 1

This satisfies SCP-3836.