### PR TITLE
Show paralog neighborhoods, widen cache in related genes ideogram (SCP-4495)

### DIFF
--- a/app/javascript/components/visualization/RelatedGenesIdeogram.jsx
+++ b/app/javascript/components/visualization/RelatedGenesIdeogram.jsx
@@ -159,6 +159,7 @@ export default function RelatedGenesIdeogram({
       onClickAnnot,
       onPlotRelatedGenes,
       onWillShowAnnotTooltip,
+      showParalogNeighborhoods: taxon === 'Homo sapiens', // Works around bug in Ideogram 1.37.0, remove upon upgrade
       onLoad() {
         // Handles edge case: when organism lacks chromosome-level assembly
         if (!genomeHasChromosomes()) {return}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
     "fflate": "^0.7.3",
-    "ideogram": "1.36.0",
+    "ideogram": "1.37.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.13.0",
     "morpheus-app": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6733,10 +6733,10 @@ identity-obj-proxy@^3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ideogram@1.36.0:
-  version "1.36.0"
-  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.36.0.tgz#231f68f25884dd8257a8ba99b39534726fad7968"
-  integrity sha512-+DS/bPp0cUWXUyMMyPTll2KN9vhMj91wAuJreRaVXkITPbLqtrnoIHUxlcU2hOh5JcoRZFLj7hys0z6iN9satQ==
+ideogram@1.37.0:
+  version "1.37.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.37.0.tgz#d5c10b3704336a339e10d18eaa98dc0003ec8100"
+  integrity sha512-7djn3PsvPzs1Z53UyXUZm1OQCKpYCH1wUFQTytc+/umwlyI85RoFWsUw4lpiaMoqFjghP8wTlwGr3UfQ5EixDg==
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"


### PR DESCRIPTION
This lets users see genomically-clustered paralogs at a glance.  It also widens paralog search space, often showing more (and more interesting) paralogs for a given gene of interest.  And it does so faster and more compactly than before.

### Paralog neighborhoods
Previously, paralogs very near each other in the genome were hidden.  That's because paralogs were displayed as triangular annotations beside the chromosome.  Nearby paralogs would completely overlap, and thus be invisible to the user.  Now, such "paralog neighborhoods" are shown as pink annotations that overlap the chromosome.  This reveals previously obscured related genes, and highlights genomic regions with particularly dense collections of paralogs.

Here's how it looks:

https://user-images.githubusercontent.com/1334561/176502882-82eb6705-c237-4bdc-80a9-714f9dbe8f48.mov

### Wider, faster, more compact paralog cache
This also widens the cache for paralogs: now storing _all_ paralogs, instead of only up to 10 for each gene.  Additionally, it improves compression ratios and parse times, yielding faster initialization for the related genes ideogram.  Beyond enriching the current display, this more robust cache provides a foundation for new functionality like paralog neighborhoods.  Compared to #1450, this refined service worker cache size decreases from 22 MB to 8.4 MB: 70% smaller.  Start time decreases from 951 ms to 762 ms: 20% faster.

To test:
* Go to synthetic study "Human all genes"
  * If you don't yet have it in your local SCP, start delayed job worker (`rails jobs:work`), then in another tab run `echo "SyntheticStudyPopulator.populate('human_all_genes')" | bundle exec rails console -e development`
* Search gene "BTN1A1"
* Verify pink overlay annotations -- i.e. paralog neighborhoods -- appear over part of chromosomes 6 and 5
* Hover over paralog neighborhood on chromosome 6
* Confirm tooltip appears and says "Paralog neighborhood" with several genes listed
* Click on first gene in tooltip, BTN3A2
* Confirm related genes ideogram UI looks like it does in video (the scatter plots are expected to be different)

This integration of upstream enhancements was done as part of Developer Choice Days. It satisfies SCP-4495.