### PR TITLE
Refine when "Differential expression" button is shown (SCP-4435)

### DIFF
--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -37,6 +37,7 @@ export default function DifferentialExpressionPanel({
   const clusterName = exploreParamsWithDefaults?.cluster
   const bucketId = exploreInfo?.bucketId
   const annotation = getAnnotationObject(exploreParamsWithDefaults, exploreInfo)
+  const deObjects = exploreInfo?.differentialExpression
 
   const [checked, setChecked] = useState(initChecked(deGenes))
   const [deFileUrl, setDeFileUrl] = useState(null)
@@ -60,6 +61,7 @@ export default function DifferentialExpressionPanel({
         setDeGroup={setDeGroup}
         setDeFileUrl={setDeFileUrl}
         countsByLabel={countsByLabel}
+        deObjects={deObjects}
       />
 
       {deGenes &&

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -576,7 +576,6 @@ export default function ExploreDisplayTabs({
               exploreParamsWithDefaults={exploreParamsWithDefaults}
               exploreInfo={exploreInfo}
               clusterName={exploreParamsWithDefaults.cluster}
-              bucketId={exploreInfo?.bucketId}
               annotation={exploreParamsWithDefaults.annotation}
               setShowDeGroupPicker={setShowDeGroupPicker}
               setDeGenes={setDeGenes}

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -57,15 +57,23 @@ function annotHasDe(exploreInfo, exploreParams) {
 
   let annotHasDe = false
   const annotList = exploreInfo.annotationList
+  let selectedCluster
   let selectedAnnot
   if (exploreParams?.cluster) {
+    selectedCluster = exploreParams.cluster
     selectedAnnot = exploreParams.annotation
   } else {
+    selectedCluster = annotList.default_cluster
     selectedAnnot = annotList.default_annotation
   }
 
-  const matchingAnnot = getMatchedAnnotation(selectedAnnot, annotList)
-  annotHasDe = matchingAnnot?.is_differential_expression_enabled
+  annotHasDe = exploreInfo.differentialExpression.some(deItem => {
+    return (
+      deItem.cluster_name === selectedCluster &&
+      deItem.annotation_name === selectedAnnot.name &&
+      deItem.annotation_scope === selectedAnnot.scope
+    )
+  })
 
   return annotHasDe
 }

--- a/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
+++ b/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
@@ -67,39 +67,38 @@ async function fetchDeGenes(bucketId, deFilePath, numGenes=15) {
   return deGenes.slice(0, numGenes)
 }
 
+/** Gets matching deObject for the given group and cluster + annot combo */
+function getMatchingDeOption(deObjects, group, clusterName, annotation) {
+  const deObject = deObjects.find(deObj => {
+    return (
+      deObj.cluster_name === clusterName &&
+      deObj.annotation_name === annotation.name &&
+      deObj.annotation_scope === annotation.scope
+    )
+  })
+
+  return deObject.select_options.find(option => {
+    return option[0] === group
+  })
+}
+
 /** Pick groups of cells for differential expression (DE) */
 export default function DifferentialExpressionGroupPicker({
   bucketId, clusterName, annotation, deGenes, deGroup, setDeGroup, setDeGenes, setDeFileUrl,
   countsByLabel, deObjects
 }) {
   let groups = getLegendSortedLabels(countsByLabel)
-  let deObject = null
   groups = groups.filter(group => {
-    deObject = deObjects.find(deObj => {
-      return (
-        deObj.cluster_name === clusterName &&
-        deObj.annotation_name === annotation.name &&
-        deObj.annotation_scope === annotation.scope
-      )
-    })
-    return deObject.select_options.some(option => {
-      return option[0] === group
-    })
+    const deOption = getMatchingDeOption(deObjects, group, clusterName, annotation)
+    return deOption !== undefined
   })
 
   /** Update group in differential expression picker */
   async function updateDeGroup(newGroup) {
     setDeGroup(newGroup)
 
-    const deFileName = `${[
-      clusterName,
-      annotation.name,
-      newGroup,
-      annotation.scope,
-      'wilcoxon'
-    ]
-      .map(s => s.replaceAll(nonAlphaNumericRegex, '_'))
-      .join('--') }.tsv`
+    const deOption = getMatchingDeOption(deObjects, newGroup, clusterName, annotation)
+    const deFileName = deOption[1]
 
     const basePath = '_scp_internal/differential_expression/'
     const deFilePath = `${basePath}${deFileName}`.replaceAll('/', '%2F')

--- a/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
+++ b/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
@@ -68,11 +68,24 @@ async function fetchDeGenes(bucketId, deFilePath, numGenes=15) {
 }
 
 /** Pick groups of cells for differential expression (DE) */
-export default function DeGroupPicker({
+export default function DifferentialExpressionGroupPicker({
   bucketId, clusterName, annotation, deGenes, deGroup, setDeGroup, setDeGenes, setDeFileUrl,
-  countsByLabel
+  countsByLabel, deObjects
 }) {
-  const groups = getLegendSortedLabels(countsByLabel)
+  let groups = getLegendSortedLabels(countsByLabel)
+  let deObject = null
+  groups = groups.filter(group => {
+    deObject = deObjects.find(deObj => {
+      return (
+        deObj.cluster_name === clusterName &&
+        deObj.annotation_name === annotation.name &&
+        deObj.annotation_scope === annotation.scope
+      )
+    })
+    return deObject.select_options.some(option => {
+      return option[0] === group
+    })
+  })
 
   /** Update group in differential expression picker */
   async function updateDeGroup(newGroup) {

--- a/test/js/explore/differential-expression-panel.test.js
+++ b/test/js/explore/differential-expression-panel.test.js
@@ -34,6 +34,148 @@ describe('Differential expression panel', () => {
       'taxonNames': [
         'Homo sapiens'
       ],
+      'differentialExpression': [
+        {
+          'cluster_name': 'Epithelial Cells UMAP',
+          'annotation_name': 'directly_breastfeeding_YN',
+          'annotation_scope': 'study',
+          'select_options': [
+            [
+              'yes',
+              'Epithelial_Cells_UMAP--directly_breastfeeding_YN--yes--study--wilcoxon.tsv'
+            ],
+            [
+              'NA',
+              'Epithelial_Cells_UMAP--directly_breastfeeding_YN--NA--study--wilcoxon.tsv'
+            ]
+          ]
+        },
+        {
+          'cluster_name': 'Epithelial Cells UMAP',
+          'annotation_name': 'Epithelial Cell Subclusters',
+          'annotation_scope': 'cluster',
+          'select_options': [
+            [
+              'Secretory Lactocytes',
+              'Epithelial_Cells_UMAP--Epithelial_Cell_Subclusters--Secretory_Lactocytes--cluster--wilcoxon.tsv'
+            ],
+            [
+              'LC1',
+              'Epithelial_Cells_UMAP--Epithelial_Cell_Subclusters--LC1--cluster--wilcoxon.tsv'
+            ],
+            [
+              'KRT high lactocytes 1',
+              'Epithelial_Cells_UMAP--Epithelial_Cell_Subclusters--KRT_high_lactocytes_1--cluster--wilcoxon.tsv'
+            ],
+            [
+              'Cycling Lactocytes',
+              'Epithelial_Cells_UMAP--Epithelial_Cell_Subclusters--Cycling_Lactocytes--cluster--wilcoxon.tsv'
+            ],
+            [
+              'MT High Secretory Lactocytes',
+              'Epithelial_Cells_UMAP--Epithelial_Cell_Subclusters--MT_High_Secretory_Lactocytes--cluster--wilcoxon.tsv'
+            ],
+            [
+              'KRT high lactocytes 2',
+              'Epithelial_Cells_UMAP--Epithelial_Cell_Subclusters--KRT_high_lactocytes_2--cluster--wilcoxon.tsv'
+            ]
+          ]
+        },
+        {
+          'cluster_name': 'Epithelial Cells UMAP',
+          'annotation_name': 'mother_medications_YN',
+          'annotation_scope': 'study',
+          'select_options': [
+            [
+              'no',
+              'Epithelial_Cells_UMAP--mother_medications_YN--no--study--wilcoxon.tsv'
+            ],
+            [
+              'yes',
+              'Epithelial_Cells_UMAP--mother_medications_YN--yes--study--wilcoxon.tsv'
+            ],
+            [
+              'sunflower lecithin ',
+              'Epithelial_Cells_UMAP--mother_medications_YN--sunflower_lecithin_--study--wilcoxon.tsv'
+            ],
+            [
+              'NA',
+              'Epithelial_Cells_UMAP--mother_medications_YN--NA--study--wilcoxon.tsv'
+            ]
+          ]
+        },
+        {
+          'cluster_name': 'Epithelial Cells UMAP',
+          'annotation_name': 'reported_menstruating_YN',
+          'annotation_scope': 'study',
+          'select_options': [
+            [
+              'no',
+              'Epithelial_Cells_UMAP--reported_menstruating_YN--no--study--wilcoxon.tsv'
+            ],
+            [
+              'N',
+              'Epithelial_Cells_UMAP--reported_menstruating_YN--N--study--wilcoxon.tsv'
+            ],
+            [
+              'NA',
+              'Epithelial_Cells_UMAP--reported_menstruating_YN--NA--study--wilcoxon.tsv'
+            ]
+          ]
+        },
+
+        {
+          'cluster_name': 'All Cells UMAP',
+          'annotation_name': 'reported_infant_medical_events_description',
+          'annotation_scope': 'study',
+          'select_options': [
+            [
+              'NA',
+              'All_Cells_UMAP--reported_infant_medical_events_description--NA--study--wilcoxon.tsv'
+            ],
+            [
+              'no',
+              'All_Cells_UMAP--reported_infant_medical_events_description--no--study--wilcoxon.tsv'
+            ],
+            [
+              'maybe a stomache bug ',
+              'All_Cells_UMAP--reported_infant_medical_events_description--maybe_a_stomache_bug_--study--wilcoxon.tsv'
+            ],
+            [
+              'hot and sleepy',
+              'All_Cells_UMAP--reported_infant_medical_events_description--hot_and_sleepy--study--wilcoxon.tsv'
+            ],
+            [
+              'jaundice',
+              'All_Cells_UMAP--reported_infant_medical_events_description--jaundice--study--wilcoxon.tsv'
+            ],
+            [
+              'lounge tie removal mid july, vaccinations a few weeks prior ',
+              'All_Cells_UMAP--reported_infant_medical_events_description--lounge_tie_removal_mid_july__vaccinations_a_few_weeks_prior_--study--wilcoxon.tsv'
+            ],
+            [
+              'runny nose',
+              'All_Cells_UMAP--reported_infant_medical_events_description--runny_nose--study--wilcoxon.tsv'
+            ],
+            [
+              'runny nose, diarrhea, vomitting, no fever',
+              'All_Cells_UMAP--reported_infant_medical_events_description--runny_nose__diarrhea__vomitting__no_fever--study--wilcoxon.tsv'
+            ],
+            [
+              'maybe still jaundice',
+              'All_Cells_UMAP--reported_infant_medical_events_description--maybe_still_jaundice--study--wilcoxon.tsv'
+            ],
+            [
+              'stomach bug (August), runny nose (October/ currently)',
+              'All_Cells_UMAP--reported_infant_medical_events_description--stomach_bug__August___runny_nose__October__currently_--study--wilcoxon.tsv'
+            ],
+            [
+              'influenza vaccine received on 4/8/19',
+              'All_Cells_UMAP--reported_infant_medical_events_description--influenza_vaccine_received_on_4_8_19--study--wilcoxon.tsv'
+            ]
+          ]
+        }
+      ],
       'annotationList': {
         'annotations': [
           {


### PR DESCRIPTION
This refines the conditions under which the "Differential expression" button is shown at right in the Explore tab.

Previously, there were often cases where the button was shown when there were no DE results available.  This was due to crudely handling annotation in the context of the current clustering.  That's now refined in the upstream SCP API per #1540, which is integrated here.

Here's how it looks:

https://user-images.githubusercontent.com/1334561/174895492-bfc0b2cf-4858-4fff-a451-c79323235568.mov

To test:
* Ensure you did test steps from https://github.com/broadinstitute/single_cell_portal_core/pull/1526
* Run DE on the same study via Rails console: DifferentialExpressionService.run_differential_expression_on_all(annotation of your local DE study)
* Navigate to Study Overview for that study
* Confirm "Differential expression" button is not shown for default clustering
* Change to the other clustering
* Confirm "Differential expression" button is shown

This satisfies SCP-4435.