### PR TITLE
Eh handle paren

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -520,7 +520,6 @@ module Api
       def self.get_study_attribute(search_result, attribute)
         if search_result.is_a?(Study)
           search_result.send(attribute)
-        else
         elsif !search_result.nil?
           search_result[attribute]
         else 

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -520,10 +520,8 @@ module Api
       def self.get_study_attribute(search_result, attribute)
         if search_result.is_a?(Study)
           search_result.send(attribute)
-        elsif !search_result.nil?
+        else
           search_result[attribute]
-        else 
-          []
         end
       end
 

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -521,7 +521,10 @@ module Api
         if search_result.is_a?(Study)
           search_result.send(attribute)
         else
+        elsif !search_result.nil?
           search_result[attribute]
+        else 
+          []
         end
       end
 

--- a/app/javascript/components/search/results/SearchQueryDisplay.jsx
+++ b/app/javascript/components/search/results/SearchQueryDisplay.jsx
@@ -119,9 +119,9 @@ export default function SearchQueryDisplay({ terms, facets }) {
   }
   if (hasTerms) {
     termsDisplay = (
-      <span>Text contains (
+      <span>Text contains: 
         { formattedJoinedList(terms, 'search-term', ' OR ') }
-      )</span>)
+      </span>)
     if (hasFacets) {
       termsDisplay = <span>({termsDisplay})</span>
     }

--- a/app/javascript/components/search/results/SearchQueryDisplay.jsx
+++ b/app/javascript/components/search/results/SearchQueryDisplay.jsx
@@ -119,7 +119,7 @@ export default function SearchQueryDisplay({ terms, facets }) {
   }
   if (hasTerms) {
     termsDisplay = (
-      <span>Text contains: 
+      <span>Text contains: &nbsp;
         { formattedJoinedList(terms, 'search-term', ' OR ') }
       </span>)
     if (hasFacets) {

--- a/app/javascript/components/search/results/SearchQueryDisplay.jsx
+++ b/app/javascript/components/search/results/SearchQueryDisplay.jsx
@@ -119,7 +119,7 @@ export default function SearchQueryDisplay({ terms, facets }) {
   }
   if (hasTerms) {
     termsDisplay = (
-      <span>Text contains: &nbsp;
+      <span>Text contains:&nbsp;
         { formattedJoinedList(terms, 'search-term', ' OR ') }
       </span>)
     if (hasFacets) {

--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -353,7 +353,7 @@ class SearchFacet
 
   # find all possible matches for a partial filter value
   def find_filter_matches(filter_value, filter_list: :filters)
-    flatten_filters(filter_list).select { |filter| filter.match(/#{filter_value}/i) }.map(&:to_s)
+    flatten_filters(filter_list).select { |filter| filter.match(/#{Regexp.escape(filter_value)}/i) }.map(&:to_s)
   end
 
   # matches on whole words/phrases for terms to filter list

--- a/test/js/search/search-query-display.test.js
+++ b/test/js/search/search-query-display.test.js
@@ -64,7 +64,7 @@ describe('Search query display text', () => {
     const { container } = render((
       <SearchQueryDisplay facets={[]} terms={['foo']}/>
     ))
-    expect(container.getElementsByClassName('query-text')[0].textContent.trim("Text contains: foo")).toEqual()
+    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual('Text contains: foo')
   })
 
 
@@ -72,7 +72,7 @@ describe('Search query display text', () => {
     const { container } = render((
       <SearchQueryDisplay facets={[]} terms={['(foo']}/>
     ))
-    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual("Text contains: (foo")
+    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual('Text contains: (foo')
   })
 
   it('renders terms and a single facet', async () => {
@@ -80,7 +80,7 @@ describe('Search query display text', () => {
       <SearchQueryDisplay facets={oneStringFacet} terms={['foo', 'bar']}/>
     ))
 
-    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual("(Text contains: foo OR bar) AND (Metadata contains (species: Homo sapiens))")
+    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual('(Text contains: foo OR bar) AND (Metadata contains (species: Homo sapiens))')
   })
 
   it('renders or-ed facets properly', async () => {

--- a/test/js/search/search-query-display.test.js
+++ b/test/js/search/search-query-display.test.js
@@ -64,7 +64,7 @@ describe('Search query display text', () => {
     const { container } = render((
       <SearchQueryDisplay facets={[]} terms={['foo']}/>
     ))
-    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual('Text contains: foo')
+    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual('Text contains: foo')
   })
 
 
@@ -72,7 +72,7 @@ describe('Search query display text', () => {
     const { container } = render((
       <SearchQueryDisplay facets={[]} terms={['(foo']}/>
     ))
-    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual('Text contains: (foo')
+    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual('Text contains: (foo')
   })
 
   it('renders terms and a single facet', async () => {
@@ -80,7 +80,7 @@ describe('Search query display text', () => {
       <SearchQueryDisplay facets={oneStringFacet} terms={['foo', 'bar']}/>
     ))
 
-    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual('(Text contains: foo OR bar) AND (Metadata contains (species: Homo sapiens))')
+    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual('(Text contains: foo OR bar) AND (Metadata contains (species: Homo sapiens))')
   })
 
   it('renders or-ed facets properly', async () => {

--- a/test/js/search/search-query-display.test.js
+++ b/test/js/search/search-query-display.test.js
@@ -64,14 +64,23 @@ describe('Search query display text', () => {
     const { container } = render((
       <SearchQueryDisplay facets={[]} terms={['foo']}/>
     ))
-    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual('Text contains (foo)')
+    expect(container.getElementsByClassName('query-text')[0].textContent.trim("Text contains: foo")).toEqual()
+  })
+
+
+  it('renders terms including one with mismatched parenthesis', async () => {
+    const { container } = render((
+      <SearchQueryDisplay facets={[]} terms={['(foo']}/>
+    ))
+    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual("Text contains: (foo")
   })
 
   it('renders terms and a single facet', async () => {
     const { container } = render((
       <SearchQueryDisplay facets={oneStringFacet} terms={['foo', 'bar']}/>
     ))
-    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual('(Text contains (foo OR bar)) AND (Metadata contains (species: Homo sapiens))')
+
+    expect(container.getElementsByClassName('query-text')[0].textContent.trim()).toEqual("(Text contains: foo OR bar) AND (Metadata contains (species: Homo sapiens))")
   })
 
   it('renders or-ed facets properly', async () => {


### PR DESCRIPTION
We got this error in Sentry:
Where a user had an unmatched parenthesis. This caused an error that got reported to Sentry. We also noted that the users search input matched closely to the helper text so I revised that to not use extraneous parenthesis to hopefully avoid this sort of issue in the future.

To test:
- Pull this branch
- Open up the home page of SCP
- 