### PR TITLE
Fixing `BulkDownloadControllerTest` for single-study download (SCP-3995)

### DIFF
--- a/test/api/bulk_download_controller_test.rb
+++ b/test/api/bulk_download_controller_test.rb
@@ -198,10 +198,8 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
                            ))
       assert_response :success
       all_dirs_mock.verify
-      file_types.each do |file_type|
-        1.upto(5).each do |i|
-          assert json.include? "#{file_type}/file_#{i}.#{file_type}"
-        end
+      @files.values.flatten.each do |file|
+        assert json.include? file
       end
     end
   end

--- a/test/api/bulk_download_controller_test.rb
+++ b/test/api/bulk_download_controller_test.rb
@@ -143,8 +143,8 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
                               user: @user,
                               test_array: @@studies_to_clean)
     @files = {
-      csv: 1.upto(5).map { |i| "csv/file_#{i}.csv" },
-      xlsx: 1.upto(5).map { |i| "xlsx/file_#{i}.xlsx" }
+      csv: [ "csv/file_1.csv" ],
+      xlsx: [ "xlsx/file_2.xlsx" ]
     }
     # single directory test
     @files.each do |file_type, files|
@@ -159,7 +159,7 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
       auth_code = json['auth_code']
       mock = Minitest::Mock.new
       files.each do |file|
-        mock_signed_url = "https://www.googleapis.com/storage/v1/b/#{study.bucket_id}/#{file_type}/#{file}"
+        mock_signed_url = "https://www.googleapis.com/storage/v1/b/#{study.bucket_id}/#{file}"
         mock.expect :execute_gcloud_method, mock_signed_url,
                     [:generate_signed_url, 0, study.bucket_id, file, { expires: 1.day.to_i }]
       end
@@ -182,9 +182,9 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     auth_code = json['auth_code']
     all_dirs_mock = Minitest::Mock.new
-    @files.each do |file_type, dir_files|
+    @files.each do |_, dir_files|
       dir_files.each do |file|
-        mock_signed_url = "https://www.googleapis.com/storage/v1/b/#{study.bucket_id}/#{file_type}/#{file}"
+        mock_signed_url = "https://www.googleapis.com/storage/v1/b/#{study.bucket_id}/#{file}"
         all_dirs_mock.expect :execute_gcloud_method, mock_signed_url,
                              [:generate_signed_url, 0, study.bucket_id, file, { expires: 1.day.to_i }]
       end


### PR DESCRIPTION
This update (attempts) to address a recurring issue where the test `BulkDownloadControllerTest#test_should_honor_directory_parameter_for_single-study_bulk_download` fails with a mock expectation error where an unexpected argument is passed to the mock.  This test did not fail reproducibly (and almost never locally), but did seem to have an increased error rate in CI when the test was run towards the end of a build.  This fix now simplifies the test to reduce the number of files per directory from 5 to 1, and reuses the same file list each time rather than regenerating it every assertion.  Repeated local runs of single test, whole suite, and complete build have shown that the test does not fail anymore with this particular error.

MANUAL TESTING
1. Pull this branch, and run `rails_local_setup.rb && source config/secrets/.source_env.bash`
2. Run the corresponding test with `bin/rails test test/api/bulk_download_controller_test.rb -n /honor/`
3. Optional: repeatedly run the test using the while loop below (you can exit at any time with `^C`:

```
code=0
while [ $code -eq 0 ]
do
  bin/rails test test/api/bulk_download_controller_test.rb -n /honor/
  code=$?
done
```

This PR satisfies SCP-3995.