### PR TITLE
Enrich pathway interactions, reduce noise, fix descriptions in related genes ideogram (SCP-3962)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
-    "ideogram": "1.32.0",
+    "ideogram": "1.34.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.13.0",
     "morpheus-app": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6061,6 +6061,11 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fflate@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.7.3.tgz#288b034ff0e9c380eaa2feff48c787b8371b7fa5"
+  integrity sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw==
+
 figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
@@ -7009,10 +7014,10 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ideogram@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.32.0.tgz#93729d2296ebb19f5e1493a0729994ca79b4c3e9"
-  integrity sha512-i6F4iIBuUx40jFXwxBUQegmKxHE2SDOP5bOwizH5qvE03fpFPKwHcMkifQwHOLQviF0FOPsPMwpNuBXme/I1Yg==
+ideogram@1.34.0:
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.34.0.tgz#7d5e9a151c452e26b0224ab057073b390b464479"
+  integrity sha512-TgefcX8yo/sAwG8wM+0vX9Q5wYEL7AlJLPGPRDF8XlGYydH85egySCupmKTyt+w/8M/+gbTJhaPWFDnUEg3fpA==
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"
@@ -7021,6 +7026,7 @@ ideogram@1.32.0:
     d3-fetch "^2.0.0"
     d3-format "^2.0.0"
     d3-scale "^3.2.3"
+    fflate "^0.7.3"
 
 ieee754@^1.1.4:
   version "1.2.1"


### PR DESCRIPTION
This improves the related genes ideogram.

# Enhance pathway interaction detail
Previously, all interacting genes were described as merely "interacting" -- a rather broad characterization.  

Now, using rich GPML data from WikiPathways, more detailed types of interactions are often reported.  So gene A might "inhibit" or "stimulate" etc. gene B.  In addition to the finer categorization, directionality is now also often reported.  So gene C might "inhibit" gene D, or "be inhibited by" gene E.

This increases the value of related genes ideogram by giving researchers more specific biochemical insight, often tied directly to effects on gene expression.  It can help generate hypotheses and guide exploration.

Here's how it looks.

https://user-images.githubusercontent.com/1334561/154088389-6620fab0-4115-49f9-adcc-4d6678e1935c.mov

# Reduce noise
Relevance and layout improvements in (#1280) are now also refined to reduce noise.  Fewer labels are now typically shown.  Highly interesting-yet-nearby genes now more often have both of their labels shown, though still not overlapping.  Finally, as they are generally poorly described, paralogs that have names which are accessions no longer shown.  This gives space for more interesting genes.

# Fix duplicative paralog descriptions
Previously, the tooltip in paralogs had a bug where it often showed two instances of e.g. "Paralog of Pten".  This rarely affected the display in human but was common in mouse.  That's now fixed.

To test:
* Install JS package updates: `yarn install`
* If you haven't already, then populate new "human_all_genes" study, e.g. via `echo "SyntheticStudyPopulator.populate('human_all_genes')" | bundle exec rails console -e development`
* Navigate to it in web browser
* Search PTEN
* Hover over purple triangles, i.e. "interacting gene" annotations.  Verify that at least some report detailed interactions, e.g. hovering over GABPA reports "Acts on PTEN in".
* Navigate to a study that has realistic mouse data, i.e. many / all mouse genes.  Jonah's Slide-seq proof of concept is a good example.
* Search Pten
* Hover over pink triangles, i.e. "paralogous gene" annotations.  Verify that none say "Paralog of" twice.

This satisfies SCP-3962.   It incorporates fixes for #1301, following #1304, as well as other refinements and optimizations.