### PR TITLE
Allow trailing whitespace on sparse matrix (SCP-4063)

### DIFF
--- a/app/javascript/lib/validation/expression-matrices-validation.js
+++ b/app/javascript/lib/validation/expression-matrices-validation.js
@@ -356,7 +356,7 @@ function validateValuesAreNumeric(line, isLastLine, lineNum, dataObj) {
 }
 
 /**
-   * Validate the first line in the sparse Matrix begins with '%%MatrixMarket'
+   * Validate the first line in the sparse matrix begins with '%%MatrixMarket'
    */
 function validateMTXHeaderLine(line) {
   const issues = []

--- a/app/javascript/lib/validation/expression-matrices-validation.js
+++ b/app/javascript/lib/validation/expression-matrices-validation.js
@@ -42,12 +42,15 @@ export async function parseSparseMatrixFile(chunker, mimeType, fileOptions) {
   await chunker.iterateLines(rawLine => {
     rawHeaderLine = rawLine
   }, 1)
+  const header = rawHeaderLine.trim().split(whitespaceDelimiter)
 
-  issues = validateMTXHeaderLine(rawHeaderLine)
+  issues = validateMTXHeaderLine(header)
 
   await chunker.iterateLines((rawLine, lineNum, isLastLine) => {
-    issues = issues.concat(validateSparseColumnNumber(rawLine, isLastLine, lineNum, dataObj))
-    issues = issues.concat(validateSparseNoBlankLines(rawLine, isLastLine, lineNum, dataObj))
+    const line = rawLine.trim().split(whitespaceDelimiter)
+
+    issues = issues.concat(validateSparseColumnNumber(line, isLastLine, lineNum, dataObj))
+    issues = issues.concat(validateSparseNoBlankLines(line, isLastLine, lineNum, dataObj))
     // add other line-by-line validations here
   })
   return { issues, whitespaceDelimiter, numColumns: dataObj.correctNumberOfColumns }
@@ -265,7 +268,7 @@ function validateSparseNoBlankLines(line, isLastLine, lineNum, dataObj) {
   dataObj.blankLineRows = dataObj.blankLineRows ? dataObj.blankLineRows : []
 
   // if the line is empty, note it
-  if (line.trim().length === 0) {
+  if (line.length === 1 && line[0] === '') {
     dataObj.blankLineRows.push(lineNum)
   }
 
@@ -295,8 +298,8 @@ function validateSparseColumnNumber(line, isLastLine, lineNum, dataObj) {
   dataObj.correctNumberOfColumns = dataObj.correctNumberOfColumns ? dataObj.correctNumberOfColumns : ''
 
   // use the first non-comment, non-blank, non-header row to determine correct number of columns
-  if (!line.startsWith('%') && line.trim().length > 0) {
-    const numColumns = line.split(whitespaceDelimiter).length
+  if ((line[0] !== '%') && line.length > 1 && line[0] !== '') {
+    const numColumns = line.length
     dataObj.correctNumberOfColumns = dataObj.correctNumberOfColumns ? dataObj.correctNumberOfColumns : numColumns
     if (dataObj.correctNumberOfColumns !== numColumns) {
       dataObj.rowsWithWrongColumnNumbers.push(lineNum)
@@ -353,13 +356,12 @@ function validateValuesAreNumeric(line, isLastLine, lineNum, dataObj) {
 }
 
 /**
-   * Validate the first line in the sparse Matrix begins with the string '%%MatrixMarket'
+   * Validate the first line in the sparse Matrix begins with '%%MatrixMarket'
    */
 function validateMTXHeaderLine(line) {
   const issues = []
-  const mtxHeader = line.slice(0, 14)
-  if (mtxHeader !== '%%MatrixMarket') {
-    const msg = `First line must begin with "%%MatrixMarket", not "${mtxHeader}"`
+  if (line[0] !== '%%MatrixMarket') {
+    const msg = `First line must begin with "%%MatrixMarket", not "${line}"`
     issues.push(['error', 'format:cap:missing-mtx-value', msg])
   }
 

--- a/app/javascript/lib/validation/expression-matrices-validation.js
+++ b/app/javascript/lib/validation/expression-matrices-validation.js
@@ -361,7 +361,7 @@ function validateValuesAreNumeric(line, isLastLine, lineNum, dataObj) {
 function validateMTXHeaderLine(line) {
   const issues = []
   if (line[0] !== '%%MatrixMarket') {
-    const msg = `First line must begin with "%%MatrixMarket", not "${line}"`
+    const msg = `First line must begin with "%%MatrixMarket", not "${line[0]}"`
     issues.push(['error', 'format:cap:missing-mtx-value', msg])
   }
 

--- a/db/seed/synthetic_studies/human_raw_counts/raw1_human_5k_cells_80_genes.raw_sparse.mtx
+++ b/db/seed/synthetic_studies/human_raw_counts/raw1_human_5k_cells_80_genes.raw_sparse.mtx
@@ -1,5 +1,5 @@
 %%MatrixMarket matrix coordinate integer general
-80 5120 81920 
+80 5120 82003 
 1 1 1
 1 7 2
 1 12 2


### PR DESCRIPTION
Scanpy and ingest pipeline don't care if a sparse matrix has trailing whitespace, they just ignore it so this updates the CSFV to also ignore that.

To test:
- pull this branch
- attempt to upload a sparse matrix that has trailing white spaces on any of the rows and there should be no error

Also updated a test file that had the incorrect number of lines listed.