### PR TITLE
Create a github action workflow to auto delete PR branches on merge (SCP-3670)

### DIFF
--- a/.github/workflows/delete-branch-after-pr-merge.yml
+++ b/.github/workflows/delete-branch-after-pr-merge.yml
@@ -1,0 +1,25 @@
+name: Delete Feature Branch after Merge
+
+# Controls when the workflow will run
+on:
+  pull_request:
+    types: [ closed ]
+    
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  
+jobs:
+  merge_job:
+    # this job will only run if the PR has been merged
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - name: Delete merged branch
+    # from the github actions marketplace repo here: https://github.com/pabio/delete-merged-action
+      uses: koj-co/delete-merged-action@master
+      with:
+      # do not delete master or development branches
+        branches: "!master, !development, *"
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/delete-branch-after-pr-merge.yml
+++ b/.github/workflows/delete-branch-after-pr-merge.yml
@@ -1,4 +1,4 @@
-name: Delete Feature Branch after Merge
+name: Delete feature branch after merge
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
This adds a github actions workflow to delete feature branches when the PR is merged. This includes a check to ensure the branches to be deleted are not development or master. You can see the output of the workflow run in the github actions tab.

To test:
- Go to this repo: https://github.com/ehanna4/testing-actions
- make a PR ( I have provided a couple of branches already called like 'test-branch-1' etc that you can use so you don't have to clone the repo)
- merge that PR
- check out the action tab and observe the output which should say that branch gets deleted

<img width="716" alt="Screen Shot 2022-04-13 at 9 45 38 AM" src="https://user-images.githubusercontent.com/54322292/163198015-583d23ea-fe80-4e8c-9287-f772b6042834.png">



Open to hearing peoples thoughts on this idea. There is an option in the settings on a repo to have branches auto-delete on merge however I did not choose this option because you can't specify branches to not be able to be deleted (i.e. development). It's unclear to me if having those branches be protected would prevent them being deleted however I think it's safer and more clear having it spelled out in the workflow which branches should not be deleted rather than relying on github knowing not to delete protected branches (if that is even possible). 

This of course introduces a dependency on the job from `koj-co/delete-merged-action@master` to handle the deleting action. But I felt this was a safe choice after looking over the code in the repo, it's listed on the github actions marketplace (https://github.com/marketplace/actions/delete-merged-action), and it's been archived so there shouldn't be any surprise changes to the job.
