### PR TITLE
Adding feature_flag info to study file_info endpoint (SCP-3955)

### DIFF
--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -92,7 +92,7 @@ module Api
             'Studies'
           ]
           key :summary, 'Get Study info'
-          key :description, 'Gets information about a single Study'
+          key :description, 'Gets attribute, file, feature flag, and configuration information about a single Study'
           key :operationId, 'study_file_info_path'
           parameter do
             key :name, :id
@@ -118,7 +118,7 @@ module Api
               property :feature_flags do
                 key :type, :object
                 key :title, 'FeatureFlagOptions'
-                key :description, 'Hash of FeatureFlagOption values w/ defaults, e.g. flag_name => flag_value'
+                key :description, 'Hash of FeatureFlagOption values with defaults, e.g. flag_name => flag_value'
               end
               property :menu_options do
                 key :type, :object
@@ -189,6 +189,7 @@ module Api
                     property :name do
                       key :type, :string
                     end
+                    # show ID of associated parent Taxon for storing belongs_to association
                     property :taxon_id do
                       key :type, :string
                     end

--- a/app/javascript/components/upload/MetadataStep.js
+++ b/app/javascript/components/upload/MetadataStep.js
@@ -37,7 +37,7 @@ function MetadataForm({
   bucketName
 }) {
   const userState = useContext(UserContext)
-  const featureFlagState = userState.featureFlagsWithDefaults
+  const featureFlagState = serverState.feature_flags
   const conventionRequired = featureFlagState && featureFlagState.convention_required
 
   const file = formState.files.find(metadataFileFilter)

--- a/app/javascript/components/upload/ProcessedExpressionStep.js
+++ b/app/javascript/components/upload/ProcessedExpressionStep.js
@@ -2,7 +2,6 @@ import React, { useEffect, useContext } from 'react'
 
 import ExpressionFileForm from './ExpressionFileForm'
 import { rawCountsFileFilter, expressionFileStructureHelp } from './RawCountsStep'
-import { UserContext } from 'providers/UserProvider'
 import { AddFileButton } from './form-components'
 
 const DEFAULT_NEW_PROCESSED_FILE = {
@@ -42,8 +41,7 @@ function ProcessedUploadForm({
   const rawCountsFiles = formState.files.filter(rawCountsFileFilter).filter(f => f.status != 'new')
   const rawCountsOptions = rawCountsFiles.map(rf => ({ label: rf.name, value: rf._id }))
 
-  const userState = useContext(UserContext)
-  const featureFlagState = userState.featureFlagsWithDefaults
+  const featureFlagState = serverState.feature_flags
   const rawCountsRequired = featureFlagState && featureFlagState.raw_counts_required_frontend
 
   const hasRawCounts = !!rawCountsFiles.filter(file => file.status === 'uploaded').length

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -231,7 +231,7 @@
 <input type="hidden" id="user-provider-info" value='<%=
   {
     email: current_user&.email,
-    featureFlagsWithDefaults: FeatureFlaggable.feature_flags_for_instances(@selected_branding_group, current_user)
+    featureFlagsWithDefaults: FeatureFlaggable.feature_flags_for_instances(@selected_branding_group, current_user, @study)
   }.to_json %>'/>
 </body>
 </html>

--- a/test/api/studies_controller_test.rb
+++ b/test/api/studies_controller_test.rb
@@ -14,11 +14,13 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
                                public: true,
                                test_array: @@studies_to_clean)
     @random_seed = SecureRandom.uuid
+    @feature_flag = FeatureFlag.create(name: 'my_flag', default_value: false)
     sign_in_and_update @user
   end
 
   after(:all) do
     Study.where(name: /#{@random_seed}/).map(&:destroy_and_remove_workspace)
+    @feature_flag.destroy
   end
 
   teardown do
@@ -179,5 +181,28 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
     }
     execute_http_request(:patch, api_v1_study_path(id: @study.id.to_s), request_payload: update_attributes, user: @user_2)
     assert_response 403
+  end
+
+  test 'should get study file_info hash' do
+    sign_in_and_update(@user)
+    execute_http_request(:get, file_info_api_v1_study_path(@study.accession), user: @user)
+    assert_response :success
+    %i[study files feature_flags menu_options].each do |key|
+      assert json[key].present?
+    end
+    # validate that feature flags are represented
+    @user.set_flag_option(@feature_flag.name, true)
+    @user.reload
+    execute_http_request(:get, file_info_api_v1_study_path(@study.accession), user: @user)
+    assert_response :success
+    returned_flag = json.dig('feature_flags', @feature_flag.name)
+    assert returned_flag
+    # confirm study overrides user flags
+    @study.set_flag_option(@feature_flag.name, false)
+    @study.reload
+    execute_http_request(:get, file_info_api_v1_study_path(@study.accession), user: @user)
+    assert_response :success
+    returned_flag = json.dig('feature_flags', @feature_flag.name)
+    assert_not returned_flag
   end
 end

--- a/test/api/studies_controller_test.rb
+++ b/test/api/studies_controller_test.rb
@@ -187,7 +187,7 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
     sign_in_and_update(@user)
     execute_http_request(:get, file_info_api_v1_study_path(@study.accession), user: @user)
     assert_response :success
-    %i[study files feature_flags menu_options].each do |key|
+    %w[study files feature_flags menu_options].each do |key|
       assert json[key].present?
     end
     # validate that feature flags are represented

--- a/test/api/studies_controller_test.rb
+++ b/test/api/studies_controller_test.rb
@@ -188,7 +188,7 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
     execute_http_request(:get, file_info_api_v1_study_path(@study.accession), user: @user)
     assert_response :success
     %w[study files feature_flags menu_options].each do |key|
-      assert json[key].present?
+      assert json.keys.include?(key), "Did not find #{key} in json response: #{json.keys}"
     end
     # validate that feature flags are represented
     @user.set_flag_option(@feature_flag.name, true)

--- a/test/js/upload-wizard/file-info-responses.js
+++ b/test/js/upload-wizard/file-info-responses.js
@@ -538,5 +538,6 @@ export const EMPTY_STUDY = {
     'accession': 'SCP34'
   },
   files: [],
+  feature_flags: {},
   menu_options: BASIC_MENU_OPTIONS
 }

--- a/test/js/upload-wizard/upload-wizard-test-utils.js
+++ b/test/js/upload-wizard/upload-wizard-test-utils.js
@@ -24,6 +24,9 @@ export function getSelectByLabelText(screen, text) {
 export async function renderWizardWithStudy({
   studyInfo=EMPTY_STUDY, featureFlags={}, studyAccession='SCP1', studyName='Chickens'
 }) {
+  // merge featureFlags data into studyInfo.feature_flags since this is where the upload wizard looks now
+  studyInfo.feature_flags = featureFlags
+
   const studyInfoSpy = jest.spyOn(ScpApi, 'fetchStudyFileInfo')
   // pass in a clone of the response since it may get modified by the cache operations
   studyInfoSpy.mockImplementation(params => {


### PR DESCRIPTION
This update allows for `FeatureFlagOption` info to be retrieved from the `Api::V1::StudiesController#file_info` endpoint.  This now allows for the React upload wizard to check for user- or study-based exemptions for raw counts & metadata convention.  This simplifies the feature flag checking code, and allows for future refactoring to remove DOM-based rendering/reading of `FeatureFlagOption` values and pivot to an API-based model.  This update also swaggerizes the `Api::V1::StudiesController#file_info` endpoint for easier testing/debugging moving forward.

MANUAL TESTING
1. Boot as normal
2. In the rails console, set the `default_value` for `raw_counts_required_frontend` to `true`
```
FeatureFlag.find_by(name: 'raw_counts_required_frontend').update(default_value: true)
```
3. Back in the UI, sign in with an admin account and go to the upload wizard for any study that has no raw count expression files and click into the 'processed expression' tab
4. Validate that the upload form is disabled:
![Screen Shot 2022-02-01 at 2 14 37 PM](https://user-images.githubusercontent.com/729968/152036727-090edfb0-0d2c-474e-9fc7-d279408aff3b.png)
5. In a separate tab, go to the 'Feature Flags' admin console by selecting 'Feature Flags' from the profile dropdown menu
6. Select `study` for `Object class`, and then enter the accession the study from above
![Screen Shot 2022-02-01 at 2 25 34 PM](https://user-images.githubusercontent.com/729968/152037083-3e5155f0-071b-4c42-83c8-d781d359973b.png)
7. Set the value for `raw_counts_required_frontend` to `false` and save
8. Back in the upload wizard, refresh the page and validate that the form is now enabled
![Screen Shot 2022-02-01 at 2 11 46 PM](https://user-images.githubusercontent.com/729968/152037397-80841199-83fe-413e-9a61-4848b3fad92d.png)
9. (Optional) Back in the Feature Flag console, select `user` for `Object class` and enter the email of the current user
10. (Optional) Set `raw_counts_required_frontend` to `true` and save
11. (Optional) Back in the upload wizard, refresh the page and validate that the form is still enabled (study-based feature flags should take precedence over user-based ones in the upload wizard)

This PR satisfies SCP-3955.
