### PR TITLE
removing 'replace' button for already-uploaded files (SCP-4081)

### DIFF
--- a/app/javascript/components/upload/FileUploadControl.js
+++ b/app/javascript/components/upload/FileUploadControl.js
@@ -93,9 +93,12 @@ export default function FileUploadControl({
       })
     }
   }
-  let buttonText = file.upload_file_name ? 'Replace' : 'Choose file'
+  const isFileChosen = !!file.upload_file_name
+  const isFileOnServer = file.status !== 'new'
+
+  let buttonText = isFileChosen ? 'Replace' : 'Choose file'
   let buttonClass = 'fileinput-button btn terra-tertiary-btn'
-  if (!file.upload_file_name && !file.uploadSelection) {
+  if (!isFileChosen && !file.uploadSelection) {
     buttonClass = 'fileinput-button btn btn-primary'
   }
   if (fileValidation.validating) {
@@ -122,14 +125,16 @@ export default function FileUploadControl({
       bucketName={bucketName}
     />
     &nbsp;
-    <button className={buttonClass} id={`fileButton-${file._id}`} data-testid="file-input-btn">
-      { buttonText }
-      <input className="file-upload-input" data-testid="file-input"
-        type="file"
-        id={inputId}
-        onChange={handleFileSelection}
-        accept={inputAcceptExts.join(',')}/>
-    </button>
+    { !isFileOnServer &&
+      <button className={buttonClass} id={`fileButton-${file._id}`} data-testid="file-input-btn">
+        { buttonText }
+        <input className="file-upload-input" data-testid="file-input"
+          type="file"
+          id={inputId}
+          onChange={handleFileSelection}
+          accept={inputAcceptExts.join(',')}/>
+      </button>
+    }
 
     { fileValidation.errorMsgs?.length > 0 && <div className="validation-error" data-testid="file-content-validation">
       Could not use {fileValidation.filename}:

--- a/test/js/upload-wizard/file-upload-control.test.js
+++ b/test/js/upload-wizard/file-upload-control.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react'
+import { render, screen, cleanup, waitForElementToBeRemoved } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 
 import FileUploadControl from 'components/upload/FileUploadControl'
@@ -209,5 +209,57 @@ describe('file upload control validates the selected file', () => {
       .toHaveTextContent('First row, first column must be "NAME" (case insensitive). Your value was "notNAME')
     expect(screen.getByTestId('file-content-validation'))
       .toHaveTextContent('Second row, first column must be "TYPE" (case insensitive). Your value was "foo"')
+  })
+
+  it('shows the file chooser button appropriately', async () => {
+    const file = {
+      _id: '123',
+      name: '',
+      status: 'new',
+      file_type: 'Cluster'
+    }
+    render((
+      <FileUploadControl
+        file={file}
+        allFiles={[file]}
+        allowedFileExts={['.txt']}
+        validationMessages={{}}/>
+    ))
+    expect(screen.queryAllByText('Choose file')).toHaveLength(1)
+    cleanup()
+
+    const file2 = {
+      _id: '123',
+      name: 'cluster.txt',
+      status: 'new',
+      file_type: 'Cluster',
+      upload_file_name: 'cluster.txt'
+    }
+    render((
+      <FileUploadControl
+        file={file2}
+        allFiles={[file2]}
+        allowedFileExts={['.txt']}
+        validationMessages={{}}/>
+    ))
+    expect(screen.queryAllByText('Replace')).toHaveLength(1)
+    cleanup()
+
+    const file3 = {
+      _id: '123',
+      name: 'cluster.txt',
+      upload_file_name: 'cluster.txt',
+      status: 'uploaded',
+      file_type: 'Cluster'
+    }
+    render((
+      <FileUploadControl
+        file={file3}
+        allFiles={[file3]}
+        allowedFileExts={['.txt']}
+        validationMessages={{}}/>
+    ))
+    expect(screen.queryAllByText('Choose file')).toHaveLength(0)
+    expect(screen.queryAllByText('Replace')).toHaveLength(0)
   })
 })


### PR DESCRIPTION
SCP-4081  This removes the 'Replace' option for files that have already been uploaded.  The feature was desirable, but was leading to bugs like https://broadinstitute.zendesk.com/agent/tickets/269187. 

I looked into updating the backend to treat 'replace' as 'delete and recreate', but the error handling edge cases were too many, and communicating to the UX that "there's now a file that should be treated the same as the old file, but that has a new id", would be problematic.

TO TEST:
1. open upload wizard for a study
2. for existing files, observe there is no 'Choose file' or 'Replace' button
3. click "add file"
4. observe there is a 'choose file' button
5. choose a file
6. observe a 'Replace' button replaces the 'Choose file' button
