### PR TITLE
Hotfix: launching DE jobs on sparse matrices (SCP-4196)

### DIFF
--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -148,9 +148,11 @@ class DifferentialExpressionService
 
     de_params[:matrix_file_path] = raw_matrix.gs_url
     if raw_matrix.file_type == 'MM Coordinate Matrix'
-      de_params[:matrix_file_type] = 'sparse'
-      gene_file = raw_matrix.bundled_file_by_type('10X Genes File')
-      barcode_file = raw_matrix.bundled_file_by_type('10X Barcodes File')
+      de_params[:matrix_file_type] = 'mtx'
+      # we know bundle exists and is completed as :raw_matrix_for_cluster_cells will throw an exception if it isn't
+      bundle = raw_matrix.study_file_bundle
+      gene_file = bundle.bundled_file_by_type('10X Genes File')
+      barcode_file = bundle.bundled_file_by_type('10X Barcodes File')
       de_params[:gene_file] = gene_file.gs_url
       de_params[:barcode_file] = barcode_file.gs_url
     else
@@ -210,7 +212,7 @@ class DifferentialExpressionService
   def self.validate_study(study)
     raise ArgumentError, 'Requested study does not exist' if study.nil?
     raise ArgumentError, "#{study.accession} is not public" unless study.public?
-    raise ArgumentError, "#{study.accession} is not initialized" unless study.initialized?
+    raise ArgumentError, "#{study.accession} cannot view cluster plots" unless study.can_visualize_clusters?
   end
 
   # shortcut to log to STDOUT and Rails log simultaneously

--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -59,7 +59,8 @@ class DifferentialExpressionParameters
   def to_options_array
     options_array = []
     attributes.each do |attr_name, value|
-      options_array += [self.class.to_cli_opt(attr_name), value] if value.present?
+      # quote value to allow for non-word characters
+      options_array += [self.class.to_cli_opt(attr_name), "#{value}"] if value.present?
     end
     options_array << '--differential-expression'
     options_array

--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -24,7 +24,7 @@ class DifferentialExpressionParameters
             format: { with: GS_URL_REGEXP, message: 'is not a valid GS url' }
   validates :annotation_type, inclusion: %w[group]
   validates :annotation_scope, inclusion: %w[cluster study]
-  validates :matrix_file_type, inclusion: %w[dense sparse]
+  validates :matrix_file_type, inclusion: %w[dense mtx]
   validates :gene_file, :barcode_file,
             presence: true,
             format: {

--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -31,7 +31,7 @@ class DifferentialExpressionParameters
               with: GS_URL_REGEXP,
               message: 'is not a valid GS url'
             },
-            if: -> { matrix_file_type == 'sparse' }
+            if: -> { matrix_file_type == 'mtx' }
 
   # convert attribute name into CLI-formatted option
   def self.to_cli_opt(param_name)

--- a/test/integration/lib/differential_expression_service_test.rb
+++ b/test/integration/lib/differential_expression_service_test.rb
@@ -5,7 +5,7 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
   before(:all) do
     @user = FactoryBot.create(:api_user, test_array: @@users_to_clean)
     @basic_study = FactoryBot.create(:detached_study,
-                                     name_prefix: 'File Parse Service Test',
+                                     name_prefix: 'DifferentialExpressionService Test',
                                      user: @user,
                                      test_array: @@studies_to_clean)
 
@@ -84,6 +84,85 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
     IngestJob.stub :new, mock do
       job_launched = DifferentialExpressionService.run_differential_expression_job(
         @cluster_file, @basic_study, @user, **@job_params
+      )
+      assert job_launched
+      mock.verify
+      job_mock.verify
+    end
+  end
+
+  test 'should run differential expression job with sparse matrix' do
+    study = FactoryBot.create(:detached_study,
+                              name_prefix: 'Sparse DE Test',
+                              user: @user,
+                              test_array: @@studies_to_clean)
+
+    cells = %w[Cell_A Cell_B Cell_C]
+    matrix = FactoryBot.create(:study_file,
+                               name: 'raw.txt',
+                               study: study,
+                               file_type: 'MM Coordinate Matrix',
+                               parse_status: 'parsed',
+                               status: 'uploaded',
+                               expression_file_info: {
+                                 is_raw_counts: true,
+                                 units: 'raw counts',
+                                 library_preparation_protocol: 'Drop-seq',
+                                 biosample_input_type: 'Whole cell',
+                                 modality: 'Proteomic'
+                               })
+
+    genes = FactoryBot.create(:study_file,
+                              name: 'genes.txt',
+                              study: study,
+                              status: 'uploaded',
+                              file_type: '10X Genes File')
+
+    barcodes = FactoryBot.create(:study_file,
+                                 name: 'barcodes.txt',
+                                 study: study,
+                                 status: 'uploaded',
+                                 file_type: '10X Barcodes File')
+
+    bundle = StudyFileBundle.new(study: study, bundle_type: matrix.file_type)
+    bundle.add_files(matrix, genes, barcodes)
+    bundle.save!
+    cluster_file = FactoryBot.create(:cluster_file,
+                                    name: 'cluster_diffexp.txt',
+                                    study: study,
+                                    cell_input: {
+                                      x: [1, 4, 6],
+                                      y: [7, 5, 3],
+                                      cells: cells
+                                    })
+    FactoryBot.create(:metadata_file,
+                      name: 'metadata.txt',
+                      study: study,
+                      cell_input: cells,
+                      annotation_input: [
+                        { name: 'species', type: 'group', values: %w[dog cat dog] },
+                        { name: 'disease', type: 'group', values: %w[none none measles] }
+                      ])
+    annotation = {
+      annotation_name: 'species',
+      annotation_type: 'group',
+      annotation_scope: 'study'
+    }
+
+    data_array_params = {
+      name: 'raw.txt Cells', array_type: 'cells', linear_data_type: 'Study', study_id: study.id,
+      cluster_name: 'raw.txt', array_index: 0, linear_data_id: study.id, study_file_id: matrix.id,
+      cluster_group_id: nil, subsample_annotation: nil, subsample_threshold: nil, values: cells
+    }
+    DataArray.create(data_array_params)
+
+    job_mock = Minitest::Mock.new
+    job_mock.expect(:push_remote_and_launch_ingest, Delayed::Job.new, [Hash])
+    mock = Minitest::Mock.new
+    mock.expect(:delay, job_mock)
+    IngestJob.stub :new, mock do
+      job_launched = DifferentialExpressionService.run_differential_expression_job(
+        cluster_file, study, @user, **annotation
       )
       assert job_launched
       mock.verify

--- a/test/models/differential_expression_parameters_test.rb
+++ b/test/models/differential_expression_parameters_test.rb
@@ -22,7 +22,7 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
       cluster_file: 'gs://test_bucket/cluster.tsv',
       cluster_name: 'UMAP',
       matrix_file_path: 'gs://test_bucket/sparse.tsv',
-      matrix_file_type: 'sparse',
+      matrix_file_type: 'mtx',
       gene_file: 'gs://test_bucket/genes.tsv',
       barcode_file: 'gs://test_bucket/barcodes.tsv'
     }


### PR DESCRIPTION
This applies `git cherry-pick 5c63943^..bdad962` to merge #1520 as a hotfix into `master`.

For convenient reference, the cherry pick syntax is `git cherry-pick <oldest commit SHA>^..<newest commit SHA>`.   Creating a branch off master per our [docs](https://docs.google.com/document/d/1rKcOQPtkbhZCbTqxTnaT-4E29VLzkJrm0kAoWjLx3QA/edit#heading=h.fojnq9y2hk31) and running the command up top shows:
```
wm10d-4e7:single_cell_portal_core eweitz$ git cherry-pick 5c63943^..bdad962
[jb-de-backfill-sparse-hotfix 0028f39cb] Fixing bugs with launching DE jobs on sparse matrices
 Author: bistline <bistline@broadinstitute.org>
 Date: Mon Jun 6 12:34:42 2022 -0400
 3 files changed, 87 insertions(+), 6 deletions(-)
[jb-de-backfill-sparse-hotfix fb572f8c5] fixing test regressions
 Author: bistline <bistline@broadinstitute.org>
 Date: Mon Jun 6 13:22:01 2022 -0400
 2 files changed, 2 insertions(+), 2 deletions(-)
[jb-de-backfill-sparse-hotfix ac4ea6d53] quote values to allow for non-word characters
 Author: bistline <bistline@broadinstitute.org>
 Date: Tue Jun 7 10:02:02 2022 -0400
 1 file changed, 2 insertions(+), 1 deletion(-)
```