### PR TITLE
making sync survey link open new tab (SCP-4015)

### DIFF
--- a/app/views/studies/sync_study.html.erb
+++ b/app/views/studies/sync_study.html.erb
@@ -19,6 +19,7 @@
       href="https://forms.gle/V6uT94jbGq5pTeMG6"
       class="btn terra-secondary-btn"
       rel="noopener"
+      target="_blank"
       data-analytics-name="sync-survey-link"
       data-toggle="tooltip"
       data-original-title="Go to survey"


### PR DESCRIPTION
Oops, I was too busy bikeshedding the button styling when testing to notice that it wasn't opening a new tab.

TO TEST:
1. click on survey link in sync tool
2. confirm it opens the survey in a new tab