### PR TITLE
Link to sync survey (SCP-4015)

### DIFF
--- a/app/views/studies/sync_study.html.erb
+++ b/app/views/studies/sync_study.html.erb
@@ -13,6 +13,20 @@
     </p>
   </div>
 </div>
+<a
+  href="https://forms.gle/V6uT94jbGq5pTeMG6"
+  class="btn btn-primary"
+  rel="noopener"
+  data-analytics-name="sync-survey-link"
+  data-toggle="tooltip"
+  data-original-title="Go to survey"
+  data-placement="right"
+  style="margin: 5px;"
+>
+  Take a 3-question survey to help improve sync
+</a>
+
+
 <% if params[:configuration_name].present? && @special_sync %>
   <div class="bs-callout bs-callout-default">
     <h4>Specialized sync for: <span class="label label-primary"><%= params[:configuration_name] %></span></h4>

--- a/app/views/studies/sync_study.html.erb
+++ b/app/views/studies/sync_study.html.erb
@@ -13,18 +13,21 @@
     </p>
   </div>
 </div>
-<a
-  href="https://forms.gle/V6uT94jbGq5pTeMG6"
-  class="btn btn-primary"
-  rel="noopener"
-  data-analytics-name="sync-survey-link"
-  data-toggle="tooltip"
-  data-original-title="Go to survey"
-  data-placement="right"
-  style="margin: 5px;"
->
-  Take a 3-question survey to help improve sync
-</a>
+<div class="row">
+  <div class="col-md-12 bottom-pad">
+    <a
+      href="https://forms.gle/V6uT94jbGq5pTeMG6"
+      class="btn terra-secondary-btn"
+      rel="noopener"
+      data-analytics-name="sync-survey-link"
+      data-toggle="tooltip"
+      data-original-title="Go to survey"
+      data-placement="right"
+    >
+      Take a 3-question survey to help improve sync
+    </a>
+  </div>
+</div>
 
 
 <% if params[:configuration_name].present? && @special_sync %>


### PR DESCRIPTION
This adds a link to a Google Forms [survey about sync](https://forms.gle/V6uT94jbGq5pTeMG6).  Here's how it looks:

https://user-images.githubusercontent.com/1334561/152177135-e50d0041-7f88-4b61-a94c-298ec8bf0c53.mov

Two notes to clarify things that might stand out:
* Omitting `noreferrer` has been secure for almost 5 years; see [details](https://github.com/broadinstitute/single_cell_portal_core/pull/1328#discussion_r790874788)
* Given this is intended as brief, unique link, styling inline seems most maintainable

To test:
* Go to sync page
* Confirm link appears at top of page
* Click link
* Confirm it goes to survey

This satisfies SCP-4015.