### PR TITLE
Widen availability of differential expression frontend (SCP-4374)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -368,15 +368,6 @@ module Api
           end
         end
 
-        # Pin public DE pilot study to second row of home page default study list
-        # TODO (SCP-4374): Remove this block once frontend uses is_differential_expression_enabled
-        if Rails.env.production? && params[:terms].blank? && @facets.empty? && @selected_branding_group.nil?
-          de_accession = "SCP1671"
-          differential_expression_study = @studies.find {|study| study.accession == de_accession}
-          @studies.delete_if {|study| study.accession == de_accession}
-          @studies.insert(1, differential_expression_study)
-        end
-
         @matching_accessions = @studies.map { |study| self.class.get_study_attribute(study, :accession) }
 
         logger.info "Final list of matching studies: #{@matching_accessions}"

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -48,7 +48,7 @@ const tabList = [
   { key: 'images', label: 'Images' }
 ]
 
-/** Determine if currently selected annotation has differential outputs available */
+/** Determine if currently selected annotation has differential expression outputs available */
 function annotHasDe(exploreInfo, exploreParams) {
   const flags = getFeatureFlagsWithDefaults()
   if (!exploreInfo || flags?.differential_expression_frontend) {
@@ -104,16 +104,14 @@ export default function ExploreDisplayTabs({
   const [currentPointsSelected, setCurrentPointsSelected] = useState(null)
 
   // Differential expression settings
-  // TODO (SCP-4374): Integrate is_differential_expression_enabled from API
-  const [showDeGroupPicker, setShowDeGroupPicker] = useState(false)
+  const isDifferentialExpressionEnabled = annotHasDe(exploreInfo, exploreParams)
+  const [, setShowDeGroupPicker] = useState(false)
   const [deGenes, setDeGenes] = useState(null)
   const [deGroup, setDeGroup] = useState(null)
   const [showDifferentialExpressionPanel, setShowDifferentialExpressionPanel] = useState(deGenes !== null)
 
   // Hash of trace label names to the number of points in that trace
   const [countsByLabel, setCountsByLabel] = useState(null)
-
-  const isDifferentialExpressionEnabled = annotHasDe(exploreInfo, exploreParams)
 
   const plotContainerClass = 'explore-plot-tab-content'
 

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -51,7 +51,7 @@ const tabList = [
 /** Determine if currently selected annotation has differential expression outputs available */
 function annotHasDe(exploreInfo, exploreParams) {
   const flags = getFeatureFlagsWithDefaults()
-  if (!exploreInfo || flags?.differential_expression_frontend) {
+  if (!flags?.differential_expression_frontend || !exploreInfo) {
     return false
   }
 


### PR DESCRIPTION
This expands the DE pilot MVP (#1502), letting users explore differential expression for more studies as enabled upstream.

Now, users can view differential expression for any annotation that has DE outputs available from our initial backfill of 10 [valuable studies](https://docs.google.com/spreadsheets/d/1f09NOe7d1LCqU7pvFMCIJGcNrhO_7Y0eaqSq8OQJZv4/edit#gid=0).  This is designed to gather larger sample sizes for [DE usage analytics](https://mixpanel.com/project/2120588/view/19059/app/dashboards#id=3292575) that inform future work, and more fully technically explore the differential expression MVP.  The implementation removes hard-coding for our DE pilot and generalizes when the "Differential expression" button is shown.

To test:
1. If you haven't already, populate the DE test study and its DE outputs in your local SCP, as described in #1502
2. Ensure the `differential_expression_frontend` feature flag is enabled for that study, as described there
3. Enter your Rails console:  `rails console -e development`
4. Manually enable DE on the default annotation: `Study.find_by(accession: 'SCP138').cell_metadata.find_by(name: 'General_Celltype').update(is_differential_expression_enabled: true)`
5. Navigate to the DE test study: "Human milk - differential expression"
6. Confirm "Differential expression" button appears in the default annotation (i.e., "General_Celltype")
7. Switch to another annotation
8. Confirm "Differential expression" button does not appear

N.B.: That DE test study fails to run in the current DE pipeline, due to an out-of-memory error thrown in the PAPI job.  I've also verified this works with a higher-fidelity example -- a local copy of staging SCP294 (production SCP1539) -- with DE outputs populated using the DE backfill script.

This satisfies SCP-4374.