### PR TITLE
Update library preparation protocol dropdown (SCP-4082)

### DIFF
--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -44,6 +44,7 @@ class ExpressionFileInfo
                                 '10x feature barcode/multiplexing', # scRNAseq
                                 '10x Ig enrichment', # targeted transcriptomic
                                 '10x multiome', # multiomic ATAC-seq
+                                '10x scATAC-seq', # scATAC-seq
                                 '10x TCR enrichment', # targeted transcriptomic
                                 '10x Visium', # spatial transcriptomic
                                 'CEL-seq2', # scRNAseq
@@ -55,7 +56,6 @@ class ExpressionFileInfo
                                 'MARS-seq', # scRNAseq
                                 'MERFISH', # spatial transcriptomic
                                 'osmFISH', # spatial transcriptomic
-                                'scATAC-seq/10x', # scATAC-seq
                                 'scATAC-seq/Fluidigm', # scATAC-seq
                                 'sci-ATAC-seq', # scATAC-seq
                                 'sci-RNA-seq', # scRNAseq

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -32,41 +32,47 @@ class ExpressionFileInfo
   ].freeze
   validates :modality, inclusion: { in: MODALITY_VALUES }
 
-  LIBRARY_PREPARATION_VALUES = ["10x 3' v1",
-                                "10x 3' v2",
-                                "10x 3' v3",
-                                "10x 5' v1",
-                                "10x 5' v2",
-                                "10x 5' v3",
-                                'CEL-seq2',
-                                'Drop-seq',
-                                'inDrop',
-                                'MARS-seq',
-                                'sci-RNA-seq',
-                                'Seq-Well S^3',
-                                'Seq-Well v1',
-                                'Smart-like',
-                                'Smart-seq2/Fluidigm C1',
-                                'Smart-seq2/plate-based',
-                                # non-scRNAseq Assays
-                                # single cell ATAC-seq assays
-                                'dsc-ATAC-seq',
-                                'dsci-ATAC-seq',
-                                'scATAC-seq/10x',
-                                'scATAC-seq/Fluidigm',
-                                'sci-ATAC-seq',
-                                'scTHS-seq',
-                                'snATAC-seq',
-                                # spatial transcriptomics assays
-                                '10x Visium',
-                                'MERFISH',
-                                'osmFISH',
-                                'SeqFISH+',
-                                'Slide-seq',
-                                'smFISH',
-                                'STARmap', # Note WIP for EFO term: https://broadinstitute.zendesk.com/agent/tickets/139334
-                                # single cell ChIP-seq assays
-                                'Drop-ChIP'].freeze
+  LIBRARY_PREPARATION_VALUES = [
+                                "10x 3' v1", # scRNAseq
+                                "10x 3' v2", # scRNAseq
+                                "10x 3' v3", # scRNAseq
+                                "10x 5' v1", # scRNAseq
+                                "10x 5' v2", # scRNAseq
+                                "10x 5' v3", # scRNAseq
+                                '10x feature barcode/cell surface protein', # targeted proteomic
+                                '10x feature barcode/CRISPR', # expression perturbation
+                                '10x feature barcode/multiplexing', # scRNAseq
+                                '10x Ig enrichment', # targeted transcriptomic
+                                '10x multiome', # multiomic ATAC-seq
+                                '10x TCR enrichment', # targeted transcriptomic
+                                '10x Visium', # spatial transcriptomic
+                                'CEL-seq2', # scRNAseq
+                                'Drop-ChIP', # scChIP-seq
+                                'Drop-seq', # scRNAseq
+                                'dsc-ATAC-seq', # scATAC-seq
+                                'dsci-ATAC-seq', # scATAC-seq
+                                'inDrop', # scRNAseq
+                                'MARS-seq', # scRNAseq
+                                'MERFISH', # spatial transcriptomic
+                                'osmFISH', # spatial transcriptomic
+                                'scATAC-seq/10x', # scATAC-seq
+                                'scATAC-seq/Fluidigm', # scATAC-seq
+                                'sci-ATAC-seq', # scATAC-seq
+                                'sci-RNA-seq', # scRNAseq
+                                'scTHS-seq', # scATAC-seq
+                                'Seq-Well S^3', # scRNAseq
+                                'Seq-Well v1', # scRNAseq
+                                'SeqFISH+', # spatial transcriptomic
+                                'SHARE-seq', # multiomic ATAC-seq
+                                'Slide-seq', # spatial transcriptomic
+                                'Slide-seqV2', # spatial transcriptomic
+                                'Smart-like', # scRNAseq
+                                'Smart-seq2/Fluidigm C1', # scRNAseq
+                                'Smart-seq2/plate-based', # scRNAseq
+                                'smFISH', # spatial transcriptomic
+                                'snATAC-seq', # scATAC-seq
+                                'STARmap',  # spatial transcriptomic
+                              ].freeze
   validates :library_preparation_protocol, inclusion: { in: LIBRARY_PREPARATION_VALUES }
 
   validate :unset_units_unless_raw_counts


### PR DESCRIPTION
Long-time SCP study owner, Amanda Kedaigle let us know she has an upcoming study with SHARE-seq data (Zendesk 270215). She suggested adding both SHARE-seq and 10x multome (a comparable 10x protocol) to our library preparation protocol dropdown.

The dropdown had been organized by assay type but that organization was in comments only visible to developers. To make protocols more easily findable by study owners, the list has been re-organized to present protocols alphabetically.

PR adds the following terms the list of options:
'10x feature barcode/cell surface protein', # targeted proteomic
'10x feature barcode/CRISPR', # expression perturbation
'10x feature barcode/multiplexing', # scRNAseq
'10x Ig enrichment', # targeted transcriptomic
'10x multiome', # multiomic ATAC-seq
'10x TCR enrichment', # targeted transcriptomic
'SHARE-seq', # multiomic ATAC-seq
'Slide-seq', # spatial transcriptomic
'Slide-seqV2', # spatial transcriptomic

Also updated "scATAC-seq/10x" to "10x scATAC-seq" for uniformity
(studies with "scATAC-seq/10x" stored were [updated](https://broadinstitute.slack.com/archives/G01HY2DJTFY/p1645028901167319))

To test:
in your local instance, verify that the list is now organized alphabetically and the new terms above now appears in the dropdown list for library preparation protocol

This PR supports SCP-4082.