### PR TITLE
scatter plot performance improvements (SCP-4259)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -242,8 +242,6 @@ function RawScatterPlot({
       PlotUtils.sortTraces(plotlyTraces, activeTraceLabel)
       Plotly.react(graphElementId, plotlyTraces, scatterData.layout)
     }
-    // look for updates of individual properties, so that we don't rerender if the containing array
-    // happens to be a different instance
   }, [activeTraceLabel])
 
   // Handles window resizing
@@ -253,8 +251,6 @@ function RawScatterPlot({
     if (scatterData && !isLoading) {
       resizePlot()
     }
-    // look for updates of individual properties, so that we don't rerender if the containing array
-    // happens to be a different instance
   }, [widthAndHeight.height, widthAndHeight.width])
 
   // Handles Plotly `data` updates, e.g. changes in color profile

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -221,8 +221,30 @@ function RawScatterPlot({
     }
     // look for updates of individual properties, so that we don't rerender if the containing array
     // happens to be a different instance
-  }, [hiddenTraces.join(','), Object.values(editedCustomColors).join(','),
-    Object.values(customColors).join(','), activeTraceLabel, expressionFilter.join(',')])
+  }, [Object.values(editedCustomColors).join(','),
+    Object.values(customColors).join(','), expressionFilter.join(',')])
+
+  useUpdateEffect(() => {
+    // Don't update if graph hasn't loaded
+    if (scatterData && !isLoading) {
+      const plotlyTraces = document.getElementById(graphElementId).data
+      PlotUtils.updateTraceVisibility(plotlyTraces, hiddenTraces)
+      Plotly.react(graphElementId, plotlyTraces, scatterData.layout)
+    }
+    // look for updates of individual properties, so that we don't rerender if the containing array
+    // happens to be a different instance
+  }, [hiddenTraces.join(',')])
+
+  useUpdateEffect(() => {
+    // Don't update if graph hasn't loaded
+    if (scatterData && !isLoading) {
+      const plotlyTraces = document.getElementById(graphElementId).data
+      PlotUtils.sortTraces(plotlyTraces, activeTraceLabel)
+      Plotly.react(graphElementId, plotlyTraces, scatterData.layout)
+    }
+    // look for updates of individual properties, so that we don't rerender if the containing array
+    // happens to be a different instance
+  }, [activeTraceLabel])
 
   // Handles window resizing
   const widthAndHeight = getScatterDimensions(scatterData, dimensionProps, genes)

--- a/app/javascript/lib/plot.js
+++ b/app/javascript/lib/plot.js
@@ -136,23 +136,42 @@ PlotUtils.filterTrace = function({
   }
   // now fix the length of the new arrays in each trace to the number of values that were written,
   // and push the traces into an array
-  const sortedLabels = PlotUtils.getPlotSortedLabels(unfilteredCountsByLabel, activeTraceLabel, false)
-  const traces = sortedLabels.map(key => {
-    const fTrace = traceMap[key]
+  const traces = Object.values(traceMap)
+  traces.forEach(fTrace => {
     const subArrays = [fTrace.x, fTrace.y, fTrace.z, fTrace.annotations, fTrace.expression, fTrace.cells]
     subArrays.forEach(arr => {
       if (arr) {
         arr.length = fTrace.newLength
       }
     })
-    countsByLabel[key] = fTrace.x.length
+    countsByLabel[fTrace.name] = fTrace.x.length
     delete fTrace.newLength
-    fTrace.visible = hiddenTraces.includes(key) ? 'legendonly' : true
-
-    return fTrace
   })
+  PlotUtils.sortTraces(traces, activeTraceLabel)
+  PlotUtils.updateTraceVisibility(traces, hiddenTraces)
   const expRange = isFilteringByExpression ? [expMin, expMax] : null
   return [traces, countsByLabel, expRange]
+}
+
+PlotUtils.updateTraceVisibility = function(traces, hiddenTraces) {
+  traces.forEach(trace => {
+    trace.visible = hiddenTraces.includes(trace.name) ? 'legendonly' : true
+  })
+}
+
+PlotUtils.sortTraces = function(traces, activeTraceLabel) {
+  const unspecifiedIsActive = activeTraceLabel === UNSPECIFIED_ANNOTATION_NAME
+  /** Sort traces by number of cells (largest first), but always put the activeTraceLabel last
+   * and the unspecified annotations first
+   * If the activeLabel *is* the unspecified cells, then put them last
+  */
+  function traceCountsSort(a, b) {
+    if (activeTraceLabel === a.name || (UNSPECIFIED_ANNOTATION_NAME === b.name && !unspecifiedIsActive)) {return 1}
+    if (activeTraceLabel === b.name || (UNSPECIFIED_ANNOTATION_NAME === a.name && !unspecifiedIsActive)) {return -1}
+    return b.x.length - a.x.length
+  }
+
+  return traces.sort(traceCountsSort)
 }
 
 /** sort the passsed in trace by expression value */
@@ -209,18 +228,7 @@ PlotUtils.getColorForLabel = function(label, customColors={}, editedCustomColors
 
 /** Returns an array of labels, sorted in the order in which they should be plotted (last is 'on top') */
 PlotUtils.getPlotSortedLabels = function(countsByLabel, activeTraceLabel) {
-  const unspecifiedIsActive = activeTraceLabel === UNSPECIFIED_ANNOTATION_NAME
-  /** Sort annotation labels by number of cells (largest first), but always put the activeTraceLabel last
-   * and the unspecified annotations first
-   * If the activeLabel *is* the unspecified cells, then put them last
-  */
-  function labelCountsSort(a, b) {
-    if (activeTraceLabel === a[0] || (UNSPECIFIED_ANNOTATION_NAME === b[0] && !unspecifiedIsActive)) {return 1}
-    if (activeTraceLabel === b[0] || (UNSPECIFIED_ANNOTATION_NAME === a[0] && !unspecifiedIsActive)) {return -1}
-    return b[1] - a[1]
-  }
-  const sortedEntries = Object.entries(countsByLabel).sort(labelCountsSort)
-  return sortedEntries.map(entry => entry[0])
+
 }
 
 

--- a/app/javascript/lib/plot.js
+++ b/app/javascript/lib/plot.js
@@ -159,12 +159,13 @@ PlotUtils.updateTraceVisibility = function(traces, hiddenTraces) {
   })
 }
 
-PlotUtils.sortTraces = function(traces, activeTraceLabel) {
-  const unspecifiedIsActive = activeTraceLabel === UNSPECIFIED_ANNOTATION_NAME
-  /** Sort traces by number of cells (largest first), but always put the activeTraceLabel last
+/** Sort traces by number of cells (largest first), but always put the activeTraceLabel last
    * and the unspecified annotations first
    * If the activeLabel *is* the unspecified cells, then put them last
   */
+PlotUtils.sortTraces = function(traces, activeTraceLabel) {
+  const unspecifiedIsActive = activeTraceLabel === UNSPECIFIED_ANNOTATION_NAME
+  /** sort function for implementing the logic described above */
   function traceCountsSort(a, b) {
     if (activeTraceLabel === a.name || (UNSPECIFIED_ANNOTATION_NAME === b.name && !unspecifiedIsActive)) {return 1}
     if (activeTraceLabel === b.name || (UNSPECIFIED_ANNOTATION_NAME === a.name && !unspecifiedIsActive)) {return -1}
@@ -224,13 +225,6 @@ PlotUtils.getColorForLabel = function(label, customColors={}, editedCustomColors
   }
   return editedCustomColors[label] ?? customColors[label] ?? PlotUtils.getColorBrewerColor(i)
 }
-
-
-/** Returns an array of labels, sorted in the order in which they should be plotted (last is 'on top') */
-PlotUtils.getPlotSortedLabels = function(countsByLabel, activeTraceLabel) {
-
-}
-
 
 /** Returns an array of labels, sorted in the order in which they should be displayed in the legend */
 PlotUtils.getLegendSortedLabels = function(countsByLabel) {

--- a/test/js/visualization/scatter-plot.test.js
+++ b/test/js/visualization/scatter-plot.test.js
@@ -47,7 +47,11 @@ it('shows custom legend with default group scatter plot', async () => {
     return Promise.resolve([response, CACHE_PERF_PARAMS])
   })
   const fakePlot = jest.spyOn(Plotly, 'react')
-  fakePlot.mockImplementation(() => {})
+  fakePlot.mockImplementation((id, traces, layout) => {
+    // graph updates are often done in-place using the plotly data stored on the element
+    // so we put it there
+    document.getElementById(id).data = traces
+  })
   const fakeLogScatter = jest.spyOn(ScpApiMetrics, 'logScatterPlot')
   fakeLogScatter.mockImplementation(() => {})
 


### PR DESCRIPTION
No functional changes.  These are the performance improvements unlocked by switching from cell-based hiding to trace-based hiding in  #1451 .  Instead of recomputing everything when a label is hidden or brought to the front, now we just reorder or modify the traces in-place.  I think this also makes the code more legible, as now we have sorting and hiding split out into separate functions

For a 1MM cell study, in my local environment, this reduced the time to hide a trace from ~0.8sec to ~0.4sec.  Likewise bringing traces to the front via hovering got faster as well. 

TO TEST:
1. load a cluster scatter plot
2. click around, hovering, hiding, showing traces
3. confirm behavior is as expected. 