### PR TITLE
Add logger property for front or back app call (SCP-3991)

### DIFF
--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -365,7 +365,8 @@ export function log(name, props = {}) {
     appId: 'single-cell-portal',
     appPath: getAnalyticsPageName(),
     appFullPath: getAppFullPath(),
-    env
+    env,
+    logger: 'app-frontend'
   }, getDefaultProperties())
 
   const tab = getTabProperty()

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -156,6 +156,7 @@ class MetricsService
     # browser: client browser name
     # browser_version: client browser version
     # os: client operating system
+    # logger: identifer that this event comes from the applications backend
     props = {
       appFullPath: self.sanitize_url(request.fullpath),
       appPath: self.get_page_name(request.parameters['controller'], request.parameters['action']),

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -96,7 +96,8 @@ class MetricsService
     props.merge!({
       appId: 'single-cell-portal',
       env: Rails.env,
-      registeredForTerra: user.registered_for_firecloud
+      registeredForTerra: user.registered_for_firecloud,
+      logger: 'app-backend'
     })
 
     headers = get_default_headers(user)
@@ -166,7 +167,8 @@ class MetricsService
       browser: browser.name,
       browser_version: browser.version,
       brand: request.query_parameters.dig('scpbr'),
-      env: Rails.env
+      env: Rails.env,
+      logger: 'app-backend'
     }
 
     # add study accession if this action was study-specific

--- a/test/integration/lib/metrics_service_test.rb
+++ b/test/integration/lib/metrics_service_test.rb
@@ -120,9 +120,9 @@ class MetricsServiceTest < ActiveSupport::TestCase
       browser_version: browser.version,
       brand: nil,
       env: Rails.env,
+      logger: 'app-backend',
       authenticated: false,
-      distinct_id: user_id,
-      logger: "app-backend"
+      distinct_id: user_id
     }.with_indifferent_access
 
     expected_args = {

--- a/test/integration/lib/metrics_service_test.rb
+++ b/test/integration/lib/metrics_service_test.rb
@@ -22,7 +22,8 @@ class MetricsServiceTest < ActiveSupport::TestCase
       clusterType: "3d",
       numClusterPoints: 15,
       canSubsample: false,
-      metadataFilePresent: false
+      metadataFilePresent: false,
+      logger:"app-backend"
     }
 
     # As passed from MetricsService.log to MetricsService.post_to_bard
@@ -120,7 +121,8 @@ class MetricsServiceTest < ActiveSupport::TestCase
       brand: nil,
       env: Rails.env,
       authenticated: false,
-      distinct_id: user_id
+      distinct_id: user_id,
+      logger: "app-backend"
     }.with_indifferent_access
 
     expected_args = {
@@ -187,7 +189,8 @@ class MetricsServiceTest < ActiveSupport::TestCase
     event = 'fake-event'
     input_props = {
       foo: 'bar',
-      bing: 'baz'
+      bing: 'baz',
+      logger: "app-backend"
     }
 
     expected_output_props = input_props.merge(


### PR DESCRIPTION
Add the logger property to mixpanel calls to indicate whether it was the front or backend of the app making the call.
![Screen Shot 2022-01-20 at 2 26 20 PM](https://user-images.githubusercontent.com/54322292/150409019-94ad5184-c925-4e75-8177-b69c9639932d.png)

To test:
- pull this branch
- do anything clicky in the UI (i.e. click a button or change pages)
- do something back-endy like downloading files
- 
Then check out dev Mixpanel 
(Toggling between Mixpanel envs is done with the dropdown in the upper right)
![Screen Shot 2022-01-20 at 2 33 19 PM](https://user-images.githubusercontent.com/54322292/150409422-5f0a00fb-b245-4090-a76e-4e78fb4507e9.png)

Check out the Events tab and filter by the logger property with value of each 'app-backend' and 'app-frontend' 
![Screen Shot 2022-01-20 at 2 32 57 PM](https://user-images.githubusercontent.com/54322292/150409551-0f7b082a-8717-4d67-aca8-ea129f3e6046.png)
![Screen Shot 2022-01-20 at 2 33 07 PM](https://user-images.githubusercontent.com/54322292/150409644-f3f6c79f-ea72-419a-874a-36c0763fd9c1.png)


