### PR TITLE
update to ingest release 1.14.0

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.13.1'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.14.0'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
Incorporate ingest pipeline matrix error logging to Mixpanel [(link to scp-ingest-pipeline PR for details)](https://github.com/broadinstitute/scp-ingest-pipeline/pull/232)