### PR TITLE
Updating to rails-baseimage:2.1.0, Ruby 2.6.10 (SCP-4456)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # use KDUX base Rails image, configure only project-specific items here
-FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:2.0.0
+FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:2.1.0
 
 # Set ruby version
-RUN bash -lc 'rvm --default use ruby-2.6.9'
+RUN bash -lc 'rvm --default use ruby-2.6.10'
 RUN bash -lc 'rvm rvmrc warning ignore /home/app/webapp/Gemfile'
 
 # Set up project dir, install gems, set up script to migrate database and precompile static assets on run

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.9'
+ruby '2.6.10'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '6.1.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -608,7 +608,7 @@ DEPENDENCIES
   will_paginate_mongoid
 
 RUBY VERSION
-   ruby 2.6.9p207
+   ruby 2.6.10p210
 
 BUNDLED WITH
    2.2.24


### PR DESCRIPTION
Updates to the latest version of our Docker base image, which includes updating to Ruby `2.6.10` and Passenger `6.0.14`, as well as applying security patches to the underlying `ubuntu` OS.

#### MANUAL TESTING
There are two ways you can verify this update:

**Run portal in Dockerized mode (15-20m)**
1. From the project root, run the following:
```
bin/load_env_secrets.sh -p secret/kdux/scp/development/$(whoami)/scp_config.json \
                        -r secret/kdux/scp/development/$(whoami)/read_only_service_account.json \
                        -s secret/kdux/scp/development/$(whoami)/scp_service_account.json
```
2. Verify the container builds and starts, and the startup script completes (look for the following message in the container `STDOUT`)
```
*** Running /etc/my_init.d/30_presetup_nginx.sh...
*** Booting runit daemon...
*** Runit started as PID 480
ok: run: /etc/service/nginx-log-forwarder: (pid 489) 0s
Jun 23 12:34:36 localhost cron[487]: (CRON) INFO (pidfile fd = 3)
Jun 23 12:34:36 localhost cron[487]: (CRON) INFO (Running @reboot jobs)
[ N 2022-06-23 12:34:36.5217 495/T1 age/Wat/WatchdogMain.cpp:1373 ]: Starting Passenger watchdog...
[ N 2022-06-23 12:34:36.5492 498/T1 age/Cor/CoreMain.cpp:1340 ]: Starting Passenger core...
[ N 2022-06-23 12:34:36.5517 498/T1 age/Cor/CoreMain.cpp:256 ]: Passenger core running in multi-application mode.
[ N 2022-06-23 12:34:36.5672 498/T1 age/Cor/CoreMain.cpp:1015 ]: Passenger core online, PID 498
[ N 2022-06-23 12:34:39.4455 498/T5 age/Cor/SecurityUpdateChecker.h:519 ]: Security update check: no update found (next check in 24 hours)

```
**Run Docker container manually (2-3m)**
Instead of running the portal container, you can simply pull the base image directly and run it, and manually verify the updates.  This will be much faster than the full Docker build:
1. Pull the image with `docker pull gcr.io/broad-singlecellportal-staging/rails-baseimage:2.1.0`
2. Once pulled, run it with `docker run --rm -it gcr.io/broad-singlecellportal-staging/rails-baseimage:2.1.0 bash`
3. Verify the Ruby version is correct (you need to specify `ruby2.6` since we didn't build the portal image which configures the alias for `ruby`) :
```
root@ad80a2ea2f38:/usr/bin# ruby2.6 --version
ruby 2.6.10p210 (2022-04-12 revision 67958) [x86_64-linux]
```
4. Confirm the passenger version:
```
root@ad80a2ea2f38:/usr/bin# passenger --version
Phusion Passenger(R) 6.0.14
```