### PR TITLE
clearing files from tmp directory (SCP-4189)

### DIFF
--- a/app/lib/synthetic_study_populator.rb
+++ b/app/lib/synthetic_study_populator.rb
@@ -30,6 +30,8 @@ class SyntheticStudyPopulator
     # copy the files to a temp directory, since CarrierWave will delete them after upload
     temp_file_dir = "/tmp/synthetic_studies/#{synthetic_study_folder}"
     FileUtils.mkdir_p(temp_file_dir)
+    # clear the tmp file directory just in case it already existed
+    FileUtils.rm_rf(Dir["#{temp_file_dir}/*"])
     FileUtils.cp_r("#{synthetic_study_path}/.", temp_file_dir)
 
     puts("Populating synthetic study from #{temp_file_dir}")


### PR DESCRIPTION
Attempts to fix test instability by clearing files from tmp directory.

TO TEST:
1. make PR
2. see if the SyntheticStudyPopulatorTest passes on the PR build