### PR TITLE
Fix import: oneGiB, not GiB (SCP-4013)

### DIFF
--- a/app/javascript/lib/validation/chunked-line-reader.js
+++ b/app/javascript/lib/validation/chunked-line-reader.js
@@ -1,4 +1,4 @@
-import { DEFAULT_CHUNK_SIZE, GiB, readFileBytes } from './io'
+import { DEFAULT_CHUNK_SIZE, oneGiB, readFileBytes } from './io'
 
 const newlineRegex = /\r?\n/
 
@@ -43,7 +43,7 @@ export default class ChunkedLineReader {
    * maxBytesPerLine (default: 1 GiB) can be set to avoid reading the entire file into memory in the event
    * the file is missing proper newlines.
   */
-  async iterateLines({ func, maxLines = Number.MAX_SAFE_INTEGER, maxBytesPerLine = GiB }) {
+  async iterateLines({ func, maxLines = Number.MAX_SAFE_INTEGER, maxBytesPerLine = oneGiB }) {
     const prevLinesRead = this.linesRead
     while (
       (this.hasMoreChunks || this.chunkLines.length) &&


### PR DESCRIPTION
This fixes a trivial bug caused by an oversight of mine in #1399, which wasn't caught by `yarn ui-test`.