### PR TITLE
Integration for differential expression PAPI jobs (SCP-4194)

### DIFF
--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -1,0 +1,67 @@
+# class to hold parameters specific to differential expression jobs in PAPI
+class DifferentialExpressionParameters
+  include ActiveModel::Model
+
+  # regular expression to validate GS url format
+  GS_URL_REGEXP = %r{\Ags://}.freeze
+
+  # annotation_name: name of annotation to use for DE
+  # annotation_type: type of annotation, must be 'group'
+  # annotation_scope: scope of annotation (study, cluster)
+  # annotation_file: source file for above annotation
+  # cluster_file: clustering file with cells to use as control list for DE
+  # cluster_name: name of associated ClusterGroup object
+  # matrix_file_path: raw counts matrix with source expression data
+  # matrix_file_type: type of raw counts matrix (dense, sparse)
+  # gene_file (optional): genes/features file for sparse matrix
+  # barcode_file (optional): barcodes file for sparse matrix
+  attr_accessor :annotation_name, :annotation_type, :annotation_scope, :annotation_file, :cluster_file,
+                :cluster_name, :matrix_file_path, :matrix_file_type, :gene_file, :barcode_file
+
+  validates :annotation_name, :annotation_type, :annotation_scope, :annotation_file, :cluster_file,
+            :cluster_name, :matrix_file_path, :matrix_file_type, presence: true
+  validates :annotation_file, :cluster_file, :matrix_file_path,
+            format: { with: GS_URL_REGEXP, message: 'is not a valid GS url' }
+  validates :annotation_type, inclusion: %w[group]
+  validates :annotation_scope, inclusion: %w[cluster study]
+  validates :matrix_file_type, inclusion: %w[dense sparse]
+  validates :gene_file, :barcode_file,
+            presence: true,
+            format: {
+              with: GS_URL_REGEXP,
+              message: 'is not a valid GS url'
+            },
+            if: -> { matrix_file_type == 'sparse' }
+
+  # convert attribute name into CLI-formatted option
+  def self.to_cli_opt(param_name)
+    "--#{param_name.to_s.gsub(/_/, '-')}"
+  end
+
+  # default attributes hash
+  def attributes
+    {
+      annotation_name: annotation_name,
+      annotation_type: annotation_type,
+      annotation_scope: annotation_scope,
+      annotation_file: annotation_file,
+      cluster_file: cluster_file,
+      cluster_name: cluster_name,
+      matrix_file_path: matrix_file_path,
+      matrix_file_type: matrix_file_type,
+      gene_file: gene_file,
+      barcode_file: barcode_file
+    }.with_indifferent_access
+  end
+
+  # return array of all initialized attributes in Python CLI form, e.g. annotation_name => --annotation-name
+  # will also append --differential-expression at the end
+  def to_options_array
+    options_array = []
+    attributes.each do |attr_name, value|
+      options_array += [self.class.to_cli_opt(attr_name), value] if value.present?
+    end
+    options_array << '--differential-expression'
+    options_array
+  end
+end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -23,20 +23,17 @@ class IngestJob
   attr_accessor :reparse
   # Boolean indication of whether or not to delete file from bucket on parse failure
   attr_accessor :persist_on_fail
-  # extra key/value storage of attributes
-  attr_accessor :options
 
   # number of tries to push a file to a study bucket
   MAX_ATTEMPTS = 3
 
   # Mappings between actions & models (for cleaning up data on re-parses)
   MODELS_BY_ACTION = {
-      ingest_expression: Gene,
-      ingest_cluster: ClusterGroup,
-      ingest_cell_metadata: CellMetadatum,
-      subsample: ClusterGroup,
-      differential_expression: nil # data only lives in files in the bucket, has special handling
-  }.freeze
+    ingest_expression: Gene,
+    ingest_cluster: ClusterGroup,
+    ingest_cell_metadata: CellMetadatum,
+    subsample: ClusterGroup
+  }
 
   # Push a file to a workspace bucket in the background and then launch an ingest run and queue polling
   # Can also clear out existing data if necessary (in case of a re-parse)
@@ -51,49 +48,49 @@ class IngestJob
   #   - (RuntimeError) => If file cannot be pushed to remote bucket
   def push_remote_and_launch_ingest(skip_push: false)
     begin
-      file_identifier = "#{study_file.bucket_location}:#{study_file.id}"
-      rails_model = MODELS_BY_ACTION[action]
-      if reparse && rails_model
+      file_identifier = "#{self.study_file.bucket_location}:#{self.study_file.id}"
+      if self.reparse
         Rails.logger.info "Deleting existing data for #{file_identifier}"
-        rails_model.where(study_id: study.id, study_file_id: study_file.id).delete_all
-        DataArray.where(study_id: study.id, study_file_id: study_file.id).delete_all
+        rails_model = MODELS_BY_ACTION[action]
+        rails_model.where(study_id: self.study.id, study_file_id: self.study_file.id).delete_all
+        DataArray.where(study_id: self.study.id, study_file_id: self.study_file.id).delete_all
         Rails.logger.info "Data cleanup for #{file_identifier} complete, now beginning Ingest"
       end
       # first check if file is already in bucket (in case user is syncing)
-      remote = ApplicationController.firecloud_client.get_workspace_file(study.bucket_id, study_file.bucket_location)
+      remote = ApplicationController.firecloud_client.get_workspace_file(self.study.bucket_id, self.study_file.bucket_location)
       if remote.nil?
-        is_pushed = poll_for_remote(skip_push: skip_push)
+        is_pushed = self.poll_for_remote(skip_push: skip_push)
       else
         is_pushed = true # file is already in bucket
       end
       if !is_pushed
         # push has failed 3 times, so exit and report error
-        log_message = "Unable to push #{file_identifier} to #{study.bucket_id}"
+        log_message = "Unable to push #{file_identifier} to #{self.study.bucket_id}"
         Rails.logger.error log_message
         raise RuntimeError.new(log_message)
       else
-        if can_launch_ingest?
+        if self.can_launch_ingest?
           Rails.logger.info "Remote found for #{file_identifier}, launching Ingest job"
-          submission = ApplicationController.papi_client.run_pipeline(study_file: study_file, user: user, action: action)
+          submission = ApplicationController.papi_client.run_pipeline(study_file: self.study_file, user: self.user, action: self.action)
           Rails.logger.info "Ingest run initiated: #{submission.name}, queueing Ingest poller"
-          IngestJob.new(pipeline_name: submission.name, study: study, study_file: study_file,
-                        user: user, action: action, reparse: reparse, persist_on_fail: persist_on_fail)
-                   .poll_for_completion
+          IngestJob.new(pipeline_name: submission.name, study: self.study, study_file: self.study_file,
+                        user: self.user, action: self.action, reparse: self.reparse,
+                        persist_on_fail: self.persist_on_fail).poll_for_completion
         else
           run_at = 2.minutes.from_now
           Rails.logger.info "Remote found for #{file_identifier} but ingest gated by other parse jobs, queuing another check for #{run_at}"
-          delay(run_at: run_at).push_remote_and_launch_ingest
+          self.delay(run_at: run_at).push_remote_and_launch_ingest
         end
       end
     rescue => e
       Rails.logger.error "Error in launching ingest of #{file_identifier}: #{e.class.name}:#{e.message}"
-      ErrorTracker.report_exception(e, user, study, study_file, { action: action})
+      ErrorTracker.report_exception(e, self.user, self.study, self.study_file, { action: self.action})
       # notify admins of failure, and notify user that admins are looking into the issue
-      SingleCellMailer.notify_admin_parse_launch_fail(study, study_file, user, action, e).deliver_now
-      user_message = "<p>An error has occurred when attempting to launch the parse job associated with #{study_file.upload_file_name}.  "
+      SingleCellMailer.notify_admin_parse_launch_fail(self.study, self.study_file, self.user, self.action, e).deliver_now
+      user_message = "<p>An error has occurred when attempting to launch the parse job associated with #{self.study_file.upload_file_name}.  "
       user_message += "Support staff has been notified and are investigating the issue.  "
       user_message += "If you require immediate assistance, please contact scp-support@broadinstitute.zendesk.com.</p>"
-      SingleCellMailer.user_notification(user, "Unable to parse #{study_file.upload_file_name}", user_message).deliver_now
+      SingleCellMailer.user_notification(self.user, "Unable to parse #{self.study_file.upload_file_name}", user_message).deliver_now
     end
   end
 
@@ -107,14 +104,14 @@ class IngestJob
   def poll_for_remote(skip_push: false)
     attempts = 1
     is_pushed = false
-    file_identifier = "#{study_file.bucket_location}:#{study_file.id}"
+    file_identifier = "#{self.study_file.bucket_location}:#{self.study_file.id}"
     while !is_pushed && attempts <= MAX_ATTEMPTS
       unless skip_push
-        Rails.logger.info "Preparing to push #{file_identifier} to #{study.bucket_id}"
-        study.send_to_firecloud(study_file)
+        Rails.logger.info "Preparing to push #{file_identifier} to #{self.study.bucket_id}"
+        self.study.send_to_firecloud(study_file)
       end
       Rails.logger.info "Polling for upload of #{file_identifier}, attempt #{attempts}"
-      remote = ApplicationController.firecloud_client.get_workspace_file(study.bucket_id, study_file.bucket_location)
+      remote = ApplicationController.firecloud_client.get_workspace_file(self.study.bucket_id, self.study_file.bucket_location)
       if remote.present?
         is_pushed = true
       else
@@ -132,24 +129,24 @@ class IngestJob
   # * *returns*
   #   - (Boolean) => T/F if file can launch PAPI ingest job
   def can_launch_ingest?
-    case study_file.file_type
+    case self.study_file.file_type
     when /Matrix/
       # expression matrices currently cannot be ingested in parallel due to constraints around validating cell names
       # this block ensures that all other matrices have all cell names ingested and at least one gene entry, which
       # ensures the matrix has validated
-      other_matrix_files = StudyFile.where(study_id: study.id, file_type: /Matrix/, :id.ne => study_file.id)
+      other_matrix_files = StudyFile.where(study_id: self.study.id, file_type: /Matrix/, :id.ne => self.study_file.id)
       # only check other matrix files of the same type, as this is what will be checked when validating
-      similar_matrix_files = other_matrix_files.select {|matrix| matrix.is_raw_counts_file? == study_file.is_raw_counts_file?}
+      similar_matrix_files = other_matrix_files.select {|matrix| matrix.is_raw_counts_file? == self.study_file.is_raw_counts_file?}
       similar_matrix_files.each do |matrix_file|
         if matrix_file.parsing?
-          matrix_cells = study.expression_matrix_cells(matrix_file)
-          matrix_genes = Gene.where(study_id: study.id, study_file_id: matrix_file.id)
+          matrix_cells = self.study.expression_matrix_cells(matrix_file)
+          matrix_genes = Gene.where(study_id: self.study.id, study_file_id: matrix_file.id)
           if !matrix_cells || matrix_genes.empty?
             # return false if matrix hasn't validated, unless the other matrix was uploaded after this file
             # this is to prevent multiple matrix files queueing up and blocking each other from initiating PAPI jobs
             # also, a timeout 24 hours is added to prevent all matrix files from queueing infinitely if one
             # fails to launch an ingest job for some reason
-            if matrix_file.created_at < study_file.created_at && matrix_file.created_at > 24.hours.ago
+            if matrix_file.created_at < self.study_file.created_at && matrix_file.created_at > 24.hours.ago
               return false
             end
           end
@@ -176,12 +173,12 @@ class IngestJob
   #   - (Hash) => Hash of all instance variables
   def attributes
     {
-      study: study,
-      study_file: study_file,
-      user: user,
-      action: action,
-      reparse: reparse,
-      persist_on_fail: persist_on_fail
+      study: self.study,
+      study_file: self.study_file,
+      user: self.user,
+      action: self.action,
+      reparse: self.reparse,
+      persist_on_fail: self.persist_on_fail
     }
   end
 
@@ -190,7 +187,7 @@ class IngestJob
   # * *returns*
   #   - (Google::Apis::GenomicsV2alpha1::Operation)
   def get_ingest_run
-    ApplicationController.papi_client.get_pipeline(name: pipeline_name)
+    ApplicationController.papi_client.get_pipeline(name: self.pipeline_name)
   end
 
   # Determine if this ingest run has done by checking current status
@@ -198,7 +195,7 @@ class IngestJob
   # * *returns*
   #   - (Boolean) => Indication of whether or not job has completed
   def done?
-    get_ingest_run.done?
+    self.get_ingest_run.done?
   end
 
   # Get all errors for ingest job
@@ -206,7 +203,7 @@ class IngestJob
   # * *returns*
   #   - (Google::Apis::GenomicsV2alpha1::Status)
   def error
-    get_ingest_run.error
+    self.get_ingest_run.error
   end
 
   # Determine if a job failed by checking for errors
@@ -214,7 +211,7 @@ class IngestJob
   # * *returns*
   #   - (Boolean) => Indication of whether or not job failed via an unrecoverable error
   def failed?
-    error.present?
+    self.error.present?
   end
 
   # Get a status label for current state of job
@@ -222,8 +219,8 @@ class IngestJob
   # * *returns*
   #   - (String) => Status label
   def current_status
-    if done?
-      failed? ? 'Error' : 'Completed'
+    if self.done?
+      self.failed? ? 'Error' : 'Completed'
     else
       'Running'
     end
@@ -234,7 +231,7 @@ class IngestJob
   # * *returns*
   #   - (Hash) => Metadata of PAPI job, including events, environment, labels, etc.
   def metadata
-    get_ingest_run.metadata
+    self.get_ingest_run.metadata
   end
 
   # Get all the events for a given ingest job in chronological order
@@ -242,7 +239,7 @@ class IngestJob
   # * *returns*
   #   - (Array<Google::Apis::GenomicsV2alpha1::Event>) => Array of pipeline events, sorted by timestamp
   def events
-    metadata['events'].sort_by! {|event| event['timestamp'] }
+    self.metadata['events'].sort_by! {|event| event['timestamp'] }
   end
 
   # Get all messages from all events
@@ -250,7 +247,7 @@ class IngestJob
   # * *returns*
   #   - (Array<String>) => Array of all messages in chronological order
   def event_messages
-    events.map {|event| event['description']}
+    self.events.map {|event| event['description']}
   end
 
   # Reconstruct the command line from the pipeline actions
@@ -259,7 +256,7 @@ class IngestJob
   #   - (String) => Deserialized command line
   def command_line
     command_line = ""
-    metadata['pipeline']['actions'].each do |action|
+    self.metadata['pipeline']['actions'].each do |action|
       command_line += action['commands'].join(' ') + "\n"
     end
     command_line.chomp("\n")
@@ -270,6 +267,7 @@ class IngestJob
   # * *returns*
   #   - (Array<DateTime>) => Array of initial and terminal timestamps from PAPI events
   def get_runtime_timestamps
+    events = self.events
     start_time = DateTime.parse(events.first['timestamp'])
     completion_time = DateTime.parse(events.last['timestamp'])
     [start_time, completion_time]
@@ -280,15 +278,15 @@ class IngestJob
   # * *returns*
   #   - (String) => Text representation of total elapsed time
   def get_total_runtime
-    TimeDifference.between(*get_runtime_timestamps).humanize
+    TimeDifference.between(*self.get_runtime_timestamps).humanize
   end
 
-   # Get the total runtime of parsing from event timestamps, in milliseconds
+  # Get the total runtime of parsing from event timestamps, in milliseconds
   #
   # * *returns*
   #   - (Integer) => Total elapsed time in milliseconds
   def get_total_runtime_ms
-    (TimeDifference.between(*get_runtime_timestamps).in_seconds * 1000).to_i
+    (TimeDifference.between(*self.get_runtime_timestamps).in_seconds * 1000).to_i
   end
 
   # Launch a background polling process.  Will check for completion, and if the pipeline has not completed
@@ -298,39 +296,39 @@ class IngestJob
   # * *params*
   #   - +run_at+ (DateTime) => Time at which to run new polling check
   def poll_for_completion(run_at: 1.minute.from_now)
-    if done? && !failed?
-      Rails.logger.info "IngestJob poller: #{pipeline_name} is done!"
-      Rails.logger.info "IngestJob poller: #{pipeline_name} status: #{current_status}"
-      study_file.update(parse_status: 'parsed')
-      study_file.bundled_files.each { |sf| sf.update(parse_status: 'parsed') }
-      study.reload # refresh cached instance of study
-      study_file.reload # refresh cached instance of study_file
-      set_study_state_after_ingest
-      study_file.invalidate_cache_by_file_type # clear visualization caches for file
-      log_to_mixpanel
-      subject = "#{study_file.file_type} file: '#{study_file.upload_file_name}' has completed parsing"
-      message = generate_success_email_array
-      SingleCellMailer.notify_user_parse_complete(user.email, subject, message, study).deliver_now
-    elsif done? && failed?
-      Rails.logger.error "IngestJob poller: #{pipeline_name} has failed."
+    if self.done? && !self.failed?
+      Rails.logger.info "IngestJob poller: #{self.pipeline_name} is done!"
+      Rails.logger.info "IngestJob poller: #{self.pipeline_name} status: #{self.current_status}"
+      self.study_file.update(parse_status: 'parsed')
+      self.study_file.bundled_files.each { |sf| sf.update(parse_status: 'parsed') }
+      self.study.reload # refresh cached instance of study
+      self.study_file.reload # refresh cached instance of study_file
+      self.set_study_state_after_ingest
+      self.study_file.invalidate_cache_by_file_type # clear visualization caches for file
+      self.log_to_mixpanel
+      subject = "#{self.study_file.file_type} file: '#{self.study_file.upload_file_name}' has completed parsing"
+      message = self.generate_success_email_array
+      SingleCellMailer.notify_user_parse_complete(self.user.email, subject, message, self.study).deliver_now
+    elsif self.done? && self.failed?
+      Rails.logger.error "IngestJob poller: #{self.pipeline_name} has failed."
       # log errors to application log for inspection
-      log_error_messages
-      log_to_mixpanel # log before queuing file for deletion to preserve properties
-      create_study_file_copy
-      study_file.update(parse_status: 'failed')
-      DeleteQueueJob.new(study_file).delay.perform
-      ApplicationController.firecloud_client.delete_workspace_file(study.bucket_id, study_file.bucket_location) unless persist_on_fail
-      study_file.bundled_files.each do |bundled_file|
-        ApplicationController.firecloud_client.delete_workspace_file(study.bucket_id, bundled_file.bucket_location) unless persist_on_fail
+      self.log_error_messages
+      self.log_to_mixpanel # log before queuing file for deletion to preserve properties
+      self.create_study_file_copy
+      self.study_file.update(parse_status: 'failed')
+      DeleteQueueJob.new(self.study_file).delay.perform
+      ApplicationController.firecloud_client.delete_workspace_file(self.study.bucket_id, self.study_file.bucket_location) unless self.persist_on_fail
+      self.study_file.bundled_files.each do |bundled_file|
+        ApplicationController.firecloud_client.delete_workspace_file(self.study.bucket_id, bundled_file.bucket_location) unless self.persist_on_fail
       end
-      subject = "Error: #{study_file.file_type} file: '#{study_file.upload_file_name}' parse has failed"
-      user_email_content = generate_error_email_body
-      SingleCellMailer.notify_user_parse_fail(user.email, subject, user_email_content, study).deliver_now
-      admin_email_content = generate_error_email_body(email_type: :dev)
-      SingleCellMailer.notify_admin_parse_fail(user.email, subject, admin_email_content).deliver_now
+      subject = "Error: #{self.study_file.file_type} file: '#{self.study_file.upload_file_name}' parse has failed"
+      user_email_content = self.generate_error_email_body
+      SingleCellMailer.notify_user_parse_fail(self.user.email, subject, user_email_content, self.study).deliver_now
+      admin_email_content = self.generate_error_email_body(email_type: :dev)
+      SingleCellMailer.notify_admin_parse_fail(self.user.email, subject, admin_email_content).deliver_now
     else
-      Rails.logger.info "IngestJob poller: #{pipeline_name} is not done; queuing check for #{run_at}"
-      delay(run_at: run_at).poll_for_completion
+      Rails.logger.info "IngestJob poller: #{self.pipeline_name} is not done; queuing check for #{run_at}"
+      self.delay(run_at: run_at).poll_for_completion
     end
   end
 
@@ -340,24 +338,24 @@ class IngestJob
   # * *yields*
   #   - Study#set_cell_count, :set_study_default_options, Study#set_gene_count, and :set_study_initialized
   def set_study_state_after_ingest
-    case study_file.file_type
+    case self.study_file.file_type
     when 'Metadata'
-      study.set_cell_count
-      set_study_default_options
-      launch_subsample_jobs
+      self.study.set_cell_count
+      self.set_study_default_options
+      self.launch_subsample_jobs
       # update search facets if convention data
-      if study_file.use_metadata_convention
+      if self.study_file.use_metadata_convention
         SearchFacet.delay.update_all_facet_filters
       end
     when /Matrix/
-      study.delay.set_gene_count
+      self.study.delay.set_gene_count
     when 'Cluster'
-      set_cluster_point_count
-      set_study_default_options
-      launch_subsample_jobs
-      set_subsampling_flags
+      self.set_cluster_point_count
+      self.set_study_default_options
+      self.launch_subsample_jobs
+      self.set_subsampling_flags
     end
-    set_study_initialized
+    self.set_study_initialized
   end
 
   # Set the default options for a study after ingesting Clusters/Cell Metadata
@@ -365,33 +363,33 @@ class IngestJob
   # * *yields*
   #   - Sets study default options for clusters/annotations
   def set_study_default_options
-    case study_file.file_type
+    case self.study_file.file_type
     when 'Metadata'
-      if study.default_options[:annotation].blank?
+      if self.study.default_options[:annotation].blank?
         cell_metadatum = study.cell_metadata.keep_if(&:can_visualize?).first || study.cell_metadata.first
-        study.default_options[:annotation] = cell_metadatum.annotation_select_value
+        self.study.default_options[:annotation] = cell_metadatum.annotation_select_value
         if cell_metadatum.annotation_type == 'numeric'
-          study.default_options[:color_profile] = 'Reds'
+          self.study.default_options[:color_profile] = 'Reds'
         end
       end
     when 'Cluster'
-      if study.default_options[:cluster].nil?
-        cluster = study.cluster_groups.by_name(study_file.name)
-        study.default_options[:cluster] = cluster.name
-        if study.default_options[:annotation].blank? && cluster.cell_annotations.any?
+      if self.study.default_options[:cluster].nil?
+        cluster = study.cluster_groups.by_name(self.study_file.name)
+        self.study.default_options[:cluster] = cluster.name
+        if self.study.default_options[:annotation].blank? && cluster.cell_annotations.any?
           annotation = cluster.cell_annotations.select { |annot| cluster.can_visualize_cell_annotation?(annot) }.first ||
             cluster.cell_annotations.first
-          study.default_options[:annotation] = cluster.annotation_select_value(annotation)
+          self.study.default_options[:annotation] = cluster.annotation_select_value(annotation)
           if annotation[:type] == 'numeric'
-            study.default_options[:color_profile] = 'Reds'
+            self.study.default_options[:color_profile] = 'Reds'
           end
         end
       end
     end
-    Rails.logger.info "Setting default options in #{study.name}: #{study.default_options}"
-    study.save
+    Rails.logger.info "Setting default options in #{self.study.name}: #{self.study.default_options}"
+    self.study.save
     # warm all default caches for this study
-    ClusterCacheService.delay(queue: :cache).cache_study_defaults(study)
+    ClusterCacheService.delay(queue: :cache).cache_study_defaults(self.study)
   end
 
   # set the point count on a cluster group after successful ingest
@@ -399,7 +397,7 @@ class IngestJob
   # * *yields*
   #   - sets the :points attribute on a ClusterGroup
   def set_cluster_point_count
-    cluster_group = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
+    cluster_group = ClusterGroup.find_by(study_id: self.study.id, study_file_id: self.study_file.id)
     cluster_group.set_point_count!
     Rails.logger.info "Point count on #{cluster_group.name}:#{cluster_group.id} set to #{cluster_group.points}"
   end
@@ -409,8 +407,8 @@ class IngestJob
   # * *yields*
   #   - Sets study initialized to True if needed
   def set_study_initialized
-    if study.cluster_groups.any? && study.genes.any? && study.cell_metadata.any? && !study.initialized?
-      study.update(initialized: true)
+    if self.study.cluster_groups.any? && self.study.genes.any? && self.study.cell_metadata.any? && !self.study.initialized?
+      self.study.update(initialized: true)
     end
   end
 
@@ -419,41 +417,41 @@ class IngestJob
   # * *yields*
   #   - (IngestJob) => new ingest job for subsampling
   def launch_subsample_jobs
-    case study_file.file_type
+    case self.study_file.file_type
     when 'Cluster'
       # only subsample if ingest_cluster was just run, new cluster is > 1K points, and a metadata file is parsed
-      cluster_ingested = action.to_sym == :ingest_cluster
-      cluster = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
-      metadata_parsed = study.metadata_file.present? && study.metadata_file.parsed?
+      cluster_ingested = self.action.to_sym == :ingest_cluster
+      cluster = ClusterGroup.find_by(study_id: self.study.id, study_file_id: self.study_file.id)
+      metadata_parsed = self.study.metadata_file.present? && self.study.metadata_file.parsed?
       if cluster_ingested && metadata_parsed && cluster.can_subsample? && !cluster.is_subsampling?
         # immediately set cluster.is_subsampling = true to gate race condition if metadata file just finished parsing
         cluster.update(is_subsampling: true)
-        file_identifier = "#{study_file.bucket_location}:#{study_file.id}"
-        Rails.logger.info "Launching subsampling ingest run for #{file_identifier} after #{action}"
-        submission = ApplicationController.papi_client.run_pipeline(study_file: study_file, user: user,
+        file_identifier = "#{self.study_file.bucket_location}:#{self.study_file.id}"
+        Rails.logger.info "Launching subsampling ingest run for #{file_identifier} after #{self.action}"
+        submission = ApplicationController.papi_client.run_pipeline(study_file: self.study_file, user: self.user,
                                                                     action: :ingest_subsample)
         Rails.logger.info "Subsampling run initiated: #{submission.name}, queueing Ingest poller"
-        IngestJob.new(pipeline_name: submission.name, study: study, study_file: study_file,
-                      user: user, action: :ingest_subsample, reparse: false,
-                      persist_on_fail: persist_on_fail).poll_for_completion
+        IngestJob.new(pipeline_name: submission.name, study: self.study, study_file: self.study_file,
+                      user: self.user, action: :ingest_subsample, reparse: false,
+                      persist_on_fail: self.persist_on_fail).poll_for_completion
       end
     when 'Metadata'
       # subsample all cluster files that have already finished parsing.  any in-process cluster parses, or new submissions
       # will be handled by the above case.  Again, only subsample for completed clusters > 1K points
-      metadata_identifier = "#{study_file.bucket_location}:#{study_file.id}"
-      study.study_files.where(file_type: 'Cluster', parse_status: 'parsed').each do |cluster_file|
-        cluster = ClusterGroup.find_by(study_id: study.id, study_file_id: cluster_file.id)
+      metadata_identifier = "#{self.study_file.bucket_location}:#{self.study_file.id}"
+      self.study.study_files.where(file_type: 'Cluster', parse_status: 'parsed').each do |cluster_file|
+        cluster = ClusterGroup.find_by(study_id: self.study.id, study_file_id: cluster_file.id)
         if cluster.can_subsample? && !cluster.is_subsampling?
           # set cluster.is_subsampling = true to avoid future race conditions
           cluster.update(is_subsampling: true)
           file_identifier = "#{cluster_file.bucket_location}:#{cluster_file.id}"
-          Rails.logger.info "Launching subsampling ingest run for #{file_identifier} after #{action} of #{metadata_identifier}"
-          submission = ApplicationController.papi_client.run_pipeline(study_file: cluster_file, user: user,
+          Rails.logger.info "Launching subsampling ingest run for #{file_identifier} after #{self.action} of #{metadata_identifier}"
+          submission = ApplicationController.papi_client.run_pipeline(study_file: cluster_file, user: self.user,
                                                                       action: :ingest_subsample)
           Rails.logger.info "Subsampling run initiated: #{submission.name}, queueing Ingest poller"
-          IngestJob.new(pipeline_name: submission.name, study: study, study_file: cluster_file,
-                        user: user, action: :ingest_subsample, reparse: reparse,
-                        persist_on_fail: persist_on_fail).poll_for_completion
+          IngestJob.new(pipeline_name: submission.name, study: self.study, study_file: cluster_file,
+                        user: self.user, action: :ingest_subsample, reparse: self.reparse,
+                        persist_on_fail: self.persist_on_fail).poll_for_completion
         end
       end
     end
@@ -461,11 +459,11 @@ class IngestJob
 
   # Set correct subsampling flags on a cluster after job completion
   def set_subsampling_flags
-    case action
+    case self.action
     when :ingest_subsample
-      cluster_group = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
+      cluster_group = ClusterGroup.find_by(study_id: self.study.id, study_file_id: self.study_file.id)
       if cluster_group.is_subsampling? && cluster_group.find_subsampled_data_arrays.any?
-        Rails.logger.info "Setting subsampled flags for #{study_file.upload_file_name}:#{study_file.id} (#{cluster_group.name}) for visualization"
+        Rails.logger.info "Setting subsampled flags for #{self.study_file.upload_file_name}:#{self.study_file.id} (#{cluster_group.name}) for visualization"
         cluster_group.update(subsampled: true, is_subsampling: false)
       end
     end
@@ -478,22 +476,22 @@ class IngestJob
   def create_study_file_copy
     begin
       ApplicationController.firecloud_client.execute_gcloud_method(:copy_workspace_file, 0,
-                                                                   study.bucket_id,
-                                                                   study_file.bucket_location,
-                                                                   study_file.parse_fail_bucket_location)
-      if study_file.is_bundled? && study_file.is_bundle_parent?
-        study_file.bundled_files.each do |file|
+                                                                   self.study.bucket_id,
+                                                                   self.study_file.bucket_location,
+                                                                   self.study_file.parse_fail_bucket_location)
+      if self.study_file.is_bundled? && self.study_file.is_bundle_parent?
+        self.study_file.bundled_files.each do |file|
           # put in same directory as parent file for ease of debugging
-          bundled_file_location = "parse_logs/#{study_file.id}/#{file.upload_file_name}"
+          bundled_file_location = "parse_logs/#{self.study_file.id}/#{file.upload_file_name}"
           ApplicationController.firecloud_client.execute_gcloud_method(:copy_workspace_file, 0,
-                                                                       study.bucket_id,
+                                                                       self.study.bucket_id,
                                                                        file.bucket_location,
                                                                        bundled_file_location)
         end
       end
       true
     rescue => e
-      ErrorTracker.report_exception(e, user, study_file, { action: :create_study_file_copy})
+      ErrorTracker.report_exception(e, self.user, self.study_file, { action: :create_study_file_copy})
       false
     end
   end
@@ -503,7 +501,7 @@ class IngestJob
   # * *returns*
   #   - (String) => String representation of path to detailed log file
   def dev_error_filepath
-    "parse_logs/#{study_file.id}/log.txt"
+    "parse_logs/#{self.study_file.id}/log.txt"
   end
 
   # path to user-level error log file in study bucket
@@ -511,7 +509,7 @@ class IngestJob
   # * *returns*
   #   - (String) => String representation of path to log file
   def user_error_filepath
-    "parse_logs/#{study_file.id}/user_log.txt"
+    "parse_logs/#{self.study_file.id}/user_log.txt"
   end
 
   # in case of an error, retrieve the contents of the warning or error file to email to the user
@@ -525,9 +523,9 @@ class IngestJob
   # * *returns*
   #   - (String) => Contents of file
   def read_parse_logfile(filepath, delete_on_read: true, range: nil)
-    if ApplicationController.firecloud_client.workspace_file_exists?(study.bucket_id, filepath)
-      file_contents = ApplicationController.firecloud_client.execute_gcloud_method(:read_workspace_file, 0, study.bucket_id, filepath)
-      ApplicationController.firecloud_client.execute_gcloud_method(:delete_workspace_file, 0, study.bucket_id, filepath) if delete_on_read
+    if ApplicationController.firecloud_client.workspace_file_exists?(self.study.bucket_id, filepath)
+      file_contents = ApplicationController.firecloud_client.execute_gcloud_method(:read_workspace_file, 0, self.study.bucket_id, filepath)
+      ApplicationController.firecloud_client.execute_gcloud_method(:delete_workspace_file, 0, self.study.bucket_id, filepath) if delete_on_read
       # read file range manually since GCS download requests don't honor range parameter apparently
       range.present? ? file_contents.read[range] : file_contents.read
     end
@@ -538,35 +536,35 @@ class IngestJob
   # * *returns*
   #   - (Hash) => Hash of job statistics to use with IngestJob#log_to_mixpanel
   def get_job_analytics
-    file_type = study_file.file_type
+    file_type = self.study_file.file_type
 
-    trigger = study_file.remote_location.present? ?  'sync' : 'upload'
+    trigger = self.study_file.remote_location.present? ?  'sync' : 'upload'
 
     # Event properties to log to Mixpanel.
     # Mixpanel uses camelCase for props; snake_case would degrade Mixpanel UX.
     job_props = {
-      perfTime: get_total_runtime_ms, # Latency in milliseconds
-      fileName: study_file.name,
+      perfTime: self.get_total_runtime_ms, # Latency in milliseconds
+      fileName: self.study_file.name,
       fileType: file_type,
-      fileSize: study_file.upload_file_size,
-      action: action,
-      studyAccession: study.accession,
+      fileSize: self.study_file.upload_file_size,
+      action: self.action,
+      studyAccession: self.study.accession,
       trigger: trigger,
-      jobStatus: failed? ? 'failed' : 'success'
+      jobStatus: self.failed? ? 'failed' : 'success'
     }
 
     case file_type
     when /Matrix/
       # since genes are not ingested for raw count matrices, report number of cells ingested
-      cells = study.expression_matrix_cells(study_file)
+      cells = self.study.expression_matrix_cells(self.study_file)
       cell_count = cells.present? ? cells.count : 0
-      job_props.merge!({ numCells: cell_count, is_raw_counts: study_file.is_raw_counts_file? })
-      if !study_file.is_raw_counts_file?
-        genes = Gene.where(study_id: study.id, study_file_id: study_file.id).count
+      job_props.merge!({ numCells: cell_count, is_raw_counts: self.study_file.is_raw_counts_file? })
+      if !self.study_file.is_raw_counts_file?
+        genes = Gene.where(study_id: self.study.id, study_file_id: self.study_file.id).count
         job_props.merge!({:numGenes => genes})
       end
     when 'Metadata'
-      use_metadata_convention = study_file.use_metadata_convention
+      use_metadata_convention = self.study_file.use_metadata_convention
       job_props.merge!({useMetadataConvention: use_metadata_convention})
       if use_metadata_convention
         project_name = 'alexandria_convention' # hard-coded is fine for now, consider implications if we get more projects
@@ -579,10 +577,10 @@ class IngestJob
         )
       end
     when 'Cluster'
-      cluster = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
-      job_props.merge!({metadataFilePresent: study.metadata_file.present?})
+      cluster = ClusterGroup.find_by(study_id: self.study.id, study_file_id: self.study_file.id)
+      job_props.merge!({metadataFilePresent: self.study.metadata_file.present?})
       # must make sure cluster is present, as parse failures may result in no data having been stored
-      if action == :ingest_cluster && cluster.present?
+      if self.action == :ingest_cluster && cluster.present?
         cluster_type = cluster.cluster_type
         cluster_points = cluster.points
         can_subsample = cluster.can_subsample?
@@ -603,9 +601,9 @@ class IngestJob
   # * *yields*
   #  - MetricsService.log => reports output of IngestJob#get_job_analytics to Mixpanel via Bard
   def log_to_mixpanel
-    mixpanel_log_props = get_job_analytics
+    mixpanel_log_props = self.get_job_analytics
     # log job properties to Mixpanel
-    MetricsService.log('ingest', mixpanel_log_props, user)
+    MetricsService.log('ingest', mixpanel_log_props, self.user)
   end
 
   # generates parse completion email body
@@ -613,22 +611,22 @@ class IngestJob
   # * *returns*
   #   - (Array) => List of message strings to print in a completion email
   def generate_success_email_array
-    file_type = study_file.file_type
+    file_type = self.study_file.file_type
 
-    message = ["Total parse time: #{get_total_runtime}"]
+    message = ["Total parse time: #{self.get_total_runtime}"]
 
     case file_type
     when /Matrix/
       # since genes are not ingested for raw count matrices, report number of cells ingested
-      if study_file.is_raw_counts_file?
-        cells = study.expression_matrix_cells(study_file).count
+      if self.study_file.is_raw_counts_file?
+        cells = self.study.expression_matrix_cells(self.study_file).count
         message << "Cells ingested: #{cells}"
       else
-        genes = Gene.where(study_id: study.id, study_file_id: study_file.id).count
+        genes = Gene.where(study_id: self.study.id, study_file_id: self.study_file.id).count
         message << "Gene-level entries created: #{genes}"
       end
     when 'Metadata'
-      use_metadata_convention = study_file.use_metadata_convention
+      use_metadata_convention = self.study_file.use_metadata_convention
       if use_metadata_convention
         project_name = 'alexandria_convention' # hard-coded is fine for now, consider implications if we get more projects
         current_schema_version = get_latest_schema_version(project_name)
@@ -639,7 +637,7 @@ class IngestJob
         message << "Ingest Pipeline Docker image version: #{ingest_image_attributes[:tag]}"
         message << "Group-type metadata columns with more than 200 unique values are not made available for visualization."
       end
-      cell_metadata = CellMetadatum.where(study_id: study.id, study_file_id: study_file.id)
+      cell_metadata = CellMetadatum.where(study_id: self.study.id, study_file_id: self.study_file.id)
       message << "Entries created:"
       cell_metadata.each do |metadata|
         unless metadata.nil?
@@ -647,36 +645,31 @@ class IngestJob
         end
       end
     when 'Cluster'
-      cluster = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
-      case action
-      when :ingest_cluster
+      cluster = ClusterGroup.find_by(study_id: self.study.id, study_file_id: self.study_file.id)
+      if self.action == :ingest_cluster
         cluster_type = cluster.cluster_type
         message << "Cluster created: #{cluster.name}, type: #{cluster_type}"
         if cluster.cell_annotations.any?
           message << "Annotations:"
           cluster.cell_annotations.each do |annot|
-            message << get_annotation_message(annotation_source: cluster, cell_annotation: annot)
+            message << self.get_annotation_message(annotation_source: cluster, cell_annotation: annot)
           end
         end
         cluster_points = cluster.points
         message << "Total points in cluster: #{cluster_points}"
 
         can_subsample = cluster.can_subsample?
-        metadata_file_present = study.metadata_file.present?
+        metadata_file_present = self.study.metadata_file.present?
 
         # notify user that subsampling is about to run and inform them they can't delete cluster/metadata files
         if can_subsample && metadata_file_present
-          message << 'This cluster file will now be processed to compute representative subsamples for visualization.'
-          message << 'You will receive an additional email once this has completed.'
-          message << 'While subsamples are being computed, you will not be able to remove this cluster file or your metadata file.'
+          message << "This cluster file will now be processed to compute representative subsamples for visualization."
+          message << "You will receive an additional email once this has completed."
+          message << "While subsamples are being computed, you will not be able to remove this cluster file or your metadata file."
         end
-      when :subsample
+      else
         message << "Subsampling has completed for #{cluster.name}"
         message << "Subsamples generated: #{cluster.subsample_thresholds_required.join(', ')}"
-      when :differential_expression
-        message << 'Differential expression calculations using the following parameters has completed.'
-        message << "Cluster: #{cluster.name}"
-        message << "Annotation: #{}"
       end
     end
     message
@@ -688,7 +681,7 @@ class IngestJob
   # * *returns*
   #   - (String) => HTML anchor tag with link to file directory that can be opened in the browser after authenticating
   def generate_bucket_browser_tag
-    link = "#{study.google_bucket_url}/parse_logs/#{study_file.id}"
+    link = "#{self.study.google_bucket_url}/parse_logs/#{self.study_file.id}"
     '<a href="' + link + '">' + link + '</a>'
   end
 
@@ -704,17 +697,17 @@ class IngestJob
   def generate_error_email_body(email_type: :user)
     case email_type
     when :user
-      error_contents = read_parse_logfile(user_error_filepath)
-      message_body = "<p>'#{study_file.upload_file_name}' has failed during parsing.</p>"
+      error_contents = self.read_parse_logfile(self.user_error_filepath)
+      message_body = "<p>'#{self.study_file.upload_file_name}' has failed during parsing.</p>"
     when :dev
       # only read first megabyte of error log to avoid email delivery failure
-      error_contents = read_parse_logfile(dev_error_filepath, delete_on_read: false, range: 0..1.megabyte)
-      message_body = "<p>The file '#{study_file.upload_file_name}' uploaded by #{user.email} to #{study.accession} failed to ingest.</p>"
-      message_body += "<p>A copy of this file can be found at #{generate_bucket_browser_tag}</p>"
+      error_contents = self.read_parse_logfile(self.dev_error_filepath, delete_on_read: false, range: 0..1.megabyte)
+      message_body = "<p>The file '#{self.study_file.upload_file_name}' uploaded by #{self.user.email} to #{self.study.accession} failed to ingest.</p>"
+      message_body += "<p>A copy of this file can be found at #{self.generate_bucket_browser_tag}</p>"
       message_body += "<p>Detailed logs and PAPI events as follows:"
     else
-      error_contents = read_parse_logfile(user_error_filepath)
-      message_body = "<p>'#{study_file.upload_file_name}' has failed during parsing.</p>"
+      error_contents = self.read_parse_logfile(self.user_error_filepath)
+      message_body = "<p>'#{self.study_file.upload_file_name}' has failed during parsing.</p>"
     end
 
     if error_contents.present?
@@ -727,13 +720,13 @@ class IngestJob
     if !error_contents.present? || email_type == :dev
       message_body += "<h3>Event Messages</h3>"
       message_body += "<ul>"
-      event_messages.each do |e|
+      self.event_messages.each do |e|
         message_body += "<li><pre>#{ERB::Util.html_escape(e)}</pre></li>"
       end
       message_body += "</ul>"
     end
 
-    if study_file.file_type == 'Metadata'
+    if self.study_file.file_type == 'Metadata'
       faq_link = "https://singlecell.zendesk.com/hc/en-us/articles/360060610092-Metadata-Validation-Errors-FAQ"
       message_body += "<h3>Common Errors for Metadata Files</h3>"
       message_body += "<p>You can view a list of common metadata validation errors and solutions in our documentation: "
@@ -741,10 +734,10 @@ class IngestJob
     end
 
     message_body += "<h3>Job Details</h3>"
-    message_body += "<p>Study Accession: <strong>#{study.accession}</strong></p>"
-    message_body += "<p>Study File ID: <strong>#{study_file.id}</strong></p>"
-    message_body += "<p>Ingest Run ID: <strong>#{pipeline_name}</strong></p>"
-    message_body += "<p>Command Line: <strong>#{command_line}</strong></p>"
+    message_body += "<p>Study Accession: <strong>#{self.study.accession}</strong></p>"
+    message_body += "<p>Study File ID: <strong>#{self.study_file.id}</strong></p>"
+    message_body += "<p>Ingest Run ID: <strong>#{self.pipeline_name}</strong></p>"
+    message_body += "<p>Command Line: <strong>#{self.command_line}</strong></p>"
     ingest_image_attributes = AdminConfiguration.get_ingest_docker_image_attributes
     message_body << "<p>Ingest Pipeline Docker image version: <strong>#{ingest_image_attributes[:tag]}</strong></p>"
     message_body
@@ -755,8 +748,8 @@ class IngestJob
   # * *yields*
   #   - Error log messages in event of parse failure
   def log_error_messages
-    event_messages.each do |message|
-      Rails.logger.error "#{pipeline_name} log: #{message}"
+    self.event_messages.each do |message|
+      Rails.logger.error "#{self.pipeline_name} log: #{message}"
     end
   end
 

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -23,6 +23,8 @@ class IngestJob
   attr_accessor :reparse
   # Boolean indication of whether or not to delete file from bucket on parse failure
   attr_accessor :persist_on_fail
+  # extra key/value storage of attributes
+  attr_accessor :options
 
   # number of tries to push a file to a study bucket
   MAX_ATTEMPTS = 3
@@ -32,8 +34,9 @@ class IngestJob
       ingest_expression: Gene,
       ingest_cluster: ClusterGroup,
       ingest_cell_metadata: CellMetadatum,
-      subsample: ClusterGroup
-  }
+      subsample: ClusterGroup,
+      differential_expression: nil # data only lives in files in the bucket, has special handling
+  }.freeze
 
   # Push a file to a workspace bucket in the background and then launch an ingest run and queue polling
   # Can also clear out existing data if necessary (in case of a re-parse)
@@ -48,49 +51,49 @@ class IngestJob
   #   - (RuntimeError) => If file cannot be pushed to remote bucket
   def push_remote_and_launch_ingest(skip_push: false)
     begin
-      file_identifier = "#{self.study_file.bucket_location}:#{self.study_file.id}"
-      if self.reparse
+      file_identifier = "#{study_file.bucket_location}:#{study_file.id}"
+      rails_model = MODELS_BY_ACTION[action]
+      if reparse && rails_model
         Rails.logger.info "Deleting existing data for #{file_identifier}"
-        rails_model = MODELS_BY_ACTION[action]
-        rails_model.where(study_id: self.study.id, study_file_id: self.study_file.id).delete_all
-        DataArray.where(study_id: self.study.id, study_file_id: self.study_file.id).delete_all
+        rails_model.where(study_id: study.id, study_file_id: study_file.id).delete_all
+        DataArray.where(study_id: study.id, study_file_id: study_file.id).delete_all
         Rails.logger.info "Data cleanup for #{file_identifier} complete, now beginning Ingest"
       end
       # first check if file is already in bucket (in case user is syncing)
-      remote = ApplicationController.firecloud_client.get_workspace_file(self.study.bucket_id, self.study_file.bucket_location)
+      remote = ApplicationController.firecloud_client.get_workspace_file(study.bucket_id, study_file.bucket_location)
       if remote.nil?
-        is_pushed = self.poll_for_remote(skip_push: skip_push)
+        is_pushed = poll_for_remote(skip_push: skip_push)
       else
         is_pushed = true # file is already in bucket
       end
       if !is_pushed
         # push has failed 3 times, so exit and report error
-        log_message = "Unable to push #{file_identifier} to #{self.study.bucket_id}"
+        log_message = "Unable to push #{file_identifier} to #{study.bucket_id}"
         Rails.logger.error log_message
         raise RuntimeError.new(log_message)
       else
-        if self.can_launch_ingest?
+        if can_launch_ingest?
           Rails.logger.info "Remote found for #{file_identifier}, launching Ingest job"
-          submission = ApplicationController.papi_client.run_pipeline(study_file: self.study_file, user: self.user, action: self.action)
+          submission = ApplicationController.papi_client.run_pipeline(study_file: study_file, user: user, action: action)
           Rails.logger.info "Ingest run initiated: #{submission.name}, queueing Ingest poller"
-          IngestJob.new(pipeline_name: submission.name, study: self.study, study_file: self.study_file,
-                        user: self.user, action: self.action, reparse: self.reparse,
-                        persist_on_fail: self.persist_on_fail).poll_for_completion
+          IngestJob.new(pipeline_name: submission.name, study: study, study_file: study_file,
+                        user: user, action: action, reparse: reparse, persist_on_fail: persist_on_fail)
+                   .poll_for_completion
         else
           run_at = 2.minutes.from_now
           Rails.logger.info "Remote found for #{file_identifier} but ingest gated by other parse jobs, queuing another check for #{run_at}"
-          self.delay(run_at: run_at).push_remote_and_launch_ingest
+          delay(run_at: run_at).push_remote_and_launch_ingest
         end
       end
     rescue => e
       Rails.logger.error "Error in launching ingest of #{file_identifier}: #{e.class.name}:#{e.message}"
-      ErrorTracker.report_exception(e, self.user, self.study, self.study_file, { action: self.action})
+      ErrorTracker.report_exception(e, user, study, study_file, { action: action})
       # notify admins of failure, and notify user that admins are looking into the issue
-      SingleCellMailer.notify_admin_parse_launch_fail(self.study, self.study_file, self.user, self.action, e).deliver_now
-      user_message = "<p>An error has occurred when attempting to launch the parse job associated with #{self.study_file.upload_file_name}.  "
+      SingleCellMailer.notify_admin_parse_launch_fail(study, study_file, user, action, e).deliver_now
+      user_message = "<p>An error has occurred when attempting to launch the parse job associated with #{study_file.upload_file_name}.  "
       user_message += "Support staff has been notified and are investigating the issue.  "
       user_message += "If you require immediate assistance, please contact scp-support@broadinstitute.zendesk.com.</p>"
-      SingleCellMailer.user_notification(self.user, "Unable to parse #{self.study_file.upload_file_name}", user_message).deliver_now
+      SingleCellMailer.user_notification(user, "Unable to parse #{study_file.upload_file_name}", user_message).deliver_now
     end
   end
 
@@ -104,14 +107,14 @@ class IngestJob
   def poll_for_remote(skip_push: false)
     attempts = 1
     is_pushed = false
-    file_identifier = "#{self.study_file.bucket_location}:#{self.study_file.id}"
+    file_identifier = "#{study_file.bucket_location}:#{study_file.id}"
     while !is_pushed && attempts <= MAX_ATTEMPTS
       unless skip_push
-        Rails.logger.info "Preparing to push #{file_identifier} to #{self.study.bucket_id}"
-        self.study.send_to_firecloud(study_file)
+        Rails.logger.info "Preparing to push #{file_identifier} to #{study.bucket_id}"
+        study.send_to_firecloud(study_file)
       end
       Rails.logger.info "Polling for upload of #{file_identifier}, attempt #{attempts}"
-      remote = ApplicationController.firecloud_client.get_workspace_file(self.study.bucket_id, self.study_file.bucket_location)
+      remote = ApplicationController.firecloud_client.get_workspace_file(study.bucket_id, study_file.bucket_location)
       if remote.present?
         is_pushed = true
       else
@@ -129,24 +132,24 @@ class IngestJob
   # * *returns*
   #   - (Boolean) => T/F if file can launch PAPI ingest job
   def can_launch_ingest?
-    case self.study_file.file_type
+    case study_file.file_type
     when /Matrix/
       # expression matrices currently cannot be ingested in parallel due to constraints around validating cell names
       # this block ensures that all other matrices have all cell names ingested and at least one gene entry, which
       # ensures the matrix has validated
-      other_matrix_files = StudyFile.where(study_id: self.study.id, file_type: /Matrix/, :id.ne => self.study_file.id)
+      other_matrix_files = StudyFile.where(study_id: study.id, file_type: /Matrix/, :id.ne => study_file.id)
       # only check other matrix files of the same type, as this is what will be checked when validating
-      similar_matrix_files = other_matrix_files.select {|matrix| matrix.is_raw_counts_file? == self.study_file.is_raw_counts_file?}
+      similar_matrix_files = other_matrix_files.select {|matrix| matrix.is_raw_counts_file? == study_file.is_raw_counts_file?}
       similar_matrix_files.each do |matrix_file|
         if matrix_file.parsing?
-          matrix_cells = self.study.expression_matrix_cells(matrix_file)
-          matrix_genes = Gene.where(study_id: self.study.id, study_file_id: matrix_file.id)
+          matrix_cells = study.expression_matrix_cells(matrix_file)
+          matrix_genes = Gene.where(study_id: study.id, study_file_id: matrix_file.id)
           if !matrix_cells || matrix_genes.empty?
             # return false if matrix hasn't validated, unless the other matrix was uploaded after this file
             # this is to prevent multiple matrix files queueing up and blocking each other from initiating PAPI jobs
             # also, a timeout 24 hours is added to prevent all matrix files from queueing infinitely if one
             # fails to launch an ingest job for some reason
-            if matrix_file.created_at < self.study_file.created_at && matrix_file.created_at > 24.hours.ago
+            if matrix_file.created_at < study_file.created_at && matrix_file.created_at > 24.hours.ago
               return false
             end
           end
@@ -173,12 +176,12 @@ class IngestJob
   #   - (Hash) => Hash of all instance variables
   def attributes
     {
-      study: self.study,
-      study_file: self.study_file,
-      user: self.user,
-      action: self.action,
-      reparse: self.reparse,
-      persist_on_fail: self.persist_on_fail
+      study: study,
+      study_file: study_file,
+      user: user,
+      action: action,
+      reparse: reparse,
+      persist_on_fail: persist_on_fail
     }
   end
 
@@ -187,7 +190,7 @@ class IngestJob
   # * *returns*
   #   - (Google::Apis::GenomicsV2alpha1::Operation)
   def get_ingest_run
-    ApplicationController.papi_client.get_pipeline(name: self.pipeline_name)
+    ApplicationController.papi_client.get_pipeline(name: pipeline_name)
   end
 
   # Determine if this ingest run has done by checking current status
@@ -195,7 +198,7 @@ class IngestJob
   # * *returns*
   #   - (Boolean) => Indication of whether or not job has completed
   def done?
-    self.get_ingest_run.done?
+    get_ingest_run.done?
   end
 
   # Get all errors for ingest job
@@ -203,7 +206,7 @@ class IngestJob
   # * *returns*
   #   - (Google::Apis::GenomicsV2alpha1::Status)
   def error
-    self.get_ingest_run.error
+    get_ingest_run.error
   end
 
   # Determine if a job failed by checking for errors
@@ -211,7 +214,7 @@ class IngestJob
   # * *returns*
   #   - (Boolean) => Indication of whether or not job failed via an unrecoverable error
   def failed?
-    self.error.present?
+    error.present?
   end
 
   # Get a status label for current state of job
@@ -219,8 +222,8 @@ class IngestJob
   # * *returns*
   #   - (String) => Status label
   def current_status
-    if self.done?
-      self.failed? ? 'Error' : 'Completed'
+    if done?
+      failed? ? 'Error' : 'Completed'
     else
       'Running'
     end
@@ -231,7 +234,7 @@ class IngestJob
   # * *returns*
   #   - (Hash) => Metadata of PAPI job, including events, environment, labels, etc.
   def metadata
-    self.get_ingest_run.metadata
+    get_ingest_run.metadata
   end
 
   # Get all the events for a given ingest job in chronological order
@@ -239,7 +242,7 @@ class IngestJob
   # * *returns*
   #   - (Array<Google::Apis::GenomicsV2alpha1::Event>) => Array of pipeline events, sorted by timestamp
   def events
-    self.metadata['events'].sort_by! {|event| event['timestamp'] }
+    metadata['events'].sort_by! {|event| event['timestamp'] }
   end
 
   # Get all messages from all events
@@ -247,7 +250,7 @@ class IngestJob
   # * *returns*
   #   - (Array<String>) => Array of all messages in chronological order
   def event_messages
-    self.events.map {|event| event['description']}
+    events.map {|event| event['description']}
   end
 
   # Reconstruct the command line from the pipeline actions
@@ -256,7 +259,7 @@ class IngestJob
   #   - (String) => Deserialized command line
   def command_line
     command_line = ""
-    self.metadata['pipeline']['actions'].each do |action|
+    metadata['pipeline']['actions'].each do |action|
       command_line += action['commands'].join(' ') + "\n"
     end
     command_line.chomp("\n")
@@ -267,7 +270,6 @@ class IngestJob
   # * *returns*
   #   - (Array<DateTime>) => Array of initial and terminal timestamps from PAPI events
   def get_runtime_timestamps
-    events = self.events
     start_time = DateTime.parse(events.first['timestamp'])
     completion_time = DateTime.parse(events.last['timestamp'])
     [start_time, completion_time]
@@ -278,7 +280,7 @@ class IngestJob
   # * *returns*
   #   - (String) => Text representation of total elapsed time
   def get_total_runtime
-    TimeDifference.between(*self.get_runtime_timestamps).humanize
+    TimeDifference.between(*get_runtime_timestamps).humanize
   end
 
    # Get the total runtime of parsing from event timestamps, in milliseconds
@@ -286,7 +288,7 @@ class IngestJob
   # * *returns*
   #   - (Integer) => Total elapsed time in milliseconds
   def get_total_runtime_ms
-    (TimeDifference.between(*self.get_runtime_timestamps).in_seconds * 1000).to_i
+    (TimeDifference.between(*get_runtime_timestamps).in_seconds * 1000).to_i
   end
 
   # Launch a background polling process.  Will check for completion, and if the pipeline has not completed
@@ -296,39 +298,39 @@ class IngestJob
   # * *params*
   #   - +run_at+ (DateTime) => Time at which to run new polling check
   def poll_for_completion(run_at: 1.minute.from_now)
-    if self.done? && !self.failed?
-      Rails.logger.info "IngestJob poller: #{self.pipeline_name} is done!"
-      Rails.logger.info "IngestJob poller: #{self.pipeline_name} status: #{self.current_status}"
-      self.study_file.update(parse_status: 'parsed')
-      self.study_file.bundled_files.each { |sf| sf.update(parse_status: 'parsed') }
-      self.study.reload # refresh cached instance of study
-      self.study_file.reload # refresh cached instance of study_file
-      self.set_study_state_after_ingest
-      self.study_file.invalidate_cache_by_file_type # clear visualization caches for file
-      self.log_to_mixpanel
-      subject = "#{self.study_file.file_type} file: '#{self.study_file.upload_file_name}' has completed parsing"
-      message = self.generate_success_email_array
-      SingleCellMailer.notify_user_parse_complete(self.user.email, subject, message, self.study).deliver_now
-    elsif self.done? && self.failed?
-      Rails.logger.error "IngestJob poller: #{self.pipeline_name} has failed."
+    if done? && !failed?
+      Rails.logger.info "IngestJob poller: #{pipeline_name} is done!"
+      Rails.logger.info "IngestJob poller: #{pipeline_name} status: #{current_status}"
+      study_file.update(parse_status: 'parsed')
+      study_file.bundled_files.each { |sf| sf.update(parse_status: 'parsed') }
+      study.reload # refresh cached instance of study
+      study_file.reload # refresh cached instance of study_file
+      set_study_state_after_ingest
+      study_file.invalidate_cache_by_file_type # clear visualization caches for file
+      log_to_mixpanel
+      subject = "#{study_file.file_type} file: '#{study_file.upload_file_name}' has completed parsing"
+      message = generate_success_email_array
+      SingleCellMailer.notify_user_parse_complete(user.email, subject, message, study).deliver_now
+    elsif done? && failed?
+      Rails.logger.error "IngestJob poller: #{pipeline_name} has failed."
       # log errors to application log for inspection
-      self.log_error_messages
-      self.log_to_mixpanel # log before queuing file for deletion to preserve properties
-      self.create_study_file_copy
-      self.study_file.update(parse_status: 'failed')
-      DeleteQueueJob.new(self.study_file).delay.perform
-      ApplicationController.firecloud_client.delete_workspace_file(self.study.bucket_id, self.study_file.bucket_location) unless self.persist_on_fail
-      self.study_file.bundled_files.each do |bundled_file|
-        ApplicationController.firecloud_client.delete_workspace_file(self.study.bucket_id, bundled_file.bucket_location) unless self.persist_on_fail
+      log_error_messages
+      log_to_mixpanel # log before queuing file for deletion to preserve properties
+      create_study_file_copy
+      study_file.update(parse_status: 'failed')
+      DeleteQueueJob.new(study_file).delay.perform
+      ApplicationController.firecloud_client.delete_workspace_file(study.bucket_id, study_file.bucket_location) unless persist_on_fail
+      study_file.bundled_files.each do |bundled_file|
+        ApplicationController.firecloud_client.delete_workspace_file(study.bucket_id, bundled_file.bucket_location) unless persist_on_fail
       end
-      subject = "Error: #{self.study_file.file_type} file: '#{self.study_file.upload_file_name}' parse has failed"
-      user_email_content = self.generate_error_email_body
-      SingleCellMailer.notify_user_parse_fail(self.user.email, subject, user_email_content, self.study).deliver_now
-      admin_email_content = self.generate_error_email_body(email_type: :dev)
-      SingleCellMailer.notify_admin_parse_fail(self.user.email, subject, admin_email_content).deliver_now
+      subject = "Error: #{study_file.file_type} file: '#{study_file.upload_file_name}' parse has failed"
+      user_email_content = generate_error_email_body
+      SingleCellMailer.notify_user_parse_fail(user.email, subject, user_email_content, study).deliver_now
+      admin_email_content = generate_error_email_body(email_type: :dev)
+      SingleCellMailer.notify_admin_parse_fail(user.email, subject, admin_email_content).deliver_now
     else
-      Rails.logger.info "IngestJob poller: #{self.pipeline_name} is not done; queuing check for #{run_at}"
-      self.delay(run_at: run_at).poll_for_completion
+      Rails.logger.info "IngestJob poller: #{pipeline_name} is not done; queuing check for #{run_at}"
+      delay(run_at: run_at).poll_for_completion
     end
   end
 
@@ -338,24 +340,24 @@ class IngestJob
   # * *yields*
   #   - Study#set_cell_count, :set_study_default_options, Study#set_gene_count, and :set_study_initialized
   def set_study_state_after_ingest
-    case self.study_file.file_type
+    case study_file.file_type
     when 'Metadata'
-      self.study.set_cell_count
-      self.set_study_default_options
-      self.launch_subsample_jobs
+      study.set_cell_count
+      set_study_default_options
+      launch_subsample_jobs
       # update search facets if convention data
-      if self.study_file.use_metadata_convention
+      if study_file.use_metadata_convention
         SearchFacet.delay.update_all_facet_filters
       end
     when /Matrix/
-      self.study.delay.set_gene_count
+      study.delay.set_gene_count
     when 'Cluster'
-      self.set_cluster_point_count
-      self.set_study_default_options
-      self.launch_subsample_jobs
-      self.set_subsampling_flags
+      set_cluster_point_count
+      set_study_default_options
+      launch_subsample_jobs
+      set_subsampling_flags
     end
-    self.set_study_initialized
+    set_study_initialized
   end
 
   # Set the default options for a study after ingesting Clusters/Cell Metadata
@@ -363,33 +365,33 @@ class IngestJob
   # * *yields*
   #   - Sets study default options for clusters/annotations
   def set_study_default_options
-    case self.study_file.file_type
+    case study_file.file_type
     when 'Metadata'
-      if self.study.default_options[:annotation].blank?
+      if study.default_options[:annotation].blank?
         cell_metadatum = study.cell_metadata.keep_if(&:can_visualize?).first || study.cell_metadata.first
-        self.study.default_options[:annotation] = cell_metadatum.annotation_select_value
+        study.default_options[:annotation] = cell_metadatum.annotation_select_value
         if cell_metadatum.annotation_type == 'numeric'
-          self.study.default_options[:color_profile] = 'Reds'
+          study.default_options[:color_profile] = 'Reds'
         end
       end
     when 'Cluster'
-      if self.study.default_options[:cluster].nil?
-        cluster = study.cluster_groups.by_name(self.study_file.name)
-        self.study.default_options[:cluster] = cluster.name
-        if self.study.default_options[:annotation].blank? && cluster.cell_annotations.any?
+      if study.default_options[:cluster].nil?
+        cluster = study.cluster_groups.by_name(study_file.name)
+        study.default_options[:cluster] = cluster.name
+        if study.default_options[:annotation].blank? && cluster.cell_annotations.any?
           annotation = cluster.cell_annotations.select { |annot| cluster.can_visualize_cell_annotation?(annot) }.first ||
             cluster.cell_annotations.first
-          self.study.default_options[:annotation] = cluster.annotation_select_value(annotation)
+          study.default_options[:annotation] = cluster.annotation_select_value(annotation)
           if annotation[:type] == 'numeric'
-            self.study.default_options[:color_profile] = 'Reds'
+            study.default_options[:color_profile] = 'Reds'
           end
         end
       end
     end
-    Rails.logger.info "Setting default options in #{self.study.name}: #{self.study.default_options}"
-    self.study.save
+    Rails.logger.info "Setting default options in #{study.name}: #{study.default_options}"
+    study.save
     # warm all default caches for this study
-    ClusterCacheService.delay(queue: :cache).cache_study_defaults(self.study)
+    ClusterCacheService.delay(queue: :cache).cache_study_defaults(study)
   end
 
   # set the point count on a cluster group after successful ingest
@@ -397,7 +399,7 @@ class IngestJob
   # * *yields*
   #   - sets the :points attribute on a ClusterGroup
   def set_cluster_point_count
-    cluster_group = ClusterGroup.find_by(study_id: self.study.id, study_file_id: self.study_file.id)
+    cluster_group = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
     cluster_group.set_point_count!
     Rails.logger.info "Point count on #{cluster_group.name}:#{cluster_group.id} set to #{cluster_group.points}"
   end
@@ -407,8 +409,8 @@ class IngestJob
   # * *yields*
   #   - Sets study initialized to True if needed
   def set_study_initialized
-    if self.study.cluster_groups.any? && self.study.genes.any? && self.study.cell_metadata.any? && !self.study.initialized?
-      self.study.update(initialized: true)
+    if study.cluster_groups.any? && study.genes.any? && study.cell_metadata.any? && !study.initialized?
+      study.update(initialized: true)
     end
   end
 
@@ -417,41 +419,41 @@ class IngestJob
   # * *yields*
   #   - (IngestJob) => new ingest job for subsampling
   def launch_subsample_jobs
-    case self.study_file.file_type
+    case study_file.file_type
     when 'Cluster'
       # only subsample if ingest_cluster was just run, new cluster is > 1K points, and a metadata file is parsed
-      cluster_ingested = self.action.to_sym == :ingest_cluster
-      cluster = ClusterGroup.find_by(study_id: self.study.id, study_file_id: self.study_file.id)
-      metadata_parsed = self.study.metadata_file.present? && self.study.metadata_file.parsed?
+      cluster_ingested = action.to_sym == :ingest_cluster
+      cluster = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
+      metadata_parsed = study.metadata_file.present? && study.metadata_file.parsed?
       if cluster_ingested && metadata_parsed && cluster.can_subsample? && !cluster.is_subsampling?
         # immediately set cluster.is_subsampling = true to gate race condition if metadata file just finished parsing
         cluster.update(is_subsampling: true)
-        file_identifier = "#{self.study_file.bucket_location}:#{self.study_file.id}"
-        Rails.logger.info "Launching subsampling ingest run for #{file_identifier} after #{self.action}"
-        submission = ApplicationController.papi_client.run_pipeline(study_file: self.study_file, user: self.user,
+        file_identifier = "#{study_file.bucket_location}:#{study_file.id}"
+        Rails.logger.info "Launching subsampling ingest run for #{file_identifier} after #{action}"
+        submission = ApplicationController.papi_client.run_pipeline(study_file: study_file, user: user,
                                                                     action: :ingest_subsample)
         Rails.logger.info "Subsampling run initiated: #{submission.name}, queueing Ingest poller"
-        IngestJob.new(pipeline_name: submission.name, study: self.study, study_file: self.study_file,
-                      user: self.user, action: :ingest_subsample, reparse: false,
-                      persist_on_fail: self.persist_on_fail).poll_for_completion
+        IngestJob.new(pipeline_name: submission.name, study: study, study_file: study_file,
+                      user: user, action: :ingest_subsample, reparse: false,
+                      persist_on_fail: persist_on_fail).poll_for_completion
       end
     when 'Metadata'
       # subsample all cluster files that have already finished parsing.  any in-process cluster parses, or new submissions
       # will be handled by the above case.  Again, only subsample for completed clusters > 1K points
-      metadata_identifier = "#{self.study_file.bucket_location}:#{self.study_file.id}"
-      self.study.study_files.where(file_type: 'Cluster', parse_status: 'parsed').each do |cluster_file|
-        cluster = ClusterGroup.find_by(study_id: self.study.id, study_file_id: cluster_file.id)
+      metadata_identifier = "#{study_file.bucket_location}:#{study_file.id}"
+      study.study_files.where(file_type: 'Cluster', parse_status: 'parsed').each do |cluster_file|
+        cluster = ClusterGroup.find_by(study_id: study.id, study_file_id: cluster_file.id)
         if cluster.can_subsample? && !cluster.is_subsampling?
           # set cluster.is_subsampling = true to avoid future race conditions
           cluster.update(is_subsampling: true)
           file_identifier = "#{cluster_file.bucket_location}:#{cluster_file.id}"
-          Rails.logger.info "Launching subsampling ingest run for #{file_identifier} after #{self.action} of #{metadata_identifier}"
-          submission = ApplicationController.papi_client.run_pipeline(study_file: cluster_file, user: self.user,
+          Rails.logger.info "Launching subsampling ingest run for #{file_identifier} after #{action} of #{metadata_identifier}"
+          submission = ApplicationController.papi_client.run_pipeline(study_file: cluster_file, user: user,
                                                                       action: :ingest_subsample)
           Rails.logger.info "Subsampling run initiated: #{submission.name}, queueing Ingest poller"
-          IngestJob.new(pipeline_name: submission.name, study: self.study, study_file: cluster_file,
-                        user: self.user, action: :ingest_subsample, reparse: self.reparse,
-                        persist_on_fail: self.persist_on_fail).poll_for_completion
+          IngestJob.new(pipeline_name: submission.name, study: study, study_file: cluster_file,
+                        user: user, action: :ingest_subsample, reparse: reparse,
+                        persist_on_fail: persist_on_fail).poll_for_completion
         end
       end
     end
@@ -459,11 +461,11 @@ class IngestJob
 
   # Set correct subsampling flags on a cluster after job completion
   def set_subsampling_flags
-    case self.action
+    case action
     when :ingest_subsample
-      cluster_group = ClusterGroup.find_by(study_id: self.study.id, study_file_id: self.study_file.id)
+      cluster_group = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
       if cluster_group.is_subsampling? && cluster_group.find_subsampled_data_arrays.any?
-        Rails.logger.info "Setting subsampled flags for #{self.study_file.upload_file_name}:#{self.study_file.id} (#{cluster_group.name}) for visualization"
+        Rails.logger.info "Setting subsampled flags for #{study_file.upload_file_name}:#{study_file.id} (#{cluster_group.name}) for visualization"
         cluster_group.update(subsampled: true, is_subsampling: false)
       end
     end
@@ -476,22 +478,22 @@ class IngestJob
   def create_study_file_copy
     begin
       ApplicationController.firecloud_client.execute_gcloud_method(:copy_workspace_file, 0,
-                                                                   self.study.bucket_id,
-                                                                   self.study_file.bucket_location,
-                                                                   self.study_file.parse_fail_bucket_location)
-      if self.study_file.is_bundled? && self.study_file.is_bundle_parent?
-        self.study_file.bundled_files.each do |file|
+                                                                   study.bucket_id,
+                                                                   study_file.bucket_location,
+                                                                   study_file.parse_fail_bucket_location)
+      if study_file.is_bundled? && study_file.is_bundle_parent?
+        study_file.bundled_files.each do |file|
           # put in same directory as parent file for ease of debugging
-          bundled_file_location = "parse_logs/#{self.study_file.id}/#{file.upload_file_name}"
+          bundled_file_location = "parse_logs/#{study_file.id}/#{file.upload_file_name}"
           ApplicationController.firecloud_client.execute_gcloud_method(:copy_workspace_file, 0,
-                                                                       self.study.bucket_id,
+                                                                       study.bucket_id,
                                                                        file.bucket_location,
                                                                        bundled_file_location)
         end
       end
       true
     rescue => e
-      ErrorTracker.report_exception(e, self.user, self.study_file, { action: :create_study_file_copy})
+      ErrorTracker.report_exception(e, user, study_file, { action: :create_study_file_copy})
       false
     end
   end
@@ -501,7 +503,7 @@ class IngestJob
   # * *returns*
   #   - (String) => String representation of path to detailed log file
   def dev_error_filepath
-    "parse_logs/#{self.study_file.id}/log.txt"
+    "parse_logs/#{study_file.id}/log.txt"
   end
 
   # path to user-level error log file in study bucket
@@ -509,7 +511,7 @@ class IngestJob
   # * *returns*
   #   - (String) => String representation of path to log file
   def user_error_filepath
-    "parse_logs/#{self.study_file.id}/user_log.txt"
+    "parse_logs/#{study_file.id}/user_log.txt"
   end
 
   # in case of an error, retrieve the contents of the warning or error file to email to the user
@@ -523,9 +525,9 @@ class IngestJob
   # * *returns*
   #   - (String) => Contents of file
   def read_parse_logfile(filepath, delete_on_read: true, range: nil)
-    if ApplicationController.firecloud_client.workspace_file_exists?(self.study.bucket_id, filepath)
-      file_contents = ApplicationController.firecloud_client.execute_gcloud_method(:read_workspace_file, 0, self.study.bucket_id, filepath)
-      ApplicationController.firecloud_client.execute_gcloud_method(:delete_workspace_file, 0, self.study.bucket_id, filepath) if delete_on_read
+    if ApplicationController.firecloud_client.workspace_file_exists?(study.bucket_id, filepath)
+      file_contents = ApplicationController.firecloud_client.execute_gcloud_method(:read_workspace_file, 0, study.bucket_id, filepath)
+      ApplicationController.firecloud_client.execute_gcloud_method(:delete_workspace_file, 0, study.bucket_id, filepath) if delete_on_read
       # read file range manually since GCS download requests don't honor range parameter apparently
       range.present? ? file_contents.read[range] : file_contents.read
     end
@@ -536,35 +538,35 @@ class IngestJob
   # * *returns*
   #   - (Hash) => Hash of job statistics to use with IngestJob#log_to_mixpanel
   def get_job_analytics
-    file_type = self.study_file.file_type
+    file_type = study_file.file_type
 
-    trigger = self.study_file.remote_location.present? ?  'sync' : 'upload'
+    trigger = study_file.remote_location.present? ?  'sync' : 'upload'
 
     # Event properties to log to Mixpanel.
     # Mixpanel uses camelCase for props; snake_case would degrade Mixpanel UX.
     job_props = {
-      perfTime: self.get_total_runtime_ms, # Latency in milliseconds
-      fileName: self.study_file.name,
+      perfTime: get_total_runtime_ms, # Latency in milliseconds
+      fileName: study_file.name,
       fileType: file_type,
-      fileSize: self.study_file.upload_file_size,
-      action: self.action,
-      studyAccession: self.study.accession,
+      fileSize: study_file.upload_file_size,
+      action: action,
+      studyAccession: study.accession,
       trigger: trigger,
-      jobStatus: self.failed? ? 'failed' : 'success'
+      jobStatus: failed? ? 'failed' : 'success'
     }
 
     case file_type
     when /Matrix/
       # since genes are not ingested for raw count matrices, report number of cells ingested
-      cells = self.study.expression_matrix_cells(self.study_file)
+      cells = study.expression_matrix_cells(study_file)
       cell_count = cells.present? ? cells.count : 0
-      job_props.merge!({ numCells: cell_count, is_raw_counts: self.study_file.is_raw_counts_file? })
-      if !self.study_file.is_raw_counts_file?
-        genes = Gene.where(study_id: self.study.id, study_file_id: self.study_file.id).count
+      job_props.merge!({ numCells: cell_count, is_raw_counts: study_file.is_raw_counts_file? })
+      if !study_file.is_raw_counts_file?
+        genes = Gene.where(study_id: study.id, study_file_id: study_file.id).count
         job_props.merge!({:numGenes => genes})
       end
     when 'Metadata'
-      use_metadata_convention = self.study_file.use_metadata_convention
+      use_metadata_convention = study_file.use_metadata_convention
       job_props.merge!({useMetadataConvention: use_metadata_convention})
       if use_metadata_convention
         project_name = 'alexandria_convention' # hard-coded is fine for now, consider implications if we get more projects
@@ -577,10 +579,10 @@ class IngestJob
         )
       end
     when 'Cluster'
-      cluster = ClusterGroup.find_by(study_id: self.study.id, study_file_id: self.study_file.id)
-      job_props.merge!({metadataFilePresent: self.study.metadata_file.present?})
+      cluster = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
+      job_props.merge!({metadataFilePresent: study.metadata_file.present?})
       # must make sure cluster is present, as parse failures may result in no data having been stored
-      if self.action == :ingest_cluster && cluster.present?
+      if action == :ingest_cluster && cluster.present?
         cluster_type = cluster.cluster_type
         cluster_points = cluster.points
         can_subsample = cluster.can_subsample?
@@ -601,9 +603,9 @@ class IngestJob
   # * *yields*
   #  - MetricsService.log => reports output of IngestJob#get_job_analytics to Mixpanel via Bard
   def log_to_mixpanel
-    mixpanel_log_props = self.get_job_analytics
+    mixpanel_log_props = get_job_analytics
     # log job properties to Mixpanel
-    MetricsService.log('ingest', mixpanel_log_props, self.user)
+    MetricsService.log('ingest', mixpanel_log_props, user)
   end
 
   # generates parse completion email body
@@ -611,22 +613,22 @@ class IngestJob
   # * *returns*
   #   - (Array) => List of message strings to print in a completion email
   def generate_success_email_array
-    file_type = self.study_file.file_type
+    file_type = study_file.file_type
 
-    message = ["Total parse time: #{self.get_total_runtime}"]
+    message = ["Total parse time: #{get_total_runtime}"]
 
     case file_type
     when /Matrix/
       # since genes are not ingested for raw count matrices, report number of cells ingested
-      if self.study_file.is_raw_counts_file?
-        cells = self.study.expression_matrix_cells(self.study_file).count
+      if study_file.is_raw_counts_file?
+        cells = study.expression_matrix_cells(study_file).count
         message << "Cells ingested: #{cells}"
       else
-        genes = Gene.where(study_id: self.study.id, study_file_id: self.study_file.id).count
+        genes = Gene.where(study_id: study.id, study_file_id: study_file.id).count
         message << "Gene-level entries created: #{genes}"
       end
     when 'Metadata'
-      use_metadata_convention = self.study_file.use_metadata_convention
+      use_metadata_convention = study_file.use_metadata_convention
       if use_metadata_convention
         project_name = 'alexandria_convention' # hard-coded is fine for now, consider implications if we get more projects
         current_schema_version = get_latest_schema_version(project_name)
@@ -637,7 +639,7 @@ class IngestJob
         message << "Ingest Pipeline Docker image version: #{ingest_image_attributes[:tag]}"
         message << "Group-type metadata columns with more than 200 unique values are not made available for visualization."
       end
-      cell_metadata = CellMetadatum.where(study_id: self.study.id, study_file_id: self.study_file.id)
+      cell_metadata = CellMetadatum.where(study_id: study.id, study_file_id: study_file.id)
       message << "Entries created:"
       cell_metadata.each do |metadata|
         unless metadata.nil?
@@ -645,31 +647,36 @@ class IngestJob
         end
       end
     when 'Cluster'
-      cluster = ClusterGroup.find_by(study_id: self.study.id, study_file_id: self.study_file.id)
-      if self.action == :ingest_cluster
+      cluster = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
+      case action
+      when :ingest_cluster
         cluster_type = cluster.cluster_type
         message << "Cluster created: #{cluster.name}, type: #{cluster_type}"
         if cluster.cell_annotations.any?
           message << "Annotations:"
           cluster.cell_annotations.each do |annot|
-            message << self.get_annotation_message(annotation_source: cluster, cell_annotation: annot)
+            message << get_annotation_message(annotation_source: cluster, cell_annotation: annot)
           end
         end
         cluster_points = cluster.points
         message << "Total points in cluster: #{cluster_points}"
 
         can_subsample = cluster.can_subsample?
-        metadata_file_present = self.study.metadata_file.present?
+        metadata_file_present = study.metadata_file.present?
 
         # notify user that subsampling is about to run and inform them they can't delete cluster/metadata files
         if can_subsample && metadata_file_present
-          message << "This cluster file will now be processed to compute representative subsamples for visualization."
-          message << "You will receive an additional email once this has completed."
-          message << "While subsamples are being computed, you will not be able to remove this cluster file or your metadata file."
+          message << 'This cluster file will now be processed to compute representative subsamples for visualization.'
+          message << 'You will receive an additional email once this has completed.'
+          message << 'While subsamples are being computed, you will not be able to remove this cluster file or your metadata file.'
         end
-      else
+      when :subsample
         message << "Subsampling has completed for #{cluster.name}"
         message << "Subsamples generated: #{cluster.subsample_thresholds_required.join(', ')}"
+      when :differential_expression
+        message << 'Differential expression calculations using the following parameters has completed.'
+        message << "Cluster: #{cluster.name}"
+        message << "Annotation: #{}"
       end
     end
     message
@@ -681,7 +688,7 @@ class IngestJob
   # * *returns*
   #   - (String) => HTML anchor tag with link to file directory that can be opened in the browser after authenticating
   def generate_bucket_browser_tag
-    link = "#{self.study.google_bucket_url}/parse_logs/#{self.study_file.id}"
+    link = "#{study.google_bucket_url}/parse_logs/#{study_file.id}"
     '<a href="' + link + '">' + link + '</a>'
   end
 
@@ -697,17 +704,17 @@ class IngestJob
   def generate_error_email_body(email_type: :user)
     case email_type
     when :user
-      error_contents = self.read_parse_logfile(self.user_error_filepath)
-      message_body = "<p>'#{self.study_file.upload_file_name}' has failed during parsing.</p>"
+      error_contents = read_parse_logfile(user_error_filepath)
+      message_body = "<p>'#{study_file.upload_file_name}' has failed during parsing.</p>"
     when :dev
       # only read first megabyte of error log to avoid email delivery failure
-      error_contents = self.read_parse_logfile(self.dev_error_filepath, delete_on_read: false, range: 0..1.megabyte)
-      message_body = "<p>The file '#{self.study_file.upload_file_name}' uploaded by #{self.user.email} to #{self.study.accession} failed to ingest.</p>"
-      message_body += "<p>A copy of this file can be found at #{self.generate_bucket_browser_tag}</p>"
+      error_contents = read_parse_logfile(dev_error_filepath, delete_on_read: false, range: 0..1.megabyte)
+      message_body = "<p>The file '#{study_file.upload_file_name}' uploaded by #{user.email} to #{study.accession} failed to ingest.</p>"
+      message_body += "<p>A copy of this file can be found at #{generate_bucket_browser_tag}</p>"
       message_body += "<p>Detailed logs and PAPI events as follows:"
     else
-      error_contents = self.read_parse_logfile(self.user_error_filepath)
-      message_body = "<p>'#{self.study_file.upload_file_name}' has failed during parsing.</p>"
+      error_contents = read_parse_logfile(user_error_filepath)
+      message_body = "<p>'#{study_file.upload_file_name}' has failed during parsing.</p>"
     end
 
     if error_contents.present?
@@ -720,13 +727,13 @@ class IngestJob
     if !error_contents.present? || email_type == :dev
       message_body += "<h3>Event Messages</h3>"
       message_body += "<ul>"
-      self.event_messages.each do |e|
+      event_messages.each do |e|
         message_body += "<li><pre>#{ERB::Util.html_escape(e)}</pre></li>"
       end
       message_body += "</ul>"
     end
 
-    if self.study_file.file_type == 'Metadata'
+    if study_file.file_type == 'Metadata'
       faq_link = "https://singlecell.zendesk.com/hc/en-us/articles/360060610092-Metadata-Validation-Errors-FAQ"
       message_body += "<h3>Common Errors for Metadata Files</h3>"
       message_body += "<p>You can view a list of common metadata validation errors and solutions in our documentation: "
@@ -734,10 +741,10 @@ class IngestJob
     end
 
     message_body += "<h3>Job Details</h3>"
-    message_body += "<p>Study Accession: <strong>#{self.study.accession}</strong></p>"
-    message_body += "<p>Study File ID: <strong>#{self.study_file.id}</strong></p>"
-    message_body += "<p>Ingest Run ID: <strong>#{self.pipeline_name}</strong></p>"
-    message_body += "<p>Command Line: <strong>#{self.command_line}</strong></p>"
+    message_body += "<p>Study Accession: <strong>#{study.accession}</strong></p>"
+    message_body += "<p>Study File ID: <strong>#{study_file.id}</strong></p>"
+    message_body += "<p>Ingest Run ID: <strong>#{pipeline_name}</strong></p>"
+    message_body += "<p>Command Line: <strong>#{command_line}</strong></p>"
     ingest_image_attributes = AdminConfiguration.get_ingest_docker_image_attributes
     message_body << "<p>Ingest Pipeline Docker image version: <strong>#{ingest_image_attributes[:tag]}</strong></p>"
     message_body
@@ -748,8 +755,8 @@ class IngestJob
   # * *yields*
   #   - Error log messages in event of parse failure
   def log_error_messages
-    self.event_messages.each do |message|
-      Rails.logger.error "#{self.pipeline_name} log: #{message}"
+    event_messages.each do |message|
+      Rails.logger.error "#{pipeline_name} log: #{message}"
     end
   end
 

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -41,8 +41,8 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   def initialize(project=self.class.compute_project, service_account_credentials=self.class.get_primary_keyfile)
 
     credentials = {
-        scope: GOOGLE_SCOPES,
-        json_key_io: File.open(service_account_credentials)
+      scope: GOOGLE_SCOPES,
+      json_key_io: File.open(service_account_credentials)
     }
 
     authorizer = Google::Auth::ServiceAccountCredentials.make_creds(credentials)
@@ -101,11 +101,11 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
     resources = create_resources_object(regions: ['us-central1'])
     command_line = get_command_line(study_file: study_file, action: action, user_metrics_uuid: user.metrics_uuid)
     labels = {
-        study_accession: accession,
-        user_id: user.id.to_s,
-        file_id: study_file.id.to_s,
-        action: action,
-        docker_image: AdminConfiguration.get_ingest_docker_image
+      study_accession: accession,
+      user_id: user.id.to_s,
+      file_id: study_file.id.to_s,
+      action: action,
+      docker_image: AdminConfiguration.get_ingest_docker_image
     }
     environment = set_environment_variables
     action = create_actions_object(commands: command_line, environment: environment)
@@ -142,8 +142,8 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   #   - (Google::Apis::GenomicsV2alpha1::RunPipelineRequest)
   def create_run_pipeline_request_object(pipeline:, labels: {})
     Google::Apis::GenomicsV2alpha1::RunPipelineRequest.new(
-        pipeline: pipeline,
-        labels: labels
+      pipeline: pipeline,
+      labels: labels
     )
   end
 
@@ -159,10 +159,10 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   #   - (Google::Apis::GenomicsV2alpha1::Pipeline)
   def create_pipeline_object(actions:, environment:, resources:, timeout: nil)
     Google::Apis::GenomicsV2alpha1::Pipeline.new(
-        actions: actions,
-        environment: environment,
-        resources: resources,
-        timeout: timeout
+      actions: actions,
+      environment: environment,
+      resources: resources,
+      timeout: timeout
     )
   end
 
@@ -184,12 +184,12 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   #   - (Google::Apis::GenomicsV2alpha1::Action)
   def create_actions_object(commands: [], environment: {}, flags: [], labels: {}, timeout: nil)
     Google::Apis::GenomicsV2alpha1::Action.new(
-        commands: commands,
-        environment: environment,
-        flags: flags,
-        image_uri: AdminConfiguration.get_ingest_docker_image,
-        labels: labels,
-        timeout: timeout
+      commands: commands,
+      environment: environment,
+      flags: flags,
+      image_uri: AdminConfiguration.get_ingest_docker_image,
+      labels: labels,
+      timeout: timeout
     )
   end
 
@@ -206,13 +206,13 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   #   - (Hash) => Hash of required environment variables
   def set_environment_variables
     {
-        'DATABASE_HOST' => ENV['MONGO_INTERNAL_IP'],
-        'MONGODB_USERNAME' => 'single_cell',
-        'MONGODB_PASSWORD' => ENV['PROD_DATABASE_PASSWORD'],
-        'DATABASE_NAME' => Mongoid::Config.clients["default"]["database"],
-        'GOOGLE_PROJECT_ID' => project,
-        'SENTRY_DSN' => ENV['SENTRY_DSN'],
-        'BARD_HOST_URL' => Rails.application.config.bard_host_url
+      'DATABASE_HOST' => ENV['MONGO_INTERNAL_IP'],
+      'MONGODB_USERNAME' => 'single_cell',
+      'MONGODB_PASSWORD' => ENV['PROD_DATABASE_PASSWORD'],
+      'DATABASE_NAME' => Mongoid::Config.clients["default"]["database"],
+      'GOOGLE_PROJECT_ID' => project,
+      'SENTRY_DSN' => ENV['SENTRY_DSN'],
+      'BARD_HOST_URL' => Rails.application.config.bard_host_url
     }
   end
 
@@ -220,14 +220,15 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   #
   # * *params*
   #   - regions: (Array<String>) => An array of GCP regions allowed for VM allocation
+  #   - vm: (Google::Apis::GenomicsV2alpha1::VirtualMachine) => Existing VM config to use, other than default
   #
   # * *return*
   #   - (Google::Apis::GenomicsV2alpha1::Resources)
-  def create_resources_object(regions:)
+  def create_resources_object(regions:, vm: nil)
     Google::Apis::GenomicsV2alpha1::Resources.new(
-         project_id: project,
-         regions: regions,
-         virtual_machine: create_virtual_machine_object
+      project_id: project,
+      regions: regions,
+      virtual_machine: vm.nil? ? create_virtual_machine_object : vm
     )
   end
 
@@ -243,10 +244,10 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   #   - (Google::Apis::GenomicsV2alpha1::VirtualMachine)
   def create_virtual_machine_object(machine_type: 'n1-highmem-4', boot_disk_size_gb: 300, preemptible: false)
     virtual_machine = Google::Apis::GenomicsV2alpha1::VirtualMachine.new(
-        machine_type: machine_type,
-        preemptible: preemptible,
-        boot_disk_size_gb: boot_disk_size_gb,
-        service_account: Google::Apis::GenomicsV2alpha1::ServiceAccount.new(email: issuer, scopes: GOOGLE_SCOPES)
+      machine_type: machine_type,
+      preemptible: preemptible,
+      boot_disk_size_gb: boot_disk_size_gb,
+      service_account: Google::Apis::GenomicsV2alpha1::ServiceAccount.new(email: issuer, scopes: GOOGLE_SCOPES)
     )
     # assign correct network/sub-network if specified
     if GCP_NETWORK_NAME.present? && GCP_SUB_NETWORK_NAME.present?
@@ -302,7 +303,7 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
 
     # add optional command line arguments based on file type and action
     if action.to_s == 'differential_expression'
-      optional_args = get_de_parameters(study_file, extra_options)
+      optional_args = get_de_parameters(extra_options)
     else
       optional_args = get_command_line_options(study_file, action)
     end
@@ -347,7 +348,6 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   # get command line arguments for differential expression runs
   #
   # * *params*
-  #   - +study+file+ (StudyFile) => Clustering StudyFile to use as main DE input
   #   - +options+ (Hash) => Hash of DE-specific parameters, whose names must include all values from DE_PARAMETER_NAMES
   #
   # * *returns*
@@ -355,26 +355,38 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   #
   # * *raises*
   #   - (ArgumentError) => if any required parameters from DE_PARAMETER_NAMES are missing or malformed
-  def get_de_parameters(study_file, options)
+  def get_de_parameters(options)
     # validate input parameters
-    safe_parameters = options.select { |name, _| DE_PARAMETER_NAMES.include?(name.to_s) }
-    puts safe_parameters
-    missing_parameters = DE_PARAMETER_NAMES - safe_parameters.keys.map(&:to_s)
-    raise ArgumentError, "cannot run differential expression due to missing parameters: " \
-                         "#{missing_parameters.join(', ')}" if missing_parameters.any?
+    safe_params = options.select { |name, _| DE_PARAMETER_NAMES.include?(name.to_s) }
+    missing_params = DE_PARAMETER_NAMES - safe_params.keys.map(&:to_s)
+    if missing_params.any?
+      raise ArgumentError, "cannot run differential expression due to missing parameters: #{missing_params.join(', ')}"
+    end
 
     # add all good parameters to params array so they can be deserialized as command line options for Docker
     # will throw an exception if value passed is invalid for the given parameter type
     de_params = []
-    safe_parameters.each do |param_name, value|
+    safe_params.each do |param_name, value|
       if %w[cluster_file annotation_file matrix_file_path].include?(param_name)
         raise ArgumentError, "#{param_name} contains a non-gs URL value: #{value}" unless value.start_with?('gs://')
       end
 
-      de_params += [transform_de_param(param_name), value]
+      de_params += [to_cli_opt(param_name), value]
     end
     de_params << '--differential-expression' # final argument that has no value
     de_params
+  end
+
+  # transform a parameter from Hash key or String into a representation that can be called in the Python CLI
+  # converts underscores (_) to dashes (-) and prepends double dashes (--)
+  #
+  # * *params*
+  #   - +param_name+ (Symbol, String) => Name of parameter
+  #
+  # * *returns*
+  #   - (String) => New parameter name, encoded as kwarg for Python command line
+  def to_cli_opt(param_name)
+    "--#{param_name.to_s.gsub(/_/, '-')}"
   end
 
   private
@@ -404,17 +416,5 @@ class PapiClient < Struct.new(:project, :service_account_credentials, :service)
   #   - (JSON) => Sanitized JSON object with escaped double quotes
   def sanitize_json(json)
     json.gsub("\"", "'")
-  end
-
-  # transform a parameter for differential expression runs
-  # converts underscores (_) to dashes (-) and prepens double dashes (--)
-  #
-  # * *params*
-  #   - +param_name+ (String) => Name of parameter
-  #
-  # * *returns*
-  #   - (String) => New parameter name, encoded for Python command line
-  def transform_de_param(param_name)
-    "--#{param_name.to_s.gsub(/_/, '-')}"
   end
 end

--- a/test/models/differential_expression_parameters_test.rb
+++ b/test/models/differential_expression_parameters_test.rb
@@ -1,0 +1,76 @@
+require 'test_helper'
+
+class DifferentialExpressionParametersTest < ActiveSupport::TestCase
+
+  before(:all) do
+    @dense_options = {
+      annotation_name: 'Category',
+      annotation_type: 'group',
+      annotation_scope: 'cluster',
+      annotation_file: 'gs://test_bucket/metadata.tsv',
+      cluster_file: 'gs://test_bucket/cluster.tsv',
+      cluster_name: 'UMAP',
+      matrix_file_path: 'gs://test_bucket/dense.tsv',
+      matrix_file_type: 'dense'
+    }
+
+    @sparse_options = {
+      annotation_name: 'Category',
+      annotation_type: 'group',
+      annotation_scope: 'cluster',
+      annotation_file: 'gs://test_bucket/metadata.tsv',
+      cluster_file: 'gs://test_bucket/cluster.tsv',
+      cluster_name: 'UMAP',
+      matrix_file_path: 'gs://test_bucket/sparse.tsv',
+      matrix_file_type: 'sparse',
+      gene_file: 'gs://test_bucket/genes.tsv',
+      barcode_file: 'gs://test_bucket/barcodes.tsv'
+    }
+  end
+
+  test 'should instantiate and validate parameters' do
+    dense_params = DifferentialExpressionParameters.new(@dense_options)
+    assert dense_params.valid?
+    sparse_params = DifferentialExpressionParameters.new(@sparse_options)
+    assert sparse_params.valid?
+
+    # test conditional validations
+    dense_params.annotation_file = ''
+    dense_params.annotation_type = 'numeric'
+    dense_params.annotation_scope = 'foo'
+    dense_params.matrix_file_type = 'bar'
+    assert_not dense_params.valid?
+    assert_equal %i[annotation_file annotation_scope annotation_type matrix_file_type],
+                 dense_params.errors.attribute_names.sort
+    sparse_params.gene_file = 'foo'
+    assert_not sparse_params.valid?
+    assert_equal [:gene_file], sparse_params.errors.attribute_names
+  end
+
+  test 'should format differential expression parameters for python cli' do
+    dense_params = DifferentialExpressionParameters.new(@dense_options)
+    options_array = dense_params.to_options_array
+    dense_params.attributes.each do |name, value|
+      next if value.blank? # gene_file and barcode_file will not be set
+
+      expected_name = DifferentialExpressionParameters.to_cli_opt(name)
+      assert_includes options_array, expected_name
+      assert_includes options_array, value
+    end
+    assert_includes options_array, '--differential-expression'
+
+    sparse_params = DifferentialExpressionParameters.new(@sparse_options)
+    options_array = sparse_params.to_options_array
+    sparse_params.attributes.each do |name, value|
+      expected_name = DifferentialExpressionParameters.to_cli_opt(name)
+      assert_includes options_array, expected_name
+      assert_includes options_array, value
+    end
+    assert_includes options_array, '--differential-expression'
+  end
+
+  test 'converts keys into cli options' do
+    assert_equal '--annotation-name', DifferentialExpressionParameters.to_cli_opt(:annotation_name)
+    assert_equal '--foo', DifferentialExpressionParameters.to_cli_opt('foo')
+  end
+end

--- a/test/models/papi_client_test.rb
+++ b/test/models/papi_client_test.rb
@@ -1,0 +1,74 @@
+require 'test_helper'
+
+class PapiClientTest < ActiveSupport::TestCase
+
+  before(:all) do
+    @client = ApplicationController.papi_client
+    @user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                               name_prefix: 'Papi Client Test',
+                               user: @user,
+                               test_array: @@studies_to_clean)
+
+    @expression_matrix = FactoryBot.create(:study_file, name: 'dense.txt', file_type: 'Expression Matrix', study: @study)
+
+    @expression_matrix.build_expression_file_info(is_raw_counts: true, units: 'raw counts',
+                                                  library_preparation_protocol: 'MARS-seq',
+                                                  modality: 'Transcriptomic: unbiased',
+                                                  biosample_input_type: 'Whole cell')
+    @expression_matrix.save!
+    @cluster_file = FactoryBot.create(:cluster_file,
+                                      name: 'cluster.txt', study: @study,
+                                      cell_input: {
+                                        x: [1, 4, 6],
+                                        y: [7, 5, 3],
+                                        z: [2, 8, 9],
+                                        cells: %w[A B C]
+                                      },
+                                      x_axis_label: 'PCA 1',
+                                      y_axis_label: 'PCA 2',
+                                      z_axis_label: 'PCA 3',
+                                      cluster_type: '3d',
+                                      annotation_input: [
+                                        { name: 'Category', type: 'group', values: %w[bar bar baz] },
+                                        { name: 'Intensity', type: 'numeric', values: [1.1, 2.2, 3.3] }
+                                      ])
+  end
+
+  test 'should instantiate client and assign attributes' do
+    client = PapiClient.new
+    assert client.project.present?
+    assert client.service_account_credentials.present?
+    assert client.service.present?
+  end
+
+  test 'should get client issuer' do
+    issuer = @client.issuer
+    assert issuer.match(/gserviceaccount\.com$/)
+  end
+
+  test 'should list pipelines' do
+    pipelines = @client.list_pipelines
+    skip "could not find any pipelines" if !!pipelines&.operations&.empty?
+    assert pipelines.present?
+    assert pipelines.operations.any?
+  end
+
+  test 'should assemble pipeline parameters and submit job' do
+    # we're not actually testing a submission here, as this is also covered in several other integration test suites
+    # this is just testing the interface and ensuring we get to service.run_pipeline
+    @client.service.stub :run_pipeline, true do
+      submission = @client.run_pipeline(study_file: @expression_matrix, user: @user, action: :ingest_expression)
+      assert submission
+    end
+  end
+
+  test 'should get individual pipeline run' do
+    pipelines = @client.list_pipelines
+    skip "could not find any pipelines" if !!pipelines&.operations&.empty?
+    pipeline = pipelines.operations.sample
+    requested_pipeline = @client.get_pipeline(name: pipeline.name)
+    assert_equal pipeline.name, requested_pipeline.name
+    assert_equal pipeline.metadata.dig('pipeline', 'actions'), requested_pipeline.metadata.dig('pipeline','actions')
+  end
+end

--- a/test/models/papi_client_test.rb
+++ b/test/models/papi_client_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 
+# tests for creating various Google Pipelines API (PAPI) objects and submitting/getting running pipelines
 class PapiClientTest < ActiveSupport::TestCase
 
   before(:all) do
@@ -29,6 +30,12 @@ class PapiClientTest < ActiveSupport::TestCase
                                       y_axis_label: 'PCA 2',
                                       z_axis_label: 'PCA 3',
                                       cluster_type: '3d',
+                                      x_axis_min: -1,
+                                      x_axis_max: 1,
+                                      y_axis_min: -2,
+                                      y_axis_max: 2,
+                                      z_axis_min: -3,
+                                      z_axis_max: 3,
                                       annotation_input: [
                                         { name: 'Category', type: 'group', values: %w[bar bar baz] },
                                         { name: 'Intensity', type: 'numeric', values: [1.1, 2.2, 3.3] }
@@ -49,7 +56,7 @@ class PapiClientTest < ActiveSupport::TestCase
 
   test 'should list pipelines' do
     pipelines = @client.list_pipelines
-    skip "could not find any pipelines" if !!pipelines&.operations&.empty?
+    skip 'could not find any pipelines' if !!pipelines&.operations&.empty?
     assert pipelines.present?
     assert pipelines.operations.any?
   end
@@ -65,10 +72,113 @@ class PapiClientTest < ActiveSupport::TestCase
 
   test 'should get individual pipeline run' do
     pipelines = @client.list_pipelines
-    skip "could not find any pipelines" if !!pipelines&.operations&.empty?
+    skip 'could not find any pipelines' if !!pipelines&.operations&.empty?
     pipeline = pipelines.operations.sample
     requested_pipeline = @client.get_pipeline(name: pipeline.name)
     assert_equal pipeline.name, requested_pipeline.name
-    assert_equal pipeline.metadata.dig('pipeline', 'actions'), requested_pipeline.metadata.dig('pipeline','actions')
+    assert_equal pipeline.metadata.dig('pipeline', 'actions'), requested_pipeline.metadata.dig('pipeline', 'actions')
+  end
+
+  test 'should set env vars for pipeline' do
+    env_vars = @client.set_environment_variables
+    assert env_vars.keys.include? 'DATABASE_HOST'
+    assert env_vars.keys.include? 'MONGODB_USERNAME'
+    assert env_vars.keys.include? 'GOOGLE_PROJECT_ID'
+    assert_equal @client.project, env_vars['GOOGLE_PROJECT_ID']
+  end
+
+  test 'should create virtual machine config' do
+    vm = @client.create_virtual_machine_object
+    assert vm.is_a? Google::Apis::GenomicsV2alpha1::VirtualMachine
+    # create different machine type
+    machine_type = 'n2-standard-4'
+    n2_vm = @client.create_virtual_machine_object(machine_type: machine_type, boot_disk_size_gb: 10, preemptible: true)
+    assert n2_vm.is_a? Google::Apis::GenomicsV2alpha1::VirtualMachine
+    assert_equal machine_type, n2_vm.machine_type
+    assert_equal 10, n2_vm.boot_disk_size_gb
+    assert n2_vm.preemptible
+  end
+
+  test 'should create resources object' do
+    regions = %w[us-central1]
+    resources = @client.create_resources_object(regions: regions)
+    assert resources.is_a? Google::Apis::GenomicsV2alpha1::Resources
+    assert_equal regions, resources.regions
+    # try overriding default VM
+    machine_type = 'n2-standard-4'
+    n2_vm = @client.create_virtual_machine_object(machine_type: machine_type)
+    n2_resources = @client.create_resources_object(regions: regions, vm: n2_vm)
+    assert_equal n2_vm, n2_resources.virtual_machine
+  end
+
+  test 'should construct command line for pipeline jobs by file_type' do
+    exp_cmd = @client.get_command_line(study_file: @expression_matrix, action: :ingest_expression,
+                                       user_metrics_uuid: @user.metrics_uuid)
+    assert exp_cmd.any?
+    assert exp_cmd.include? @study.id.to_s
+    assert exp_cmd.include? @expression_matrix.id.to_s
+    assert exp_cmd.include? @expression_matrix.gs_url
+    assert exp_cmd.include? @user.metrics_uuid
+    assert exp_cmd.include? 'dense'
+
+    # try differential expression validation
+    assert_raises ArgumentError do
+      @client.get_command_line(study_file: @cluster_file, action: :differential_expression,
+                               user_metrics_uuid: @user.metrics_uuid)
+    end
+
+    # validate extra args population
+    de_opts = {
+      annotation_name: 'Category',
+      annotation_type: 'group',
+      annotation_scope: 'cluster',
+      annotation_file: @cluster_file.gs_url,
+      cluster_file: @cluster_file.gs_url,
+      cluster_name: 'cluster.txt',
+      matrix_file_path: @expression_matrix.gs_url,
+      matrix_file_type: 'dense'
+    }
+    de_cmd = @client.get_command_line(study_file: @cluster_file, action: :differential_expression,
+                                      user_metrics_uuid: @user.metrics_uuid, extra_options: de_opts)
+    assert de_cmd.any?
+    de_opts.each do |opt_name, opt_val|
+      converted_name = @client.to_cli_opt(opt_name)
+      assert de_cmd.include? converted_name
+      assert de_cmd.include? opt_val
+    end
+    assert de_cmd.include? '--differential-expression'
+  end
+
+  test 'should get extra command line options' do
+    cluster_cmd = @client.get_command_line(study_file: @cluster_file, action: :ingest_cluster,
+                                           user_metrics_uuid: @user.metrics_uuid)
+    assert cluster_cmd.include? '--domain-ranges'
+    sanitized_domains = "{'x':[-1,1],'y':[-2,2],'z':[-3,3]}"
+    assert cluster_cmd.include? sanitized_domains
+  end
+
+  # this test covers many sub-methods that are required to create a pipeline request, such as creating resources,
+  # environment, actions, and pipelines objects
+  test 'should create pipelines request object' do
+    exp_cmd = @client.get_command_line(study_file: @expression_matrix, action: :ingest_expression,
+                                       user_metrics_uuid: @user.metrics_uuid)
+    environment = @client.set_environment_variables
+    actions = @client.create_actions_object(commands: exp_cmd, environment: environment)
+    regions = %w[us-central1]
+    resources = @client.create_resources_object(regions: regions)
+    pipeline = @client.create_pipeline_object(actions: actions, environment: environment, resources: resources)
+    labels = { foo: 'bar' }
+    pipeline_request = @client.create_run_pipeline_request_object(pipeline: pipeline, labels: labels)
+    assert pipeline_request.is_a? Google::Apis::GenomicsV2alpha1::RunPipelineRequest
+    assert_equal pipeline, pipeline_request.pipeline
+    assert_equal actions, pipeline_request.pipeline.actions
+    assert_equal environment, pipeline_request.pipeline.environment
+    assert_equal resources, pipeline_request.pipeline.resources
+    assert_equal exp_cmd, pipeline_request.pipeline.actions.commands
+  end
+
+  test 'converts keys into cli options' do
+    assert_equal '--annotation-name', @client.to_cli_opt(:annotation_name)
+    assert_equal '--foo', @client.to_cli_opt('foo')
   end
 end


### PR DESCRIPTION
This update adds basic command-line integration of launching differential expression jobs from the Rails console using the `PapiClient` class.  This will now take the various inputs required and submit a job via the Pipelines API, which will localize files from the study bucket, run the calculations, and the delocalize outputs back to the bucket.

In addition, this adds test coverage for the `PapiClient` class to ensure against future updates breaking our PAPI submission infrastructure.  Also, extra parameters for differential expression jobs are now managed by the `DifferentialExpressionParameters` class, which will handle validating and setting CLI options for PAPI.

MANUAL TESTING
To fully validate that you can run a DE job on actual data, this will require creating a new study using the following example data (taken from [this](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP294/de-test-2) study on staging).  The example data can be downloaded from here:

[https://console.cloud.google.com/storage/browser/broad-singlecellportal-staging-testing-data/SCP294_DE](https://console.cloud.google.com/storage/browser/broad-singlecellportal-staging-testing-data/SCP294_DE?project=broad-singlecellportal-staging&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&prefix=&forceOnObjectsSortingFiltering=false)

You will need to ingest at least the metadata, clustering, and raw counts matrix for this example to work.
1. Pull this branch, boot as normal, and start `Delayed::Job` workers
2. Set your `Ingest Pipeline Docker Image` to `gcr.io/broad-singlecellportal-staging/scp-ingest-jlc_delocalize_de:dce674337152`
3. Create a new study using the above example data, and ingest required files (this should take 5-10 minutes total)
   *  You can get expression matrix information from `file_supplemental_info.tsv`, though it is not required for this to succeed
4. Once the data is ingested successfully, open up the "Study Details" page for this study and click the link to open the bucket in a browser
5. In a separate rails console session, run the following snippet to assemble the required parameters for the job, interpolating in the accession for your new study:
```
study = Study.find_by(accession: <new study accession>)
cluster_file = study.cluster_ordinations_files.first
metadata_file = study.metadata_file
user = study.user
action = :differential_expression
matrix_file = study.expression_matrix_files.first
options = {
  annotation_name: 'cell_type__ontology_label',
  annotation_type: 'group', 
  annotation_scope: 'study',
  annotation_file: metadata_file.gs_url,
  cluster_file: cluster_file.gs_url,
  cluster_name: cluster_file.name,
  matrix_file_path: matrix_file.gs_url,
  matrix_file_type: 'dense'
}
de_params = DifferentialExpressionParams.new(options)
``` 
6. Submit the job to PAPI:
```
client = ApplicationController.papi_client
job = client.run_pipeline(study_file: cluster_file, user: user, action: action, params_object: de_params)
```
7. To poll for completion, you can re-run the following snippet to ensure that the job completes:
```
pipeline = client.get_pipeline(name: job.name)
pipeline.done?
pipeline.error
```
8. Once `pipeline.done?` returns `true`, confirm that `pipeline.error` returns `nil`
9. Go back to the storage browser tab and validate that the DE output files appear in the bucket:
![Screen Shot 2022-05-04 at 3 39 26 PM](https://user-images.githubusercontent.com/729968/166812978-686a9cae-fe41-4dae-8f2c-d4bc55661d04.png)

This PR satisfies SCP-4194.