### PR TITLE
Remove the incorrect validations from dense file validation (SCP-4034)

### DIFF
--- a/app/javascript/lib/validation/expression-matrices-validation.js
+++ b/app/javascript/lib/validation/expression-matrices-validation.js
@@ -3,8 +3,7 @@
 */
 
 import {
-  getParsedHeaderLines, parseLine,
-  validateUniqueCellNamesWithinFile, validateMetadataLabelMatches, validateGroupColumnCounts
+  getParsedHeaderLines, parseLine, validateUniqueCellNamesWithinFile
 } from './shared-validation'
 
 
@@ -21,8 +20,6 @@ export async function parseDenseMatrixFile(chunker, mimeType, fileOptions) {
     issues = issues.concat(validateValuesAreNumeric(line, isLastLine, lineNum, dataObj))
     issues = issues.concat(validateColumnNumber(line, isLastLine, headers, lineNum, dataObj))
     issues = issues.concat(validateUniqueCellNamesWithinFile(line, isLastLine, dataObj))
-    issues = issues.concat(validateMetadataLabelMatches(headers, line, isLastLine, dataObj))
-    issues = issues.concat(validateGroupColumnCounts(headers, line, isLastLine, dataObj))
     // add other line-by-line validations here
   })
   return { issues, delimiter, numColumns: headers[0].length }
@@ -237,7 +234,7 @@ function validateValuesAreNumeric(line, isLastLine, lineNum, dataObj) {
 
     const msg = `All values (other than the first column and header row) in a dense matrix file must be numeric. ` +
       `Please ensure all values in ${rowText}: ${notedBadRows}, are numbers.`
-    issues.push(['error', 'format:invalid-type:not-numeric', msg])
+    issues.push(['error', 'content:invalid-type:not-numeric', msg])
   }
 
   return issues

--- a/app/javascript/lib/validation/shared-validation.js
+++ b/app/javascript/lib/validation/shared-validation.js
@@ -152,7 +152,9 @@ export function validateMetadataLabelMatches(headers, line, isLastLine, dataObj)
 }
 
 
-/** raises a warning if a group column has more than 200 unique values */
+/**
+ * For cluster and metadata files raises a warning if a group column has more than 200 unique values
+ * */
 export function validateGroupColumnCounts(headers, line, isLastLine, dataObj) {
   const issues = []
   const excludedColumns = ['NAME']

--- a/test/js/lib/validate-file-content.test.js
+++ b/test/js/lib/validate-file-content.test.js
@@ -118,7 +118,7 @@ describe('Client-side file validation', () => {
     })
     const { errors } = await validateFileContent(file, 'Expression Matrix')
     expect(errors).toHaveLength(1)
-    expect(errors[0][1]).toEqual('format:invalid-type:not-numeric')
+    expect(errors[0][1]).toEqual('content:invalid-type:not-numeric')
   })
 
   it('catches row with wrong number of columns in expression matrix file', async () => {


### PR DESCRIPTION
parseDenseMatrix() was incorrectly and unnecessarily calling validateMetadataLabelMatches() and validateGroupColumnCounts(). This issue was brought to light when the file MIT_Milk_Study_Raw_counts.txt was attempted to be uploaded and the warnings were about issues that should not be applied to dense matrices.

Before:
<img width="679" alt="Screen Shot 2022-01-26 at 9 55 30 AM" src="https://user-images.githubusercontent.com/54322292/151208500-afb80a66-eed3-4caa-a217-9c058f27090a.png">

This removes those incorrect validations.
To test:
- Pull this branch
- Have a study you can upload a raw counts matrix to
- download MIT_Milk_Study_Raw_counts.txt.gz from SCP1671 in prod
- upload this file
- note it will take a couple of minutes
- observe no warning messages.

Success Now:
![Screen Shot 2022-01-26 at 11 44 18 AM](https://user-images.githubusercontent.com/54322292/151209102-b246d9ee-4408-41e5-bd3e-cdd2f7605d28.png)



Also updating an issue type to more precisely indicate its function - updated from 'format' to 'content' as the check is more accurately on the content of the file.