### PR TITLE
Ensure test BQ dataset is updated as well as default dataset (SCP-4145)

### DIFF
--- a/db/migrate/20200221193404_add_bq_organism_age_column.rb
+++ b/db/migrate/20200221193404_add_bq_organism_age_column.rb
@@ -2,9 +2,13 @@ class AddBqOrganismAgeColumn < Mongoid::Migration
   # note this operation is safe to run even if your BQ table already has the given column
   def self.up
     client = BigQueryClient.new.client
-    dataset = client.dataset(CellMetadatum::BIGQUERY_DATASET)
-    table = dataset.table(CellMetadatum::BIGQUERY_TABLE)
-    table.schema {|s| s.numeric('organism_age__seconds', mode: :nullable)}
+    [CellMetadatum::BIGQUERY_DATASET, 'cell_metadata_test'].each do |dataset_name|
+      dataset = client.dataset(dataset_name)
+      if dataset.present? # ensure test dataset exists to avoid migration failure
+        table = dataset.table(CellMetadatum::BIGQUERY_TABLE)
+        table.schema {|s| s.numeric('organism_age__seconds', mode: :nullable)}
+      end
+    end
   end
 
   def self.down


### PR DESCRIPTION
This update ensures that all BigQuery-specific database migrations reference both the "default" and the `cell_metadata_test` dataset when updating schemas.  Failure to do so can result in data failing to seed to BigQuery, which can cause tests in `test/api/search_controller_test.rb` and `test/integration/study_validation_test.rb` to fail with an _extremely_ unhelpful error message.

MANUAL TESTING
There is unfortunately no direct way to test this, as migrations in BigQuery cannot be rolled back.  As all current SCP team members have already run this migration, and had a manual update of the `cell_metadata_test` schema performed, there is no way to undo/redo the edit.

This PR satisfies SCP-4145