### PR TITLE
hiding sec-ch-ua header (SCP-4249)

### DIFF
--- a/webapp.conf
+++ b/webapp.conf
@@ -34,6 +34,9 @@ server {
     proxy_set_header  X-Forwarded-Proto $scheme;
     proxy_set_header  Host $host;
     proxy_set_header  X-Forwarded-Host $host;
+    # This address repeated bugs we've found with Chrome using non-standard quote escaping in this parameter
+    # see e.g. https://docs.google.com/document/d/1TTIGgu82qLJqGt130DlxWN5lsP7Wzo6FwuJSn5O_J_I
+    passenger_set_header sec-ch-ua "";
 
     # The following deploys your Ruby/Python/Node.js/Meteor app on Passenger.
 


### PR DESCRIPTION
this is confirmed to work in production, where this change was made to the config file live.
This was done after several failed attempts to use `proxy_set_header`, but then https://www.phusionpassenger.com/library/config/nginx/reference/#passenger_set_header indicated that since we are using the passenger nginx module, `passenger_set_header` was instead the correct parameter.

TO TEST:
 1. go to production SCP in chrome
 2. click around, confirm random 403s are not recieved