### PR TITLE
holding zoom fixed on legend show/hide (SCP-3878)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -241,6 +241,13 @@ function RawScatterPlot({
     if (scatterData && !isLoading) {
       const plotlyTraces = document.getElementById(graphElementId).data
       PlotUtils.updateTraceVisibility(plotlyTraces, hiddenTraces)
+      // disable autorange so graph does not rescale (SCP-3878)
+      // we do not need to explicitly re-enable it since a new cluster will reset the entire layout
+      scatterData.layout.xaxis.autorange = false
+      scatterData.layout.yaxis.autorange = false
+      if (scatterData.layout.zaxis) {
+        scatterData.layout.zaxis.autorange = false
+      }
       Plotly.react(graphElementId, plotlyTraces, scatterData.layout)
     }
     // look for updates of individual properties, so that we don't rerender if the containing array


### PR DESCRIPTION
Showing/hiding a legend entry no longer auto-resizes the graph. 

TO TEST:
1. Load a cluster plot for a study (e.g. the "mouse_brain" study)
2. hide a trace with points at the edge of the graph (e.g. for the "Category" annotation of the"mouse_brain" study, hide the "A" trace)
3. Observe that the graph axes stay fixed
4. Load a study with two different clusters with different ranges (e.g. the human_lymph study)
5. Switch between the clusters, showing and hiding traces, and confirm the axes change on cluster change, but remain constant for showing/hiding traces