### PR TITLE
Adding metrics for Azul search results, fixing existing count omissions (SCP-4202)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -339,6 +339,7 @@ module Api
 
         # save list of study accessions for bulk_download/bulk_download_size calls, in order of results
         @matching_accessions = @studies.map { |study| self.class.get_study_accession(study) }
+        logger.info "Total matching accessions from all non-inferred searches: #{@matching_accessions}"
 
         # if a user ran a faceted search, attempt to infer results by converting filter display values to keywords
         # Do not run inferred search if we have a preset search with an accession list

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -246,7 +246,7 @@ module Api
           # uniquify result list as one study may match multiple facets/filters
           @convention_accessions = query_results.map { |match| match[:study_accession] }.uniq
           # report on matches for metadata, ensuring we don't double-count some accessions
-          # this can happen if we get a term converstion to metadata match
+          # this can happen if we get a term conversion to metadata match
           @match_by_data ||= {}
           existing_metadata_matches = @metadata_matches.try(:keys) || []
           total_metadata_matches = (existing_metadata_matches + @convention_accessions).uniq

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -11,16 +11,19 @@ class AzulSearchService
   # each Azul result entry under 'hits' will have these keys, whether project- or file-based
   RESULT_FACET_FIELDS = %w[protocols samples specimens cellLines donorOrganisms organoids cellSuspensions].freeze
 
-  def self.append_results_to_studies(existing_studies, selected_facets:, terms:, facet_map: nil)
+  def self.append_results_to_studies(existing_studies, selected_facets:, terms:, facet_map: nil, results_matched_by_data: nil)
     # set facet_map to {}, even if facet_map is explicitly passed in as nil
     facet_map ||= {}
+    results_matched_by_data ||= {}
     azul_results = ::AzulSearchService.get_results(selected_facets: selected_facets, terms: terms)
     Rails.logger.info "Found #{azul_results.keys.size} results in Azul"
     azul_results.each do |accession, azul_result|
       existing_studies << azul_result
       facet_map[accession] = azul_result[:facet_matches]
     end
-    [existing_studies, facet_map]
+    results_matched_by_data['numResults:azul'] = azul_results.size
+    results_matched_by_data['numResults:total'] = results_matched_by_data['numResults:scp'].to_i + azul_results.size
+    { studies: existing_studies, facet_map: facet_map, results_matched_by_data: results_matched_by_data }
   end
 
   # execute a search against Azul API

--- a/app/lib/study_search_service.rb
+++ b/app/lib/study_search_service.rb
@@ -80,6 +80,9 @@ class StudySearchService
       }
 
       studies = base_studies.any_of(matches_by_text, matches_by_accession, matches_by_author, matches_by_metadata)
+      results_matched_by_data['numResults:scp'] = studies.length
+      results_matched_by_data['numResults:total'] = studies.length
+
       { studies: studies, results_matched_by_data: results_matched_by_data, metadata_matches: metadata_matches }
     when :phrase
       study_regex = escape_terms_for_regex(term_list: terms)
@@ -105,8 +108,8 @@ class StudySearchService
 
       studies = base_studies.any_of(matches_by_name, matches_by_description, matches_by_accession,
                                     matches_by_author, matches_by_metadata)
-      results_matched_by_data['numResults:scp'] = studies.length # Total number of SCP results
-      # Azul study results to be added with SCP-4202
+      results_matched_by_data['numResults:scp'] = studies.length
+      results_matched_by_data['numResults:total'] = studies.length
 
       { studies: studies, results_matched_by_data: results_matched_by_data, metadata_matches: metadata_matches }
 


### PR DESCRIPTION
This update adds two new Mixpanel metrics for the `search` event: `numResults:azul` and `numResults:total`.  These are for tracking the number of projects found in Azul, and the total number of results found across SCP & Azul, respectively.  In addition, this also fixes an omission where metadata matches from BigQuery are not being reported.  Now, these matches will be folded in with any results that were found via the `CellMetadata` collection, ensuring that accessions are not double counted.

Example of new metrics in Mixpanel:
![Screen Shot 2022-05-02 at 11 37 35 AM](https://user-images.githubusercontent.com/729968/166267313-09f65a97-585c-42a7-92db-776a2bd50ff0.png)


MANUAL TESTING
1. Boot as normal, and open Chrome DevTools > Network
2. Run a search that will return both SCP & Azul results, such as `species:Mus musculus`
3. Find the `search` event in the Network tab, and confirm that the new metrics should up, and the counts match what is shown in the UI

This PR satisfies SCP-4202.