### PR TITLE
Adding convenience methods to backfill differential expression data (SCP-4196)

### DIFF
--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -1,5 +1,109 @@
 # handle launching differential expression ingest jobs
 class DifferentialExpressionService
+  # run a differential expression job for a given study on the default cluster/annotation
+  #
+  # * *params*
+  #   - +study_accession+ (String) => Accession of study to use
+  #   - +user+ (User) => Corresponding user, will default to study owner
+  #
+  # * *yields*
+  #   - (IngestJob) => Differential expression job in PAPI
+  #
+  # * *returns*
+  #   - (Boolean) => True if job queues successfully
+  #
+  # * *raises*
+  #   - (ArgumentError) => if requested parameters do not validate
+  def self.run_differential_expression_on_default(study_accession, user: nil)
+    study = Study.find_by(accession: study_accession)
+    validate_study(study)
+    annotation_name, annotation_type, annotation_scope = study.default_annotation.split('--')
+    annotation = {
+      annotation_name: annotation_name,
+      annotation_type: annotation_type,
+      annotation_scope: annotation_scope
+    }
+    cluster_file = study.default_cluster.study_file
+    requested_user = user || study.user
+    run_differential_expression_job(cluster_file, study, requested_user, **annotation)
+  end
+
+  # same as above method, except runs differential expression job on all valid annotations
+  #
+  # * *params*
+  #   - +study_accession+ (String) => Accession of study to use
+  #   - +user+ (User) => Corresponding user, will default to study owner
+  #
+  # * *yields*
+  #   - (IngestJob) => Differential expression job in PAPI for each valid cluster/annotation combination
+  #
+  # * *raises*
+  #   - (ArgumentError) => if requested study cannot run any DE jobs
+  def self.run_differential_expression_on_all(study_accession, user: nil)
+    study = Study.find_by(accession: study_accession)
+    validate_study(study)
+    available_annotations = []
+
+    metadata = study.cell_metadata.where(annotation_type: 'group', is_differential_expression_enabled: false)
+                    .select(&:can_visualize?)
+    available_annotations += metadata.map do |meta|
+      { annotation_name: meta.name, annotation_type: meta.annotation_type, annotation_scope: 'study' }
+    end
+
+    cell_annotations = []
+    study.cluster_groups.each do |cluster|
+      next if cluster.cell_annotations.empty?
+
+      cell_annots = cluster.cell_annotations.select do |annot|
+        annot['type'] == 'group' &&
+          cluster.can_visualize_cell_annotation?(annot) &&
+          !annot[:is_differential_expression_enabled]
+      end
+
+      cell_annots.each do |annot|
+        annot[:cluster_file_id] = cluster.study_file.id # for checking associations later
+      end
+
+      cell_annotations += cell_annots
+    end
+
+    available_annotations += cell_annotations.map do |annot|
+      {
+        annotation_name: annot[:name],
+        annotation_type: annot[:type],
+        annotation_scope: 'cluster',
+        cluster_file_id: annot[:cluster_file_id]
+      }
+    end
+    raise ArgumentError, "#{study_accession} does not have any valid annotations" if available_annotations.empty?
+
+    log_message "#{study_accession} has data available for DE; validating inputs"
+    requested_user = user || study.user
+
+    job_count = 0
+    study.cluster_ordinations_files.each do |cluster_file|
+      available_annotations.each do |annotation|
+        begin
+          # skip if this is a cluster-based annotation and is not available on this cluster file
+          next if annotation[:scope] == 'cluster' && annotation[:cluster_file_id] != cluster_file.id
+
+          annotation_params = annotation.deep_dup # make a copy so we don't lose the association next time we check
+          annotation_params.delete(:cluster_file_id)
+          job_identifier = "#{study_accession}: #{cluster_file.name} (#{annotation_params})"
+          log_message "Checking DE job for #{job_identifier}"
+          DifferentialExpressionService.run_differential_expression_job(
+            cluster_file, study, requested_user, **annotation_params
+          )
+          log_message "DE job for #{job_identifier} successfully launched"
+          job_count += 1
+        rescue ArgumentError => e
+          log_message "Skipping DE job for #{job_identifier} due to: #{e.message}"
+        end
+      end
+    end
+    log_message "#{study_accession} yielded #{job_count} differential expression jobs"
+  end
+
   # handle setting up and launching a differential expression job
   #
   # * *params*
@@ -19,6 +123,7 @@ class DifferentialExpressionService
   # * *raises*
   #   - (ArgumentError) => if requested parameters do not validate
   def self.run_differential_expression_job(cluster_file, study, user, annotation_name:, annotation_type:, annotation_scope:)
+    validate_study(study)
     validate_annotation(cluster_file, study, annotation_name, annotation_type, annotation_scope)
 
     # begin assembling parameters
@@ -86,5 +191,26 @@ class DifferentialExpressionService
     identifier = "#{annotation_name}--#{annotation_type}--#{annotation_scope}"
     raise ArgumentError, "#{identifier} is not present" if annotation.nil?
     raise ArgumentError, "#{identifier} cannot be visualized" unless can_visualize
+  end
+
+  # validate a given study is able to run DE job
+  #
+  # * *params*
+  #   - +study+ (Study) => Study to validate
+  #
+  # * *raises*
+  #   - (ArgumentError) => If requested study is not eligible for DE
+  def self.validate_study(study)
+    raise ArgumentError, 'Requested study does not exist' if study.nil?
+    raise ArgumentError, "#{study.accession} is not public" unless study.public?
+    raise ArgumentError, "#{study.accession} is not initialized" unless study.initialized?
+    raise ArgumentError, "#{study.accession} has no default cluster" if study.default_cluster.blank?
+    raise ArgumentError, "#{study.accession} has no default annotation" if study.default_annotation.blank?
+  end
+
+  # shortcut to log to STDOUT and Rails log simultaneously
+  def self.log_message(message)
+    puts message
+    Rails.logger.info message
   end
 end

--- a/test/integration/lib/differential_expression_service_test.rb
+++ b/test/integration/lib/differential_expression_service_test.rb
@@ -28,7 +28,12 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
                                        y: [7, 5, 3],
                                        cells: @cells
                                      },
-                                     annotation_input: [{ name: 'foo', type: 'group', values: %w[bar bar bar] }])
+                                     annotation_input: [
+                                       {
+                                         name: 'foo', type: 'group', values: %w[bar bar baz],
+                                         is_differential_expression_enabled: false
+                                       }
+                                     ])
     FactoryBot.create(:metadata_file,
                       name: 'metadata.txt',
                       study: @basic_study,
@@ -42,13 +47,25 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
       annotation_type: 'group',
       annotation_scope: 'study'
     }
+    @basic_study.update(initialized: true)
+
+    # parameters for creating "all cells" array, since this needs to be created/destroyed after every run
+    @all_cells_array_params = {
+      name: 'raw.txt Cells', array_type: 'cells', linear_data_type: 'Study', study_id: @basic_study.id,
+      cluster_name: 'raw.txt', array_index: 0, linear_data_id: @basic_study.id, study_file_id: @raw_matrix.id,
+      cluster_group_id: nil, subsample_annotation: nil, subsample_threshold: nil, values: @cells
+    }
+  end
+
+  teardown do
+    DataArray.find_by(@all_cells_array_params)&.destroy
   end
 
   test 'should validate parameters and launch differential expression job' do
     # should fail on annotation missing
     assert_raise ArgumentError do
       DifferentialExpressionService.run_differential_expression_job(
-        @cluster_file, @basic_study, @user, annotation_name: 'foo', annotation_type: 'group', annotation_scope: 'cluster'
+        @cluster_file, @basic_study, @user, annotation_name: 'NA', annotation_type: 'group', annotation_scope: 'study'
       )
     end
 
@@ -57,10 +74,8 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
       DifferentialExpressionService.run_differential_expression_job(@cluster_file, @basic_study, @user, **@job_params)
     end
     # test launch by manually creating expression matrix cells array for validation
-    DataArray.create!(name: 'raw.txt Cells', array_type: 'cells', linear_data_type: 'Study', study_id: @basic_study.id,
-                      cluster_name: 'raw.txt', array_index: 0, linear_data_id: @basic_study.id,
-                      study_file_id: @raw_matrix.id, cluster_group_id: nil, subsample_annotation: nil,
-                      subsample_threshold: nil, values: @cells)
+    DataArray.create!(@all_cells_array_params)
+
     # we need to mock 2 levels deep as :delay should yield the :push_remote_and_launch_ingest mock
     job_mock = Minitest::Mock.new
     job_mock.expect(:push_remote_and_launch_ingest, Delayed::Job.new, [Hash])
@@ -74,5 +89,33 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
       mock.verify
       job_mock.verify
     end
+  end
+
+  test 'should run differential expression job on study defaults' do
+    # test validation
+    @basic_study.update(default_options: {})
+    assert_raise ArgumentError do
+      DifferentialExpressionService.run_differential_expression_job(@cluster_file, @basic_study, @user, **@job_params)
+    end
+
+    @basic_study.update(default_options: { cluster: 'cluster_diffexp.txt', annotation: 'species--group--study' })
+    DataArray.create!(@all_cells_array_params)
+    job_mock = Minitest::Mock.new
+    job_mock.expect(:push_remote_and_launch_ingest, Delayed::Job.new, [Hash])
+    mock = Minitest::Mock.new
+    mock.expect(:delay, job_mock)
+    IngestJob.stub :new, mock do
+      job_launched = DifferentialExpressionService.run_differential_expression_on_default(@basic_study.accession)
+      assert job_launched
+      mock.verify
+      job_mock.verify
+    end
+  end
+
+  test 'should run differential expression job on all annotations' do
+    DataArray.create!(@all_cells_array_params)
+
+    jobs_launched = DifferentialExpressionService.run_differential_expression_on_all(@basic_study.accession)
+    assert_equal 3, jobs_launched
   end
 end


### PR DESCRIPTION
This update adds two convenience methods to `DifferentialExpressionService` for backfilling data on existing studies:

1. `run_differential_expression_on_default`: for a specified study, run a DE job on the default annotation, if valid
2. `run_differential_expression_on_all`: for a specified study, run a DE job all valid study- and cluster-based annotations

Both methods accept a study accession as input, and an optional `User` object for handling email delivery (otherwise will default to the study owner).

MANUAL TESTING
1. Boot as normal, and start DelayedJob
2. Complete step 3 from #1483 if you have not already added the testing differential expression study to your local instance
3. Once ingested, load the study from above in a Rails console session and set the default annotation to `disease__ontology_label`:
```
accession = <accession of DE study>
study = Study.find_by(accession: accession)
study.default_options[:annotation] = 'disease__ontology_label--group--study'
study.save
```
4. Run a DE job on the new default annotation, and confirm the output is `true`
```
DifferentialExpressionService.run_differential_expression_on_default(accession)
```
5. (Optional) Once the job completes, run DE jobs for all remaining annotations (there should be 5 or 6, depending on what has already been computed):
```
DifferentialExpressionService.run_differential_expression_on_all(accession)
```

This PR satisfies SCP-4196