### PR TITLE
Fix single-gene Explore view when default annotation is numeric (SCP-4200)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -71,9 +71,10 @@ export default function ExploreDisplayTabs({
   // a plotly points_selected event
   const [currentPointsSelected, setCurrentPointsSelected] = useState(null)
   const plotContainerClass = 'explore-plot-tab-content'
+
   const {
     enabledTabs, isGeneList, isGene, isMultiGene, hasIdeogramOutputs
-  } = getEnabledTabs(exploreInfo, exploreParams)
+  } = getEnabledTabs(exploreInfo, exploreParamsWithDefaults)
 
   // exploreParams object without genes specified, to pass to cluster comparison plots
   const referencePlotDataParams = _clone(exploreParams)
@@ -162,7 +163,8 @@ export default function ExploreDisplayTabs({
     // if a user switches to a numeric annotation, change the tab to annotated scatter (SCP-3833)
     if (newParams.annotation?.type === 'numeric' &&
       exploreParamsWithDefaults.genes.length &&
-      exploreParamsWithDefaults.annotation?.type !== 'numeric') {
+      exploreParamsWithDefaults.annotation?.type !== 'numeric'
+    ) {
       updateParams.tab = 'annotatedScatter'
     }
     updateExploreParams(updateParams)

--- a/app/javascript/components/visualization/PlotDisplayControls.jsx
+++ b/app/javascript/components/visualization/PlotDisplayControls.jsx
@@ -33,8 +33,10 @@ export default function RenderControls({ shownTab, exploreParams, updateExploreP
     distributionPointsValue = DISTRIBUTION_POINTS_OPTIONS[0]
   }
 
-  const showScatter = shownTab === 'scatter' &&
-                      (exploreParams.annotation.type === 'numeric' || exploreParams.genes.length)
+  const showScatter = (
+    shownTab === 'scatter' &&
+    (exploreParams.annotation.type === 'numeric' || exploreParams.genes.length)
+  )
 
   return (
     <div className="render-controls">

--- a/app/javascript/components/visualization/StudyViolinPlot.jsx
+++ b/app/javascript/components/visualization/StudyViolinPlot.jsx
@@ -182,8 +182,8 @@ function getViolinTraces(
   const data = Object.entries(resultValues)
     .sort((a, b) => a[0].localeCompare(b[0], 'en', { numeric: true, ignorePunctuation: true }))
     .map(([traceName, traceData], index) => {
-    // Plotly violin trace creation, adding to main array
-    // get inputs for plotly violin creation
+      // Plotly violin trace creation, adding to main array
+      // get inputs for plotly violin creation
       const dist = traceData.y
 
       // Replace the none selection with bool false for plotly
@@ -193,7 +193,7 @@ function getViolinTraces(
 
       // Check if there is a distribution before adding trace
       if (arrayMax(dist) !== arrayMin(dist) && plotType === 'violin') {
-      // Make a violin plot if there is a distribution
+        // Make a violin plot if there is a distribution
         return {
           type: 'violin',
           name: traceName,
@@ -222,7 +222,7 @@ function getViolinTraces(
           }
         }
       } else {
-      // Make a boxplot for data with no distribution
+        // Make a boxplot for data with no distribution
         return {
           type: 'box',
           name: traceName,


### PR DESCRIPTION
This fixes a broken "Distribution" display for the single-gene Explore view when default annotation is numeric.  Showing distributions like violin plots only makes sense for categorical annotations.  Now for this case, we show an annotated scatter plot as expected, and no distribution visualization.

To test:
* Sign in to your local SCP
* Go to a study that has numeric annotations, e.g.  the synthetic study "Male mouse brain"
* Go to Settings, then click "View options", change default annotation to "Intensity", click "Update settings"
* Refresh page, go to Explore tab, search a gene -- e.g. Adcy5

Expected view:

<img width="1680" alt="Expected_single-gene_Explore_view_when_default_annotation_is_numeric__SCP_2022-03-29" src="https://user-images.githubusercontent.com/1334561/160699584-e564dc83-ca63-4777-9df4-b2a192807c04.png">

This satisfies part of SCP-4200.   A fix for the related situation in global gene search will follow in another PR.