### PR TITLE
Fixing typo in study details "default options" form (SCP-4267)

### DIFF
--- a/app/views/studies/_study_default_options_form.html.erb
+++ b/app/views/studies/_study_default_options_form.html.erb
@@ -81,8 +81,8 @@
     <% if @study.has_gene_lists? %>
       <div class="form-group row">
         <div class="col-sm-12">
-          <%= opts.label :precomputed_heatmap_label, 'Precomputed heatmap menu label' %>&nbsp;<span class="fas fa-question-circle" data-toggle="tooltip" data-placement="right" title='This is displayed above the list of uploaded precomputed heatmaps.'></span> <br />
-          <%= opts.text_field :precomputed_heatmap_label, value: @study.default_options[:precomputed_heatmap_label], placeholder: 'Precomputed heatmaps', class: 'form-control' %>
+          <%= f.label :precomputed_heatmap_label, 'Precomputed heatmap menu label' %>&nbsp;<span class="fas fa-question-circle" data-toggle="tooltip" data-placement="right" title='This is displayed above the list of uploaded precomputed heatmaps.'></span> <br />
+          <%= f.text_field :precomputed_heatmap_label, value: @study.default_options[:precomputed_heatmap_label], placeholder: 'Precomputed heatmaps', class: 'form-control' %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Fixes a regression introduced in [this PR](https://github.com/broadinstitute/single_cell_portal_core/pull/1469/files#diff-7cc20584264500aeded2ba7d6d513cf53a47e08ceea5825c8e9659bcb5e0ea4dR74) where any study with gene lists could no longer open the "study details" page.

#### MANUAL TESTING
1. Boot as normal and open "My Studies"
2. If you don't have a study locally with gene lists, start DelayedJob and add `test/test_data/marker_1_gene_list.txt` to any study
3. Click "Details" page from the ellipsis menu for that study and verify the page loads