### PR TITLE
Update sync survey link (off cycle, SCP-4153)

### DIFF
--- a/app/views/studies/sync_study.html.erb
+++ b/app/views/studies/sync_study.html.erb
@@ -39,7 +39,7 @@
       Adding data with gsutil
     </a>
     <a
-      href="https://forms.gle/V6uT94jbGq5pTeMG6"
+      href="https://forms.gle/cRDSiDj5FgFyAELo6"
       class="btn terra-secondary-btn"
       target="_blank"
       data-analytics-name="sync-survey-link"


### PR DESCRIPTION
This updates the sync survey link, to more easily measure whether user ratings change from the pre-sync-CSFV baseline.

It's cherry picked from `ew-update-sync-link` (#1409) to `master` for an off-cycle release.