### PR TITLE
Less restrictive study gene search term check (SCP-4417)

### DIFF
--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -48,7 +48,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
     if (newGeneArray) {
       newGeneArray.forEach(gene => {
         // if an entered gene is not in the valid gene options for the study
-        if (geneOptions.length > 0 && !geneOptions.find(geneOpt => geneOpt.label.toLowerCase() === gene.label.toLowerCase())) {
+        if (allGenes.length > 0 && !allGenes.find(geneOpt => geneOpt.toLowerCase() === gene.label.toLowerCase())) {
           newNotPresentGenes.add(gene.label)
         }
       })

--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -48,7 +48,8 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
     if (newGeneArray) {
       newGeneArray.forEach(gene => {
         // if an entered gene is not in the valid gene options for the study
-        if (allGenes.length > 0 && !allGenes.find(geneOpt => geneOpt.toLowerCase() === gene.label.toLowerCase())) {
+        const geneLowercase = gene.label.toLowerCase()
+        if (allGenes.length > 0 && !allGenes.find(geneOpt => geneOpt.toLowerCase() === geneLowercase)) {
           newNotPresentGenes.add(gene.label)
         }
       })


### PR DESCRIPTION
Previously was using the geneoptions which were the more restrictive genes that appeared as options in the dropdown to decide if a gene search term was valid. Instead using all the genes present in the study will be less restrictive and as such prevent the false negatives the previous change was making happen.

I don't have any local studies that have this situation so I can't 100% test but the functionality still works for my local studies and I can test better on staging.

This should fix:
2. "Searching with a "valid" but non-existent gene is causing some strange behavior including in certain sequences triggering the modal but overall causing an error"

from the ticket: https://broadworkbench.atlassian.net/browse/SCP-4417?atlOrigin=eyJpIjoiYjQxM2YxM2NmMGVmNGM4NGJiZWE5MzQyMjQwMDNkZTciLCJwIjoiaiJ9