### PR TITLE
Change `SummaryStatsUtils#storage_sanity_check` to not keep query cursor open (SCP-4334)

### DIFF
--- a/app/lib/summary_stats_utils.rb
+++ b/app/lib/summary_stats_utils.rb
@@ -50,10 +50,12 @@ class SummaryStatsUtils
   # returns a list of all missing files for entire portal for use in nightly_server_report
   def self.storage_sanity_check
     missing_files = []
-    Study.where(queued_for_deletion: false, detached: false).each do |study|
+    valid_accessions = Study.where(queued_for_deletion: false, detached: false).pluck(:accession)
+    valid_accessions.each do |accession|
+      study = Study.find_by(accession: accession)
       begin
         study_missing = study.verify_all_remotes
-        study_missing.any? ? missing_files += study_missing : nil
+        missing_files += study_missing if study_missing.any?
       rescue => e
         # check if the bucket or the workspace is missing and mark study accordingly
         study.set_study_detached_state(e)


### PR DESCRIPTION
The `SummaryStatsUtils#storage_sanity_check` checks the integrity of each study's storage bucket against known files in the database.  This is to prevent errors when trying to download files that may have been deleted from a storage bucket without SCP being updated.  This is part of the nightly server report that is delivered to admins.  This has not run for the past few days due to a problem with the MongoDB query timing out, causing the entire email job to fail.

This update changes the query type for loading studies from an open `where(...).each do |study|` block to one that terminates by loading the requested study accessions, and then loads each study individually by iterating through that array.  This prevents the query cursor from timing out and failing the operation, which then prevents the nightly server report email from delivering.

MANUAL TESTING
Since the root cause of the problem is the size of the production database, and amount of files in our default project, it is impossible to recreate those conditions locally.  You can however validate that the updated `:storage_sanity_check` method still works:
1. Pull this branch, and boot a Rails console session
2. Run `SummaryStatsUtils.storage_sanity_check` and validate that it returns either an empty array, or an array of files potentially missing from your local instance

This PR satisfies SCP-4334.