### PR TITLE
Changing default sort order to most recent initialized studies (SCP-3846)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -303,8 +303,10 @@ module Api
         when :popular
           @studies = @studies.sort_by(&:view_count).reverse
         else
-          # we have sort_type of :none, so preserve original ordering of :view_order
-          @studies = @studies.sort_by(&:view_order)
+          # we have sort_type of :none, so order by most recent initialized studies
+          # in order to sort by multiple attributes, use array notation to indicate which attribute to sort by first
+          # boolean values must be converted to an integer in order for this to work
+          @studies = @studies.sort_by { |study| [study.initialized? ? 1 : 0, study.created_at] }.reverse
         end
 
         # save list of study accessions for bulk_download/bulk_download_size calls, in order of results

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -25,6 +25,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
                                name_prefix: "Search Testing Study #{@random_seed}",
                                public: true,
                                user: @user,
+                               initialized: true,
                                test_array: @@studies_to_clean)
     FactoryBot.create(:metadata_file, name: 'metadata.txt', study: @study, use_metadata_convention: true)
     seed_example_bq_data(@study)
@@ -33,6 +34,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
                                      name_prefix: "API Test Study #{@random_seed}",
                                      public: true,
                                      user: @other_user,
+                                     initialized: false,
                                      test_array: @@studies_to_clean)
     [@study, @other_study].each do |study|
       detail = study.build_study_detail
@@ -409,5 +411,12 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     sanitized_filter = Api::V1::SearchController.sanitize_filter_value("10X 3' v3")
     expected_value = "10X 3\\' v3"
     assert_equal expected_value, sanitized_filter
+  end
+
+  test 'should return initialized studies first in empty search' do
+    execute_http_request(:get, api_v1_search_path(type: 'study'))
+    assert_response :success
+    first_study = json['studies'].first['accession']
+    assert_equal @study.accession, first_study
   end
 end


### PR DESCRIPTION
Currently, when a user visits the home page of SCP in production, the same studies are shown when no search has been entered.  This is because the "default" ordering uses a hidden attribute called `view_order`, where lower numbers take precedence over higher ones (the default for all studies is `100`). SCP admins previously have set a few studies to have low values like `1` or `10`.  Therefore, [SCP1](https://singlecell.broadinstitute.org/single_cell/study/SCP1/-single-nucleus-rna-seq-of-cell-diversity-in-the-adult-mouse-hippocampus-snuc-seq) and [SCP3](https://singlecell.broadinstitute.org/single_cell/study/SCP3/retinal-bipolar-neuron-drop-seq) are always shown first.  This has the unintended effect of making it appear that there is no new data in the portal, even though the study/cell counts continually increase.

This update now prioritizes the most recently added studies that are fully initialized, meaning all visualizations are enabled (all scatter plots & gene-based visualizations).  This will hopefully lead to more users who are unfamiliar with SCP to click into new studies by default, rather than the same two studies from 2016.  In addition, we will build a funnel in Mixpanel to attempt to track if we see an increase in users clicking into studies without running a search.

MANUAL TESTING
1. Boot as normal
2. In the Rails console, find the most recently added study: `study = Study.last`
3. Mark this study as initialized: `study.update(initialized: true)`
4. Refresh the home page, and confirm that this study is shown first when no search has been entered

This PR satisfies SCP-3846.