### PR TITLE
Address 400 Bad Request from Azul (SCP-4348)

### DIFF
--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -269,6 +269,8 @@ class HcaAzulClient
     facets.each do |facet|
       safe_facet = facet.with_indifferent_access
       hca_term = FacetNameConverter.convert_schema_column(:alexandria, :azul, safe_facet[:id])
+      next if hca_term.nil?
+
       scp_facet = facet[:db_facet]
       if scp_facet.is_numeric?
         min = safe_facet.dig(:filters, :min)

--- a/lib/facet_name_converter.rb
+++ b/lib/facet_name_converter.rb
@@ -48,6 +48,7 @@ class FacetNameConverter
     'organ_region' => 'organPart',
     'organism_age' => 'organismAge',
     'preservation_method' => 'preservationMethod',
+    'sample_type' => 'sampleEntityType',
     'sex' => 'biologicalSex',
     'species' => 'genusSpecies',
     'study_accession' => 'projectShortname',
@@ -76,7 +77,7 @@ class FacetNameConverter
   def self.convert_schema_column(source_schema, target_schema, column_name)
     validate_map_name(source_schema, target_schema)
     mappings = get_map(source_schema, target_schema)
-    mappings&.send(:[], column_name) || column_name
+    mappings&.send(:[], column_name) # do not fall back to original name as this can throw a 400 from Azul
   end
 
   # check if a column exists in a metadata schema

--- a/lib/facet_name_converter.rb
+++ b/lib/facet_name_converter.rb
@@ -25,13 +25,13 @@ class FacetNameConverter
   # map of Alexandria metadata convention names to namespace Terra Interoperability Model (TIM) names
   ALEXANDRIA_TO_TIM = {
     'biosample_id' => 'dct:identifier',
+    'biosample_type' => 'TerraCore:hasBioSampleType',
     'donor_id' => 'prov:wasDerivedFrom',
     'disease' => 'TerraCore:hasDisease',
     'library_preparation_protocol' => 'TerraCore:hasLibraryPrep',
     'organ' => 'TerraCore:hasAnatomicalSite',
     'organ_region' => 'TerraCore:hasAnatomicalRegion',
     'organism_age' => 'organism_age',
-    'sample_type' => 'TerraCore:hasBioSampleType',
     'sex' => 'TerraCore:hasSex',
     'species' => 'TerraCore:hasOrganismType',
     'study_name' => 'dct:title',
@@ -42,6 +42,7 @@ class FacetNameConverter
   # map of alexandria names to HCA Azul facet names (for searching projects/files via the Azul API)
   ALEXANDRIA_TO_AZUL = {
     'biosample_id' => 'sampleId',
+    'biosample_type' => 'sampleEntityType',
     'cell_type' => 'selectedCellType',
     'disease' => 'sampleDisease',
     'library_preparation_protocol' => 'libraryConstructionApproach',
@@ -49,7 +50,6 @@ class FacetNameConverter
     'organ_region' => 'organPart',
     'organism_age' => 'organismAge',
     'preservation_method' => 'preservationMethod',
-    'sample_type' => 'sampleEntityType',
     'sex' => 'biologicalSex',
     'species' => 'genusSpecies',
     'study_accession' => 'projectShortname',

--- a/lib/facet_name_converter.rb
+++ b/lib/facet_name_converter.rb
@@ -31,6 +31,7 @@ class FacetNameConverter
     'organ' => 'TerraCore:hasAnatomicalSite',
     'organ_region' => 'TerraCore:hasAnatomicalRegion',
     'organism_age' => 'organism_age',
+    'sample_type' => 'TerraCore:hasBioSampleType',
     'sex' => 'TerraCore:hasSex',
     'species' => 'TerraCore:hasOrganismType',
     'study_name' => 'dct:title',

--- a/test/lib/facet_name_converter_test.rb
+++ b/test/lib/facet_name_converter_test.rb
@@ -18,8 +18,6 @@ class FacetNameConverterTest < ActiveSupport::TestCase
       converted_name = FacetNameConverter.convert_schema_column(:alexandria, model_name, scp_name)
       assert_equal @expected_conversions[model_name][index], converted_name
     end
-    # test fallback
-    assert_equal @nonexistent_field, FacetNameConverter.convert_schema_column(:alexandria, model_name, @nonexistent_field)
   end
 
   test 'should convert to HCA names' do
@@ -49,5 +47,9 @@ class FacetNameConverterTest < ActiveSupport::TestCase
         assert FacetNameConverter.schema_has_column?(:alexandria, schema, column)
       end
     end
+  end
+
+  test 'should return nil on no match' do
+    assert_nil FacetNameConverter.convert_schema_column(:alexandria, :azul, @nonexistent_field)
   end
 end


### PR DESCRIPTION
(I'm trying a new format for my PRs that I think may help give people more high-level info faster, and let them gloss over implementation details if they so chose - let me know what you think!)

**BACKGROUND**

Certain study search queries are returning `400 Bad Request` from Azul when issued.  This results in that particular search request not getting any results from Azul, when there may have been HCA projects that matched the search.  Specifically, the term `organoid` was resulting in a query in Azul that was invalid.

**CHANGES**

The underlying issue is in how we convert metadata names from the Alexandria schema to the names that Azul uses as facets.  Specifically, our search facet of `sample_type` did not have a mapping listed.  This is a combination of an oversight, as the term `sampleEntityType` in Azul is a direct analog, and also that this facet was superseded in newer versions of the Alexandria convention by `biosample_type`.  Adding that mapping in `FacetNameConverter` for `biosample_type` fixes this particular problem. Moving forward, and mappings that do not exist will now be discarded to prevent future facet conversion issues.  This way, we can leave the existing `sample_type` facet in place on production (since there is data in BigQuery for this), but it will be ignored now in XDSS requests.

It is worth noting that there is an associated issue where certain keyword-based search requests result in queries that _should_ find data in Azul, but do not given how their search API is constructed, and how we translate keyword-based into facet-based searches.  Solving this seems intractable, as it would require complicated logic to split out search requests into individual calls, parallelizing them, and then unifying the results after all requests complete.  Such logic could result in 200+ requests for a generic term like "cell", and as such the more optimal course is to contact the Azul team and inquire about them reinstating keyword-based searching via their API.

**MANUAL TESTING**
1. If you do not have the `biosample_type` facet in your local instance, create it with the following command in the Rails console:
```
SearchFacet.create!(name: "biosample type", identifier: "biosample_type", filters: [], is_ontology_based: false, ontology_urls: [], data_type: "string", is_array_based: false, big_query_id_column: "biosample_type", big_query_name_column: "biosample_type", big_query_conversion_column: nil, convention_name: "alexandria metadata convention", convention_version: "latest", unit: nil, min: nil, max: nil, visible: true)
```
2. Run `SearchFacet.update_all_facet_filters` to update all locally stored facets with values from Azul
3. Sign into the home page on your local instance and run a keyword search for `organoid`
4. Confirm the search request completes and finds results from Azul, such as `Kidney organoid reproducibility across multiple human iPSC lines and diminished off target cells after transplantation revealed by single cell transcriptomics`

This PR satisfies portions of SCP-4348.