### PR TITLE
Disable TCell integration in local development (SCP-4554)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,6 @@ gem 'sentry-raven'
 gem 'rubyzip'
 gem 'rack-brotli'
 gem 'time_difference'
-gem 'tcell_agent'
 gem 'sys-filesystem', require: 'sys/filesystem'
 gem 'browser'
 gem 'ruby-prof'
@@ -75,6 +74,11 @@ gem 'carrierwave', '~> 2.0'
 gem 'carrierwave-mongoid', :require => 'carrierwave/mongoid'
 gem 'uuid'
 gem 'vite_rails'
+
+# only enable TCell in deployed environments due to Chrome sec-ch-ua header issue
+group :production, :staging do
+  gem 'tcell_agent'
+end
 
 group :development, :test do
   # Access an IRB console on exception pages or by using <%= console %> in views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,6 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.2.4.0)
       execjs
-    backports (3.21.0)
     bcrypt (3.1.16)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
@@ -128,7 +127,6 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.10)
-    connection_pool (2.2.5)
     crass (1.0.6)
     daemons (1.4.0)
     debase (0.2.4.1)
@@ -155,8 +153,6 @@ GEM
     dry-cli (0.7.0)
     easy_diff (1.0.0)
     erubi (1.10.0)
-    ethon (0.14.0)
-      ffi (>= 1.15.0)
     execjs (2.7.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
@@ -165,17 +161,8 @@ GEM
       railties (>= 5.0.0)
     faraday (0.17.4)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.14.0)
-      faraday (>= 0.7.4, < 1.0)
     ffi (1.15.5)
     flamegraph (0.9.5)
-    gh (0.14.0)
-      addressable
-      backports
-      faraday (~> 0.8)
-      multi_json (~> 1.0)
-      net-http-persistent (>= 2.7)
-      net-http-pipeline
     gibberish (2.1.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -232,7 +219,6 @@ GEM
       os (>= 0.9, < 2.0)
       signet (~> 0.14)
     hashie (4.1.0)
-    highline (1.7.10)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -254,8 +240,6 @@ GEM
       thor (>= 0.14, < 2.0)
     json (2.5.1)
     jwt (2.2.3)
-    launchy (2.5.0)
-      addressable (~> 2.7)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -315,9 +299,6 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     naturally (2.2.1)
-    net-http-persistent (4.0.1)
-      connection_pool (~> 2.2)
-    net-http-pipeline (1.0.1)
     netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.13.6-x86_64-darwin)
@@ -354,9 +335,6 @@ GEM
     public_suffix (4.0.6)
     puma (5.6.4)
       nio4r (~> 2.0)
-    pusher-client (0.6.2)
-      json
-      websocket (~> 1.0)
     racc (1.6.0)
     rack (2.2.3.1)
     rack-brotli (1.1.0)
@@ -490,18 +468,7 @@ GEM
     time_difference (0.5.0)
       activesupport
     trailblazer-option (0.1.1)
-    travis (1.8.13)
-      backports
-      faraday (~> 0.9)
-      faraday_middleware (~> 0.9, >= 0.9.1)
-      gh (~> 0.13)
-      highline (~> 1.6)
-      launchy (~> 2.1)
-      pusher-client (~> 0.4)
-      typhoeus (~> 0.6, >= 0.6.8)
     truncate_html (0.9.3)
-    typhoeus (0.8.0)
-      ethon (>= 0.8.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
@@ -521,7 +488,6 @@ GEM
     warden (1.2.9)
       rack (>= 2.0.9)
     webrick (1.7.0)
-    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -600,7 +566,6 @@ DEPENDENCIES
   tcell_agent
   test-unit
   time_difference
-  travis
   truncate_html
   uuid
   vite_rails


### PR DESCRIPTION
#### BACKGROUND
The TCell web application firewall has begun flagging requests on `localhost` as suspicious and blocking them, preventing developing locally.  This is in part due to the Chrome `sec-ch-ua` header, which has been flagged previously as an issue with requests being forbidden.

#### CHANGES
TCell has been moved to a separate Gemfile group so that the client libraries are only loaded in deployed environments (i.e. `staging` and `production`).  In addition, this update removes unneeded dependencies for the `travis` gem that was previously taken out in favor of Github Actions.

#### MANUAL TESTING
1. Pull branch and run `bundle install`, then start the server normally
2. Pull up the home page in Chrome and validate that it loads