### PR TITLE
fixing bug in update study settings analyis tab (SCP-4129)

### DIFF
--- a/app/javascript/components/explore/ExploreView.js
+++ b/app/javascript/components/explore/ExploreView.js
@@ -40,6 +40,7 @@ function RoutableExploreTab({ studyAccession }) {
         if (userSpecificInfo.canCompute) {
           // show the analysis tab
           const fragment = document.createRange().createContextualFragment(userSpecificInfo.analysisTabContent)
+          document.getElementById('study-analysis').innerHTML = ''
           document.getElementById('study-analysis').appendChild(fragment)
           document.getElementById('study-analysis-nav').classList.remove('hidden')
         }


### PR DESCRIPTION
Saving study settings causes a reload of the explore tab, which caused a reload of the analysis tab, which caused errors and table duplications.  This fixes that by making sure to clear the existing content first before rendering

![image](https://user-images.githubusercontent.com/2800795/154759596-dd6be384-25ff-4671-a1b7-1e9502a21b02.png)


TO TEST:
1. load a study with an analysis tab
2. update the study settings (e.g. change the point size)
3. wait for the study settings to save, and the explore tab to rerender
4. go to the analysis tab, and confirm it still looks correct (no duplicated content), and that no error modals popped up