### PR TITLE
Fixing collection count in banner (SCP-4050)

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -50,7 +50,7 @@ class SiteController < ApplicationController
 
     # filter list if in branding group mode
     if @selected_branding_group.present?
-      @viewable = @viewable.where(branding_group_id: @selected_branding_group.id)
+      @viewable = @viewable.where(:branding_group_ids.in => [@selected_branding_group.id])
     end
 
     # determine study/cell count based on viewable to user


### PR DESCRIPTION
This update fixes a discrepancy between the number of studies shown in the banner when a collection is loaded, and the count displayed for an empty search result.  This had to do with a previous PR to allow for [studies to be in multiple collections](https://github.com/broadinstitute/single_cell_portal_core/pull/1265) that changed how the association was stored in the database, and the count for the banner was never updated to reflect this change (though search requests were, hence the discrepancy).

MANUAL TESTING
1. Boot as normal
2. If you have no collections in your local instance, either create one and add studies to it, or run the `SyntheticBrandingGroupPopulator` to create some
3. Open the collection view page, and select a collection (make a note of how many studies should be in it as well)
4. Back on the home page, validate that the number displayed in the banner matches the number of studies that show in the search results box
![Screen Shot 2022-01-31 at 3 33 53 PM](https://user-images.githubusercontent.com/729968/151868895-c3d15e0c-90e5-4580-80ed-5409b2b10a48.png)

This PR satisfies SCP-4050.