### PR TITLE
Improve speed and reliability of related genes ideogram (SCP-4260)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
     "fflate": "^0.7.3",
-    "ideogram": "1.34.0",
+    "ideogram": "1.36.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.13.0",
     "morpheus-app": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6651,10 +6651,10 @@ identity-obj-proxy@^3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ideogram@1.34.0:
-  version "1.34.0"
-  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.34.0.tgz#7d5e9a151c452e26b0224ab057073b390b464479"
-  integrity sha512-TgefcX8yo/sAwG8wM+0vX9Q5wYEL7AlJLPGPRDF8XlGYydH85egySCupmKTyt+w/8M/+gbTJhaPWFDnUEg3fpA==
+ideogram@1.36.0:
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.36.0.tgz#231f68f25884dd8257a8ba99b39534726fad7968"
+  integrity sha512-+DS/bPp0cUWXUyMMyPTll2KN9vhMj91wAuJreRaVXkITPbLqtrnoIHUxlcU2hOh5JcoRZFLj7hys0z6iN9satQ==
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"


### PR DESCRIPTION
This makes related genes ideogram search and update instantly, enabling nimbler exploration.

Previously, Ideogram would request most data for related genes over the Internet, directly from third-party APIs.  

Now, Ideogram fetches from those origin APIs once, then loads a compressed cache of all relevant data from that API in the background.  That web cache technique was described in #1280; this simply applies that proven approach to more data.  Unlike that first application, though, these performance improvements are drastic: finding all related genes upon a new search speeds up from 2-6 seconds before to < 100 ms now.

It also improves resilience, by reducing use of third-party APIs.  Blips were uncommon, but now will be even rarer.  Label sorting and layout are also refined, and pathway hyperlinks in tooltips now have class attributes enabling analysis of how often they're clicked.

Here's how it looks.

https://user-images.githubusercontent.com/1334561/163201738-486c6908-6174-4689-802c-4e724ebaa018.mov

To test:
* Install JS package updates: `yarn install`
* Restart `vite`: terminate the process if running, then run `bin/vite dev`
* If you haven't already, then populate new "human_all_genes" study, e.g. via `echo "SyntheticStudyPopulator.populate('human_all_genes')" | bundle exec rails console -e development`
* Navigate to it in web browser
* Search PTEN
* Hover over purple triangles, i.e. "interacting gene" annotations.  Click some, verify clicked genes are searched.
* Hover over pink triangles, i.e. "paralogous gene" annotations.  Click some, verify clicked genes are searched.

This integration of upstream enhancements was done as part of Developer Choice Days.  It satisfies SCP-4260.