### PR TITLE
improving performance of large data array loading (SCP-3756)

### DIFF
--- a/app/models/concerns/concatenatable.rb
+++ b/app/models/concerns/concatenatable.rb
@@ -7,7 +7,8 @@ module Concatenatable
   # concatenate the values together into a single contiguous array
   def concatenate_arrays(query)
     arrays = where(query)
-    ids = arrays.pluck(:id, :array_index).sort_by(&:last).map(&:first)
-    ids.map { |id| find(id).values }.reduce([], :+)
+    arr_vals = arrays.pluck(:array_index, :values)
+    arr_vals = arr_vals.sort_by(&:first)
+    arr_vals.reduce([]) { |aggregate, arr_val|  aggregate.concat(arr_val.last) }
   end
 end


### PR DESCRIPTION
In performance testing large plot rendering, I noticed some suboptimal loading of data arrays.  This preserves doing the sort in rails (necessary to avoid mongo sort limits), but now fetches the data in a single query, and does not unnecessarily duplicate arrays on assembly.  Note that in Ruby [1] + [2] will create a new array, while [1].concat([2]) will just append the result to the original, and so is much more performant for stitching together multiple large arrays.  See https://stackoverflow.com/questions/40510579/how-to-efficiently-concatenate-multiple-arrays-in-ruby 

This resulted in a 10-20% speedup in my local instance (~100sec vs ~90sec to load a 1.3M cell cluster).  I suspect this will have negligible impact in production, but the development speedup will be worth it (and we can check our production perf numbers just in case this has an impact :) )

TO TEST:
1. Load a large study
2. confirm the data displays correctly