### PR TITLE
Asynchronously loading the analysis tab (SCP-4071)

### DIFF
--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -636,17 +636,7 @@ module Api
       end
 
       def get_study_submissions
-        workspace = ApplicationController.firecloud_client.get_workspace(@study.firecloud_project, @study.firecloud_workspace)
-        @submissions = ApplicationController.firecloud_client.get_workspace_submissions(@study.firecloud_project, @study.firecloud_workspace)
-        # update any AnalysisSubmission records with new statuses
-        @submissions.each do |submission|
-          update_analysis_submission(submission)
-        end
-        # remove deleted submissions from list of runs
-        if !workspace['workspace']['attributes']['deleted_submissions'].blank?
-          deleted_submissions = workspace['workspace']['attributes']['deleted_submissions']['items']
-          @submissions.delete_if {|submission| deleted_submissions.include?(submission['submissionId'])}
-        end
+        @submissions = TerraAnalysisService.list_submissions(@study)
         render json: @submissions
       end
 

--- a/app/controllers/api/v1/visualization/explore_controller.rb
+++ b/app/controllers/api/v1/visualization/explore_controller.rb
@@ -140,9 +140,9 @@ module Api
           render json: {
             annotations: AnnotationVizService.available_annotations(@study, cluster: nil, current_user: current_api_user),
             canEdit: @study.can_edit?(current_api_user),
-            allow_firecloud_access: allow_firecloud_access,
-            can_compute: can_compute,
-            analysis_tab_content: analysis_tab_content
+            allowFirecloudAccess: allow_firecloud_access,
+            canCompute: can_compute,
+            analysisTabContent: analysis_tab_content
           }
         end
 

--- a/app/controllers/api/v1/visualization/explore_controller.rb
+++ b/app/controllers/api/v1/visualization/explore_controller.rb
@@ -117,9 +117,32 @@ module Api
         end
 
         def study_user_info
+          allow_firecloud_access = AdminConfiguration.firecloud_access_enabled?
+          can_compute = false
+          analysis_tab_content = nil
+          if allow_firecloud_access
+            can_compute = TerraAnalysisService.user_can_compute?(@study, current_api_user)
+            if can_compute
+              submissions = TerraAnalysisService.list_submissions(@study)
+              workflows_list = AnalysisConfiguration.available_analyses
+              # The analysis tab code wasn't worth porting over to React/API due to how rarely it is used, so we just
+              # render the template as a string and pass it via API to get put on the page
+              # See https://marcqualie.com/2020/07/rendering-templates-in-rails-api-controllers for technical detail
+              analysis_tab_content = ActionController::Renderer.for(ApplicationController)
+                .render(partial: '/site/study_analysis', locals: {
+                  '@submissions': submissions,
+                  '@workflows_list': workflows_list,
+                  '@study': @study
+                })
+            end
+          end
+
           render json: {
             annotations: AnnotationVizService.available_annotations(@study, cluster: nil, current_user: current_api_user),
-            canEdit: @study.can_edit?(current_api_user)
+            canEdit: @study.can_edit?(current_api_user),
+            allow_firecloud_access: allow_firecloud_access,
+            can_compute: can_compute,
+            analysis_tab_content: analysis_tab_content
           }
         end
 

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -159,24 +159,6 @@ class SiteController < ApplicationController
     set_study_permissions(@study.detached?)
     set_study_default_options
     set_study_download_options
-
-    if @allow_firecloud_access && @user_can_compute
-      # load list of previous submissions
-      workspace = ApplicationController.firecloud_client.get_workspace(@study.firecloud_project, @study.firecloud_workspace)
-      @submissions = ApplicationController.firecloud_client.get_workspace_submissions(@study.firecloud_project, @study.firecloud_workspace)
-
-      @submissions.each do |submission|
-        update_analysis_submission(submission)
-      end
-      # remove deleted submissions from list of runs
-      if !workspace['workspace']['attributes']['deleted_submissions'].blank?
-        deleted_submissions = workspace['workspace']['attributes']['deleted_submissions']['items']
-        @submissions.delete_if {|submission| deleted_submissions.include?(submission['submissionId'])}
-      end
-
-      # load list of available workflows
-      @workflows_list = load_available_workflows
-    end
   end
 
   def record_download_acceptance
@@ -402,17 +384,7 @@ class SiteController < ApplicationController
 
   # get all submissions for a study workspace
   def get_workspace_submissions
-    workspace = ApplicationController.firecloud_client.get_workspace(@study.firecloud_project, @study.firecloud_workspace)
-    @submissions = ApplicationController.firecloud_client.get_workspace_submissions(@study.firecloud_project, @study.firecloud_workspace)
-    # update any AnalysisSubmission records with new statuses
-    @submissions.each do |submission|
-      update_analysis_submission(submission)
-    end
-    # remove deleted submissions from list of runs
-    if !workspace['workspace']['attributes']['deleted_submissions'].blank?
-      deleted_submissions = workspace['workspace']['attributes']['deleted_submissions']['items']
-      @submissions.delete_if {|submission| deleted_submissions.include?(submission['submissionId'])}
-    end
+    @submissions = TerraAnalysisService.list_submissions(@study)
   end
 
   # retrieve analysis configuration and associated parameters
@@ -685,7 +657,6 @@ class SiteController < ApplicationController
     @allow_firecloud_access = false
     @allow_downloads = false
     @allow_edits = false
-    @allow_computes = false
     return if study_detached
     begin
       @allow_firecloud_access = AdminConfiguration.firecloud_access_enabled?
@@ -700,7 +671,6 @@ class SiteController < ApplicationController
         buckets_ok = system_status.dig(FireCloudClient::BUCKETS_SERVICE, 'ok') == true
         @allow_downloads = buckets_ok
         @allow_edits = sam_ok && rawls_ok
-        @allow_computes = sam_ok && rawls_ok && agora_ok
       end
     rescue => e
       logger.error "Error checking FireCloud API status: #{e.class.name} -- #{e.message}"
@@ -719,9 +689,6 @@ class SiteController < ApplicationController
     return if study_detached || !@allow_firecloud_access
     begin
       @user_can_edit = @study.can_edit?(current_user)
-      if @allow_computes
-        @user_can_compute = @study.can_compute?(current_user)
-      end
       if @allow_downloads
         @user_can_download = @user_can_edit ? true : @study.can_download?(current_user)
         @user_embargoed = @user_can_edit ? false : @study.embargoed?(current_user)
@@ -861,17 +828,6 @@ class SiteController < ApplicationController
   # load list of available workflows
   def load_available_workflows
     AnalysisConfiguration.available_analyses
-  end
-
-  # update AnalysisSubmissions when loading study analysis tab
-  # will not backfill existing workflows to keep our submission history clean
-  def update_analysis_submission(submission)
-    analysis_submission = AnalysisSubmission.find_by(submission_id: submission['submissionId'])
-    if analysis_submission.present?
-      workflow_status = submission['workflowStatuses'].keys.first # this only works for single-workflow analyses
-      analysis_submission.update(status: workflow_status)
-      analysis_submission.delay.set_completed_on # run in background to avoid UI blocking
-    end
   end
 
   # handle updates to reviewer access settings

--- a/app/javascript/components/explore/ExploreView.js
+++ b/app/javascript/components/explore/ExploreView.js
@@ -29,7 +29,7 @@ function RoutableExploreTab({ studyAccession }) {
   async function loadStudyData() {
     const exploreResponse = await fetchExplore(studyAccession)
     setExploreInfo(exploreResponse)
-    // after the explore info is received, fetch the user-specific annotations, but do it
+    // after the explore info is received, fetch the user-specific study data, but do it
     // after a timeout to ensure the visualization data gets fetched first
     window.setTimeout(async () => {
       const userSpecificInfo = await fetchStudyUserInfo(studyAccession)
@@ -37,6 +37,12 @@ function RoutableExploreTab({ studyAccession }) {
         const newInfo = _cloneDeep(oldExploreInfo)
         newInfo.annotationList.annotations = userSpecificInfo.annotations
         newInfo.canEdit = userSpecificInfo.canEdit
+        if (userSpecificInfo.can_compute) {
+          // show the analysis tab
+          const fragment = document.createRange().createContextualFragment(userSpecificInfo.analysis_tab_content)
+          document.getElementById('study-analysis').appendChild(fragment)
+          document.getElementById('study-analysis-nav').classList.remove('hidden')
+        }
         return newInfo
       })
     }, 500)

--- a/app/javascript/components/explore/ExploreView.js
+++ b/app/javascript/components/explore/ExploreView.js
@@ -37,9 +37,9 @@ function RoutableExploreTab({ studyAccession }) {
         const newInfo = _cloneDeep(oldExploreInfo)
         newInfo.annotationList.annotations = userSpecificInfo.annotations
         newInfo.canEdit = userSpecificInfo.canEdit
-        if (userSpecificInfo.can_compute) {
+        if (userSpecificInfo.canCompute) {
           // show the analysis tab
-          const fragment = document.createRange().createContextualFragment(userSpecificInfo.analysis_tab_content)
+          const fragment = document.createRange().createContextualFragment(userSpecificInfo.analysisTabContent)
           document.getElementById('study-analysis').appendChild(fragment)
           document.getElementById('study-analysis-nav').classList.remove('hidden')
         }

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -582,11 +582,6 @@ export async function updateCurrentUser(updatedUser, mock=false) {
   await scpApi('/current_user', init, mock, true)
 }
 
-/** get information on the user's analysis/compute access for the given study */
-export async function fetchAnalysisAccess(studyAccession, mock=false) {
-  return await scpApi(`/studies/${studyAccession}/analysis_access`, defaultInit(), mock)
-}
-
 /**
  * Returns a list of matching filters for a given facet
  *

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -582,6 +582,11 @@ export async function updateCurrentUser(updatedUser, mock=false) {
   await scpApi('/current_user', init, mock, true)
 }
 
+/** get information on the user's analysis/compute access for the given study */
+export async function fetchAnalysisAccess(studyAccession, mock=false) {
+  return await scpApi(`/studies/${studyAccession}/analysis_access`, defaultInit(), mock)
+}
+
 /**
  * Returns a list of matching filters for a given facet
  *

--- a/app/lib/terra_analysis_service.rb
+++ b/app/lib/terra_analysis_service.rb
@@ -1,0 +1,52 @@
+# methods related to terra workflow analyses
+# corresponding to the 'analysis' tab in study overview
+class TerraAnalysisService
+
+  def self.list_submissions(study)
+    # load list of previous submissions
+    workspace = ApplicationController.firecloud_client.get_workspace(study.firecloud_project, study.firecloud_workspace)
+    submissions = ApplicationController.firecloud_client.get_workspace_submissions(study.firecloud_project, study.firecloud_workspace)
+
+    submissions.each do |submission|
+      update_analysis_submission(submission)
+    end
+    # remove deleted submissions from list of runs
+    if !workspace['workspace']['attributes']['deleted_submissions'].blank?
+      deleted_submissions = workspace['workspace']['attributes']['deleted_submissions']['items']
+      submissions.delete_if {|submission| deleted_submissions.include?(submission['submissionId'])}
+    end
+    submissions
+  end
+
+  # update AnalysisSubmissions when loading study analysis tab
+  # will not backfill existing workflows to keep our submission history clean
+  def self.update_analysis_submission(submission)
+    analysis_submission = AnalysisSubmission.find_by(submission_id: submission['submissionId'])
+    if analysis_submission.present?
+      workflow_status = submission['workflowStatuses'].keys.first # this only works for single-workflow analyses
+      analysis_submission.update(status: workflow_status)
+      analysis_submission.delay.set_completed_on # run in background to avoid UI blocking
+    end
+  end
+
+  # check if a user can run workflows on the given study
+  def self.user_can_compute?(study, user)
+    if user.nil? || !user.registered_for_firecloud?
+      false
+    else
+      begin
+        workspace_acl = ApplicationController.firecloud_client.get_workspace_acl(study.firecloud_project, study.firecloud_workspace)
+        if workspace_acl['acl'][user.email].nil?
+          # check if user has project-level permissions
+          user.is_billing_project_owner?(study.firecloud_project)
+        else
+          workspace_acl['acl'][user.email]['canCompute']
+        end
+      rescue => e
+        ErrorTracker.report_exception(e, user, { study: study.attributes.to_h.except('description')})
+        Rails.logger.error "Unable to retrieve compute permissions for #{user.email}: #{e.message}"
+        false
+      end
+    end
+  end
+end

--- a/app/views/site/_study_tabs_nav.html.erb
+++ b/app/views/site/_study_tabs_nav.html.erb
@@ -16,13 +16,7 @@
     <% else %>
       <li role="presentation" class="study-nav disabled" id="study-download-nav"><a href="#study-download" data-toggle="tooltip" title="Please sign in to download data">Download <i class="fas fa-fw fa-download"></i></a></li>
     <% end %>
-    <% if @allow_firecloud_access && @user_can_compute %>
-      <% if @allow_computes %>
-        <li role="presentation" class="study-nav" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tab">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
-      <% else %>
-        <li role="presentation" class="study-nav disabled" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tooltip" title="Study workspaces are currently unavailable - please try again later.">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
-      <% end %>
-    <% end %>
+    <li role="presentation" class="study-nav hidden" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tab">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
     <% if @allow_firecloud_access && @user_can_edit %>
       <% if @allow_edits %>
         <li role="presentation" class="study-nav" id="study-settings-nav"><a href="#study-settings" data-toggle="tab">Settings <i class="fas fa-fw fa-cogs"></i></a></li>

--- a/app/views/site/analysis/_submit_workflow.html.erb
+++ b/app/views/site/analysis/_submit_workflow.html.erb
@@ -1,6 +1,6 @@
 <h2>Submit a Workflow</h2>
 <p class="lead help-block">Configure and submit a workflow using the wizard below. You will be able to check the status of this workflow in the table above once submitted.</p>
-<%= form_for(:workflow, url: create_workspace_submission_path(@study.accession, @study.name), html: {class: 'form', id: 'workflow-submission'}, data: {remote: true}) do |f| %>
+<%= form_for(:workflow, url: create_workspace_submission_path(@study.accession, @study.url_safe_name), html: {class: 'form', id: 'workflow-submission'}, data: {remote: true}) do |f| %>
   <div id="workflow-wizard">
     <ul class="nav wizard">
       <li role="presentation" class="wizard-nav" id="select-workflow-nav"><a href="#select-workflow" data-toggle="tab">1. Select Workflow</a></li>

--- a/app/views/site/analysis/_submit_workflow.html.erb
+++ b/app/views/site/analysis/_submit_workflow.html.erb
@@ -1,6 +1,6 @@
 <h2>Submit a Workflow</h2>
 <p class="lead help-block">Configure and submit a workflow using the wizard below. You will be able to check the status of this workflow in the table above once submitted.</p>
-<%= form_for(:workflow, url: create_workspace_submission_path, html: {class: 'form', id: 'workflow-submission'}, data: {remote: true}) do |f| %>
+<%= form_for(:workflow, url: create_workspace_submission_path(@study.accession, @study.name), html: {class: 'form', id: 'workflow-submission'}, data: {remote: true}) do |f| %>
   <div id="workflow-wizard">
     <ul class="nav wizard">
       <li role="presentation" class="wizard-nav" id="select-workflow-nav"><a href="#select-workflow" data-toggle="tab">1. Select Workflow</a></li>

--- a/app/views/site/study.html.erb
+++ b/app/views/site/study.html.erb
@@ -17,11 +17,10 @@
         <%= render partial: 'study_download_data' %>
       </div>
     <% end %>
-    <% if @allow_firecloud_access && @user_can_compute %>
-      <div class="tab-pane" id="study-analysis" role="tabpanel">
-        <%= render partial: 'study_analysis' %>
-      </div>
-    <% end %>
+
+    <div class="tab-pane" id="study-analysis" role="tabpanel">
+    </div>
+
     <% if @allow_firecloud_access && @allow_edits && @user_can_edit %>
       <div class="tab-pane" id="study-settings" role="tabpanel">
         <div class="row">


### PR DESCRIPTION
SCP-4071 Major thanks to Jon for helping me test this.  This adds 'canCompute' and 'analysisTabContent' to the user_study_info endpoint (which is also used to determine if the user can edit the study and load user annotations).  This endpoint is only fetched after the rest of the study loads. The analysis tab content is rendered using the existing template logic, so there is no change to the analysis UX.

I originally tried an alternate approach putting analysis-tab-check logic into a brand new endpoint, which was checked from a script inside `_study_tabs_nav.html.erb`.  This was nice in keeping the code isolated, but tricky from a timing perspective, as there was no easy way to ensure the async call would fire after the rest of the study async calls.  Also, this made the mental model of the page more complex, as now there were 4 different async calls being made, from two different places.  So I consolidated it inside the study_user_info endpoint with the advantage of code and page simplicity, but the drawback that user annotations and custom controls have to wait on the analysis tab.

TO TEST:
1. sign in as an admin
2. load a study
3. confirm that the other 4 tabs load first, and then the  analysis tab loads later (it may be ~15 seconds later in development)
4. confirm that user annotations and the "customize colors" still appear correctly within the explore tab
5. (If you have analyses configured in your environment).  Use the analysis tab to launch a workflow