### PR TITLE
Adding troubleshooting tip to curl (SCP-4528)

### DIFF
--- a/app/javascript/components/search/controls/download/DownloadCommand.jsx
+++ b/app/javascript/components/search/controls/download/DownloadCommand.jsx
@@ -10,7 +10,7 @@ const isWindows = clientOS.match(/Win/)
 
 /** component for rendering a copyable bulk download command for an array of file ids.
     Queries the server to retrieve the appropriate auth code. */
-export default function DownloadCommand({ fileIds=[], azulFiles, totalSizeDisplay }) {
+export default function DownloadCommand({ fileIds=[], azulFiles }) {
   const [isLoading, setIsLoading] = useState(true)
   const [authInfo, setAuthInfo] = useState({ authCode: null, timeInterval: 3000 })
   const [refreshNum, setRefreshNum] = useState(0)
@@ -49,7 +49,8 @@ export default function DownloadCommand({ fileIds=[], azulFiles, totalSizeDispla
         <h4>Copy the command below and paste it into your {terminalDescription} terminal</h4>
         This command is valid for one use within <span className='countdown'>
           {Math.floor(authInfo.timeInterval / 60)}
-        </span> minutes.
+        </span> minutes.  If a certificate validation error occurs, adding the "-k" option will skip certificate validation.
+e.g. `curl -k "https://singlecell...."`
         <div className='input-group'>
           <input
             ref={textInputRef}
@@ -79,17 +80,6 @@ export default function DownloadCommand({ fileIds=[], azulFiles, totalSizeDispla
         </div>
       </div>
     }
-    {totalSizeDisplay}
-
-    <div class="col-md-12 detail">
-      <br/><br/><br/>
-      <p> <b>Troubleshooting:</b> If the above command results in a curl error relating to certificates (common in hosted machines),
-         this may be caused by your machine not having a trust chain that includes the certificate from https://singlecell.broadinstitute.org.
-        <br/>You can solve the problem either by installing that certifcate onto the machine, or adding the "-k" option to the curl command, which skips certificate
-        validation.  e.g. `curl -k "https://singlecell...."`
-      </p>
-    
-    </div>
   </div>
 }
 

--- a/app/javascript/components/search/controls/download/DownloadCommand.jsx
+++ b/app/javascript/components/search/controls/download/DownloadCommand.jsx
@@ -10,7 +10,7 @@ const isWindows = clientOS.match(/Win/)
 
 /** component for rendering a copyable bulk download command for an array of file ids.
     Queries the server to retrieve the appropriate auth code. */
-export default function DownloadCommand({ fileIds=[], azulFiles }) {
+export default function DownloadCommand({ fileIds=[], azulFiles, totalSizeDisplay }) {
   const [isLoading, setIsLoading] = useState(true)
   const [authInfo, setAuthInfo] = useState({ authCode: null, timeInterval: 3000 })
   const [refreshNum, setRefreshNum] = useState(0)
@@ -79,6 +79,17 @@ export default function DownloadCommand({ fileIds=[], azulFiles }) {
         </div>
       </div>
     }
+    {totalSizeDisplay}
+
+    <div class="col-md-12 detail">
+      <br/><br/><br/>
+      <p> <b>Troubleshooting:</b> If the above command results in a curl error relating to certificates (common in hosted machines),
+         this may be caused by your machine not having a trust chain that includes the certificate from https://singlecell.broadinstitute.org.
+        <br/>You can solve the problem either by installing that certifcate onto the machine, or adding the "-k" option to the curl command, which skips certificate
+        validation.  e.g. `curl -k "https://singlecell...."`
+      </p>
+    
+    </div>
   </div>
 }
 

--- a/app/javascript/components/search/controls/download/DownloadSelectionModal.jsx
+++ b/app/javascript/components/search/controls/download/DownloadSelectionModal.jsx
@@ -78,11 +78,6 @@ export default function DownloadSelectionModal({ studyAccessions, show, setShow 
     </button>
   }
 
-  const totalSizeDisplay = <div className="download-size-message">
-    <label htmlFor="download-size-amount">Total size</label>
-    <span data-testid="download-size-amount" id="download-size-amount">{prettyBytes}</span>
-  </div>
-
   return <Modal
     id='bulk-download-modal'
     className="full-height-modal"
@@ -134,14 +129,18 @@ export default function DownloadSelectionModal({ studyAccessions, show, setShow 
                   columnTypes={AZUL_COLUMNS}/>
               </div>
             }
-            {totalSizeDisplay}
           </div>
         }
         { stepNum === 2 && <DownloadCommand
           closeParent={() => setShow(false)}
           fileIds={selectedFileIds}
-          azulFiles={selectedAzulFiles}
-          totalSizeDisplay={totalSizeDisplay}/> }
+          azulFiles={selectedAzulFiles}/> }
+        { !isLoading &&
+          <div className="download-size-message">
+            <label htmlFor="download-size-amount">Total size</label>
+            <span data-testid="download-size-amount" id="download-size-amount">{prettyBytes}</span>
+          </div>
+        }
       </div>
     </Modal.Body>
     <Modal.Footer>

--- a/app/javascript/components/search/controls/download/DownloadSelectionModal.jsx
+++ b/app/javascript/components/search/controls/download/DownloadSelectionModal.jsx
@@ -78,6 +78,11 @@ export default function DownloadSelectionModal({ studyAccessions, show, setShow 
     </button>
   }
 
+  const totalSizeDisplay = <div className="download-size-message">
+    <label htmlFor="download-size-amount">Total size</label>
+    <span data-testid="download-size-amount" id="download-size-amount">{prettyBytes}</span>
+  </div>
+
   return <Modal
     id='bulk-download-modal'
     className="full-height-modal"
@@ -129,18 +134,14 @@ export default function DownloadSelectionModal({ studyAccessions, show, setShow 
                   columnTypes={AZUL_COLUMNS}/>
               </div>
             }
+            {totalSizeDisplay}
           </div>
         }
         { stepNum === 2 && <DownloadCommand
           closeParent={() => setShow(false)}
           fileIds={selectedFileIds}
-          azulFiles={selectedAzulFiles}/> }
-        { !isLoading &&
-          <div className="download-size-message">
-            <label htmlFor="download-size-amount">Total size</label>
-            <span data-testid="download-size-amount" id="download-size-amount">{prettyBytes}</span>
-          </div>
-        }
+          azulFiles={selectedAzulFiles}
+          totalSizeDisplay={totalSizeDisplay}/> }
       </div>
     </Modal.Body>
     <Modal.Footer>

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -15,7 +15,7 @@
             <h2 class="text-center">Bulk Download</h2>
           </div>
           <div class="modal-body">
-            <% if !@study.has_bucket_access?(current_user) %>
+            <% if @study.has_bucket_access?(current_user) %>
             <p class="lead">To download all files using <code>gsutil</code>, run the following command:</p>
             <pre>gsutil -m cp -r gs://<%= @study.bucket_id %> [target path]</pre>
               <% if @directories.any? %>
@@ -71,13 +71,6 @@
                   </thead>
                 </table>
               <% end %>
-             <br/><br/><br/>
-             <p class="detail">
-              <b>Troubleshooting:</b> If the above command results in a curl error relating to certificates (common in hosted machines),
-         this may be caused by your machine not having a trust chain that includes the certificate from https://singlecell.broadinstitute.org.
-        <br/>You can solve the problem either by installing that certifcate onto the machine, or adding the "-k" option to the curl command, which skips certificate
-        validation.  e.g. `curl -k "https://singlecell...."`
-              </p>
             <% else %>
               <%# The user is trying to download a public study that is currently embargoed. %>
               <p class="lead">No downloads are available to you for this study yet</p>
@@ -179,7 +172,8 @@
                   '</button>' +
                   '</span>' +
                   '</div>' +
-                  '<div style="font-size: 12px">Valid for one use within ' + countdownValue + ' minutes.  Paste into Mac/Linux/Unix terminal and execute to download.</div>'
+                  '<div style="font-size: 16px">Valid for one use within ' + countdownValue + ' minutes.  Paste into Mac/Linux/Unix terminal and execute to download.<br/><br/>' + 
+                  'If a certificate validation error occurs, adding the "-k" option will skip certificate validation.<br/>  e.g. `curl -k "https://singlecell...."`</div>'
               );
             }
           );

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -15,7 +15,7 @@
             <h2 class="text-center">Bulk Download</h2>
           </div>
           <div class="modal-body">
-            <% if @study.has_bucket_access?(current_user) %>
+            <% if !@study.has_bucket_access?(current_user) %>
             <p class="lead">To download all files using <code>gsutil</code>, run the following command:</p>
             <pre>gsutil -m cp -r gs://<%= @study.bucket_id %> [target path]</pre>
               <% if @directories.any? %>
@@ -71,7 +71,13 @@
                   </thead>
                 </table>
               <% end %>
-
+             <br/><br/><br/>
+             <p class="detail">
+              <b>Troubleshooting:</b> If the above command results in a curl error relating to certificates (common in hosted machines),
+         this may be caused by your machine not having a trust chain that includes the certificate from https://singlecell.broadinstitute.org.
+        <br/>You can solve the problem either by installing that certifcate onto the machine, or adding the "-k" option to the curl command, which skips certificate
+        validation.  e.g. `curl -k "https://singlecell...."`
+              </p>
             <% else %>
               <%# The user is trying to download a public study that is currently embargoed. %>
               <p class="lead">No downloads are available to you for this study yet</p>


### PR DESCRIPTION
Couldn't resist testing out SCP development on my new machine.  This adds help text about using the -k option to both bulk download modals.  If this looks good to folks, I'll make a corresponding ticket before merging.

![image](https://user-images.githubusercontent.com/2800795/178088697-bcda193e-4156-49d9-a474-37c0acbfdae5.png)

![image](https://user-images.githubusercontent.com/2800795/178088832-385885a2-19dd-46f2-b83a-e2748844858f.png)

TO TEST:
1. sign in, and do any search.  
2. click bulk download, then 'next'
3. confirm troubleshooting text appears
4. Browse to a study not created by the user you are signed in as, and go to the download tab
5. click "bulk download" 
6. confirm help text appears