### PR TITLE
Validate that dense matrices do not have empty values (SCP-4036)

### DIFF
--- a/app/javascript/lib/validation/expression-matrices-validation.js
+++ b/app/javascript/lib/validation/expression-matrices-validation.js
@@ -348,7 +348,7 @@ function validateSparseColumnNumber(line, isLastLine, lineNum, dataObj) {
 function hasEmptyOrNonNumericValue(array) {
   for (let i = 0; i < array.length; i++) {
     const value = array[i]
-    if (value === '' || Number.isNaN(value)) {return true}
+    if (value === '' || isNaN(value)) {return true}
   }
   return false
 }

--- a/app/javascript/lib/validation/expression-matrices-validation.js
+++ b/app/javascript/lib/validation/expression-matrices-validation.js
@@ -172,7 +172,7 @@ function getDenseMatrixDelimiter(rawHeader, rawNextTwoLines) {
       } // otherwise check the first 3 lines lengths against each other (see r-formatting description for futher explanation)
       else if (secondLineLength - 1 === headerLength ||
         thirdLineLength === secondLineLength ||
-        thirdLineLength === headerLength) { bestDelimiter = delimiter }
+        thirdLineLength === headerLength) {bestDelimiter = delimiter}
     }
   }
 
@@ -344,6 +344,10 @@ function validateSparseColumnNumber(line, isLastLine, lineNum, dataObj) {
   return issues
 }
 
+/** Determine if value passes `content:type:not-numeric` rule */
+function isEmptyOrNonNumeric(value) {
+  return value === '' || Number.isNaN(value)
+}
 
 /**
  * Validate all values are numbers outside first column cell name
@@ -354,7 +358,7 @@ function validateValuesAreNumeric(line, isLastLine, lineNum, dataObj) {
   // skip first column
   const lineWithoutFirstColumn = line.slice(1)
 
-  if (lineWithoutFirstColumn.some(isNaN)) {
+  if (lineWithoutFirstColumn.some(isEmptyOrNonNumeric)) {
     dataObj.rowsWithNonNumericValues.push(lineNum)
   }
 
@@ -368,7 +372,7 @@ function validateValuesAreNumeric(line, isLastLine, lineNum, dataObj) {
     }
 
     const msg = `All values (other than the first column and header row) in a dense matrix file must be numeric. ` +
-      `Please ensure all values in ${rowText}: ${notedBadRows}, are numbers.`
+      `Please ensure all values in ${rowText} ${notedBadRows} are numbers.`
     issues.push(['error', 'content:type:not-numeric', msg])
   }
 

--- a/app/javascript/lib/validation/expression-matrices-validation.js
+++ b/app/javascript/lib/validation/expression-matrices-validation.js
@@ -345,8 +345,12 @@ function validateSparseColumnNumber(line, isLastLine, lineNum, dataObj) {
 }
 
 /** Determine if value passes `content:type:not-numeric` rule */
-function isEmptyOrNonNumeric(value) {
-  return value === '' || Number.isNaN(value)
+function hasEmptyOrNonNumericValue(array) {
+  for (let i = 0; i < array.length; i++) {
+    const value = array[i]
+    if (value === '' || Number.isNaN(value)) {return true}
+  }
+  return false
 }
 
 /**
@@ -358,7 +362,7 @@ function validateValuesAreNumeric(line, isLastLine, lineNum, dataObj) {
   // skip first column
   const lineWithoutFirstColumn = line.slice(1)
 
-  if (lineWithoutFirstColumn.some(isEmptyOrNonNumeric)) {
+  if (hasEmptyOrNonNumericValue(lineWithoutFirstColumn)) {
     dataObj.rowsWithNonNumericValues.push(lineNum)
   }
 

--- a/test/js/lib/validate-file-content.test.js
+++ b/test/js/lib/validate-file-content.test.js
@@ -158,7 +158,7 @@ describe('Client-side file validation', () => {
   it('catches non-numeric entry in expression matrix file', async () => {
     const file = createMockFile({
       fileName: 'foo5.csv',
-      content: 'GENE,X,Y\nItm2a,p,5\nEif2b2,3,0\nPf2b2,1,9'
+      content: 'GENE,X,Y\nItm2a,p,5\nEif2b2,3,0\nPf2b2,1,9' // has an invalid value "p"
     })
     const { errors } = await validateLocalFile(file, { file_type: 'Expression Matrix' })
     expect(errors).toHaveLength(1)
@@ -166,13 +166,15 @@ describe('Client-side file validation', () => {
   })
 
   it('catches empty entry in expression matrix file', async () => {
-    const content =
-    'GENE\tBM19_4dpp_r1_TAAGCAGTGGTA\tBM19_4dpp_r1_AAGCAGTGGTAT\n' +
-    'A1BG\t0.0\t0.0\n' +
-    'A1BG-AS1\t0.0\t0.0\n' +
-    'A1CF\t\t\n'
-
-    const file = createMockFile({ fileName: 'foo5b.tsv', content })
+    const file = createMockFile({
+      fileName: 'foo5b.tsv',
+      content: (
+        'GENE\tBM19_4dpp_r1_TAAGCAGTGGTA\tBM19_4dpp_r1_AAGCAGTGGTAT\n' +
+        'A1BG\t0.0\t0.0\n' +
+        'A1BG-AS1\t0.0\t0.0\n' +
+        'A1CF\t\t\n' // There's an empty value on this line.
+      )
+    })
     const { errors } = await validateLocalFile(file, { file_type: 'Expression Matrix' })
     expect(errors).toHaveLength(1)
     expect(errors[0][1]).toEqual('content:type:not-numeric')

--- a/test/js/lib/validate-file-content.test.js
+++ b/test/js/lib/validate-file-content.test.js
@@ -165,6 +165,19 @@ describe('Client-side file validation', () => {
     expect(errors[0][1]).toEqual('content:type:not-numeric')
   })
 
+  it('catches empty entry in expression matrix file', async () => {
+    const content =
+    'GENE\tBM19_4dpp_r1_TAAGCAGTGGTA\tBM19_4dpp_r1_AAGCAGTGGTAT\n' +
+    'A1BG\t0.0\t0.0\n' +
+    'A1BG-AS1\t0.0\t0.0\n' +
+    'A1CF\t\t\n'
+
+    const file = createMockFile({ fileName: 'foo5b.tsv', content })
+    const { errors } = await validateLocalFile(file, { file_type: 'Expression Matrix' })
+    expect(errors).toHaveLength(1)
+    expect(errors[0][1]).toEqual('content:type:not-numeric')
+  })
+
   it('catches row with wrong number of columns in expression matrix file', async () => {
     const file = createMockFile({
       fileName: 'foo6.csv',


### PR DESCRIPTION
This enriches client-side file validation (CSFV) so that empty values in dense expression matrices are detected as errors.

<img width="1673" alt="Fail_validation_for_dense_matrices_with_empty_values_CSFV__SCP_2022-03-07" src="https://user-images.githubusercontent.com/1334561/157124053-2e6b0e08-021f-4c46-9bec-377d971f0831.png">

To test:
* Go to upload UI
* Open Network panel in DevTools
* Try to upload [hasNaN_trim.txt](https://github.com/broadinstitute/single_cell_portal_core/files/8201091/hasNaN_trim.txt) as raw or processed matrix
* Confirm UI shows validation error message: "All values (other than the first column and header row) in a dense matrix file must be numeric. Please ensure all values in row 3 are numbers."
* In Network panel, verify log to Bard / Mixpanel contains `file-validation` with `errorTypes: ["content:type:not-numeric"]`

This satisfies SCP-4036.
