### PR TITLE
adding exception for sync tool directory listings (SCP-4239)

### DIFF
--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -769,7 +769,9 @@ module Api
           file_type = DirectoryListing.file_type_from_extension(file.name)
           directory_name = DirectoryListing.get_folder_name(file.name)
           if @file_extension_map.has_key?(directory_name) && !@file_extension_map.dig(directory_name, file_type).nil? &&
-            @file_extension_map.dig(directory_name, file_type) >= DirectoryListing::MIN_SIZE
+            @file_extension_map.dig(directory_name, file_type) >= DirectoryListing::MIN_SIZE &&
+            # for the root directory, only put sequence files in a block
+            (directory_name != '/' || DirectoryListing::PRIMARY_DATA_TYPES.include?(file_type))
             process_directory_listing_file(file, file_type)
           else
             # we are now dealing with singleton files or sequence data, so process accordingly (making sure to ignore directories)

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1288,8 +1288,13 @@ class StudiesController < ApplicationController
       # check first if file type is in file map in a group larger than 10 (or 20 for text files)
       file_type = DirectoryListing.file_type_from_extension(file.name)
       directory_name = DirectoryListing.get_folder_name(file.name)
-      if @file_extension_map.has_key?(directory_name) && !@file_extension_map.dig(directory_name, file_type).nil? &&
-         @file_extension_map.dig(directory_name, file_type) >= DirectoryListing::MIN_SIZE
+
+      if @file_extension_map.has_key?(directory_name) &&
+         !@file_extension_map.dig(directory_name, file_type).nil? &&
+         @file_extension_map.dig(directory_name, file_type) >= DirectoryListing::MIN_SIZE &&
+         # for the root directory, only put sequence files in a block
+         (directory_name != '/' || DirectoryListing::PRIMARY_DATA_TYPES.include?(file_type))
+
         process_directory_listing_file(file, file_type)
       else
         # we are now dealing with singleton files or sequence data, so process accordingly (making sure to ignore directories)


### PR DESCRIPTION
Previously, any group of 10/20+ files with the same extension would get made into a 'block' in sync tool, which means they could not be ingested, but only bulk uploaded as misc/other.  This adds an exception to that treatment for non-sequence data files in the root directory.  This will be needed for Jonah to upload his 100+ clusters via sync tool.  For now, this is definitely in the 'quick fix' category.  Once Jon returns, who knows more about the use cases for DirectoryListing, we can revisit this and expand/refine the exception, and add tests around it.

TO TEST:
1. for an existing study, add 20+ cluster files to the workspace bucket (they can all be copies of the same file with different names)
2. Visit sync tool for that study
3. confirm the files appear individually, and are able to be specified as cluster files