### PR TITLE
Fix COVID-19 collection global search results (SCP-4183)

### DIFF
--- a/app/views/site/covid19.html.erb
+++ b/app/views/site/covid19.html.erb
@@ -37,6 +37,9 @@
        </span>
       <div class="tab-content top-pad">
         <div id="home-page-content"></div>
+        <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+          window.SCP.renderComponent('home-page-content', 'HomePageContent', {})
+        </script>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This fixes a regression on staging that causes no studies for our COVID-19 "preset" collection to display.

To test:
* In home page, click "Browse collections"
* Click "[COVID-19 Studies](https://localhost:3000/single_cell/covid19)"
* Confirm you see studies listed
* If you don't, run the following in your local terminal:
  * `rails c -e development`
  * `some_public_accessions = Study.where(public: true)[0..2].pluck(:accession)`
  * `PresetSearch.first` <-- If this returns `nil`, then we'll see _all_ your studies as COVID-19 studies -- confirming this fix shows something, but not quite what we want
  * `PresetSearch.find_by(name: "covid19").update(accession_list: some_public_accessions)`
 * Load "COVID-19 Studies" again, confirm you see studies

This satisfies SCP-4183.