### PR TITLE
adding last_public and last_initialized to study report (SCP-4253)

### DIFF
--- a/app/lib/reports_service.rb
+++ b/app/lib/reports_service.rb
@@ -63,7 +63,8 @@ class ReportsService
 
     history_hash = ReportsService.study_histories
     study_hash.keys.each do |study_id|
-      study_hash[study_id][:last_public] = history_hash[study_id] ? history_hash[study_id][:last_public] : nil
+      study_hash[study_id][:last_public] = history_hash.dig(study_id, :last_public)
+      study_hash[study_id][:last_initialized] = history_hash.dig(study_id, :last_initialized)
       study_hash[study_id][:last_initialized] = history_hash[study_id] ? history_hash[study_id][:last_initialized] : nil
     end
 

--- a/app/lib/reports_service.rb
+++ b/app/lib/reports_service.rb
@@ -6,7 +6,7 @@ class ReportsService
       service_method: :study_data,
       data_columns: %i[accession created_at cell_count user_id public view_count
                        owner_domain owner_email admin_owned metadata_convention
-                       metadata_file_created has_raw_counts]
+                       metadata_file_created has_raw_counts last_public last_initialized]
     }
   }.freeze
 
@@ -60,6 +60,29 @@ class ReportsService
         study_hash[study_id][:has_raw_counts] ||= is_raw_counts.present? ? is_raw_counts['is_raw_counts'] : false
       end
     end
+
+    history_hash = ReportsService.study_histories
+    study_hash.keys.each do |study_id|
+      study_hash[study_id][:last_public] = history_hash[study_id] ? history_hash[study_id][:last_public] : nil
+      study_hash[study_id][:last_initialized] = history_hash[study_id] ? history_hash[study_id][:last_initialized] : nil
+    end
+
     study_hash.values
+  end
+
+  def self.study_histories()
+    study_hash = {}
+    public_histories = HistoryTracker.where(scope: 'study', 'modified.public': true).order_by(created_at: :asc)
+    public_histories.each do |history|
+      study_id = history.association_chain[0]['id'].to_s
+      study_hash[study_id] = {last_public: history.created_at}
+    end
+    initialized_histories = HistoryTracker.where(scope: 'study', 'modified.initialized': true).order_by(created_at: :asc)
+    initialized_histories.each do |history|
+      study_id = history.association_chain[0]['id'].to_s
+      study_hash[study_id] ||= {}
+      study_hash[study_id][:last_initialized] = history.created_at
+    end
+    study_hash
   end
 end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1738,6 +1738,15 @@ class Study
     end
   end
 
+
+  def last_public_date
+    history_tracks.where('modified.public': true).order_by(created_at: :desc).first&.created_at
+  end
+
+  def last_initialized_date
+    history_tracks.where('modified.initialized': true).order_by(created_at: :desc).first&.created_at
+  end
+
   private
 
   ###


### PR DESCRIPTION
This adds the most recent time a study was made public and the most recent time it was initialized to the study report.  This also adds a couple of helper methods to `study.rb` for computing them for individual studies (although they are non-trivial DB queries, so for performance reasons likely should be used sparingly).  The report does not use the helper methods, and instead uses a bulk query to fetch the data for all studies at once.

Note that this does not instrument any specific mixpanel events with these times -- the goal is, per Leyla's recent demo to use lookup tables to provide that capability

TO TEST:
1. toggle some studies public/private in your local instance
2. go to 'Reports' in the main SCP menu, and then export the 'Study Data' report
3. confirm that for each study, last_public and last_initialized reflect the correct times