### PR TITLE
fixing cluster renaming bugs (SCP-4255)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -342,7 +342,7 @@ module Api
           message: 'name info',
           uploadFilename: safe_file_params[:upload_file_name],
           originalFilename: safe_file_params[:upload]&.original_filename,
-          filename: safe_file_params[:name],
+          fileName: safe_file_params[:name],
           fileId: study_file._id.to_s,
           fileType: study_file.file_type,
           fileSize: study_file.upload_file_size
@@ -373,7 +373,7 @@ module Api
           end
         end
 
-        if ['Expression Matrix', 'MMc Coordinate Matrix'].include?(study_file.file_type) && !safe_file_params[:y_axis_label].blank?
+        if ['Expression Matrix', 'MM Coordinate Matrix'].include?(study_file.file_type) && !safe_file_params[:y_axis_label].blank?
           # if user is supplying an expression axis label, update default options hash
           options = study.default_options.dup
           options.merge!(expression_label: safe_file_params[:y_axis_label])

--- a/test/api/study_files_controller_test.rb
+++ b/test/api/study_files_controller_test.rb
@@ -12,9 +12,10 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
                                name_prefix: 'StudyFile Study',
                                public: true,
                                user: @user,
-                               test_array: @@studies_to_clean,
-                               predefined_file_types: %w[cluster])
-    @study_file = @study.study_files.first
+                               test_array: @@studies_to_clean)
+    @study_file = FactoryBot.create(:cluster_file,
+                               name: 'clusterA.txt',
+                               study: @study)
   end
 
   setup do
@@ -85,6 +86,19 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
     execute_http_request(:delete, api_v1_study_study_file_path(study_id: @study.id, id: study_file_id))
     assert_response 204, "Did not successfully delete study file, expected response of 204 but found #{@response.response_code}"
   end
+
+  test 'can update cluster name' do
+    cluster_file = @study_file
+    update_attributes = {
+      study_file: {
+        name: 'updated name'
+      }
+    }
+    execute_http_request(:patch, api_v1_study_study_file_path(study_id: @study.id, id: cluster_file._id), request_payload: update_attributes)
+    assert_equal 'updated name', json['name']
+    assert_equal 'updated name', @study.cluster_groups.first.reload.name
+  end
+
 
   # create a study file bundle using the study_files_controller method
   test 'should create study file bundle' do


### PR DESCRIPTION
This is a more polished version of the hotfix that went out in #1442 , and includes a unit test.

TO TEST:
1. upload a cluster file (or have an existing one)
2. in the upload wizard, rename the cluster
3. go to the Explore tab, confirm the cluster rename appears in the clusters dropdown