### PR TITLE
Refine disabling of "Sync" button (SCP-4137)

### DIFF
--- a/app/views/studies/_shared_sync_functions.js.erb
+++ b/app/views/studies/_shared_sync_functions.js.erb
@@ -13,6 +13,12 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', async function(
     var taxonTarget = form.find('.taxon-select-target');
     var submitBtn = $('#sync-study-file-<%= study_file.id %>');
 
+    $(`#sync-study-file-${fileId}`)
+      .prop('disabled', null)
+      .attr('data-toggle', null)
+      .attr('data-original-title', null)
+      .attr('data-placement', null)
+
     // render fields & process entries based on file type
     if (fileType === 'Cluster') {
         extraInfo.html("<%= j(render partial: 'cluster_axis_fields', locals: {f: f.dup}) %>");
@@ -99,12 +105,6 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', async function(
             submitBtn.attr('disabled', false);
         }
     }
-
-    $(`#sync-study-file-${fileId}`)
-      .prop('disabled', null)
-      .attr('data-toggle', null)
-      .attr('data-original-title', null)
-      .attr('data-placement', null)
 
     // FileUploadControl updates this more elegantly via React,
     // but this direct approach is easier and as effective here.

--- a/app/views/studies/_shared_sync_functions.js.erb
+++ b/app/views/studies/_shared_sync_functions.js.erb
@@ -135,7 +135,7 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', async function(
       target, studyAccession, errorMsgs, warningMsgs, fileName, true
     )
 
-    if (issues.errors.length > 1) {
+    if (issues.errors.length > 0) {
       // Disable the "Sync" button
       $(`#sync-study-file-${fileId}`)
         .prop('disabled', true)

--- a/app/views/studies/_shared_sync_functions.js.erb
+++ b/app/views/studies/_shared_sync_functions.js.erb
@@ -100,6 +100,12 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', async function(
         }
     }
 
+    $(`#sync-study-file-${fileId}`)
+      .prop('disabled', null)
+      .attr('data-toggle', null)
+      .attr('data-original-title', null)
+      .attr('data-placement', null)
+
     // FileUploadControl updates this more elegantly via React,
     // but this direct approach is easier and as effective here.
     let useConvention = false
@@ -128,7 +134,6 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', async function(
     window.SCP.renderValidationMessage(
       target, studyAccession, errorMsgs, warningMsgs, fileName, true
     )
-
 
     if (issues.errors.length > 1) {
       // Disable the "Sync" button


### PR DESCRIPTION
This fixes UX papercuts with sync CSFV.

Previously, if the user selected the wrong SCP file type -- e.g. "Dense matrix" for a metadata file -- the "Sync" button would become disabled, and the user would have to refresh the page to re-enable the button.  That's an unnecessary chore. 

Another problem was that the button would only disable if there were _multiple_ errors; it should disable even if there's only one.

Now, the Sync button re-enables when the user re-selects the file type (and remains so if valid), and disables even if there's just one error.

To test:
* Go to sync page in a study with unsynced files
* Select a wrong file type for a file that is otherwise valid
* Confirm "Sync" button disables
* Select right file type for same file
* Confirm "Sync" button enables
* Select a file with only one error
* Confirm "Sync" button disables