### PR TITLE
List all shared studies in "My Studies" page (SCP-4507)

### DIFF
--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -49,7 +49,7 @@ module Api
 
       # GET /single_cell/api/v1/studies
       def index
-        @studies = Study.editable(current_api_user)
+        @studies = Study.accessible(current_api_user)
         study_owner_ids = @studies.pluck(:id, :user_id)
         user_info = User.where(:id.in => study_owner_ids.map{ |plucked_arr| plucked_arr[1] }).pluck(:id, :email)
         # create a hash of study_id => owner email


### PR DESCRIPTION
#### BACKGROUND
Previously, users who were delegated "View" or "Reviewer" access to studies could see them listed in the "My Studies" view.  Since that view migrated over to a React component, this was accidentally changed to only studies with "Edit" access.

#### CHANGES
Now, when loading the "My Studies" page, the list of studies retrieved will honor all sharing access via `Study.accessible(current_user)`.  This will take into account all levels of sharing - Edit, View, and Reviewer - though the latter is now deprecated, but still valid for those users who were granted it.

NOTE - this does not dynamically change the content of the "actions" popup menu.  All actions will still be listed, though authorization will still be enforced server-side, meaning view/reviewer shares will be prevented from performing anything.  Further work would need to be done in order to disable this menu on a per-study basis.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Load the "My Studies" page and select "Study settings" for any study listed
3. Add a share for a different account and grant `View` access
4. Sign out, and sign back in with that other account
5. Go to "My Studies" and confirm the newly shared study is listed
6. Click any link in the actions popup and confirm you get a notice saying "You are not allowed to perform that action"