### PR TITLE
Fix so JS or Ruby test fails the CI check (SCP-4165)

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -125,7 +125,10 @@ set -o pipefail
 if [[ "$TEST_FILEPATH" == "" ]]; then
   # "2>&1 | tee yarn_test.log" puts the output of the tests both into stdout and the yarn_test.log file
   yarn ui-test 2>&1 | tee yarn_test.log
-  RETURN_CODE=$? # immediately capture exit code to prevent this from getting clobbered
+  code=$? # immediately capture exit code to prevent this from getting clobbered
+  if [[ $code -ne 0 ]]; then
+    RETURN_CODE=$code
+  fi
 fi
 
 # configure and invoke command for rails tests
@@ -151,7 +154,9 @@ grep -A2 -B1 ")\sFailure:\|)\sError:" rails_test.log | \
     grep -v ")\sFailure:\|)\sError:\|--" >> test_summary.txt
 
 # the return code will be 1 if either the js or rails tests exited with 1
-(( RETURN_CODE = exit_status || $code ))
+if [[ $code -ne 0 ]]; then
+  RETURN_CODE=$code
+fi
 
 if [[ "$CODECOV_TOKEN" != "" ]] && [[ "$CI" == "true" ]]; then
   echo "uploading all coverage data to codecov"

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -154,9 +154,7 @@ grep -A2 -B1 ")\sFailure:\|)\sError:" rails_test.log | \
     grep -v ")\sFailure:\|)\sError:\|--" >> test_summary.txt
 
 # the return code will be 1 if either the js or rails tests exited with 1
-if [[ $code -ne 0 ]]; then
-  RETURN_CODE=$code
-fi
+(( RETURN_CODE = RETURN_CODE || $code ))
 
 if [[ "$CODECOV_TOKEN" != "" ]] && [[ "$CI" == "true" ]]; then
   echo "uploading all coverage data to codecov"

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -125,10 +125,7 @@ set -o pipefail
 if [[ "$TEST_FILEPATH" == "" ]]; then
   # "2>&1 | tee yarn_test.log" puts the output of the tests both into stdout and the yarn_test.log file
   yarn ui-test 2>&1 | tee yarn_test.log
-  code=$? # immediately capture exit code to prevent this from getting clobbered
-  if [[ $code -ne 0 ]]; then
-    RETURN_CODE=$code
-  fi
+  RETURN_CODE=$? # immediately capture exit code to prevent this from getting clobbered
 fi
 
 # configure and invoke command for rails tests

--- a/test/js/lib/validate-file-content.test.js
+++ b/test/js/lib/validate-file-content.test.js
@@ -151,7 +151,7 @@ describe('Client-side file validation', () => {
       content: 'IS_NOT_GENE,X,Y\nItm2a,0,5\nEif2b2,3,0\nPf2b2,1,9'
     })
     const { errors } = await validateLocalFile(file, { file_type: 'Expression Matrix' })
-    expect(errors).toHaveLength(1)
+    expect(errors).toHaveLength(3)
     expect(errors[0][1]).toEqual('format:cap:missing-gene-column')
   })
 

--- a/test/js/lib/validate-file-content.test.js
+++ b/test/js/lib/validate-file-content.test.js
@@ -151,7 +151,7 @@ describe('Client-side file validation', () => {
       content: 'IS_NOT_GENE,X,Y\nItm2a,0,5\nEif2b2,3,0\nPf2b2,1,9'
     })
     const { errors } = await validateLocalFile(file, { file_type: 'Expression Matrix' })
-    expect(errors).toHaveLength(3)
+    expect(errors).toHaveLength(1)
     expect(errors[0][1]).toEqual('format:cap:missing-gene-column')
   })
 


### PR DESCRIPTION
Fixes a bug where the RETURN_CODE had been getting re-set to the result of the Ruby tests always (see comment) now if either the JS or Ruby tests fail the test failure will result in a true failure at the `SCP Continuous Integration / Run-All-Tests (pull_request)` level.

[Slack Discussion](https://broadinstitute.slack.com/archives/CBEHTH601/p1646757615557049)
