### PR TITLE
fixing name of user annotations test class (SCP- 4311)

### DIFF
--- a/test/api/user_annotations_controller_test.rb
+++ b/test/api/user_annotations_controller_test.rb
@@ -3,7 +3,7 @@ require 'user_tokens_helper'
 require 'test_helper'
 require 'includes_helper'
 
-class StudyFilesControllerTest < ActionDispatch::IntegrationTest
+class UserAnnotationsControllerTest < ActionDispatch::IntegrationTest
 
   before(:all) do
     @user = FactoryBot.create(:api_user, test_array: @@users_to_clean)


### PR DESCRIPTION
So, if you ever start seeing weird test failures in a test class that you didn't modify and that don't reproduce locally when you run that individual test, double-check that you didn't copy-pasta that class name into your new test cases.  The errors were from conflicting before(:all) resolutions

TO TEST:
1. run `rails test  test/api/user_annotations_controller_test.rb test/api/study_files_controller_test.rb` to confirm the test suites can be run together.