### PR TITLE
Speed up filtering and resizing scatter plot (SCP-3865)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -81,8 +81,21 @@ function RawScatterPlot({
     setHiddenTraces(newShownTraces)
   }
 
+  /** Update layout, without recomputing traces */
+  function resizePlot() {
+    let scatter = Object.assign({}, scatterData)
+    const widthAndHeight = getScatterDimensions(scatter, dimensionProps)
+    scatter = Object.assign(scatter, widthAndHeight)
+    const layout = getPlotlyLayout(scatter)
+
+    Plotly.relayout(graphElementId, layout)
+
+    setScatterData(scatter)
+  }
+
   /** Process scatter plot data fetched from server */
   function processScatterPlot(clusterResponse=null) {
+    console.log('processScatterPlot')
     let [scatter, perfTimes] =
       (clusterResponse ? clusterResponse : [scatterData, null])
 
@@ -158,7 +171,7 @@ function RawScatterPlot({
   }, [cluster, annotation.name, subsample, consensus, genes.join(','), isAnnotatedScatter])
 
   const widthAndHeight = getScatterDimensions(scatterData, dimensionProps, genes)
-  // Handles custom scatter legend updates and window resizing
+  // Handles custom scatter legend updates
   useUpdateEffect(() => {
     // Don't update if graph hasn't loaded
     if (scatterData && !isLoading) {
@@ -166,7 +179,17 @@ function RawScatterPlot({
     }
     // look for updates of individual properties, so that we don't rerender if the containing array
     // happens to be a different instance
-  }, [hiddenTraces.join(','), widthAndHeight.height, widthAndHeight.width])
+  }, [hiddenTraces.join(',')])
+
+  // Handles window resizing
+  useUpdateEffect(() => {
+    // Don't update if graph hasn't loaded
+    if (scatterData && !isLoading) {
+      resizePlot()
+    }
+    // look for updates of individual properties, so that we don't rerender if the containing array
+    // happens to be a different instance
+  }, [widthAndHeight.height, widthAndHeight.width])
 
   // Handles Plotly `data` updates, e.g. changes in color profile
   useUpdateEffect(() => {

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -92,20 +92,10 @@ function RawScatterPlot({
     const layout = getPlotlyLayout(scatter)
 
     const traceArgs = {
-      axes: scatter.axes,
-      data: scatter.data,
-      annotName: scatter.annotParams.name,
-      annotType: scatter.annotParams.type,
-      genes: scatter.genes,
-      isAnnotatedScatter: scatter.isAnnotatedScatter,
+      genes,
+      isAnnotatedScatter,
       isCorrelatedScatter,
       scatterColor,
-      dataScatterColor: scatter.scatterColor,
-      pointAlpha: scatter.pointAlpha,
-      pointSize: scatter.pointSize,
-      showPointBorders: scatter.showClusterPointBorders,
-      is3D: scatter.is3D,
-      labelCorrelations,
       hiddenTraces,
       scatter
     }
@@ -295,21 +285,18 @@ function shouldReverseScale(scatterColor) {
 
 /** get the array of plotly traces for plotting */
 export function getPlotlyTraces({
-  axes,
-  data,
-  annotType,
-  annotName,
   genes,
   isAnnotatedScatter,
   isCorrelatedScatter,
   scatterColor,
-  dataScatterColor,
-  pointAlpha,
-  pointSize,
-  is3D,
   hiddenTraces,
   scatter
 }) {
+  const { axes, data, pointAlpha, pointSize, is3D } = scatter
+  const dataScatterColor = scatter.scatterColor
+  const annotName = scatter.annotParams.name
+  const annotType = scatter.annotParams.type
+
   const trace = {
     type: is3D ? 'scatter3d' : 'scattergl',
     mode: 'markers',
@@ -363,6 +350,7 @@ export function getPlotlyTraces({
         expressionsWithIndices[i] = [data.expression[i], i]
       }
       expressionsWithIndices.sort((a, b) => a[0] - b[0])
+
       // initialize the other arrays (see )
       trace.x = new Array(data.expression.length)
       trace.y = new Array(data.expression.length)
@@ -371,9 +359,11 @@ export function getPlotlyTraces({
       }
       trace.annotations = new Array(data.expression.length)
       trace.cells = new Array(data.expression.length)
+
       colors = new Array(data.expression.length)
+
+      // now that we know the indices, reorder the other data arrays
       for (let i = 0; i < expressionsWithIndices.length; i++) {
-        // now that we know the indices, reorder the other data arrays
         const sortedIndex = expressionsWithIndices[i][1]
         trace.x[i] = data.x[sortedIndex]
         trace.y[i] = data.y[sortedIndex]

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -95,7 +95,6 @@ function RawScatterPlot({
 
   /** Update layout, without recomputing traces */
   function resizePlot() {
-    console.log('in resizePlot')
     const scatter = updateScatterLayout()
     Plotly.relayout(graphElementId, scatter.layout)
     setScatterData(scatter)
@@ -103,7 +102,6 @@ function RawScatterPlot({
 
   /** Update legend counts and recompute traces, without recomputing layout */
   function updateCountsAndGetTraces(scatter) {
-    console.log('updateCountsAndGetTraces')
     const traceArgs = {
       genes,
       isAnnotatedScatter,
@@ -120,7 +118,6 @@ function RawScatterPlot({
 
   /** Process scatter plot data fetched from server */
   function processScatterPlot(clusterResponse=null) {
-    console.log('processScatterPlot')
     let [scatter, perfTimes] =
       (clusterResponse ? clusterResponse : [scatterData, null])
 

--- a/app/javascript/components/visualization/ScatterPlot.js
+++ b/app/javascript/components/visualization/ScatterPlot.js
@@ -82,26 +82,28 @@ function RawScatterPlot({
   }
 
   /** Get new, updated scatter object instance, and new layout */
-  function getNewScatterAndLayout(scatter=null) {
+  function updateScatterLayout(scatter=null) {
     if (!scatter) {
       scatter = Object.assign({}, scatterData) // New instance forces render
     }
     const widthAndHeight = getScatterDimensions(scatter, dimensionProps)
     scatter = Object.assign(scatter, widthAndHeight)
-    const layout = getPlotlyLayout(scatter)
+    scatter.layout = getPlotlyLayout(scatter)
 
-    return { scatter, layout }
+    return scatter
   }
 
   /** Update layout, without recomputing traces */
   function resizePlot() {
-    const { scatter, layout } = getNewScatterAndLayout()
-    Plotly.relayout(graphElementId, layout)
+    console.log('in resizePlot')
+    const scatter = updateScatterLayout()
+    Plotly.relayout(graphElementId, scatter.layout)
     setScatterData(scatter)
   }
 
   /** Update legend counts and recompute traces, without recomputing layout */
   function updateCountsAndGetTraces(scatter) {
+    console.log('updateCountsAndGetTraces')
     const traceArgs = {
       genes,
       isAnnotatedScatter,
@@ -122,9 +124,8 @@ function RawScatterPlot({
     let [scatter, perfTimes] =
       (clusterResponse ? clusterResponse : [scatterData, null])
 
-    const sl = getNewScatterAndLayout(scatter)
-    scatter = sl.scatter
-    const layout = sl.layout
+    scatter = updateScatterLayout(scatter)
+    const layout = scatter.layout
 
     const plotlyTraces = updateCountsAndGetTraces(scatter)
 
@@ -186,7 +187,7 @@ function RawScatterPlot({
   useUpdateEffect(() => {
     // Don't update if graph hasn't loaded
     if (scatterData && !isLoading) {
-      processScatterPlot()
+      updateCountsAndGetTraces(scatterData)
     }
     // look for updates of individual properties, so that we don't rerender if the containing array
     // happens to be a different instance

--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.js
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.js
@@ -177,9 +177,6 @@ export default function ScatterPlotLegend({
   const [showIsEnabled, hideIsEnabled] =
     getShowHideEnabled(hiddenTraces, countsByLabel)
 
-  console.log('in ScatterPlotLegend, height:')
-  console.log(height)
-
   return (
     <div
       className={`scatter-legend ${filteredClass}`}

--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.js
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.js
@@ -177,6 +177,9 @@ export default function ScatterPlotLegend({
   const [showIsEnabled, hideIsEnabled] =
     getShowHideEnabled(hiddenTraces, countsByLabel)
 
+  console.log('in ScatterPlotLegend, height:')
+  console.log(height)
+
   return (
     <div
       className={`scatter-legend ${filteredClass}`}

--- a/test/js/visualization/scatter-plot.test-data.js
+++ b/test/js/visualization/scatter-plot.test-data.js
@@ -1,20 +1,26 @@
 /** @fileoverview Mock responses for scatter plot tests */
 
 export const BASIC_PLOT_DATA = {
-  axes: {
-    aspects: null,
-    titles: {
-      magnitude: 'Expression',
-      x: 'X',
-      y: 'Y',
-      z: 'Z'
-    }
-  },
   scatter: {
     annotParams: {
       name: 'Category',
       type: 'group',
       scope: 'cluster'
+    },
+    axes: {
+      aspects: null,
+      titles: {
+        magnitude: 'Expression',
+        x: 'X',
+        y: 'Y',
+        z: 'Z'
+      }
+    },
+    data: {
+      x: [1, 2, 3, 4, 5, 6, 7, 8],
+      y: [1, 2, 3, 4, 5, 6, 7, 8],
+      cells: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'],
+      annotations: ['s1', 's1', 's1', 's1', 's2', 's2', 's1', 's2']
     },
     genes: ['foo']
   },
@@ -26,13 +32,7 @@ export const BASIC_PLOT_DATA = {
   pointAlpha: 1,
   is3d: false,
   annotType: 'group',
-  annotName: 'biosample_id',
-  data: {
-    x: [1, 2, 3, 4, 5, 6, 7, 8],
-    y: [1, 2, 3, 4, 5, 6, 7, 8],
-    cells: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'],
-    annotations: ['s1', 's1', 's1', 's1', 's2', 's2', 's1', 's2']
-  }
+  annotName: 'biosample_id'
 }
 
 /**

--- a/test/js/visualization/scatter-plot.test.js
+++ b/test/js/visualization/scatter-plot.test.js
@@ -111,7 +111,7 @@ it('shows custom legend with default group scatter plot', async () => {
 describe('getPlotlyTraces handles expression graphs', () => {
   it('sorts points in order of expression', async () => {
     const plotData = _cloneDeep(BASIC_PLOT_DATA)
-    plotData.data.expression = [0.1, 0.0, 2, 4.5, 0, 6.5, 0, 3.1]
+    plotData.scatter.data.expression = [0.1, 0.0, 2, 4.5, 0, 6.5, 0, 3.1]
     plotData.genes = ['foo']
 
     const traces = getPlotlyTraces(plotData)
@@ -128,7 +128,7 @@ describe('getPlotlyTraces handles expression graphs', () => {
 
   it('resets the limits in cases of all zero expression', async () => {
     const plotData = _cloneDeep(BASIC_PLOT_DATA)
-    plotData.data.expression = [0, 0, 0, 0, 0, 0, 0, 0]
+    plotData.scatter.data.expression = [0, 0, 0, 0, 0, 0, 0, 0]
     plotData.genes = ['foo']
 
     const traces = getPlotlyTraces(plotData)
@@ -139,7 +139,7 @@ describe('getPlotlyTraces handles expression graphs', () => {
 
   it('reverses the colors of non-Reds color scales', async () => {
     const plotData = _cloneDeep(BASIC_PLOT_DATA)
-    plotData.data.expression = [0, 0, 0, 0, 0, 0, 0, 0]
+    plotData.scatter.data.expression = [0, 0, 0, 0, 0, 0, 0, 0]
     plotData.genes = ['foo']
 
     let traces = getPlotlyTraces(plotData)


### PR DESCRIPTION
This optimizes performance and improves separation of concerns for recent legend updates, per a [review comment](https://github.com/broadinstitute/single_cell_portal_core/pull/1240#discussion_r744861850).

Previously, resizing the window would re-compute traces, and updating traces would re-compute layout (among several other things).  Now, resizing and updating traces avoid such unnecessary processing.  This speeds up those interactions.  

It also extracts code from the `processScatterPlot` function, separating reusable chunks into their own functions.  And it cleans up some needless redundancy in the `traceArgs` parameter.

To test:
1. Open `ScatterPlot.js`
2. At top of `getPlotlyLayout` function, add `console.log('in getPlotlyLayout')`
3. At top of `getPlotlyTraces` function, add `console.log('in getPlotlyTraces')`
4. Open Console panel in DevTools, filter to console output that contains "getPlotly"
5. Open a study that has a scatter plot
6. Confirm that `in getPlotlyLayout` and `in getPlotlyTraces` were logged to DevTools Console
7. Resize window
8. Confirm log of `in getPlotlyLayout` and not `in getPlotlyTraces`
9. Click on a label in the legend to filter shown traces
10. Confirm log of `in getPlotlyTraces` and not `in getPlotlyLayout`
11. Change "Clustering" and "Annotation"
12. Confirm log of `in getPlotlyTraces` and `in getPlotlyLayout`
13. Checkout `development`
14. Do steps 1-10, but note how `in getPlotlyLayout` and `in getPlotlyTraces` are always both logged

This satisfies SCP-3865.