### PR TITLE
Consolidating metadata annotation processing (SCP-4018)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -116,10 +116,16 @@ class ApplicationController < ActionController::Base
   def set_study_default_options
     @default_cluster = @study.default_cluster
     @default_cluster_annotations = {
-      'Study Wide' => @study.viewable_metadata.map(&:annotation_select_option),
+      'Study Wide' => [],
       'Cluster-based' => [],
-      'Cannot Display' => @study.cell_metadata.reject(&:can_visualize?).map(&:annotation_select_option)
+      'Cannot Display'=> []
     }
+    metadata_annotations = AnnotationVizService.available_metadata_annotations(@study)
+    metadata_annotations.each do |annot|
+      annot_key = annot[:scope] == 'invalid' ? 'Cannot Display' : 'Study Wide'
+      @default_cluster_annotations[annot_key] << [annot[:name], "#{annot[:name]}--#{annot[:type]}--#{annot[:scope]}"]
+    end
+
     @default_cluster&.cell_annotations&.each do |cell_annotation|
       if @default_cluster&.can_visualize_cell_annotation?(cell_annotation)
         @default_cluster_annotations['Cluster-based'] << @default_cluster&.formatted_cell_annotation(cell_annotation)

--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -2,6 +2,8 @@
  *  These live in a separate utility because multiple endpoints (explore, cluster, etc..)
  *  return annotationLists of the same basic structure */
 
+import { ParseException } from './validation/shared-validation'
+
 /** custom styling for cluster control-style select */
 export const clusterSelectStyle = {
   control: provided => ({
@@ -18,6 +20,7 @@ export const emptyDataParams = {
 }
 
 export const UNSPECIFIED_ANNOTATION_NAME = '--Unspecified--'
+const GROUP_VIZ_THRESHOLD_MAX = 200
 
 /** takes the server response and returns subsample default subsample for the cluster */
 export function getDefaultSubsampleForCluster(annotationList, clusterName) {
@@ -53,7 +56,14 @@ export function annotationKeyProperties(annotation) {
  */
 export function getAnnotationDisplayName(annotation) {
   if (annotation.scope === 'invalid') {
-    const annotLabel = annotation.values.length === 1 ? 'Only one label' : 'Too many labels'
+    let annotLabel = ''
+    if (annotation.values.length === 1) {
+      annotLabel = 'Only one value'
+    } else if (annotation.values.length > GROUP_VIZ_THRESHOLD_MAX) {
+      annotLabel = 'Too many values'
+    } else {
+      annotLabel = 'Ontology label used'
+    }
     return `${annotation.name} (${annotLabel})`
   } else {
     return annotation.name

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -111,7 +111,7 @@ class AnnotationVizService
   # returns a flat array of annotation objects, with name, scope, annotation_type, and values for each
   def self.available_annotations(study, cluster: nil, current_user: nil, annotation_type: nil)
     annotations = []
-    metadata_annots = available_metadata_annotations(study, annotation_type)
+    metadata_annots = available_metadata_annotations(study, annotation_type: annotation_type)
     annotations.concat(metadata_annots)
     cluster_annots = []
     if cluster.present?
@@ -139,8 +139,9 @@ class AnnotationVizService
     all_metadata = study.cell_metadata.to_a
     all_names = all_metadata.map(&:name)
     all_metadata.map do |annot|
-      # viewable if the type is numeric or there's no corresponding label
-      is_viewable = annot.annotation_type == 'numeric' || all_names.exclude?(annot.name + '__ontology_label')
+      # viewable if the type is numeric or there's no corresponding label and it's within the range of visualization values
+      is_viewable = annot.annotation_type == 'numeric' ||
+        all_names.exclude?(annot.name + '__ontology_label') && CellMetadatum::GROUP_VIZ_THRESHOLD === annot.values.size
       {
         name: annot.name,
         type: annot.annotation_type,

--- a/test/integration/lib/annotation_viz_service_test.rb
+++ b/test/integration/lib/annotation_viz_service_test.rb
@@ -119,4 +119,26 @@ class AnnotationVizServiceTest < ActiveSupport::TestCase
     assert species_annot.present?
     assert_equal 'invalid', species_annot[:scope]
   end
+
+  test 'should mark metadata ontology annotation validity' do
+    study = FactoryBot.create(:detached_study,
+                              name_prefix: 'metadata ontology',
+                              user: @user,
+                              test_array: @@studies_to_clean)
+
+    FactoryBot.create(:metadata_file, name: 'metadata.txt', study: study, annotation_input: [
+      { name: 'species', type: 'group', values: %w[id1 id1 id2] },
+      { name: 'species__ontology_label', type: 'group', values: %w[dog dog cat] },
+    ])
+    annots = AnnotationVizService.available_annotations(study)
+    assert_equal 2, annots.size
+    species_annot = annots.detect { |a| a[:name] == 'species' }
+    assert species_annot.present?
+    assert_equal 'invalid', species_annot[:scope]
+
+    species_label_annot = annots.detect { |a| a[:name] == 'species__ontology_label' }
+    assert species_label_annot.present?
+    assert_equal 'study', species_label_annot[:scope]
+
+  end
 end


### PR DESCRIPTION
SCP-4018.  We are currently making 2 calls per metadata column on every study overview page load (and then we make the same calls again for the explore_info endpoint).   So for a convention compliant study, that's often 40+ calls.   Put together, these calls represented almost a third of DB calls for loading a convention-compliant study in the explore tab.  This consolidates that down to one call each.  There is certainly other work to be done on SCP-4018, but this seemed a big enough chunk that it was worth its own PR.

This also fixes a bug where annotations that were not shown due to having a corresponding ontology label were instead listed as having 'too many labels'

TO TEST:
 1. load a metadata-compliant study in explore tab.  
 2. confirm it renders correctly, and all annotations appear
 3. Confirm the default cluster&annotation menus in the study settings tab render and operate correctly
 3.   run `rails test test/integration/lib/annotation_viz_service_test.rb`