### PR TITLE
adding HCA ToS to bulk download dialog

### DIFF
--- a/app/javascript/components/search/controls/download/DownloadSelectionModal.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionModal.js
@@ -118,6 +118,9 @@ export default function DownloadSelectionModal({ studyAccessions, show, setShow 
             { showAzulSelectionPane &&
               <div>
                 <h4>Human Cell Atlas studies</h4>
+                <span className="detail">HCA studies are vailable under
+                  their <a href="https://data.humancellatlas.org/about/data-use-agreement" target="_blank" rel="noopener noreferrer">Data Use Agreement</a>
+                </span>
                 <DownloadSelectionTable
                   isLoading={isLoadingAzul}
                   downloadInfo={downloadInfoAzul}

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -327,7 +327,7 @@ nav.search-links, #search-panel {
 }
 
 .download-table-container {
-  margin: 2em 0em 1em 0em;
+  margin: 1em 0em 1em 0em;
   overflow-x: hidden;
 }
 .download-size-message {


### PR DESCRIPTION
Adds a link to HCA Data Use Agreement.  It might look nicer below the table, but keeping it above the table makes sure it is visible even when results are long

![image](https://user-images.githubusercontent.com/2800795/155186832-6b90ed6d-96ac-4163-8d9b-be578966a792.png)

TO TEST:
1. Make sure XDSS is enabled in your environment
2. do a search, e.g. "lymph" which returns SCP and HCA studies
3. click 'Download'
4. confirm text appears, and link takes you to HCA agreement in a new tab
