### PR TITLE
Do not return HCA projects in collection searches (SCP-4295)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -265,7 +265,8 @@ module Api
 
         # perform Azul search if there are facets/terms provided by user
         # run this before inferred search so that they are weighted and sorted correctly
-        if @facets.present? || @term_list.present?
+        # skip if user is searching inside a collection
+        if (@facets.present? || @term_list.present?) && @selected_branding_group.nil?
           begin
             @studies, @studies_by_facet = ::AzulSearchService.append_results_to_studies(@studies,
                                                                                         selected_facets: @facets,

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -155,6 +155,26 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_equal source_facets, matched_facets, "Did not match on correct facets; expected #{source_facets} but found #{matched_facets}"
   end
 
+  test 'should not query azul when collection is present' do
+    branding_group = FactoryBot.create(:branding_group, user_list: [@user])
+    terms = 'COVID-19'
+    mock = Minitest::Mock.new
+    mock.expect(:get_results, {}, [[], [terms]])
+    AzulSearchService.stub(:append_results_to_studies, mock) do
+      assert_raises MockExpectationError do
+        execute_http_request(:get,
+                             api_v1_search_path(
+                               type: 'study',
+                               terms: terms,
+                               scpbr: branding_group.name_as_id
+                             ))
+        assert_response :success
+        # this should raise a MockExpectationError as :get_results will not be called, as no Azul search was performed
+        mock.verify
+      end
+    end
+  end
+
   test 'should return search results using numeric facets' do
     facet = SearchFacet.find_by(identifier: 'organism_age')
     facet.update_filter_values! # in case there is a race condition with parsing & facet updates


### PR DESCRIPTION
This update adds a clause to skip running cross-dataset searches if a user is searching inside a collection.  This is to avoid any confusion as to the provenance of the data, as no officially hosted HCA projects are a part of any SCP collections (though there are some studies based off of the data, but not the original source projects).

MANUAL TESTING
1. Boot as normal
2. Run a search request that will return HCA results, such as `species:Homo sapiens`
3. If you do not have any collections in your local instance, run `SyntheticBrandingGroupPopulator.populate_all` to load some collections
4. Sign in, and select a collection from the `Browse collections` page
5. Re-run the same search as above, and validate that no HCA projects are returned

This PR satisfies SCP-4295.