### PR TITLE
Exclude stop words from text-based queries (SCP-4077)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -3,17 +3,6 @@ module Api
     class SearchController < ApiBaseController
       include StudySearchResultsObjects
 
-      # list of common 'stop words' to scrub from term-based search requests
-      # these are unhelpful in search contexts as they artificially inflate irrelevant results
-      # from https://gist.github.com/sebleier/554280
-      STOP_WORDS = %w[i me my myself we our ours ourselves you your yours yourself yourselves he him his himself she
-                      her hers herself it its itself they them their theirs themselves what which who whom this that
-                      these those am is are was were be been being have has had having do does did doing a an the and
-                      but if or because as until while of at by for with about against between into through during
-                      before after above below to from up down in out on off over under again further then once here
-                      there when where why how all any both each few more most other some such no nor not only own same
-                      so than too very s t can will just don should now].freeze
-
       # regex to match on 'sequence_file' and 'analysis_file' entries from TDR
       TDR_FILE_OUTPUT_TYPE_MATCH = /_file/.freeze
 
@@ -508,7 +497,7 @@ module Api
 
       # exclude known stop words from a list of terms to increase search result relevance
       def self.reject_stop_words_from_terms(terms)
-        terms&.reject { |t| STOP_WORDS.include? t } || []
+        terms&.reject { |t| ::StudySearchService::STOP_WORDS.include? t } || []
       end
 
       # escape regular expression control characters from list of search terms and format for search

--- a/app/lib/study_search_service.rb
+++ b/app/lib/study_search_service.rb
@@ -1,9 +1,20 @@
 # collection of methods for searching studies
-
 class StudySearchService
 
   MAX_GENE_SEARCH = 50
-  MAX_GENE_SEARCH_MSG = "For performance reasons, gene search is limited to #{MAX_GENE_SEARCH} genes. Please use multiple searches to view more genes."
+  MAX_GENE_SEARCH_MSG = "For performance reasons, gene search is limited to #{MAX_GENE_SEARCH} genes. Please use " \
+                        'multiple searches to view more genes.'.freeze
+
+  # list of common 'stop words' to scrub from term-based search requests
+  # these are unhelpful in search contexts as they artificially inflate irrelevant results
+  # from https://gist.github.com/sebleier/554280
+  STOP_WORDS = %w[i me my myself we our ours ourselves you your yours yourself yourselves he him his himself she
+                  her hers herself it its itself they them their theirs themselves what which who whom this that
+                  these those am is are was were be been being have has had having do does did doing a an the and
+                  but if or because as until while of at by for with about against between into through during
+                  before after above below to from up down in out on off over under again further then once here
+                  there when where why how all any both each few more most other some such no nor not only own same
+                  so than too very s t can will just don should now].freeze
 
   def self.find_studies_by_gene_param(gene_param, study_ids)
     genes = sanitize_gene_params(gene_param)

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -410,4 +410,16 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     expected_value = "10X 3\\' v3"
     assert_equal expected_value, sanitized_filter
   end
+
+  test 'should filter stop words from queries' do
+    terms = %w[human mouse study data]
+    filtered_terms = Api::V1::SearchController.reject_stop_words_from_terms(terms)
+    assert_equal terms, filtered_terms
+    stop_words = %w[in the about at on for]
+    filtered_terms = Api::V1::SearchController.reject_stop_words_from_terms(stop_words)
+    assert_empty filtered_terms
+    mixed_query = terms + stop_words
+    filtered_terms = Api::V1::SearchController.reject_stop_words_from_terms(mixed_query)
+    assert_equal terms, filtered_terms
+  end
 end


### PR DESCRIPTION
[Stop words](https://en.wikipedia.org/wiki/Stop_word) are commonly used words (conjunctions, articles, prepositions) that are excluded from many natural language processing functions.  For instance, when running text index queries in MongoDB, any non-quoted stop words will be automatically filtered out.  This [link](https://singlecell.broadinstitute.org/single_cell?type=study&page=1&terms=of%20for%20the%20in%20about%20at) demonstrates how this is already in effect on production.

However, because we are manually sorting search results (since we have to fold in external results from sources like TDR and Azul), these terms are still being used to sort results by relevance.  SCP currently uses a crude metric where results are ordered by the aggregate count of all term matches.  Studies that contain a large number of stop words in their titles/descriptions will therefore be prioritized over possibly more relevant studies.  This [link](https://singlecell.broadinstitute.org/single_cell?type=study&page=1&terms=Molecular%20logic%20of%20cellular%20diversification%20in%20the%20mouse%20cerebral%20cortex) demonstrates how an unquoted search for an exact study title does not return that study as the first result (it is instead buried on page 10) due to the artificial weighting caused by counting stop words.

This update filters out common stop words using [this list](https://gist.github.com/sebleier/554280) (there is no canonical list that is used across technologies/contexts, and this one is of moderate length, compared to others).  By filtering stop words before any queries are run (even though MongoDB already does this), we do not need to update any downstream weighting/matching code as the unwanted terms have already been excluded.

MANUAL TESTING
1. Boot as normal
2. For the best results, run `SyntheticStudyPopulator.populate_all` if you are missing most of the synthetic studies, specifically `Tuberculosis subtypes in human male, blood study with arrays`
3. Run a text search for `Tuberculosis subtypes in human male`, without quotes
4. Validate that this study is returned first, specifically ahead of `Human retinal cells and retinopathy`, which would have had a higher weighting based on the word `in`
5. Validate that the word `in` is not highlighted in any result

This PR satisfies SCP-4077.