### PR TITLE
fixing sorting bugs, adding `:created_at` and `:view_count for` HCA entries (SCP-4287)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -308,24 +308,29 @@ module Api
           @studies = @studies.sort_by { |study| @accession_list.index(study.accession) }
         when :facet
           @studies = @studies.sort_by do |study|
-            accession = self.class.get_study_accession(study)
+            accession = self.class.get_study_attribute(study, :accession)
             metadata_weight = @metadata_matches.present? ?
-                                @metadata_matches.dig(study.accession, :facet_search_weight).to_i : 0
+                                @metadata_matches.dig(accession, :facet_search_weight).to_i : 0
             -(@studies_by_facet[accession][:facet_search_weight] + metadata_weight)
           end
         when :recent
-          @studies = @studies.sort_by(&:created_at).reverse
+          @studies = @studies.sort_by { |study| self.class.get_study_attribute(study, :created_at) }.reverse
         when :popular
-          @studies = @studies.sort_by(&:view_count).reverse
+          @studies = @studies.sort_by { |study| self.class.get_study_attribute(study, :view_count) }.reverse
         else
           # we have sort_type of :none, so order by most recent initialized studies
           # in order to sort by multiple attributes, use array notation to indicate which attribute to sort by first
           # boolean values must be converted to an integer in order for this to work
-          @studies = @studies.sort_by { |study| [study.initialized? ? 1 : 0, study.created_at] }.reverse
+          @studies = @studies.sort_by do |study|
+            [
+              self.class.get_study_attribute(study, :initialized) ? 1 : 0,
+              self.class.get_study_attribute(study, :created_at)
+            ]
+          end.reverse
         end
 
         # save list of study accessions for bulk_download/bulk_download_size calls, in order of results
-        @matching_accessions = @studies.map { |study| self.class.get_study_accession(study) }
+        @matching_accessions = @studies.map { |study| self.class.get_study_attribute(study, :accession) }
         logger.info "Total matching accessions from all non-inferred searches: #{@matching_accessions}"
 
         # if a user ran a faceted search, attempt to infer results by converting filter display values to keywords
@@ -351,7 +356,7 @@ module Api
           end
         end
 
-        @matching_accessions = @studies.map { |study| self.class.get_study_accession(study) }
+        @matching_accessions = @studies.map { |study| self.class.get_study_attribute(study, :accession) }
 
         logger.info "Final list of matching studies: #{@matching_accessions}"
         @results = @studies.paginate(page: params[:page], per_page: Study.per_page)
@@ -490,9 +495,13 @@ module Api
         end
       end
 
-      # extract study accession, accounting for source (SCP vs. external)
-      def self.get_study_accession(search_result)
-        search_result.try(:accession) || search_result[:accession]
+      # extract study attribute (like accession) accounting for source (SCP vs. external)
+      def self.get_study_attribute(search_result, attribute)
+        if search_result.is_a?(Study)
+          search_result.send(attribute)
+        else
+          search_result[attribute]
+        end
       end
 
       # extract any "quoted phrases" from query string and tokenize terms

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -39,6 +39,7 @@ class AzulSearchService
     project_results = client.projects(query: query_json)
     project_results['hits'].each do |entry|
       entry_hash = entry.with_indifferent_access
+      submission_date = entry_hash[:dates].first[:submissionDate]
       project_hash = entry_hash[:projects].first # there will only ever be one project here
       short_name = project_hash[:projectShortname]
       project_id = project_hash[:projectId]
@@ -48,6 +49,8 @@ class AzulSearchService
         name: project_hash[:projectTitle],
         description: project_hash[:projectDescription],
         hca_project_id: project_id,
+        created_at: submission_date, # for sorting purposes
+        view_count: 0, # for sorting purposes
         facet_matches: {},
         term_matches: {},
         file_information: [

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -72,8 +72,9 @@ Rails.application.configure do
 
   config.disable_admin_notifications = true
 
-  # set MongoDB logging level
+  # set MongoDB & Google API logging level
   Mongoid.logger.level = Logger::INFO
+  Google::Apis.logger.level = Logger::INFO
 
   if ENV["RAILS_LOG_TO_STDOUT"].present? && ENV['CI']
     logger           = ActiveSupport::Logger.new(STDOUT)

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -468,4 +468,35 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     filtered_terms = Api::V1::SearchController.reject_stop_words_from_terms(mixed_query)
     assert_equal terms, filtered_terms
   end
+
+  test 'should support all sorting options' do
+    # use Azul mocks for faster tests
+    # TODO: migrate all other search tests to use Azul mocks (SCP-4328)
+    tcell_json = File.open(Rails.root.join('test/test_data/azul/human_tcell.json')).read
+    human_tcell_response = JSON.parse(tcell_json).with_indifferent_access
+    mock_azul_facets = {
+      genusSpecies: {
+        is: ['Homo sapiens']
+      }
+    }.with_indifferent_access
+
+    # test all 3 sorting options
+    ['recent', 'popular', 'foo', nil].each do |sort_order|
+      mock = Minitest::Mock.new
+      mock.expect :format_query_from_facets, mock_azul_facets, [Array]
+      mock.expect :merge_query_objects, mock_azul_facets, [Hash, nil]
+      mock.expect :projects, human_tcell_response, [Hash]
+      ApplicationController.stub :hca_azul_client, mock do
+        facet_query = "species:#{HOMO_SAPIENS_FILTER[:id]}"
+        execute_http_request(:get,
+                             api_v1_search_path(
+                               type: 'study',
+                               facets: facet_query,
+                               order: sort_order.to_s
+                             ))
+        assert_response :success
+        mock.verify
+      end
+    end
+  end
 end

--- a/test/test_data/azul/human_tcell.json
+++ b/test/test_data/azul/human_tcell.json
@@ -251,6 +251,11 @@
           "totalCells": null
         }
       ],
+      "dates": [
+        {
+          "submissionDate": "2019-09-13T17:52:10.963000Z"
+        }
+      ],
       "fileTypeSummaries": [
         {
           "format": "csv",

--- a/test/test_data/azul/human_thymus.json
+++ b/test/test_data/azul/human_thymus.json
@@ -316,6 +316,11 @@
           "totalCells": 16000
         }
       ],
+      "dates": [
+        {
+          "submissionDate": "2020-09-14T16:53:23.627000Z"
+        }
+      ],
       "fileTypeSummaries": [
         {
           "format": "fastq.gz",

--- a/test/test_data/azul/pulmonary_fibrosis.json
+++ b/test/test_data/azul/pulmonary_fibrosis.json
@@ -264,6 +264,11 @@
       "totalCells": 112500
     }
   ],
+      "dates": [
+        {
+          "submissionDate": "2020-07-15T15:14:32.164000Z"
+        }
+      ],
       "fileTypeSummaries": [
     {
       "format": "fastq.gz",


### PR DESCRIPTION
This update fixes some lingering bugs with sorting results from cross-dataset search requests, where results are either instances of the `Study` class, or `Hash` entries representing HCA projects.  Now, any requested search & sort order will support a mix of both result classes.  In addition, HCA entries now include their original `submissionDate` as a proxy for `created_at`, and a default `view_count` of `0`, as we have no data on views from Azul.

This update also changes the default logging level for all Google API calls in the `test` environment to `:info`, from `:debug`.

MANUAL TESTING
1. Pull this branch and boot as normal
2. Open the Swagger API documentation, and go to the search endpoint
3. Run a search that will return a mix of SCP & HCA entries, such as:
    * facets: `species:NCBITaxon_9606`
    * terms: `HIV`
4. Note that results return in a specific order by looking at the `matching_accessions` attribute in the response
5. Change the `order` parameter to both `recent` and `popular`, and note that the request completes and changes the order accordingly

This PR satisfies SCP-4287.

