### PR TITLE
Correctly report substantive errors to Mixpanel (SCP-4085)

### DIFF
--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -182,11 +182,12 @@ class MetricsService
     }
 
     # configure properties/headers depending on user presence
-    if user.present?
+    # only pass user token if user is registered for Terra to avoid 4xx/5xx errors
+    if user.present? && user.registered_for_firecloud
       props.merge!({ authenticated: true, registeredForTerra: user.registered_for_firecloud })
       headers.merge!({'Authorization' => "Bearer #{user.token_for_api_call.dig('access_token')}"})
     else
-      props.merge!({ authenticated: false, distinct_id: request.cookies['user_id'] })
+      props.merge!({ authenticated: user.present?, distinct_id: request.cookies['user_id'] })
     end
 
     post_body = {'event' => 'error', 'properties' => props}.to_json

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -178,6 +178,6 @@ class RequestUtils
   def self.static_asset_error?(exception)
     return false unless exception.is_a?(ActionController::RoutingError)
 
-    exception.message.match(/(assets|packs|apple-touch)/) ? true : false
+     /(assets|packs|apple-touch)/.match?(exception.message)
   end
 end

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -157,9 +157,9 @@ class RequestUtils
   # handle upstream reporting/logging of errors in custom exceptions controllers
   def self.log_exception(request, params, user: nil, study: nil)
     @exception = request.env['action_dispatch.exception']
-    MetricsService.report_error(@exception, request, user, study)
-    ErrorTracker.report_exception(@exception, user, params)
     Rails.logger.error ([@exception.message] + @exception.backtrace).join($/)
+    ErrorTracker.report_exception(@exception, user, params)
+    MetricsService.report_error(@exception, request, user, study)
   end
 
   # format exception JSON responses

--- a/test/integration/lib/request_utils_test.rb
+++ b/test/integration/lib/request_utils_test.rb
@@ -72,4 +72,18 @@ class RequestUtilsTest < ActiveSupport::TestCase
     assert_equal exception.message, json_response[:error]
     assert_equal exception.class.name, json_response[:error_class]
   end
+
+  test 'should ignore static asset errors' do
+    error = RuntimeError.new('this is a normal error')
+    assert_not RequestUtils.static_asset_error?(error)
+    paths = [
+      'No route matches [GET] "/apple-touch-icon-precomposed.png"',
+      'No route matches [GET] "/single_cell/packs/foo.js"',
+      'No route matches [GET] "/single_cell/assets/does-not-exist.css"'
+    ]
+    paths.each do |path|
+      asset_error = ActionController::RoutingError.new(path)
+      assert RequestUtils.static_asset_error?(asset_error)
+    end
+  end
 end


### PR DESCRIPTION
Currently, when an error is caught and we attempt to report upstream to Mixpanel, there is a corner case that can result in a `400` response from Bard if the user is signed in but not registered for Terra.  This is because passing the `Authorization: Bearer` header will instruct Bard to look up that Google user in SAM, and that user does not exist.  Locally, we see the same error, but it oddly results in a `503` instead of `400` (ideally, it should be a `401`, but oh well).

This update now checks to ensure the user is registered for Terra before setting the `Authorization: Bearer` header on exception reporting.  In addition, a new `static_asset_error?` helper has been added to silently ignore reporting any `404` errors when a user's browser attempts to load a non-existent static asset.  This will cover the very noisy and annoying `'No route matches [GET] "/apple-touch-icon-precomposed.png"'` error, as well as any missing JS map files.

MANUAL TESTING
1. Pull this branch, and edit the block in `config/environments/development.rb` starting on line 62 to be:
```
config.exceptions_app = lambda do |env|
  if env['action_dispatch.original_path']&.include?('api/v1')
    Api::V1::ExceptionsController.action(:render_error).call(env)
  else
    ExceptionsController.action(:render_error).call(env)
  end
end
```
2. Boot as normal, and sign in with any Google account that is not registered for Terra
3. Open `log/development.log` in the Console app to watch the logfile
4. In your browser, enter a request for "https://localhost:3000/single_cell/foo"
5. Confirm the "We're sorry, but something went wrong" page loads
6. In `development.log`, note a line for reporting to Bard:
```
Reporting error analytics to mixpanel for (ActionController::RoutingError) No route matches [GET] "/single_cell/foo"
```
7. Confirm there is no `503` or `400` response immediately afterwards from Bard
8. Back in the browser, enter a request for "https://localhost:3000/single_cell/assets/does-not-exist"
9. Confirm the error page still renders, and that in `development.log`, there is no reporting to Bard/Sentry listed

This PR satisfies SCP-4085.