### PR TITLE
Enable feature flag for CSFV again (SCP-)

### DIFF
--- a/app/javascript/lib/validation/validate-file.js
+++ b/app/javascript/lib/validation/validate-file.js
@@ -6,6 +6,7 @@ import { oneGiB, oneMiB } from '~/lib/validation/io'
 import ValidateFileContent from './validate-file-content'
 import { logFileValidation } from './log-validation'
 import { fetchBucketFile } from '~/lib/scp-api'
+import { getFeatureFlagsWithDefaults } from '~/providers/UserProvider'
 
 
 /** take an array of [category, type, msg] issues, and format it */
@@ -49,6 +50,13 @@ function validateFileName(file, studyFile, allStudyFiles, allowedFileExts=['*'])
  * @param allowedFileExts { String[] } array of allowable extensions, ['*'] for all
  */
 async function validateLocalFile(file, studyFile, allStudyFiles=[], allowedFileExts=['*']) {
+
+  // if clientside file validation feature flag is false skip validation
+  const flags = getFeatureFlagsWithDefaults()
+  if (!flags?.clientside_validation) {
+    const issues = formatIssues([])
+    return issues
+  }
   const nameIssues = validateFileName(file, studyFile, allStudyFiles, allowedFileExts)
 
   let issuesObj

--- a/test/js/lib/validate-file-content.test.js
+++ b/test/js/lib/validate-file-content.test.js
@@ -7,17 +7,23 @@ import { REQUIRED_CONVENTION_COLUMNS } from 'lib/validation/validate-file-conten
 import { getLogProps } from 'lib/validation/log-validation'
 import ValidationMessage from 'components/validation/ValidationMessage'
 import * as MetricsApi from 'lib/metrics-api'
+import * as UserProvider from '~/providers/UserProvider'
 
 import { createMockFile } from './file-mock-utils'
 
 const validateLocalFile = ValidateFile.validateLocalFile
 
 describe('Client-side file validation', () => {
+  jest
+    .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
+    .mockReturnValue({
+      clientside_validation: true
+    })
+
   it('catches and logs errors in files', async () => {
     const file = createMockFile({ fileName: 'metadata_bad_type_header.txt' })
 
     const fileType = 'Metadata'
-
     const fakeLog = jest.spyOn(MetricsApi, 'log')
     fakeLog.mockImplementation(() => { })
 

--- a/test/js/lib/validate-file-content.test.js
+++ b/test/js/lib/validate-file-content.test.js
@@ -421,3 +421,60 @@ describe('Client-side file validation', () => {
     expect(displayedWarning).toHaveTextContent(issues.warnings[0][2])
   })
 })
+
+// With the client side file validation feature flag set to false expect invalid files to pass
+describe('Client-side file validation feature flag is false', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
+      .mockReturnValue({
+        clientside_validation: false
+      })
+  })
+
+  it('Does not catch missing headers in metadata file', async () => {
+    const file = createMockFile({
+      fileName: 'foo2.txt',
+      content: 'NAME,biosample_id,CellID\nTYPE,numeric,numeric\nCELL_0001,id1,cell1'
+    })
+    const { errors } = await validateLocalFile(file, { file_type: 'Metadata', use_metadata_convention: true })
+    expect(errors).toHaveLength(0)
+  })
+
+  it('Does not catch missing GENE header in expression matrix file', async () => {
+    const file = createMockFile({
+      fileName: 'foo4.txt',
+      content: 'IS_NOT_GENE,X,Y\nItm2a,0,5\nEif2b2,3,0\nPf2b2,1,9'
+    })
+    const { errors } = await validateLocalFile(file, { file_type: 'Expression Matrix' })
+    expect(errors).toHaveLength(0)
+  })
+
+  it('Does not catch row with wrong number of columns in sparse matrix file', async () => {
+    const file = createMockFile({
+      fileName: 'foo6.mtx',
+      content: '%%MatrixMarket matrix coordinate integer general\n%\n4 8 9\n4 3 0\n4 1'
+    })
+    const { errors } = await validateLocalFile(file, { file_type: 'MM Coordinate Matrix' })
+    expect(errors).toHaveLength(0)
+  })
+
+  it('Does not catch duplicate row values in barcodes file', async () => {
+    const file = createMockFile({
+      fileName: 'foo6.tsv',
+      content: 'fake000\nfake001\nfake002\nfake000'
+    })
+    const { errors } = await validateLocalFile(file, { file_type: '10X Barcodes File' })
+    expect(errors).toHaveLength(0)
+  })
+
+  it('Does not catch  duplicate cell names in cluster file', async () => {
+    const file = createMockFile({
+      fileName: 'foo.txt',
+      content: 'NAME,X,Y\nTYPE,numeric,numeric\nCELL_0001,34.472,32.211\nCELL_0001,15.975,10.043'
+    })
+    const { errors } = await validateLocalFile(file, { file_type: 'Cluster' })
+    expect(errors).toHaveLength(0)
+  })
+}
+)

--- a/test/js/upload-wizard/file-upload-control.test.js
+++ b/test/js/upload-wizard/file-upload-control.test.js
@@ -5,13 +5,21 @@ import '@testing-library/jest-dom/extend-expect'
 import { StudyContext } from 'components/upload/upload-utils'
 import FileUploadControl from 'components/upload/FileUploadControl'
 import { fireFileSelectionEvent } from '../lib/file-mock-utils'
-
+import * as UserProvider from '~/providers/UserProvider'
 
 describe('file upload control defaults the name of the file', () => {
   afterEach(() => {
     // Restores all mocks back to their original value
     jest.restoreAllMocks()
   })
+
+  beforeEach(
+    jest
+      .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
+      .mockReturnValue({
+        clientside_validation: true
+      })
+  )
 
   it('updates the name of the selected file', async () => {
     const file = {
@@ -59,7 +67,11 @@ it('updates the file upload name but preserves custom name', async () => {
   }
   const updateFileHolder = { updateFile: () => {} }
   const updateFileSpy = jest.spyOn(updateFileHolder, 'updateFile')
-
+  jest
+    .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
+    .mockReturnValue({
+      clientside_validation: true
+    })
   render(
     <StudyContext.Provider value={{ accession: 'SCP123' }}>
       <FileUploadControl
@@ -87,6 +99,15 @@ it('updates the file upload name but preserves custom name', async () => {
 })
 
 describe('file upload control validates the selected file', () => {
+  beforeEach(
+    jest
+      .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
+      .mockReturnValue({
+        clientside_validation: true
+      })
+  )
+
+
   it('validates the extension', async () => {
     const file = {
       _id: '123',

--- a/test/js/upload-wizard/upload-expression-data.test.js
+++ b/test/js/upload-wizard/upload-expression-data.test.js
@@ -17,10 +17,10 @@ describe('it allows uploading of expression matrices', () => {
     jest.setTimeout(10000)
 
     jest
-    .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
-    .mockReturnValue({
-      clientside_validation: true
-    })
+      .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
+      .mockReturnValue({
+        clientside_validation: true
+      })
   })
 
   it('uploads a raw counts mtx file', async () => {

--- a/test/js/upload-wizard/upload-expression-data.test.js
+++ b/test/js/upload-wizard/upload-expression-data.test.js
@@ -9,11 +9,18 @@ import {
 import { fireFileSelectionEvent } from '../lib/file-mock-utils'
 
 import { renderWizardWithStudy, getSelectByLabelText, mockCreateStudyFile } from './upload-wizard-test-utils'
+import * as UserProvider from '~/providers/UserProvider'
 
 describe('it allows uploading of expression matrices', () => {
   beforeAll(() => {
     jest.restoreAllMocks()
     jest.setTimeout(10000)
+
+    jest
+    .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
+    .mockReturnValue({
+      clientside_validation: true
+    })
   })
 
   it('uploads a raw counts mtx file', async () => {

--- a/test/js/upload-wizard/upload-images.test.js
+++ b/test/js/upload-wizard/upload-images.test.js
@@ -1,15 +1,21 @@
 import { screen, fireEvent, waitForElementToBeRemoved } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
-import _cloneDeep from 'lodash/cloneDeep'
 
-import * as ScpApi from 'lib/scp-api'
 import { IMAGE_FILE } from './file-info-responses'
 import { fireFileSelectionEvent } from '../lib/file-mock-utils'
 import { renderWizardWithStudy, saveButton, mockCreateStudyFile } from './upload-wizard-test-utils'
+import * as UserProvider from '~/providers/UserProvider'
 
 describe('Upload wizard supports reference images', () => {
   it('validates bad file names, starts upload of JPEG file', async () => {
     const createFileSpy = mockCreateStudyFile(IMAGE_FILE)
+
+    jest
+      .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
+      .mockReturnValue({
+        clientside_validation: true
+      })
+
     await renderWizardWithStudy({ featureFlags: { reference_image_upload: true } })
 
     const formData = new FormData()

--- a/test/js/upload-wizard/upload-new-study.test.js
+++ b/test/js/upload-wizard/upload-new-study.test.js
@@ -9,7 +9,10 @@ import {
   RAW_COUNTS_FILE, PROCESSED_MATRIX_FILE, METADATA_FILE,
   CLUSTER_FILE, COORDINATE_LABEL_FILE, FASTQ_FILE
 } from './file-info-responses'
-import { renderWizardWithStudy, getSelectByLabelText, saveButton, mockCreateStudyFile } from './upload-wizard-test-utils'
+import {
+  renderWizardWithStudy, getSelectByLabelText, saveButton, mockCreateStudyFile
+} from './upload-wizard-test-utils'
+import * as UserProvider from '~/providers/UserProvider'
 
 const processedFileName = 'example_processed_dense.txt'
 const rawCountsFileName = 'example_raw_counts.txt'
@@ -29,8 +32,12 @@ describe('creation of study files', () => {
 
   it('allows upload of all common file types in sequence', async () => {
     const createFileSpy = jest.spyOn(ScpApi, 'createStudyFile')
-
-    await renderWizardWithStudy({ featureFlags: { raw_counts_required_frontend: true } })
+    jest
+      .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
+      .mockReturnValue({
+        clientside_validation: true
+      })
+    await renderWizardWithStudy({ featureFlags: { raw_counts_required_frontend: true, clientside_validation: true } })
     expect(screen.getByText('View study')).toHaveProperty('href', 'http://localhost/single_cell/study/SCP1')
 
     await testRawCountsUpload({ createFileSpy })


### PR DESCRIPTION
At some point we lost the use of the CSFV feature flag so that going at setting the flag to 'false' did not actually stop the validation from happening on file uploads.

This PR seeks to reinstate this logic.

To test:
- Pull this PR and start it up locally
- load up localhost:3000 and sign in as your admin account

I found this easiest to open up 2 tabs for the following

Test scenario using user FF:
- in one tab open the uploadwizard for a study you own
- in another tab open the featureflag settings
- set the ff for `clientside_validation` for your user to be `true`
- refresh the tab with the upload wizard
- attempt to upload an invalid file in the upload wizard and observe error messages
-----------------------------
- now go back to the ff settings tab and set the `clientside_validation` flag to false
- refresh the tab with the upload wizard
- attempt to upload an invalid file in the upload wizard and observe no error messages
