### PR TITLE
Adding Windows support for bulk download via cURL (SCP-4001)

### DIFF
--- a/app/javascript/components/search/controls/download/DownloadCommand.js
+++ b/app/javascript/components/search/controls/download/DownloadCommand.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react'
 
 import LoadingSpinner from 'lib/LoadingSpinner'
 import { fetchAuthCode, stringifyQuery } from 'lib/scp-api'
+import { _ } from '@databiosphere/bard-client/src/utils'
 
 /** component for rendering a copyable bulk download command for an array of file ids.
     Queries the server to retrieve the appropriate auth code. */
@@ -82,6 +83,9 @@ export default function DownloadCommand({ fileIds=[], azulFiles }) {
  * @returns {Object} Object for auth code, time interval, and download command
  */
 function getDownloadCommand(authCode, downloadId) {
+  // Get client os and determine correct curl invocation
+  const clientOS = _.info.os()
+  const curlExec = clientOS.match(/Win/) ? 'curl.exe' : 'curl'
   const queryParams = {
     auth_code: authCode,
     download_id: downloadId,
@@ -104,8 +108,8 @@ function getDownloadCommand(authCode, downloadId) {
   // To consider: check the node environment (either at compile or runtime)
   // instead of the hostname
   const downloadCommand = (
-    `curl "${url}" -${curlSecureFlag}o cfg.txt; ` +
-    `curl -K cfg.txt && rm cfg.txt` // Removes only if curl succeeds
+    `${curlExec} "${url}" -${curlSecureFlag}o cfg.txt; ` +
+    `${curlExec} -K cfg.txt && rm cfg.txt` // Removes only if curl succeeds
   )
 
   return downloadCommand

--- a/app/javascript/components/search/controls/download/DownloadCommand.js
+++ b/app/javascript/components/search/controls/download/DownloadCommand.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react'
 
 import LoadingSpinner from 'lib/LoadingSpinner'
 import { fetchAuthCode, stringifyQuery } from 'lib/scp-api'
-import { _ } from '@databiosphere/bard-client/src/utils'
+import { _ as bardUtils } from '@databiosphere/bard-client/src/utils'
 
 /** component for rendering a copyable bulk download command for an array of file ids.
     Queries the server to retrieve the appropriate auth code. */
@@ -84,7 +84,7 @@ export default function DownloadCommand({ fileIds=[], azulFiles }) {
  */
 function getDownloadCommand(authCode, downloadId) {
   // Get client os and determine correct curl invocation
-  const clientOS = _.info.os()
+  const clientOS = bardUtils.info.os()
   const curlExec = clientOS.match(/Win/) ? 'curl.exe' : 'curl'
   const queryParams = {
     auth_code: authCode,

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -144,4 +144,14 @@ class RequestUtils
     end
     return nil
   end
+
+  # format a file path for a specific operating system
+  # will default to unix-style paths, unless Windows OS is specified
+  def self.format_path_for_os(path, os = '')
+    if os =~ /Win/
+      path.gsub(%r{/}, '\\')
+    else
+      path
+    end
+  end
 end

--- a/app/models/directory_listing.rb
+++ b/app/models/directory_listing.rb
@@ -143,10 +143,7 @@ class DirectoryListing
   # supports Unix- and Windows-formatted paths
   def bulk_download_pathname(file, os: '')
     path = "#{study.accession}/#{bulk_download_folder(file)}"
-    if os =~ /Win/
-      path.gsub!(%r{/}, '\\') # reformat with backslashes once computed to include bulk_download_folder
-    end
-    path
+    RequestUtils.format_path_for_os(path, os)
   end
 
   # helper to get total number of bytes in directory

--- a/app/models/directory_listing.rb
+++ b/app/models/directory_listing.rb
@@ -140,8 +140,13 @@ class DirectoryListing
   end
 
   # output path for bulk download
-  def bulk_download_pathname(file)
-    "#{self.study.accession}/#{bulk_download_folder(file)}"
+  # supports Unix- and Windows-formatted paths
+  def bulk_download_pathname(file, os: '')
+    path = "#{study.accession}/#{bulk_download_folder(file)}"
+    if os =~ /Win/
+      path.gsub!(%r{/}, '\\') # reformat with backslashes once computed to include bulk_download_folder
+    end
+    path
   end
 
   # helper to get total number of bytes in directory

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -766,8 +766,13 @@ class StudyFile
 
   # generate a download path to use with bulk_download
   # takes the form of :study_accession/:output_directory_name/:filename
-  def bulk_download_pathname
-    "#{self.study.accession}/#{self.output_directory_name}/#{self.upload_file_name}"
+  # supports Unix- and Windows-formatted paths
+  def bulk_download_pathname(os: '')
+    path = "#{self.study.accession}/#{self.output_directory_name}/#{self.upload_file_name}"
+    if os =~ /Win/
+      path.gsub!(%r{/}, '\\') # reformat with backslashes once computed to include bulk_download_type
+    end
+    path
   end
 
   # Map of StudyFile#file_type to ::BULK_DOWNLOAD_TYPES, maintaining relationship for bundled files to parent

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -768,11 +768,8 @@ class StudyFile
   # takes the form of :study_accession/:output_directory_name/:filename
   # supports Unix- and Windows-formatted paths
   def bulk_download_pathname(os: '')
-    path = "#{self.study.accession}/#{self.output_directory_name}/#{self.upload_file_name}"
-    if os =~ /Win/
-      path.gsub!(%r{/}, '\\') # reformat with backslashes once computed to include bulk_download_type
-    end
-    path
+    path = "#{study.accession}/#{output_directory_name}/#{upload_file_name}"
+    RequestUtils.format_path_for_os(path, os)
   end
 
   # Map of StudyFile#file_type to ::BULK_DOWNLOAD_TYPES, maintaining relationship for bundled files to parent

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -122,6 +122,8 @@
               var authCode = response.authCode;
               var timeInterval = response.timeInterval; // token expires after this many seconds
               var expiresMinutes = timeInterval / 60;
+              const isWindows = !!window.navigator.platform.match(/Win/) // determine client OS for formatting
+              const curlExec = isWindows ? 'curl.exe' : 'curl'
               const accession = "<%= @study.accession %>"
               const curlSecureFlag = "<%= Rails.env.development? ? '-k' : '' %>"
               const matcher = /root-dir/
@@ -145,8 +147,8 @@
 
               // This is what the user will run in their terminal to download the data.
               var downloadCommand = (
-                  'curl &quot;' + url + '&quot; ' + curlSecureFlag + ' -o cfg.txt; ' +
-                  'curl -K cfg.txt && rm cfg.txt'
+                  `${curlExec} &quot;` + url + '&quot; ' + curlSecureFlag + ' -o cfg.txt; ' +
+                  `${curlExec} -K cfg.txt && rm cfg.txt`
               );
 
               var commandID = 'command-' + authCode;

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -147,7 +147,7 @@
 
               // This is what the user will run in their terminal to download the data.
               var downloadCommand = (
-                  `${curlExec} &quot;` + url + '&quot; ' + curlSecureFlag + ' -o cfg.txt; ' +
+                  `${curlExec} &quot;${url}&quot; ${curlSecureFlag} -o cfg.txt; ' +
                   `${curlExec} -K cfg.txt && rm cfg.txt`
               );
 

--- a/test/integration/lib/request_utils_test.rb
+++ b/test/integration/lib/request_utils_test.rb
@@ -51,4 +51,16 @@ class RequestUtilsTest < ActiveSupport::TestCase
     assert_equal invalid_output, sanitized_invalid_list,
                  "Did not correctly sanitize characters from list; #{invalid_output} != #{sanitized_invalid_list}"
   end
+
+  test 'should format file path for os' do
+    path = 'path/to/some/file.txt'
+    unix_os_list = ['Mac OS X', 'macOSX', 'Generic Linux', 'Android', 'iOS (iPhone)']
+    unix_os_list.each do |operating_system|
+      formatted_path = RequestUtils.format_path_for_os(path, operating_system)
+      assert_equal path, formatted_path
+    end
+    windows_path = RequestUtils.format_path_for_os(path, 'Windows')
+    expected_path = "path\\to\\some\\file.txt"
+    assert_equal expected_path, windows_path
+  end
 end


### PR DESCRIPTION
Currently, users wishing to bulk download files (either from search results, or within an individual study) via `curl` can only do so on Mac OSX or other *nix-like computers, as the commands and configurations are formatted for those operating systems.  This update adds support for Windows machines by detecting the operating system both client- and server-side.  The following changes have been made for Windows machines:

1. Invocation of cURL will change to `curl.exe`
2. All file paths in `cfg.txt` will use backslashes (`\`) instead of forward slashes (`/`)

MANUAL TESTING
1. Boot as normal and sign in
2. Run any search that returns studies (e.g. `species:Homo sapiens` and `disease:tuberculosis`)
3. Note: if you are testing on a Macintosh, in `app/controllers/api/v1/bulk_download_controller.rb`, line 303, enter `os = 'Windows'` to force Windows cURL configuration
4. Click the "Download" button, and progress through the bulk download UX until you get the cURL command
5. Copy everything up to the first semicolon (specifically, leave off the final `curl -K cfg.txt && rm cfg.txt`)
6. Paste the command into a shell to download the configuration file and confirm it succeeds
7. Open the configuration in a text editor and confirm that the output paths are Windows-formatted:
```
--create-dirs

--compressed

url="https://storage.googleapis.com/fc-42753b8c-eece-4242-9f1f-3f955d07c4ea/cluster.tsv?GoogleAccessId=default-service-account%40broad-singlecellportal-bistlin.iam.gserviceaccount.com&Expires=..."
output="SCP61\cluster\cluster.tsv"

url="https://storage.googleapis.com/fc-42753b8c-eece-4242-9f1f-3f955d07c4ea/expression_processed.tsv?GoogleAccessId=default-service-account%40broad-singlecellportal-bistlin.iam.gserviceaccount.com&Expires=..."
output="SCP61\expression\expression_processed.tsv"
```

This PR satisfies SCP-4001.