### PR TITLE
update CSFV errorType name to match ingest pipeline

### DIFF
--- a/app/javascript/lib/validation/expression-matrices-validation.js
+++ b/app/javascript/lib/validation/expression-matrices-validation.js
@@ -18,7 +18,7 @@ export async function parseDenseMatrixFile(chunker, mimeType, fileOptions) {
   // validating the header required extra lines from the file,
   // return the file reader to the first non-header line to continue validating file
   chunker.resetToFileStart()
-  await chunker.iterateLines(() => {}, 1)
+  await chunker.iterateLines(() => { }, 1)
 
   const secondLineOfFile = firstTwoContentLines[0]
 
@@ -98,7 +98,7 @@ async function getParsedDenseMatrixHeaderLine(chunker) {
 
   if (rawHeader.trim().length === 0) {
     throw new ParseException('format:cap:missing-header-lines',
-        `Your file is missing a required header line`)
+      `Your file is missing a required header line`)
   }
 
   // get the 2 lines following the header line
@@ -150,9 +150,9 @@ function getDenseMatrixDelimiter(rawHeader, rawNextTwoLines) {
       if (secondLineLength === headerLength) {
         bestDelimiter = delimiter
       } // otherwise check the first 3 lines lengths against each other (see r-formatting description for futher explanation)
-      else if (secondLineLength -1 === headerLength ||
+      else if (secondLineLength - 1 === headerLength ||
         thirdLineLength === secondLineLength ||
-        thirdLineLength === headerLength) {bestDelimiter = delimiter}
+        thirdLineLength === headerLength) { bestDelimiter = delimiter }
     }
   }
 
@@ -192,8 +192,8 @@ function validateDenseHeader(header, nextTwoLines) {
 
   if (!isValid) {
     issues.push(['error', 'format:cap:missing-gene-column',
-    `Improperly formatted header row beginning with: '${header[0]}'. ` +
-    `${specificMsg}`])
+      `Improperly formatted header row beginning with: '${header[0]}'. ` +
+      `${specificMsg}`])
   }
 
   return issues
@@ -349,7 +349,7 @@ function validateValuesAreNumeric(line, isLastLine, lineNum, dataObj) {
 
     const msg = `All values (other than the first column and header row) in a dense matrix file must be numeric. ` +
       `Please ensure all values in ${rowText}: ${notedBadRows}, are numbers.`
-    issues.push(['error', 'content:invalid-type:not-numeric', msg])
+    issues.push(['error', 'content:type:not-numeric', msg])
   }
 
   return issues


### PR DESCRIPTION
Update errorType naming in CSFV to match updated name in ingest pipeline. Eric pointed out that the "invalid" in "content:invalid-type:not-numeric" was unnecessary. The errorType name is being updated in ingest for SCP-4037

To test:
In your local instance, select the following dense matrix files from the scp-ingest-pipeline repo for matrix CSFV:
tests/data/dense_matrix_non_numeric.txt

confirm that in the Mixpanel log for the CSFV `file-validation` event, you see:
errorTypes: ["content:type:not-numeric"]

This satisfies SCP-4091
