### PR TITLE
Pin DE pilot to default home page study list (SCP-4366)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -368,6 +368,15 @@ module Api
           end
         end
 
+        # Pin public DE pilot study to second row of home page default study list
+        # TODO (SCP-4374): Remove this block once frontend uses is_differential_expression_enabled
+        if Rails.env.production? && !params[:terms].present? && !@facets.any?
+          de_accession = "SCP1671"
+          differential_expression_study = @studies.find {|study| study.accession == de_accession}
+          @studies.delete_if {|study| study.accession == de_accession}
+          @studies.insert(1, differential_expression_study)
+        end
+
         @matching_accessions = @studies.map { |study| self.class.get_study_attribute(study, :accession) }
 
         logger.info "Final list of matching studies: #{@matching_accessions}"


### PR DESCRIPTION
This pins our differential expression pilot to the home page, to help assess user interest in differential expression.

The DE pilot -- [SCP1671](https://singlecell.broadinstitute.org/single_cell/study/SCP1671), "Cellular and transcriptional diversity over the course of human lactation" -- will be the second study in the study list shown upon loading the home page.  It will only be pinned if the user hasn't searched.  

By making the study more prominent, we hope to increase its traffic and thus faster measure if users engage with the new differential expression MVP (#1502).  Otherwise, we risk getting a false-positive lack of signal, or especially noisy engagement rates due to low-cardinality data.

To test:
1. Go to default home page, without searching anything
2. Go to last page, get accession for a study in it -- we'll call this the DE pilot here
3. In `app/controllers/api/v1/search_controller.rb` line 373, comment out `Rails.env.production? && `
4. Replace SCP1671 with accession from step 2
5. Go to default home page, without searching anything
6. Confirm study originally on last page is now on first page
7. Do a keyword search
8. Confirm "DE pilot" study is not 2nd result
9. Do a faceted search
10. Confirm "DE pilot" study is not 2nd result

This satisfies SCP-4366.