### PR TITLE
Refactor `window.SCP.readOnlyToken` into view for streaming files (SCP-4020)

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1000,6 +1000,16 @@ class Study
     self.expression_matrices.any_of({'expression_file_info.is_raw_counts' => false}, {expression_file_info: nil}).exists?
   end
 
+  def has_image_files?
+    study_files.by_type('Image').any?
+  end
+
+  # check if study has any files that can be streamed from the bucket for visualization
+  # this includes BAM, inferCNV Ideogram annotations, and Image files
+  def has_streamable_files?
+    has_bam_files? || has_analysis_outputs?('infercnv', 'ideogram.js') || has_image_files?
+  end
+
   # quick getter to return any cell metadata that can_visualize?
   def viewable_metadata
     viewable = []

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,6 @@
       }
 
       window.SCP.userAccessToken = '<%= get_user_access_token(current_user) %>';
-      window.SCP.readOnlyToken = '<%= get_read_access_token(@study, current_user) %>'
       window.SCP.userSignedIn = <%= user_signed_in? %>;
       window.SCP.environment = '<%= Rails.env %>';
 

--- a/app/views/site/_study_visualize.html.erb
+++ b/app/views/site/_study_visualize.html.erb
@@ -1,6 +1,11 @@
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
   window.SCP.studyAccession = '<%= @study.accession %>';
   window.SCP.renderExploreView(document.getElementById('study-visualize'), window.SCP.studyAccession)
+  <% if @study.has_streamable_files? %>
+    if (typeof window.SCP.readOnlyToken === 'undefined') {
+      window.SCP.readOnlyToken = '<%= get_read_access_token(@study, current_user) %>'
+    }
+  <% end %>
 </script>
 
 
@@ -11,11 +16,6 @@
   Minimal DOM scaffolding and server-side data for genomic visualizations.
   See partials referenced below and scp-igv.js for larger bodies of code.
   -->
-  <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-    if (typeof accessToken === 'undefined') {
-      window.accessToken = '<%= get_read_access_token(@study, current_user) %>';
-    }
-  </script>
   <% if @study.has_analysis_outputs?('infercnv', 'ideogram.js') and action_name == 'study' %>
     <div id="ideogram-container" style="margin-top: 12px">
       <div id="filters-container">
@@ -60,7 +60,7 @@
       window.fetch = function () {
         if (arguments[0].includes('https://www.googleapis.com')) {
           var myHeaders = new Headers({
-            'Authorization': 'Bearer ' + accessToken
+            'Authorization': 'Bearer ' + window.SCP.readOnlyToken
           });
           arguments[1] = {headers: myHeaders};
         }


### PR DESCRIPTION
This update narrows the usage of `window.SCP.readOnlyToken` in an effort to mitigate the impact of the planned Terra terms of service updates.  Since all registered Terra users will need to re-accept the terms of service on or about 2022.02.15, any API requests made with user credentials who are not in compliance will be rejected.  Since generating pet service account tokens (the kind of token used in `window.SCP.readOnlyToken`) will fall into this category of API requests, this update only generates those tokens when explicitly needed.  This is in an effort to prevent the "Session timed out" modal from showing on every page load, as this would happen due to the `401/403` response from the Terra API.  The scenarios in which `window.SCP.readOnlyToken` is required are limited to visualization requests in private studies (public studies are unaffected), and include:

1. Viewing BAM files in IGV
2. Viewing inferCNV Ideogram annotations
3. Viewing Image files alongside scatter plots

**NOTE**: This update does not address concerns raised in SCP-3258 regarding the refactoring of genome visualization-specific code into the more accepted paradigm of JSON API + React.  This is purely a mitigation step to reduce incidence of spurious "Session timed out" modals on page loads for registered Terra users.

MANUAL TESTING
1. Boot as normal and sign in
2. In the Chrome Dev Tools JS console, validate that `window.SCP.readOnlyToken` is `undefined`
3. Load any study with BAM files, or upload `test/test_data/fixed_neurons_6days_2000_possorted_genome_bam_test_data.bam` and the associated `bai` file to an existing study (select `mouse` for the species and `GRCm38` for the assembly)
4. Open the Explore tab for the study, then click on the Genome tab, and confirm that IGV initializes and the BAM file loads without error
5. Back in the Chrome Dev Tools JS console, validate that `window.SCP.readOnlyToken` is now has a value starting with `ya29` 
6. If using the above BAM file, enter `chr1:3,043,159-3,043,318` into the IGV search bar, and validate the reads show as below:
![Screen Shot 2022-01-21 at 10 57 49 AM](https://user-images.githubusercontent.com/729968/150558694-5b8544b5-8564-4375-a5ec-d3bbf716ab27.png)
7. Go back to the home page, and validate that `window.SCP.readOnlyToken` is now back to `undefined`

This PR satisfies SCP-4020.