### PR TITLE
fixing show/hide traces bug in array-based labels (SCP-4322)

### DIFF
--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
@@ -119,7 +119,7 @@ function getShowHideEnabled(hiddenTraces, countsByLabel) {
   const numHiddenTraces = hiddenTraces.length
   const numLabels = Object.keys(countsByLabel).length
 
-  let enabled // [isShowAllEnabled, isHideAllEnabled]
+  let enabled = [true, true] // [isShowAllEnabled, isHideAllEnabled]
 
   if (countsByLabel === null) {
     // When nothing has loaded yet
@@ -246,14 +246,14 @@ export default function ScatterPlotLegend({
               <a
                 role="button"
                 data-analytics-name='split-traces-unsplit'
-                onClick={() => {setSplitLabelArrays(false)}}
+                onClick={() => {updateHiddenTraces([], false, true); setSplitLabelArrays(false)}}
               >Merge array labels</a>
             }
             { !splitLabelArrays &&
               <a
                 role="button"
                 data-analytics-name='split-traces-split'
-                onClick={() => {setSplitLabelArrays(true)}}
+                onClick={() => {updateHiddenTraces([], false, true); setSplitLabelArrays(true)}}
               >Split array labels</a>
             }
           </div>


### PR DESCRIPTION
Jonah discovered a bug when toggling between merge/split labels and using show/hide all.  Essentially, the hiddenLabels weren't being cleared when toggling between split/unsplit. And so `getShowHideEnabled` would return undefined as the number of hiddenLabels might be larger than the total number of labels.  This change both handles clearing the hiddenLabels, and also adding a fallback for `getShowHideEnabled` -- if it can't figure out what's going on, both buttons will be enabled.

TO TEST:
1. open a study (e.g. `array_mouse_eye` Murine Vision synthetic study) with array-based labels
2.  in the explore tab, go to the array-based annotation (`cell_type_array`) in the study above.  
3. show/hide traces while toggling back and forth between split and merged labels, using the show/hide all buttons as well
4. confirm no error occurs.