### PR TITLE
Ensure completed MTX bundle for raw counts requirement (SCP-4326)

### DIFF
--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -247,9 +247,17 @@ module Api
       end
 
       def file_info
+        files_obj = []
+        @study.study_files.each do |study_file|
+          file_hash = study_file.attributes
+          if study_file.is_bundled?
+            file_hash[:has_completed_bundle] = study_file.has_completed_bundle?
+          end
+          files_obj << file_hash
+        end
         response_obj = {
           study: @study.attributes,
-          files: @study.study_files,
+          files: files_obj,
           feature_flags: FeatureFlaggable.feature_flags_for_instances(current_api_user, @study)
         }
         if params[:include_options]

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -248,7 +248,7 @@ module Api
 
       def file_info
         files_obj = []
-        @study.study_files.each do |study_file|
+        @study.study_files.where(queued_for_deletion: false).each do |study_file|
           file_hash = study_file.attributes
           file_hash[:is_complete] = study_file.should_bundle? ? study_file.has_completed_bundle? : true
           files_obj << file_hash

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -250,9 +250,7 @@ module Api
         files_obj = []
         @study.study_files.each do |study_file|
           file_hash = study_file.attributes
-          if study_file.is_bundled?
-            file_hash[:has_completed_bundle] = study_file.has_completed_bundle?
-          end
+          file_hash[:is_complete] = study_file.should_bundle? ? study_file.has_completed_bundle? : true
           files_obj << file_hash
         end
         response_obj = {

--- a/app/javascript/components/upload/ExpandableFileForm.jsx
+++ b/app/javascript/components/upload/ExpandableFileForm.jsx
@@ -152,7 +152,7 @@ function SaveButton({ file, saveFile, validationMessages = {} }) {
     const validationPopup = <Popover id={`save-invalid-${file._id}`} className="tooltip-wide">
       {Object.keys(validationMessages).map(key => <div key={key}>{validationMessages[key]}</div>)}
     </Popover>
-    saveButton = <OverlayTrigger trigger={['hover', 'focus']} rootClose placement="top" overlay={validationPopup}>
+    saveButton = <OverlayTrigger trigger={['hover', 'focus']} rootClose placement="left" overlay={validationPopup}>
       <div>{saveButton}</div>
     </OverlayTrigger>
   } else if (file.isSaving) {

--- a/app/javascript/components/upload/ExpressionFileForm.jsx
+++ b/app/javascript/components/upload/ExpressionFileForm.jsx
@@ -16,6 +16,9 @@ const REQUIRED_FIELDS = [{ label: 'species', propertyName: 'taxon_id' },
 const RAW_COUNTS_REQUIRED_FIELDS = REQUIRED_FIELDS.concat([{
   label: 'units', propertyName: 'expression_file_info.units'
 }])
+const PROCESSED_ASSOCIATION_FIELD = [
+  { label: 'Associated raw counts files', propertyName: 'expression_file_info.raw_counts_associations' }
+]
 
 /** renders a form for editing/uploading an expression file (raw or processed) and any bundle children */
 export default function ExpressionFileForm({
@@ -28,7 +31,8 @@ export default function ExpressionFileForm({
   fileMenuOptions,
   rawCountsOptions,
   bucketName,
-  isInitiallyExpanded
+  isInitiallyExpanded,
+  featureFlagState
 }) {
   const associatedChildren = findBundleChildren(file, allFiles)
   const speciesOptions = fileMenuOptions.species.map(spec => ({ label: spec.common_name, value: spec.id }))
@@ -37,7 +41,11 @@ export default function ExpressionFileForm({
   const isRawCountsFile = file.expression_file_info.is_raw_counts
 
   const allowedFileExts = isMtxFile ? FileTypeExtensions.mtx : FileTypeExtensions.plainText
-  const requiredFields = isRawCountsFile ? RAW_COUNTS_REQUIRED_FIELDS : REQUIRED_FIELDS
+  let requiredFields = isRawCountsFile ? RAW_COUNTS_REQUIRED_FIELDS : REQUIRED_FIELDS
+  const rawCountsRequired = featureFlagState && featureFlagState.raw_counts_required_frontend
+  if (rawCountsRequired && !isRawCountsFile) {
+    requiredFields = requiredFields.concat(PROCESSED_ASSOCIATION_FIELD)
+  }
   const validationMessages = validateFile({ file, allFiles, allowedFileExts, requiredFields })
 
   const associatedRawCounts = file.expression_file_info.raw_counts_associations.map(id => ({

--- a/app/javascript/components/upload/ProcessedExpressionStep.jsx
+++ b/app/javascript/components/upload/ProcessedExpressionStep.jsx
@@ -40,7 +40,7 @@ function ProcessedUploadForm({
   const processedParentFiles = formState.files.filter(processedFileFilter)
   const fileMenuOptions = serverState.menu_options
   const rawCountsFiles = formState.files.filter(rawCountsFileFilter).filter(
-    f => f.status != 'new' && f?.has_completed_bundle
+    f => f.status != 'new' && f.is_complete
   )
   const rawCountsOptions = rawCountsFiles.map(rf => ({ label: rf.name, value: rf._id }))
 
@@ -111,7 +111,9 @@ function ProcessedUploadForm({
             rawCountsOptions={rawCountsOptions}
             fileMenuOptions={fileMenuOptions}
             bucketName={formState.study.bucket_id}
-            isInitiallyExpanded={processedParentFiles.length === 1}/>
+            isInitiallyExpanded={processedParentFiles.length === 1}
+            featureFlagState={featureFlagState}
+          />
         })}
         <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_PROCESSED_FILE}/>
         { !isEnabled && <div className="file-upload-overlay" data-testid="processed-matrix-overlay"></div> }

--- a/app/javascript/components/upload/ProcessedExpressionStep.jsx
+++ b/app/javascript/components/upload/ProcessedExpressionStep.jsx
@@ -39,7 +39,9 @@ function ProcessedUploadForm({
 }) {
   const processedParentFiles = formState.files.filter(processedFileFilter)
   const fileMenuOptions = serverState.menu_options
-  const rawCountsFiles = formState.files.filter(rawCountsFileFilter).filter(f => f.status != 'new')
+  const rawCountsFiles = formState.files.filter(rawCountsFileFilter).filter(
+    f => f.status != 'new' && f?.has_completed_bundle
+  )
   const rawCountsOptions = rawCountsFiles.map(rf => ({ label: rf.name, value: rf._id }))
 
   const featureFlagState = serverState.feature_flags
@@ -58,12 +60,13 @@ function ProcessedUploadForm({
     { !isEnabled &&
       <div className="row">
         <div className="col-md-12 padded">
-          Uploading a raw count matrix is now required in order to access to processed matrix uploads.
-          <br/>
-          <br/>
-          If you are unable or do not wish to upload a raw count matrix, you can request an exemption using the link below.
-          <br/>
-          <br/>
+          <p className="left-margin">
+            Uploading a raw count matrix is now required in order to access to processed matrix uploads.
+          </p>
+          <p className="left-margin">
+            If you are unable or do not wish to upload a raw count matrix, you can request an exemption using the link
+            below.
+          </p>
           <div className="row">
             <div className="col-md-3 col-md-offset-2">
               <a className="action" onClick={() => setCurrentStep({ name: 'rawCounts' })}>

--- a/app/javascript/components/upload/ProcessedExpressionStep.jsx
+++ b/app/javascript/components/upload/ProcessedExpressionStep.jsx
@@ -61,7 +61,8 @@ function ProcessedUploadForm({
       <div className="row">
         <div className="col-md-12 padded">
           <p className="left-margin">
-            Uploading a raw count matrix is now required in order to access to processed matrix uploads.
+            Uploading a raw count matrix is required before uploading a processed matrix. Raw count matrices in sparse
+            (MTX) format must also include associated features/barcodes files.
           </p>
           <p className="left-margin">
             If you are unable or do not wish to upload a raw count matrix, you can request an exemption using the link

--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -165,7 +165,9 @@ export function validateFile({ file, allFiles, allowedFileExts=[], requiredField
 /** checks required fields are present */
 function validateRequiredFields(file, requiredFields, validationMessages) {
   requiredFields.forEach(field => {
-    if (!_get(file, field.propertyName)) {
+    const existingValue = _get(file, field.propertyName)
+    const isBlank = !existingValue || (typeof existingValue === 'object' && existingValue.length === 0)
+    if (isBlank) {
       validationMessages[field.propertyName] = `You must specify ${field.label}`
     }
   })

--- a/app/models/concerns/feature_flaggable.rb
+++ b/app/models/concerns/feature_flaggable.rb
@@ -250,9 +250,14 @@ module FeatureFlaggable
   def self.flag_override_for_instances(flag_name, override_value, *instances)
     feature_flag = FeatureFlag.find_by(name: flag_name.to_s)
     # if feature flag doesn't exist, return true as it may have been retired (or this is a CI and it wasn't seeded)
-    # also, if override and default are same, return true, since this is used in a validation context and false will
-    # invoke a validation error
-    return true if feature_flag.nil? || override_value == feature_flag.default_value
+    # if we're using this for a validation context, it is wise to check for flag presence before this call
+    return true if feature_flag.nil?
+
+    # if override value and default value are the same, return false
+    # the logic for this is that we're asking if there are any overrides to the default, and if the two values are the
+    # same, there cannot be an override
+    # take care in using this value as the results may not be intuitive in a validation context
+    return false if override_value == feature_flag.default_value
 
     class_names = []
     ids = []

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -125,7 +125,8 @@ class ExpressionFileInfo
       'raw_counts_required_backend', false, *user_accounts, study_file.study
     )
       errors.add(
-        :base, 'You must specify at least one associated raw count file that has genes and barcodes before saving'
+        :base, 'You must specify at least one associated raw count file before saving.  Raw count files in sparse ' \
+               '(MTX) format must also include associated features/barcodes files.'
       )
     end
   end

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -112,8 +112,10 @@ class ExpressionFileInfo
     if raw_counts_associations.any?
       raw_counts_associations.each do |study_file_id|
         raw_matrix = StudyFile.find(study_file_id)
-        # enforce bundle completion on matrix
-        return true if raw_matrix&.is_raw_counts_file? && raw_matrix&.has_completed_bundle?
+        # enforce bundle completion on matrix, if needed
+        # if matrix does not need to be bundled (e.g. is dense), then return true for is_completed
+        is_completed = raw_matrix&.should_bundle? ? raw_matrix.has_completed_bundle? : true
+        return true if raw_matrix&.is_raw_counts_file? && is_completed
       end
     end
 

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -814,6 +814,11 @@ class StudyFile
     self.study_file_bundle.present?
   end
 
+  # determine if study file should have a bundle (i.e. is not valid without completed bundle)
+  def should_bundle?
+    StudyFileBundle::REQUIRE_BUNDLE.include?(file_type)
+  end
+
   # gracefully check if study_file_bundle is both present and completed
   def has_completed_bundle?
     self.study_file_bundle.try(:completed?)

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1332,6 +1332,9 @@ class StudyFile
   # ensure that metadata file adheres to convention acceptance criteria, if turned on
   # will check for exemption from any users associated with given study
   def ensure_metadata_convention
+    convention_required = FeatureFlag.find_by(name: 'convention_required')
+    return true if convention_required.nil? || convention_required.default_value == false
+
     # check for exemption across all associated users & study object
     user_accounts = study.associated_users(permission: 'Edit')
     unless FeatureFlaggable.flag_override_for_instances(

--- a/test/js/upload-wizard/file-info-responses.js
+++ b/test/js/upload-wizard/file-info-responses.js
@@ -23,6 +23,7 @@ export const RAW_COUNTS_FILE = {
   'human_data': false,
   'human_fastq_url': 'null',
   'is_spatial': false,
+  'is_complete': true,
   'name': 'example_raw_counts.txt',
   'options': {},
   'parse_status': 'parsed',

--- a/test/js/upload-wizard/upload-new-study.test.js
+++ b/test/js/upload-wizard/upload-new-study.test.js
@@ -149,9 +149,10 @@ async function testProcessedUpload({ createFileSpy }) {
   expect(screen.getByRole('tooltip')).not.toHaveTextContent('You must specify species')
 
   await selectEvent.select(getSelectByLabelText(screen, 'Library preparation protocol *'), 'Drop-seq')
-  expect(saveButton()).not.toBeDisabled()
+  expect(saveButton()).toBeDisabled()
 
   await selectEvent.select(getSelectByLabelText(screen, 'Associated raw counts files'), rawCountsFileName)
+  expect(saveButton()).not.toBeDisabled()
 
   fireEvent.click(saveButton())
   await waitForElementToBeRemoved(() => screen.getByTestId('file-save-spinner'))

--- a/test/models/feature_flag_test.rb
+++ b/test/models/feature_flag_test.rb
@@ -81,8 +81,8 @@ class FeatureFlagTest < ActiveSupport::TestCase
     FeatureFlag.create(name: flag_name.to_s, default_value: false)
     assert_not FeatureFlaggable.flag_override_for_instances(flag_name, true, @user)
     assert_not FeatureFlaggable.flag_override_for_instances(flag_name, true, @user, @branding_group)
-    # assert that override same as default value always returns true
-    assert FeatureFlaggable.flag_override_for_instances(flag_name, false, @user)
+    # assert that override same as default value always returns false, since there's no override in effect
+    assert_not FeatureFlaggable.flag_override_for_instances(flag_name, false, @user)
     @user.set_flag_option(flag_name, true)
     assert FeatureFlaggable.flag_override_for_instances(flag_name, true, @user)
     assert FeatureFlaggable.flag_override_for_instances(flag_name, true, @user, @branding_group)


### PR DESCRIPTION
#### BACKGROUND
It was discovered recently that users were unintentionally circumventing the raw counts upload requirement by supplying only an MTX file, and not associated barcodes/features files.  This has implications for both downstream analysis and differential expression, as both would be blocked.  In addition, the enforcement of the feature flag on the front end broke and was no longer prompting users to upload raw data first, leaving only the backend validation in place.

#### CHANGES
The upload wizard will now validate raw count files by checking a new `is_complete` property which has been added to the `file_info` API endpoint.  This property is a check to determine if the matrix file _should_ be bundled (i.e. is an MTX file), and if so, are all required files uploaded.  Furthermore, the `raw_counts_required_fronted` feature flag is now enforced at the UI level, and will prevent users from uploading/saving processed expression matrices.  In addition, this update refines logic for feature flag overrides for handling `raw_counts_required_backend` and `convention_required` flags to make the behavior more explicit.

#### MANUAL TESTING
1. Boot as normal, start DelayedJob, and sign in
2. In a Rails console session, ensure all `raw_counts_required` feature flags are turned on:
```
FeatureFlag.where(name: /raw_counts_required/).update_all(default_value: true)
```
3. Back in the portal, create a new study, or go to an existing study w/o any expression matrices
4. In the Raw Counts tab, upload `test/test_data/GRCh38/test_matrix.mtx`
5. In the Processed Matrix tab, hover over the save button and note the following messages:
![Screen Shot 2022-06-16 at 12 02 18 PM](https://user-images.githubusercontent.com/729968/174120723-263a2c5c-c3c6-4e19-93eb-69f777fefd28.png)
6. Attempt to upload `test/test_data/expression_matrix_example.txt`, and note the save button is still disabled for the raw counts association
7. Upload `test/test_data/GRCh38/test_genes.tsv` and `test/test_data/GRCh38/barcodes.tsv` back in the Raw Counts tab
8. Once uploaded, refresh the page, and then set the `Associated raw counts file` for `test/test_data/expression_matrix_example.txt` and confirm the upload succeeds
9. Optional: turn off the `raw_counts_required_frontend` feature flag, and attempt to upload another processed matrix, and note the following error:
 ![Screen Shot 2022-06-16 at 12 04 35 PM](https://user-images.githubusercontent.com/729968/174121198-32a54a19-5ac6-4505-8b85-124517c08ef1.png)