### PR TITLE
Update description style on misc. step (SCP-4070)

### DIFF
--- a/app/javascript/components/upload/MiscellaneousStep.js
+++ b/app/javascript/components/upload/MiscellaneousStep.js
@@ -38,7 +38,7 @@ function MiscellaneousForm({
   return <div>
     <div className="row">
       <div className="col-md-12">
-        <p className="text-center">
+        <p className="form-terra">
           Any documentation or other support files. These will not be displayed directly, but will be avaialble for users to download.
         </p>
       </div>

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "jest-environment-enzyme": "^7.1.2",
     "jest-enzyme": "^7.1.2",
     "jest-fetch-mock": "^3.0.3",
-    "node-fetch": "^3.1.1",
+    "node-fetch": "^2.6.1",
     "prettier": "^1.19.1",
     "prettier-eslint": "^11.0.0",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
Tiny update to make the description section of the misc. step match the rest of the wizard steps.
Before:
![Screen Shot 2022-01-24 at 2 08 51 PM](https://user-images.githubusercontent.com/54322292/150848570-9c5d3f0f-b929-4688-a23f-5dd407498b45.png)

After:
![Screen Shot 2022-01-24 at 2 09 13 PM](https://user-images.githubusercontent.com/54322292/150848606-69307570-89c1-4a40-a488-abac4360e359.png)

Compare to the reference image step:
![Screen Shot 2022-01-24 at 2 09 01 PM](https://user-images.githubusercontent.com/54322292/150848631-c6147228-45fe-4dd6-a6e2-3c3fe30f625e.png)
