### PR TITLE
fixing gene-annotation caching (SCP-4399)

### DIFF
--- a/app/javascript/components/explore/plot-data-cache.js
+++ b/app/javascript/components/explore/plot-data-cache.js
@@ -217,7 +217,7 @@ export function createCache() {
     return Promise.all(promises).then(resultArray => {
       let mergedResult = null
       resultArray.forEach(result => {
-        mergedResult = cache._mergeClusterResponse(studyAccession, result, cluster, annotation, subsample)
+        mergedResult = cache._mergeClusterResponse(studyAccession, result, cluster, annotation, subsample, genes)
       })
       return mergedResult
     }).catch(error => {
@@ -234,7 +234,7 @@ export function createCache() {
 
 
   /** adds the data for a given study/clusterName, overwriting any previous entry */
-  cache._mergeClusterResponse = (accession, clusterResponse, requestedCluster, requestedAnnotation, requestedSubsample) => {
+  cache._mergeClusterResponse = (accession, clusterResponse, requestedCluster, requestedAnnotation, requestedSubsample, requestedGenes) => {
     const scatter = clusterResponse[0]
     const cacheEntry = cache._findOrCreateEntry(accession, scatter.cluster, scatter.subsample)
 
@@ -257,7 +257,7 @@ export function createCache() {
     if (!requestedAnnotation.name || scatter.annotParams.name === requestedAnnotation.name) {
       Fields.annotation.merge(cacheEntry, scatter)
     }
-    if (scatter.genes.length) {
+    if (scatter.genes.length && scatter.genes.join('') === requestedGenes.join('')) {
       Fields.expression.merge(cacheEntry, scatter)
     }
     return clusterResponse


### PR DESCRIPTION
This fixes the bug tracked in https://sentry.io/organizations/broad-institute/issues/3301350854/events/0a39d257841843bebaa8bf2392597b35/?project=1424198.  If a user loads an expression scatter graph without subsampling, switches genes, and then switches annotations, depending on load order, the cache can misfire resulting in an eternal spinner on the expression graph

TO TEST:
1.  Load the Male mouse brain study, and view the 'disease__ontology_label' annotation
2. do a gene search for "Apoe"
3. wait for the graphs to load
4. reload the page
5. do a gene search for 'Agtr1'
6. change the annotation to "donor_id"
7. Observe that both graphs load correctly