### PR TITLE
Check for axis before setting (SCP-4489)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -225,11 +225,11 @@ function RawScatterPlot({
       genes,
       isAnnotatedScatter,
       isCorrelatedScatter
-    }).then(processScatterPlot).catch(err => { 
+    }).then(processScatterPlot).catch(err => {
       setIsLoading(false)
       setErrorContent([`${err}`])
       setShowError(true)
-       })
+    })
   }, [cluster, annotation.name, subsample, consensus, genes.join(','), isAnnotatedScatter])
 
   // Handles custom scatter legend updates
@@ -252,11 +252,17 @@ function RawScatterPlot({
       PlotUtils.updateTraceVisibility(plotlyTraces, hiddenTraces)
       // disable autorange so graph does not rescale (SCP-3878)
       // we do not need to explicitly re-enable it since a new cluster will reset the entire layout
-      scatterData.layout.xaxis.autorange = false
-      scatterData.layout.yaxis.autorange = false
+
+      if (scatterData.layout.xaxis) {
+        scatterData.layout.xaxis.autorange = false
+      }
+      if (scatterData.layout.yaxis) {
+        scatterData.layout.yaxis.autorange = false
+      }
       if (scatterData.layout.zaxis) {
         scatterData.layout.zaxis.autorange = false
       }
+
       Plotly.react(graphElementId, plotlyTraces, scatterData.layout)
     }
     // look for updates of individual properties, so that we don't rerender if the containing array


### PR DESCRIPTION
Previously we try to set `scatterData.layout.xaxis.autorange` without checking that `scatterData.layout.xaxis` exists causing an error.

With this PR we now have checks to make sure `scatterData.layout.xaxis` and `scatterData.layout.yaxis` is there before trying to set autorange.

To Test:
- You need a study that has 3d clusters (This is the prod study that the user wrote in about, so I copied a few of those files to my local https://singlecell.broadinstitute.org/single_cell/study/SCP1830/spatial-atlas-of-molecular-cell-types-and-aav-accessibility-across-the-whole-mouse-brain?cluster=cluster.csv&spatialGroups=well11_spatial.csv&annotation=Tissue_Symbol--group--study&subsample=100000&hiddenTraces=BS_Fiber_B%2CAmyg_PALa#study-visualize)
- Pull this branch, and go to the study you have that has 3d clusters in your local
- attempt to show/hide any item in the legend
- no error should appear and the dots should appear/disappear as expected
![Screen Shot 2022-07-15 at 11 30 34 AM](https://user-images.githubusercontent.com/54322292/179256249-67110a9e-e932-40be-871c-99d9eeb4d9f7.png)


To see the bug go to https://singlecell.broadinstitute.org/single_cell/study/SCP1830/spatial-atlas-of-molecular-cell-types-and-aav-accessibility-across-the-whole-mouse-brain?cluster=cluster.csv&spatialGroups=well11_spatial.csv&annotation=Tissue_Symbol--group--study&subsample=100000&hiddenTraces=BS_Fiber_B%2CAmyg_PALa#study-visualize and try clicking in the legend and you will see an error about autorange not being settable.

![Screen Shot 2022-07-15 at 11 30 18 AM](https://user-images.githubusercontent.com/54322292/179256230-dbfe9d99-8051-48ee-aae8-0612e2ee39af.png)
