### PR TITLE
Updating to latest version of `singlecellportal/rails-baseimage` (SCP-4290)

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -26,6 +26,7 @@ jobs:
           RAILS_LOG_TO_STDOUT: true
           VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
           VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
+          CI: true
         run: |
           export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )
           bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:1.3.2
+FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:2.0.0
 
 # Set ruby version
-RUN bash -lc 'rvm --default use ruby-2.6.6'
+RUN bash -lc 'rvm --default use ruby-2.6.9'
 RUN bash -lc 'rvm rvmrc warning ignore /home/app/webapp/Gemfile'
 
 # Set up project dir, install gems, set up script to migrate database and precompile static assets on run

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.6'
+ruby '2.6.9'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '6.1.4.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -608,7 +608,7 @@ DEPENDENCIES
   will_paginate_mongoid
 
 RUBY VERSION
-   ruby 2.6.6p146
+   ruby 2.6.9p207
 
 BUNDLED WITH
    2.2.24

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SINGLE CELL PORTAL README
 
 [![codecov](https://codecov.io/gh/broadinstitute/single_cell_portal_core/branch/development/graph/badge.svg?token=HMWE5BO2a4)](https://codecov.io/gh/broadinstitute/single_cell_portal_core)
-[![Build Status](https://app.travis-ci.com/broadinstitute/single_cell_portal_core.svg?branch=development)](https://app.travis-ci.com/broadinstitute/single_cell_portal_core)
+![Build Status](https://github.com/broadinstitute/single_cell_portal_core/actions/workflows/run-all-tests.yml/badge.svg)
 ## SETUP
 
 This application is built and deployed using [Docker](https://www.docker.com), specifically native

--- a/app/lib/summary_stats_utils.rb
+++ b/app/lib/summary_stats_utils.rb
@@ -106,7 +106,11 @@ class SummaryStatsUtils
           break
         end
       end
-      jobs = ApplicationController.papi_client.list_pipelines(page_token: jobs.next_page_token) if !all_from_range
+      if all_from_range || jobs.next_page_token.blank?
+        break
+      else
+        jobs = ApplicationController.papi_client.list_pipelines(page_token: jobs.next_page_token)
+      end
     end
     ingest_jobs
   end

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -105,9 +105,12 @@ bin/delayed_job restart $PASSENGER_APP_ENV -n 6 || { echo "FAILED to start DELAY
 # in an error; this is just an FYI that static assets are needed for more
 # than just `yarn ui-test`.
 if [[ "$TEST_FILEPATH" == "" ]]; then
-  echo "Precompiling assets, yarn and webpacker..."
+  echo "Precompiling assets, yarn and vite..."
   export NODE_OPTIONS="--max-old-space-size=4096"
-  RAILS_ENV=test bundle exec vite install
+  RAILS_ENV=test bundle exec vite:install_dependencies
+  if [[ "$CI" == true ]]; then
+    git config --global --add safe.directory $(pwd)
+  fi
   git checkout .
   RAILS_ENV=test NODE_ENV=test bin/bundle exec rake assets:clean
   RAILS_ENV=test NODE_ENV=test yarn install --force --trace

--- a/lib/study_cleanup_tools.rb
+++ b/lib/study_cleanup_tools.rb
@@ -65,7 +65,8 @@ module StudyCleanupTools
     corrupted_workspace_names = ['upload-wizard-test-pb6y0',
     'download-agreement-686b0d44c83659cd70616a3f0874fde5',
     'testing-study-6ec03b371c7cf59262df98424ff516e1',
-    'new-study-99f2a94b-f8a6-4efb-aa3b-4ecef24e1dad']
+    'new-study-99f2a94b-f8a6-4efb-aa3b-4ecef24e1dad',
+    'testing-study-jdwjl']
     workspaces.each do |workspace|
       ws_attr = workspace.dig('workspace')
       ws_name = ws_attr['name']

--- a/webapp.conf
+++ b/webapp.conf
@@ -5,7 +5,7 @@ server {
 }
 
 server {
-    listen 443;
+    listen 443 ssl;
     server_name $hostname;
     root /home/app/webapp/public;
     passenger_app_root /home/app/webapp;
@@ -62,7 +62,6 @@ server {
     # address nginx 499 errors & CPU spikes
     passenger_ignore_client_abort on;
 
-    ssl on;
     ssl_certificate /etc/pki/tls/certs/localhost.crt;
     ssl_certificate_key /etc/pki/tls/private/localhost.key;
 


### PR DESCRIPTION
This updates our Dockerfile to use the latest release of `singlecellportal/rails-baseimage:2.0.0`.  This changes the underlying `ubuntu` image from `18.04` to `20.04`, as well as updating to the latest release of the `phusion/passenger-docker` image.  In addition, this update changes our default Ruby version to `2.6.9`, and will allow us to update to `3.1.x` in the future if we so choose.

This also fixes the link to the CI badge that has been broken since we migrated to Github Actions.

MANUAL TESTING
To ensure that this image builds correctly:
1. Pull this branch
2. Authenticate into vault, and ensure Docker is running on your machine
3. Run either one of the following commands in the project root directory:
```
### only build the Docker image
docker build -t single_cell_docker:latest -f Dockerfile .

### build the Docker image and boot the portal container (will take dramatically longer)
bin/load_env_secrets.sh -p secret/kdux/scp/development/$(whoami)/scp_config.json \
                        -r secret/kdux/scp/development/$(whoami)/read_only_service_account.json \
                        -s secret/kdux/scp/development/$(whoami)/scp_service_account.json
```

This PR satisfies SCP-4290