### PR TITLE
Fixing test regression from adding biosample_type mapping to FacetNameConverter (SCP-4407)

### DIFF
--- a/test/integration/lib/azul_search_service_test.rb
+++ b/test/integration/lib/azul_search_service_test.rb
@@ -207,7 +207,7 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
   test 'should retrieve all facets/filters' do
     facets = AzulSearchService.get_all_facet_filters
     expected_keys = %w[organ disease organism_age preservation_method species study_name organ_region
-                       library_preparation_protocol sex study_description cell_type].sort
+                       library_preparation_protocol sex study_description cell_type biosample_type].sort
     assert_equal expected_keys, facets.keys.sort
     diseases = facets.dig('disease', 'filters')
     assert_includes diseases, 'normal'


### PR DESCRIPTION
**BACKGROUND**
A test regression was introduced in #1524 and incorrectly labelled as a "false positive", as changes introduced in that PR broke a test that has consistently failed since that merge.

**CHANGES**
Adding a mapping for `biosample_type` to FacetNameConverter broke an assertion in AzulSearchServiceTest#test_should_retrieve_all_facets/filters.  Adding in that name to the list of expected values fixed the problem.

**MANUAL TESTING**
1. Pull this branch and load secrets through `rails_local_setup.rb && source config/secrets/.source_env.bash`
2. Run all AzulSearchService tests with `bin/rails test test/integration/lib/azul_search_service_test.rb` and confirm they pass

This PR satisfies SCP-4407.

