### PR TITLE
Stop forcing JSON responses in API (SCP-4261)

### DIFF
--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -16,18 +16,26 @@ module Api
           key :description, 'Create and return a one-time authorization code (OTAC) to identify a user for bulk downloads'
           key :operationId, 'bulk_download_auth_code_path'
           parameter do
-            key :name, :file_ids
-            key :type, :string
+            key :name, :bulk_download
+            key :type, :object
             key :in, :body
-            key :description, 'Comma-delimited list of StudyFile IDs (such as returned from the summary endpoint)'
-            key :required, true
-          end
-          parameter do
-            key :name, :tdr_files
-            key :type, :json
-            key :in, :body
-            key :description, 'Hash of file arrays to download from TDR, keyed by accession. Each file should specify URL and name'
-            key :required, true
+            schema do
+              property :file_ids do
+                key :type, :string
+                key :description, 'Comma-delimited list of StudyFile IDs (such as returned from the summary endpoint)'
+                key :required, true
+                key :example, "6269614d94ec8f18bd30f94a,6269614e94ec8f18bd30f94b,6269614f94ec8f18bd30f94c"
+              end
+              property :tdr_files do
+                key :type, :object
+                key :description, 'Hash of file arrays to download from TDR, keyed by accession. Each file should specify name, file_type, and project_id'
+                key :required, true
+                key :example, "{ HCAProjectName: [{'project_id': 'a39728aa-70a0-4201-b0a2-81b7badf3e71', " \
+                              "'name': 'HCAProjectName.tsv', 'file_type': 'Project Manifest', 'count': 1}, " \
+                              "{'project_id': 'a39728aa-70a0-4201-b0a2-81b7badf3e71', 'file_format': 'loom', " \
+                              "'file_type': 'analysis_file', 'count'=>2}]}"
+              end
+            end
           end
           response 200 do
             key :description, 'One-time auth code and time interval, in seconds'

--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -33,7 +33,7 @@ module Api
                 key :example, "{ HCAProjectName: [{'project_id': 'a39728aa-70a0-4201-b0a2-81b7badf3e71', " \
                               "'name': 'HCAProjectName.tsv', 'file_type': 'Project Manifest', 'count': 1}, " \
                               "{'project_id': 'a39728aa-70a0-4201-b0a2-81b7badf3e71', 'file_format': 'loom', " \
-                              "'file_type': 'analysis_file', 'count'=>2}]}"
+                              "'file_type': 'analysis_file', 'count': 2}]}"
               end
             end
           end

--- a/app/controllers/api/v1/concerns/content_type.rb
+++ b/app/controllers/api/v1/concerns/content_type.rb
@@ -11,12 +11,8 @@ module Api
         # default to JSON responses, disallow other Accept content types or format requests
         # will allow */*, application/json, or text/plain in any part of Accept header and respond with JSON
         def validate_content_type!
-          accept_header = request.headers['Accept'].present? ? request.headers['Accept'] : ''
-          if !accept_header.match(Regexp.union(%w(*/* application/json text/plain)))
-            head 406
-          else
-            request.format = :json # override format to force JSON response
-          end
+          accept_header = request.headers['Accept'].presence || ''
+          head 406 unless accept_header.match(Regexp.union(%w[*/* application/json text/plain]))
         end
       end
     end

--- a/test/api/bulk_download_controller_test.rb
+++ b/test/api/bulk_download_controller_test.rb
@@ -421,11 +421,4 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
     assert_equal [@basic_study.accession, study.accession].sort, scp_accessions.sort
     assert_equal %w[FakeHCAProject AnotherFakeHCAProject].sort, hca_accessions.sort
   end
-
-  test 'should sanitize parameters for auth_code endpoint' do
-    good_params = {
-      file_ids: [BSON::ObjectId.new, BSON::ObjectId.new],
-
-    }
-  end
 end

--- a/test/api/bulk_download_controller_test.rb
+++ b/test/api/bulk_download_controller_test.rb
@@ -421,4 +421,11 @@ class BulkDownloadControllerTest < ActionDispatch::IntegrationTest
     assert_equal [@basic_study.accession, study.accession].sort, scp_accessions.sort
     assert_equal %w[FakeHCAProject AnotherFakeHCAProject].sort, hca_accessions.sort
   end
+
+  test 'should sanitize parameters for auth_code endpoint' do
+    good_params = {
+      file_ids: [BSON::ObjectId.new, BSON::ObjectId.new],
+
+    }
+  end
 end


### PR DESCRIPTION
This update addresses two issues that when combined sometimes resulted in an `ActionDispatch::Http::Parameters::ParseError` when attempting to generate an auth code during bulk download requests.  These two issues were:

1. Forcing `json` responses via `app/controllers/api/v1/concerns/content_type.rb` when `json` is already the default response type (from `config/routes.rb#L8`)
2. Calling `params.permit` in `BulkDownloadController#auth_code` to filter out unwanted parameters, which was dropping the `format` parameter from the request, and would show up as `Unpermitted parameter: :format` in the logs

Now, [strong parameters](https://api.rubyonrails.org/classes/ActionController/StrongParameters.html) are used for selecting & filtering both `file_ids` and `azul_files` from auth code requests.  In addition, the `content_type` concern will only respond `406` to requests with bad `Accept` headers, and not attempt to force a JSON response when not needed.

MANUAL TESTING
1. Boot as normal and sign in
2. Issue any search request and click "Download"
3. Proceed through to the `cURL` command
4. In `development.log` or output from `rails s`, look for the last entry showing the `POST` to the `auth_code` endpoint
```
Started POST "/single_cell/api/v1/bulk_download/auth_code" for 127.0.0.1 at 2022-04-25 14:44:23 -0400
Processing by Api::V1::BulkDownloadController#auth_code as JSON
```
5. Note that `Unpermitted parameter: :format` does not appear in the log