### PR TITLE
fixing case of download agreement test (SCP-4006)

### DIFF
--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -153,7 +153,8 @@ class BulkDownloadService
     # collect array of study accession requiring acceptance of download agreement (checking for expiration)
     agreement_accessions = []
     DownloadAgreement.all.each do |agreement|
-      agreement_accessions << agreement.study.accession unless agreement.expired?
+      # we may have orphaned download agreements, so ensure this is nil-safed
+      agreement_accessions << agreement.study&.accession unless agreement.expired? || !agreement.study
     end
     requires_agreement = permitted_accessions & agreement_accessions
     if requires_agreement.any?

--- a/test/integration/download_agreement_test.rb
+++ b/test/integration/download_agreement_test.rb
@@ -20,6 +20,12 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     sign_in_and_update @user
   end
 
+  # we use after(:each) because after(:all) will not have @download_agreement in scope
+  after(:each) do
+    @download_agreement&.destroy
+    @download_acceptance&.destroy
+  end
+
   test 'should enforce download agreement' do
     # ensure normal download works
     get download_file_path(accession: @study.accession,
@@ -40,8 +46,8 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
     assert_response :success, 'Did not get curl config for bulk download'
 
     # enable download agreement, assert 403
-    download_agreement = DownloadAgreement.new(study_id: @study.id, content: 'This is the agreement content')
-    download_agreement.save!
+    @download_agreement = DownloadAgreement.new(study_id: @study.id, content: 'This is the agreement content')
+    @download_agreement.save!
 
     get download_file_path(accession: @study.accession,
                            study_name: @study.url_safe_name,
@@ -53,12 +59,12 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
                                                                         auth_code: totat[:totat]),
                          user: @user)
     assert_response :forbidden, "Did not correctly respond 403 for bulk download: #{response.code}"
-    assert response.body.include?('download agreement'),
+    assert response.body.include?('Download agreement'),
            "Error response did not reference download agreement: #{response.body}"
 
     # accept agreement and validate downloads resume
-    download_acceptance = DownloadAcceptance.new(email: @user.email, download_agreement: download_agreement)
-    download_acceptance.save!
+    @download_acceptance = DownloadAcceptance.new(email: @user.email, download_agreement: @download_agreement)
+    @download_acceptance.save!
 
     get download_file_path(accession: @study.accession,
                            study_name: @study.url_safe_name,
@@ -73,9 +79,5 @@ class DownloadAgreementTest < ActionDispatch::IntegrationTest
                                                                         auth_code: totat[:totat]),
                          user: @user)
     assert_response :success, 'Did get curl config for bulk download after accepting download agreement'
-
-    # clean up
-    download_agreement.destroy
-    download_acceptance.destroy
   end
 end


### PR DESCRIPTION
Minitest scoping is always an adventure.  This both cleans up the delete method, and nil-safes the production check just in case we end up with orphans in the future.

TO TEST:
1.  run `rails test test/integration/download_agreement_test.rb`
2. observe success
3. on line 68, add `assert false` to make the test fail after the download agreement is created
4. run  `rails test test/integration/download_agreement_test.rb`
5. observe test fails
6. remove the `assert false`
7. run  `rails test test/integration/download_agreement_test.rb`
8. observe test succeeds (previously, it would fail due to the agreement not being cleaned