### PR TITLE
improving scroll display of facet accordion (SCP-3945)

### DIFF
--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -202,23 +202,6 @@ nav.search-links, #search-panel {
     }
   }
 
-  #facets-accordion {
-    background: #eff2f5;
-    overflow-y: scroll;
-    overflow-x: hidden;
-    .facet {
-      width: 98%;
-      display: block;
-      margin: 5px 2px;
-      .filters-box-searchable {
-        position: relative;
-        width: 98%;
-        border: none;
-        margin-top: -2px;
-      }
-    }
-  }
-
   .filters-box-header {
     margin: 5px 0px;
     display: flex;
@@ -240,7 +223,8 @@ nav.search-links, #search-panel {
   }
 
   #facets-accordion {
-    height: 300px;
+    background: #eff2f5;
+    overflow-x: hidden;
     .filters-box-searchable {
       margin-left: 0px;
     }
@@ -256,6 +240,17 @@ nav.search-links, #search-panel {
       width: 100%;
       display: block;
       border: 1px solid #ddd;
+    }
+    .facet {
+      width: 98%;
+      display: block;
+      margin: 5px 2px;
+      .filters-box-searchable {
+        position: relative;
+        width: 98%;
+        border: none;
+        margin-top: -2px;
+      }
     }
   }
 


### PR DESCRIPTION
SCP-3945.  This updates the scroll behavior on the facet accordion to mimic the scroll behavior of facets not in the accordion.  Previously, there was a mismatch between the max heights that meant a user would have to scroll down  inside the accordion to see the apply button if there were more than ~7 options. Now the apply button is not hidden behind a scrollbar.
![image](https://user-images.githubusercontent.com/2800795/149396336-d41fb284-3e7a-4d4d-b801-ab4dd15954b6.png)


In the event that the user's monitor is very short (<650px) they would have to scroll (similar to how they would have to scroll for other facets), but the scrolling is more clearly indicated, since the bottom of the accordion is no longer visible, and easier to accomplish, since it is scrolling the whole document. 
![image](https://user-images.githubusercontent.com/2800795/149396313-dd67b039-56cc-4560-a1b7-3b930f50530c.png)

TO TEST:
1. View home page
2. open 'more facets'
3. expand library preparation protocol, confirm apply button is visible
