### PR TITLE
adding api_test_helper require to includes_helper (SCP-4342)

### DIFF
--- a/test/includes_helper.rb
+++ b/test/includes_helper.rb
@@ -1,3 +1,5 @@
+require 'api_test_helper'
+
 class ActionDispatch::IntegrationTest
   include ::Minitest::Hooks
   include ::SelfCleaningSuite


### PR DESCRIPTION
Previously, some tests were not capable of being run independently without dependency errors, e.g. `test/integration/study_creation_test.rb`.  This adds a require for 'api_test_helper' to `includes_helper.rb` so that it is not required for each test to have that dependency if needed.

TO TEST
1. run `rails test test/integration/study_creation_test.rb:102` 
2. confirm the test runs, and does not immediately fail with a missing module error

 