### PR TITLE
adding spatial checkbox to sync tool 

### DIFF
--- a/app/views/studies/_cluster_axis_fields.html.erb
+++ b/app/views/studies/_cluster_axis_fields.html.erb
@@ -1,3 +1,21 @@
+
+ <div class="form-group row">
+  <div class="col-sm-4" >
+    <%= f.label :is_spatial, 'Coordinate data type: ' %><br/>
+    <%= f.label :is_spatial_false, {for: "is_spatial_false_#{study_file._id}"} do %>
+      <%= f.radio_button :is_spatial, false, {id: "is_spatial_false_#{study_file._id}", class: "is_spatial_false"}  %>
+      Clustering
+    <% end %>
+    &nbsp;
+    <%= f.label :is_spatial_true, {for: "is_spatial_true_#{study_file._id}"} do %>
+      <%= f.radio_button :is_spatial, true, {id: "is_spatial_true_#{study_file._id}", class: "is_spatial_true"} %>
+      Spatial transcriptomics positions
+    <% end %>
+    <i class='fas fa-question-circle' data-toggle="tooltip"
+        title="To associate a spatial transcriptomics file with specific cluster files, use the 'Upload/Edit files' page after all files are synced.">
+    </i>
+  </div>
+</div>
 <div class="form-group row">
   <div class="col-sm-4">
     <%= f.label :x_axis_label, 'X Axis Label' %><br />

--- a/app/views/studies/_orphaned_study_file_form.html.erb
+++ b/app/views/studies/_orphaned_study_file_form.html.erb
@@ -34,7 +34,7 @@
   </div>
   <div id="study-file-<%= study_file._id %>-extra-info">
     <% if study_file.file_type == 'Cluster'  %>
-      <%= render partial: 'cluster_axis_fields', locals: {f: f.dup} %>
+      <%= render partial: 'cluster_axis_fields', locals: {study_file: study_file, f: f.dup} %>
     <% elsif study_file.file_type == 'Metadata' %>
       <%= render partial: 'metadata_file_fields', locals: {f: f.dup} %>
     <% elsif study_file.file_type == 'Expression Matrix' || study_file.file_type == 'MM Coordinate Matrix' %>

--- a/app/views/studies/_shared_sync_functions.js.erb
+++ b/app/views/studies/_shared_sync_functions.js.erb
@@ -21,7 +21,7 @@ $('#study-file-<%= study_file.id %>').on('change', '.file-type', async function(
 
     // render fields & process entries based on file type
     if (fileType === 'Cluster') {
-        extraInfo.html("<%= j(render partial: 'cluster_axis_fields', locals: {f: f.dup}) %>");
+        extraInfo.html("<%= j(render partial: 'cluster_axis_fields', locals: {study_file: study_file, f: f.dup}) %>");
         nameField.attr('readonly', false);
     } else if (fileType === 'Metadata') {
         extraInfo.html("<%= j(render partial: 'metadata_file_fields', locals: {f: f.dup}) %>");

--- a/app/views/studies/_study_file_form.html.erb
+++ b/app/views/studies/_study_file_form.html.erb
@@ -34,7 +34,7 @@
   </div>
   <div id="study-file-<%= study_file._id %>-extra-info">
     <% if study_file.file_type == 'Cluster'  %>
-      <%= render partial: 'cluster_axis_fields', locals: {f: f.dup} %>
+      <%= render partial: 'cluster_axis_fields', locals: {study_file: study_file, f: f.dup} %>
     <% elsif study_file.file_type == 'Metadata' %>
       <%= render partial: 'metadata_file_fields', locals: {f: f.dup} %>
     <% elsif study_file.file_type == 'Expression Matrix' || study_file.file_type == 'MM Coordinate Matrix' %>

--- a/app/views/studies/_synced_bundled_study_file_form.html.erb
+++ b/app/views/studies/_synced_bundled_study_file_form.html.erb
@@ -24,7 +24,7 @@
   </div>
   <div id="study-file-<%= study_file._id %>-extra-info">
     <% if study_file.file_type == 'Cluster'  %>
-      <%= render partial: 'cluster_axis_fields', locals: {f: f.dup} %>
+      <%= render partial: 'cluster_axis_fields', locals: {study_file: study_file, f: f.dup} %>
     <% elsif study_file.file_type == 'Expression Matrix' || study_file.file_type == 'MM Coordinate Matrix' %>
       <%= render partial: 'expression_file_fields', locals: {study_file: study_file, f: f.dup} %>
     <% end %>

--- a/app/views/studies/_synced_study_file_form.html.erb
+++ b/app/views/studies/_synced_study_file_form.html.erb
@@ -26,7 +26,7 @@
   </div>
   <div id="study-file-<%= study_file._id %>-extra-info">
     <% if study_file.file_type == 'Cluster'  %>
-      <%= render partial: 'cluster_axis_fields', locals: {f: f.dup} %>
+      <%= render partial: 'cluster_axis_fields', locals: {study_file: study_file, f: f.dup} %>
     <% elsif study_file.file_type == 'Metadata' %>
       <%= render partial: 'metadata_file_fields', locals: {f: f.dup} %>
     <% elsif study_file.file_type == 'Expression Matrix' || study_file.file_type == 'MM Coordinate Matrix' %>


### PR DESCRIPTION
This adds a checkbox for designating a cluster file as spatial.  Per the discussion in the ticket, the ability to associate spatial files with clusters is not included in this file.  Instead a help icon directing users to use the upload wizard for that functionality is added.

![image](https://user-images.githubusercontent.com/2800795/173485622-aedb4542-1e42-4ed4-aebb-a4d458efd2e0.png)

TO TEST:
1. load a study in sync tool with at least one cluster file
2. use the newly added checkbox to change the file from clustering to spatial
3. select 'update'
4. confirm the checkbox selection is saved
5. Go to the upload wizard, and confirm the file is listed under the 'spatial' section
