### PR TITLE
fixing azul test suite to reflect updated fields (SCP-4218)

### DIFF
--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -119,7 +119,7 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     files = ApplicationController.hca_azul_client.files(size: 1)
     assert_equal 1, files.size
     file = files.first
-    keys = %w[name format size url source].sort
+    keys = %w[name format size url fileSource].sort
     assert_equal keys, file.keys.sort & keys
   end
 
@@ -128,7 +128,7 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     files = ApplicationController.hca_azul_client.files(query: @query_json, size: 1)
     assert_equal 1, files.size
     file = files.first
-    keys = %w[name format size url source].sort
+    keys = %w[name format size url fileSource].sort
     assert_equal keys, file.keys.sort & keys
   end
 


### PR DESCRIPTION
I'm guessing that HCA removed the 'source' field from their responses (which we were not using anyway).  We use the 'fileSource' field to determine whether a study file is an analysis file, so I've updated the test to check for that field

TO TEST: 

1. run `rails test test/integration/hca_azul_client_test.rb`
2. confirm passage
