### PR TITLE
Restoring file downloads in upload wizard (SCP-4079)

### DIFF
--- a/app/javascript/components/download/FileDownloadControl.js
+++ b/app/javascript/components/download/FileDownloadControl.js
@@ -1,21 +1,16 @@
 import React from 'react'
-import { fetchBucketFile } from 'lib/scp-api'
 import { bytesToSize } from 'lib/stats'
 
 /** renders a file download control for the given file object */
-export default function FileDownloadControl({ file, bucketName }) {
+export default function FileDownloadControl({ file }) {
   const fileName = file.upload_file_name
+  const studyAccession = window.SCP?.currentStudyAccession
+  const studyName = window.SCP?.currentStudyName
 
-  /** Load file when button is clicked */
+  /** when button is clicked, open new window on method to redirect to signed URL */
   const handleDownloadClick = () => {
-    getBucketLocalUrl(bucketName, fileName).then(value => window.open(value, '_blank', 'noopener,noreferrer'))
-  }
-
-  /** get the remote file path */
-  async function getBucketLocalUrl() {
-    const response = await fetchBucketFile(bucketName, fileName)
-    const fileBlob = await response.blob()
-    return URL.createObjectURL(fileBlob)
+    const downloadUrl = `/single_cell/data/private/${studyAccession}/${studyName}?filename=${fileName}`
+    window.open(downloadUrl, '_blank', 'noopener,noreferrer')
   }
 
   // don't show the control if there's no remote file, or if the user has already selected a replacement
@@ -30,7 +25,7 @@ export default function FileDownloadControl({ file, bucketName }) {
           title='You can download this file once it has been fully uploaded. Check back soon.'>
           Awaiting remote file
         </span> :
-          <a onClick={() => handleDownloadClick()} className="btn terra-tertiary-btn">
+          <a onClick={() => handleDownloadClick()} className="btn terra-tertiary-btn" download={fileName}>
             {<span className="fas fa-download"></span> } {bytesToSize(file.upload_file_size)}
           </a>
         }

--- a/app/javascript/components/download/FileDownloadControl.js
+++ b/app/javascript/components/download/FileDownloadControl.js
@@ -1,11 +1,13 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { bytesToSize } from 'lib/stats'
+import { StudyContext } from 'components/upload/UploadWizard'
 
 /** renders a file download control for the given file object */
 export default function FileDownloadControl({ file }) {
   const fileName = file.upload_file_name
-  const studyAccession = window.SCP?.currentStudyAccession
-  const studyName = window.SCP?.currentStudyName
+  const studyObject = useContext(StudyContext)
+  const studyAccession = studyObject?.studyAccession
+  const studyName = studyObject?.studyName
 
   /** when button is clicked, open new window on method to redirect to signed URL */
   const handleDownloadClick = () => {

--- a/app/javascript/components/download/FileDownloadControl.js
+++ b/app/javascript/components/download/FileDownloadControl.js
@@ -6,8 +6,8 @@ import { StudyContext } from 'components/upload/UploadWizard'
 export default function FileDownloadControl({ file }) {
   const fileName = file.upload_file_name
   const studyObject = useContext(StudyContext)
-  const studyAccession = studyObject?.studyAccession
-  const studyName = studyObject?.studyName
+  const studyAccession = studyObject?.accession
+  const studyName = studyObject?.url_safe_name
 
   /** when button is clicked, open new window on method to redirect to signed URL */
   const handleDownloadClick = () => {

--- a/app/javascript/components/download/FileDownloadControl.js
+++ b/app/javascript/components/download/FileDownloadControl.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 import { bytesToSize } from 'lib/stats'
-import { StudyContext } from 'components/upload/UploadWizard'
+import { StudyContext } from 'components/upload/upload-utils'
 import LoadingSpinner from 'lib/LoadingSpinner'
 
 /** renders a file download control for the given file object */
@@ -20,7 +20,7 @@ export default function FileDownloadControl({ file }) {
     // don't show the control if there's no remote file, or if the user has already selected a replacement
     return null
   }
-  
+
   if (!file.upload_file_name && file.human_data) {
     // don't show the control if this is a sequence file hosted elsewhere
     return null

--- a/app/javascript/components/upload/FileUploadControl.js
+++ b/app/javascript/components/upload/FileUploadControl.js
@@ -119,7 +119,6 @@ export default function FileUploadControl({
     </label>
     <FileDownloadControl
       file={file}
-      bucketName={bucketName}
     />
     &nbsp;
     <button className={buttonClass} id={`fileButton-${file._id}`} data-testid="file-input-btn">

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -67,10 +67,9 @@ export function RawUploadWizard({ studyAccession, name }) {
   const [formState, setFormState] = useState(null)
 
   // study attributes to pass to the StudyContext later for use throughout the RawUploadWizard component, if needed
-  const studyObj = {
-    studyAccession: serverState?.study?.accession,
-    studyName: serverState?.study?.url_safe_name
-  }
+  // use complete study object, rather than defaultStudyState so that any updates to study.rb will be reflected in
+  // this context
+  const studyObj = serverState?.study
 
   const allowReferenceImageUpload = serverState?.feature_flags?.reference_image_upload
 

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -15,7 +15,7 @@ import * as queryString from 'query-string'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons'
 
-import { formatFileFromServer, formatFileForApi, newStudyFileObj } from './upload-utils'
+import { formatFileFromServer, formatFileForApi, newStudyFileObj, StudyContext } from './upload-utils'
 import {
   createStudyFile, updateStudyFile, deleteStudyFile,
   fetchStudyFileInfo, sendStudyFileChunk, RequestCanceller
@@ -53,14 +53,6 @@ const STEPS = [
 
 const MAIN_STEPS = STEPS.slice(0, 4)
 const SUPPLEMENTAL_STEPS = STEPS.slice(4)
-
-const defaultStudyState = {
-  accession: null,
-  url_safe_name: null
-}
-
-// context to pass through UploadWizard
-export const StudyContext = React.createContext(defaultStudyState)
 
 /** shows the upload wizard */
 export function RawUploadWizard({ studyAccession, name }) {

--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -1,10 +1,14 @@
 import _uniqueId from 'lodash/uniqueId'
 import _get from 'lodash/get'
+import React from 'react'
 
 export const PARSEABLE_TYPES = ['Cluster', 'Coordinate Labels', 'Expression Matrix', 'MM Coordinate Matrix',
   '10X Genes File', '10X Barcodes File', 'Gene List', 'Metadata', 'Analysis Output']
 
 const EXPRESSION_INFO_TYPES = ['Expression Matrix', 'MM Coordinate Matrix']
+
+// context to pass through UploadWizard
+export const StudyContext = React.createContext(null)
 
 /** properties used to track file state on the form, but that should not be sent to the server
  *  this also includes properties that are only modifiable on the server (and so should also

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,8 @@
 
       window.SCP.gaTrackingId = '<%= ENV['GA_TRACKING_ID'] %>';
       window.SCP.analyticsPageName = '<%= get_page_name %>';
-      window.SCP.currentStudyAccession = '<%= @study.try(:accession) ? @study.try(:accession) : "" %>'
+      window.SCP.currentStudyAccession = '<%= @study&.accession %>'
+      window.SCP.currentStudyName = '<%= @study&.url_safe_name %>'
 
       // if we had search forms to preserve, recall and resubmit
       if ( localStorage.getItem('previous-search-url') ) {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,6 @@
       window.SCP.gaTrackingId = '<%= ENV['GA_TRACKING_ID'] %>';
       window.SCP.analyticsPageName = '<%= get_page_name %>';
       window.SCP.currentStudyAccession = '<%= @study&.accession %>'
-      window.SCP.currentStudyName = '<%= @study&.url_safe_name %>'
 
       // if we had search forms to preserve, recall and resubmit
       if ( localStorage.getItem('previous-search-url') ) {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
     if env['action_dispatch.original_path']&.include?('api/v1')
       Api::V1::ExceptionsController.action(:render_error).call(env)
     else
-      ActionDispatch::PublicExceptions.new(Rails.public_path).call(env)
+      ActionDispatch::PublicExceptions.new(Rails.public_path)
     end
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
     if env['action_dispatch.original_path']&.include?('api/v1')
       Api::V1::ExceptionsController.action(:render_error).call(env)
     else
-      ActionDispatch::PublicExceptions.new(Rails.public_path)
+      ActionDispatch::PublicExceptions.new(Rails.public_path).call(env)
     end
   end
 


### PR DESCRIPTION
This fixes a regression where the file download links in the upload wizard stopped working due to the refactoring of `window.SCP.readOnlyToken` in #1324.  In addition, rather than streaming the blob of bytes through the app, this update restores the original functionality of generating a signed URL and opening a new tab directly on the resource in the bucket to let the client handle the download, rather that our server.  This also preserves the original filename, instead of the UUID that had been assigned before.  A newly created `StudyContext` React context can now be accessed anywhere in the upload wizard, which will have the entire study object loaded from the server.

MANUAL TESTING
1. Boot as normal and sign in
2. Load the upload wizard for any study that already has files
3. Click the file download links, and validate that the file opens in a new window (txt files will render in the browser, other types will download directly)

This PR satisfies SCP-4079.