### PR TITLE
fixing legend counts for hidden traces (SCP-4259)

### DIFF
--- a/app/javascript/lib/plot.js
+++ b/app/javascript/lib/plot.js
@@ -114,35 +114,24 @@ PlotUtils.filterTrace = function({
     expFilterMax = expMin + totalRange * expressionFilter[1]
   }
 
-  const labelNameHash = {}
-  if (isHidingByLabel) {
-    // build a hash of label => present so we can quickly filter
-    for (let i = 0; i < hiddenTraces.length; i++) {
-      labelNameHash[hiddenTraces[i]] = true
-    }
-  }
-
   // this is the main filter/group loop.  Loop over every cell and determine whether it needs to be filtered,
   // and if it needs to be grouped.
   for (let i = 0; i < oldLength; i++) {
     // if we're not filtering by expression, or the cell is in the range, show it
     if (!isFilteringByExpression || (expressionData[i] >= expFilterMin && expressionData[i] <= expFilterMax)) {
-      // if we're not hiding by label, or the label is present in the list, include it
-      if (!isHidingByLabel || !labelNameHash[trace.annotations[i]]) {
-        const fTrace = groupByAnnotation ? traceMap[trace.annotations[i]] : traceMap.main
-        const newIndex = fTrace.newLength
-        fTrace.x[newIndex] = trace.x[i]
-        fTrace.y[newIndex] = trace.y[i]
-        if (hasZvalues) {
-          fTrace.z[newIndex] = trace.z[i]
-        }
-        fTrace.cells[newIndex] = trace.cells[i]
-        fTrace.annotations[newIndex] = trace.annotations[i]
-        if (hasExpression) {
-          fTrace.expression[newIndex] = trace.expression[i]
-        }
-        fTrace.newLength++
+      const fTrace = groupByAnnotation ? traceMap[trace.annotations[i]] : traceMap.main
+      const newIndex = fTrace.newLength
+      fTrace.x[newIndex] = trace.x[i]
+      fTrace.y[newIndex] = trace.y[i]
+      if (hasZvalues) {
+        fTrace.z[newIndex] = trace.z[i]
       }
+      fTrace.cells[newIndex] = trace.cells[i]
+      fTrace.annotations[newIndex] = trace.annotations[i]
+      if (hasExpression) {
+        fTrace.expression[newIndex] = trace.expression[i]
+      }
+      fTrace.newLength++
     }
   }
   // now fix the length of the new arrays in each trace to the number of values that were written,
@@ -158,6 +147,8 @@ PlotUtils.filterTrace = function({
     })
     countsByLabel[key] = fTrace.x.length
     delete fTrace.newLength
+    fTrace.visible = hiddenTraces.includes(key) ? 'legendonly' : true
+
     return fTrace
   })
   const expRange = isFilteringByExpression ? [expMin, expMax] : null

--- a/test/js/explore/plot-utils.test.js
+++ b/test/js/explore/plot-utils.test.js
@@ -16,21 +16,24 @@ describe('Plot grouping function cache', () => {
       y: [4, 7],
       annotations: ['a', 'a'],
       cells: ['c1', 'c4'],
-      name: 'a'
+      name: 'a',
+      visible: true
     })
     expect(traces[1]).toEqual({
       x: [2, 5],
       y: [5, 8],
       annotations: ['b', 'b'],
       cells: ['c2', 'c5'],
-      name: 'b'
+      name: 'b',
+      visible: true
     })
     expect(traces[2]).toEqual({
       x: [3],
       y: [6],
       annotations: ['c'],
       cells: ['c3'],
-      name: 'c'
+      name: 'c',
+      visible: true
     })
 
     expect(countsByLabel).toEqual({ a: 2, b: 2, c: 1 })
@@ -92,9 +95,11 @@ describe('Plot grouping function cache', () => {
 
     const [allTraces] = PlotUtils.filterTrace({ trace: data, groupByAnnotation: true, hiddenTraces: [] })
     expect(allTraces.find(t => t.name === 'a').cells).toHaveLength(2)
+    expect(allTraces.find(t => t.name === 'a').visible).toEqual(true)
 
     const [traces] = PlotUtils.filterTrace({ trace: data, groupByAnnotation: true, hiddenTraces: ['a'] })
-    expect(traces.find(t => t.name === 'a').cells).toHaveLength(0)
+    expect(traces.find(t => t.name === 'a').cells).toHaveLength(2)
+    expect(['a', 'b', 'c'].map(name => traces.find(t => t.name === name).visible)).toEqual(['legendonly', true, true])
 
     const [traces2] = PlotUtils.filterTrace({
       trace: data, groupByAnnotation: true, hiddenTraces: ['a'], activeTraceLabel: 'b'
@@ -102,11 +107,10 @@ describe('Plot grouping function cache', () => {
     expect(traces2.map(t => t.name)).toEqual(['a', 'c', 'b'])
 
     const [traces3] = PlotUtils.filterTrace({ trace: data, groupByAnnotation: true, hiddenTraces: ['b', 'c'] })
-    expect(traces3.find(t => t.name === 'b').cells).toHaveLength(0)
-    expect(traces3.find(t => t.name === 'c').cells).toHaveLength(0)
+    expect(['a', 'b', 'c'].map(name => traces3.find(t => t.name === name).visible)).toEqual([true, 'legendonly', 'legendonly'])
 
     const [traces4] = PlotUtils.filterTrace({ trace: data, groupByAnnotation: true, hiddenTraces: ['b', 'c', 'a'] })
-    expect(traces4.map(t => t.cells.length)).toEqual([0, 0, 0])
+    expect(['a', 'b', 'c'].map(name => traces4.find(t => t.name === name).visible)).toEqual(['legendonly', 'legendonly', 'legendonly'])
   })
 
   it('sorts expression data ', async () => {
@@ -150,7 +154,8 @@ describe('Plot grouping function cache', () => {
       annotations: ['b', 'a'],
       cells: ['c2', 'c4'],
       expression: [4, 5.5],
-      name: 'main'
+      name: 'main',
+      visible: true
     })
 
     const [trace2] = PlotUtils.filterTrace({


### PR DESCRIPTION
Hiding a trace in the legend no longer makes the number of points displayed go to zero.  this also opens up substantial performance optimizations, as using the visibility attribute rather than cell removal means that we can show/hide traces without doing a full recompute of all traces.  Likewise, we can reorder traces without doing a recompute.  Those optimizations are not part of this PR, as we want to get this out before release.

TO TEST:
  1. load study explore tab with cluster
  2. click show/hide traces
  3. confirm the number of points next to each legend label does not change when they are shown/hidden