### PR TITLE
add 10x 5' v1 as library_preparation_protocol option (SCP-4048)

### DIFF
--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -35,6 +35,7 @@ class ExpressionFileInfo
   LIBRARY_PREPARATION_VALUES = ["10x 3' v1",
                                 "10x 3' v2",
                                 "10x 3' v3",
+                                "10x 5' v1",
                                 "10x 5' v2",
                                 "10x 5' v3",
                                 'CEL-seq2',


### PR DESCRIPTION
A user pointed out [via zendesk](https://broadinstitute.zendesk.com/agent/tickets/267401) we have `10x 5' v2` and `10x 5' v3` in our library_preparation_protocol dropdown but not `10x 5' v1`

Because there are already several files annotated as `10x 5' v3`, this PR merely adds `10x 5' v1` to the list of options.

To test:
in your local instance, verify that `10x 5' v1` now appears in the dropdown list for library preparation protocol