### PR TITLE
Add timeout on CSFV (SCP-4035)

### DIFF
--- a/app/javascript/lib/validation/chunked-line-reader.js
+++ b/app/javascript/lib/validation/chunked-line-reader.js
@@ -20,6 +20,7 @@ export default class ChunkedLineReader {
     this.linesRead = 0
     this.currentFragment = null // currentFragment stores the parts of lines that cross chunk boundaries
     this.chunkLines = []
+    this.startTime = new Date().getTime() // start the CSFV timer
     this.updateHasMoreChunks()
     this.updateHasMoreLines()
   }
@@ -41,7 +42,7 @@ export default class ChunkedLineReader {
    * maxBytesPerLine can be set to avoid reading the entire file into memory in the event the file is missing
    * proper newlines
   */
-  async iterateLines({ func, maxLines = Number.MAX_SAFE_INTEGER, maxBytesPerLine = 1000*1000*1024, startTime }) {
+  async iterateLines({ func, maxLines = Number.MAX_SAFE_INTEGER, maxBytesPerLine = 1000*1000*1024 }) {
     const prevLinesRead = this.linesRead
     while ((this.hasMoreChunks || this.chunkLines.length) &&
            !(this.linesRead === 0 && this.nextByteToRead > maxBytesPerLine) &&

--- a/app/javascript/lib/validation/chunked-line-reader.js
+++ b/app/javascript/lib/validation/chunked-line-reader.js
@@ -6,9 +6,9 @@ const newlineRegex = /\r?\n/
  * reads lines from a file in a chunked way, so that the file does not have to be in memory all at once
  * Basic usage:
  * const chunker = new ChunkedLineReader(file)
- * chunker.iterateLines((line, lineNum, isLastLine) => {
+ * chunker.iterateLines({func: (line, lineNum, isLastLine) => {
  *   // do stuff
- * }) {
+ * }}) {
  * }
  */
 export default class ChunkedLineReader {
@@ -22,20 +22,7 @@ export default class ChunkedLineReader {
     this.chunkLines = []
     this.updateHasMoreChunks()
     this.updateHasMoreLines()
-    this.resetToFileStart()
-    this.shouldStopReadingFile()
   }
-
-  /**
-   * Exception thrown for issues arrising during file reading
-   * @param {} key 
-   * @param {*} msg 
-   */
-  FileReadingException(key, msg) {
-    this.message = msg
-    this.key = key
-  }
-
 
   /**
    * Reset the reader to the start of the file
@@ -49,25 +36,12 @@ export default class ChunkedLineReader {
   }
 
   /**
-   * Calculate if should stop reading file lines
-   */
-  shouldStopReadingFile(timerStart) {
-    const max = timerStart + 10000 // timerStart is in milliseoconds so add 10,000 milliseconds
-    const currentTime = new Date().getTime()
-    if (currentTime > max) {
-      throw new this.FileReadingException('time-limit-exceeded',
-      `This file is too large for full client side validation, you can continue and save it and wait for the serverside validation to confirm validation.`)
-    }
-  }
-
-  /**
    * iterates over the remaining lines in the file, calling func(line, lineNum, isLastLine) for each line
    * (lineNum is 0-indexed).
    * maxBytesPerLine can be set to avoid reading the entire file into memory in the event the file is missing
    * proper newlines
   */
-  async iterateLines(func, maxLines=Number.MAX_SAFE_INTEGER, startTime) {
-    const maxBytesPerLine=1000*1000*1024
+  async iterateLines({ func, maxLines = Number.MAX_SAFE_INTEGER, maxBytesPerLine = 1000*1000*1024, startTime }) {
     const prevLinesRead = this.linesRead
     while ((this.hasMoreChunks || this.chunkLines.length) &&
            !(this.linesRead === 0 && this.nextByteToRead > maxBytesPerLine) &&
@@ -81,9 +55,18 @@ export default class ChunkedLineReader {
         this.updateHasMoreLines()
         func(line, this.linesRead - 1, !this.hasMoreLines)
       }
-      this.shouldStopReadingFile(startTime)
     }
   }
+
+  /**
+   * Reset the reader to the end of the file
+   */
+  setToFileEnd() {
+    this.chunkLines = []
+    this.hasMoreChunks = false
+    this.hasMoreLines = false
+  }
+
 
   /**
    * reads a file as lines in a set of 'chunks'  Each chunk is determined by chunkSize

--- a/app/javascript/lib/validation/chunked-line-reader.js
+++ b/app/javascript/lib/validation/chunked-line-reader.js
@@ -20,7 +20,7 @@ export default class ChunkedLineReader {
     this.linesRead = 0
     this.currentFragment = null // currentFragment stores the parts of lines that cross chunk boundaries
     this.chunkLines = []
-    this.startTime = new Date().getTime() // start the CSFV timer
+    this.startTime = Date.now() // start the CSFV timer
     this.updateHasMoreChunks()
     this.updateHasMoreLines()
   }

--- a/app/javascript/lib/validation/expression-matrices-validation.js
+++ b/app/javascript/lib/validation/expression-matrices-validation.js
@@ -11,8 +11,6 @@ const whitespaceDelimiter = /\s+/
 
 /** Parse a dense matrix file */
 export async function parseDenseMatrixFile(chunker, mimeType, fileOptions, timerStart) {
-  console.log('timerStartinbeginingofdense', timerStart)
-
   const { header, delimiter, firstTwoContentLines } = await getParsedDenseMatrixHeaderLine(chunker, timerStart)
 
   let issues = validateDenseHeader(header, firstTwoContentLines)
@@ -46,20 +44,24 @@ export async function parseSparseMatrixFile(chunker, mimeType, fileOptions, time
   const dataObj = {} // object to track multi-line validation concerns
 
   let rawHeaderLine = null
-  await chunker.iterateLines({ func: rawLine => {
-    rawHeaderLine = rawLine
-  }, maxLines: 1, startTime: timerStart})
+  await chunker.iterateLines({
+    func: rawLine => {
+      rawHeaderLine = rawLine
+    }, maxLines: 1, startTime: timerStart
+  })
   const header = rawHeaderLine.trim().split(whitespaceDelimiter)
 
   issues = validateMTXHeaderLine(header)
 
-  await chunker.iterateLines({func: (rawLine, lineNum, isLastLine) => {
-    const line = rawLine.trim().split(whitespaceDelimiter)
+  await chunker.iterateLines({
+    func: (rawLine, lineNum, isLastLine) => {
+      const line = rawLine.trim().split(whitespaceDelimiter)
 
-    issues = issues.concat(validateSparseColumnNumber(line, isLastLine, lineNum, dataObj))
-    issues = issues.concat(validateSparseNoBlankLines(line, isLastLine, lineNum, dataObj))
+      issues = issues.concat(validateSparseColumnNumber(line, isLastLine, lineNum, dataObj))
+      issues = issues.concat(validateSparseNoBlankLines(line, isLastLine, lineNum, dataObj))
     // add other line-by-line validations here
-  }, startTime: timerStart} )
+    }, startTime: timerStart
+  })
   return { issues, whitespaceDelimiter, numColumns: dataObj.correctNumberOfColumns }
 }
 
@@ -69,10 +71,12 @@ export async function parseBarcodesFile(chunker, mimeType, fileOptions, timerSta
   let issues = []
 
   const dataObj = {} // object to track multi-line validation concerns
-  await chunker.iterateLines({ func: (rawLine, lineNum, isLastLine) => {
-    issues = issues.concat(validateUniqueRowValuesWithinFile(rawLine, isLastLine, dataObj))
+  await chunker.iterateLines({
+    func: (rawLine, lineNum, isLastLine) => {
+      issues = issues.concat(validateUniqueRowValuesWithinFile(rawLine, isLastLine, dataObj))
     // add other line-by-line validations here
-  }, startTime: timerStart})
+    }, startTime: timerStart
+  })
   return { issues }
 }
 
@@ -82,10 +86,12 @@ export async function parseFeaturesFile(chunker, mimeType, fileOptions, timerSta
   let issues = []
 
   const dataObj = {} // object to track multi-line validation concerns
-  await chunker.iterateLines({func: (rawLine, lineNum, isLastLine) => {
-    issues = issues.concat(validateUniqueRowValuesWithinFile(rawLine, isLastLine, dataObj))
+  await chunker.iterateLines({
+    func: (rawLine, lineNum, isLastLine) => {
+      issues = issues.concat(validateUniqueRowValuesWithinFile(rawLine, isLastLine, dataObj))
     // add other line-by-line validations here
-  }, startTime: timerStart})
+    }, startTime: timerStart
+  })
   return { issues }
 }
 
@@ -98,12 +104,12 @@ async function getParsedDenseMatrixHeaderLine(chunker, timerStart) {
   let rawHeader = null
   // the lines following the header line are needed for R-formatted file header validation
   const rawNextTwoLines = []
-  console.log('indense header:', timerStart)
 
-  await chunker.iterateLines({func: line => {
-    console.log('inside iterate lines in desnse header')
-    rawHeader = line
-  }, maxLines: 1, startTime: timerStart})
+  await chunker.iterateLines({
+    func: line => {
+      rawHeader = line
+    }, maxLines: 1, startTime: timerStart
+  })
 
   if (rawHeader.trim().length === 0) {
     throw new ParseException('format:cap:missing-header-lines',
@@ -111,9 +117,11 @@ async function getParsedDenseMatrixHeaderLine(chunker, timerStart) {
   }
 
   // get the 2 lines following the header line
-  await chunker.iterateLines({func: line => {
-    rawNextTwoLines.push(line)
-  }, maxLines: 2, startTime: timerStart})
+  await chunker.iterateLines({
+    func: line => {
+      rawNextTwoLines.push(line)
+    }, maxLines: 2, startTime: timerStart
+  })
 
   const delimiter = getDenseMatrixDelimiter(rawHeader, rawNextTwoLines)
 

--- a/app/javascript/lib/validation/shared-validation.js
+++ b/app/javascript/lib/validation/shared-validation.js
@@ -203,8 +203,7 @@ export function timeOutCSFV(chunker) {
     // quit early by setting the file reader to the end of the file so it can't read anymore
     chunker.setToFileEnd()
     issues.push(['warn', 'timeout',
-      'Due to the size of the file, validation will occur after upload. Please be aware '+
-        'the absence of errors/warnings here is NOT an indication of the validity of the file.'])
+      'Due to this file\'s size, it will be fully validated after upload, and any errors will be emailed to you.'])
   }
   return issues
 }

--- a/app/javascript/lib/validation/shared-validation.js
+++ b/app/javascript/lib/validation/shared-validation.js
@@ -15,12 +15,12 @@ export function ParseException(key, msg) {
  * reads in a two lines to be used as header lines, sniffs the delimiter,
  * and returns the lines parsed by the sniffed delimiter
  */
-export async function getParsedHeaderLines(chunker, mimeType, startTime) {
+export async function getParsedHeaderLines(chunker, mimeType) {
   const headerLines = []
   await chunker.iterateLines({
     func: (line, lineNum, isLastLine) => {
       headerLines.push(line)
-    }, maxLines: 2, startTime
+    }, maxLines: 2
   })
   if (headerLines.length < 2 || headerLines.some(hl => hl.length === 0)) {
     throw new ParseException('format:cap:missing-header-lines',
@@ -193,9 +193,9 @@ export function validateGroupColumnCounts(headers, line, isLastLine, dataObj) {
  * Timeout the CSFV if taking longer than 10 seconds
  *
  */
-export function timeOutCSFV(startTime, chunker) {
+export function timeOutCSFV(chunker) {
   const maxTime = 10000 // in milliseconds this equates to 10 seconds
-  const maxRealTime = startTime + maxTime
+  const maxRealTime = chunker.startTime + maxTime
   const currentTime = new Date().getTime()
   const issues = []
 

--- a/app/javascript/lib/validation/shared-validation.js
+++ b/app/javascript/lib/validation/shared-validation.js
@@ -15,12 +15,12 @@ export function ParseException(key, msg) {
  * reads in a two lines to be used as header lines, sniffs the delimiter,
  * and returns the lines parsed by the sniffed delimiter
  */
-export async function getParsedHeaderLines(chunker, mimeType, timerStart) {
+export async function getParsedHeaderLines(chunker, mimeType, startTime) {
   const headerLines = []
   await chunker.iterateLines({
     func: (line, lineNum, isLastLine) => {
       headerLines.push(line)
-    }, maxLines: 2, startTime: timerStart
+    }, maxLines: 2, startTime
   })
   if (headerLines.length < 2 || headerLines.some(hl => hl.length === 0)) {
     throw new ParseException('format:cap:missing-header-lines',
@@ -193,9 +193,9 @@ export function validateGroupColumnCounts(headers, line, isLastLine, dataObj) {
  * Timeout the CSFV if taking longer than 10 seconds
  *
  */
-export function timeOutCSFV(timerStart, chunker) {
+export function timeOutCSFV(startTime, chunker) {
   const maxTime = 10000 // in milliseconds this equates to 10 seconds
-  const maxRealTime = timerStart + maxTime
+  const maxRealTime = startTime + maxTime
   const currentTime = new Date().getTime()
   const issues = []
 

--- a/app/javascript/lib/validation/shared-validation.js
+++ b/app/javascript/lib/validation/shared-validation.js
@@ -15,11 +15,11 @@ export function ParseException(key, msg) {
  * reads in a two lines to be used as header lines, sniffs the delimiter,
  * and returns the lines parsed by the sniffed delimiter
  */
-export async function getParsedHeaderLines(chunker, mimeType) {
+export async function getParsedHeaderLines(chunker, mimeType, timerStart) {
   const headerLines = []
   await chunker.iterateLines((line, lineNum, isLastLine) => {
     headerLines.push(line)
-  }, 2)
+  }, 2, timerStart)
   if (headerLines.length < 2 || headerLines.some(hl => hl.length === 0)) {
     throw new ParseException('format:cap:missing-header-lines',
       `Your file is missing newlines or some required header lines`)
@@ -67,7 +67,7 @@ export function parseLine(line, delimiter) {
   const splitLine = line.split(delimiter)
   const parsedLine = new Array(parseLine.length)
   for (let i = 0; i < splitLine.length; i++) {
-    parsedLine[i] = splitLine[i].trim().replaceAll(/^"|"$/g, '')
+    parsedLine[i] = splitLine[i].trim().replace(/^"|"$/g, '')
   }
   return parsedLine
 }

--- a/app/javascript/lib/validation/shared-validation.js
+++ b/app/javascript/lib/validation/shared-validation.js
@@ -69,7 +69,7 @@ export function parseLine(line, delimiter) {
   const splitLine = line.split(delimiter)
   const parsedLine = new Array(parseLine.length)
   for (let i = 0; i < splitLine.length; i++) {
-    parsedLine[i] = splitLine[i].trim().replace(/^"|"$/g, '')
+    parsedLine[i] = splitLine[i].trim().replaceAll(/^"|"$/g, '')
   }
   return parsedLine
 }
@@ -203,8 +203,8 @@ export function timeOutCSFV(startTime, chunker) {
     // quit early by setting the file reader to the end of the file so it can't read anymore
     chunker.setToFileEnd()
     issues.push(['warn', 'timeout',
-      'Due to the size of the file, validation will occur after upload, please be aware '+
-        'the absense of errors/warnings here is NOT a reflection of the state of the file.'])
+      'Due to the size of the file, validation will occur after upload. Please be aware '+
+        'the absence of errors/warnings here is NOT an indication of the validity of the file.'])
   }
   return issues
 }

--- a/app/javascript/lib/validation/shared-validation.js
+++ b/app/javascript/lib/validation/shared-validation.js
@@ -202,7 +202,7 @@ export function timeOutCSFV(chunker) {
   if (currentTime > maxRealTime) {
     // quit early by setting the file reader to the end of the file so it can't read anymore
     chunker.setToFileEnd()
-    issues.push(['warn', 'timeout',
+    issues.push(['warn', 'incomplete:timeout',
       'Due to this file\'s size, it will be fully validated after upload, and any errors will be emailed to you.'])
   }
   return issues

--- a/app/javascript/lib/validation/shared-validation.js
+++ b/app/javascript/lib/validation/shared-validation.js
@@ -196,7 +196,7 @@ export function validateGroupColumnCounts(headers, line, isLastLine, dataObj) {
 export function timeOutCSFV(chunker) {
   const maxTime = 10000 // in milliseconds this equates to 10 seconds
   const maxRealTime = chunker.startTime + maxTime
-  const currentTime = new Date().getTime()
+  const currentTime = Date.now()
   const issues = []
 
   if (currentTime > maxRealTime) {

--- a/app/javascript/lib/validation/validate-file-content.js
+++ b/app/javascript/lib/validation/validate-file-content.js
@@ -381,7 +381,6 @@ export async function validateFileContent(file, fileType, fileOptions={}) {
   const perfTime = Math.round(performance.now() - startTime)
 
   const errorObj = formatIssues(issues)
-  console.log('errorobj:', errorObj)
   const logProps = getLogProps(fileInfo, errorObj, perfTime)
   log('file-validation', logProps)
 
@@ -437,8 +436,7 @@ function getLogProps(fileInfo, errorObj, perfTime) {
   }
 
   if (errors.length === 0) {
-    console.log('warnings,', warnings)
-    if(warnings.flat().includes('timeout')){
+    if (warnings.flat().includes('timeout')) {
       return Object.assign({ status: 'timeout' }, defaultProps)
     }
     return Object.assign({ status: 'success' }, defaultProps)

--- a/app/javascript/lib/validation/validate-file-content.js
+++ b/app/javascript/lib/validation/validate-file-content.js
@@ -439,8 +439,8 @@ function getLogProps(fileInfo, errorObj, perfTime) {
   }
 
   if (errors.length === 0) {
-    if (warnings.flat().includes('timeout')) {
-      return Object.assign({ status: 'timeout' }, defaultProps)
+    if (warnings.flat().includes('incomplete:timeout')) {
+      return Object.assign({ status: 'incomplete' }, defaultProps)
     }
     return Object.assign({ status: 'success' }, defaultProps)
   } else {

--- a/app/javascript/lib/validation/validate-file-content.js
+++ b/app/javascript/lib/validation/validate-file-content.js
@@ -252,8 +252,8 @@ function validateClusterCoordinates(headers) {
 
 
 /** parse a metadata file, and return an array of issues, along with file parsing info */
-export async function parseMetadataFile(chunker, mimeType, fileOptions, timerStart) {
-  const { headers, delimiter } = await getParsedHeaderLines(chunker, mimeType, timerStart)
+export async function parseMetadataFile(chunker, mimeType, fileOptions, startTime) {
+  const { headers, delimiter } = await getParsedHeaderLines(chunker, mimeType, startTime)
   let issues = validateCapFormat(headers)
   issues = issues.concat(validateNoMetadataCoordinates(headers))
   if (fileOptions.use_metadata_convention) {
@@ -270,14 +270,14 @@ export async function parseMetadataFile(chunker, mimeType, fileOptions, timerSta
       issues = issues.concat(validateMetadataLabelMatches(headers, line, isLastLine, dataObj))
       issues = issues.concat(validateGroupColumnCounts(headers, line, isLastLine, dataObj))
     // add other line-by-line validations here
-    }, startTime: timerStart
+    }, startTime
   })
   return { issues, delimiter, numColumns: headers[0].length }
 }
 
 /** parse a cluster file, and return an array of issues, along with file parsing info */
-export async function parseClusterFile(chunker, mimeType, timerStart) {
-  const { headers, delimiter } = await getParsedHeaderLines(chunker, mimeType, timerStart)
+export async function parseClusterFile(chunker, mimeType, startTime) {
+  const { headers, delimiter } = await getParsedHeaderLines(chunker, mimeType, startTime)
   let issues = validateCapFormat(headers)
   issues = issues.concat(validateClusterCoordinates(headers))
   // add other header validations here
@@ -289,7 +289,7 @@ export async function parseClusterFile(chunker, mimeType, timerStart) {
       issues = issues.concat(validateUniqueCellNamesWithinFile(line, isLastLine, dataObj))
       issues = issues.concat(validateGroupColumnCounts(headers, line, isLastLine, dataObj))
     // add other line-by-line validations here
-    }, startTime: timerStart
+    }, startTime
   })
 
   return { issues, delimiter, numColumns: headers[0].length }
@@ -339,7 +339,7 @@ async function parseFile(file, fileType, fileOptions={}) {
   }
   const parseResult = { fileInfo, issues: [] }
   try {
-    const timerStart = new Date().getTime() // start the CSFV timer
+    const startTime = new Date().getTime() // start the CSFV timer
     fileInfo.isGzipped = await validateGzipEncoding(file)
     // if the file is compressed or we can't figure out the compression, don't try to parse further
     if (fileInfo.isGzipped || !PARSEABLE_TYPES.includes(fileType)) {
@@ -355,7 +355,7 @@ async function parseFile(file, fileType, fileOptions={}) {
     }
     if (parseFunctions[fileType]) {
       const chunker = new ChunkedLineReader(file)
-      const { issues, delimiter, numColumns } = await parseFunctions[fileType](chunker, fileInfo.fileMimeType, fileOptions, timerStart)
+      const { issues, delimiter, numColumns } = await parseFunctions[fileType](chunker, fileInfo.fileMimeType, fileOptions, startTime)
       fileInfo.linesRead = chunker.linesRead
       fileInfo.delimiter = delimiter
       fileInfo.numColumns = numColumns

--- a/app/javascript/lib/validation/validate-file-content.js
+++ b/app/javascript/lib/validation/validate-file-content.js
@@ -439,7 +439,7 @@ function getLogProps(fileInfo, errorObj, perfTime) {
   }
 
   if (errors.length === 0) {
-    if (warnings.flat().includes('incomplete:timeout')) {
+    if (warnings.flat().includes('incomplete')) {
       return Object.assign({ status: 'incomplete' }, defaultProps)
     }
     return Object.assign({ status: 'success' }, defaultProps)

--- a/test/js/lib/chunked-line-reader.test.js
+++ b/test/js/lib/chunked-line-reader.test.js
@@ -8,9 +8,11 @@ describe('chunked line reader', () => {
     const chunker = new ChunkedLineReader(file)
     const expectedLines = ['line1', 'line2', 'line3']
     expect.assertions(7)
-    await chunker.iterateLines((line, lineNum, isLastLine) => {
-      expect(line).toEqual(expectedLines[lineNum])
-      expect(isLastLine).toEqual(lineNum === 2)
+    await chunker.iterateLines({
+      func: (line, lineNum, isLastLine) => {
+        expect(line).toEqual(expectedLines[lineNum])
+        expect(isLastLine).toEqual(lineNum === 2)
+      }
     })
     expect(chunker.linesRead).toEqual(3)
   })
@@ -21,9 +23,11 @@ describe('chunked line reader', () => {
     const expectedLines = ['line1', 'line2', 'line3', 'line4']
     expect.assertions(8)
 
-    await chunker.iterateLines((line, lineNum, isLastLine) => {
-      expect(line).toEqual(expectedLines[lineNum])
-      expect(isLastLine).toEqual(lineNum === 3)
+    await chunker.iterateLines({
+      func: (line, lineNum, isLastLine) => {
+        expect(line).toEqual(expectedLines[lineNum])
+        expect(isLastLine).toEqual(lineNum === 3)
+      }
     })
   })
 
@@ -32,9 +36,12 @@ describe('chunked line reader', () => {
     const chunker = new ChunkedLineReader(file, 5)
     const expectedLines = ['line1', 'line2', 'line3']
     expect.assertions(7)
-    await chunker.iterateLines((line, lineNum, isLastLine) => {
-      expect(line).toEqual(expectedLines[lineNum])
-      expect(isLastLine).toEqual(lineNum === 2)
+
+    await chunker.iterateLines({
+      func: (line, lineNum, isLastLine) => {
+        expect(line).toEqual(expectedLines[lineNum])
+        expect(isLastLine).toEqual(lineNum === 2)
+      }
     })
     expect(chunker.hasMoreLines).toEqual(false)
   })
@@ -44,9 +51,12 @@ describe('chunked line reader', () => {
     const chunker = new ChunkedLineReader(file, 6)
     const expectedLines = ['line1', 'line2', 'line3']
     expect.assertions(7)
-    await chunker.iterateLines((line, lineNum, isLastLine) => {
-      expect(line).toEqual(expectedLines[lineNum])
-      expect(isLastLine).toEqual(lineNum === 2)
+
+    await chunker.iterateLines({
+      func: (line, lineNum, isLastLine) => {
+        expect(line).toEqual(expectedLines[lineNum])
+        expect(isLastLine).toEqual(lineNum === 2)
+      }
     })
     expect(chunker.hasMoreLines).toEqual(false)
   })
@@ -57,9 +67,12 @@ describe('chunked line reader', () => {
 
     const expectedLines = ['line1', 'line2', 'line3', 'line4']
     expect.assertions(9)
-    await chunker.iterateLines((line, lineNum, isLastLine) => {
-      expect(line).toEqual(expectedLines[lineNum])
-      expect(isLastLine).toEqual(lineNum === 3)
+
+    await chunker.iterateLines({
+      func: (line, lineNum, isLastLine) => {
+        expect(line).toEqual(expectedLines[lineNum])
+        expect(isLastLine).toEqual(lineNum === 3)
+      }
     })
     expect(chunker.hasMoreLines).toEqual(false)
   })
@@ -69,10 +82,13 @@ describe('chunked line reader', () => {
     const chunker = new ChunkedLineReader(file, 7)
     const expectedLines = ['abcdefghij', 'klmnopqrstuv', 'wxyz123456']
     expect.assertions(6)
+
     // now check that we can read the same file correctly using the iterator
-    await chunker.iterateLines((line, lineNum, isLastLine) => {
-      expect(line).toEqual(expectedLines[lineNum])
-      expect(isLastLine).toEqual(lineNum === 2)
+    await chunker.iterateLines({
+      func: (line, lineNum, isLastLine) => {
+        expect(line).toEqual(expectedLines[lineNum])
+        expect(isLastLine).toEqual(lineNum === 2)
+      }
     })
   })
 })


### PR DESCRIPTION
Adds a timeout to client side validation of 10 seconds. So if a user attempts to upload a super big file the CSFV will timeout after 10 seconds and print out a warning to the user letting them know that the validation will have to occur after file upload. Struggled to find good data on what the timeout time limit ought to be, went with 10 seconds as that felt acceptable anecdotally but again couldn't find any standards on this so input is welcome.

This adds a status type of 'timeout' for the mixpanel event as this isn't really a true "failure" or "success" and is presented as a "warning" to users in the UI.

also updates the iterateLines() function to take its params as an object for cleaner handling.
<img width="1212" alt="Screen Shot 2022-02-09 at 3 36 22 PM" src="https://user-images.githubusercontent.com/54322292/153285821-e1a7f495-0c9c-4753-9768-e55d0d63831a.png">

To test:
- pull this branch
- attempt to upload a super big file, such as the `MIT_Milk_Study_Raw_counts.txt` file which you can obtain from the study SCP1671 in prod
- observe that after 10 seconds the file stops trying to validate and a warning appears and you can click save