### PR TITLE
Hotfix: Decrease server load for global gene search (SCP-4432)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -371,7 +371,16 @@ module Api
         @matching_accessions = @studies.map { |study| self.class.get_study_attribute(study, :accession) }
 
         logger.info "Final list of matching studies: #{@matching_accessions}"
-        @results = @studies.paginate(page: params[:page], per_page: Study.per_page)
+
+        # Only return 5 studies if global gene search, to mitigate performance
+        # issues related to expression filtering (SCP-4432)
+        if params[:genes].present?
+          per_page = 5
+        else
+          per_page = Study.per_page
+        end
+
+        @results = @studies.paginate(page: params[:page], per_page: per_page)
         render json: search_results_obj, status: 200
       end
 

--- a/app/javascript/components/search/genes/StudyGeneExpressions.jsx
+++ b/app/javascript/components/search/genes/StudyGeneExpressions.jsx
@@ -24,7 +24,9 @@ export default function StudyGeneExpressions({ study }) {
   let controlClusterParams = _clone(clusterParams)
   if (annotationList && !clusterParams.cluster) {
     // if the user hasn't specified anything yet, but we have the study defaults, use those
-    controlClusterParams = Object.assign(controlClusterParams, getDefaultClusterParams(annotationList))
+    controlClusterParams = Object.assign(
+      controlClusterParams, getDefaultClusterParams(annotationList, null, 10_000)
+    )
   }
 
   let studyRenderComponent

--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -21,17 +21,19 @@ export const emptyDataParams = {
 
 export const UNSPECIFIED_ANNOTATION_NAME = '--Unspecified--'
 const GROUP_VIZ_THRESHOLD_MAX = 200
+const MAX_DEFAULT_SUBSAMPLE = 100_000
 
-/** takes the server response and returns subsample default subsample for the cluster */
-export function getDefaultSubsampleForCluster(annotationList, clusterName) {
+/** takes the server response and returns default subsample for the cluster */
+export function getDefaultSubsampleForCluster(annotationList, clusterName, max = MAX_DEFAULT_SUBSAMPLE) {
   const subsampleOptions = annotationList.subsample_thresholds[clusterName]
   if (subsampleOptions?.length) {
-    // find the max subsample less than or equal to 100000
-    const defaultSubsample = Math.max(...subsampleOptions.filter(opt => opt <= 100000))
-    // if it's 100000, that means the study has more than 100000 cells, and so the
-    // default is to show 100000.  otherwise we'll show all cells by default
-    if (defaultSubsample === 100000) {
-      return 100000
+    // find the max subsample less than or equal to max
+    const defaultSubsample = Math.max(...subsampleOptions.filter(opt => opt <= max))
+    // if it's max, that means the study has more than default max cells, and so the
+    // default is to show max default subsampling threshold.
+    // otherwise we'll show all cells by default
+    if (defaultSubsample === max) {
+      return max
     }
   }
   return 'all'
@@ -98,12 +100,12 @@ export function getAnnotationForIdentifier(identifier) {
 
 
 /** extracts default parameters from an annotationList of the type returned by the explore API */
-export function getDefaultClusterParams(annotationList, spatialGroups) {
+export function getDefaultClusterParams(annotationList, spatialGroups, maxSubsample = MAX_DEFAULT_SUBSAMPLE) {
   const defaultCluster = annotationList.default_cluster
   const clusterParams = {
     cluster: defaultCluster,
     annotation: annotationKeyProperties(annotationList.default_annotation),
-    subsample: getDefaultSubsampleForCluster(annotationList, annotationList.default_cluster),
+    subsample: getDefaultSubsampleForCluster(annotationList, annotationList.default_cluster, maxSubsample),
     spatialGroups: getDefaultSpatialGroupsForCluster(defaultCluster, spatialGroups)
   }
   return clusterParams


### PR DESCRIPTION
This mitigates outage risk by crudely decreasing server CPU load for global gene searches.

Previously, global gene search used a
* Page size of 10
* Default subsampling threshold of 100k cells

Now:
* Page size of 5
* Subsampling of 10k
 
This aims to decrease server load caused by recent scientific refinements related to gene expression filtering (#1510), while keeping that science intact.  Unmitigated server load from such filtering seems to have been a significant cause in transient outages on June 9 after releasing SCP 1.19.

To test:
* Ensure you have some large visualization studies in your local environment
* Open DevTools Network tab
* Do a global gene search
* Note 5 violin plot requests, with none having a subsampling of 100000, and ideally some having a subsampling of 10000

This satisfies SCP-4432.