### PR TITLE
streamlining view count update query (SCP-4297)

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -149,7 +149,8 @@ class SiteController < ApplicationController
 
   # load single study and view top-level clusters
   def study
-    @study.update(view_count: @study.view_count + 1)
+    # this skips all validation/callbacks for efficiency
+    @study.update_attribute(:view_count, @study.view_count + 1)
 
     # set general state of study to enable various tabs in UI
     # double check on download availability: first, check if administrator has disabled downloads


### PR DESCRIPTION
BACKGROUND
We want to eliminate any N+1 queries related to clusters, as those may cause performance issues for the U19 study that has 100+ clusters
CHANGES
This changes the view count incrementer to skip study model validations.  These validations aren't needed since we're just updating an integer field.  This saves ~20 queries, including one query per study file.  The good news is that in development, given that queries take ~0.05 seconds, this saves almost a second in study loading time.

TO TEST:
1. Uncomment lines 154-155 from config/develoment.rb to turn on mongoid logging
2.  Load a study with 3+ clusters (e.g. the human_lymph_node synthetic study)
3.  Confirm that there are no batches of cluster_group queries repeated for each study file.  They will have ` {"find"=>"cluster_groups", "filter"=>{"study_file_id"=>...` 
