### PR TITLE
Allow setting custom GCE machine_type for differential expression jobs (SCP-4408)

### DIFF
--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -171,19 +171,6 @@ class DifferentialExpressionService
     end
   end
 
-  # create a GCE virtual machine for use in a DE job
-  # uses GCE N1 "high memory" machine types
-  # https://cloud.google.com/compute/docs/general-purpose-machines#n1-high-memory
-  #
-  # * *params*
-  #   - +machine_type+ (String) => Type of requested machine
-  #
-  # * *returns*
-  #   - (Google::Apis::GenomicsV2alpha1::VirtualMachine)
-  def self.create_custom_virtual_machine(machine_type:)
-    ApplicationController.papi_client.create_virtual_machine_object(machine_type: machine_type)
-  end
-
   # validate annotation exists and can be visualized for a DE job
   #
   # * *params*

--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -185,6 +185,15 @@ class DifferentialExpressionService
     cluster = study.cluster_groups.by_name(cluster_file.name)
     raise ArgumentError, "cannot find cluster for #{cluster_file.name}" if cluster.nil?
 
+    if DifferentialExpressionResult.where(study: study,
+                                          cluster: cluster,
+                                          annotation_name: annotation_name,
+                                          annotation_scope: annotation_scope).exists?
+      raise ArgumentError,
+            "#{annotation_name} already exists for #{study.accession}:#{cluster_file.name}, " \
+            'please delete the existing results before retrying'
+    end
+
     can_visualize = false
     if annotation_scope == 'cluster'
       annotation = cluster.cell_annotations&.detect do |annot|

--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -186,7 +186,7 @@ class DifferentialExpressionService
     raise ArgumentError, "cannot find cluster for #{cluster_file.name}" if cluster.nil?
 
     if DifferentialExpressionResult.where(study: study,
-                                          cluster: cluster,
+                                          cluster_group: cluster,
                                           annotation_name: annotation_name,
                                           annotation_scope: annotation_scope).exists?
       raise ArgumentError,

--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -2,7 +2,7 @@
 class DifferentialExpressionParameters
   include ActiveModel::Model
 
-  # acceptable Google N1 machine times
+  # acceptable Google N1 machine types
   # https://cloud.google.com/compute/docs/general-purpose-machines#n1-high-memory
   GOOGLE_VM_MACHINE_TYPES = [2, 4, 8, 16, 32, 64, 96].map { |i| "n1-highmem-#{i}" }.freeze
 

--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -1,6 +1,12 @@
 # class to hold parameters specific to differential expression jobs in PAPI
 class DifferentialExpressionParameters
   include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  # amount of RAM (in MB) to allocate for custom differential expression VMs
+  # to address exit code 137: Indicates failure as container received SIGKILL
+  # (Manual intervention or ‘oom-killer’ [OUT-OF-MEMORY])
+  CUSTOM_VM_RAM_MB = 53_248
 
   # regular expression to validate GS url format
   GS_URL_REGEXP = %r{\Ags://}.freeze
@@ -14,8 +20,17 @@ class DifferentialExpressionParameters
   # matrix_file_type: type of raw counts matrix (dense, sparse)
   # gene_file (optional): genes/features file for sparse matrix
   # barcode_file (optional): barcodes file for sparse matrix
-  attr_accessor :annotation_name, :annotation_scope, :annotation_file, :cluster_file,
-                :cluster_name, :matrix_file_path, :matrix_file_type, :gene_file, :barcode_file
+  # ram_in_mb (optional): override for setting amount of RAM on VM
+  attribute :annotation_name, type: String
+  attribute :annotation_scope, type: String
+  attribute :annotation_file, type: String
+  attribute :cluster_file,type: String
+  attribute :cluster_name, type: String
+  attribute :matrix_file_path, type: String
+  attribute :matrix_file_type, type: String
+  attribute :gene_file, type: String
+  attribute :barcode_file, type: String
+  attribute :ram_in_mb, default: CUSTOM_VM_RAM_MB
 
   validates :annotation_name, :annotation_scope, :annotation_file, :cluster_file,
             :cluster_name, :matrix_file_path, :matrix_file_type, presence: true
@@ -57,7 +72,6 @@ class DifferentialExpressionParameters
   def to_options_array
     options_array = []
     attributes.each do |attr_name, value|
-      # quote value to allow for non-word characters
       options_array += [self.class.to_cli_opt(attr_name), "#{value}"] if value.present?
     end
     options_array << '--differential-expression'

--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -24,8 +24,9 @@ class DifferentialExpressionResult
   field :matrix_file_id, type: BSON::ObjectId # associated raw count matrix study file
 
   validates :annotation_scope, inclusion: { in: %w[study cluster] }
-  validates :annotation_name, :cluster_name, :matrix_file_id, presence: true
+  validates :cluster_name, :matrix_file_id, presence: true
   validates :computational_method, inclusion: { in: SUPPORTED_COMP_METHODS }
+  validates :annotation_name, presence: true, uniqueness: { scope: %i[study cluster_group annotation_scope] }
   validate :has_observed_values?
   validate :matrix_file_exists?
 

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -97,7 +97,7 @@ class PapiClient
 
     # override default VM if this is a differential expression job
     if action.to_sym == :differential_expression
-      custom_vm = DifferentialExpressionService.create_custom_virtual_machine(ram_in_mb: params_object.ram_in_mb)
+      custom_vm = DifferentialExpressionService.create_custom_virtual_machine(machine_type: params_object.machine_type)
       resources = create_resources_object(regions: ['us-central1'], vm: custom_vm)
     else
       resources = create_resources_object(regions: ['us-central1'])

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -97,7 +97,7 @@ class PapiClient
 
     # override default VM if this is a differential expression job
     if action.to_sym == :differential_expression
-      custom_vm = DifferentialExpressionService.create_custom_virtual_machine
+      custom_vm = DifferentialExpressionService.create_custom_virtual_machine(ram_in_mb: params_object.ram_in_mb)
       resources = create_resources_object(regions: ['us-central1'], vm: custom_vm)
     else
       resources = create_resources_object(regions: ['us-central1'])

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -91,10 +91,18 @@ class PapiClient
   #   - (Google::Apis::ServerError) => An error occurred on the server and the request can be retried
   #   - (Google::Apis::ClientError) =>  The request is invalid and should not be retried without modification
   #   - (Google::Apis::AuthorizationError) => Authorization is required
-  def run_pipeline(study_file: , user:, action:, params_object: nil)
+  def run_pipeline(study_file:, user:, action:, params_object: nil)
     study = study_file.study
     accession = study.accession
-    resources = create_resources_object(regions: ['us-central1'])
+
+    # override default VM if this is a differential expression job
+    if action.to_sym == :differential_expression
+      custom_vm = DifferentialExpressionService.create_custom_virtual_machine
+      resources = create_resources_object(regions: ['us-central1'], vm: custom_vm)
+    else
+      resources = create_resources_object(regions: ['us-central1'])
+    end
+
     command_line = get_command_line(study_file: study_file, action: action, user_metrics_uuid: user.metrics_uuid,
                                     params_object: params_object)
     labels = {
@@ -124,7 +132,7 @@ class PapiClient
   #
   # * *return*
   #   - (Google::Apis::GenomicsV2alpha1::Operation)
-  def get_pipeline(name: , fields: nil, user: nil)
+  def get_pipeline(name:, fields: nil, user: nil)
     quota_user = user.present? ? user.id.to_s : nil
     service.get_project_operation(name, fields: fields, quota_user: quota_user)
   end

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -97,7 +97,7 @@ class PapiClient
 
     # override default VM if this is a differential expression job
     if action.to_sym == :differential_expression
-      custom_vm = DifferentialExpressionService.create_custom_virtual_machine(machine_type: params_object.machine_type)
+      custom_vm = create_virtual_machine_object(machine_type: params_object.machine_type)
       resources = create_resources_object(regions: ['us-central1'], vm: custom_vm)
     else
       resources = create_resources_object(regions: ['us-central1'])

--- a/test/integration/lib/differential_expression_service_test.rb
+++ b/test/integration/lib/differential_expression_service_test.rb
@@ -195,4 +195,13 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
     jobs_launched = DifferentialExpressionService.run_differential_expression_on_all(@basic_study.accession)
     assert_equal 3, jobs_launched
   end
+
+  test 'should create custom VM for DE jobs' do
+    vm = DifferentialExpressionService.create_custom_virtual_machine
+    assert_equal "custom-4-#{DifferentialExpressionService::CUSTOM_VM_RAM_MB}", vm.machine_type
+
+    # test overriding memory
+    custom_ram_vm = DifferentialExpressionService.create_custom_virtual_machine(ram_in_mb: 8192)
+    assert_equal 'custom-4-8192', custom_ram_vm.machine_type
+  end
 end

--- a/test/integration/lib/differential_expression_service_test.rb
+++ b/test/integration/lib/differential_expression_service_test.rb
@@ -197,8 +197,9 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
   end
 
   test 'should create custom VM for DE jobs' do
-    vm = DifferentialExpressionService.create_custom_virtual_machine
-    assert_equal "custom-4-#{DifferentialExpressionService::CUSTOM_VM_RAM_MB}", vm.machine_type
+    params = DifferentialExpressionParameters.new
+    vm = DifferentialExpressionService.create_custom_virtual_machine(ram_in_mb: params.ram_in_mb)
+    assert_equal "custom-4-#{DifferentialExpressionParameters::CUSTOM_VM_RAM_MB}", vm.machine_type
 
     # test overriding memory
     custom_ram_vm = DifferentialExpressionService.create_custom_virtual_machine(ram_in_mb: 8192)

--- a/test/integration/lib/differential_expression_service_test.rb
+++ b/test/integration/lib/differential_expression_service_test.rb
@@ -195,15 +195,4 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
     jobs_launched = DifferentialExpressionService.run_differential_expression_on_all(@basic_study.accession)
     assert_equal 3, jobs_launched
   end
-
-  test 'should create custom VM for DE jobs' do
-    params = DifferentialExpressionParameters.new
-    vm = DifferentialExpressionService.create_custom_virtual_machine(machine_type: params.machine_type)
-    assert_equal params.machine_type, vm.machine_type
-
-    # test overriding memory
-    random_machine = DifferentialExpressionParameters::GOOGLE_VM_MACHINE_TYPES.sample
-    custom_vm = DifferentialExpressionService.create_custom_virtual_machine(machine_type: random_machine)
-    assert_equal random_machine, custom_vm.machine_type
-  end
 end

--- a/test/integration/lib/differential_expression_service_test.rb
+++ b/test/integration/lib/differential_expression_service_test.rb
@@ -198,11 +198,12 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
 
   test 'should create custom VM for DE jobs' do
     params = DifferentialExpressionParameters.new
-    vm = DifferentialExpressionService.create_custom_virtual_machine(ram_in_mb: params.ram_in_mb)
-    assert_equal "custom-4-#{DifferentialExpressionParameters::CUSTOM_VM_RAM_MB}", vm.machine_type
+    vm = DifferentialExpressionService.create_custom_virtual_machine(machine_type: params.machine_type)
+    assert_equal params.machine_type, vm.machine_type
 
     # test overriding memory
-    custom_ram_vm = DifferentialExpressionService.create_custom_virtual_machine(ram_in_mb: 8192)
-    assert_equal 'custom-4-8192', custom_ram_vm.machine_type
+    random_machine = DifferentialExpressionParameters::GOOGLE_VM_MACHINE_TYPES.sample
+    custom_vm = DifferentialExpressionService.create_custom_virtual_machine(machine_type: random_machine)
+    assert_equal random_machine, custom_vm.machine_type
   end
 end

--- a/test/models/differential_expression_parameters_test.rb
+++ b/test/models/differential_expression_parameters_test.rb
@@ -40,8 +40,9 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
     assert_equal %i[annotation_file annotation_scope matrix_file_type],
                  dense_params.errors.attribute_names.sort
     sparse_params.gene_file = 'foo'
+    sparse_params.machine_type = 'foo'
     assert_not sparse_params.valid?
-    assert_equal [:gene_file], sparse_params.errors.attribute_names
+    assert_equal [:machine_type, :gene_file], sparse_params.errors.attribute_names
   end
 
   test 'should format differential expression parameters for python cli' do
@@ -73,6 +74,6 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
 
   test 'should provide default ram_in_mb for DE jobs' do
     params = DifferentialExpressionParameters.new
-    assert_equal DifferentialExpressionParameters::CUSTOM_VM_RAM_MB, params.ram_in_mb
+    assert_equal 'n1-highmem-8', params.machine_type
   end
 end

--- a/test/models/differential_expression_parameters_test.rb
+++ b/test/models/differential_expression_parameters_test.rb
@@ -70,4 +70,9 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
     assert_equal '--annotation-name', DifferentialExpressionParameters.to_cli_opt(:annotation_name)
     assert_equal '--foo', DifferentialExpressionParameters.to_cli_opt('foo')
   end
+
+  test 'should provide default ram_in_mb for DE jobs' do
+    params = DifferentialExpressionParameters.new
+    assert_equal DifferentialExpressionParameters::CUSTOM_VM_RAM_MB, params.ram_in_mb
+  end
 end

--- a/test/models/differential_expression_parameters_test.rb
+++ b/test/models/differential_expression_parameters_test.rb
@@ -72,7 +72,7 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
     assert_equal '--foo', DifferentialExpressionParameters.to_cli_opt('foo')
   end
 
-  test 'should provide default ram_in_mb for DE jobs' do
+  test 'should set default machine type for DE jobs' do
     params = DifferentialExpressionParameters.new
     assert_equal 'n1-highmem-8', params.machine_type
   end

--- a/test/models/differential_expression_result_test.rb
+++ b/test/models/differential_expression_result_test.rb
@@ -150,4 +150,13 @@ class DifferentialExpressionResultTest  < ActiveSupport::TestCase
                                                     matrix_file_id: @raw_matrix.id).exists?
     end
   end
+
+  test 'should prevent creating duplicate results' do
+    duplicate_result = DifferentialExpressionResult.new(
+      study: @study, cluster_group: @cluster_file.cluster_groups.first, annotation_name: 'species',
+      annotation_scope: 'study', matrix_file_id: @raw_matrix.id
+    )
+    assert_not duplicate_result.valid?
+    assert_equal [:annotation_name], duplicate_result.errors.attribute_names
+  end
 end


### PR DESCRIPTION
#### BACKGROUND
Some differential expression jobs fail after being invoked due to an out of memory (OOM) exception, which is denoted by an exit code of `137`.  This prevents these particular annotations from having differential expression results calculated for viewing in the Explore tab.

#### CHANGES
Now, when launching a differential expression job, the default machine type is increased from `n1-highmem-4` (4 cores, 26 GB RAM) to `n1-highmem-8` (8 cores, 52 GB RAM).  The reason for using the pre-built image is that the `n1-highmem` class of machine types in GCE all have the maximum amount available of RAM per core.  Therefore, to get more memory, we must add cores.  

In addition, it is now possible to override the new default of `n1-highmem-8` with any other `n1-highmem` machine type (from `n1-highmem-2` up to `n1-highmem-96`).  This will allow SCP admins to custom tailor individual jobs that may require more resources without needing to deploy new code to the server.  This can be configured with the `machine_type` parameter in `DifferentialExpressionService.run_differential_expression_job`.

This also fixes an issue where duplicate `DifferentialExpressionResult` instances could both point to the same collection of output files.  Now, a uniqueness constraint is placed so that only one result can exist for a given study/cluster/annotation combination.  Also, `DifferentialExpressionService` will check to see if there are already existing results for the requested combination and throw an error if they are present.

#### MANUAL TESTING
1. Pull this branch and start `Delayed::Job` with `bin/rails jobs:work`
2. In a separate terminal, open the Rails console
3. Select any pre-existing `DifferentialExpressionResult` and re-populate the parameters:
```
result = DifferentialExpressionResult.all.sample
study = result.study
cluster_file = result.cluster_file
user = study.user
params = { annotation_name: result.annotation_name, annotation_scope: result.annotation_scope }
```
4. Delete the existing result, and launch a new job to repopulate them:
```
result.destroy
DifferentialExpressionService.run_differential_expression_job(cluster_file, study, user, **params)
```
5. In `development.log`, note the new custom machine type in the `:resources` section of the running pipeline:
```
:resources:
  ...
  :virtual_machine:
    :boot_disk_size_gb: 300
    :machine_type: n1-highmem-8
    :preemptible: false
    ...
```