### PR TITLE
Storing references for valid differential expression results (SCP-4437, SCP-4438, SCP-4404)

### DIFF
--- a/app/controllers/api/v1/visualization/explore_controller.rb
+++ b/app/controllers/api/v1/visualization/explore_controller.rb
@@ -153,6 +153,7 @@ module Api
             annotationList: AnnotationVizService.get_study_annotation_options(study, user),
             clusterGroupNames: ClusterVizService.load_cluster_group_options(study),
             spatialGroups: spatial_group_options,
+            differentialExpression: AnnotationVizService.differential_expression_menu_opts(study),
             imageFiles: image_options,
             clusterPointAlpha: study.default_cluster_point_alpha,
             colorProfile: study.default_color_profile,

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -221,8 +221,7 @@ class AnnotationVizService
         cluster_name: diff_exp_result.cluster_group.name, # use current name, not cached name
         annotation_name: diff_exp_result.annotation_name,
         annotation_scope: diff_exp_result.annotation_scope,
-        observed_values: diff_exp_result.observed_values,
-        result_files: diff_exp_result.result_files
+        select_options: diff_exp_result.result_files.to_a # to_a turns Hash into nested array of arrays for select opts
       }
     end
   end

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -213,4 +213,16 @@ class AnnotationVizService
     return values if annotation_type == 'numeric'
     values.map {|value| value.blank? ? MISSING_VALUE_LABEL : value }
   end
+
+  # create a menu configuration for differential expression results for a given study
+  def self.differential_expression_menu_opts(study)
+    study.differential_expression_results.map do |diff_exp_result|
+      {
+        cluster_name: diff_exp_result.cluster_group.name, # use current name, not cached name
+        annotation: diff_exp_result.annotation_identifier,
+        observed_values: diff_exp_result.observed_values,
+        media_urls: diff_exp_result.media_urls
+      }
+    end
+  end
 end

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -221,7 +221,8 @@ class AnnotationVizService
         cluster_name: diff_exp_result.cluster_group.name, # use current name, not cached name
         annotation_name: diff_exp_result.annotation_name,
         annotation_scope: diff_exp_result.annotation_scope,
-        observed_values: diff_exp_result.observed_values
+        observed_values: diff_exp_result.observed_values,
+        result_files: diff_exp_result.result_files
       }
     end
   end

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -219,9 +219,9 @@ class AnnotationVizService
     study.differential_expression_results.map do |diff_exp_result|
       {
         cluster_name: diff_exp_result.cluster_group.name, # use current name, not cached name
-        annotation: diff_exp_result.annotation_identifier,
-        observed_values: diff_exp_result.observed_values,
-        media_urls: diff_exp_result.media_urls
+        annotation_name: diff_exp_result.annotation_name,
+        annotation_scope: diff_exp_result.annotation_scope,
+        observed_values: diff_exp_result.observed_values
       }
     end
   end

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -221,7 +221,7 @@ class AnnotationVizService
         cluster_name: diff_exp_result.cluster_group.name, # use current name, not cached name
         annotation_name: diff_exp_result.annotation_name,
         annotation_scope: diff_exp_result.annotation_scope,
-        select_options: diff_exp_result.result_files.to_a # to_a turns Hash into nested array of arrays for select opts
+        select_options: diff_exp_result.select_options # to_a turns Hash into nested array of arrays for select opts
       }
     end
   end

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -285,7 +285,7 @@ class ClusterVizService
   #   - +annotation_name+  (String) => Name of requested annotation
   #   - +annotation_type+  (String) => Type of requested annotation (should be 'group')
   #   - +annotation_scope+ (String) => Scope of requested annotation ('study' or 'cluster')
-  def self.get_cells_by_label(cluster, annotation_name, annotation_type, annotation_scope)
+  def self.cells_by_annotation_label(cluster, annotation_name, annotation_type, annotation_scope)
     study = cluster.study
     cells = cluster.concatenate_data_arrays('text', 'cells')
     annotation = { name: annotation_name, scope: annotation_scope, type: annotation_type }

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -275,4 +275,26 @@ class ClusterVizService
 
     raw_matrix
   end
+
+  # find what annotation values are represented for this combination of cluster & annotation
+  # primarily important as a validation for differential expression, as DE cannot be run on single-value annotations,
+  # or on labels that have only one cell
+  #
+  # * *params*
+  #   - +cluster+    (ClusterGroup) => Clustering object being used as control cell list
+  #   - +annotation_name+  (String) => Name of requested annotation
+  #   - +annotation_type+  (String) => Type of requested annotation (should be 'group')
+  #   - +annotation_scope+ (String) => Scope of requested annotation ('study' or 'cluster')
+  def self.get_cells_by_label(cluster, annotation_name, annotation_type, annotation_scope)
+    study = cluster.study
+    cells = cluster.concatenate_data_arrays('text', 'cells')
+    annotation = { name: annotation_name, scope: annotation_scope, type: annotation_type }
+    labels = get_annotation_values_array(study, cluster, annotation, cells, nil, nil)
+    cells_by_label = {}
+    labels.each_with_index do |label, index|
+      cells_by_label[label] ||= []
+      cells_by_label[label] << cells[index]
+    end
+    cells_by_label
+  end
 end

--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -200,6 +200,13 @@ class DifferentialExpressionService
     identifier = "#{annotation_name}--#{annotation_type}--#{annotation_scope}"
     raise ArgumentError, "#{identifier} is not present" if annotation.nil?
     raise ArgumentError, "#{identifier} cannot be visualized" unless can_visualize
+
+    # last, validate that the requested annotation & cluster will provide a valid intersection of annotation values
+    # specifically, discard any annotation/cluster combos that only result in one distinct label
+    cells_by_label = ClusterVizService.get_cells_by_label(cluster, annotation_name, annotation_type, annotation_scope)
+    if cells_by_label.keys < 2
+      raise ArgumentError, "#{identifier} does not have enough labels represented in #{cluster.name}"
+    end
   end
 
   # validate a given study is able to run DE job

--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -203,7 +203,7 @@ class DifferentialExpressionService
 
     # last, validate that the requested annotation & cluster will provide a valid intersection of annotation values
     # specifically, discard any annotation/cluster combos that only result in one distinct label
-    cells_by_label = ClusterVizService.get_cells_by_label(cluster, annotation_name, annotation_type, annotation_scope)
+    cells_by_label = ClusterVizService.cells_by_annotation_label(cluster, annotation_name, annotation_type, annotation_scope)
     if cells_by_label.keys < 2
       raise ArgumentError, "#{identifier} does not have enough labels represented in #{cluster.name}"
     end

--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -20,6 +20,7 @@ class DifferentialExpressionResult
 
   before_validation :set_observed_values, :set_cluster_name
 
+  # pointer to source annotation object, either CellMetadatum of ClusterGroup#cell_annotation
   def annotation_object
     case annotation_scope
     when 'study'
@@ -46,14 +47,6 @@ class DifferentialExpressionResult
     de_params = [cluster_name, annotation_name, label, annotation_scope, 'wilcoxon']
     filename = de_params.map { |val| val.gsub(/\W+/, '_') }.join('--')
     "_scp_internal/differential_expression/#{filename}.tsv"
-  end
-
-  # return a Hash of observed annotation values to GCS media URLs for each DE output file
-  # does not use Ruby GCS bindings as this adds latency; rather, URLs are manually computed since they're static
-  def media_urls
-    base_url = "https://storage.googleapis.com/download/storage/v1/b/#{study.bucket_id}/o"
-    urls = observed_values.map { |label| "#{base_url}/#{bucket_path_for(label)}?alt=media" }
-    Hash[observed_values.zip(urls)]
   end
 
   private

--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -4,7 +4,7 @@ class DifferentialExpressionResult
   include Mongoid::Timestamps
 
   # minimum number of observed_values, or cells per observed_value
-  MIN_VALUES = 2
+  MIN_OBSERVED_VALUES = 2
 
   belongs_to :study
   belongs_to :cluster_group
@@ -31,13 +31,32 @@ class DifferentialExpressionResult
     end
   end
 
-  # get an individual differential expression output file media url for a given annotation label
-  def media_url_for(label)
+  # get query string formatted annotation identifier, e.g. cell_type__ontology_label--group--study
+  def annotation_identifier
+    case annotation_scope
+    when 'study'
+      annotation_object.annotation_select_value
+    when 'cluster'
+      cluster_group.annotation_select_value(annotation_object)
+    end
+  end
+
+  # compute the relative path inside a GCS bucket of a DE output file for a given annotation label
+  def bucket_path_for(label)
     de_params = [cluster_name, annotation_name, label, annotation_scope, 'wilcoxon']
     filename = de_params.map { |val| val.gsub(/\W+/, '_') }.join('--')
-    file_path = "_scp_internal/differential_expression/#{filename}.tsv"
+    "_scp_internal/differential_expression/#{filename}.tsv"
+  end
+
+  # return array of all media URLs
+  def media_urls
+    observed_values.map { |value| media_url_for(value) }.compact
+  end
+
+  # get an individual differential expression output file media url for a given annotation label
+  def media_url_for(label)
     begin
-      remote = ApplicationController.firecloud_client.get_workspace_file(study.bucket_id, file_path)
+      remote = ApplicationController.firecloud_client.get_workspace_file(study.bucket_id, bucket_path_for(label))
       remote.media_url
     rescue NoMethodError => e
       Rails.logger.error "Error retrieving media url for DE output #{label} in #{study.accession}: #{e.message}"
@@ -50,8 +69,11 @@ class DifferentialExpressionResult
 
   # find the intersection of annotation values from the source, filtered for cells observed in cluster
   def set_observed_values
-    cells_by_label = ClusterVizService.get_cells_by_label(cluster_group, annotation_name, 'group', annotation_scope)
-    observed = cells_by_label.keys.reject { |label| cells_by_label[label].count < MIN_VALUES }
+    cells_by_label = ClusterVizService.cells_by_annotation_label(cluster_group,
+                                                                 annotation_name,
+                                                                 'group',
+                                                                 annotation_scope)
+    observed = cells_by_label.keys.reject { |label| cells_by_label[label].count < MIN_OBSERVED_VALUES }
     self.observed_values = observed
   end
 
@@ -60,6 +82,8 @@ class DifferentialExpressionResult
   end
 
   def has_observed_values?
-    errors.add(:observed_values, "must have at least #{MIN_VALUES} values") if observed_values.count < MIN_VALUES
+    if observed_values.count < MIN_OBSERVED_VALUES
+      errors.add(:observed_values, "must have at least #{MIN_OBSERVED_VALUES} values")
+    end
   end
 end

--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -1,0 +1,65 @@
+# store pointers to differential expression output sets for a given cluster/annotation
+class DifferentialExpressionResult
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  # minimum number of observed_values, or cells per observed_value
+  MIN_VALUES = 2
+
+  belongs_to :study
+  belongs_to :cluster_group
+
+  field :cluster_name, type: String # cache name of cluster at time of creation to avoid renaming issues
+  field :observed_values, type: Array, default: []
+  field :annotation_name, type: String
+  field :annotation_scope, type: String
+
+  validates :annotation_scope, inclusion: { in: %w[study cluster] }
+  validates :annotation_name, :cluster_name, presence: true
+  validate :has_observed_values?
+
+  before_validation :set_observed_values, :set_cluster_name
+
+  def annotation_object
+    case annotation_scope
+    when 'study'
+      study.cell_metadata.by_name_and_type(annotation_name, 'group')
+    when 'cluster'
+      cluster_group.cell_annotations.detect do |annotation|
+        annotation[:name] == annotation_name && annotation[:scope] == 'group'
+      end
+    end
+  end
+
+  # get an individual differential expression output file media url for a given annotation label
+  def media_url_for(label)
+    de_params = [cluster_name, annotation_name, label, annotation_scope, 'wilcoxon']
+    filename = de_params.map { |val| val.gsub(/\W+/, '_') }.join('--')
+    file_path = "_scp_internal/differential_expression/#{filename}.tsv"
+    begin
+      remote = ApplicationController.firecloud_client.get_workspace_file(study.bucket_id, file_path)
+      remote.media_url
+    rescue NoMethodError => e
+      Rails.logger.error "Error retrieving media url for DE output #{label} in #{study.accession}: #{e.message}"
+      ErrorTracker.report_exception(e, nil, self, { requested_label: label })
+      nil # avoid returning integer value from reporting error
+    end
+  end
+
+  private
+
+  # find the intersection of annotation values from the source, filtered for cells observed in cluster
+  def set_observed_values
+    cells_by_label = ClusterVizService.get_cells_by_label(cluster_group, annotation_name, 'group', annotation_scope)
+    observed = cells_by_label.keys.reject { |label| cells_by_label[label].count < MIN_VALUES }
+    self.observed_values = observed
+  end
+
+  def set_cluster_name
+    self.cluster_name = cluster_group.name
+  end
+
+  def has_observed_values?
+    errors.add(:observed_values, "must have at least #{MIN_VALUES} values") if observed_values.count < MIN_VALUES
+  end
+end

--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -27,7 +27,7 @@ class DifferentialExpressionResult
       study.cell_metadata.by_name_and_type(annotation_name, 'group')
     when 'cluster'
       cluster_group.cell_annotations.detect do |annotation|
-        annotation[:name] == annotation_name && annotation[:scope] == 'group'
+        annotation[:name] == annotation_name && annotation[:type] == 'group'
       end
     end
   end
@@ -64,6 +64,11 @@ class DifferentialExpressionResult
   def result_files
     files = observed_values.map { |label| filename_for(label) }
     Hash[observed_values.zip(files)]
+  end
+
+  # nested array of arrays representation of :result_files (for select menu options)
+  def select_options
+    result_files.to_a
   end
 
   private

--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -42,11 +42,28 @@ class DifferentialExpressionResult
     end
   end
 
-  # compute the relative path inside a GCS bucket of a DE output file for a given annotation label
+  # compute the relative path inside a GCS bucket of a DE output file for a given label
   def bucket_path_for(label)
-    de_params = [cluster_name, annotation_name, label, annotation_scope, 'wilcoxon']
-    filename = de_params.map { |val| val.gsub(/\W+/, '_') }.join('--')
-    "_scp_internal/differential_expression/#{filename}.tsv"
+    "_scp_internal/differential_expression/#{filename_for(label)}"
+  end
+
+  # individual filename of label-specific result
+  def filename_for(label)
+    basename = [
+      cluster_name,
+      annotation_name,
+      label,
+      annotation_scope,
+      'wilcoxon'
+    ].map { |val| val.gsub(/\W+/, '_') }.join('--')
+    "#{basename}.tsv"
+  end
+
+  # map of all observed result files, of label value => label-specific filenames
+  # this is important as it sidesteps the issue of study owners renaming clusters, as cluster_name is cached here
+  def result_files
+    files = observed_values.map { |label| filename_for(label) }
+    Hash[observed_values.zip(files)]
   end
 
   private

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -374,7 +374,7 @@ class IngestJob
     when :ingest_subsample
       set_subsampling_flags
     when :differential_expression
-      set_differential_expression_flags
+      create_differential_expression_results
     end
     set_study_initialized
   end
@@ -488,7 +488,7 @@ class IngestJob
   end
 
   # set corresponding differential expression flags on associated annotation
-  def set_differential_expression_flags
+  def create_differential_expression_results
     annotation_identifier = "#{params_object.annotation_name}--group--#{params_object.annotation_scope}"
     Rails.logger.info "Setting differential expression flags for annotation: #{annotation_identifier}"
     if params_object.annotation_scope == 'cluster'

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -490,18 +490,13 @@ class IngestJob
   # set corresponding differential expression flags on associated annotation
   def create_differential_expression_results
     annotation_identifier = "#{params_object.annotation_name}--group--#{params_object.annotation_scope}"
-    Rails.logger.info "Setting differential expression flags for annotation: #{annotation_identifier}"
-    if params_object.annotation_scope == 'cluster'
-      cluster = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
-      # update cell annotation in place
-      cluster.cell_annotations.each do |annotation|
-        annotation[:is_differential_expression_enabled] = true if annotation[:name] == params_object.annotation_name
-      end
-      cluster.save
-    else
-      meta = study.cell_metadata.by_name_and_type(params_object.annotation_name, params_object.annotation_type)
-      meta.update(is_differential_expression_enabled: true)
-    end
+    Rails.logger.info "Creating differential expression results objects for annotation: #{annotation_identifier}"
+    cluster = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
+    de_result = DifferentialExpressionResult.new(
+      study: study, cluster_group: cluster, cluster_name: cluster.name,
+      annotation_name: params_object.annotation_name, annotation_scope: params_object.annotation_scope
+    )
+    de_result.save
   end
 
   # set corresponding is_differential_expression_enabled flags on annotations

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -243,6 +243,8 @@ class Study
   has_one :reviewer_access, dependent: :delete_all
   accepts_nested_attributes_for :reviewer_access, allow_destroy: true
 
+  has_many :differential_expression_results, dependent: :delete_all
+
   # field definitions
   field :name, type: String
   field :embargo, type: Date

--- a/db/migrate/20220613143906_create_differential_expression_results.rb
+++ b/db/migrate/20220613143906_create_differential_expression_results.rb
@@ -1,0 +1,70 @@
+class CreateDifferentialExpressionResults < Mongoid::Migration
+
+  def self.check_de_results(results_obj)
+    de_identifier = "#{results_obj.study.accession}:#{results_obj.cluster_name} (#{results_obj.annotation_identifier})"
+    Rails.logger.info "Checking DE results for #{de_identifier}"
+    if results_obj.valid?
+      Rails.logger.info "Results for #{de_identifier} valid, saving"
+      results_obj.save!
+      # determine if there are some output files that are still invalid and should be removed
+      # can be determined with the difference between the list of original values and observed values
+      annotation = results_obj.annotation_object
+      source_labels = annotation.respond_to?(:values) ? annotation.values : annotation[:values]
+      invalid_labels = source_labels - results_obj.observed_values
+      invalid_labels.each do |label|
+        remove_output_file(results_obj, label)
+      end
+    else
+      Rails.logger.info "Results for #{de_identifier} invalid, removing outputs from bucket"
+      # clean up any output files in the bucket
+      annotation = results_obj.annotation_object
+      possible_values = annotation.respond_to?(:values) ? annotation.values : annotation[:values]
+      possible_values.each do |label|
+        remove_output_file(results_obj, label)
+      end
+      results_obj.delete # remove object as it is invalid
+    end
+  end
+
+  def self.remove_output_file(results_obj, label)
+    begin
+      output_location = results_obj.bucket_path_for(label)
+      remote = ApplicationController.firecloud_client.get_workspace_file(results_obj.study.bucket_id, output_location)
+      remote.delete if remote.present?
+      Rails.logger.info "Removed output file at #{output_location}"
+    rescue => e
+      Rails.logger.error "Unable to remove possible DE output '#{output_location}' - #{e.message}"
+      ErrorTracker.report_exception(e, nil, results_obj, { output_location: output_location })
+    end
+  end
+
+  def self.up
+    CellMetadatum.where(is_differential_expression_enabled: true).each do |metadata|
+      study = metadata.study
+      study.cluster_groups.each do |cluster_group|
+        de_result = DifferentialExpressionResult.new(
+          cluster_group: cluster_group, study: study, cluster_name: cluster_group.name,
+          annotation_name: metadata.name, annotation_scope: 'study'
+        )
+        check_de_results(de_result)
+      end
+    end
+    ClusterGroup.where(:cell_annotations.ne => []).each do |cluster_group|
+      cluster_group.cell_annotations.each do |annotation|
+        safe_annotation = annotation.with_indifferent_access
+        next if !safe_annotation[:is_differential_expression_enabled]
+
+        study = cluster_group.study
+        de_result = DifferentialExpressionResult.new(
+          cluster_group: cluster_group, study: study, cluster_name: cluster_group.name,
+          annotation_name: safe_annotation[:name], annotation_scope: 'cluster'
+        )
+        check_de_results(de_result)
+      end
+    end
+  end
+
+  def self.down
+    DifferentialExpressionResult.delete_all
+  end
+end

--- a/test/factories/differential_expression_results.rb
+++ b/test/factories/differential_expression_results.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :differential_expression_result do
+    observed_values { [] }
+    cluster_name { cluster.name }
+    annotation_name { }
+    annotation_scope { }
+  end
+end

--- a/test/models/differential_expression_result_test.rb
+++ b/test/models/differential_expression_result_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class DifferentialExpressionResultTest  < ActiveSupport::TestCase
+end

--- a/test/models/differential_expression_result_test.rb
+++ b/test/models/differential_expression_result_test.rb
@@ -30,41 +30,86 @@ class DifferentialExpressionResultTest  < ActiveSupport::TestCase
                                       cell_input: {
                                         x: @coordinates,
                                         y: @coordinates,
-                                        cells: @cells
-                                      })
+                                        cells: @cells,
+                                      },
+                                      annotation_input: [
+                                        { name: 'disease', type: 'group', values: @diseases }
+                                      ])
+    @cluster_group = ClusterGroup.find_by(study: @study, study_file: @cluster_file)
+
     FactoryBot.create(:metadata_file,
                       name: 'metadata.txt',
                       study: @study,
                       cell_input: @cells,
                       annotation_input: [
                         { name: 'species', type: 'group', values: @species },
-                        { name: 'disease', type: 'group', values: @diseases },
                         { name: 'library_preparation_protocol', type: 'group', values: @library_preparation_protocol }
                       ])
 
-    @differential_expression_result = DifferentialExpressionResult.create(
+    @species_result = DifferentialExpressionResult.create(
       study: @study, cluster_group: @cluster_file.cluster_groups.first, annotation_name: 'species',
       annotation_scope: 'study'
     )
+
+    @disease_result = DifferentialExpressionResult.create(
+      study: @study, cluster_group: @cluster_file.cluster_groups.first, annotation_name: 'disease',
+      annotation_scope: 'cluster'
+    )
   end
 
-  test 'should validate DE results' do
-    assert @differential_expression_result.valid?
-    assert_equal %w[cat dog], @differential_expression_result.observed_values.sort
+  test 'should validate DE results and set observed values' do
+    assert @species_result.valid?
+    assert_equal %w[cat dog], @species_result.observed_values.sort
+    assert_equal @cluster_group.name, @species_result.cluster_name
 
-    disease_result = DifferentialExpressionResult.new(
-      study: @study, cluster_group: @cluster_file.cluster_groups.first, annotation_name: 'disease',
-      annotation_scope: 'study'
-    )
-
-    assert disease_result.valid?
-    assert_equal %w[measles none], disease_result.observed_values.sort
+    assert @disease_result.valid?
+    assert_equal %w[measles none], @disease_result.observed_values.sort
+    assert_equal @cluster_group.name, @disease_result.cluster_name
 
     library_result = DifferentialExpressionResult.new(
-      study: @study, cluster_group: @cluster_file.cluster_groups.first, annotation_name: 'library_preparation_protocol',
+      study: @study, cluster_group: @cluster_group, annotation_name: 'library_preparation_protocol',
       annotation_scope: 'study'
     )
 
     assert_not library_result.valid?
+  end
+
+  test 'should retrieve source annotation object' do
+    assert @species_result.annotation_object.present?
+    assert @species_result.annotation_object.is_a?(CellMetadatum)
+    assert_equal @species_result.observed_values.sort,
+                 @species_result.annotation_object.values.sort
+
+    assert @disease_result.annotation_object.present?
+    assert @disease_result.annotation_object.is_a?(Hash) # cell_annotation from ClusterGroup
+    assert_equal @disease_result.observed_values.sort, @disease_result.annotation_object[:values].sort
+  end
+
+  test 'should return relative bucket pathname for individual label' do
+    prefix = "_scp_internal/differential_expression"
+    @species_result.observed_values.each do |label|
+      expected_filename = "#{prefix}/cluster_diffexp_txt--species--#{label}--study--wilcoxon.tsv"
+      assert_equal expected_filename, @species_result.bucket_path_for(label)
+    end
+
+    @disease_result.observed_values.each do |label|
+      expected_filename = "#{prefix}/cluster_diffexp_txt--disease--#{label}--cluster--wilcoxon.tsv"
+      assert_equal expected_filename, @disease_result.bucket_path_for(label)
+    end
+  end
+
+  test 'should return array of select options for observed outputs' do
+    species_opts = {
+      dog: 'cluster_diffexp_txt--species--dog--study--wilcoxon.tsv',
+      cat: 'cluster_diffexp_txt--species--cat--study--wilcoxon.tsv'
+    }.with_indifferent_access
+
+    disease_opts = {
+      measles: 'cluster_diffexp_txt--disease--measles--cluster--wilcoxon.tsv',
+      none: 'cluster_diffexp_txt--disease--none--cluster--wilcoxon.tsv'
+    }.with_indifferent_access
+
+    assert_equal species_opts.to_a, @species_result.select_options
+    assert_equal disease_opts.to_a, @disease_result.select_options
   end
 end

--- a/test/models/differential_expression_result_test.rb
+++ b/test/models/differential_expression_result_test.rb
@@ -1,4 +1,70 @@
 require 'test_helper'
 
 class DifferentialExpressionResultTest  < ActiveSupport::TestCase
+
+  before(:all) do
+    @user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                                     name_prefix: 'DifferentialExpressionResult Test',
+                                     user: @user,
+                                     test_array: @@studies_to_clean)
+
+    @cells = %w[A B C D E F G]
+    @coordinates = 1.upto(7).to_a
+    @species = %w[dog cat dog dog cat cat cat]
+    @diseases = %w[measles measles measles none none measles measles]
+    @library_preparation_protocol = Array.new(7, "10X 5' v3")
+    @raw_matrix = FactoryBot.create(:expression_file,
+                                    name: 'raw.txt',
+                                    study: @study,
+                                    expression_file_info: {
+                                      is_raw_counts: true,
+                                      units: 'raw counts',
+                                      library_preparation_protocol: 'Drop-seq',
+                                      biosample_input_type: 'Whole cell',
+                                      modality: 'Proteomic'
+                                    })
+    @cluster_file = FactoryBot.create(:cluster_file,
+                                      name: 'cluster_diffexp.txt',
+                                      study: @study,
+                                      cell_input: {
+                                        x: @coordinates,
+                                        y: @coordinates,
+                                        cells: @cells
+                                      })
+    FactoryBot.create(:metadata_file,
+                      name: 'metadata.txt',
+                      study: @study,
+                      cell_input: @cells,
+                      annotation_input: [
+                        { name: 'species', type: 'group', values: @species },
+                        { name: 'disease', type: 'group', values: @diseases },
+                        { name: 'library_preparation_protocol', type: 'group', values: @library_preparation_protocol }
+                      ])
+
+    @differential_expression_result = DifferentialExpressionResult.create(
+      study: @study, cluster_group: @cluster_file.cluster_groups.first, annotation_name: 'species',
+      annotation_scope: 'study'
+    )
+  end
+
+  test 'should validate DE results' do
+    assert @differential_expression_result.valid?
+    assert_equal %w[cat dog], @differential_expression_result.observed_values.sort
+
+    disease_result = DifferentialExpressionResult.new(
+      study: @study, cluster_group: @cluster_file.cluster_groups.first, annotation_name: 'disease',
+      annotation_scope: 'study'
+    )
+
+    assert disease_result.valid?
+    assert_equal %w[measles none], disease_result.observed_values.sort
+
+    library_result = DifferentialExpressionResult.new(
+      study: @study, cluster_group: @cluster_file.cluster_groups.first, annotation_name: 'library_preparation_protocol',
+      annotation_scope: 'study'
+    )
+
+    assert_not library_result.valid?
+  end
 end


### PR DESCRIPTION
#### BACKGROUND
After backfilling differential expression results on candidate studies in production, it was noted that several corner cases arose where some results were considered invalid, or simply failed to output anything in the study bucket.  These include:

* For a given source annotation, while it may have multiple possible values, only one of those values may be represented in a given clustering file
* Some values may only be represented by a single cell in a given clustering file, meaning there is not enough data to compute results
* There was no way of knowing what combinations of clustering/annotations in a given study would have valid results, as the information was only stored at the annotation level.

#### CHANGES
SCP-4437: A new model called `DifferentialExpressionResult` will now store references to a given clustering object and specific annotation, denoting that there are valid differential expression results available for visualization.  The attribute `observed_values` keeps track of the individual annotation values that successfully generated output files.  When the `DifferentialExpressionResult` object is created, validations run to compute what values would have succeeded in the differential expression job, and if enough values (2+) had enough cells represented (2+) the object will save.  If either of those validations fail, the object will not save, and therefore will not be available from the differential expression picker menu.  This same validation code is also used in the `DifferentialExpressionService` to determine what jobs to launch, meaning that moving forward, fewer invalid output files should be generated.  This data is now available in the `/explore` API endpoint for a given study under the `differentialExpression` key.  Each object represents a set of outputs for a specific cluster and annotation, and has a `select_options` array that can be used to directly populate the differential expression picker in the UI.

SCP-4438: A data migration was created to move data from the `is_differential_expression_enabled` flag on annotations into `DifferentialExpressionResult` instances.  While performing the migration, any invalid outputs files that were generated as a part of a differential expression PAPI job will be removed from the bucket.

SCP-4404: Each `DifferentialExpressionResult` will cache the current name of the `ClusterGroup` object at the time of valid outputs being written to the study bucket.  This will prevent links to files breaking if a user changes the name of a `ClusterGroup`, and alleviates the need to rename files in buckets on said updates.  These values will be sourced from the `/explore` API response, and will contain a map of specific annotation labels to outputs files with the correct names.

#### MANUAL TESTING
IMPORTANT: If you do not have any differential expression outputs available in your local instance, please follow the instructions from #1512 to backfill some example data before running the manual testing steps

1. Pull branch and run any pending migrations with `./rails_local_setup.rb && source config/secrets/.source_env.bash`
2. Watch the `development.log` file, and look for entries like the following:
```
Checking DE results for SCP67:UMAP_crush (cell_type__ontology_label--group--study)
Results for SCP67:UMAP_crush (cell_type__ontology_label--group--study) valid, saving
Save complete, keeping valid outputs for pericyte cell, macrophage, perineuronal satellite cell, fibroblast, Schwann cell, myeloid cell, erythrocyte, primary neuron, endothelial cell, innate lymphoid cell
Found 1 invalid outputs: N/A, deleting
```
3. Boot local instance, and open the Network tab in Chrome Dev Tools
4. Load the above study, and filter for the `/explore` API response
5. Click "Preview" and confirm that there is an entry called `differentialExpression` with outputs similar to the following:
![differentialExpression](https://user-images.githubusercontent.com/729968/173675250-4970c980-a8ee-4dd6-8172-4869630ccf2a.png)

