### PR TITLE
Updating bulk download labels & HCA filtering (SCP-3982)

### DIFF
--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -169,7 +169,7 @@ const COLUMNS = {
   analysis: {
     title: 'Analysis',
     types: ['analysis_file'],
-    info: 'Expression matrix files, including processed or raw count files',
+    info: 'Loom files of finalized raw counts.  This does not include contributor generated files or intermediate files. Those can be downloaded directly from HCA',
     default: true
   },
   sequence: {

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -144,7 +144,7 @@ const COLUMNS = {
     types: ['Expression Matrix', 'MM Coordinate Matrix', '10X Genes File', '10X Barcodes File'],
     info: <span>
       Expression matrix files, including processed or raw count files.<br/>
-      <a href="https://singlecell.zendesk.com/hc/en-us/articles/360060610292-Matrix-Files" target="_blank" rel="nofollow noreferrer">
+      <a href="https://singlecell.zendesk.com/hc/en-us/articles/360060610292-Matrix-Files" target="_blank" rel="noopener noreferrer">
         Matrix file documentation
       </a>
     </span>,
@@ -155,7 +155,7 @@ const COLUMNS = {
     types: ['Cluster'],
     info: <span>
       Clustering coordinate files, including 2D and 3D clustering, as well as spatial.<br/>
-      <a href="https://singlecell.zendesk.com/hc/en-us/articles/360060609792-Cluster-Files" target="_blank" rel="nofollow noreferrer">
+      <a href="https://singlecell.zendesk.com/hc/en-us/articles/360060609792-Cluster-Files" target="_blank" rel="noopener noreferrer">
         Cluster file documentation.
       </a>
     </span>,
@@ -166,7 +166,7 @@ const COLUMNS = {
     types: ['Metadata'],
     info: <span>
       The listing of all cells in the study, along with associated metadata such as species, cell type, etc.<br/>
-      <a href="https://singlecell.zendesk.com/hc/en-us/articles/360060610232-Metadata-File-Overview" target="_blank" rel="nofollow noreferrer">
+      <a href="https://singlecell.zendesk.com/hc/en-us/articles/360060610232-Metadata-File-Overview" target="_blank" rel="noopener noreferrer">
         Metadata file documentation.
       </a>
     </span>,
@@ -182,7 +182,7 @@ const COLUMNS = {
     title: 'Analysis',
     types: ['analysis_file'],
     info: <span>
-      Loom files of <a href="https://broadinstitute.github.io/warp/docs/Pipelines/Optimus_Pipeline/Loom_schema/" target="_blank" rel="nofollow noreferrer">finalized raw counts.</a><br/>
+      Loom files of <a href="https://broadinstitute.github.io/warp/docs/Pipelines/Optimus_Pipeline/Loom_schema/" target="_blank" rel="noopener noreferrer">finalized raw counts.</a><br/>
        This does not include contributor generated files or intermediate files, which can be downloaded directly from HCA
     </span>,
     default: true

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -5,6 +5,7 @@ import _cloneDeep from 'lodash/cloneDeep'
 
 import { bytesToSize } from 'lib/stats'
 import LoadingSpinner from 'lib/LoadingSpinner'
+import InfoPopup from 'lib/InfoPopup'
 
 
 /** component that renders a list of studies so that individual studies/files can be selected
@@ -97,12 +98,8 @@ export default function DownloadSelectionTable({
                     { COLUMNS[colType].title }
                   </label>
                   &nbsp;
-                  <FontAwesomeIcon data-analytics-name="download-modal-column-info"
-                    data-toggle="tooltip"
-                    data-container="terra-table"
-                    data-original-title={COLUMNS[colType].info}
-                    className="action log-click help-icon"
-                    icon={faInfoCircle} />
+                  <InfoPopup dataAnalyticsName={`download-modal-column-info-${colType}`}
+                    content={<span>{COLUMNS[colType].info}</span>}/>
                 </td>
               })}
             </tr>
@@ -145,19 +142,34 @@ const COLUMNS = {
   matrix: {
     title: 'Matrix',
     types: ['Expression Matrix', 'MM Coordinate Matrix', '10X Genes File', '10X Barcodes File'],
-    info: 'Expression matrix files, including processed or raw count files',
+    info: <span>
+      Expression matrix files, including processed or raw count files.<br/>
+      <a href="https://singlecell.zendesk.com/hc/en-us/articles/360060610292-Matrix-Files" target="_blank" rel="nofollow noreferrer">
+        Matrix file documentation
+      </a>
+    </span>,
     default: true
   },
   cluster: {
     title: 'Clustering',
     types: ['Cluster'],
-    info: 'Clustering coordinate files, including 2D and 3D clustering, as well as spatial',
+    info: <span>
+      Clustering coordinate files, including 2D and 3D clustering, as well as spatial.<br/>
+      <a href="https://singlecell.zendesk.com/hc/en-us/articles/360060609792-Cluster-Files" target="_blank" rel="nofollow noreferrer">
+        Cluster file documentation.
+      </a>
+    </span>,
     default: true
   },
   metadata: {
     title: 'Metadata',
     types: ['Metadata'],
-    info: 'The listing of all cells in the study, along with associated metadata such as species, cell type, etc.',
+    info: <span>
+      The listing of all cells in the study, along with associated metadata such as species, cell type, etc.<br/>
+      <a href="https://singlecell.zendesk.com/hc/en-us/articles/360060610232-Metadata-File-Overview" target="_blank" rel="nofollow noreferrer">
+        Metadata file documentation.
+      </a>
+    </span>,
     default: true
   },
   project_manifest: {
@@ -169,7 +181,10 @@ const COLUMNS = {
   analysis: {
     title: 'Analysis',
     types: ['analysis_file'],
-    info: 'Loom files of finalized raw counts.  This does not include contributor generated files or intermediate files. Those can be downloaded directly from HCA',
+    info: <span>
+      Loom files of <a href="https://broadinstitute.github.io/warp/docs/Pipelines/Optimus_Pipeline/Loom_schema/" target="_blank" rel="nofollow noreferrer">finalized raw counts.</a><br/>
+       This does not include contributor generated files or intermediate files, which can be downloaded directly from HCA
+    </span>,
     default: true
   },
   sequence: {

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -182,8 +182,8 @@ const COLUMNS = {
     title: 'Analysis',
     types: ['analysis_file'],
     info: <span>
-      Loom files of <a href="https://broadinstitute.github.io/warp/docs/Pipelines/Optimus_Pipeline/Loom_schema/" target="_blank" rel="noopener noreferrer">finalized raw counts.</a><br/>
-       This does not include contributor generated files or intermediate files, which can be downloaded directly from HCA
+      Loom files of <a href="https://broadinstitute.github.io/warp/docs/Pipelines/Optimus_Pipeline/Loom_schema/" target="_blank" rel="noopener noreferrer">finalized raw counts</a>.<br/>
+       This does not include contributor generated files or intermediate files, which can be downloaded directly from HCA.
     </span>,
     default: true
   },

--- a/app/javascript/lib/InfoPopup.js
+++ b/app/javascript/lib/InfoPopup.js
@@ -3,6 +3,7 @@ import { Popover, OverlayTrigger } from 'react-bootstrap'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
 import _uniqueId from 'lodash/uniqueId'
+
 /**
  * thin wrapper around OverlayTrigger and Popover to render popup help content
  * popup will work even when underlying element is disabled.

--- a/app/javascript/lib/InfoPopup.js
+++ b/app/javascript/lib/InfoPopup.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Popover, OverlayTrigger } from 'react-bootstrap'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
+import _uniqueId from 'lodash/uniqueId'
+/**
+ * thin wrapper around OverlayTrigger and Popover to render popup help content
+ * popup will work even when underlying element is disabled.
+ * All arguments are passed through to either Popover or OverlayTrigger
+*/
+export default function InfoPopup({
+  content, // the content of the popover
+  target=<FontAwesomeIcon icon={faQuestionCircle} className="action help-icon"/>, // the element to attach the popover to
+  trigger=['click'], // what actions trigger the popup, for hover tips, use ['hover', 'focus']
+  placement='top',
+  className='tooltip-wide',
+  dataAnalyticsName='info-popup', // clicks on the target will be logged, with this as the 'text' sent to Mixpanel
+  id // needs to have a unique id for popover to render. if none is provided, a default unique string will be made
+}) {
+  id = id || _uniqueId('help-popup-')
+  const popoverContent = <Popover id={id} className={className}>
+    {content}
+  </Popover>
+  return <OverlayTrigger rootClose trigger={trigger} placement={placement} overlay={popoverContent}>
+    <span className="log-click" data-analytics-name={dataAnalyticsName}>{target}</span>
+  </OverlayTrigger>
+}

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -195,7 +195,7 @@ class AzulSearchService
         FILE_EXT_BY_DOWNLOAD_TYPE.each_pair do |file_type, extensions|
           if extensions.include? file_summary['format']
             if file_type == 'analysis_file' && !is_analysis_file(file_summary)
-              assigned_file_type = file_type = 'contributed_analysis_file'
+              assigned_file_type = 'contributed_analysis_file'
             else
               assigned_file_type = file_type
             end

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -185,7 +185,6 @@ class AzulSearchService
       }
       content = file_summary['contentDescription']
       assigned_file_type = 'other'
-      puts file_summary
       case content
       when /Matrix/
         assigned_file_type = is_analysis_file(file_summary) ? 'analysis_file' : 'contributed_analysis_file'

--- a/test/integration/lib/azul_search_service_test.rb
+++ b/test/integration/lib/azul_search_service_test.rb
@@ -156,7 +156,7 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
     other_files = summary.map { |project| project[:studyFiles].reject { |file| file[:file_type] == 'Project Manifest' } }
                          .flatten
     other_files.each do |file_info|
-      assert_equal %w[source count upload_file_size file_format accession project_id file_type], file_info.keys
+      assert_equal %w[source count upload_file_size file_format accession project_id file_type is_intermediate].sort, file_info.keys.sort
     end
   end
 


### PR DESCRIPTION
SCP-3982.  The functional change is to only show finalized loom files as 'analysis' files in the UX.  Note that we still pass along every file we find to the UI components in case we want to later refine the UI with message like "[X] contributor generated files may be available here". But the non-finalized loom analysis files are now classified as "contributor_analysis_files and hidden in the UI. 

The info popups have also been improved -- the SCP types link to the appropriate zendesk documentation, and the HCA analysis popup links to the HCA info page. 

![image](https://user-images.githubusercontent.com/2800795/150713113-d9a3176e-3ab4-420a-a47e-1cec598a3e41.png)


TO TEST:
1. sign in and have XDSS enabled
2. do a search that yields both HCA and SCP studies (`cow lung`) worked in my environment
3. Confirm the SCP file column info popups link appropriately
4. Confirm the HCA 'analysis' column info popup links appropriately
5. Confirm zero or one file shows up in the analysis column for each HCA study 
 