### PR TITLE
Hotfix: Ignore pinning DE study if viewing collection (SCP-4388)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -370,7 +370,7 @@ module Api
 
         # Pin public DE pilot study to second row of home page default study list
         # TODO (SCP-4374): Remove this block once frontend uses is_differential_expression_enabled
-        if Rails.env.production? && params[:terms].blank? && @facets.empty?
+        if Rails.env.production? && params[:terms].blank? && @facets.empty? && @selected_branding_group.nil?
           de_accession = "SCP1671"
           differential_expression_study = @studies.find {|study| study.accession == de_accession}
           @studies.delete_if {|study| study.accession == de_accession}


### PR DESCRIPTION
This is a hotfix to ignore pinning the differential expression example study to empty search results when viewing a collection.  The bug is that this study does not exist in any collection other than Alexandria on production, and as such will insert a `nil` object into the array of studies, which then errors out when attempting to correctly sort/weight results.

MANUAL TESTING
1. Pull branch and boot as normal
2. If you do not have any collections, run `SyntheticBrandingGroupPopulator.populate_all` (you will need DelayedJob running for this)
3. In `app/controllers/api/v1/search_controller.rb`, line 373, remove `Rails.env.production? &&`
4. Click "Browse collections" and select any collection
5. Confirm that the home page loads studies w/o error

This PR satisfies SCP-4388.