### PR TITLE
Fix broken tests (SCP-4506)

### DIFF
--- a/app/javascript/lib/validation/expression-matrices-validation.js
+++ b/app/javascript/lib/validation/expression-matrices-validation.js
@@ -204,10 +204,10 @@ function validateDenseHeader(header, nextTwoLines) {
     isValid = false
   }
 
-  // check that there are no blank header columns, with the exception of the first column for R-formatted files
-  const noMissingCols = header.lastIndexOf('') !== 0 || header.lastIndexOf('') !== -1
+  // check that there are no blank header columns, with the exception of the first column being optional for R-formatted files
+  const onlyAppropriateMissingColumns = header.lastIndexOf('') === 0 || header.lastIndexOf('') === -1
 
-  if (secondLine.length !== header.length || !noMissingCols) {
+  if (secondLine.length !== header.length || !onlyAppropriateMissingColumns) {
     specificMsg += 'Ensure the header row contains the same number of columns as the following rows.'
     isValid = false
   }

--- a/app/javascript/lib/validation/expression-matrices-validation.js
+++ b/app/javascript/lib/validation/expression-matrices-validation.js
@@ -204,7 +204,10 @@ function validateDenseHeader(header, nextTwoLines) {
     isValid = false
   }
 
-  if (secondLine.length !== header.length || header.lastIndexOf('') !== 0) {
+  // check that there are no blank header columns, with the exception of the first column for R-formatted files
+  const noMissingCols = header.lastIndexOf('') !== 0 || header.lastIndexOf('') !== -1
+
+  if (secondLine.length !== header.length || !noMissingCols) {
     specificMsg += 'Ensure the header row contains the same number of columns as the following rows.'
     isValid = false
   }


### PR DESCRIPTION
Broke the tests with the addition of:
`header.lastIndexOf('') !== 0` in https://github.com/broadinstitute/single_cell_portal_core/pull/1553
which was checking that the only blank columns would be in position 0 for the header for an r-formatted dense matrix. However, if there are no indexes of `''` then `header.lastIndexOf('') !== 0` returns -1 so the check needed to be adjusted to account for that. 
