### PR TITLE
Dynamically change language for bulk download command based on OS (SCP-4090)

### DIFF
--- a/app/javascript/components/search/controls/download/DownloadCommand.js
+++ b/app/javascript/components/search/controls/download/DownloadCommand.js
@@ -4,6 +4,10 @@ import LoadingSpinner from 'lib/LoadingSpinner'
 import { fetchAuthCode, stringifyQuery } from 'lib/scp-api'
 import { _ as bardUtils } from '@databiosphere/bard-client/src/utils'
 
+// Get client os and determine correct curl invocation & UI language
+const clientOS = bardUtils.info.os()
+const isWindows = clientOS.match(/Win/)
+
 /** component for rendering a copyable bulk download command for an array of file ids.
     Queries the server to retrieve the appropriate auth code. */
 export default function DownloadCommand({ fileIds=[], azulFiles }) {
@@ -28,6 +32,7 @@ export default function DownloadCommand({ fileIds=[], azulFiles }) {
   }, [refreshNum])
 
   const downloadCommand = getDownloadCommand(authInfo.authCode, authInfo.downloadId)
+  const terminalDescription = isWindows ? 'Windows PowerShell window' : 'Mac/Linux/Unix terminal'
 
   return <div className="download-url-modal row">
     <br/><br/><br/>
@@ -41,7 +46,7 @@ export default function DownloadCommand({ fileIds=[], azulFiles }) {
     {
       !isLoading &&
       <div className="col-md-12">
-        <h4>Copy the command below and paste it into your Mac/Linux/Unix terminal</h4>
+        <h4>Copy the command below and paste it into your {terminalDescription}</h4>
         This command is valid for one use within <span className='countdown'>
           {Math.floor(authInfo.timeInterval / 60)}
         </span> minutes.
@@ -83,9 +88,6 @@ export default function DownloadCommand({ fileIds=[], azulFiles }) {
  * @returns {Object} Object for auth code, time interval, and download command
  */
 function getDownloadCommand(authCode, downloadId) {
-  // Get client os and determine correct curl invocation
-  const clientOS = bardUtils.info.os()
-  const isWindows = clientOS.match(/Win/)
   const curlExec = isWindows ? 'curl.exe' : 'curl'
   const queryParams = {
     auth_code: authCode,


### PR DESCRIPTION
This update automatically detects the client's operating system and changes the language in the bulk download modal accordingly.  For Windows-based machines:

![windows](https://user-images.githubusercontent.com/729968/155202707-bf7bda2e-61c6-44d9-a747-1978ae7cd121.png)

For Mac/Linux machines:

![mac](https://user-images.githubusercontent.com/729968/155202714-995eba6c-61c8-4e85-8c65-4f100f859d9d.png)

MANUAL TESTING
1. Boot as normal and sign in
2. Run any search that will return studies, and click the `Download` button
3. Click `Next`, and validate that the language is appropriate for your machine OS
4. In `app/javascript/components/search/controls/download/DownloadCommand.js#L9`, set `isWindows` to the opposite of what it should be for your machine (e.g. `true` if you are on a Mac)
5. Re-run the search, click download again, and validate that the language has changed to reflect the opposite operating system

This PR satisfies SCP-4090.