### PR TITLE
Enable intellisense for Vite-style JS imports

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,11 +4,7 @@
     "allowSyntheticDefaultImports": false,
     "baseUrl": "./",
     "paths": {
-      "components/*": ["app/javascript/components/*"],
-      "lib/*": ["app/javascript/lib/*"],
-      "packs/*": ["app/javascript/packs/*"],
-      "providers/*": ["app/javascript/providers/*"],
-      "styles/*": ["app/javascript/styles/*"]
+      "~/*": ["app/javascript/*"]
     }
   },
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
This enables IDE code completion, docstring-on-hover, and other aspects of IDE intellisense for JavaScript imports starting with `~`, as introduced with Vite.  It improves developer experience (DX) within an editor.

Previously, without intellisense:

<img width="1680" alt="Without_intellisense__SCP_2022-04-29" src="https://user-images.githubusercontent.com/1334561/166067286-f02fb61c-8bf9-4981-b3b6-4fa3e56f5d95.png">

Now, with intellisense:

<img width="1680" alt="With_intellisense__SCP_2022-04-29" src="https://user-images.githubusercontent.com/1334561/166067297-a4b1c505-1e46-4829-8d33-69aaf99f78e9.png">

To test:
* Pull branch
* Restart VS Code
* Hover over a `log` call in `ScatterPlotLegend.jsx`
* Confirm docstring for `log` function appears, as shown in "with intellisense" screenshot above

This satisfies SCP-4324.  Thanks to Devon for actually finding the solution!