### PR TITLE
Minor fixes to Upload Wizard (SCP-4105)

### DIFF
--- a/app/javascript/components/upload/MetadataStep.js
+++ b/app/javascript/components/upload/MetadataStep.js
@@ -59,7 +59,7 @@ function MetadataForm({
       <div className="col-md-12">
         <div className="form-terra">
           <div className="row">
-            <div className="col-md-12" id="metadata-convention-explainer">
+            <div className="col-md-12" id="overflow-x-scroll">
               A <b>metadata file</b> lists all cells in the study
               <img src={metadataExplainerImage}/>
             </div>

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -340,20 +340,20 @@ export function RawUploadWizard({ studyAccession, name }) {
     <StudyContext.Provider value={studyObj}>
       <div className="upload-wizard-react">
         <div className="row">
-          <div className="col-md-12 wizard-top-bar">
-            <span>{serverState?.study?.name}</span> / &nbsp;
-            <a href={`/single_cell/study/${studyAccession}`}>View study</a>
+          <div className="col-md-12 wizard-top-bar no-wrap-ellipsis">
+          <a href={`/single_cell/study/${studyAccession}`}>View study</a> / &nbsp;
+            <span >{serverState?.study?.name}</span>
           </div>
         </div>
         <div className="row wizard-content">
-          <div className="col-md-3">
+          <div>
             <WizardNavPanel {...{
               formState, serverState, currentStep, setCurrentStep, studyAccession, mainSteps: MAIN_STEPS,
               supplementalSteps: SUPPLEMENTAL_STEPS, studyName: name
             }} />
           </div>
-          <div className="col-md-9">
-            <div className="flexbox-align-center top-margin">
+          <div>
+            <div className="flexbox-align-center top-margin margin-left">
               <h4>{currentStep.header}</h4>
               <div className="prev-next-buttons">
                 { prevStep && <button

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -342,7 +342,7 @@ export function RawUploadWizard({ studyAccession, name }) {
         <div className="row">
           <div className="col-md-12 wizard-top-bar no-wrap-ellipsis">
           <a href={`/single_cell/study/${studyAccession}`}>View study</a> / &nbsp;
-            <span >{serverState?.study?.name}</span>
+            <span title="{serverState?.study?.name}">{serverState?.study?.name}</span>
           </div>
         </div>
         <div className="row wizard-content">

--- a/app/javascript/components/upload/UploadWizard.js
+++ b/app/javascript/components/upload/UploadWizard.js
@@ -352,7 +352,7 @@ export function RawUploadWizard({ studyAccession, name }) {
               supplementalSteps: SUPPLEMENTAL_STEPS, studyName: name
             }} />
           </div>
-          <div>
+          <div id="overflow-x-scroll">
             <div className="flexbox-align-center top-margin margin-left">
               <h4>{currentStep.header}</h4>
               <div className="prev-next-buttons">

--- a/app/javascript/components/upload/WizardNavPanel.js
+++ b/app/javascript/components/upload/WizardNavPanel.js
@@ -19,7 +19,7 @@ function RawWizardNavPanel({
   const [othersExpanded, setOthersExpanded] = useState(true)
   const expansionIcon = othersExpanded ? faChevronUp : faChevronDown
 
-  return <div className="position-fixed">
+  return <div className="wizard-side-panel">
     <ul className="upload-wizard-steps" role="tablist" data-analytics-name="upload-wizard-primary-steps">
       { mainSteps.map((step, index) =>
         <StepTabHeader key={index}

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -808,3 +808,9 @@ figcaption.ck-editor__editable {
   background: unset;
   border: unset;
 }
+
+.no-wrap-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -702,7 +702,7 @@ ul.pager li.dimmed {
   padding-right: 15px;
 }
 
-#metadata-convention-explainer {
+#overflow-x-scroll {
   overflow-x: scroll;
 }
 

--- a/app/javascript/styles/_uploadWizard.scss
+++ b/app/javascript/styles/_uploadWizard.scss
@@ -1,11 +1,9 @@
 .upload-wizard-react {
   .position-fixed {
     width: 25%;
-    min-width: 190px;
-    position: fixed;
+    min-width: 229px;
     height: calc(100% - 50px); // leave room for footer and navbar
     overflow-y: auto;
-    margin-left: -15px;
     background: rgb(219, 225, 232);
   }
   .wizard-top-bar {
@@ -13,11 +11,10 @@
     width: 100%;
     padding: 0.5em;
     padding-left: 1em;
-    position: fixed;
     z-index: 100;
   }
   .wizard-content {
-    margin-top: 34px;
+    display: flex;
     min-width: 730px;
   }
 }
@@ -118,7 +115,6 @@
 }
 
 .file-upload-overlay {
-  position: absolute;
   left: 0;
   top: 0;
   width: 100%;
@@ -149,4 +145,8 @@
 
 .prev-next-buttons {
   margin-left: auto;
+}
+
+.margin-left {
+  margin-left: 15px;
 }

--- a/app/javascript/styles/_uploadWizard.scss
+++ b/app/javascript/styles/_uploadWizard.scss
@@ -1,6 +1,7 @@
 .upload-wizard-react {
   .position-fixed {
     width: 25%;
+    min-width: 190px;
     position: fixed;
     height: calc(100% - 50px); // leave room for footer and navbar
     overflow-y: auto;
@@ -9,6 +10,7 @@
   }
   .wizard-top-bar {
     background: #ddd;
+    width: 100%;
     padding: 0.5em;
     padding-left: 1em;
     position: fixed;
@@ -16,6 +18,7 @@
   }
   .wizard-content {
     margin-top: 34px;
+    min-width: 730px;
   }
 }
 

--- a/app/javascript/styles/_uploadWizard.scss
+++ b/app/javascript/styles/_uploadWizard.scss
@@ -1,5 +1,5 @@
 .upload-wizard-react {
-  .position-fixed {
+  .wizard-side-panel {
     width: 25%;
     min-width: 229px;
     height: calc(100% - 50px); // leave room for footer and navbar
@@ -15,7 +15,6 @@
   }
   .wizard-content {
     display: flex;
-    min-width: 730px;
   }
 }
 

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -174,7 +174,7 @@
         <div class="well well-sm container-fluid upload-wizard">
           <div class="row">
             <h2 class="col-sm-12">Step 3. Upload Metadata File <small class="initialize-label" id="initialize_metadata_form_completed"></small></h2>
-            <div class="col-sm-12" id="metadata-convention-explainer">
+            <div class="col-sm-12" id="overflow-x-scroll">
               <%= image_tag "metadata-convention-explainer.jpg" %>
             </div>
           </div>


### PR DESCRIPTION
This is the minimum changes from my dev choice project - still working on cooler/more dynamic fixes but wanted to at minimum put up code to fix some of the strange behavior that's on prod.

Fixes:
 - Bug that Devon noted where if a study has a very long name it used to cause an overlap, now the study name will be truncated
 - Previously if you sized the window small the content in the right side of the wizard would cover over the wizard steps panel. Now the two parts of the wizard content are more fixed in size/position so that resizing won't lose content and so that the panel doesn't get unnecessarily wide allowing for more real-estate to go towards the main content of the page.

To test:
- pull this branch
- open up a study to the upload wizard
- try moving around the window and observe that the panel and right-side content both stay accessible.

*Note
- there is a bug that is not addressed where the navbar doesn't dynamically resize in time so sometimes the "Help & resources" "create study" "profile" buttons swing down into the main page content. This exists in Prod and is not addressed in this PR


https://user-images.githubusercontent.com/54322292/154144396-6cd2e39f-d3cb-4639-bd07-745bfa6280fd.mov
