### PR TITLE
Update to use ingest 1.19.1 (SCP-4445)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.19.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.19.1'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
Update production to use [ingest pipeline 1.19.1](https://github.com/broadinstitute/scp-ingest-pipeline/pull/258).

This fixes ingest delocalization bug (SCP-4445)