### PR TITLE
Primary Human Data must have human as species (SCP-4030)

### DIFF
--- a/app/javascript/components/upload/SequenceFileForm.js
+++ b/app/javascript/components/upload/SequenceFileForm.js
@@ -45,6 +45,7 @@ export default function SequenceFileForm({
     requiredFields = BAM_REQUIRED_FIELDS
   }
   const validationMessages = validateFile({ file, allFiles, requiredFields, allowedFileExts })
+  const humanTaxon = speciesOptions.find(opt => opt.label === 'human')
 
   return <div className="row top-margin" key={file._id}>
     <div className="col-md-12">
@@ -66,7 +67,7 @@ export default function SequenceFileForm({
             <input type="radio"
               name={`sequenceHuman-${file._id}`}
               value="true" checked={file.human_data}
-              onChange={e => updateFile(file._id, { human_data: true, file_type: 'Fastq', uploadSelection: null })}/>
+              onChange={e => updateFile(file._id, { human_data: true, file_type: 'Fastq', uploadSelection: null, taxon_id: humanTaxon.value })}/>
               &nbsp;Yes
           </label>
         </div>
@@ -108,6 +109,7 @@ export default function SequenceFileForm({
             <Select options={speciesOptions}
               data-analytics-name="sequence-species-select"
               value={selectedSpecies}
+              isDisabled={file.human_data}
               placeholder="Select one..."
               onChange={val => updateFile(file._id, { taxon_id: val.value })}/>
           </label>


### PR DESCRIPTION
If the file has been indicated to be a Primary Human Data sequence file the species should be human. Previously the user would be able to change the species even when having selected this. This will fix it so that a user cannot change the species when the Primary Human Data option has been selected. Please note a user is able to have the species be a human without having chosen the Primary Human Data.

Current/Previous Behavior:
![Screen Shot 2022-01-25 at 1 57 31 PM](https://user-images.githubusercontent.com/54322292/151044251-2fc67f20-4b3f-46b6-8944-5950d2edea1c.png)

To test:
- Pull this branch
- go to the wizard to the sequence file upload section
- click back and forth between Yes and No on the Primary Human Data option and try changing the species

Video showing the new behavior plus printing the value in the "selectedSpecies" variable
https://user-images.githubusercontent.com/54322292/151044228-f6f58f43-8aa1-4dc3-8973-8fc03729ab8a.mov

