### PR TITLE
adding git remote update to deploy.sh script (SCP-4185)

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -114,7 +114,8 @@ function main {
 
     # update source on remote host to pull in changes before deployment
     echo "### pulling updated source from git on branch $GIT_BRANCH ###"
-    run_remote_command "git fetch --all --tags" || exit_with_error_message "could not checkout $GIT_BRANCH"
+    run_remote_command "git remote update" || exit_with_error_message "git remote update failed"
+    run_remote_command "git fetch --all --tags" || exit_with_error_message "git fetch --all failed"
     run_remote_command "git checkout yarn.lock" || exit_with_error_message "could not reset yarn.lock file"
     run_remote_command "git checkout $GIT_BRANCH && git pull" || exit_with_error_message "could not checkout $GIT_BRANCH"
     echo "### COMPLETED ###"


### PR DESCRIPTION
PReviously, the jenkins [deploy hotfix to staging](https://scp-jenkins.dsp-techops.broadinstitute.org/job/scp-deploy-hotfix-to-staging) job would fail if the git branch you were trying to deploy was created after the most recent successful build.  This adds a `git remote update` command to ensure git has the latest branch records

TO TEST:
1) pull this branch
2) create a new branch, based off this branch, with a trivial change
3) push your new branch
4) configure the [deploy hotfix to staging](https://scp-jenkins.dsp-techops.broadinstitute.org/job/scp-deploy-hotfix-to-staging) job to point to your new branch
5) run the job, and confirm it does not fail to deploy 