### PR TITLE
fixing cluster name setting in UX (SCP-4101)

### DIFF
--- a/app/javascript/components/upload/FileUploadControl.jsx
+++ b/app/javascript/components/upload/FileUploadControl.jsx
@@ -31,7 +31,7 @@ export default function FileUploadControl({
 
     let newName = selectedFile.name
 
-    // for cluster files, don't change an existing specified name
+    // for cluster and other named files, don't change an existing customized name
     if (FILE_TYPES_ALLOWING_SET_NAME.includes(file.file_type) && file.name && file.name !== file.upload_file_name) {
       newName = file.name
     }
@@ -41,7 +41,7 @@ export default function FileUploadControl({
     if (issues.errors.length === 0) {
       updateFile(file._id, {
         uploadSelection: selectedFile,
-        upload_file_name: newName,
+        upload_file_name: selectedFile.name,
         name: newName
       })
     }

--- a/test/js/upload-wizard/file-upload-control.test.js
+++ b/test/js/upload-wizard/file-upload-control.test.js
@@ -50,6 +50,42 @@ describe('file upload control defaults the name of the file', () => {
   })
 })
 
+it('updates the file upload name but preserves custom name', async () => {
+  const file = {
+    _id: '123',
+    name: 'previousName',
+    status: 'new',
+    file_type: 'Cluster'
+  }
+  const updateFileHolder = { updateFile: () => {} }
+  const updateFileSpy = jest.spyOn(updateFileHolder, 'updateFile')
+
+  render(
+    <StudyContext.Provider value={{ accession: 'SCP123' }}>
+      <FileUploadControl
+        file={file}
+        allFiles={[file]}
+        updateFile={updateFileHolder.updateFile}
+        allowedFileExts={['.txt']}
+        validationMessages={{}}/>
+    </StudyContext.Provider>
+  )
+
+  expect(screen.getByRole('button')).toHaveTextContent('Choose file')
+  expect(screen.queryByTestId('file-name-validation')).toBeNull()
+
+  const fileObj = fireFileSelectionEvent(screen.getByTestId('file-input'), {
+    fileName: 'cluster.txt',
+    content: 'NAME,X,Y\nTYPE,numeric,numeric\nCell1,1,0\n'
+  })
+  await waitForElementToBeRemoved(() => screen.getByTestId('file-validation-spinner'))
+  expect(updateFileSpy).toHaveBeenLastCalledWith('123', {
+    uploadSelection: fileObj,
+    name: 'previousName',
+    upload_file_name: 'cluster.txt'
+  })
+})
+
 describe('file upload control validates the selected file', () => {
   it('validates the extension', async () => {
     const file = {


### PR DESCRIPTION
BACKGROUND
Eric gets all the credit for this one -- fix was trivial once we knew the reproduction steps.  For a long time we've been seeing 'invalid file type' for files that seemed to have valid suffixes

CHANGES
Fixed error in name assignment logic for cluster file form

TO TEST:
1. go to cluster upload in the upload wizard for a study
2. Select "Add file"
3. *Before* you select the file, enter a name for the cluster that does not have a suffix (e.g. 'Cluster1')
4. select a valid cluster file
5. Save & Upload, and confirm the file ingests correctly.