### PR TITLE
HOTFIX - fix cluster renaming bug (SCP-4255)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -296,6 +296,7 @@ module Api
       # if the save is successful and includes a complete upload, will send it to firecloud
       # and kick off a parse job if requested
       def perform_update(study_file)
+        study = study_file.study
         safe_file_params = study_file_params
         is_chunked = false
         content_range = RequestUtils.parse_content_range_header(request.headers)
@@ -338,14 +339,14 @@ module Api
 
         # log the name properties to help with understanding SCP-4159
         MetricsService.log('file-update', {
-          studyAccession: @study.accession,
+          studyAccession: study.accession,
           message: 'name info',
           uploadFilename: safe_file_params[:upload_file_name],
           originalFilename: safe_file_params[:upload]&.original_filename,
           filename: safe_file_params[:name],
-          fileId: @study_file._id.to_s,
-          fileType: @study_file.file_type,
-          fileSize: @study_file.upload_file_size
+          fileId: study_file._id.to_s,
+          fileType: study_file.file_type,
+          fileSize: study_file.upload_file_size
         }, current_api_user)
 
         study_file.update!(safe_file_params)
@@ -355,29 +356,29 @@ module Api
 
         # if a gene list or cluster got updated, we need to update the associated records
         if safe_file_params[:file_type] == 'Gene List' && name_changed
-          precomputed_entry = PrecomputedScore.find_by(study_file_id: safe_file_params[:_id])
+          precomputed_entry = PrecomputedScore.find_by(study_file: study_file)
           if precomputed_entry.present?
-            logger.info "Updating gene list #{@precomputed_entry.name} to match #{safe_file_params[:name]}"
+            logger.info "Updating gene list #{precomputed_entry.name} to match #{study_file[:name]}"
             precomputed_entry.update(name: study_file.name)
           end
         elsif safe_file_params[:file_type] == 'Cluster' && name_changed
-          cluster = ClusterGroup.find_by(study_file_id: safe_file_params[:_id])
+          cluster = ClusterGroup.find_by(study_file: study_file)
           if cluster.present?
-            logger.info "Updating cluster #{@cluster.name} to match #{safe_file_params[:name]}"
+            logger.info "Updating cluster #{cluster.name} to match #{study_file.name}"
             # before updating, check if the defaults also need to change
-            if @study.default_cluster == @cluster
-              @study.default_options[:cluster] = study_file.name
-              @study.save
+            if study.default_cluster == cluster
+              study.default_options[:cluster] = study_file.name
+              study.save
             end
-            @cluster.update(name: study_file.name)
+            cluster.update(name: study_file.name)
           end
         end
 
         if ['Expression Matrix', 'MM Coordinate Matrix'].include?(safe_file_params[:file_type]) && !safe_file_params[:y_axis_label].blank?
           # if user is supplying an expression axis label, update default options hash
-          options = @study.default_options.dup
+          options = study.default_options.dup
           options.merge!(expression_label: safe_file_params[:y_axis_label])
-          @study.update(default_options: options)
+          study.update(default_options: options)
         end
 
         if safe_file_params[:upload].present? && !is_chunked


### PR DESCRIPTION
Renaming a study file after creation would succeed, but not rename the underlying clusterGroup, which means the UI will not be updated.  I would like to merge/release this tonight to unblock Stefano's study creation.  The bug was on line 364
`cluster = ClusterGroup.find_by(study_file_id: safe_file_params[:_id])`
This never found the existing cluster group, since earlier in the method we delete the safe_file_params[:_id] for security.  

I've also included some general cleanup of the API method to make it not use instance variables

TO TEST:
1. upload a cluster file
2. view the cluster in the UX
3. in the upload wizard, change the name of the cluster
4. view the cluster in the UX, and confirm the name change propagated