### PR TITLE
Adding missing response object key in `DataRepoClientTest#test_should_get_snapshot` (SCP-4047)

### DIFF
--- a/test/integration/data_repo_client_test.rb
+++ b/test/integration/data_repo_client_test.rb
@@ -142,8 +142,8 @@ class DataRepoClientTest < ActiveSupport::TestCase
     skip_if_api_down
     snapshot = @data_repo_client.get_snapshot(@snapshot_id)
     assert snapshot.present?
-    expected_keys = %w[id name description createdDate source tables
-                       relationships profileId dataProject accessInformation].sort
+    expected_keys = %w[id name description createdDate creationInformation source tables relationships profileId
+                       dataProject accessInformation].sort
     assert_equal expected_keys, snapshot.keys.sort
   end
 


### PR DESCRIPTION
This update fixes a newly broken test where the response object from Terra Data Repo now has a new `creationInformation` hash.

MANUAL TESTING
1. Pull this branch and run `./rails_local_setup.rb && source config/secrets/.source_env.bash`
2. Run `bin/rails test test/integration/data_repo_client_test.rb` and validate that `test_should_get_snapshot` passes

This PR satisfies SCP-4047.