### PR TITLE
Fix BSON::String::IllegalKey for bulkdownload Azul files (SCP-4201)

### DIFF
--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -307,8 +307,8 @@ module Api
           download_req = DownloadRequest.find(params[:download_id])
           render json: { error: 'Invalid download_id provided' }, status: 400 and return if download_req.blank?
 
+          azul_files = download_req.decoded_azul_files
           file_ids = download_req.file_ids
-          azul_files = download_req.azul_files
         elsif params[:file_ids]
           begin
             file_ids = RequestUtils.validate_id_list(params[:file_ids])

--- a/app/models/download_request.rb
+++ b/app/models/download_request.rb
@@ -7,7 +7,40 @@ class DownloadRequest
 
   field :auth_code, type: String
   field :file_ids # Mongo ids of study files to download
-  field :tdr_files, type: Hash, default: {} # Hash of TDR project shortnames to arrays of access urls
-  field :azul_files, type: Hash, default: {} # Hash of Azul file summaries (Project Manifests, analysis_files, etc)
+  field :tdr_files, type: String # Hash of TDR project shortnames to arrays of access urls
+  field :azul_files, type: String # Hash of Azul file summaries (Project Manifests, analysis_files, etc)
   field :user_id # User making the request
+
+  before_save :sanitize_hashes
+
+  ALLOWED_TRANSFORMS = %i[encode decode]
+
+  # This is called before the data is saved to the DB to ensure the file hashes are encoded
+  # in the way the DB can accept
+  def sanitize_hashes 
+    if self.azul_files.is_a?(Hash)
+    self.tdr_files =  self.class.transform_files(tdr_files, :encode)
+      self.azul_files = self.class.transform_files(azul_files, :encode)
+    end
+  end
+  
+  # decode JSON-ified tdr files back into their original hash format
+  def decoded_tdr_files
+    self.class.transform_files(tdr_files, :decode)
+  end
+
+  # decode JSON-ified azul files back into their original hash format
+  def decoded_azul_files
+    self.class.transform_files(azul_files, :decode)
+  end
+
+  # helper to transform a hash to/from JSON for storage in the DB
+  # transformation options are encode which will result in JSON-ifing the hash or
+  # decode which will return the JSON-ified files back to thier original hash format
+  # This is necessary to work around MongoDBs constraints on '.' and '$' in hash keys
+  def self.transform_files(file_data, transform = :encode)  
+    raise ArgumentError, "#{transform} is not a valid transform" unless ALLOWED_TRANSFORMS.include?(transform)
+    file_data = transform.eql?(:encode) ? ActiveSupport::JSON.encode(file_data) : ActiveSupport::JSON.decode(file_data.gsub('=>', ':'))
+    return file_data
+    end
 end

--- a/db/migrate/20220401103323_encode_azul_files_names.rb
+++ b/db/migrate/20220401103323_encode_azul_files_names.rb
@@ -1,0 +1,18 @@
+class EncodeAzulFilesNames < Mongoid::Migration
+    def self.up
+      download_reqs = DownloadRequest.where(:azul_files.ne => nil)
+      download_reqs.each do |req|
+        encoded_azul_files = DownloadRequest.transform_files(req.azul_files, :encode)
+        req.update(azul_files: encoded_azul_files)
+      end
+    end
+  
+    def self.down
+    download_reqs = DownloadRequest.where(:azul_files.ne => nil)
+    download_reqs.each do |req|
+        decoded_azul_files = DownloadRequest.transform_files( req.azul_files, :decode)
+        req.update(azul_files: decoded_azul_files)
+      end
+    end
+  end
+  

--- a/test/api/bulk_download_controller_test.rb
+++ b/test/api/bulk_download_controller_test.rb
@@ -324,7 +324,7 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
     download_id = json['download_id']
     download_request = DownloadRequest.find(download_id)
     assert download_request.present?
-    azul_files = download_request.azul_files
+    azul_files = download_request.decoded_azul_files
     assert azul_files.keys.include?('FakeHCAStudy1')
     assert_not azul_files.keys.include?('FakeHCAStudy2')
   end
@@ -341,6 +341,46 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
             file_type: 'Project Manifest',
             project_id: hca_project_id,
             name: 'FakeHCAStudy1.tsv'
+          }
+        ]
+      }
+    }
+    execute_http_request(:post, api_v1_bulk_download_auth_code_path, request_payload: payload, user: @user)
+    assert_response :success
+    download_id = json['download_id']
+    auth_code = json['auth_code']
+    mock = Minitest::Mock.new
+    manifest_info = {
+      Status: 302,
+      Location: 'https://service.azul.data.humancellatlas.org/manifest/files?catalog=dcp12&format=compact&' \
+                "filters=%7B%22projectId%22%3A+%7B%22is%22%3A+%5B%22#{hca_project_id}%22%5D%7D%7D&objectKey=" \
+                'manifests%2FFakeHCAStudy1.tsv'
+    }.with_indifferent_access
+    mock.expect :project_manifest_link, manifest_info, [hca_project_id]
+    ApplicationController.stub :hca_azul_client, mock do
+      execute_http_request(:get,
+                           api_v1_bulk_download_generate_curl_config_path(
+                             auth_code: auth_code, download_id: download_id
+                           ),
+                           user: @user)
+      assert_response :success
+      mock.verify
+      assert json.include? manifest_info[:Location]
+    end
+  end
+
+  test 'should complete download request for HCA project' do
+    hca_project_id = SecureRandom.uuid
+    payload = {
+      file_ids: [],
+      azul_files: {
+        FakeHCAStudy1: [
+          {
+            count: 1,
+            upload_file_size: 1.megabyte,
+            file_type: 'Project Manifest',
+            project_id: hca_project_id,
+            name: 'Fa..keHCAStudy1.tsv'
           }
         ]
       }

--- a/test/models/download_request_test.rb
+++ b/test/models/download_request_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class DownloadRequestTest < ActiveSupport::TestCase
+
+  before(:all) do
+    @azul_hash = {
+        'Fake.HCA.Study.1' => [
+          {
+            'source' => 'hca',
+            'count' => 1,
+            'upload_file_size' => 10.megabytes,
+            'file_format' => 'loom',
+            'file_type' => 'analysis_file',
+            'accession' => 'FakeHCAStudy1',
+            'project_id' => 'hca_project_id'
+          }
+        ],
+        'Fake.HcaS.tu.d.y.2' => []
+      }
+      
+    @encoded_azul_hash = "{\"Fake.HCA.Study.1\":[{\"source\":\"hca\",\"count\":1,\"upload_file_size\":10485760,\"file_format\":\"loom\",\"file_type\":\"analysis_file\",\"accession\":\"FakeHCAStudy1\",\"project_id\":\"hca_project_id\"}],\"Fake.HcaS.tu.d.y.2\":[]}"
+
+  end
+
+  test 'should transform azul_file hashes to JSON and back' do
+    assert_equal @encoded_azul_hash, DownloadRequest.transform_files(@azul_hash)
+    assert_equal @azul_hash, DownloadRequest.transform_files(@encoded_azul_hash, :decode)
+    assert_raises ArgumentError do
+        DownloadRequest.transform_files(@azul_hash, :foo)
+    end
+  end
+end
+


### PR DESCRIPTION
This fixes a bug where an Azul study name contained a '.' which is an illegal key value for a hash in MongoDB. This change will update the azul files hash to be encoded to a JSON string before persisting to the DB thereby avoiding the hash key constraints of MongoDB entirely. This is closely modeled after the fix that was done to correct this issue for custom color annotations.

To test:
- Pull this branch
- Sign into SCP
- Do a search for 'Interneuron' (this will give a result of an Azul study that has a period at the end of it's name)
- click download
- confirm you are able to run the curl command to download this study.