### PR TITLE
Update production to use ingest release 1.13.0

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.12.4'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.13.0'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
[Details on changes and testing](https://github.com/broadinstitute/scp-ingest-pipeline/pull/228) in ingest pipeline Release 1.13.0, with this PR the docker image should not need to be set manually for tests.