### PR TITLE
Adding trigger to defaultProps for file-validation reporting (SCP-4031)

### DIFF
--- a/app/javascript/lib/validation/validate-file-content.js
+++ b/app/javascript/lib/validation/validate-file-content.js
@@ -424,6 +424,7 @@ function getLogProps(fileInfo, errorObj, perfTime) {
   const defaultProps = {
     ...fileInfo,
     perfTime,
+    trigger,
     delimiter: friendlyDelimiter,
     numTableCells: fileInfo.numColumns ? fileInfo.numColumns * fileInfo.linesRead : 0
   }
@@ -433,7 +434,6 @@ function getLogProps(fileInfo, errorObj, perfTime) {
   } else {
     return Object.assign(defaultProps, {
       status: 'failure',
-      trigger,
       summary,
       numErrors: errors.length,
       numWarnings: warnings.length,


### PR DESCRIPTION
This fixes a bug with logging `trigger` on `file-validation` events in Mixpanel where it was only passed on validation failure, not success.  This moves `trigger` into `defaultProps` so that it is passed with all `file-validation` events.

MANUAL TESTING

1. Boot as normal and sign in
2. Create a new study, or go to the upload wizard for an existing study
3. Open the network tab in Chrome Dev Tools
4. Upload both `cluster_bad_no_coordinates.txt` from `test/test_data/validation` and `cluster_example.txt` from `test/test_data` and confirm that `trigger` is set to `upload` in both `file-validation` Mixpanel event payloads:

Success:

![success](https://user-images.githubusercontent.com/729968/151059635-50fa330a-edab-4b88-b0ed-8e4af551ce08.png)

Failure:

![failure](https://user-images.githubusercontent.com/729968/151059649-faa47739-fd31-40d5-90b1-8ee944043083.png)

This PR satisfies SCP-4031.