### PR TITLE
Fix subsampling info icon (SCP-4357)

### DIFF
--- a/app/javascript/components/visualization/controls/SubsampleSelector.jsx
+++ b/app/javascript/components/visualization/controls/SubsampleSelector.jsx
@@ -49,23 +49,23 @@ export default function SubsampleSelector({
 
   return (
     <div className="form-group">
-      <label className="labeled-select">
+      <label className="labeled-select"> Subsampling&nbsp;
         <OverlayTrigger trigger="click" rootClose placement="top" overlay={subsamplingPopover}>
-          <span>Subsampling <FontAwesomeIcon data-analytics-name="subsampling-help-icon"
+          <FontAwesomeIcon data-analytics-name="subsampling-help-icon"
             className="action log-click help-icon" icon={faInfoCircle}/>
-          </span>
         </OverlayTrigger>
-        <Select options={subsampleOptions}
-          data-analytics-name="subsample-select"
-          value={{
-            label: subsample == 'all' ? 'All Cells' : `${subsample}`,
-            value: `${subsample}`
-          }}
-          onChange={newSubsample => updateClusterParams({
-            subsample: newSubsample.value
-          })}
-          styles={clusterSelectStyle}/>
       </label>
+      <Select options={subsampleOptions}
+        data-analytics-name="subsample-select"
+        value={{
+          label: subsample == 'all' ? 'All Cells' : `${subsample}`,
+          value: `${subsample}`
+        }}
+        onChange={newSubsample => updateClusterParams({
+          subsample: newSubsample.value
+        })}
+        styles={clusterSelectStyle}/>
+
     </div>
   )
 }


### PR DESCRIPTION
Previously the info icon did not open the info blurb. The fixed the code so that now clicking the icon will open the help text

To reproduce problem:

- Go to Explore tab in Prod
- Hover and/or click on the “i” info icon to left of “Subsampling” menu label
- Note no tooltip or popup is shown

-------------------------------------

To see fix pull this branch:

- Go to Explore tab in Prod
- Hover and/or click on the “i” info icon to left of “Subsampling” menu label
- Note tooltip or popup is shown