### PR TITLE
Fix global gene search for studies with default numeric annotation (SCP-4200)

### DIFF
--- a/app/controllers/api/v1/study_search_results_objects.rb
+++ b/app/controllers/api/v1/study_search_results_objects.rb
@@ -60,6 +60,8 @@ module Api
           if @gene_results.present?
             study_obj[:gene_matches] = @gene_results[:genes_by_study][study.id].uniq
             study_obj[:can_visualize_clusters] = study.can_visualize_clusters?
+            is_numeric = study.default_annotation.split('--')[1] == 'numeric'
+            study_obj[:is_default_annotation_numeric] = is_numeric
           end
         else
           study_obj = {

--- a/app/controllers/api/v1/study_search_results_objects.rb
+++ b/app/controllers/api/v1/study_search_results_objects.rb
@@ -62,6 +62,7 @@ module Api
             study_obj[:can_visualize_clusters] = study.can_visualize_clusters?
             is_numeric = study.default_annotation.split('--')[1] == 'numeric'
             study_obj[:is_default_annotation_numeric] = is_numeric
+            study_obj[:annotation_list] = AnnotationVizService.get_study_annotation_options(study, current_api_user)
           end
         else
           study_obj = {

--- a/app/controllers/api/v1/study_search_results_objects.rb
+++ b/app/controllers/api/v1/study_search_results_objects.rb
@@ -60,8 +60,7 @@ module Api
           if @gene_results.present?
             study_obj[:gene_matches] = @gene_results[:genes_by_study][study.id].uniq
             study_obj[:can_visualize_clusters] = study.can_visualize_clusters?
-            is_numeric = study.default_annotation.split('--')[1] == 'numeric'
-            study_obj[:is_default_annotation_numeric] = is_numeric
+            study_obj[:default_annotation] = study.default_annotation
             study_obj[:annotation_list] = AnnotationVizService.get_study_annotation_options(study, current_api_user)
           end
         else

--- a/app/controllers/api/v1/study_search_results_objects.rb
+++ b/app/controllers/api/v1/study_search_results_objects.rb
@@ -60,7 +60,7 @@ module Api
           if @gene_results.present?
             study_obj[:gene_matches] = @gene_results[:genes_by_study][study.id].uniq
             study_obj[:can_visualize_clusters] = study.can_visualize_clusters?
-            study_obj[:default_annotation] = study.default_annotation
+            study_obj[:default_annotation_id] = study.default_annotation
             study_obj[:annotation_list] = AnnotationVizService.get_study_annotation_options(study, current_api_user)
           end
         else

--- a/app/javascript/components/explore/ExploreTabRouter.jsx
+++ b/app/javascript/components/explore/ExploreTabRouter.jsx
@@ -3,7 +3,7 @@ import { navigate, useLocation } from '@reach/router'
 import * as queryString from 'query-string'
 
 import { stringifyQuery, geneParamToArray, geneArrayToParam } from '~/lib/scp-api'
-import { getIdentifierForAnnotation } from '~/lib/cluster-utils'
+import { getIdentifierForAnnotation, getAnnotationForIdentifier } from '~/lib/cluster-utils'
 import { DEFAULT_ROW_CENTERING } from '~/components/visualization/Heatmap'
 import { logStudyGeneSearch } from '~/lib/metrics-api'
 
@@ -75,9 +75,8 @@ function buildExploreParamsFromQuery(query) {
     type: ''
   }
   if (queryParams.annotation) {
-    const [name, type, scope] = queryParams.annotation.split('--')
-    annotation = { name, type, scope }
-    if (name && name.length > 0) {
+    annotation = getAnnotationForIdentifier(queryParams.annotation)
+    if (annotation.name && annotation.name.length > 0) {
       exploreParams.userSpecified.annotation = true
     }
   }

--- a/app/javascript/components/search/genes/StudyGeneExpressions.jsx
+++ b/app/javascript/components/search/genes/StudyGeneExpressions.jsx
@@ -22,7 +22,7 @@ import {
  */
 function getBasicAnnotations(study) {
   let basicAnnotationList = null
-  if (study.annotation_list) {
+  if (study.annotation_list?.annotations.length > 0) {
     basicAnnotationList = study.annotation_list
     basicAnnotationList.annotations = basicAnnotationList.annotations.filter(a => a.scope !== 'user')
   }

--- a/app/javascript/components/search/genes/StudyGeneExpressions.jsx
+++ b/app/javascript/components/search/genes/StudyGeneExpressions.jsx
@@ -20,7 +20,8 @@ export default function StudyGeneExpressions({ study }) {
   const [clusterParams, setClusterParams] = useState(_clone(emptyDataParams))
   const [annotationList, setAnnotationList] = useState(study.annotation_list ?? null)
   let controlClusterParams = _clone(clusterParams)
-
+const defaultAnnotation = getAnnotationFromIdentifier(study.default_annotation)
+const defaultAnnotationIsNumeric = defaultAnnotation?.type === 'numeric'
   if (annotationList && !clusterParams.cluster) {
     // if the user hasn't specified anything yet, but we have the study defaults, use those
     controlClusterParams = Object.assign(controlClusterParams, getDefaultClusterParams(annotationList))

--- a/app/javascript/components/search/genes/StudyGeneExpressions.jsx
+++ b/app/javascript/components/search/genes/StudyGeneExpressions.jsx
@@ -10,18 +10,34 @@ import AnnotationSelector from '~/components/visualization/controls/AnnotationSe
 import SubsampleSelector from '~/components/visualization/controls/SubsampleSelector'
 import ConsensusSelector from '~/components/visualization/controls/ConsensusSelector'
 import { fetchClusterOptions } from '~/lib/scp-api'
-import { getDefaultClusterParams, getAnnotationValues, emptyDataParams } from '~/lib/cluster-utils'
+import {
+  getDefaultClusterParams, getAnnotationValues, emptyDataParams, getAnnotationForIdentifier
+} from '~/lib/cluster-utils'
 
+/**
+ * Get annotations that aren't custom
+ *
+ * TODO (SCP-4242): Handle custom annotations in global gene search,
+ * then remove this function.
+ */
+function getBasicAnnotations(study) {
+  let basicAnnotationList = null
+  if (study.annotation_list) {
+    basicAnnotationList = study.annotation_list
+    basicAnnotationList.annotations = basicAnnotationList.annotations.filter(a => a.scope !== 'user')
+  }
+  return basicAnnotationList
+}
 
 /** Renders expression data for a study.  This assumes that the study has a 'gene_matches' property
     to inform which genes to show data for
   */
 export default function StudyGeneExpressions({ study }) {
   const [clusterParams, setClusterParams] = useState(_clone(emptyDataParams))
-  const [annotationList, setAnnotationList] = useState(study.annotation_list ?? null)
+  const [annotationList, setAnnotationList] = useState(getBasicAnnotations(study))
   let controlClusterParams = _clone(clusterParams)
-const defaultAnnotation = getAnnotationFromIdentifier(study.default_annotation)
-const defaultAnnotationIsNumeric = defaultAnnotation?.type === 'numeric'
+  const defaultAnnotation = getAnnotationForIdentifier(study.default_annotation_id)
+  const defaultAnnotationIsNumeric = defaultAnnotation?.type === 'numeric'
   if (annotationList && !clusterParams.cluster) {
     // if the user hasn't specified anything yet, but we have the study defaults, use those
     controlClusterParams = Object.assign(controlClusterParams, getDefaultClusterParams(annotationList))
@@ -48,13 +64,14 @@ const defaultAnnotationIsNumeric = defaultAnnotation?.type === 'numeric'
       genes={study.gene_matches}
       {...controlClusterParams}
       annotationValues={annotationValues}/>
-  } else if (study.is_default_annotation_numeric) {
+  } else if (defaultAnnotationIsNumeric) {
     // render annotated scatter plot if study has default annotation of type "numeric"
     studyRenderComponent = <ScatterPlot
       studyAccession={study.accession}
       genes={study.gene_matches}
       {...clusterParams}
       isAnnotatedScatter={true}
+      dimensionProps={{ verticalPad: 400 }}
     />
   } else {
     // render violin for single genes or collapsed

--- a/app/javascript/components/search/genes/StudyGeneExpressions.jsx
+++ b/app/javascript/components/search/genes/StudyGeneExpressions.jsx
@@ -4,6 +4,7 @@ import _clone from 'lodash/clone'
 import StudySearchResult, { getByline } from '~/components/search/results/StudySearchResult'
 import DotPlot from '~/components/visualization/DotPlot'
 import StudyViolinPlot from '~/components/visualization/StudyViolinPlot'
+import ScatterPlot from '~/components/visualization/ScatterPlot'
 import ClusterSelector from '~/components/visualization/controls/ClusterSelector'
 import AnnotationSelector from '~/components/visualization/controls/AnnotationSelector'
 import SubsampleSelector from '~/components/visualization/controls/SubsampleSelector'
@@ -46,6 +47,14 @@ export default function StudyGeneExpressions({ study }) {
       genes={study.gene_matches}
       {...controlClusterParams}
       annotationValues={annotationValues}/>
+  } else if (study.is_default_annotation_numeric) {
+    // render annotated scatter plot if study has default annotation of type "numeric"
+    studyRenderComponent = <ScatterPlot
+      studyAccession={study.accession}
+      genes={study.gene_matches}
+      {...clusterParams}
+      isAnnotatedScatter={true}
+    />
   } else {
     // render violin for single genes or collapsed
     studyRenderComponent = <StudyViolinPlot

--- a/app/javascript/components/search/genes/StudyGeneExpressions.jsx
+++ b/app/javascript/components/search/genes/StudyGeneExpressions.jsx
@@ -18,7 +18,7 @@ import { getDefaultClusterParams, getAnnotationValues, emptyDataParams } from '~
   */
 export default function StudyGeneExpressions({ study }) {
   const [clusterParams, setClusterParams] = useState(_clone(emptyDataParams))
-  const [annotationList, setAnnotationList] = useState(null)
+  const [annotationList, setAnnotationList] = useState(study.annotation_list ?? null)
   let controlClusterParams = _clone(clusterParams)
 
   if (annotationList && !clusterParams.cluster) {

--- a/app/javascript/components/search/genes/StudyGeneExpressions.jsx
+++ b/app/javascript/components/search/genes/StudyGeneExpressions.jsx
@@ -22,7 +22,7 @@ import {
  */
 function getBasicAnnotations(study) {
   let basicAnnotationList = null
-  if (study.annotation_list?.annotations.length > 0) {
+  if (study.annotation_list?.can_visualize_clusters) {
     basicAnnotationList = study.annotation_list
     basicAnnotationList.annotations = basicAnnotationList.annotations.filter(a => a.scope !== 'user')
   }

--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -70,12 +70,29 @@ export function getAnnotationDisplayName(annotation) {
   }
 }
 
-/** transmutes an annotation into a string identifier of form {name}--{type}--{scope} */
+/** Transforms annotation object to string identifier of form {name}--{type}--{scope} */
 export function getIdentifierForAnnotation(annotation) {
   if (!annotation) {
     return '----'
   }
   return `${annotation.id ? annotation.id : annotation.name}--${annotation.type}--${annotation.scope}`
+}
+
+/** Transforms string identifier of {name}--{type}--{scope} to annotation object */
+export function getAnnotationForIdentifier(identifier) {
+  if (!identifier) {
+    return null
+  }
+  const splitId = identifier.split('--')
+  let annotation = { name: '', type: '', scope: '' }
+  if (splitId.length > 1) {
+    annotation = {
+      name: splitId[0],
+      type: splitId[1],
+      scope: splitId[2]
+    }
+  }
+  return annotation
 }
 
 

--- a/public/mock_data/search/annotated_scatter_plot/adcy5_human_all_genes.json
+++ b/public/mock_data/search/annotated_scatter_plot/adcy5_human_all_genes.json
@@ -1,0 +1,55 @@
+{
+  "data": {
+    "x": [
+      1.0,
+      1.0
+    ],
+    "y": [
+      9480.2,
+      9481.2
+    ],
+    "cells": [
+      "AE_1",
+      "AE_2"
+    ],
+    "annotations": [
+      1.0,
+      1.0
+    ]
+  },
+  "pointSize": 3,
+  "userSpecifiedRanges": null,
+  "showClusterPointBorders": false,
+  "description": null,
+  "is3D": false,
+  "isSubsampled": false,
+  "isAnnotatedScatter": true,
+  "isCorrelatedScatter": false,
+  "isSpatial": false,
+  "numPoints": 2,
+  "axes": {
+    "titles": {
+      "x": null,
+      "y": "Expression"
+    },
+    "aspects": null
+  },
+  "hasCoordinateLabels": false,
+  "coordinateLabels": [],
+  "pointAlpha": 1.0,
+  "cluster": "cluster.tsv",
+  "genes": [
+    "ADCY5"
+  ],
+  "annotParams": {
+    "name": "Intensity",
+    "type": "numeric",
+    "scope": "cluster",
+    "values": [],
+    "identifier": "Intensity--numeric--cluster"
+  },
+  "subsample": "all",
+  "consensus": null,
+  "customColors": {},
+  "clusterFileId": "61a7e4a362561862ea13daa0"
+}

--- a/public/mock_data/search/annotated_scatter_plot/study_human_all_genes.json
+++ b/public/mock_data/search/annotated_scatter_plot/study_human_all_genes.json
@@ -12,5 +12,159 @@
     "adcy5"
   ],
   "can_visualize_clusters": true,
-  "is_default_annotation_numeric": true
+  "is_default_annotation_numeric": true,
+  "annotation_list": {
+    "default_cluster": "cluster.tsv",
+    "default_annotation": {
+      "name": "Intensity",
+      "type": "numeric",
+      "scope": "cluster",
+      "values": [],
+      "identifier": "Intensity--numeric--cluster"
+    },
+    "annotations": [
+      {
+        "name": "biosample_id",
+        "type": "group",
+        "values": [
+          "AE_D06_02"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "biosample_type",
+        "type": "group",
+        "values": [
+          "PrimaryBioSample_PrimaryCulture"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "disease",
+        "type": "group",
+        "values": [
+          "MONDO_0018076"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "disease__ontology_label",
+        "type": "group",
+        "values": [
+          "tuberculosis"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "organ",
+        "type": "group",
+        "values": [
+          "UBERON_0000178"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "organ__ontology_label",
+        "type": "group",
+        "values": [
+          "blood"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "library_preparation_protocol",
+        "type": "group",
+        "values": [
+          "EFO_0009899"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "library_preparation_protocol__ontology_label",
+        "type": "group",
+        "values": [
+          "10x 3' v2"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "donor_id",
+        "type": "group",
+        "values": [
+          "AE_D06"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "species",
+        "type": "group",
+        "values": [
+          "NCBITaxon_9606"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "species__ontology_label",
+        "type": "group",
+        "values": [
+          "Homo sapiens"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "sex",
+        "type": "group",
+        "values": [
+          "unknown"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "is_living",
+        "type": "group",
+        "values": [
+          "unknown"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "cell_type",
+        "type": "group",
+        "values": [
+          "CL_0000066"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "cell_type__ontology_label",
+        "type": "group",
+        "values": [
+          "epithelial cell"
+        ],
+        "scope": "invalid"
+      },
+      {
+        "name": "Category",
+        "type": "group",
+        "values": [
+          "A"
+        ],
+        "scope": "invalid",
+        "cluster_name": "cluster.tsv"
+      },
+      {
+        "name": "Intensity",
+        "type": "numeric",
+        "values": [],
+        "scope": "cluster",
+        "cluster_name": "cluster.tsv"
+      }
+    ],
+    "clusters": [
+      "cluster.tsv"
+    ],
+    "subsample_thresholds": {
+      "cluster.tsv": []
+    }
+  }
 }

--- a/public/mock_data/search/annotated_scatter_plot/study_human_all_genes.json
+++ b/public/mock_data/search/annotated_scatter_plot/study_human_all_genes.json
@@ -1,0 +1,16 @@
+{
+  "study_source": "SCP",
+  "accession": "SCP113",
+  "name": "Human all genes",
+  "description": "Synthetic study containing all human genes, useful for testing e.g. related genes ideogram. Jean Chang, Eric Weitz, Jon Bistline, Eno-Abasi Augustine-Akpan, Emily Hanna, Devon Bush, Vicky Horst, Leyla Tarhan.  Journal of SCP Synthetic Studies.  Volume 1, p1, February 2020.  Adding synthetic study data to development and staging environments has been shown to improve testability of new code.  We extend those findings to the Single Cell Portal by adding this synthetic data.'sample_type': {'cultured primary cells': 130}, 'disease': {'MONDO_0005109': 10, 'MONDO_0018076': 120}, 'disease__ontology_label': {'HIV infectious disease': 10, 'tuberculosis': 120}, 'organ': {'UBERON_0000178': 130}, 'organ__ontology_label': {'blood': 130}, 'library_preparation_protocol': {'EFO_0009899': 130}, 'library_preparation_protocol__ontology_label': {'10X 3' v2 sequencing': 130},  'species': {'NCBITaxon_9606': 130}, 'species__ontology_label': {'Homo sapiens': 130}, 'sex': {'unknown': 130}, 'is_living': {'unknown': 130}, 'cell_type': {'CL_0000034': 20, 'CL_0000066': 73, 'CL_0000075': 20, 'CL_0000094': 1, 'CL_0000236': 16}, 'cell_type__ontology_label': {'B cell': 16, 'columnar/cuboidal epithelial cell': 20, 'epithelial cell': 73, 'granulocyte': 1, 'stem cell': 20}}",
+  "public": true,
+  "detached": false,
+  "cell_count": 2,
+  "gene_count": 50820,
+  "study_url": "/single_cell/study/SCP113/human-all-genes",
+  "gene_matches": [
+    "adcy5"
+  ],
+  "can_visualize_clusters": true,
+  "is_default_annotation_numeric": true
+}

--- a/test/js/search/annotated-scatter-plot.test.js
+++ b/test/js/search/annotated-scatter-plot.test.js
@@ -1,0 +1,70 @@
+// Without disabling eslint code, Promises are auto inserted
+/* eslint-disable*/
+
+import React from 'react'
+import { render, waitForElementToBeRemoved, screen } from '@testing-library/react'
+import { enableFetchMocks } from 'jest-fetch-mock'
+import Plotly from 'plotly.js-dist'
+import jquery from 'jquery'
+
+import ScatterPlot from 'components/visualization/ScatterPlot'
+
+jest.mock('lib/scp-api-metrics', () => ({
+  logScatterPlot: jest.fn()
+}))
+
+const fs = require('fs')
+
+enableFetchMocks()
+
+const mockStudyPath = 'public/mock_data/search/annotated_scatter_plot/study_human_all_genes.json'
+const study = JSON.parse(fs.readFileSync(mockStudyPath), 'utf8')
+
+const mockAnnotatedScatterPath =
+  'public/mock_data/search/annotated_scatter_plot/adcy5_human_all_genes.json'
+const plots = fs.readFileSync(mockAnnotatedScatterPath)
+
+beforeAll(() => {
+  global.$ = jquery
+})
+// Note: tests that mock global.fetch must be cleared after every test
+afterEach(() => {
+  // Restores all mocks back to their original value
+  jest.restoreAllMocks()
+})
+
+describe('Annotated scatter plot in global gene search', () => {
+  beforeEach(() => {
+    fetch.resetMocks()
+  })
+
+  it('configures Plotly annotated scatter', async() => {
+    fetch.mockResponseOnce(plots)
+    const mockPlot = jest.spyOn(Plotly, 'react')
+    mockPlot.mockImplementation(() => {})
+
+    render(
+      <ScatterPlot
+        studyAccession={study.accession}
+        genes={study.gene_matches}
+        cluster=''
+        annotation={{name: '', type: '', scope: ''}}
+        isAnnotatedScatter={study.is_default_annotation_numeric}
+      />
+    )
+
+    await waitForElementToBeRemoved(() => screen.getByTestId('study-scatter-1-loading-icon'))
+
+    var args = mockPlot.mock.calls[0];
+
+    expect(args[0]).toBe('study-scatter-1')
+
+    const firstTrace = args[1][0]
+    expect(firstTrace.type).toBe('scattergl')
+    expect(firstTrace.y).toHaveLength(2)
+
+    expect(args[2].yaxis.title).toBe('Expression')
+
+  })
+
+})


### PR DESCRIPTION
This fixes the display of results for global gene search when the study has a default annotation of type "numeric".

Previously, likely for at least 1-2 years, an error was displayed for such results.  Now, an annotated scatter plot is shown, similar to what's shown in gene search for the Explore tab in Study Overview (#1435).

Here's how it looks:

https://user-images.githubusercontent.com/1334561/161144590-a0d6c4f2-6c27-4f77-9566-69766fb9f524.mov

This satisfies SCP-4200.