### PR TITLE
Remove `annotation_type` parameter for DE, adding `computational_method` (SCP-4454, SCP-4456)

### DIFF
--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -283,12 +283,11 @@ class ClusterVizService
   # * *params*
   #   - +cluster+    (ClusterGroup) => Clustering object being used as control cell list
   #   - +annotation_name+  (String) => Name of requested annotation
-  #   - +annotation_type+  (String) => Type of requested annotation (should be 'group')
   #   - +annotation_scope+ (String) => Scope of requested annotation ('study' or 'cluster')
-  def self.cells_by_annotation_label(cluster, annotation_name, annotation_type, annotation_scope)
+  def self.cells_by_annotation_label(cluster, annotation_name, annotation_scope)
     study = cluster.study
     cells = cluster.concatenate_data_arrays('text', 'cells')
-    annotation = { name: annotation_name, scope: annotation_scope, type: annotation_type }
+    annotation = { name: annotation_name, scope: annotation_scope, type: 'group' } # only valid for group-based
     labels = get_annotation_values_array(study, cluster, annotation, cells, nil, nil)
     cells_by_label = {}
     labels.each_with_index do |label, index|

--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -21,9 +21,10 @@ class DifferentialExpressionService
     raise ArgumentError, "#{study.accession} has no default annotation" if study.default_annotation.blank?
 
     annotation_name, annotation_type, annotation_scope = study.default_annotation.split('--')
+    raise ArgumentError, "#{study.accession} default annotation is not group-based" if annotation_type != 'group'
+
     annotation = {
       annotation_name: annotation_name,
-      annotation_type: annotation_type,
       annotation_scope: annotation_scope
     }
     cluster_file = study.default_cluster.study_file
@@ -76,7 +77,6 @@ class DifferentialExpressionService
     eligible_annotations += cell_annotations.map do |annot|
       {
         annotation_name: annot[:name],
-        annotation_type: annot[:type],
         annotation_scope: 'cluster',
         cluster_file_id: annot[:cluster_file_id]
       }
@@ -118,7 +118,6 @@ class DifferentialExpressionService
   #   - +study+            (Study) => Study to which StudyFile belongs
   #   - +user+             (User) => User initiating parse action (for email delivery)
   #   - +annotation_name+  (String) => Name of requested annotation
-  #   - +annotation_type+  (String) => Type of requested annotation (should be 'group')
   #   - +annotation_scope+ (String) => Scope of requested annotation ('study' or 'cluster')
   #
   # * *yields*
@@ -129,14 +128,13 @@ class DifferentialExpressionService
   #
   # * *raises*
   #   - (ArgumentError) => if requested parameters do not validate
-  def self.run_differential_expression_job(cluster_file, study, user, annotation_name:, annotation_type:, annotation_scope:)
+  def self.run_differential_expression_job(cluster_file, study, user, annotation_name:, annotation_scope:)
     validate_study(study)
-    validate_annotation(cluster_file, study, annotation_name, annotation_type, annotation_scope)
+    validate_annotation(cluster_file, study, annotation_name, annotation_scope)
 
     # begin assembling parameters
     de_params = {
       annotation_name: annotation_name,
-      annotation_type: annotation_type,
       annotation_scope: annotation_scope,
       annotation_file: annotation_scope == 'cluster' ? cluster_file.gs_url : study.metadata_file.gs_url,
       cluster_file: cluster_file.gs_url,
@@ -177,33 +175,32 @@ class DifferentialExpressionService
   #   - +cluster_file+      (StudyFile) => Clustering file being used as control cell list
   #   - +study+            (Study) => Study to which StudyFile belongs
   #   - +annotation_name+  (String) => Name of requested annotation
-  #   - +annotation_type+  (String) => Type of requested annotation (should be 'group')
   #   - +annotation_scope+ (String) => Scope of requested annotation ('study' or 'cluster')
   #
   # * *raises*
   #   - (ArgumentError) => if requested parameters do not validate
-  def self.validate_annotation(cluster_file, study, annotation_name, annotation_type, annotation_scope)
+  def self.validate_annotation(cluster_file, study, annotation_name, annotation_scope)
     cluster = study.cluster_groups.by_name(cluster_file.name)
     raise ArgumentError, "cannot find cluster for #{cluster_file.name}" if cluster.nil?
 
     can_visualize = false
     if annotation_scope == 'cluster'
       annotation = cluster.cell_annotations&.detect do |annot|
-        annot[:name] == annotation_name && annot[:type] == annotation_type
+        annot[:name] == annotation_name && annot[:type] == 'group'
       end
       can_visualize = annotation && cluster.can_visualize_cell_annotation?(annotation)
     else
-      annotation = study.cell_metadata.by_name_and_type(annotation_name, annotation_type)
+      annotation = study.cell_metadata.by_name_and_type(annotation_name, 'group')
       can_visualize = annotation&.can_visualize?
     end
 
-    identifier = "#{annotation_name}--#{annotation_type}--#{annotation_scope}"
-    raise ArgumentError, "#{identifier} is not present" if annotation.nil?
+    identifier = "#{annotation_name}--group--#{annotation_scope}"
+    raise ArgumentError, "#{identifier} is not present or is numeric-based" if annotation.nil?
     raise ArgumentError, "#{identifier} cannot be visualized" unless can_visualize
 
     # last, validate that the requested annotation & cluster will provide a valid intersection of annotation values
     # specifically, discard any annotation/cluster combos that only result in one distinct label
-    cells_by_label = ClusterVizService.cells_by_annotation_label(cluster, annotation_name, annotation_type, annotation_scope)
+    cells_by_label = ClusterVizService.cells_by_annotation_label(cluster, annotation_name, annotation_scope)
     if cells_by_label.keys.count < 2
       raise ArgumentError, "#{identifier} does not have enough labels represented in #{cluster.name}"
     end

--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -54,7 +54,7 @@ class DifferentialExpressionService
     metadata = study.cell_metadata.where(annotation_type: 'group', is_differential_expression_enabled: false)
                     .select(&:can_visualize?)
     eligible_annotations += metadata.map do |meta|
-      { annotation_name: meta.name, annotation_type: meta.annotation_type, annotation_scope: 'study' }
+      { annotation_name: meta.name, annotation_scope: 'study' }
     end
 
     cell_annotations = []
@@ -95,7 +95,10 @@ class DifferentialExpressionService
 
           annotation_params = annotation.deep_dup # make a copy so we don't lose the association next time we check
           annotation_params.delete(:cluster_file_id)
-          job_identifier = "#{study_accession}: #{cluster_file.name} (#{annotation_params.values.join('--')})"
+          annotation_identifier = [annotation_params['annotation_name'],
+                                   'group',
+                                   annotation_params['annotation_scope']].join('--')
+          job_identifier = "#{study_accession}: #{cluster_file.name} (#{annotation_identifier})"
           log_message "Checking DE job for #{job_identifier}"
           DifferentialExpressionService.run_differential_expression_job(
             cluster_file, study, requested_user, **annotation_params

--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -6,7 +6,6 @@ class DifferentialExpressionParameters
   GS_URL_REGEXP = %r{\Ags://}.freeze
 
   # annotation_name: name of annotation to use for DE
-  # annotation_type: type of annotation, must be 'group'
   # annotation_scope: scope of annotation (study, cluster)
   # annotation_file: source file for above annotation
   # cluster_file: clustering file with cells to use as control list for DE
@@ -15,14 +14,13 @@ class DifferentialExpressionParameters
   # matrix_file_type: type of raw counts matrix (dense, sparse)
   # gene_file (optional): genes/features file for sparse matrix
   # barcode_file (optional): barcodes file for sparse matrix
-  attr_accessor :annotation_name, :annotation_type, :annotation_scope, :annotation_file, :cluster_file,
+  attr_accessor :annotation_name, :annotation_scope, :annotation_file, :cluster_file,
                 :cluster_name, :matrix_file_path, :matrix_file_type, :gene_file, :barcode_file
 
-  validates :annotation_name, :annotation_type, :annotation_scope, :annotation_file, :cluster_file,
+  validates :annotation_name, :annotation_scope, :annotation_file, :cluster_file,
             :cluster_name, :matrix_file_path, :matrix_file_type, presence: true
   validates :annotation_file, :cluster_file, :matrix_file_path,
             format: { with: GS_URL_REGEXP, message: 'is not a valid GS url' }
-  validates :annotation_type, inclusion: %w[group]
   validates :annotation_scope, inclusion: %w[cluster study]
   validates :matrix_file_type, inclusion: %w[dense mtx]
   validates :gene_file, :barcode_file,
@@ -42,7 +40,7 @@ class DifferentialExpressionParameters
   def attributes
     {
       annotation_name: annotation_name,
-      annotation_type: annotation_type,
+      annotation_type: 'group',
       annotation_scope: annotation_scope,
       annotation_file: annotation_file,
       cluster_file: cluster_file,

--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -77,7 +77,6 @@ class DifferentialExpressionResult
   def set_observed_values
     cells_by_label = ClusterVizService.cells_by_annotation_label(cluster_group,
                                                                  annotation_name,
-                                                                 'group',
                                                                  annotation_scope)
     observed = cells_by_label.keys.reject { |label| cells_by_label[label].count < MIN_OBSERVED_VALUES }
     self.observed_values = observed

--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -6,6 +6,13 @@ class DifferentialExpressionResult
   # minimum number of observed_values, or cells per observed_value
   MIN_OBSERVED_VALUES = 2
 
+  # supported computational methods for differential expression results in Scanpy
+  # from https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.rank_genes_groups.html
+  DEFAULT_COMP_METHOD = 'wilcoxon'.freeze
+  SUPPORTED_COMP_METHODS = [
+    DEFAULT_COMP_METHOD, 'logreg', 't-test', 't-test_overestim_var'
+  ].freeze
+
   belongs_to :study
   belongs_to :cluster_group
 
@@ -13,9 +20,11 @@ class DifferentialExpressionResult
   field :observed_values, type: Array, default: []
   field :annotation_name, type: String
   field :annotation_scope, type: String
+  field :computational_method, type: String, default: DEFAULT_COMP_METHOD
 
   validates :annotation_scope, inclusion: { in: %w[study cluster] }
   validates :annotation_name, :cluster_name, presence: true
+  validates :computational_method, inclusion: { in: SUPPORTED_COMP_METHODS }
   validate :has_observed_values?
 
   before_validation :set_observed_values, :set_cluster_name
@@ -54,7 +63,7 @@ class DifferentialExpressionResult
       annotation_name,
       label,
       annotation_scope,
-      'wilcoxon'
+      computational_method
     ].map { |val| val.gsub(/\W+/, '_') }.join('--')
     "#{basename}.tsv"
   end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -629,7 +629,7 @@ class IngestJob
       annotation_params = {
         cluster: cluster,
         annot_name: params_object.annotation_name,
-        annot_type: params_object.annotation_type,
+        annot_type: 'group',
         annot_scope: params_object.annotation_scope
       }
       annotation = AnnotationVizService.get_selected_annotation(study, **annotation_params)

--- a/db/migrate/20220616194822_set_de_computational_method.rb
+++ b/db/migrate/20220616194822_set_de_computational_method.rb
@@ -1,0 +1,8 @@
+class SetDeComputationalMethod < Mongoid::Migration
+  def self.up
+    DifferentialExpressionResult.update_all(computational_method: 'wilcoxon')
+  end
+
+  def self.down
+  end
+end

--- a/test/integration/lib/cluster_viz_service_test.rb
+++ b/test/integration/lib/cluster_viz_service_test.rb
@@ -227,4 +227,19 @@ class ClusterVizServiceTest < ActiveSupport::TestCase
     assert_empty ClusterVizService.subsampling_options(new_cluster)
     assert_nil ClusterVizService.default_subsampling(new_cluster)
   end
+
+  test 'should return map of annotation labels to cells for a cluster' do
+    cluster = ClusterGroup.find_by(study: @study, study_file: @study_cluster_file_1)
+    study_map = {
+      dog: %w[A C],
+      cat: %w[B]
+    }.with_indifferent_access
+    assert_equal study_map, ClusterVizService.cells_by_annotation_label(cluster, 'species', 'study')
+
+    cluster_map = {
+      bar: %w[A B],
+      baz: %w[C]
+    }.with_indifferent_access
+    assert_equal cluster_map, ClusterVizService.cells_by_annotation_label(cluster, 'Category', 'cluster')
+  end
 end

--- a/test/integration/lib/differential_expression_service_test.rb
+++ b/test/integration/lib/differential_expression_service_test.rb
@@ -44,7 +44,6 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
                       ])
     @job_params = {
       annotation_name: 'species',
-      annotation_type: 'group',
       annotation_scope: 'study'
     }
     @basic_study.update(initialized: true)
@@ -65,7 +64,7 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
     # should fail on annotation missing
     assert_raise ArgumentError do
       DifferentialExpressionService.run_differential_expression_job(
-        @cluster_file, @basic_study, @user, annotation_name: 'NA', annotation_type: 'group', annotation_scope: 'study'
+        @cluster_file, @basic_study, @user, annotation_name: 'NA', annotation_scope: 'study'
       )
     end
 
@@ -145,7 +144,6 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
                       ])
     annotation = {
       annotation_name: 'species',
-      annotation_type: 'group',
       annotation_scope: 'study'
     }
 

--- a/test/models/differential_expression_parameters_test.rb
+++ b/test/models/differential_expression_parameters_test.rb
@@ -5,7 +5,6 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
   before(:all) do
     @dense_options = {
       annotation_name: 'Category',
-      annotation_type: 'group',
       annotation_scope: 'cluster',
       annotation_file: 'gs://test_bucket/metadata.tsv',
       cluster_file: 'gs://test_bucket/cluster.tsv',
@@ -16,7 +15,6 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
 
     @sparse_options = {
       annotation_name: 'Category',
-      annotation_type: 'group',
       annotation_scope: 'cluster',
       annotation_file: 'gs://test_bucket/metadata.tsv',
       cluster_file: 'gs://test_bucket/cluster.tsv',
@@ -36,11 +34,10 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
 
     # test conditional validations
     dense_params.annotation_file = ''
-    dense_params.annotation_type = 'numeric'
     dense_params.annotation_scope = 'foo'
     dense_params.matrix_file_type = 'bar'
     assert_not dense_params.valid?
-    assert_equal %i[annotation_file annotation_scope annotation_type matrix_file_type],
+    assert_equal %i[annotation_file annotation_scope matrix_file_type],
                  dense_params.errors.attribute_names.sort
     sparse_params.gene_file = 'foo'
     assert_not sparse_params.valid?

--- a/test/models/papi_client_test.rb
+++ b/test/models/papi_client_test.rb
@@ -90,7 +90,6 @@ class PapiClientTest < ActiveSupport::TestCase
       client = PapiClient.new
       de_opts = {
         annotation_name: 'Category',
-        annotation_type: 'group',
         annotation_scope: 'cluster',
         annotation_file: @cluster_file.gs_url,
         cluster_file: @cluster_file.gs_url,


### PR DESCRIPTION
#### BACKGROUND
The parameter `annotation_type` has been identified as superfluous for differential expression jobs, as it can only ever have the value of `group` - `numeric` annotations do not qualify for DE.  In addition, it was proposed that we could add a new parameter - `computational_method` - in the case where we decide to support other DE methodologies beside `wilcoxon`.  Currently, our DE library in [scanpy](https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.rank_genes_groups.html#scanpy.tl.rank_genes_groups) supports 3 others besides`wilcoxon`: `logreg`, `t-test`, and `t-test_overestim_var`.

#### CHANGES
Wiring for passing `annotation_type` has largely been removed, though it is still present in `DifferentialExpressionParameters` as it is still a required input to DE jobs in `scp-ingest-pipeline`, but is now hard-coded to `group`.  In addition, `computational_method` is now being stored in `DifferentialExpressionResult`, with the default of `wilcoxon`, and support for the other 3.  Extra validation code has been added to ensure that only `group` based annotations are used.  This update also adds test coverage for `ClusterVizService.cells_by_annotation_label`, as it was previously uncovered.

#### MANUAL TESTING
_Note: you may use an existing study that has raw counts data, and both a group- and numeric-based annotation.  The instructions below are for creating a new, minimally-initialized study._

1.  Pull branch and ensure all migrations have been run with `bin/rails db:migrate`, then boot as normal and sign in
2. Create a new study, and upload `test/test_data/expression_matrix_example.txt` as a raw count file, and `test/test_data/cluster_example.txt` as a cluster file and wait for ingest to complete (should be ~2-3 min)
3. In a Rails console session, using the study above, run a differential expression job with the following parameters and validate it returns `true`:
```
study = Study.find_by(accession: '<accession of new study>')
DifferentialExpressionService.run_differential_expression_job(study.default_cluster.study_file, study, study.user, annotation_name: 'Category', annotation_scope: 'cluster' )
=> true
```
4. Attempt to run another DE job with the following parameters and ensure that an `ArgumentError` is raised:
```
DifferentialExpressionService.run_differential_expression_job(study.default_cluster.study_file, study, study.user, annotation_name: 'Intensity', annotation_scope: 'cluster' )
...
Traceback (most recent call last):
        3: from (irb):11
        2: from app/lib/differential_expression_service.rb:136:in `run_differential_expression_job'
        1: from app/lib/differential_expression_service.rb:201:in `validate_annotation'
ArgumentError (Intensity--group--cluster is not present or is numeric-based)
```