### PR TITLE
Revert "improving performance of large data array loading" (SCP-4281)

### DIFF
--- a/app/models/concerns/concatenatable.rb
+++ b/app/models/concerns/concatenatable.rb
@@ -7,8 +7,7 @@ module Concatenatable
   # concatenate the values together into a single contiguous array
   def concatenate_arrays(query)
     arrays = where(query)
-    arr_vals = arrays.pluck(:array_index, :values)
-    arr_vals = arr_vals.sort_by(&:first)
-    arr_vals.reduce([]) { |aggregate, arr_val|  aggregate.concat(arr_val.last) }
+    ids = arrays.pluck(:id, :array_index).sort_by(&:last).map(&:first)
+    ids.map { |id| find(id).values }.reduce([], :+)
   end
 end


### PR DESCRIPTION
This reverts commit 8ebc3eeb3e069cd10d859207c17a229548a876c2.  It was done to improve performance (mostly in development) of loading large studies.  But the result was a couple of mongo connection issues, so we're reverting it here.  See https://sentry.io/organizations/broad-institute/issues/3193612380/?project=1424198&query=is%3Aunresolved for an example error

TO TEST:
1. load a cluster view of a large study (with > 100,000 cells)
2. observe that the study loads