### PR TITLE
fixing auth code analytics capture (SCP-4207)

### DIFF
--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -220,7 +220,7 @@ export function getLogPlotProps() {
 /**
  * Extract the number of Azul files that have been chosen for download
  */
-function getNumAzulFiles(azulFiles) {
+function getNumAzulFiles(azulFiles={}) {
   let totalNumFiles = 0
   for (const studyEntry of Object.entries(azulFiles)) {
     const [azulStudyId, fileList] = studyEntry

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -84,7 +84,7 @@ function defaultPostInit(mock=false) {
  * // returns {authCode: 123456, timeInterval: 1800}
  * fetchAuthCode(true)
  */
-export async function fetchAuthCode(fileIds, azulFiles, mock=false) {
+export async function fetchAuthCode(fileIds=[], azulFiles=[], mock=false) {
   const init = defaultPostInit(mock)
   init.body = JSON.stringify({
     file_ids: fileIds,

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -117,7 +117,8 @@
 
           // Get a time-based one time authentication token (totat),
           // then show the download command
-          window.SCP.API.fetchAuthCode().then(
+          const fileIds = <%= @study.study_files.pluck(:_id).map(&:to_s).to_s.html_safe %>
+          window.SCP.API.fetchAuthCode(fileIds, []).then(
             function (response) {
               var authCode = response.authCode;
               var timeInterval = response.timeInterval; // token expires after this many seconds


### PR DESCRIPTION
I think the recent extra instrumentation added to azul files in search bulk download created this bug in single-study bulk download.  I've increased the amount of nil-safing in the analytics methods, and also updated the call to generateAuthCode from the single-study page to include the list of file ids

TO TEST:
1. sign in as a user without direct google bucket access (e.g. not the study owner), so e.g. your personal gmail account
2. open a study, and go to download
3. press 'bulk download'
4. follow instructions, and confirm you can download the study files locally.