### PR TITLE
Update to Ingest Pipeline 1.14.2 (SCP-4139)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.14.1'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.14.2'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
Incorporate ingest pipeline update to log ingest ValueError events as file-validation failures [link to scp-ingest-pipeline PR for details](https://github.com/broadinstitute/scp-ingest-pipeline/pull/236)