### PR TITLE
Align CSFV annotation errorTypes names with Ingest Pipeline (SCP-4046)

### DIFF
--- a/app/javascript/lib/validation/expression-matrices-validation.js
+++ b/app/javascript/lib/validation/expression-matrices-validation.js
@@ -108,7 +108,7 @@ function validateUniqueRowValuesWithinFile(rawLine, isLastLine, dataObj) {
     const nameTxt = (dataObj.duplicateRowValues.size > 1) ? 'duplicates' : 'duplicate'
     const dupString = [...dataObj.duplicateRowValues].slice(0, 10).join(', ')
     const msg = `Row values must be unique within a file. ${dataObj.duplicateRowValues.size} ${nameTxt} found, including: ${dupString}`
-    issues.push(['error', 'duplicate:values-within-file', msg])
+    issues.push(['error', 'content:duplicate:values-within-file', msg])
   }
   return issues
 }
@@ -249,7 +249,7 @@ function validateGeneInHeader(headers) {
   const issues = []
   if (headers[0].toUpperCase() !== 'GENE') {
     const msg = 'Dense matrices require the first value of the file to be "GENE". ' +
-       `However, the first value for this file is "${headers[0]}".`
+      `However, the first value for this file is "${headers[0]}".`
     issues.push(['error', 'format:cap:missing-gene-column', msg])
   }
 

--- a/app/javascript/lib/validation/shared-validation.js
+++ b/app/javascript/lib/validation/shared-validation.js
@@ -22,7 +22,7 @@ export async function getParsedHeaderLines(chunker, mimeType) {
   }, 2)
   if (headerLines.length < 2 || headerLines.some(hl => hl.length === 0)) {
     throw new ParseException('format:cap:missing-header-lines',
-        `Your file is missing newlines or some required header lines`)
+      `Your file is missing newlines or some required header lines`)
   }
   const delimiter = sniffDelimiter(headerLines, mimeType)
   const headers = headerLines.map(l => parseLine(l, delimiter))
@@ -93,7 +93,7 @@ export function validateUniqueCellNamesWithinFile(line, isLastLine, dataObj) {
     const nameTxt = (dataObj.duplicateCellNames.size > 1) ? 'duplicates' : 'duplicate'
     const dupString = [...dataObj.duplicateCellNames].slice(0, 10).join(', ')
     const msg = `Cell names must be unique within a file. ${dataObj.duplicateCellNames.size} ${nameTxt} found, including: ${dupString}`
-    issues.push(['error', 'duplicate:cells-within-file', msg])
+    issues.push(['error', 'content:duplicate:cells-within-file', msg])
   }
   return issues
 }
@@ -110,11 +110,11 @@ export function validateMetadataLabelMatches(headers, line, isLastLine, dataObj)
   // if this is the first time through, identify the columns to check, and initialize data structures to track mismatches
   if (!dataObj.dragCheckColumns) {
     dataObj.dragCheckColumns = headers[0].map((colName, index) => {
-      const labelColumnIndex = headers[0].indexOf(`${colName }__ontology_label`)
+      const labelColumnIndex = headers[0].indexOf(`${colName}__ontology_label`)
       if (excludedColumns.includes(colName) ||
-          colName.endsWith('ontology_label') ||
-          headers[1][index] === 'numeric' ||
-          labelColumnIndex === -1) {
+        colName.endsWith('ontology_label') ||
+        headers[1][index] === 'numeric' ||
+        labelColumnIndex === -1) {
         return null
       }
       // for each column, track a hash of label=>value,
@@ -141,8 +141,8 @@ export function validateMetadataLabelMatches(headers, line, isLastLine, dataObj)
     dataObj.dragCheckColumns.forEach(dcc => {
       if (dcc.mismatchedVals.size > 0) {
         const labelString = [...dcc.mismatchedVals].slice(0, 10).join(', ')
-        const moreLabelsString = dcc.mismatchedVals.size > 10 ? ` and ${dcc.mismatchedVals.size - 10} others`: ''
-        issues.push(['error', 'content:metadata:mismatched-id-label',
+        const moreLabelsString = dcc.mismatchedVals.size > 10 ? ` and ${dcc.mismatchedVals.size - 10} others` : ''
+        issues.push(['error', 'ontology:multiply-assigned-label',
           `${dcc.colName} has different ID values mapped to the same label.
           Label(s) with more than one corresponding ID: ${labelString}${moreLabelsString}`])
       }

--- a/test/js/lib/validate-file-content.test.js
+++ b/test/js/lib/validate-file-content.test.js
@@ -14,7 +14,7 @@ describe('Client-side file validation', () => {
     const fileType = 'Metadata'
 
     const fakeLog = jest.spyOn(MetricsApi, 'log')
-    fakeLog.mockImplementation(() => {})
+    fakeLog.mockImplementation(() => { })
 
     const expectedSummary = 'Your file had 1 error'
 
@@ -76,7 +76,7 @@ describe('Client-side file validation', () => {
     })
     const { errors } = await validateFileContent(file, 'Cluster')
     expect(errors).toHaveLength(1)
-    expect(errors[0][1]).toEqual('duplicate:cells-within-file')
+    expect(errors[0][1]).toEqual('content:duplicate:cells-within-file')
     expect(errors[0][2]).toEqual('Cell names must be unique within a file. 1 duplicate found, including: CELL_0001')
   })
 
@@ -87,7 +87,7 @@ describe('Client-side file validation', () => {
     })
     const { errors } = await validateFileContent(file, 'Expression Matrix')
     expect(errors).toHaveLength(1)
-    expect(errors[0][1]).toEqual('duplicate:cells-within-file')
+    expect(errors[0][1]).toEqual('content:duplicate:cells-within-file')
   })
 
   it('catches missing headers in metadata file', async () => {
@@ -168,7 +168,7 @@ describe('Client-side file validation', () => {
     })
     const { errors } = await validateFileContent(file, '10X Barcodes File')
     expect(errors).toHaveLength(1)
-    expect(errors[0][1]).toEqual('duplicate:values-within-file')
+    expect(errors[0][1]).toEqual('content:duplicate:values-within-file')
   })
 
   it('catches duplicate row values in features file', async () => {
@@ -178,7 +178,7 @@ describe('Client-side file validation', () => {
     })
     const { errors } = await validateFileContent(file, '10X Genes File')
     expect(errors).toHaveLength(1)
-    expect(errors[0][1]).toEqual('duplicate:values-within-file')
+    expect(errors[0][1]).toEqual('content:duplicate:values-within-file')
   })
 
   it('allows missing headers in metadata file if convention not used ', async () => {
@@ -197,7 +197,7 @@ describe('Client-side file validation', () => {
     })
     const { errors } = await validateFileContent(file, 'Metadata', { use_metadata_convention: false })
     expect(errors).toHaveLength(1)
-    expect(errors[0][1]).toEqual('content:metadata:mismatched-id-label')
+    expect(errors[0][1]).toEqual('ontology:multiply-assigned-label')
     expect(errors[0][2]).toContain('Homo sapiens')
     expect(errors[0][2]).toContain('species')
   })


### PR DESCRIPTION
Align CSFV annotation errorTypes names with Ingest Pipeline by making the following changes:
duplicate:cells-within-file -> content:duplicate:cells-within-file
duplicate:values-within-file -> content:duplicate:values-within-file 
content:metadata:mismatched-id-label -> ontology:multiply-assigned-label

To Test: 
In your local instance, try uploading the [excel drag test file](https://raw.githubusercontent.com/broadinstitute/scp-ingest-pipeline/development/tests/data/annotation/metadata/convention/invalid_excel_drag.txt) from scp-ingest-pipeline.

Then in Mixpanel Dev (https://mixpanel.com/project/2085496/view/19055/app/events#)
look for your file-validation event and confirm that errorTypes is now `ontology:multiply-assigned-label` (and not `content:metadata:mismatched-id-label`)

This satisfies SCP-4046 and supports SCP-3921