### PR TITLE
removing unneeded dev logs/errors (SCP-4172)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -151,6 +151,6 @@ Rails.application.configure do
   config.profile_performance = false
 
   # show mongo logs in the console
-  Mongoid.logger = Logger.new($stdout)
-  Mongo::Logger.logger = Logger.new($stdout)
+  # Mongoid.logger = Logger.new($stdout)
+  # Mongo::Logger.logger = Logger.new($stdout)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -286,6 +286,10 @@ Rails.application.routes.draw do
     get 'app', to: 'site#index'
     get 'app/*path', to: 'site#index'
 
+    # avoid exception for igv css map missing -- just return no content.
+    # this file is only requested in development
+    get '*a/igv.css.map', to: -> (env) { [204, {}, ['']] }
+
     root to: 'site#index'
     end
 end


### PR DESCRIPTION
since we don't want to fork/update igv just to remove the css map misconfiguration, we're adding a wildcard route that returns 204  no-content in response to a request for the igv.css.map file from any path.  The wildcard is necessary since the resource requested might be `https://localhost:3000/single_cell/study/SCP91/igv.css.map` 

This also turns of mongoDB query logging by default.  It's super useful at times, but makes using the rails console too chatty.  

TO TEST:
1. load home page
2. watch rails console
3. observe no igv.css.map error
4. observe no chatty mongo query logs