### PR TITLE
fixing auth on user_annotations controller (SCP-4311)

### DIFF
--- a/app/controllers/api/v1/user_annotations_controller.rb
+++ b/app/controllers/api/v1/user_annotations_controller.rb
@@ -4,7 +4,7 @@ module Api
     class UserAnnotationsController < ApiBaseController
       include Concerns::ApiCaching
 
-      before_action :set_current_api_user!
+      before_action :authenticate_api_user!
       before_action :set_study
       before_action :check_study_view_permission
 

--- a/test/api/user_annotations_controller_test.rb
+++ b/test/api/user_annotations_controller_test.rb
@@ -1,0 +1,29 @@
+require 'api_test_helper'
+require 'user_tokens_helper'
+require 'test_helper'
+require 'includes_helper'
+
+class StudyFilesControllerTest < ActionDispatch::IntegrationTest
+
+  before(:all) do
+    @user = FactoryBot.create(:api_user, test_array: @@users_to_clean)
+    @user2 = FactoryBot.create(:api_user, test_array: @@users_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                               name_prefix: 'UserAnnotation Study',
+                               public: false,
+                               user: @user,
+                               test_array: @@studies_to_clean)
+    @study_file = FactoryBot.create(:cluster_file,
+                               name: 'clusterA.txt',
+                               study: @study)
+  end
+
+  test 'enforces permissions' do
+    execute_http_request(:post, api_v1_study_user_annotations_path(@study))
+    assert_equal 401, response.status
+
+    sign_in_and_update(@user2)
+    execute_http_request(:post, api_v1_study_user_annotations_path(@study), user: @user2)
+    assert_equal 403, response.status
+  end
+end


### PR DESCRIPTION
I spent a few minutes attempting to add a positive auth case, but the setup was complex enough that it wasn't worth it for this ticket given the relatively low usage of user annotations.  

TO TEST:
1. run `rails test test/api/user_annotations_controller_test.rb `
2. (if desired) Sign in to local instance
3. open a study in the explore tab and click 'create annotation'
4. wait 30mins until you get unauthed (or sign yourself out by byebugging an API controller method, and then doing `sign_out current_api_user` from the resulting console)
5. select an annotation, and then hit 'save'
6. Confirm the error appears as an auth error, not a 500