### PR TITLE
Skip Azul file query if no project files requested in bulk download (SCP-4072)

### DIFF
--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -86,6 +86,9 @@ class BulkDownloadService
         # now process remainder of analysis/sequence files for download
         # each file_info hash will contain project IDs and file_types that can be used in a single query to Azul
         # to get all matching files
+        # if no other files, skip to next project
+        next if files.empty?
+
         project_id = files.first['project_id'] # project_id is same for all entries in this block
         file_query = { 'projectId' => { 'is' => [project_id] } }
         files.each do |file_info|


### PR DESCRIPTION
This update fixes a bug in generating curl configurations for HCA projects when there are no analysis/sequence files requested or available for a given project.  The `BulkDownloadService` will now skip generating the file query for the specified project.

MANUAL TESTING
1. Boot as normal and sign in with an account with `cross_dataset_search_backend` enabled
2. Run a search for `species:Homo sapiens` and `disease:COVID-19`
3. Click the `Download` button, and unselect everything except for the entry for `A molecular single-cell lung atlas of lethal COVID-19`
4. Proceed all the way through the bulk download process (including pasting the command into the terminal) and validate that the command completes successfully

This PR satisfies SCP-4072.