### PR TITLE
Update title to Loom (SCP-4095)

### DIFF
--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -178,9 +178,9 @@ const COLUMNS = {
     info: 'List of available project files and associated project-level metadata.',
     default: true
   },
-  loom: {
+  analysis: {
     title: 'Loom',
-    types: ['loom_file'],
+    types: ['analysis_file'],
     info: <span>
       Loom files of <a href="https://broadinstitute.github.io/warp/docs/Pipelines/Optimus_Pipeline/Loom_schema/" target="_blank" rel="noopener noreferrer">finalized raw counts</a>.<br/>
        This does not include contributor generated files or intermediate files, which can be downloaded directly from HCA.

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -179,7 +179,7 @@ const COLUMNS = {
     default: true
   },
   analysis: {
-    title: 'Analysis',
+    title: 'Loom',
     types: ['analysis_file'],
     info: <span>
       Loom files of <a href="https://broadinstitute.github.io/warp/docs/Pipelines/Optimus_Pipeline/Loom_schema/" target="_blank" rel="noopener noreferrer">finalized raw counts</a>.<br/>

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.js
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.js
@@ -178,9 +178,9 @@ const COLUMNS = {
     info: 'List of available project files and associated project-level metadata.',
     default: true
   },
-  analysis: {
+  loom: {
     title: 'Loom',
-    types: ['analysis_file'],
+    types: ['loom_file'],
     info: <span>
       Loom files of <a href="https://broadinstitute.github.io/warp/docs/Pipelines/Optimus_Pipeline/Loom_schema/" target="_blank" rel="noopener noreferrer">finalized raw counts</a>.<br/>
        This does not include contributor generated files or intermediate files, which can be downloaded directly from HCA.


### PR DESCRIPTION
Update the download modal to use a label of "Loom" rather than "Analysis"

This will only impact the mixpanel event `click:input-checkbox` 's property of `label` if a user choose no Loom files during download. I didn't find a way in mixpanel to link two properties in an event but it doesn't look like this is a metric we used much yet so doesn't seem like much of an issue.

To test:
- pull this branch
- search for some azul data (i.e. pulmonary) while signed in
- click to download and you will see the section label for loom files is Loom now

![Screen Shot 2022-03-04 at 3 26 33 PM](https://user-images.githubusercontent.com/54322292/156839724-17afbcd2-cb3b-43d7-b842-de335a6db9e7.png)
