### PR TITLE
Check user Terra Terms of Service status on sign-in (SCP-3640)

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -25,11 +25,19 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       # update a user's FireCloud status
       @user.delay.update_firecloud_status
       sign_in(@user)
+      @alert = nil
+      # check if user needs to accept updated Terra ToS
+      if @user.must_accept_terra_tos?
+        @alert = 'We have detected that Terra has updated their terms of service - please visit ' \
+                 "<a href='https://app.terra.bio' target='_blank'>Terra</a> to accept the updated terms.  Some " \
+                 'features may not function correctly until you do so.'
+      end
       if TosAcceptance.accepted?(@user)
         MetricsService.merge_identities_in_mixpanel(@user, cookies)
-        redirect_to request.env['omniauth.origin'] || site_path
+        requested_path = request.env['omniauth.origin'] || site_path
+        redirect_to requested_path, alert: @alert
       else
-        redirect_to accept_tos_path(@user.id)
+        redirect_to accept_tos_path(@user.id), alert: @alert
       end
     else
       redirect_to new_user_session_path

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -28,7 +28,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @alert = nil
       # check if user needs to accept updated Terra ToS
       if @user.must_accept_terra_tos?
-        @alert = 'We have detected that Terra has updated their terms of service - please visit ' \
+        @alert = 'Terra has updated their Terms of Service.  Please visit ' \
                  "<a href='https://app.terra.bio' target='_blank'>Terra</a> to accept the updated terms.  Some " \
                  'features may not function correctly until you do so.'
       end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,6 @@
       }
 
       window.SCP.userAccessToken = '<%= get_user_access_token(current_user) %>';
-      window.SCP.getReadAccessToken = '<%= get_read_access_token(@study, current_user) %>';
       window.SCP.readOnlyToken = '<%= get_read_access_token(@study, current_user) %>'
       window.SCP.userSignedIn = <%= user_signed_in? %>;
       window.SCP.environment = '<%= Rails.env %>';


### PR DESCRIPTION
In preparation for Terra's planned changes to Terms of Service acceptance, this update adds a check upon successful sign in for all users to determine if they need to accept any updated Terms of Service from Terra (similar to how SCP checks for it's own ToS updates on sign in).  In this updated flow, any users who meet the following criteria will have a message displayed notifying them of the situation, and prompt them to visit Terra to accept the updated terms:
1. User must be registered for Terra
2. User has yet to accept the current Terra Terms of Service

Note that this modal only shows on sign in, and not on every page load.  Expected failure states for users would be showing the `Your session may have timed out. Please sign in again` modal on most pages, as any API requests to orchestration would return `401/403` when issued with user credentials.  This likely will be confined to study-related pages, but could potentially happen other places as well.

New ToS alert:
![Screen Shot 2022-01-18 at 1 48 22 PM](https://user-images.githubusercontent.com/729968/149999961-538a2dd3-0ee3-40d6-9db7-004b86f232c7.png)

MANUAL TESTING
1. Boot as normal
2. Sign in with any account that is registered for Terra, and confirm no alert is shown
3. In `app/models/user.rb`, line 356, add `return true` to short-circuit the ToS check
4. Sign out, then sign in again and confirm the above modal is shown

This PR satisfies SCP-3640.
