### PR TITLE
Switch to vault role/secret for generating short-lived `VAULT_TOKEN` (SCP-3975)

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -21,11 +21,13 @@ jobs:
           sudo mv vault /usr/local/bin
       - name: Load secrets and run tests
         env:
-          VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           RAILS_LOG_TO_STDOUT: true
+          VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+          VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
         run: |
+          export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )
           bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json \
                                   -s secret/kdux/scp/staging/scp_service_account.json \
                                   -r secret/kdux/scp/staging/read_only_service_account.json \


### PR DESCRIPTION
This update switches using a stored `VAULT_TOKEN` in our GHA/Dependabot secrets store to using a vault `ROLE_ID` and `SECRET_ID` to generate a short-lived token, which our CI/CD can use for accessing SCP secrets in vault.  This is preferable to using a stored token as the role/secret IDs do not expire, and as such do not need to be rotated on a regular basis.  The policies granted are for read access only to SCP vault paths.

MANUAL TESTING
The only manual testing for this PR is that CI launches and runs without error.