### PR TITLE
Advanced search UI updates (SCP-3973, SCP-3983, SCP-4003)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -421,7 +421,7 @@ module Api
         # sanitize query string for regexp matching
         @query_string = params[:query]
         query_matcher = /#{Regexp.escape(@query_string)}/i
-        filter_list = user_signed_in? ? @search_facet.filters : @search_facet.public_filters
+        filter_list = @search_facet.filters_for_user(current_api_user)
         @matching_filters = filter_list.select { |filter| filter[:name] =~ query_matcher }
       end
 

--- a/app/javascript/components/search/controls/FacetsPanel.js
+++ b/app/javascript/components/search/controls/FacetsPanel.js
@@ -25,11 +25,11 @@ export default function FacetsPanel() {
 
   const publicStudies = window.SCP.studyStats.public
   const compliantStudies = window.SCP.studyStats.compliant
-  const percentage = (compliantStudies / publicStudies * 100).toFixed(0)
+  const percentage = Math.round(compliantStudies / publicStudies * 100)
   const helpModalContent = (<div>
-    <h4 className="text-center">Advanced Search</h4><br/>
-    Single Cell Portal supports searching on specific facets of studies by ontology classifications.  This allows users
-    to search for studies using metadata values that may not appear in titles or descriptions.
+    <h4 className="text-center">Advanced search</h4><br/>
+    Single Cell Portal supports searching on facets of studies by ontology classifications.  This lets users
+    search for studies using metadata that may not appear in titles or descriptions.
     <br/><br/>
     For example, you can search on studies that
     have <b>species</b> of <b>&quot;Homo sapiens&quot;</b> or have an <b>organ</b> of <b>&quot;brain&quot;</b>.{' '}

--- a/app/javascript/components/search/controls/FacetsPanel.js
+++ b/app/javascript/components/search/controls/FacetsPanel.js
@@ -27,7 +27,7 @@ export default function FacetsPanel() {
   const compliantStudies = window.SCP.studyStats.compliant
   const percentage = Math.round(compliantStudies / publicStudies * 100)
   const helpModalContent = (<div>
-    <h4 className="text-center">Advanced search</h4><br/>
+    <h4 className="text-center">Metadata search</h4><br/>
     Single Cell Portal supports searching on facets of studies by ontology classifications.  This lets users
     search for studies using metadata that may not appear in titles or descriptions.
     <br/><br/>
@@ -59,9 +59,9 @@ export default function FacetsPanel() {
   return (
     <div>
       <span
-        className='badge metadata-search search-title'
+        className='metadata-search search-title'
       >
-        Data search { advancedOptsLink }
+        Metadata search { advancedOptsLink }
       </span>
       <CombinedFacetControl controlDisplayName="organ" facetIds={['organ', 'organ_region']}/>
       {

--- a/app/javascript/components/search/controls/FacetsPanel.js
+++ b/app/javascript/components/search/controls/FacetsPanel.js
@@ -1,9 +1,13 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 
 import FacetControl from './FacetControl'
 import CombinedFacetControl from './CombinedFacetControl'
 import MoreFacetsButton from './MoreFacetsButton'
 import { SearchFacetContext } from 'providers/SearchFacetProvider'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
+import Modal from 'react-bootstrap/lib/Modal'
+import { closeModal } from 'components/search/controls/SearchPanel'
 
 const defaultFacetIds = ['disease', 'species']
 const moreFacetIds = [
@@ -17,14 +21,47 @@ export default function FacetsPanel() {
   const searchFacetContext = useContext(SearchFacetContext)
   const defaultFacets = searchFacetContext.facets.filter(facet => defaultFacetIds.includes(facet.id))
   const moreFacets = searchFacetContext.facets.filter(facet => moreFacetIds.includes(facet.id))
+  const [showSearchHelpModal, setShowSearchHelpModal] = useState(false)
+
+  const publicStudies = window.SCP.studyStats.public
+  const compliantStudies = window.SCP.studyStats.compliant
+  const percentage = (compliantStudies / publicStudies * 100).toFixed(0)
+  const helpModalContent = (<div>
+    <h4 className="text-center">Advanced Search</h4><br/>
+    Single Cell Portal supports searching on specific facets of studies by ontology classifications.  This allows users
+    to search for studies using metadata values that may not appear in titles or descriptions.
+    <br/><br/>
+    For example, you can search on studies that
+    have <b>species</b> of <b>&quot;Homo sapiens&quot;</b> or have an <b>organ</b> of <b>&quot;brain&quot;</b>.{' '}
+    ~<b>{percentage}% ({compliantStudies} of {publicStudies})</b> public studies in SCP provide this metadata
+    information.
+    {/*
+   more information on public/compliant studies available at
+   https://docs.google.com/spreadsheets/d/1FSpP2XTrG9FqAqD9X-BHxkCZae9vxZA3cQLow8mn-bk
+*/}
+    <br/><br/>
+    For more detailed information, visit
+    our{' '}
+    <a href="https://singlecell.zendesk.com/hc/en-us/articles/360061006431-Search-Studies"
+       target="_blank" rel="noreferrer">documentation
+    </a>.  Study authors looking to make their studies more accessible can read our
+    <a href="https://singlecell.zendesk.com/hc/en-us/articles/4406379107355-Metadata-powered-Advanced-Search"
+       target="_blank" rel="noreferrer"> metadata guide
+    </a>.
+  </div>)
+
+  const advancedOptsLink = <a className="action advanced-opts"
+                              onClick={() => setShowSearchHelpModal(true)}
+                              data-analytics-name="search-help">
+    <FontAwesomeIcon icon={faQuestionCircle} />
+  </a>
+
   return (
     <div>
       <span
         className='badge metadata-search search-title'
-        title='Search through metadata for values that may not appear in titles/descriptions, like cell type or disease'
-        data-toggle='tooltip'
       >
-        Data search
+        Data search { advancedOptsLink }
       </span>
       <CombinedFacetControl controlDisplayName="organ" facetIds={['organ', 'organ_region']}/>
       {
@@ -34,6 +71,16 @@ export default function FacetsPanel() {
       }
       <CombinedFacetControl controlDisplayName="cell type" facetIds={['cell_type', 'cell_type__custom']}/>
       <MoreFacetsButton facets={moreFacets} />
+      <Modal
+        show={showSearchHelpModal}
+        onHide={() => closeModal(setShowSearchHelpModal)}
+        animation={false}
+        bsSize='large'>
+        <Modal.Body className="">
+          { helpModalContent }
+        </Modal.Body>
+      </Modal>
     </div>
+
   )
 }

--- a/app/javascript/components/search/controls/FacetsPanel.js
+++ b/app/javascript/components/search/controls/FacetsPanel.js
@@ -57,7 +57,7 @@ export default function FacetsPanel() {
   </a>
 
   return (
-    <div>
+    <div className='metadata-search-wrap'>
       <span
         className='metadata-search search-title'
       >

--- a/app/javascript/components/search/controls/FacetsPanel.js
+++ b/app/javascript/components/search/controls/FacetsPanel.js
@@ -18,15 +18,16 @@ export default function FacetsPanel() {
   const defaultFacets = searchFacetContext.facets.filter(facet => defaultFacetIds.includes(facet.id))
   const moreFacets = searchFacetContext.facets.filter(facet => moreFacetIds.includes(facet.id))
   return (
-    <>
-      <CombinedFacetControl controlDisplayName="cell type" facetIds={['cell_type', 'cell_type__custom']}/>
+    <div>
+      <span className='badge metadata-search search-title'>Metadata search</span>
       <CombinedFacetControl controlDisplayName="organ" facetIds={['organ', 'organ_region']}/>
       {
         defaultFacets.map((facet, i) => {
           return <FacetControl facet={facet} key={i}/>
         })
       }
+      <CombinedFacetControl controlDisplayName="cell type" facetIds={['cell_type', 'cell_type__custom']}/>
       <MoreFacetsButton facets={moreFacets} />
-    </>
+    </div>
   )
 }

--- a/app/javascript/components/search/controls/FacetsPanel.js
+++ b/app/javascript/components/search/controls/FacetsPanel.js
@@ -19,7 +19,13 @@ export default function FacetsPanel() {
   const moreFacets = searchFacetContext.facets.filter(facet => moreFacetIds.includes(facet.id))
   return (
     <div>
-      <span className='badge metadata-search search-title'>Metadata search</span>
+      <span
+        className='badge metadata-search search-title'
+        title='Search through metadata for values that may not appear in titles/descriptions, like cell type or disease'
+        data-toggle='tooltip'
+      >
+        Data search
+      </span>
       <CombinedFacetControl controlDisplayName="organ" facetIds={['organ', 'organ_region']}/>
       {
         defaultFacets.map((facet, i) => {

--- a/app/javascript/components/search/controls/KeywordSearch.js
+++ b/app/javascript/components/search/controls/KeywordSearch.js
@@ -60,7 +60,7 @@ export default function KeywordSearch({ keywordPrompt }) {
       className='study-keyword-search'
     >
       <span className='text-search search-title'>
-        Title/Description search {textSearchLink}
+        Title and description search {textSearchLink}
       </span>
       <InputGroup>
         <input

--- a/app/javascript/components/search/controls/KeywordSearch.js
+++ b/app/javascript/components/search/controls/KeywordSearch.js
@@ -1,10 +1,12 @@
-import React, { useContext, useRef } from 'react'
+import React, { useContext, useRef, useState } from 'react'
 import Button from 'react-bootstrap/lib/Button'
 import InputGroup from 'react-bootstrap/lib/InputGroup'
 import Form from 'react-bootstrap/lib/Form'
-import { faSearch, faTimes } from '@fortawesome/free-solid-svg-icons'
+import { faQuestionCircle, faSearch, faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { SearchSelectionContext } from 'providers/SearchSelectionProvider'
+import Modal from 'react-bootstrap/lib/Modal'
+import { closeModal } from 'components/search/controls/SearchPanel'
 
 /**
  * Component to search using a keyword value
@@ -17,6 +19,21 @@ export default function KeywordSearch({ keywordPrompt }) {
   //  as long as the text hasn't been updated
   const showClear = selectionContext.terms && selectionContext.terms.length
   const inputField = useRef()
+  const [showTextSearchHelpModal, setTextShowSearchHelpModal] = useState(false)
+
+  const textSearchModalContent = (<div>
+    <h4 className="text-center">Title and description Search</h4><br/>
+    Using the search box below will perform a text-based search of all study titles and descriptions, and will return
+    those that contain any of the specified terms. You can quote (&quot;) phrases to find matches that contain the entire
+    phrase, and you can combine both single terms and quoted phrases in your search.
+  </div>)
+
+  const textSearchLink = <a className="action advanced-opts"
+                            onClick={() => setTextShowSearchHelpModal(true)}
+                            data-analytics-name="search-help">
+    <FontAwesomeIcon icon={faQuestionCircle} />
+  </a>
+
   /**
    * Updates terms in search context upon submitting keyword search
    */
@@ -42,7 +59,9 @@ export default function KeywordSearch({ keywordPrompt }) {
       onSubmit = {handleSubmit}
       className='study-keyword-search'
     >
-      <span className='badge text-search search-title'>Text search</span>
+      <span className='badge text-search search-title'>
+        Description search {textSearchLink}
+      </span>
       <InputGroup>
         <input
           ref = {inputField}
@@ -65,6 +84,15 @@ export default function KeywordSearch({ keywordPrompt }) {
             <FontAwesomeIcon icon={faTimes} />
           </Button> }
       </InputGroup>
+      <Modal
+        show={showTextSearchHelpModal}
+        onHide={() => closeModal(setTextShowSearchHelpModal)}
+        animation={false}
+        bsSize='large'>
+        <Modal.Body className="">
+          { textSearchModalContent }
+        </Modal.Body>
+      </Modal>
     </Form>
   )
 }

--- a/app/javascript/components/search/controls/KeywordSearch.js
+++ b/app/javascript/components/search/controls/KeywordSearch.js
@@ -11,7 +11,7 @@ import { SearchSelectionContext } from 'providers/SearchSelectionProvider'
  * optionally takes a 'keywordValue' prop with the initial value for the field
  */
 export default function KeywordSearch({ keywordPrompt }) {
-  const placeholder = keywordPrompt ? keywordPrompt : 'Enter keyword'
+  const placeholder = keywordPrompt ? keywordPrompt : 'Search title and description text'
   const selectionContext = useContext(SearchSelectionContext)
   // show clear button after a search has been done,
   //  as long as the text hasn't been updated
@@ -42,6 +42,7 @@ export default function KeywordSearch({ keywordPrompt }) {
       onSubmit = {handleSubmit}
       className='study-keyword-search'
     >
+      <span className='badge text-search search-title'>Text search</span>
       <InputGroup>
         <input
           ref = {inputField}

--- a/app/javascript/components/search/controls/KeywordSearch.js
+++ b/app/javascript/components/search/controls/KeywordSearch.js
@@ -22,7 +22,7 @@ export default function KeywordSearch({ keywordPrompt }) {
   const [showTextSearchHelpModal, setTextShowSearchHelpModal] = useState(false)
 
   const textSearchModalContent = (<div>
-    <h4 className="text-center">Title and description Search</h4><br/>
+    <h4 className="text-center">Title and description search</h4><br/>
     Using the search box below will perform a text-based search of all study titles and descriptions, and will return
     those that contain any of the specified terms. You can quote (&quot;) phrases to find matches that contain the entire
     phrase, and you can combine both single terms and quoted phrases in your search.

--- a/app/javascript/components/search/controls/KeywordSearch.js
+++ b/app/javascript/components/search/controls/KeywordSearch.js
@@ -59,8 +59,8 @@ export default function KeywordSearch({ keywordPrompt }) {
       onSubmit = {handleSubmit}
       className='study-keyword-search'
     >
-      <span className='badge text-search search-title'>
-        Description search {textSearchLink}
+      <span className='text-search search-title'>
+        Title/Description search {textSearchLink}
       </span>
       <InputGroup>
         <input

--- a/app/javascript/components/search/controls/SearchPanel.js
+++ b/app/javascript/components/search/controls/SearchPanel.js
@@ -13,7 +13,7 @@ const publicStudies = window.SCP.studyStats.public
 const compliantStudies = window.SCP.studyStats.compliant
 const percentage = (compliantStudies / publicStudies * 100).toFixed(0)
 const helpModalContent = (<div>
-  <h4 className="text-center">Metadata-powered Search</h4><br/>
+  <h4 className="text-center">Advanced Search</h4><br/>
   Single Cell Portal supports searching on specific facets of studies by ontology classifications.
   <br/><br/>
   For example, you can search on studies that

--- a/app/javascript/components/search/controls/SearchPanel.js
+++ b/app/javascript/components/search/controls/SearchPanel.js
@@ -1,41 +1,15 @@
 import React, { useContext, useEffect, useState } from 'react'
-import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import Modal from 'react-bootstrap/lib/Modal'
 
 import KeywordSearch from './KeywordSearch'
 import FacetsPanel from './FacetsPanel'
 import DownloadButton from './download/DownloadButton'
 import { StudySearchContext } from 'providers/StudySearchProvider'
 
-
-const publicStudies = window.SCP.studyStats.public
-const compliantStudies = window.SCP.studyStats.compliant
-const percentage = (compliantStudies / publicStudies * 100).toFixed(0)
-const helpModalContent = (<div>
-  <h4 className="text-center">Advanced Search</h4><br/>
-  Single Cell Portal supports searching on specific facets of studies by ontology classifications.
-  <br/><br/>
-  For example, you can search on studies that
-  have <b>species</b> of <b>&quot;Homo sapiens&quot;</b> or have an <b>organ</b> of <b>&quot;brain&quot;</b>.{' '}
-  ~<b>{percentage}% ({compliantStudies} of {publicStudies})</b> public studies in SCP provide this metadata
-  information.
-  {/*
-   more information on public/compliant studies available at
-   https://docs.google.com/spreadsheets/d/1FSpP2XTrG9FqAqD9X-BHxkCZae9vxZA3cQLow8mn-bk
-*/}
-  <br/><br/>
-  For more detailed information, visit
-  our{' '}
-  <a href="https://singlecell.zendesk.com/hc/en-us/articles/360061006431-Search-Studies"
-    target="_blank" rel="noreferrer">documentation
-  </a>.  Study authors looking to make their studies more accessible can read our
-  <a href="https://singlecell.zendesk.com/hc/en-us/articles/4406379107355-Metadata-powered-Advanced-Search"
-    target="_blank" rel="noreferrer"> metadata guide
-  </a>.
-</div>)
-
-
+/** helper method as, for unknown reasons, clicking the bootstrap modal auto-scrolls the page down */
+export function closeModal(modalShowFunc) {
+  modalShowFunc(false)
+  setTimeout(() => {scrollTo(0, 0)}, 0)
+}
 /**
  * Component for SCP faceted search UI
  * showCommonButtons defaults to true
@@ -47,19 +21,12 @@ export default function SearchPanel({
   // This search component is currently specific to the "Studies" tab, but
   // could possibly also enable search for "Genes" and "Cells" tabs.
   const searchState = useContext(StudySearchContext)
-  const [showSearchHelpModal, setShowSearchHelpModal] = useState(false)
 
   let searchButtons = <></>
   let downloadButtons = <></>
 
   searchButtons = <FacetsPanel/>
   downloadButtons = <DownloadButton searchResults={searchState.results}/>
-  const advancedOptsLink = <a className="action advanced-opts"
-    onClick={() => setShowSearchHelpModal(true)}
-    data-analytics-name="search-help">
-    <FontAwesomeIcon icon={faQuestionCircle} />
-  </a>
-
 
   useEffect(() => {
     // if a search isn't already happening, and searchOnLoad is specified, perform one
@@ -68,28 +35,12 @@ export default function SearchPanel({
     }
   })
 
-  /** helper method as, for unknown reasons, clicking the bootstrap modal auto-scrolls the page down */
-  function closeModal(modalShowFunc) {
-    modalShowFunc(false)
-    setTimeout(() => {scrollTo(0, 0)}, 0)
-  }
-
   const keywordPrompt = searchState.params.preset === 'covid19' ? 'Search COVID-19 studies' : undefined
   return (
     <div id='search-panel' style={{ display: 'flex' }}>
       { searchButtons }
       <KeywordSearch keywordPrompt={keywordPrompt}/>
-      { advancedOptsLink }
       { downloadButtons }
-      <Modal
-        show={showSearchHelpModal}
-        onHide={() => closeModal(setShowSearchHelpModal)}
-        animation={false}
-        bsSize='large'>
-        <Modal.Body className="">
-          { helpModalContent }
-        </Modal.Body>
-      </Modal>
     </div>
   )
 }

--- a/app/javascript/components/search/controls/SearchPanel.js
+++ b/app/javascript/components/search/controls/SearchPanel.js
@@ -13,7 +13,7 @@ const publicStudies = window.SCP.studyStats.public
 const compliantStudies = window.SCP.studyStats.compliant
 const percentage = (compliantStudies / publicStudies * 100).toFixed(0)
 const helpModalContent = (<div>
-  <h4 className="text-center">Advanced Search</h4><br/>
+  <h4 className="text-center">Metadata-powered Search</h4><br/>
   Single Cell Portal supports searching on specific facets of studies by ontology classifications.
   <br/><br/>
   For example, you can search on studies that
@@ -77,8 +77,8 @@ export default function SearchPanel({
   const keywordPrompt = searchState.params.preset === 'covid19' ? 'Search COVID-19 studies' : undefined
   return (
     <div id='search-panel' style={{ display: 'flex' }}>
-      <KeywordSearch keywordPrompt={keywordPrompt}/>
       { searchButtons }
+      <KeywordSearch keywordPrompt={keywordPrompt}/>
       { advancedOptsLink }
       { downloadButtons }
       <Modal

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -366,13 +366,18 @@ nav.search-links, #search-panel {
 }
 
 span.search-title {
-  border-bottom: 0.64px solid #4d72aa;
+  font-weight: bold;
+  color: #666;
   display: block;
   margin: 3px 0;
 }
 
 span.metadata-search {
   width: 98%;
+}
+
+div.metadata-search-wrap {
+  margin-right: 0.75em;
 }
 
 span.text-search {

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -183,7 +183,6 @@ nav.search-links, #search-panel {
 
   .filters-box-searchable, #facets-accordion {
     width: 560px;
-    margin-left: -220px;
     border: 1px solid #aaa;
     background: #fff;
     position: absolute;
@@ -274,7 +273,6 @@ nav.search-links, #search-panel {
 
   .combined-facet {
     width: auto;
-    margin-left: -300px;
     .filters-box-searchable {
       width: 390px;
       margin-left: 0;
@@ -368,4 +366,24 @@ nav.search-links, #search-panel {
 
 .download-url-modal .input-group {
   margin: 1em 0 2em 0;
+}
+
+span.search-title {
+  background-color: #4d72aa;
+  font-size: smaller;
+  display: block;
+  margin: 3px 0;
+  opacity: 50%;
+}
+
+span.metadata-search {
+  width: 98%;
+}
+
+span.text-search {
+  width: 312px;
+}
+
+.advanced-opts {
+  margin-top: 23px;
 }

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -320,10 +320,8 @@ nav.search-links, #search-panel {
 }
 
 .advanced-opts {
-  vertical-align: top;
-  display: inline-block;
-  padding: 0.65em 0.25em;
-  border-radius: 1em;
+  color: #fff !important;
+  display: inline;
 }
 
 .new-feature {

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -320,7 +320,6 @@ nav.search-links, #search-panel {
 }
 
 .advanced-opts {
-  color: #fff !important;
   display: inline;
 }
 
@@ -367,11 +366,9 @@ nav.search-links, #search-panel {
 }
 
 span.search-title {
-  background-color: #4d72aa;
-  font-size: smaller;
+  border-bottom: 0.64px solid #4d72aa;
   display: block;
   margin: 3px 0;
-  opacity: 50%;
 }
 
 span.metadata-search {

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -80,6 +80,8 @@ class AzulSearchService
   def self.get_facet_matches(result, facets)
     results_info = {}
     facets.each do |facet|
+      next if facet[:keyword_conversion]
+
       facet_name = facet[:id]
       RESULT_FACET_FIELDS.each do |result_field|
         azul_name = FacetNameConverter.convert_schema_column(:alexandria, :azul, facet_name)
@@ -137,10 +139,12 @@ class AzulSearchService
   def self.merge_facet_lists(*facet_lists)
     all_facets = {}
     facet_lists.compact.each do |facet_list|
-      facet_list.each do |facet|
+      # filter 'converted' facet matches so we don't show match badges in the UI
+      facet_list.reject { |facet| facet[:keyword_conversion] }.each do |facet|
         facet_identifier = facet[:id]
         all_facets[facet_identifier] ||= facet
-        next if facet[:filters].is_a? Hash # this is a numeric facet, and we only have one right now
+        # this is a numeric facet, and we only have one right now
+        next if facet[:filters].is_a? Hash
 
         facet[:filters].each do |f|
           all_facets[facet_identifier][:filters] << f unless all_facets.dig(facet_identifier, :filters).include? f

--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -308,7 +308,12 @@ class HcaAzulClient < Struct.new(:api_root)
       filters = facet.find_filter_matches(term, filter_list: :filters_with_external).map do |t|
         [{ id: t, name: t }.with_indifferent_access]
       end.flatten
-      matching_facets << { id: facet.identifier, filters: filters, db_facet: facet }.with_indifferent_access
+      matching_facets << {
+        id: facet.identifier,
+        filters: filters,
+        db_facet: facet,
+        keyword_conversion: true # mark this as a 'converted' facet to control whether showing facet match badges
+      }.with_indifferent_access
     end
     matching_facets
   end


### PR DESCRIPTION
This update applies several UI enhancements aimed at making advanced search requests easier to understand.  These include:

1. Labeling faceted search as `Metadata search` with modal information about how this searches study metadata for values not present in the study title/description
2. Labeling keyword search as `Title and description search` with placeholder text of `Search title and description text`, with a modal containing information about text-based searching
3. When a keyword match is found in Azul (by converting keywords to facets, as Azul has no keyword-based search), hide the facet match badges for that value so that it only shows the highlighted text matches

Screenshot of new UI:
![Screen Shot 2022-01-19 at 3 08 48 PM](https://user-images.githubusercontent.com/729968/150206083-3affb377-b8ac-40e7-9492-c555c9e42f69.png)

Screenshot of hidden badges:
![Screen Shot 2022-01-19 at 3 09 24 PM](https://user-images.githubusercontent.com/729968/150206099-80c9e5e5-74cd-427a-bd86-fb8f987e046d.png)

This update also fixes a bug in searching for facet filters where Azul-based results were not included in the results, despite them being shown as options in the UI.  In addition, this also fixes a problem with the `HcaAzulClientTest` where all tests are being skipped due to an ongoing partial outage on Azul that does not affect our search integration.  Now, only service information-related tests are skipped in this scenario, provided that project- and file-based queries execute and return the expected results.

MANUAL TESTING
1. Pull this branch, boot as normal, and validate the search UI matches the first screenshot
2. Sign in with an account that has `cross_dataset_search_backend` enabled, and run a search for `species:Homo sapiens` and the keyword `pulmonary`
3. Validate that 5 entries are found in Azul, and only display facet match badges for `Homo sapiens`, but still highlight the work `pulmonary` in each entry

This PR satisfies SCP-3973, SCP-3983, and SCP-4003.
