### PR TITLE
persist hidden traces (SCP-4380)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -208,6 +208,11 @@ export default function ExploreDisplayTabs({
     ) {
       updateParams.tab = 'annotatedScatter'
     }
+    // if the user changes annotation, unset hiddenTraces
+    if (newParams.annotation && newParams.annotation.name !== exploreParams.annotation.name) {
+      updateParams.hiddenTraces = []
+    }
+
     updateExploreParams(updateParams)
   }
 

--- a/app/javascript/components/explore/ExploreTabRouter.jsx
+++ b/app/javascript/components/explore/ExploreTabRouter.jsx
@@ -117,6 +117,9 @@ function buildExploreParamsFromQuery(query) {
       exploreParams.expressionFilter = filterArray
     }
   }
+
+  exploreParams.hiddenTraces = queryParams.hiddenTraces ? queryParams.hiddenTraces.split(',') : []
+  exploreParams.splitLabelArrays = queryParams.splitLabelArrays === 'true' ? true : null
   return exploreParams
 }
 
@@ -138,7 +141,9 @@ function buildQueryFromParams(exploreParams) {
     heatmapFit: exploreParams.heatmapFit,
     bamFileName: exploreParams.bamFileName,
     ideogramFileId: exploreParams.ideogramFileId,
-    expressionFilter: exploreParams.expressionFilter ? exploreParams.expressionFilter.join(FILTER_RANGE_DELIMITER) : undefined
+    expressionFilter: exploreParams.expressionFilter ? exploreParams.expressionFilter.join(FILTER_RANGE_DELIMITER) : undefined,
+    hiddenTraces: exploreParams.hiddenTraces.join(','),
+    splitLabelArrays: exploreParams.splitLabelArrays ? 'true' : undefined
   }
 
   if (querySafeOptions.spatialGroups === '' && exploreParams.userSpecified['spatialGroups']) {
@@ -157,7 +162,7 @@ function buildQueryFromParams(exploreParams) {
 /** controls list in which query string params are rendered into URL bar */
 const PARAM_LIST_ORDER = ['geneList', 'genes', 'cluster', 'spatialGroups', 'annotation', 'subsample', 'consensus',
   'tab', 'scatterColor', 'distributionPlot', 'distributionPoints',
-  'heatmapFit', 'heatmapRowCentering', 'bamFileName', 'ideogramFileId', 'expressionFilter']
+  'heatmapFit', 'heatmapRowCentering', 'bamFileName', 'ideogramFileId', 'expressionFilter', 'splitLabelArrays', 'hiddenTraces']
 /** sort function for passing to stringify to ensure url params are specified in a user-friendly order */
 function paramSorter(a, b) {
   return PARAM_LIST_ORDER.indexOf(a) - PARAM_LIST_ORDER.indexOf(b)

--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -64,7 +64,7 @@ export default function ScatterTab({
             <ScatterPlot
               {...{
                 studyAccession, plotPointsSelected, isCellSelecting, updateScatterColor,
-                countsByLabel, setCountsByLabel
+                countsByLabel, setCountsByLabel, updateExploreParams
               }}
               {...params}
               dataCache={dataCache}

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -37,22 +37,22 @@ window.Plotly = Plotly
   * @param isCellSelecting whether plotly's lasso selection tool is enabled
   * @param plotPointsSelected {function} callback for when a user selects points on the plot, which corresponds
   *   to the plotly "points_selected" event
+  * @param hiddenTraces {String[]} labels to hide from the plot
   * @param canEdit {Boolean} whether the current user has permissions to edit this study
   */
 function RawScatterPlot({
   studyAccession, cluster, annotation, subsample, consensus, genes, scatterColor, dimensionProps,
   isAnnotatedScatter=false, isCorrelatedScatter=false, isCellSelecting=false, plotPointsSelected, dataCache,
   canEdit, expressionFilter=[0, 1],
-  countsByLabel, setCountsByLabel
+  countsByLabel, setCountsByLabel, hiddenTraces=[], updateExploreParams
 }) {
   const [isLoading, setIsLoading] = useState(false)
   const [bulkCorrelation, setBulkCorrelation] = useState(null)
   const [labelCorrelations, setLabelCorrelations] = useState(null)
   const [scatterData, setScatterData] = useState(null)
   // array of trace names (strings) to show in the graph
-  const [hiddenTraces, setHiddenTraces] = useState([])
   const [graphElementId] = useState(_uniqueId('study-scatter-'))
-  const { ErrorComponent, setShowError, setErrorContent } = useErrorMessage()
+  const { ErrorComponent, setShowError } = useErrorMessage()
   const [activeTraceLabel, setActiveTraceLabel] = useState(null)
   // map of label name to color hex codes, for any labels the user has picked a color for
   const [editedCustomColors, setEditedCustomColors] = useState({})
@@ -68,24 +68,24 @@ function RawScatterPlot({
    * plot.
    */
   function updateHiddenTraces(labels, value, applyToAll=false) {
-    let newShownTraces
+    let newHiddenTraces
     if (applyToAll) {
       // Handle multi-filter interaction
-      newShownTraces = (value ? labels : [])
+      newHiddenTraces = (value ? labels : [])
     } else {
       // Handle single-filter interaction
       const label = labels
-      newShownTraces = [...hiddenTraces]
+      newHiddenTraces = [...hiddenTraces]
 
-      if (value && !newShownTraces.includes(label)) {
-        newShownTraces.push(label)
+      if (value && !newHiddenTraces.includes(label)) {
+        newHiddenTraces.push(label)
       }
       if (!value) {
-        _remove(newShownTraces, thisLabel => {return thisLabel === label})
+        _remove(newHiddenTraces, thisLabel => {return thisLabel === label})
       }
     }
 
-    setHiddenTraces(newShownTraces)
+    updateExploreParams({ hiddenTraces: newHiddenTraces })
   }
 
   /** Get new, updated scatter object instance, and new layout */

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -57,7 +57,7 @@ function RawScatterPlot({
   // map of label name to color hex codes, for any labels the user has picked a color for
   const [editedCustomColors, setEditedCustomColors] = useState({})
 
-  const isRefGroup = getIsRefGroup(annotation?.type, genes, isCorrelatedScatter)
+  const isRefGroup = getIsRefGroup(scatterData?.annotParams?.type, genes, isCorrelatedScatter)
 
   /**
    * Handle user interaction with one or more labels in legend.

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -44,7 +44,7 @@ function RawScatterPlot({
   studyAccession, cluster, annotation, subsample, consensus, genes, scatterColor, dimensionProps,
   isAnnotatedScatter=false, isCorrelatedScatter=false, isCellSelecting=false, plotPointsSelected, dataCache,
   canEdit, expressionFilter=[0, 1],
-  countsByLabel, setCountsByLabel, hiddenTraces=[], updateExploreParams
+  countsByLabel, setCountsByLabel, hiddenTraces=[], splitLabelArrays, updateExploreParams
 }) {
   const [isLoading, setIsLoading] = useState(false)
   const [bulkCorrelation, setBulkCorrelation] = useState(null)
@@ -56,9 +56,8 @@ function RawScatterPlot({
   const [activeTraceLabel, setActiveTraceLabel] = useState(null)
   // map of label name to color hex codes, for any labels the user has picked a color for
   const [editedCustomColors, setEditedCustomColors] = useState({})
-  const [splitLabelArrays, setSplitLabelArrays] = useState(null)
 
-  const [isRefGroup, setIsRefGroup] = useState(false)
+  const isRefGroup = getIsRefGroup(annotation?.type, genes, isCorrelatedScatter)
 
   /**
    * Handle user interaction with one or more labels in legend.
@@ -86,6 +85,11 @@ function RawScatterPlot({
     }
 
     updateExploreParams({ hiddenTraces: newHiddenTraces })
+  }
+
+  /** updates whether pipe-delimited label values should be split */
+  function setSplitLabelArrays(value) {
+    updateExploreParams({ splitLabelArrays: value })
   }
 
   /** Get new, updated scatter object instance, and new layout */
@@ -138,7 +142,11 @@ function RawScatterPlot({
   }
 
   /** Update legend counts and recompute traces, without recomputing layout */
-  function updateCountsAndGetTraces(scatter, isRefGroup) {
+  function updateCountsAndGetTraces(scatter) {
+    // note that we don't use the previously defined `isRefGroup` constant here, since the value
+    // may change as a result of the fetched data, but not be reflected in the isRefGroup constant
+    // until `setScatterData` is called
+    const isRG = getIsRefGroup(scatter.annotParams.type, genes, isCorrelatedScatter)
     const [traces, labelCounts] = getPlotlyTraces({
       genes,
       isAnnotatedScatter,
@@ -150,9 +158,9 @@ function RawScatterPlot({
       activeTraceLabel,
       expressionFilter,
       splitLabelArrays: splitLabelArrays ?? scatter.splitLabelArrays,
-      isRefGroup
+      isRefGroup: isRG
     })
-    if (isRefGroup) {
+    if (isRG) {
       setCountsByLabel(labelCounts)
     }
     return traces
@@ -166,10 +174,7 @@ function RawScatterPlot({
     scatter = updateScatterLayout(scatter)
     const layout = scatter.layout
 
-    const isRG = getIsRefGroup(scatter.annotParams.type, genes, isCorrelatedScatter)
-    setIsRefGroup(isRG)
-
-    const plotlyTraces = updateCountsAndGetTraces(scatter, isRG)
+    const plotlyTraces = updateCountsAndGetTraces(scatter)
 
     const startTime = performance.now()
     Plotly.react(graphElementId, plotlyTraces, layout)

--- a/test/js/explore/explore-tab-router.test.js
+++ b/test/js/explore/explore-tab-router.test.js
@@ -86,6 +86,7 @@ describe('dataParams are appropriately managed on the url', () => {
       annotation: { name: 'bar', type: 'group', scope: 'study' },
       subsample: '1000',
       spatialGroups: ['square', 'circle'],
+      splitLabelArrays: null,
       consensus: 'mean',
       heatmapRowCentering: 'z-score',
       ideogramFileId: '604fc5c4e241391a8ff93271',

--- a/test/js/explore/explore-tab-router.test.js
+++ b/test/js/explore/explore-tab-router.test.js
@@ -95,6 +95,7 @@ describe('dataParams are appropriately managed on the url', () => {
       scatterColor: '',
       tab: '',
       expressionFilter: [0, 1],
+      hiddenTraces: [],
       userSpecified: {
         annotation: true,
         bamFileName: true,

--- a/test/js/visualization/scatter-plot.test.js
+++ b/test/js/visualization/scatter-plot.test.js
@@ -74,7 +74,8 @@ it('shows custom legend with default group scatter plot', async () => {
         genes: [],
         dimensionProps: BASIC_DIMENSION_PROPS,
         setCountsByLabel() {},
-        countsByLabel
+        countsByLabel,
+        updateExploreParams: () => {}
       }}/>
   ))
 

--- a/test/js/visualization/scatter-plot.test.js
+++ b/test/js/visualization/scatter-plot.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import _cloneDeep from 'lodash/cloneDeep'
 import jquery from 'jquery'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
@@ -60,8 +60,10 @@ it('shows custom legend with default group scatter plot', async () => {
 
   const countsByLabel = COUNTS_BY_LABEL
 
-  const { container } = render((
-    <ScatterPlot studyAccession='SCP101'
+  /** shim for the explore view component that only handles passing hiddenTraces */
+  function ExploreShim() {
+    const [exploreParams, setExploreParams] = useState({ hiddenTraces: [] })
+    return <ScatterPlot studyAccession='SCP101'
       {...{
         cluster: 'cluster_many_long_odd_labels.tsv',
         annotation: {
@@ -75,9 +77,12 @@ it('shows custom legend with default group scatter plot', async () => {
         dimensionProps: BASIC_DIMENSION_PROPS,
         setCountsByLabel() {},
         countsByLabel,
-        updateExploreParams: () => {}
+        hiddenTraces: exploreParams.hiddenTraces,
+        updateExploreParams: newParams => setExploreParams(newParams)
       }}/>
-  ))
+  }
+
+  const { container } = render(<ExploreShim/>)
 
   // findByTestId would be more kosher, but the numerical leaf ("1") is
   // assigned randomly in `ScatterPlot`.  This ID has been observed with the


### PR DESCRIPTION
To support browsing spatial clusters while keeping certain cell types hidden, this persists the hidden legend entries, as well as the 'splitLabelArrays' param.  This puts the hidden traces in the URL.  This may cause issues for some extremely large number of hidden traces, but Chrome's URL limit is 2MB, so even hiding 10000 traces that are each 100 characters long should work.  

TO TEST:
 1. load a study that has two clusters with a common annotation (e.g. a study-wide annotation).  For example, the `chicken_raw_counts` synthetic study
 2. View a cluster, select the study-wide annotation, and then hide one or more traces
 3. Switch to the other cluster, confirm the traces remain hidden
 4. Switch to a different annotation, and then switch back, confirm traces are no longer hidden
 5. Load a study with pipe-delimited array labels (e.g. `array_mouse_eye` synthetic study). 
 6. Confirm that you can split/merge array labels

