### PR TITLE
adding feature flag to reference images (SCP-4067)

### DIFF
--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -45,18 +45,27 @@ const STEPS = [
   ClusteringStep,
   SpatialStep,
   CoordinateLabelStep,
-  ImageStep,
   SequenceFileStep,
   GeneListStep,
   MiscellaneousStep
 ]
 
 const MAIN_STEPS = STEPS.slice(0, 4)
-const SUPPLEMENTAL_STEPS = STEPS.slice(4, 11)
+const SUPPLEMENTAL_STEPS = STEPS.slice(4, STEPS.length)
 
 
 /** shows the upload wizard */
 export function RawUploadWizard({ studyAccession, name }) {
+  const [serverState, setServerState] = useState(null)
+  const [formState, setFormState] = useState(null)
+
+  const allowReferenceImageUpload = serverState?.feature_flags?.reference_image_upload
+
+  if (allowReferenceImageUpload && !STEPS.includes(ImageStep)) {
+    STEPS.splice(5, 0, ImageStep)
+    SUPPLEMENTAL_STEPS.splice(1, 0, ImageStep)
+  }
+
   const routerLocation = useLocation()
   const queryParams = queryString.parse(routerLocation.search)
   let currentStepIndex = STEPS.findIndex(step => step.name === queryParams.tab)
@@ -65,8 +74,6 @@ export function RawUploadWizard({ studyAccession, name }) {
   }
   const currentStep = STEPS[currentStepIndex]
 
-  const [serverState, setServerState] = useState(null)
-  const [formState, setFormState] = useState(null)
 
   // go through the files and compute any relevant derived properties, notably 'isDirty'
   if (serverState?.files && formState?.files) {

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -51,7 +51,7 @@ const STEPS = [
 ]
 
 const MAIN_STEPS = STEPS.slice(0, 4)
-const SUPPLEMENTAL_STEPS = STEPS.slice(4, STEPS.length)
+const SUPPLEMENTAL_STEPS = STEPS.slice(4)
 
 
 /** shows the upload wizard */

--- a/app/views/studies/_study_file_form.html.erb
+++ b/app/views/studies/_study_file_form.html.erb
@@ -1,6 +1,6 @@
 <%
   allow_images = FeatureFlaggable.feature_flags_for_instances(@selected_branding_group, current_user, @study)['reference_image_upload']
-  file_type_hash = allow_images ? StudyFile::STUDY_FILE_TYPE_NAME_HASH :  StudyFile::STUDY_FILE_TYPE_NAME_HASH.except('Image')
+  file_type_hash = allow_images ? StudyFile::STUDY_FILE_TYPE_NAME_HASH : StudyFile::STUDY_FILE_TYPE_NAME_HASH.except('Image')
 %>
 <%= nested_form_for(study_file, url: sync_study_file_study_path(@study._id),
                     html: {multipart: true, id: "study-file-#{study_file._id}" ,

--- a/app/views/studies/_study_file_form.html.erb
+++ b/app/views/studies/_study_file_form.html.erb
@@ -1,3 +1,7 @@
+<%
+  allow_images = FeatureFlaggable.feature_flags_for_instances(@selected_branding_group, current_user, @study)['reference_image_upload']
+  file_type_hash = allow_images ? StudyFile::STUDY_FILE_TYPE_NAME_HASH :  StudyFile::STUDY_FILE_TYPE_NAME_HASH.except('Image')
+%>
 <%= nested_form_for(study_file, url: sync_study_file_study_path(@study._id),
                     html: {multipart: true, id: "study-file-#{study_file._id}" ,
                            class: "bs-callout bs-callout-info unsynced-study-file" }, data: {remote: true}) do |f| %>
@@ -44,7 +48,7 @@
   <div class="form-group row">
     <div class="col-sm-4">
       <%= f.label :file_type %><br />
-      <%= f.select :file_type, options_for_select(StudyFile::STUDY_FILE_TYPE_NAME_HASH.invert, study_file.file_type), {include_blank: 'Please select a file type'}, class: 'form-control file-type' %>
+      <%= f.select :file_type, options_for_select(file_type_hash.invert, study_file.file_type), {include_blank: 'Please select a file type'}, class: 'form-control file-type' %>
     </div>
     <div class="col-sm-4 taxon-select-target">
       <% if StudyFile::TAXON_REQUIRED_TYPES.include?(study_file.file_type) || study_file.file_type == 'Analysis Output' %>

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -417,7 +417,10 @@
   <div id="upload-wizard-target">
   </div>
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-    window.SCP.readOnlyToken = '<%= get_read_access_token(@study, current_user) %>'
+    <% if FeatureFlaggable.feature_flags_for_instances(@selected_branding_group, current_user, @study)['reference_image_upload'] %>
+      <%# if images are enabled, we need the read-only token so we can show already-uploaded images from the bucket for reference %>
+      window.SCP.readOnlyToken = '<%= get_read_access_token(@study, current_user) %>'
+    <% end %>
     $(document).ready(function() {
       window.SCP.renderUploadWizard(document.getElementById('upload-wizard-target'), '<%= @study.accession %>', '<%= @study.name %>')
     })

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -417,6 +417,7 @@
   <div id="upload-wizard-target">
   </div>
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+    window.SCP.readOnlyToken = '<%= get_read_access_token(@study, current_user) %>'
     $(document).ready(function() {
       window.SCP.renderUploadWizard(document.getElementById('upload-wizard-target'), '<%= @study.accession %>', '<%= @study.name %>')
     })

--- a/db/migrate/20220204144540_add_ref_image_flag.rb
+++ b/db/migrate/20220204144540_add_ref_image_flag.rb
@@ -1,0 +1,20 @@
+class AddRefImageFlag < Mongoid::Migration
+  # mirror of FeatureFlag.rb, so this migration won't error if that class is renamed/altered
+  class FeatureFlagMigrator
+    include Mongoid::Document
+    store_in collection: 'feature_flags'
+    field :name, type: String
+    field :default_value, type: Boolean, default: false
+    field :description, type: String
+  end
+
+  def self.up
+    FeatureFlagMigrator.create!(name: 'reference_image_upload',
+                                default_value: false,
+                                description: 'allow reference image upload in the upload wizard')
+  end
+
+  def self.down
+    FeatureFlagMigrator.find_by(name: 'reference_image_upload').destroy
+  end
+end

--- a/test/js/upload-wizard/upload-images.test.js
+++ b/test/js/upload-wizard/upload-images.test.js
@@ -1,17 +1,16 @@
 import { screen, fireEvent, waitForElementToBeRemoved } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import _cloneDeep from 'lodash/cloneDeep'
-import selectEvent from 'react-select-event'
 
 import * as ScpApi from 'lib/scp-api'
 import { IMAGE_FILE } from './file-info-responses'
 import { fireFileSelectionEvent } from '../lib/file-mock-utils'
-import { renderWizardWithStudy, getSelectByLabelText, saveButton } from './upload-wizard-test-utils'
+import { renderWizardWithStudy, saveButton } from './upload-wizard-test-utils'
 
 describe('Upload wizard supports reference images', () => {
   it('validates bad file names, starts upload of JPEG file', async () => {
     const createFileSpy = jest.spyOn(ScpApi, 'createStudyFile')
-    await renderWizardWithStudy({})
+    await renderWizardWithStudy({ featureFlags: { reference_image_upload: true } })
 
     const formData = new FormData()
 

--- a/test/js/upload-wizard/upload-new-study.test.js
+++ b/test/js/upload-wizard/upload-new-study.test.js
@@ -48,7 +48,6 @@ describe('creation of study files', () => {
     expect(screen.getByTestId('spatial-status-badge')).toHaveClass('complete')
     expect(screen.getByTestId('coordinateLabels-status-badge')).toHaveClass('complete')
     expect(screen.getByTestId('sequence-status-badge')).toHaveClass('complete')
-    expect(screen.getByTestId('images-status-badge')).not.toHaveClass('complete')
 
     // now check that we can go back to a previously saved file and it shows correctly
     fireEvent.click(screen.getByText('Processed matrices'))


### PR DESCRIPTION
SCP-4067. Adding a feature flag so most users will not see reference images.  this feature will likely not be turned on and refined until further grant funding comes through.

This does fix a bug--previously image rendering was broken in upload wizard due to a missing token.

TO TEST:
1. run `rails db:migrate` in shell
2. Visit upload wizard -- confirm "Reference Images" does not appear in tabs
3. Visit sync tool -- confirm 'Image' is not an available file type
4. run `FeatureFlag.find_by(name: 'reference_image_upload').update!(default_value: true)` in console
5. visit upload wizard, confirm Reference Image capability appears

