### PR TITLE
Add social media links to footer (SCP-4416)

### DIFF
--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -126,6 +126,14 @@
   display: inline-block;
 }
 
+.footer-social-media-icons-block {
+  color: white;
+  font-size: 30px;
+  height: 54px;
+  padding: 5px 30px 0 15px;
+  display: inline-block;
+}
+
 .study-panel, .study-genes-panel {
   box-shadow: 0 0 2px 0 rgba(0,0,0,0.12), 0 3px 2px 0 rgba(0,0,0,0.12);
   .panel-heading {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -196,6 +196,12 @@
         <%= link_to "<i class='fas fa-chevron-circle-left fa-fw'></i> Return to Single Cell Portal".html_safe, site_path %>
       <% end %>
     </div>
+    <div class="footer-social-media-icons-block pull-right ">
+    <%= link_to "<i class='fab fa-youtube'></i>".html_safe, "https://www.youtube.com/channel/UCp_UGD74MW8up1YkWZrWkKw", target: :_blank  %>
+    &nbsp;
+    <%= link_to "<i class='fab fa-twitter-square'></i>".html_safe, "https://twitter.com/SingleCellBroad", target: :_blank  %>
+    &nbsp;
+  </div>
     <div class="clearfix"></div>
 
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -197,9 +197,9 @@
       <% end %>
     </div>
     <div class="footer-social-media-icons-block pull-right ">
-    <%= link_to "<i class='fab fa-youtube'></i>".html_safe, "https://www.youtube.com/channel/UCp_UGD74MW8up1YkWZrWkKw", target: :_blank, id: 'youtube-link'%>
+    <%= link_to "<i class='fab fa-youtube'></i>".html_safe, "https://www.youtube.com/channel/UCp_UGD74MW8up1YkWZrWkKw", target: :_blank, 'data-analytics-name' => 'youtube-link' %>
     &nbsp;
-    <%= link_to "<i class='fab fa-twitter-square', data-analytics-name='twitter-link' ></i>".html_safe, "https://twitter.com/SingleCellBroad", target: :_blank, id: 'twitter-link'  %>
+    <%= link_to "<i class='fab fa-twitter-square', data-analytics-name='twitter-link' ></i>".html_safe, "https://twitter.com/SingleCellBroad", target: :_blank, 'data-analytics-name' => 'twitter-link'  %>
     &nbsp;
   </div>
     <div class="clearfix"></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -197,9 +197,9 @@
       <% end %>
     </div>
     <div class="footer-social-media-icons-block pull-right ">
-    <%= link_to "<i class='fab fa-youtube'></i>".html_safe, "https://www.youtube.com/channel/UCp_UGD74MW8up1YkWZrWkKw", target: :_blank  %>
+    <%= link_to "<i class='fab fa-youtube'></i>".html_safe, "https://www.youtube.com/channel/UCp_UGD74MW8up1YkWZrWkKw", target: :_blank, id: 'youtube-link'%>
     &nbsp;
-    <%= link_to "<i class='fab fa-twitter-square'></i>".html_safe, "https://twitter.com/SingleCellBroad", target: :_blank  %>
+    <%= link_to "<i class='fab fa-twitter-square', data-analytics-name='twitter-link' ></i>".html_safe, "https://twitter.com/SingleCellBroad", target: :_blank, id: 'twitter-link'  %>
     &nbsp;
   </div>
     <div class="clearfix"></div>


### PR DESCRIPTION
Add links for SCP's Twitter and Youtube pages to the footer of the portal. 
Links will open in new tabs.

To test:
- pull branch
- open up the portal locally
- scroll to the bottom and observe the icon links.

![Screen Shot 2022-06-16 at 1 11 43 PM](https://user-images.githubusercontent.com/54322292/174129536-8a2e9feb-0914-4848-aaa6-14057ca0d9de.png)

Also check out how the links look in a collection which has an additional button in the footer already:
![Screen Shot 2022-06-16 at 1 21 53 PM](https://user-images.githubusercontent.com/54322292/174129986-3f825e13-cf6b-4c8b-8837-e21c6b3adbe9.png)
