### PR TITLE
Add tracking for user clicking next with Azul data to download (SCP-4157)

### DIFF
--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -217,11 +217,25 @@ export function getLogPlotProps() {
 }
 
 /**
+ * Extract the number of files that have been chosen for download
+ */
+function getNumAzulFiles(azulFiles) {
+  let numAzulFilesChosen = 0
+  for (const val of Object.entries(azulFiles)) {
+    if (val[1].length > 0) {
+      numAzulFilesChosen += val[1].length
+    }
+  }
+  return numAzulFilesChosen
+}
+
+/**
  * Log when a download is authorized.
  * This is our best web-client-side methodology for measuring downloads.
  */
-export function logDownloadAuthorization(perfTimes) {
-  const props = { perfTimes }
+export function logDownloadAuthorization(perfTimes, fileIds, azulFiles) {
+  const numAzulFilesChosen = getNumAzulFiles(azulFiles)
+  const props = { perfTimes, 'numSCPFiles': fileIds.length, 'numAzulFiles': numAzulFilesChosen }
   log('download-authorization', props)
   ga('send', 'event', 'advanced-search', 'download-authorization') // eslint-disable-line no-undef, max-len
 }

--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -217,7 +217,7 @@ export function getLogPlotProps() {
 }
 
 /**
- * Extract the number of files that have been chosen for download
+ * Extract the number of Azul files that have been chosen for download
  */
 function getNumAzulFiles(azulFiles) {
   let numAzulFilesChosen = 0
@@ -230,7 +230,7 @@ function getNumAzulFiles(azulFiles) {
 }
 
 /**
- * Log when a download is authorized.
+ * Log when a download is authorized and the number of files from each source that are being downloaded.
  * This is our best web-client-side methodology for measuring downloads.
  */
 export function logDownloadAuthorization(perfTimes, fileIds, azulFiles) {

--- a/app/javascript/lib/scp-api.js
+++ b/app/javascript/lib/scp-api.js
@@ -90,7 +90,7 @@ export async function fetchAuthCode(fileIds, azulFiles, mock=false) {
   })
   const [authCode, perfTimes] = await scpApi('/bulk_download/auth_code', init, mock)
 
-  logDownloadAuthorization(perfTimes)
+  logDownloadAuthorization(perfTimes, fileIds, azulFiles)
 
   return authCode
 }


### PR DESCRIPTION
Add tracking of the number of SCP and number of Azul files that have been chosen for download when a user clicks the 'Next' button in the download modal which triggers the `logDownloadAuthorization` event.

To test
- pull this branch
- log in to SCP
- perform a search that will have Azul results such as 'male'
- click the download button
- Check out[ this report in Mixpanel ](https://mixpanel.com/s/viTZ8)to see an event come through tracking that your user profile clicked next


<img width="1641" alt="Screen Shot 2022-03-11 at 11 08 37 AM" src="https://user-images.githubusercontent.com/54322292/157904865-9f273979-bf9e-4f8f-a7c0-f314f615b3c0.png">
<img width="1535" alt="Screen Shot 2022-03-11 at 11 08 47 AM" src="https://user-images.githubusercontent.com/54322292/157904871-09e29a0c-60f9-4d2e-8b8d-4f4710c6a257.png">
