### PR TITLE
r-formatted csfv correction

### DIFF
--- a/app/javascript/lib/validation/expression-matrices-validation.js
+++ b/app/javascript/lib/validation/expression-matrices-validation.js
@@ -185,10 +185,9 @@ function getDenseMatrixDelimiter(rawHeader, rawNextTwoLines) {
  *
  * The "cap" for an expression matrix file is the first row also called the "header"
  *
- * A dense matrix header must start with the value 'GENE' or if the file is R-formatted it can:
- *  - Not have GENE in the header and:
- *    - Have one less entry in the header than each successive row OR
- *    - Have "" as the last value in header.
+ * A dense matrix header must start with the value 'GENE' or if the file is R-formatted it can
+ * start with a blank "" value as the first value.
+ *
  */
 function validateDenseHeader(header, nextTwoLines) {
   const issues = []
@@ -198,16 +197,16 @@ function validateDenseHeader(header, nextTwoLines) {
   const secondLine = nextTwoLines[0]
   let isValid = true
   let specificMsg = ''
+  const firstValue = header[0]
 
-  if (header[0].toUpperCase() !== 'GENE') {
+  if (firstValue.toUpperCase() !== 'GENE' && firstValue !== '') {
     specificMsg = 'Try updating the first value of the header row to be "GENE". '
-    if (header.length === secondLine.length && header.slice(-1) !== '') {
-      specificMsg += 'Or try updating the final value of the header row to be a single space.'
-      isValid = false
-    } else if ((secondLine.length - 1) !== header.length) {
-      specificMsg += 'Or try updating the header row to have one less entry than each successive row.'
-      isValid = false
-    }
+    isValid = false
+  }
+
+  if (secondLine.length !== header.length) {
+    specificMsg += 'Ensure the header row contains the same number of columns as the following rows.'
+    isValid = false
   }
 
   if (!isValid) {

--- a/test/js/lib/validate-file-content.test.js
+++ b/test/js/lib/validate-file-content.test.js
@@ -157,6 +157,25 @@ describe('Client-side file validation', () => {
     expect(errors[0][1]).toEqual('format:cap:missing-gene-column')
   })
 
+  it('allows R-formatted header in expression matrix file', async () => {
+    const file = createMockFile({
+      fileName: 'foo4.txt',
+      content: '\tX\tY\nItm2a\t0\t5\nEif2b2\t3\t0\nPf2b2\t1\t9'
+    })
+    const { errors } = await validateLocalFile(file, { file_type: 'Expression Matrix' })
+    expect(errors).toHaveLength(0)
+  })
+
+  it('catches wrong length R-formatted header in expression matrix file', async () => {
+    const file = createMockFile({
+      fileName: 'foo4.txt',
+      content: ',X\nItm2a,0,5\nEif2b2,3,0\nPf2b2,1,9'
+    })
+    const { errors } = await validateLocalFile(file, { file_type: 'Expression Matrix' })
+    expect(errors).toHaveLength(1)
+    expect(errors[0][1]).toEqual('format:cap:missing-gene-column')
+  })
+
   it('catches non-numeric entry in expression matrix file', async () => {
     const file = createMockFile({
       fileName: 'foo5.csv',


### PR DESCRIPTION
Update CSFV for R-formatted dense matrices.

an R-formatted dense matrix will be missing the 'GENE' first value in the header but should still have the spot for it.

These are valid (checked by ingesting locally via Jean :) )
```
,CELL_0001,CELL_0002,CELL_0003,CELL_0004
APC,0,0,0,0
MYH11,0,7.092,0,4
```

```
	CELL_0001	CELL_0002	CELL_0003	CELL_0004
APC	0	0	0	3
MYH11	0	7.092	0	4
```

This is NOT valid (missing value at the end):
```
GENE,CELL_0001,CELL_0002,CELL_0003,
APC,0,0,0,0
MYH11,0,7.092,0,4
```