### PR TITLE
Nil-safing expression- and cluster-based visualization methods (SCP-3990)

### DIFF
--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -129,19 +129,19 @@ module Api
           if params[:cluster_name] == '_default' || params[:cluster_name].empty?
             cluster = @study.default_cluster
             if cluster.nil?
-              render json: {error: 'No default cluster exists'}, status: 404 and return
+              render json: { error: 'No default cluster exists' }, status: 404 and return
             end
           else
             cluster_name = params[:cluster_name]
             cluster = @study.cluster_groups.find_by(name: cluster_name)
             if cluster.nil?
-              render json: {error: "No cluster named #{cluster_name} could be found"}, status: 404 and return
+              render json: { error: "No cluster named #{cluster_name} could be found"}, status: 404 and return
             end
           end
           begin
             viz_data = self.class.get_cluster_viz_data(@study, cluster, params)
           rescue ArgumentError => e
-            render json: {error: e.message}, status: 404 and return
+            render json: { error: e.message }, status: 404 and return
           end
           render json: viz_data
         end

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -108,6 +108,10 @@ module Api
 
         def render_violin
           cluster = ClusterVizService.get_cluster_group(@study, params)
+          if cluster.nil?
+            render json: { error: 'Requested cluster not found' }, status: :not_found and return
+          end
+
           annotation = AnnotationVizService.get_selected_annotation(@study,
                                                                     cluster: cluster,
                                                                     annot_name: params[:annotation_name],

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -100,7 +100,7 @@ class ClusterVizService
   def self.default_subsampling(cluster)
     return nil if cluster.nil? || cluster.points < 100000
 
-    ClusterGroup::SUBSAMPLE_THRESHOLDS.select { |val| val <= 100000 }.max
+    ClusterGroup::SUBSAMPLE_THRESHOLDS.select { |val| val <= ClusterGroup::MAX_THRESHOLD }.max
   end
 
     # load custom coordinate-based annotation labels for a given cluster

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -69,7 +69,7 @@ class ExpressionVizService
 
     # grab all cells present in the cluster, and use as keys to load expression scores
     # if a cell is not present for the gene, score gets set as 0.0
-    cells = cluster.concatenate_data_arrays('text', 'cells', subsample_threshold, subsample_annotation) || []
+    cells = cluster.concatenate_data_arrays('text', 'cells', subsample_threshold, subsample_annotation)
     case annotation[:scope]
     when 'cluster'
       # we can take a subsample of the same size for the annotations since the sort order is non-stochastic (i.e. the indices chosen are the same every time for all arrays)
@@ -213,7 +213,7 @@ class ExpressionVizService
       annotations = AnnotationVizService.sanitize_values_array(
         user_annotation.concatenate_data_arrays(annotation[:name], 'annotations', subsample_threshold, subsample_annotation),
         'group'
-      ) || []
+      )
       cells = user_annotation.concatenate_data_arrays('text', 'cells', subsample_threshold, subsample_annotation)
       cells.each_with_index do |cell, index|
         values[annotations[index]][:annotations] << annotations[index]
@@ -264,7 +264,7 @@ class ExpressionVizService
     }
     return viz_data if cluster.nil? || genes.empty?
 
-    cells = cluster.concatenate_data_arrays('text', 'cells', subsample_threshold, subsample_annotation) || []
+    cells = cluster.concatenate_data_arrays('text', 'cells', subsample_threshold, subsample_annotation)
     annotation_array = ClusterVizService.get_annotation_values_array(
       study, cluster, annotation, cells, subsample_annotation, subsample_threshold
     )


### PR DESCRIPTION
This update adds various safeguards to expression- and cluster-based visualization methods in the various controllers/service libraries responsible for handling visualization requests, as well as general linting/refactoring for concision.  This is handled mainly through guard clauses to return/render if a top-level entity (such as a `ClusterGroup` object, or genes hash) is not found.  This is mainly an effort to allow normal error handling to catch these instances and let the UI gracefully rescue from these errors, as opposed to server-side errors that cause the Explore tab to break and stop rendering visualizations.

There is also one method (`ClusterVizService.transform_coordinates`) that has been removed entirely as it is no longer used.

MANUAL TESTING
**NOTE**: Before beginning, make sure that caching is disabled by running `bin/rails dev:cache` from the project root directory until the message `Development mode is no longer being cached.` is displayed.

The best way to test this particular ticket is through the Swagger API documentation:

1. Boot as normal, and get the accession of any study with clustering & gene expression data (e.g. the synthetic study `Human HIV and Tuberculosis, blood study`)
2. Open the Swagger API documentation from the `Help and resources` menu, and sign in via the "Authorize" button at the top
3. Go down to the "Expression" [data rendering](https://localhost:3000/single_cell/api/v1#/Visualization/study_visualization_expression_show) endpoint
4. Enter the study accession from above, and the following parameters:
```
genes: AGPAT2
annotation_name:  cell_type__ontology_label
annotation_type: group
annotation_scope: study
```
5. Confirm the request executes as expected and returns `200`
6. Enter `does-not-exist` for the `cluster` value and re-run the request
7. Confirm the response code is `404` and the error message is `"error": "Requested cluster not found"`

This PR satisfies SCP-3990.