### PR TITLE
 Make study usage information visible (SCP-4268)

### DIFF
--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -88,13 +88,18 @@ module Api
         usage_stats_params = {
           page_views: {
             event: 'page:view:site-study',
-            type: 'general',
+            type: 'unique',
             where_string: "properties[\"studyAccession\"] == \"#{@study.accession}\""
           },
           file_downloads: {
             event: 'click:link',
             type: 'general',
             where_string: "properties[\"studyAccession\"] == \"#{@study.accession}\" and properties[\"text\"] == \"file-download:study-single\""
+          },
+          bulk_downloads: {
+            event: 'file-download:curl-config',
+            type: 'general',
+            where_string: "\"#{@study.accession}\" in properties[\"studyAccessions\"]"
           }
         }
 

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -861,6 +861,9 @@ class StudiesController < ApplicationController
     render plain: manifest_obj
   end
 
+  def usage_stats
+  end
+
   # adding new study_file entries based on remote files in GCP
   def sync_study_file
     @study_file = @study.study_files.build

--- a/app/javascript/components/explore/GenomeView.jsx
+++ b/app/javascript/components/explore/GenomeView.jsx
@@ -87,7 +87,7 @@ function GenomeView({ studyAccession, bamFileName, uniqueGenes, isVisible, updat
 
   return <div>
     { isLoading &&
-      <LoadingSpinner data-testid="genome-view-loading-icon"/>
+      <LoadingSpinner testId="genome-view-loading-icon"/>
     }
     <div>
       <div id={igvContainerId}></div>

--- a/app/javascript/components/my-studies/StudyUsageInfo.jsx
+++ b/app/javascript/components/my-studies/StudyUsageInfo.jsx
@@ -5,11 +5,15 @@ import Plotly from 'plotly.js-dist'
 import { fetchStudyUsage } from '~/lib/scp-api'
 import LoadingSpinner from '~/lib/LoadingSpinner'
 import { supportEmailLink } from '~/lib/error-utils'
+import InfoPopup from '~/lib/InfoPopup'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faChevronUp, faChevronDown } from '@fortawesome/free-solid-svg-icons'
 
 /** display mixpanel stats for a given study */
 export default function StudyUsageInfo({ study }) {
   const [usageInfo, setUsageInfo] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [showTable, setShowTable] = useState(false)
   const [viewsGraphElementId] = useState(_uniqueId('study-usage-graph-'))
   const [downloadsGraphElementId] = useState(_uniqueId('study-usage-graph-'))
   const studyAccession = study.accession
@@ -59,7 +63,7 @@ export default function StudyUsageInfo({ study }) {
     <h3>Study statistics</h3>
     {studyAccession}: <a href={`/single_cell/study/${studyAccession}`}>{ study.name }</a><br/>
     <div className="text-center">
-      Users per month viewing this study.<br/>
+      Users per month viewing this study. <InfoPopup content="Unique users per month visiting the study overview page"/><br/>
       <LoadingSpinner isLoading={isLoading}/>
     </div>
     <div
@@ -69,7 +73,7 @@ export default function StudyUsageInfo({ study }) {
     ></div>
     <br/><br/>
     <div className="text-center">
-      File download events<br/>
+      File download events <InfoPopup content="Clicks on the single-file download button.  Bulk download stats are tracked, but not available in this view"/><br/>
       <LoadingSpinner isLoading={isLoading}/>
     </div>
     <div
@@ -79,7 +83,12 @@ export default function StudyUsageInfo({ study }) {
     ></div>
     <br/><br/>
     <div className="form-terra">
-      { !isLoading && <table className="table-terra compressed">
+      <h5 onClick={() => setShowTable(!showTable)}>
+        <span className="action">
+          { showTable ? <FontAwesomeIcon icon={faChevronUp}/> : <FontAwesomeIcon icon={faChevronDown}/> }
+        </span> Tabular Data
+      </h5>
+      { !isLoading && showTable && <table className="table-terra compressed">
         <thead>
           <tr>
             <td>Month</td>
@@ -97,7 +106,7 @@ export default function StudyUsageInfo({ study }) {
       </table> }
     </div> <br/>
     <div className="text-center">
-      If you would like more information about views, downloads, or other statistics for your studies, contact us at { supportEmailLink }
+      If you would like more information about views, downloads, or other statistics for your study, contact us at { supportEmailLink }
     </div>
   </div>
 }

--- a/app/javascript/components/my-studies/StudyUsageInfo.jsx
+++ b/app/javascript/components/my-studies/StudyUsageInfo.jsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react'
+import _uniqueId from 'lodash/uniqueId'
+import Plotly from 'plotly.js-dist'
+
+import { fetchStudyUsage } from '~/lib/scp-api'
+import LoadingSpinner from '~/lib/LoadingSpinner'
+import { supportEmailLink } from '~/lib/error-utils'
+
+/** display mixpanel stats for a given study */
+export default function StudyUsageInfo({ study }) {
+  const [usageInfo, setUsageInfo] = useState(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [viewsGraphElementId] = useState(_uniqueId('study-usage-graph-'))
+  const [downloadsGraphElementId] = useState(_uniqueId('study-usage-graph-'))
+  const studyAccession = study.accession
+  useEffect(() => {
+    fetchStudyUsage(study._id.$oid).then(response => {
+      setUsageInfo(response)
+      setIsLoading(false)
+    })
+  }, [study.accession])
+
+  const tableData = []
+
+  if (usageInfo) {
+    const viewData = usageInfo.pageViews.data
+    const viewsTrace = {
+      type: 'bar',
+      x: viewData.series,
+      y: viewData.series.map(x => {
+        return viewData.values[x] ? viewData.values[x] : 0
+      })
+    }
+    const viewsLayout = {
+      xaxis: { title: 'Month' },
+      yaxis: { title: 'Unique users' }
+    }
+    Plotly.react(viewsGraphElementId, [viewsTrace], viewsLayout)
+    tableData.push(viewsTrace.x)
+    tableData.push(viewsTrace.y)
+
+    const downloadData = usageInfo.fileDownloads.data
+    const downloadsTrace = {
+      type: 'bar',
+      x: downloadData.series,
+      y: downloadData.series.map(x => {
+        return downloadData.values[x] ? downloadData.values[x] : 0
+      })
+    }
+    const downloadsLayout = {
+      xaxis: { title: 'Month' },
+      yaxis: { title: 'Download events' }
+    }
+    Plotly.react(downloadsGraphElementId, [downloadsTrace], downloadsLayout)
+    tableData.push(downloadsTrace.y)
+  }
+
+  return <div>
+    <h3>Study statistics</h3>
+    {studyAccession}: <a href={`/single_cell/study/${studyAccession}`}>{ study.name }</a><br/>
+    <div className="text-center">
+      Users per month viewing this study.<br/>
+      <LoadingSpinner isLoading={isLoading}/>
+    </div>
+    <div
+      className="scatter-graph"
+      id={viewsGraphElementId}
+      data-testid={viewsGraphElementId}
+    ></div>
+    <br/><br/>
+    <div className="text-center">
+      File download events<br/>
+      <LoadingSpinner isLoading={isLoading}/>
+    </div>
+    <div
+      className="scatter-graph"
+      id={downloadsGraphElementId}
+      data-testid={viewsGraphElementId}
+    ></div>
+    <br/><br/>
+    <div className="form-terra">
+      { !isLoading && <table className="table-terra compressed">
+        <thead>
+          <tr>
+            <td>Month</td>
+            <td>Views</td>
+            <td>Downloads</td>
+          </tr>
+        </thead>
+        <tbody>
+          { transpose(tableData).map((row, i) => (
+            <tr key={i}>
+              { row.map((d, i2) => <td key={i2}>{d}</td>) }
+            </tr>
+          ))}
+        </tbody>
+      </table> }
+    </div> <br/>
+    <div className="text-center">
+      If you would like more information about views, downloads, or other statistics for your studies, contact us at { supportEmailLink }
+    </div>
+  </div>
+}
+/** transpose an array of arrays */
+function transpose(matrix) {
+  return matrix[0].map((col, i) => matrix.map(row => row[i]))
+}

--- a/app/javascript/components/search/controls/download/DownloadCommand.jsx
+++ b/app/javascript/components/search/controls/download/DownloadCommand.jsx
@@ -40,7 +40,7 @@ export default function DownloadCommand({ fileIds=[], azulFiles }) {
       isLoading &&
       <div className="text-center">
         Authorizing<br/>
-        <LoadingSpinner data-testid="bulk-download-loading-icon"/>
+        <LoadingSpinner testId="bulk-download-loading-icon"/>
       </div>
     }
     {

--- a/app/javascript/components/search/controls/download/DownloadSelectionTable.jsx
+++ b/app/javascript/components/search/controls/download/DownloadSelectionTable.jsx
@@ -65,7 +65,7 @@ export default function DownloadSelectionTable({
         isLoading &&
         <div className="text-center greyed">
           Loading file information<br/>
-          <LoadingSpinner data-testid="bulk-download-loading-icon"/>
+          <LoadingSpinner testId="bulk-download-loading-icon"/>
         </div>
       }
       {

--- a/app/javascript/components/upload/ExpandableFileForm.jsx
+++ b/app/javascript/components/upload/ExpandableFileForm.jsx
@@ -159,7 +159,7 @@ function SaveButton({ file, saveFile, validationMessages = {} }) {
     const savingText = file.saveProgress ? <span>Uploading {file.saveProgress}% </span> : 'Saving'
     saveButton = <button type="button"
       className="btn btn-primary margin-right">
-      {savingText} <LoadingSpinner data-testid="file-save-spinner" />
+      {savingText} <LoadingSpinner testId="file-save-spinner" />
     </button>
   }
   return saveButton
@@ -180,7 +180,7 @@ function DeleteButton({ file, deleteFile, setShowConfirmDeleteModal }) {
 
   let deleteButtonContent = 'Delete'
   if (file.isDeleting) {
-    deleteButtonContent = <span>Deleting <LoadingSpinner data-testid="file-save-spinner" /></span>
+    deleteButtonContent = <span>Deleting <LoadingSpinner testId="file-save-spinner" /></span>
   }
   let deleteButton = <button type="button" className="btn terra-secondary-btn" onClick={handleDeletePress} data-testid="file-delete">
     {deleteButtonContent}

--- a/app/javascript/components/upload/FileUploadControl.jsx
+++ b/app/javascript/components/upload/FileUploadControl.jsx
@@ -55,7 +55,7 @@ export default function FileUploadControl({
     buttonClass = 'fileinput-button btn btn-primary'
   }
   if (fileValidation.validating) {
-    buttonText = <LoadingSpinner data-testid="file-validation-spinner"/>
+    buttonText = <LoadingSpinner testId="file-validation-spinner"/>
   }
 
   let inputAcceptExts = allowedFileExts

--- a/app/javascript/components/upload/UploadWizard.jsx
+++ b/app/javascript/components/upload/UploadWizard.jsx
@@ -368,7 +368,7 @@ export function RawUploadWizard({ studyAccession, name }) {
               </div>
             </div>
             { !formState && <div className="padded text-center">
-              <LoadingSpinner data-testid="upload-wizard-spinner"/>
+              <LoadingSpinner testId="upload-wizard-spinner"/>
             </div> }
             { !!formState && <div>
               <currentStep.component

--- a/app/javascript/components/upload/form-components.jsx
+++ b/app/javascript/components/upload/form-components.jsx
@@ -69,7 +69,7 @@ export function SaveDeleteButtons({ file, updateFile, saveFile, deleteFile, vali
     const savingText = file.saveProgress ? <span>Uploading {file.saveProgress}% </span> : 'Saving'
     saveButton = <button type="button"
       className="btn btn-primary margin-right">
-      {savingText} <LoadingSpinner data-testid="file-save-spinner"/>
+      {savingText} <LoadingSpinner testId="file-save-spinner"/>
     </button>
   }
 

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -310,7 +310,7 @@ function RawScatterPlot({
       </p>
       {
         isLoading &&
-        <LoadingSpinner data-testid={`${graphElementId}-loading-icon`}/>
+        <LoadingSpinner testId={`${graphElementId}-loading-icon`}/>
       }
     </div>
   )

--- a/app/javascript/components/visualization/StudyViolinPlot.jsx
+++ b/app/javascript/components/visualization/StudyViolinPlot.jsx
@@ -127,7 +127,7 @@ function RawStudyViolinPlot({
       >
       </div>
       {
-        isLoading && <LoadingSpinner data-testid={`${graphElementId}-loading-icon`}/>
+        isLoading && <LoadingSpinner testId={`${graphElementId}-loading-icon`}/>
       }
       {/* we have to explicitly test length > 0 below, just asserting .length would
        sometimes render a zero to the page*/}

--- a/app/javascript/lib/LoadingSpinner.jsx
+++ b/app/javascript/lib/LoadingSpinner.jsx
@@ -3,7 +3,20 @@ import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDna } from '@fortawesome/free-solid-svg-icons'
 
-/** show dna spinning indicator */
-export default function LoadingSpinner(props) {
-  return <FontAwesomeIcon icon={faDna} className="gene-load-spinner" {...props}/>
+/** show dna spinning indicator.
+ * If no arguments or children are passed in, the spinner is rendered
+ * Alternatively, children can be passed in, in which case either the spinner or the children
+ * are rendered, contingent on the isLoading property
+ */
+export default function LoadingSpinner({ children, testId, isLoading }) {
+  const spinner = <FontAwesomeIcon icon={faDna} className="gene-load-spinner" data-testid={testId}/>
+  if (!children && typeof(isLoading) === 'undefined') {
+    return spinner
+  }
+  return <>
+    {isLoading && spinner}
+    {!isLoading &&
+      children
+    }
+  </>
 }

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -729,6 +729,13 @@ export function buildFacetsFromQueryString(facetsParamString) {
   return facets
 }
 
+/** retrieve usage info for the given study */
+export async function fetchStudyUsage(studyId, mock=false) {
+  const [usageInfo] = await scpApi(`/studies/${studyId}/usage_stats`, defaultInit(), mock)
+  return usageInfo
+}
+
+
 /** returns the current branding group as specified by the url  */
 export function getBrandingGroup() {
   const queryParams = queryString.parse(window.location.search)

--- a/app/javascript/styles/_forms.scss
+++ b/app/javascript/styles/_forms.scss
@@ -104,6 +104,9 @@
       border-top-right-radius: 10px;
       border-right: none;
     }
+    td {
+      border: none;
+    }
   }
   tbody {
     label {
@@ -111,7 +114,13 @@
     }
   }
   td {
-    border: 1px solid #eee;
+    border-top: 1px solid #eee;
+    padding: 0.75em;
+  }
+  &.compressed {
+    td {
+      padding: 0.1em 0.5em;
+    }
   }
 }
 

--- a/app/javascript/vite/application.js
+++ b/app/javascript/vite/application.js
@@ -8,6 +8,7 @@ import HomePageContent from '~/components/HomePageContent'
 import ExploreView from '~/components/explore/ExploreView'
 import { AuthorEmailPopup } from '~/lib/InfoPopup'
 import UploadWizard from '~/components/upload/UploadWizard'
+import StudyUsageInfo from '~/components/my-studies/StudyUsageInfo'
 import ValidationMessage from '~/components/validation/ValidationMessage'
 import ClusterAssociationSelect from '~/components/upload/ClusterAssociationSelect'
 import RawAssociationSelect from '~/components/upload/RawAssociationSelect'
@@ -40,7 +41,8 @@ document.addEventListener('DOMContentLoaded', () => {
 })
 
 const componentsToExport = {
-  HomePageContent, ExploreView, UploadWizard, ValidationMessage, ClusterAssociationSelect, RawAssociationSelect, AuthorEmailPopup
+  HomePageContent, ExploreView, UploadWizard, ValidationMessage, ClusterAssociationSelect,
+  RawAssociationSelect, AuthorEmailPopup, StudyUsageInfo
 }
 
 /** helper to render React components from non-react portions of the app

--- a/app/lib/mixpanel_client.rb
+++ b/app/lib/mixpanel_client.rb
@@ -14,7 +14,7 @@ class MixpanelClient
   # see https://developer.mixpanel.com/reference/segmentation-query
   def self.fetch_segmentation_query(
     event: nil,
-    from_date: Date.today - 2.years,
+    from_date: '2020-10-01'.to_date,
     to_date: Date.today,
     unit: 'month',
     type: 'unique',

--- a/app/lib/mixpanel_client.rb
+++ b/app/lib/mixpanel_client.rb
@@ -1,0 +1,52 @@
+# handles connecting to Mixpanel api
+
+class MixpanelClient
+  def self.authorization_string
+    mixpanel_secret = ENV['MIXPANEL_SECRET']
+    service_account_name = Rails.configuration.mixpanel_service_account
+    "Basic #{service_account_name}:#{mixpanel_secret}"
+  end
+
+  def self.project_id
+    Rails.configuration.mixpanel_project_id
+  end
+
+  # see https://developer.mixpanel.com/reference/segmentation-query
+  def self.fetch_segmentation_query(
+    event: nil,
+    from_date: Date.today - 2.years,
+    to_date: Date.today,
+    unit: 'month',
+    type: 'unique',
+    where_string: '',
+    on_string: '')
+
+    request = {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        'Authorization': authorization_string,
+        params: {
+          event: event,
+          project_id: project_id,
+          from_date: from_date.to_s,
+          to_date: to_date.to_s,
+          unit: unit,
+          type: type,
+          where: where_string,
+          on: on_string
+        }
+      },
+      url: "https://mixpanel.com/api/2.0/segmentation"
+    }
+
+    response = RestClient::Request.execute(request)
+    result = JSON.parse(response.body)
+    if on_string.empty?
+      # simplify the response so that the consumer doesn't have to dig by the event name
+      result['data']['values'] = result['data']['values'][event]
+    end
+    result
+  end
+
+end

--- a/app/views/site/_study_settings_form.html.erb
+++ b/app/views/site/_study_settings_form.html.erb
@@ -38,7 +38,10 @@
           <%= scp_link_to "Sync workspace", sync_study_path(@study), class: "#{@study.url_safe_name}-sync sync-button" %>
         </li>
         <li>
-          <%= scp_link_to "Study details", study_path(@study), class: " #{@study.url_safe_name}-sync sync-button" %>
+          <%= scp_link_to "Study details", study_path(@study), class: " #{@study.url_safe_name}-sync details-button" %>
+        </li>
+        <li>
+          <%= scp_link_to "Usage stats", usage_stats_study_path(@study), class: " #{@study.url_safe_name}-usage_stats usage-button" %>
         </li>
       </ul>
     </div>

--- a/app/views/studies/usage_stats.html.erb
+++ b/app/views/studies/usage_stats.html.erb
@@ -1,0 +1,6 @@
+<div id="usage-stats-page"></div>
+<script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+  window.SCP.renderComponent('usage-stats-page', 'StudyUsageInfo', {
+    study: <%= @study.to_json.html_safe %>
+  })
+</script>

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,10 @@ module SingleCellPortal
 
     config.autoload_paths << Rails.root.join('lib')
 
+    # for all non-prod environments, use the development mixpanel API
+    config.mixpanel_service_account = 'scp_terra_dev.f25a4f.mp-service-account'
+    config.mixpanel_project_id = 2085496
+
     # custom exceptions handling to render responses based on controller
     # uncaught API errors will now render as JSON responses w/ 500 status
     # normal controller errors will show 500 page, except in development environment (will show normal error page)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,6 +119,9 @@ Rails.application.configure do
   # Enable profiling and flamegraphs via rack-mini-profiler
   config.profile_performance = false
 
+  config.mixpanel_service_account = 'scp_terra_prod.df6bde.mp-service-account'
+  config.mixpanel_project_id = 2120588
+
   # DNS rebinding/host header injection protection
   # CIDR ip ranges from https://cloud.google.com/load-balancing/docs/health-checks#firewall_rules
   config.hosts = [

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
               post 'sync', to: 'studies#sync_study'
               get 'manifest', to: 'studies#generate_manifest'
               get 'file_info', to: 'studies#file_info'
+              get 'usage_stats', to: 'studies#usage_stats'
             end
 
             resource :explore, controller: 'visualization/explore', only: [:show] do
@@ -208,6 +209,7 @@ Rails.application.routes.draw do
         get 'load_annotation_options', to: 'studies#load_annotation_options', as: :load_annotation_options
         post 'update_default_options', to: 'studies#update_default_options', as: :update_default_options
         get 'manifest', to: 'studies#generate_manifest', as: :generate_manifest
+        get 'usage_stats', to: 'studies#usage_stats', as: :usage_stats
       end
     end
 

--- a/test/js/study-usage.test.js
+++ b/test/js/study-usage.test.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import { render, waitForElementToBeRemoved, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+
+import * as ScpApi from 'lib/scp-api'
+import Plotly from 'plotly.js-dist'
+import StudyUsageInfo from 'components/my-studies/StudyUsageInfo'
+
+
+describe('Usage info for a given study', () => {
+  it('renders data from the api call', async () => {
+    const fetchUsageInfo = jest.spyOn(ScpApi, 'fetchStudyUsage')
+    // pass in a clone of the response since it may get modified by the cache operations
+    fetchUsageInfo.mockImplementation(() => Promise.resolve(
+      {
+        bulkDownloads: {
+          data: {
+            series: ['2022-01-01', '2022-02-01', '2022-03-01'],
+            values: { '2022-01-01': 0, '2022-02-01': 2, '2022-03-01': 1 }
+          }
+        },
+        fileDownloads: {
+          data: {
+            series: ['2022-01-01', '2022-02-01', '2022-03-01'],
+            values: { '2022-01-01': 3, '2022-02-01': 4, '2022-03-01': 0 }
+          }
+        },
+        pageViews: {
+          data: {
+            series: ['2022-01-01', '2022-02-01', '2022-03-01'],
+            values: { '2022-01-01': 13, '2022-02-01': 15, '2022-03-01': 19 }
+          }
+        }
+      }
+    ))
+    const mockPlotlyReact = jest.spyOn(Plotly, 'react')
+    mockPlotlyReact.mockImplementation(() => {})
+    const study = {
+      accession: 'SCP12',
+      name: 'Test study 12',
+      _id: { $oid: 'fakeId4' }
+    }
+    render(<StudyUsageInfo study={study}/>)
+    await waitForElementToBeRemoved(() => screen.getByTestId('study-usage-spinner'))
+    expect(fetchUsageInfo).toHaveBeenLastCalledWith('fakeId4')
+
+    expect(mockPlotlyReact).toHaveBeenLastCalledWith('study-usage-graph-2', [{
+      type: 'bar',
+      x: ['2022-01-01', '2022-02-01', '2022-03-01'],
+      y: [3, 6, 1]
+    }], {
+      xaxis: { title: 'Month' },
+      yaxis: { title: 'Download events' }
+    })
+  })
+})


### PR DESCRIPTION
As shown in demo, a page, linked from Study Settings, that shows basic usage graphs for the given study
![image](https://user-images.githubusercontent.com/2800795/163267131-ad2a35eb-5e8f-4d2b-8a8f-fb3382be84db.png)

![image](https://user-images.githubusercontent.com/2800795/163266681-05b17716-c70e-4759-9ec4-52ada1b0a846.png)

This pulls the data via Mixpanel API.  Accordingly, a development and production service account were created, and the corresponding secrets were stored in Vault.  Once this is approved, and prior to merge, I'll handle updating everyone's vault secrets accordingly.

This also adds some functionality to the LoadingSpinner component so it can be used in a more streamlined way in some components--it optionally takes children and an `isLoading` parameter.  The LoadingSpinner component then takes care of the show/hide logic.

TO TEST:
1. You'll need the new mixpanel secret in your environment -- (this is just until we've put it in everyone's vault config):
             a.  run `vault read secret/kdux/scp/development/dbush/scp_config.json`
             b.  note the value for MIXPANEL_SECRET
             c.  Stop your rails server
             d.  run `export MIXPANEL_SECRET=<<the noted value>>`
             e.  restart rails server in the terminal where you ran the export command
          
2. go to the 'Settings' tab for a given study
3. click 'Usage stats' in the left. menu
4. Observe the usage stats appear 