### PR TITLE
Correct content header issues caused by gsutil and sync actions (SCP-3938)

### DIFF
--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -777,7 +777,7 @@ module Api
               # make sure file is not actually a folder by checking its size
               if file.size > 0
                 # fix content headers
-                fixed_file = StudySyncService.fix_file_content_headers(file)
+                fixed_file = ::StudySyncService.fix_file_content_headers(file)
                 # create a new entry
                 unsynced_file = StudyFile.new(study_id: @study.id, name: fixed_file.name, upload_file_name: fixed_file.name,
                                               upload_content_type: fixed_file.content_type,

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -776,8 +776,13 @@ module Api
             else
               # make sure file is not actually a folder by checking its size
               if file.size > 0
+                # fix content headers
+                fixed_file = StudySyncService.fix_file_content_headers(file)
                 # create a new entry
-                unsynced_file = StudyFile.new(study_id: @study.id, name: file.name, upload_file_name: file.name, upload_content_type: file.content_type, upload_file_size: file.size, generation: file.generation, remote_location: file.name)
+                unsynced_file = StudyFile.new(study_id: @study.id, name: fixed_file.name, upload_file_name: fixed_file.name,
+                                              upload_content_type: fixed_file.content_type,
+                                              upload_file_size: fixed_file.size, generation: fixed_file.generation,
+                                              remote_location: fixed_file.name)
                 @unsynced_files << unsynced_file
               end
             end

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -776,13 +776,10 @@ module Api
             else
               # make sure file is not actually a folder by checking its size
               if file.size > 0
-                # fix content headers
-                fixed_file = ::StudySyncService.fix_file_content_headers(file)
                 # create a new entry
-                unsynced_file = StudyFile.new(study_id: @study.id, name: fixed_file.name, upload_file_name: fixed_file.name,
-                                              upload_content_type: fixed_file.content_type,
-                                              upload_file_size: fixed_file.size, generation: fixed_file.generation,
-                                              remote_location: fixed_file.name)
+                unsynced_file = StudyFile.new(study_id: @study.id, name: file.name, upload_file_name: file.name,
+                                              upload_content_type: file.content_type, upload_file_size: file.size,
+                                              generation: file.generation, remote_location: file.name)
                 @unsynced_files << unsynced_file
               end
             end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -866,6 +866,8 @@ class StudiesController < ApplicationController
     @study_file = @study.study_files.build
     @partial = 'study_file_form'
     if @study_file.update(study_file_params)
+      # fix content headers
+      StudySyncService.fix_file_content_headers(@study_file)
       if study_file_params[:file_type] == 'Expression Matrix' && !study_file_params[:y_axis_label].blank?
         # if user is supplying an expression axis label, update default options hash
         @study.update(default_options: @study.default_options.merge(expression_label: study_file_params[:y_axis_label]))
@@ -1298,12 +1300,10 @@ class StudiesController < ApplicationController
 
           # make sure file is not actually a folder by checking its size
           if file.size > 0
-            # fix content headers
-            fixed_file = StudySyncService.fix_file_content_headers(file)
             # create a new entry
-            unsynced_file = StudyFile.new(study_id: @study.id, name: fixed_file.name, upload_file_name: fixed_file.name,
-                                          upload_content_type: fixed_file.content_type, upload_file_size: fixed_file.size,
-                                          generation: fixed_file.generation, remote_location: fixed_file.name)
+            unsynced_file = StudyFile.new(study_id: @study.id, name: file.name, upload_file_name: file.name,
+                                          upload_content_type: file.content_type, upload_file_size: file.size,
+                                          generation: file.generation, remote_location: file.name)
             unsynced_file.build_expression_file_info
             @unsynced_files << unsynced_file
           end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1295,12 +1295,15 @@ class StudiesController < ApplicationController
           # process sequence data file into appropriate directory listing
           process_directory_listing_file(file, file_type)
         else
+
           # make sure file is not actually a folder by checking its size
           if file.size > 0
+            # fix content headers
+            fixed_file = StudySyncService.fix_file_content_headers(file)
             # create a new entry
-            unsynced_file = StudyFile.new(study_id: @study.id, name: file.name, upload_file_name: file.name,
-                                          upload_content_type: file.content_type, upload_file_size: file.size,
-                                          generation: file.generation, remote_location: file.name)
+            unsynced_file = StudyFile.new(study_id: @study.id, name: fixed_file.name, upload_file_name: fixed_file.name,
+                                          upload_content_type: fixed_file.content_type, upload_file_size: fixed_file.size,
+                                          generation: fixed_file.generation, remote_location: fixed_file.name)
             unsynced_file.build_expression_file_info
             @unsynced_files << unsynced_file
           end

--- a/app/lib/study_sync_service.rb
+++ b/app/lib/study_sync_service.rb
@@ -1,0 +1,59 @@
+# collection of methods to be called during sync actions
+class StudySyncService
+  # handle setting the metadata headers for a GCS resource (e.g. file)
+  # this is used mainly to address issues when a user has directly pushed a file to a bucket via gsutil
+  # which can result in headers are not being set correctly that causes downstream issues when localizing files
+  #
+  # * *params*
+  #   - +file+ (Google::Cloud::Storage::File) => remote GCS file in workspace bucket
+  #
+  # * *returns*
+  #  - (Google::Cloud::Storage::File)
+  def self.fix_file_content_headers(file)
+    return file unless file.is_a?(Google::Cloud::Storage::File) && gzipped?(file) # uncompressed files need no updates
+
+    Rails.logger.info "correcting headers on unsynced file #{file.name} in #{file.bucket}"
+    # determine what headers need to be changed, if any
+    case file.content_type
+    when /text/
+      Rails.logger.info "setting #{file.name} content_encoding to gzip based on content_type: #{file.content_type}"
+      file.content_encoding = 'gzip'
+    when /gzip/
+      Rails.logger.info "setting #{file.name} content_type to application/octet-stream, clearing content_encoding " \
+                        "based on content_type: #{file.content_type}"
+      # use block-style update for single PATCH request
+      file.update do |f|
+        f.content_type = 'application/octet-stream'
+        f.content_encoding = ''
+      end
+    when 'application/octet-stream'
+      Rails.logger.info "unsetting #{file.name} content_encoding based on content_type: #{file.content_type}"
+      file.content_encoding = ''
+    else
+      Rails.logger.info "skipping #{file.name} header correction due to unexpected content_type: #{file.content_type}"
+    end
+    file
+  end
+
+  # tell if a file has been gzipped
+  #
+  # * *params*
+  #   - +file+ (Google::Cloud::Storage::File) => remote GCS file in workspace bucket
+  #
+  # * *returns*
+  #  - (Boolean)
+  def self.gzipped?(file)
+    return true if file.name&.end_with?('.gz') || file.content_type == 'application/gzip'
+
+    # read first two bytes into memory and check against StudyFile::GZIP_MAGIC_NUMBER
+    begin
+      first_two_bytes = file.download(range: 0..1, skip_decompress: true)
+      first_two_bytes.rewind
+      first_two_bytes.read == StudyFile::GZIP_MAGIC_NUMBER
+    rescue => e
+      Rails.logger.error "error checking gzip status on #{file.name}"
+      ErrorTracker.report_exception(e, nil, file)
+      false # we don't really know, so return false to halt execution
+    end
+  end
+end

--- a/test/integration/lib/study_sync_service_test.rb
+++ b/test/integration/lib/study_sync_service_test.rb
@@ -1,0 +1,79 @@
+require 'test_helper'
+
+class StudySyncServiceTest < ActiveSupport::TestCase
+
+  before(:all) do
+    @user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                               name_prefix: 'StudySyncServiceTest',
+                               user: @user,
+                               test_array: @@studies_to_clean)
+    @study_file = FactoryBot.create(:cluster_file,
+                                    name: 'cluster_1.txt.gz',
+                                    remote_location: 'cluster_1.txt.gz',
+                                    study: @study)
+  end
+
+  # while we could employ mocks in this test, it somewhat defeats the purpose as every GCS function call needs to
+  # be mocked in order for the test to run.  instead, we'll pay the overhead to create a real study and push a file
+  # to the bucket to assert that headers are in fact being set correctly
+  test 'should update content headers based on file content' do
+    study = FactoryBot.create(:study,
+                              name_prefix: 'StudySyncService Header Test',
+                              user: @user,
+                              test_array: @@studies_to_clean)
+    gzipped_file = File.open(Rails.root.join('test/test_data/expression_matrix_example_gzipped.txt.gz'))
+    study_file = StudyFile.create(name: 'expression_matrix_example_gzipped.txt.gz', file_type: 'Expression Matrix',
+                                 upload: gzipped_file, remote_location: 'expression_matrix_example_gzipped.txt.gz',
+                                 study: study)
+    # override upload_content_type to simulate a gsutil upload
+    study_file.update(upload_content_type: 'text/plain')
+    client = ApplicationController.firecloud_client
+    # push directly to bucket, and override content_type & content_encoding to simulate problems from gsutil/user error
+    remote = client.create_workspace_file(study.bucket_id,
+                                          gzipped_file.path,
+                                          study_file.upload_file_name,
+                                          content_type: 'text/plain',
+                                          content_encoding: 'gzip')
+    assert remote.present?
+    assert_equal 'text/plain', remote.content_type
+    assert_equal 'gzip', remote.content_encoding
+    assert StudySyncService.fix_file_content_headers(study_file)
+    updated_remote = client.get_workspace_file(study.bucket_id, study_file.bucket_location)
+    assert_equal updated_remote.content_type, 'application/gzip'
+    assert updated_remote.content_encoding.blank?
+  end
+
+  test 'should determine if file is gzipped' do
+    # test for filename
+    mock = Minitest::Mock.new
+    mock.expect(:name, @study_file.name)
+    assert StudySyncService.gzipped?(mock)
+    mock.verify
+
+    # test for content_type
+    mock = Minitest::Mock.new
+    mock.expect(:name, 'cluster_1.txt')
+    mock.expect(:content_type, 'application/gzip')
+    assert StudySyncService.gzipped?(mock)
+    mock.verify
+
+    # test for file content
+    mock = Minitest::Mock.new
+    gzipped_bytes = StringIO.new(StudyFile::GZIP_MAGIC_NUMBER)
+    mock.expect(:name, 'cluster_1.txt')
+    mock.expect(:content_type, 'text/plain')
+    mock.expect(:download, gzipped_bytes, [{ range: 0..1, skip_decompress: true }])
+    assert StudySyncService.gzipped?(mock)
+    mock.verify
+
+    # negative test
+    mock = Minitest::Mock.new
+    plain_bytes = StringIO.new('NA')
+    mock.expect(:name, 'cluster_1.txt')
+    mock.expect(:content_type, 'text/plain')
+    mock.expect(:download, plain_bytes, [{ range: 0..1, skip_decompress: true }])
+    assert_not StudySyncService.gzipped?(mock)
+    mock.verify
+  end
+end


### PR DESCRIPTION
When a user pushes a gzipped file directly to a workspace bucket and then employs the "sync" feature, there is a corner case where ingest processes will fail if the user used `gsutil` to push the file and did not override the `Content-Type` header.  Instead, the original file `Content-Type` is stored, which causes the file to fail ingest as the subsequent file download is not correctly detected as gzipped.  While this is most often seen with sparse matrix bundles (mtx, 10x features, and 10x barcodes), it can happen with any parseable, text-based file that is gzipped and pushed to a workspace bucket with `gsutil`.

This update adds the `StudySyncService`, which is a stub library that will eventually house all sync-related methods (as originally outlined in SCP-3121).  For now, this class contains methods that will determine the correct content headers for any synced file, depending on how it was uploaded, and whether or not it is gzipped (only compressed files that were synced will have their `Content-Type` and `Content-Encoding` headers overridden.

Note: there is an unrelated issue where single-column gzipped text files do not decompress properly on MacOS.  In order to decompress these files, please use `gunzip [filename]` in the terminal.

MANUAL TESTING
Before beginning, if you have `gsutil` installed, you will want to run `gcloud auth login` to make sure you are authenticated to use `gsutil`
1. Boot as normal and sign in, making sure to run `rails jobs:work` in another console to start the job worker
2. Select a study from "My Studies" and click "Show Details"
3. Do one of the following:
    -  If you do not have `gsutil` installed, click the link to open the Storage Browser, and upload the file through the browser, then click "Edit Metadata" from the ellipsis menu, and set the `Content-Type` to `text/plain`
    - If you have `gsutil` installed, push the file `test/test_data/expression_matrix_example_gzipped.txt.gz` directly to the workspace bucket (you can get the bucket ID from the `Google Storage Bucket` line) with:
```
gsutil cp test/test_data/expression_matrix_example_gzipped.txt.gz gs://[bucket_id]
```
4. Back in SCP, click "Sync Workspace" for the selected study from the "My Studies" page
5. Sync the expression matrix and confirm that the success dialog shows
6. Back in the GCS browser, refresh the page and click "Edit Metadata" again, and confirm that `Content-Type` is now set to `application/gzip`
7. Wait for the expression matrix to finish parsing and confirm it completes without error

This PR satisfies SCP-3938