### PR TITLE
updating default color scale behavior (SCP-4365)

### DIFF
--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -167,14 +167,6 @@ module Api
           include_annotation = data_fields.include?('annotation')
           include_cells = data_fields.include?('cells')
 
-          colorscale = url_params[:colorscale]
-          if colorscale.blank?
-            colorscale = study.default_color_profile
-            if colorscale.blank?
-              colorscale = 'Reds'
-            end
-          end
-
           is_annotated_scatter = !url_params[:is_annotated_scatter].blank?
           is_correlated_scatter = !url_params[:is_correlated_scatter].blank?
 

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -335,6 +335,7 @@ export default function ExploreDisplayTabs({
                     plotPointsSelected,
                     showRelatedGenesIdeogram,
                     showViewOptionsControls,
+                    scatterColor: exploreParamsWithDefaults.scatterColor,
                     dataCache
                   }}/>
               </div>

--- a/app/javascript/components/explore/ExploreView.jsx
+++ b/app/javascript/components/explore/ExploreView.jsx
@@ -72,7 +72,7 @@ function createExploreParamsWithDefaults(exploreParams, exploreInfo) {
     }
   }
   if (!exploreParams.userSpecified['scatterColor'] && exploreInfo?.colorProfile) {
-    controlExploreParams.scatterColor = exploreInfo.defaultColorProfile
+    controlExploreParams.scatterColor = exploreInfo.colorProfile
   }
   return controlExploreParams
 }

--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -16,7 +16,7 @@ const MAX_PLOTS = PLOTLY_CONTEXT_NAMES.length
   */
 export default function ScatterTab({
   exploreInfo, exploreParams, updateExploreParams, studyAccession, isGene, isMultiGene,
-  plotPointsSelected, isCellSelecting, showRelatedGenesIdeogram, showViewOptionsControls, dataCache
+  plotPointsSelected, isCellSelecting, showRelatedGenesIdeogram, showViewOptionsControls, scatterColor, dataCache
 }) {
   // maintain the map of plotly contexts to the params that generated the corresponding visualization
   const plotlyContextMap = useRef({})
@@ -65,6 +65,7 @@ export default function ScatterTab({
               }}
               {...params}
               dataCache={dataCache}
+              scatterColor={scatterColor}
               canEdit={exploreInfo.canEdit}
               dimensionProps={{
                 isMultiRow,

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -398,7 +398,7 @@ function getPlotlyTraces({
   hiddenTraces,
   scatter: {
     axes, data, pointAlpha, pointSize, is3D,
-    scatterColor: dataScatterColor,
+    colorScale: dataScatterColor,
     annotParams: { name: annotName, type: annotType },
     customColors = {}
   },

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -398,7 +398,6 @@ function getPlotlyTraces({
   hiddenTraces,
   scatter: {
     axes, data, pointAlpha, pointSize, is3D,
-    colorScale: dataScatterColor,
     annotParams: { name: annotName, type: annotType },
     customColors = {}
   },
@@ -459,13 +458,12 @@ function getPlotlyTraces({
     }
 
     if (!isAnnotatedScatter) {
-      const appliedScatterColor = getScatterColorToApply(dataScatterColor, scatterColor)
       const title = isGeneExpressionForColor ? axes.titles.magnitude : annotName
 
       Object.assign(workingTrace.marker, {
         showscale: true,
-        colorscale: appliedScatterColor,
-        reversescale: shouldReverseScale(appliedScatterColor),
+        colorscale: scatterColor,
+        reversescale: shouldReverseScale(scatterColor),
         color: colors,
         colorbar: { title, titleside: 'right' }
       })
@@ -508,15 +506,6 @@ function addHoverLabel(trace, annotName, annotType, genes, isAnnotatedScatter, i
     groupHoverTemplate = `(%{x}, %{y})<br>%{text} (%{meta})<br>${bottomRowLabel}: %{marker.color}<extra></extra>`
   }
   trace.hovertemplate = groupHoverTemplate
-}
-
-/** Gets color on the given traces.  If no color is specified, use color from data */
-function getScatterColorToApply(dataScatterColor, scatterColor) {
-  // Set color scale
-  if (!scatterColor) {
-    scatterColor = dataScatterColor
-  }
-  return scatterColor
 }
 
 /** Gets Plotly layout object for scatter plot */

--- a/app/views/site/_study_settings_viz.html.erb
+++ b/app/views/site/_study_settings_viz.html.erb
@@ -16,10 +16,6 @@
           <%= opts.label :annotation, 'Default annotation' %><br />
           <%= opts.select :annotation, grouped_options_for_select(@default_cluster_annotations, @study.default_annotation), {},class: 'form-control' %>
         </div>
-        <div class="col-sm-4">
-          <%= opts.label :color_profile, "Default color profile <i class='fas fa-info-circle' title='The default color profile only applies to the selected annotation (if the type is numeric)' data-toggle='tooltip'></i>".html_safe %><br />
-          <%= opts.select :color_profile, options_for_select(SiteController::COLORSCALE_THEMES, @study.default_color_profile), {include_blank: 'N/A'} , class: 'form-control', disabled: @study.default_annotation_type == 'group' %>
-        </div>
       </div>
       <div class="form-group row">
         <div class="col-sm-4">
@@ -33,6 +29,12 @@
         <div class="col-sm-4">
           <%= opts.label :cluster_point_alpha, "Cluster point opacity <i class='fas fa-fw fa-question-circle' data-toggle='tooltip' title='Global value for the transparency (alpha) of all cluster points.  Only values between 0 and 1 are accepted.'></i>".html_safe %><br />
           <%= opts.number_field :cluster_point_alpha, value: @study.default_cluster_point_alpha, in: 0.0..1.0, step: 0.05, class: 'form-control' %>
+        </div>
+      </div>
+      <div class="form-group row">
+        <div class="col-sm-4">
+          <%= opts.label :color_profile, "Default color profile <i class='fas fa-info-circle' title='Default color profile for numeric annotations and expression plots' data-toggle='tooltip'></i>".html_safe %><br />
+          <%= opts.select :color_profile, options_for_select(SiteController::COLORSCALE_THEMES, @study.default_color_profile), {include_blank: 'N/A'} , class: 'form-control' %>
         </div>
       </div>
       <div class="form-group row">

--- a/app/views/studies/_study_default_options_form.html.erb
+++ b/app/views/studies/_study_default_options_form.html.erb
@@ -22,15 +22,25 @@
           <%= f.label :annotation, 'Default Annotation' %><br />
           <%= f.select :annotation, grouped_options_for_select(@default_cluster_annotations, @study.default_annotation), {}, class: 'form-control' %>
         </div>
-        <div class="col-sm-4">
-          <%= f.label :color_profile, "Default Color Profile <i class='fas fa-info-circle' title='The default color profile only applies to the selected annotation (if the type is numeric)' data-toggle='tooltip'></i>".html_safe %><br />
-          <%= f.select :color_profile, options_for_select(SiteController::COLORSCALE_THEMES, @study.default_color_profile), {include_blank: 'N/A'} , class: 'form-control', disabled: @study.default_annotation_type == 'group' %>
-        </div>
       </div>
       <div class="form-group row">
         <div class="col-sm-4">
           <%= f.label :cluster_point_size, "Size of Cluster Points (in px) <i class='fas fa-fw fa-question-circle' data-toggle='tooltip' title='Global value for the size of all cluster points, in pixels.'></i>".html_safe %><br />
           <%= f.number_field :cluster_point_size, value: @study.default_cluster_point_size, class: 'form-control' %>
+        </div>
+        <div class="col-sm-4">
+          <%= f.label :cluster_point_border, 'Show Cluster Point Borders?' %><br />
+          <%= f.select :cluster_point_border, options_for_select([['Yes', true],['No', false]], @study.show_cluster_point_borders?) , {}, class: 'form-control' %>
+        </div>
+        <div class="col-sm-4">
+          <%= f.label :cluster_point_alpha, "Cluster Point Opacity <i class='fas fa-fw fa-question-circle' data-toggle='tooltip' title='Global value for the transparency (alpha) of all cluster points.  Only values between 0 and 1 are accepted.'></i>".html_safe %><br />
+          <%= f.number_field :cluster_point_alpha, value: @study.default_cluster_point_alpha, in: 0.0..1.0, step: 0.05, class: 'form-control' %>
+        </div>
+      </div>
+      <div class="form-group row">
+        <div class="col-sm-4">
+          <%= f.label :color_profile, "Default Color Profile <i class='fas fa-info-circle' title='The default color profile only applies to the selected annotation (if the type is numeric)' data-toggle='tooltip'></i>".html_safe %><br />
+          <%= f.select :color_profile, options_for_select(SiteController::COLORSCALE_THEMES, @study.default_color_profile), {include_blank: 'N/A'} , class: 'form-control' %>
         </div>
         <div class="col-sm-4">
           <%= f.label :cluster_point_border, 'Show Cluster Point Borders?' %><br />


### PR DESCRIPTION
This repurposes the study default color profile to apply to all continuous data scatter plots, and not just the default (numeric) annotation.  It also cleans up some cruft in clusters_controller and ScatterPlot -- there was still code floating around as if we were returning the colorscale to use along with the plot itself.  That's not something we do anymore (and we don't want to -- we want the color scale to be owned by the frontend).

TO TEST:
1. load a study, click around expression and numeric cluster plots and confirm the default 'Reds' colorscale is used
2. go to Study Settings, and change the default color profile to something else
3. Reload the page (take care that there are no leftover extra URL params)
4. Confirm expression and numeric annotation plots load with the selected color scale