### PR TITLE
Fixing a bug with the new Invalid Gene Search Handling (SCP-4417)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -52,7 +52,7 @@ function RawScatterPlot({
   const [scatterData, setScatterData] = useState(null)
   // array of trace names (strings) to show in the graph
   const [graphElementId] = useState(_uniqueId('study-scatter-'))
-  const { ErrorComponent, setShowError } = useErrorMessage()
+  const { ErrorComponent, setShowError, setErrorContent } = useErrorMessage()
   const [activeTraceLabel, setActiveTraceLabel] = useState(null)
   // map of label name to color hex codes, for any labels the user has picked a color for
   const [editedCustomColors, setEditedCustomColors] = useState({})

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -461,6 +461,7 @@ export async function fetchCluster({
   // don't camelcase the keys since those can be cluster names,
   // so send false for the 4th argument
   const [scatter, perfTimes] = await scpApi(apiUrl, defaultInit(), mock, false)
+
   return [scatter, perfTimes]
 
 }
@@ -544,6 +545,7 @@ export async function fetchExpressionViolin(
   // don't camelcase the keys since those can be cluster names,
   // so send false for the 4th argument
   const [violin, perfTimes] = await scpApi(apiUrl, defaultInit(), mock, false)
+  
   return [violin, perfTimes]
 }
 

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -463,7 +463,6 @@ export async function fetchCluster({
   const [scatter, perfTimes] = await scpApi(apiUrl, defaultInit(), mock, false)
 
   return [scatter, perfTimes]
-
 }
 
 /** Helper function for returning a url for fetching cluster data.  See fetchCluster above for documentation */

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -543,8 +543,14 @@ export async function fetchExpressionViolin(
   const apiUrl = `/studies/${studyAccession}/expression/violin${stringifyQuery(paramObj)}`
   // don't camelcase the keys since those can be cluster names,
   // so send false for the 4th argument
-  const [violin, perfTimes] = await scpApi(apiUrl, defaultInit(), mock, false)
-
+  let response
+  try{
+    response = await scpApi(apiUrl, defaultInit(), mock, false)
+  } catch (err) {
+    throw new Error(err)
+  }
+ 
+  const [violin, perfTimes] = response
   return [violin, perfTimes]
 }
 

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -545,7 +545,7 @@ export async function fetchExpressionViolin(
   // don't camelcase the keys since those can be cluster names,
   // so send false for the 4th argument
   const [violin, perfTimes] = await scpApi(apiUrl, defaultInit(), mock, false)
-  
+
   return [violin, perfTimes]
 }
 

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -460,8 +460,15 @@ export async function fetchCluster({
   })
   // don't camelcase the keys since those can be cluster names,
   // so send false for the 4th argument
-  const [scatter, perfTimes] = await scpApi(apiUrl, defaultInit(), mock, false)
-
+  
+  let response
+  try{
+    response = await scpApi(apiUrl, defaultInit(), mock, false)
+  } catch (err) {
+    throw new Error(err)
+  }
+ 
+  const [scatter, perfTimes] =  response
   return [scatter, perfTimes]
 }
 

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -460,16 +460,9 @@ export async function fetchCluster({
   })
   // don't camelcase the keys since those can be cluster names,
   // so send false for the 4th argument
-  
-  let response
-  try{
-    response = await scpApi(apiUrl, defaultInit(), mock, false)
-  } catch (err) {
-    throw new Error(err)
-  }
- 
-  const [scatter, perfTimes] =  response
+  const [scatter, perfTimes] = await scpApi(apiUrl, defaultInit(), mock, false)
   return [scatter, perfTimes]
+
 }
 
 /** Helper function for returning a url for fetching cluster data.  See fetchCluster above for documentation */
@@ -550,14 +543,7 @@ export async function fetchExpressionViolin(
   const apiUrl = `/studies/${studyAccession}/expression/violin${stringifyQuery(paramObj)}`
   // don't camelcase the keys since those can be cluster names,
   // so send false for the 4th argument
-  let response
-  try{
-    response = await scpApi(apiUrl, defaultInit(), mock, false)
-  } catch (err) {
-    throw new Error(err)
-  }
- 
-  const [violin, perfTimes] = response
+  const [violin, perfTimes] = await scpApi(apiUrl, defaultInit(), mock, false)
   return [violin, perfTimes]
 }
 


### PR DESCRIPTION
Add `setErrorContent` to ScatterPlot 

This should fix the error we are seeing in Sentry here: https://sentry.io/organizations/broad-institute/issues/3334336770/?project=1424198&query=is%3Aunresolved <- as this was introduced with the new code not correctly importing `setErrorContent` 
