### PR TITLE
Moving studies_controller to StudyAware (SCP-3684)

### DIFF
--- a/app/javascript/components/my-studies/StudyUsageInfo.jsx
+++ b/app/javascript/components/my-studies/StudyUsageInfo.jsx
@@ -20,7 +20,7 @@ export default function StudyUsageInfo({ study }) {
 
   /** get the usage information via API call */
   useEffect(() => {
-    fetchStudyUsage(study._id.$oid).then(response => {
+    fetchStudyUsage(study.accession).then(response => {
       setUsageInfo(response)
       setIsLoading(false)
     })

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -740,8 +740,8 @@ export function buildFacetsFromQueryString(facetsParamString) {
 }
 
 /** retrieve usage info for the given study */
-export async function fetchStudyUsage(studyId, mock=false) {
-  const [usageInfo] = await scpApi(`/studies/${studyId}/usage_stats`, defaultInit(), mock)
+export async function fetchStudyUsage(studyAccession, mock=false) {
+  const [usageInfo] = await scpApi(`/studies/${studyAccession}/usage_stats`, defaultInit(), mock)
   return usageInfo
 }
 

--- a/test/api/studies_controller_test.rb
+++ b/test/api/studies_controller_test.rb
@@ -47,10 +47,18 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    # ensure we can get study by accession
+    execute_http_request(:get, "/single_cell/api/v1/studies/#{@study.accession}")
+    assert_response :success
+    assert_equal @study.accession, json['accession']
+
     # ensure other users cannot access study
     sign_in_and_update(@user_2)
     execute_http_request(:get, api_v1_study_path(@study), user: @user_2)
     assert_response 403
+
+
+
   end
 
   # create, update & delete tested together to use new object rather than main testing study

--- a/test/api/studies_controller_test.rb
+++ b/test/api/studies_controller_test.rb
@@ -56,9 +56,6 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
     sign_in_and_update(@user_2)
     execute_http_request(:get, api_v1_study_path(@study), user: @user_2)
     assert_response 403
-
-
-
   end
 
   # create, update & delete tested together to use new object rather than main testing study

--- a/test/js/study-usage.test.js
+++ b/test/js/study-usage.test.js
@@ -42,7 +42,7 @@ describe('Usage info for a given study', () => {
     }
     render(<StudyUsageInfo study={study}/>)
     await waitForElementToBeRemoved(() => screen.getByTestId('study-usage-spinner'))
-    expect(fetchUsageInfo).toHaveBeenLastCalledWith('fakeId4')
+    expect(fetchUsageInfo).toHaveBeenLastCalledWith('SCP12')
 
     expect(mockPlotlyReact).toHaveBeenLastCalledWith('study-usage-graph-2', [{
       type: 'bar',


### PR DESCRIPTION
This updates api/v1/studies_controller to be STudyAware compatible, which means it can take either accessions or ids as the url parameter.  This then updates the new study usage page to use accession rather than id.

TO TEST:
0. open the chrome network tab 
1. go to the study settings page for a study.  Click "usage stats"
2. in the network tab, observe that a request went out for `/single_cell/api/studies/SCPXXX/usage_stats`  (as opposed to  `/single_cell/api/studies/[[study_id]]/usage_stats` 
3. Load the explore tab for a study, and confirm that clusters still load