### PR TITLE
Ignore empty/incomplete HCA project entries in bulk download (SCP-4009)

### DIFF
--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -59,12 +59,17 @@ module Api
         totat = current_api_user.create_totat(half_hour, api_v1_bulk_download_generate_curl_config_path)
         valid_params = params.permit({ file_ids: [], azul_files: {} }).to_h
 
+        # discard any empty Azul entries - this can happen if row is selected, but no file types are checked
+        if valid_params[:azul_files].present?
+          valid_azul_files = valid_params[:azul_files].reject { |_, files| files.empty? }
+        end
+
         # for now, we don't do any permissions validation on the param values -- we'll do that during the actual download, since
         # quota/files/permissions may change between the creation of the download and the actual download.
         auth_download = DownloadRequest.create!(
           auth_code: totat[:totat],
           file_ids: valid_params[:file_ids],
-          azul_files: valid_params[:azul_files],
+          azul_files: valid_azul_files,
           user_id: current_api_user.id
         )
         auth_code_response = {

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -66,10 +66,15 @@ class BulkDownloadService
         # pull out project manifest and process separately
         manifests, files = file_infos.partition { |f| f['file_type'] == 'Project Manifest' }
         manifest_info = manifests.first
-        manifest = hca_client.project_manifest_link(manifest_info['project_id'])
-        # add location directive to allow following 302 redirect to manifest location
-        manifest_config = "--location\nurl=\"#{manifest['Location']}\"\noutput=\"#{shortname}/#{manifest_info['name']}\""
-        azul_file_configs << manifest_config
+
+        # only generate manifest link if user has requested it
+        if manifest_info.present?
+          manifest = hca_client.project_manifest_link(manifest_info['project_id'])
+          # add location directive to allow following 302 redirect to manifest location
+          manifest_config = "--location\nurl=\"#{manifest['Location']}\"\noutput=\"#{shortname}/#{manifest_info['name']}\""
+          azul_file_configs << manifest_config
+        end
+
         # now process remainder of analysis/sequence files for download
         # each file_info hash will contain project IDs and file_types that can be used in a single query to Azul
         # to get all matching files


### PR DESCRIPTION
This update fixes two bugs found recently:
- If a user selects an HCA project in the bulk download modal, but selects no file types, and empty entry is created in the `DownloadRequest#azul_files` hash
- `BulkDownloadService#generate_curl_config` assumes that HCA project manifest are always present, even if user has not requested them

MANUAL TESTING
1. Boot as normal, and sign in with an account with XDSS enabled
2. Run a query for `species:Homo sapiens` and `disease:COVID-19`
3. Open the bulk download selection table, and select only the following entries:
![Screen Shot 2022-01-19 at 12 25 36 PM](https://user-images.githubusercontent.com/729968/150182897-dfc56f6a-89c2-4458-9aa3-2da8e69bb670.png)
4. Proceed all the way through to generating the curl config and pasting the command into the terminal
5. Confirm that the request succeeds and begins downloading files into a directory called `LethalCovidLungAtlas` (you can cancel out once files start as this means the request worked)

This PR satisfies SCP-4009.
