### PR TITLE
Add metrics to capture the match type for SCP studies (SCP-4155)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -329,16 +329,16 @@ module Api
           if facets_to_keywords.any?
             @inferred_terms = facets_to_keywords.values.flatten
             logger.info "Running inferred search using #{facets_to_keywords}"
-            search_match_obj = inferred_studies = self.class.generate_mongo_query_by_context(terms: facets_to_keywords,
+            search_match_obj = self.class.generate_mongo_query_by_context(terms: facets_to_keywords,
                                                                           base_studies: @viewable,
                                                                           accessions: @matching_accessions,
                                                                           query_context: :inferred)
-            @studies = search_match_obj[:studies]
+            @inferred_studies = search_match_obj[:studies]
             @match_by_data = search_match_obj[:results_matched_by_data]
-            @inferred_accessions = inferred_studies.pluck(:accession)
+            @inferred_accessions = @inferred_studies.pluck(:accession)
             logger.info "Found #{@inferred_accessions.count} inferred matches: #{@inferred_accessions}"
             @matching_accessions += @inferred_accessions
-            @studies += inferred_studies.sort_by { |study| -study.search_weight(@inferred_terms)[:total] }
+            @studies += @inferred_studies.sort_by { |study| -study.search_weight(@inferred_terms)[:total] }
           end
         end
 

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -522,7 +522,6 @@ module Api
       def self.generate_mongo_query_by_context(terms:, base_studies:, accessions:, query_context:)
         case query_context
         when :keyword
-          puts('in keyword')
           author_match_study_ids = Author.where(:$text => {:$search => terms}).pluck(:study_id)
 
           matches_by_text = base_studies.where({:$text => {:$search => terms}})

--- a/app/controllers/api/v1/study_search_results_objects.rb
+++ b/app/controllers/api/v1/study_search_results_objects.rb
@@ -13,7 +13,8 @@ module Api
           total_studies: @results.total_entries,
           total_pages: @results.total_pages,
           matching_accessions: @matching_accessions,
-          preset_search: params[:preset_search]
+          preset_search: params[:preset_search],
+          match_by_data: @match_by_data
         }
         if @selected_branding_group.present?
           response_obj[:scpbr] = @selected_branding_group.name_as_id

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -302,7 +302,6 @@ export function logStudyGeneSearch(genes, trigger, speciesList, otherProps) {
   log('search', logProps)
 }
 
-
 /**
  * Removes study name from URL, as it might have identifying information.
  * Terra UI omits workspace name in logs; this follows that precedent.

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -303,28 +303,6 @@ export function logStudyGeneSearch(genes, trigger, speciesList, otherProps) {
 }
 
 
-/** log a study search from the home page */
-export function logStudySearch(resultsMeta, otherProps) {
-  const { numMatchesByAccession, numMatchesByText, numMatchesByAuthor } = resultsMeta
-
-  // Properties
-  const logProps = {
-    scope: 'global',
-    context: 'study',
-    numMatchesByAccession,
-    numMatchesByText,
-    numMatchesByAuthor
-  }
-
-  // Merge log props from custom event
-  if (otherProps) {
-    Object.assign(logProps, otherProps)
-  }
-
-  log('search-results', logProps)
-}
-
-
 /**
  * Removes study name from URL, as it might have identifying information.
  * Terra UI omits workspace name in logs; this follows that precedent.

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -302,6 +302,29 @@ export function logStudyGeneSearch(genes, trigger, speciesList, otherProps) {
   log('search', logProps)
 }
 
+
+/** log a study search from the home page */
+export function logStudySearch(resultsMeta, otherProps) {
+  const { numMatchesByAccession, numMatchesByText, numMatchesByAuthor } = resultsMeta
+
+  // Properties
+  const logProps = {
+    scope: 'global',
+    context: 'study',
+    numMatchesByAccession,
+    numMatchesByText,
+    numMatchesByAuthor
+  }
+
+  // Merge log props from custom event
+  if (otherProps) {
+    Object.assign(logProps, otherProps)
+  }
+
+  log('search-results', logProps)
+}
+
+
 /**
  * Removes study name from URL, as it might have identifying information.
  * Terra UI omits workspace name in logs; this follows that precedent.

--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -71,11 +71,10 @@ function getFriendlyFilterListByFacet(facets) {
   return filterListByFacet
 }
 
-//emily here
 /**
  * Log global study search metrics, one type of search done on home page
  */
-export function logSearch(type, searchParams, perfTimes, searchResults) {
+export function logSearch(type, searchParams, perfTimes, searchResults={}) {
   searchNumber += 1
   if (searchNumber < 3) {
     // This prevents over-reporting searches.
@@ -88,7 +87,6 @@ export function logSearch(type, searchParams, perfTimes, searchResults) {
     // search.  This was considered very early for separate reasons, but
     // abandoned as it was invasive.  The clearly-brittle nature of preventing
     // these artifactual searches shifts that cost-benefit, somewhat.
-    console.log('in here')
     return
   }
 
@@ -100,10 +98,6 @@ export function logSearch(type, searchParams, perfTimes, searchResults) {
   const page = searchParams.page
   const preset = searchParams.preset
   const scpStudiesMatchData = searchResults?.matchByData
-
-  // perfTime:frontend:other
-
-  console.log('searchResults:', searchResults)
 
   const [numFacets, numFilters] = getNumFacetsAndFilters(facets)
   const facetList = facets ? Object.keys(facets) : []

--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -108,9 +108,9 @@ export function logSearch(type, searchParams, perfTimes, searchResults) {
     terms, numTerms, genes, numGenes, page, preset,
     facetList, numFacets, numFilters,
     perfTimes,
-    type, context: 'global', scpStudiesMatchData
+    type, context: 'global'
   }
-  const props = Object.assign(simpleProps, filterListByFacet)
+  const props = Object.assign(simpleProps, filterListByFacet, scpStudiesMatchData)
 
   log('search', props)
 

--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -99,7 +99,7 @@ export function logSearch(type, searchParams, perfTimes, searchResults) {
   const facets = searchParams.facets
   const page = searchParams.page
   const preset = searchParams.preset
-  const matchByData = searchResults?.matchByData
+  const scpStudiesMatchData = searchResults?.matchByData
 
   // perfTime:frontend:other
 
@@ -114,7 +114,7 @@ export function logSearch(type, searchParams, perfTimes, searchResults) {
     terms, numTerms, genes, numGenes, page, preset,
     facetList, numFacets, numFilters,
     perfTimes,
-    type, context: 'global', matchByData
+    type, context: 'global', scpStudiesMatchData
   }
   const props = Object.assign(simpleProps, filterListByFacet)
 

--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -74,7 +74,7 @@ function getFriendlyFilterListByFacet(facets) {
 /**
  * Log global study search metrics, one type of search done on home page
  */
-export function logSearch(type, searchParams, perfTimes, searchResults={}) {
+export function logSearch(type, searchParams, perfTimes, searchResults) {
   searchNumber += 1
   if (searchNumber < 3) {
     // This prevents over-reporting searches.

--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -71,10 +71,11 @@ function getFriendlyFilterListByFacet(facets) {
   return filterListByFacet
 }
 
+//emily here
 /**
  * Log global study search metrics, one type of search done on home page
  */
-export function logSearch(type, searchParams, perfTimes) {
+export function logSearch(type, searchParams, perfTimes, searchResults) {
   searchNumber += 1
   if (searchNumber < 3) {
     // This prevents over-reporting searches.
@@ -87,6 +88,7 @@ export function logSearch(type, searchParams, perfTimes) {
     // search.  This was considered very early for separate reasons, but
     // abandoned as it was invasive.  The clearly-brittle nature of preventing
     // these artifactual searches shifts that cost-benefit, somewhat.
+    console.log('in here')
     return
   }
 
@@ -97,6 +99,11 @@ export function logSearch(type, searchParams, perfTimes) {
   const facets = searchParams.facets
   const page = searchParams.page
   const preset = searchParams.preset
+  const matchByData = searchResults?.matchByData
+
+  // perfTime:frontend:other
+
+  console.log('searchResults:', searchResults)
 
   const [numFacets, numFilters] = getNumFacetsAndFilters(facets)
   const facetList = facets ? Object.keys(facets) : []
@@ -107,7 +114,7 @@ export function logSearch(type, searchParams, perfTimes) {
     terms, numTerms, genes, numGenes, page, preset,
     facetList, numFacets, numFilters,
     perfTimes,
-    type, context: 'global'
+    type, context: 'global', matchByData
   }
   const props = Object.assign(simpleProps, filterListByFacet)
 

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -673,11 +673,8 @@ export async function fetchSearch(type, searchParams, mock=false) {
   const path = `/search?${buildSearchQueryString(type, searchParams)}`
 
   const [searchResults, perfTimes] = await scpApi(path, defaultInit(), mock)
-  console.log('searhres:', searchResults)
 
   logSearch(type, searchParams, perfTimes, searchResults)
-  // logSearch(type, searchParams, perfTimes)
-  // add meta stuff as param to this ^
 
   return searchResults
 }

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -673,8 +673,11 @@ export async function fetchSearch(type, searchParams, mock=false) {
   const path = `/search?${buildSearchQueryString(type, searchParams)}`
 
   const [searchResults, perfTimes] = await scpApi(path, defaultInit(), mock)
+  console.log('searhres:', searchResults)
 
-  logSearch(type, searchParams, perfTimes)
+  logSearch(type, searchParams, perfTimes, searchResults)
+  // logSearch(type, searchParams, perfTimes)
+  // add meta stuff as param to this ^
 
   return searchResults
 }

--- a/app/javascript/providers/StudySearchProvider.jsx
+++ b/app/javascript/providers/StudySearchProvider.jsx
@@ -11,7 +11,6 @@ import {
 } from '~/lib/scp-api'
 import SearchSelectionProvider from './SearchSelectionProvider'
 import { buildParamsFromQuery as buildGeneParamsFromQuery } from './GeneSearchProvider'
-import { logStudySearch } from '~/lib/metrics-api'
 
 
 const emptySearch = {
@@ -121,16 +120,7 @@ export function PropsStudySearchProvider(props) {
     // reset the scroll in case they scrolled down to read prior results
     window.scrollTo(0, 0)
 
-    // add the logging
-    // and add the search results here too
-
-
     fetchSearch('study', searchParams).then(results => {
-      // console.log('results:', results)
-      // console.log('resultsMeta:', results)
-
-      // logStudySearch(resultsMeta)
-
       setSearchState({
         params: searchParams,
         isError: false,

--- a/app/javascript/providers/StudySearchProvider.jsx
+++ b/app/javascript/providers/StudySearchProvider.jsx
@@ -11,6 +11,8 @@ import {
 } from '~/lib/scp-api'
 import SearchSelectionProvider from './SearchSelectionProvider'
 import { buildParamsFromQuery as buildGeneParamsFromQuery } from './GeneSearchProvider'
+import { logStudySearch } from '~/lib/metrics-api'
+
 
 const emptySearch = {
   params: {
@@ -119,7 +121,16 @@ export function PropsStudySearchProvider(props) {
     // reset the scroll in case they scrolled down to read prior results
     window.scrollTo(0, 0)
 
+    // add the logging
+    // and add the search results here too
+
+
     fetchSearch('study', searchParams).then(results => {
+      // console.log('results:', results)
+      // console.log('resultsMeta:', results)
+
+      // logStudySearch(resultsMeta)
+
       setSearchState({
         params: searchParams,
         isError: false,

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -184,6 +184,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
                  "Did not return correct array of matching accessions, expected #{expected_accessions} but found #{matching_accessions}"
 
     assert_equal @random_seed, json['studies'].first['term_matches'].first
+    assert_equal 2, json['match_by_data']['numResults:scp:text']
 
     # test exact phrase
     search_phrase = '"API Test Study"'
@@ -195,6 +196,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
                  "Did not return correct array of matching accessions, expected #{quoted_accessions} but found #{found_accessions}"
 
     assert_equal search_phrase.gsub(/\"/, ''), json['studies'].first['term_matches'].first
+    assert_equal 1, json['match_by_data']['numResults:scp:name']
 
     # test combination
     search_phrase += ' testing'
@@ -219,7 +221,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
                   "Did not return correct array of matching accessions, expected #{expected_accessions} but found #{matching_accessions}"
 
     assert_equal search_terms, json['studies'].first['term_matches'].first
-
+    assert_equal 1, json['match_by_data']['numResults:scp:author']
 
     # test author keyword search for institution
     search_terms = 'MIT'
@@ -232,6 +234,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
                   "Did not return correct array of matching accessions, expected #{expected_accessions} but found #{matching_accessions}"
 
     assert_equal search_terms, json['studies'].first['term_matches'].first
+    assert_equal 1, json['match_by_data']['numResults:scp:author']
 
     # test regex escaping
     execute_http_request(:get, api_v1_search_path(type: 'study', terms: 'foobar scp-105 [('))


### PR DESCRIPTION
For our OKR on adding author info to studies adding this metric will enable us to more easily see how many studies match the search based on term, phrase or author match. 

This PR will only add tracking for SCP studies (aka not Azul studies), since the OKR is around author search which isn't supported for Azul at this time.

There is definitely potential follow up work to add Azul match data and more study result info. However getting this bit out for OKR tracking seemed most important so I am planning to file a follow on ticket for that other work as long as there is no strong opposition.

To test:
- Pull this branch and run it locally
- Search from the home page using different terms and/or phrases
- Check out the network tab for events titles 'search' and check out the property scpStudiesMatchData
- Or check out mixpanel dev for the same

<img width="1488" alt="Screen Shot 2022-03-22 at 3 33 04 PM" src="https://user-images.githubusercontent.com/54322292/159561242-88d1f87e-821d-4d11-a548-6b23d811d96a.png">
