### PR TITLE
Fixing broken single-study bulk download, format curl command for all OS types (SCP-4001)

### DIFF
--- a/app/javascript/components/search/controls/download/DownloadCommand.js
+++ b/app/javascript/components/search/controls/download/DownloadCommand.js
@@ -109,7 +109,7 @@ function getDownloadCommand(authCode, downloadId) {
   // instead of the hostname
   const downloadCommand = (
     `${curlExec} "${url}" -${curlSecureFlag}o cfg.txt; ` +
-    `${curlExec} -K cfg.txt && rm cfg.txt` // Removes only if curl succeeds
+    `${curlExec} -K cfg.txt; rm cfg.txt` // Removes only if curl succeeds
   )
 
   return downloadCommand

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -26,7 +26,8 @@ class BulkDownloadService
                                        azul_files: nil,
                                        context: 'study',
                                        os: '')
-    curl_configs = ['--create-dirs', '--compressed']
+    curl_configs = %w(--create-dirs)
+    curl_configs << '--compressed' unless os =~ /Win/ # most Windows installations of curl do not support --compressed
     # create an array of all objects to be downloaded, including directory files
     download_objects = study_files.to_a + directory_files
     # Get signed URLs for all files in the requested download objects

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -147,9 +147,15 @@
 
               // This is what the user will run in their terminal to download the data.
               var downloadCommand = (
-                  `${curlExec} &quot;${url}&quot; ${curlSecureFlag} -o cfg.txt; ` +
-                  `${curlExec} -K cfg.txt; rm cfg.txt`
+                  `${curlExec} &quot;${url}&quot; ${curlSecureFlag} -o cfg.txt; `
               );
+
+              // depending on OS, format downstream commands to only clean up cfg.txt if curl is successful
+              if (isWindows) {
+                downloadCommand += `${curlExec} -K cfg.txt ; if ($?) { rm cfg.txt }`
+              } else {
+                downloadCommand += `${curlExec} -K cfg.txt && rm cfg.txt`
+              }
 
               var commandID = 'command-' + authCode;
               var commandContainer = $('#command-container-' + downloadObject);

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -147,8 +147,8 @@
 
               // This is what the user will run in their terminal to download the data.
               var downloadCommand = (
-                  `${curlExec} &quot;${url}&quot; ${curlSecureFlag} -o cfg.txt; ' +
-                  `${curlExec} -K cfg.txt && rm cfg.txt`
+                  `${curlExec} &quot;${url}&quot; ${curlSecureFlag} -o cfg.txt; ` +
+                  `${curlExec} -K cfg.txt; rm cfg.txt`
               );
 
               var commandID = 'command-' + authCode;


### PR DESCRIPTION
This update fixes several new bugs with bulk download:

1. Removes `&&` in favor of `;` for command chaining as ampersands are not an allowed character in Windows PowerShell
2. Fixes a broken string interpolation that prevented single-study bulk download from opening the modal and rendering curl commands
3. Removes the `--compressed` directive for Windows machines as this is not supported by most installations of `curl.exe`

MANUAL TESTING
1. Sign in with any account
2. Run a search on the home page, progress through the bulk download UX, and validate that the `curl` command succeeds
3. Open any study that you do not have bucket permissions for (the easiest way is to sign in with a personal Gmail account and load any public study with files) and validate that the bulk download modal renders and commands work

This PR supports SCP-4001.