### PR TITLE
delaying disabling of study gene search until after explore data loads (SCP-4363)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -255,6 +255,7 @@ export default function ExploreDisplayTabs({
             <StudyGeneField genes={exploreParams.genes}
               searchGenes={searchGenes}
               allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}
+              isLoading={!exploreInfo}
               speciesList={exploreInfo ? exploreInfo.taxonNames : []}/>
             { (isGene || isGeneList || hasIdeogramOutputs) && // show if this is gene search || gene list
               <button className="action fa-lg"

--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -14,13 +14,13 @@ import { logStudyGeneSearch } from '~/lib/search-metrics'
 /** renders the gene text input
   * This shares a lot of logic with search/genes/GeneKeyword, but is kept as a separate component for
   * now, as the need for autocomplete raises additional complexity
-  * 
+  *
   * @param genes Array of genes currently inputted
   * @param searchGenes Function to call to execute the API search
   * @param allGenes String array of valid genes in the study
   * @param speciesList String array of species scientific names
   */
-export default function StudyGeneField({ genes, searchGenes, allGenes, speciesList }) {
+export default function StudyGeneField({ genes, searchGenes, allGenes, speciesList, isLoading=false }) {
   const [inputText, setInputText] = useState('')
 
   const rawSuggestions = getAutocompleteSuggestions(inputText, allGenes)
@@ -44,7 +44,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
   function handleSearch(event) {
     event.preventDefault()
     const newGeneArray = syncGeneArrayToInputText()
-    let newNotPresentGenes = new Set([]) 
+    const newNotPresentGenes = new Set([])
     if (newGeneArray) {
       newGeneArray.forEach(gene => {
         // if an entered gene is not in the valid gene options for the study
@@ -146,7 +146,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
     }
   }, [genes.join(',')])
 
-  const searchDisabled = !allGenes?.length
+  const searchDisabled = !isLoading && !allGenes?.length
 
   return (
     <form className="gene-keyword-search gene-study-keyword-search form-horizontal" onSubmit={handleSearch}>

--- a/test/js/explore/study-gene-keyword.test.js
+++ b/test/js/explore/study-gene-keyword.test.js
@@ -25,6 +25,9 @@ describe('Search query display text', () => {
 
     const { container: emptyContainer } = render(<StudyGeneField genes={[]} searchGenes={() => {}} allGenes={[]} speciesList={[]} />)
     expect(emptyContainer.querySelector('.gene-keyword-search-input').textContent.trim()).toEqual('No expression data to search')
+
+    const { container: loadingContainer } = render(<StudyGeneField genes={[]} searchGenes={() => {}} allGenes={[]} speciesList={[]} isLoading={true}/>)
+    expect(loadingContainer.querySelector('.gene-keyword-search-input').textContent.trim()).toEqual('Genes (e.g. "PTEN NF2")')
   })
 })
 


### PR DESCRIPTION
CHANGES: The study gene search bar will no longer be disabled while the explore data for a study is loading.  While this might result in some odd behavior if the user manages to type something in it and hit search before the study loads (they will see a modal indicating that the gene wasn't found in the study), that's probably more desirable than seeing the box flash every time a study loads.

TO TEST:
1. Load a study with clusters and genes
2. confirm the study gene search bar appears and is enabled throughout the loading of the study
3. Load a study with clusters and no genes (e.g. by deleting expression matrices from an existing study)
4. confirm the study gene search is initially enabled, but then disabled once the study data loads