### PR TITLE
Hotfix: Reduce maximum number of projects for Azul queries (SCP-4504)

### DIFF
--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -15,7 +15,7 @@ class HcaAzulClient
   MANIFEST_FORMATS = %w[compact full terra.bdbag terra.pfb curl].freeze
 
   # maximum number of results to return
-  MAX_RESULTS = 250
+  MAX_RESULTS = 200
 
   # maximum length of query string (in characters) for requests
   MAX_QUERY_LENGTH = 8192

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -99,6 +99,14 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     end
   end
 
+  # smoke test for issue with 502 when requesting all human projects
+  test 'should get all projects without error' do
+    query = { genusSpecies: { is: ['Homo sapiens'] } }.with_indifferent_access
+    raw_projects = @hca_azul_client.projects(query: query)
+    projects = get_entries_from_response(raw_projects, :projects)
+    assert projects.size == HcaAzulClient::MAX_RESULTS
+  end
+
   test 'should query projects using facets' do
     skip_if_api_down
     raw_projects = @hca_azul_client.projects(query: @query_json, size: 1)


### PR DESCRIPTION
#### BACKGROUND
This hotfix addresses the issue for the latest catalog (dcp17) in Azul where requesting 250 results returns a `502` when querying for `Homo sapiens`.  This update lowers the maximum number to 200, which seems to sidestep the issue.

Related Sentry issue: https://sentry.io/organizations/broad-institute/issues/3392644571/?environment=production&project=1424198&query=is%3Aunresolved&statsPeriod=24h

#### MANUAL TESTING
1. Pull branch, boot as normal, sign in
2. Run a query for `species:Homo sapiens`
3. Confirm you get back both SCP and HCA results