### PR TITLE
Handle plus sign in differential expression parameters (SCP-4534)

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -35,7 +35,8 @@ jobs:
           # More context: https://github.com/broadinstitute/single_cell_portal_core/pull/1552#discussion_r910424433
           # TODO: (SCP-4496): Move production-related GCR images out of staging project
           DOCKER_IMAGE_NAME="gcr.io/broad-singlecellportal-staging/single-cell-portal"
-          DOCKER_IMAGE_TAG="$GITHUB_HEAD_REF-$GITHUB_SHA"
+          # add ci- prefix to avoid post-merge build failing due to missing GITHUB_HEAD_REF
+          DOCKER_IMAGE_TAG="ci-$GITHUB_HEAD_REF-$GITHUB_SHA"
           docker build -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG -f test/Dockerfile-test .
           bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json \
                                   -s secret/kdux/scp/staging/scp_service_account.json \

--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -82,6 +82,8 @@ class DifferentialExpressionResult
   end
 
   # individual filename of label-specific result
+  # will convert non-word characters to underscores "_", except plus signs "+" which are changed to "pos"
+  # this is to handle cases where + or - are the only difference in labels, such as CD4+ and CD4-
   def filename_for(label)
     basename = [
       cluster_name,
@@ -89,7 +91,7 @@ class DifferentialExpressionResult
       label,
       annotation_scope,
       computational_method
-    ].map { |val| val.gsub(/\W/, '_') }.join('--')
+    ].map { |val| val.gsub(/\+/, 'pos').gsub(/\W/, '_') }.join('--')
     "#{basename}.tsv"
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.19.2'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.20.0'
 
     config.autoload_paths << Rails.root.join('lib')
 

--- a/test/models/differential_expression_result_test.rb
+++ b/test/models/differential_expression_result_test.rb
@@ -159,4 +159,11 @@ class DifferentialExpressionResultTest  < ActiveSupport::TestCase
     assert_not duplicate_result.valid?
     assert_equal [:annotation_name], duplicate_result.errors.attribute_names
   end
+
+  test 'should handle plus sign in output file names' do
+    label = 'CD4+'
+    expected_filename = '_scp_internal/differential_expression/cluster_diffexp_txt--species--CD4pos--study--wilcoxon.tsv'
+    filename = @species_result.filename_for(label)
+    assert_equal expected_filename, filename
+  end
 end

--- a/test/models/differential_expression_result_test.rb
+++ b/test/models/differential_expression_result_test.rb
@@ -162,7 +162,7 @@ class DifferentialExpressionResultTest  < ActiveSupport::TestCase
 
   test 'should handle plus sign in output file names' do
     label = 'CD4+'
-    expected_filename = '_scp_internal/differential_expression/cluster_diffexp_txt--species--CD4pos--study--wilcoxon.tsv'
+    expected_filename = 'cluster_diffexp_txt--species--CD4pos--study--wilcoxon.tsv'
     filename = @species_result.filename_for(label)
     assert_equal expected_filename, filename
   end


### PR DESCRIPTION
#### BACKGROUND
There is a specific corner case in generating filenames for differential expression outputs that can result in different annotation labels clobbering each other when the only difference between said labels are + and - signs (e.g. `CD4+` and `CD4-`).  In this scenario, both labels convert to `CD4_` and overwrite each other.

#### CHANGES
This update introduces special handling for plus signs that converts them to the string `pos`.  This is done before converting all non-word characters to underscores.  This way, the above example translates to `CD4pos` and `CD4_`, respectively.

In addition, this update fixes a bug in post-merge CI runs where the value of `$GITHUB_HEAD_REF` is not set, resulting in an invalid Docker image tag that causes the run to fail before beginning.

#### MANUAL TESTING
1. Pull this branch, boot as normal, and start DelayedJob
2. Download the following files from [scp-ingest-pipline](https://github.com/broadinstitute/scp-ingest-pipeline/tree/development/tests/data/differential_expression)
  i. [de_dense_matrix.tsv](https://github.com/broadinstitute/scp-ingest-pipeline/blob/development/tests/data/differential_expression/de_dense_matrix.tsv)
  ii. [de_dense_cluster.tsv](https://github.com/broadinstitute/scp-ingest-pipeline/blob/development/tests/data/differential_expression/de_dense_cluster.tsv)
  iii. [de_dense_metadata_sanitize.txt](https://github.com/broadinstitute/scp-ingest-pipeline/blob/development/tests/data/differential_expression/de_dense_metadata_sanitize.txt)
3. Open `de_dense_metadata_sanitize.txt` in a text editor, and update the last column header of `misc++cellaneous` to `miscellaneous` (otherwise this file will not ingest).
4.  Create a new study, and upload all 3 files, specifying `de_dense_matrix.tsv` as a raw count matrix
5. Once all 3 files have uploaded/ingested, enter a Rails console session
6. Run a differential expression job for the `miscellaneous` annotation:
```
study = Study.all.last
user = study.user
cluster_file = study.cluster_ordinations_files.first
params = { annotation_name: 'miscellaneous', annotation_scope: 'study' }
DifferentialExpressionService.run_differential_expression_job(cluster_file, study, user, **params)
=> true
```
7. Once that job completes, load the result record and validate that plus signs are handled correctly (the example below used the name `Cluster 1` for the clustering file:
```
result = DifferentialExpressionResult.all.last
pp result.result_files
{"cranial +somatomotor+ neuron"=>
  "Cluster_1--miscellaneous--cranial_possomatomotorpos_neuron--study--wilcoxon.tsv",
 "sympathetic ?cholinergic neuron"=>
  "Cluster_1--miscellaneous--sympathetic__cholinergic_neuron--study--wilcoxon.tsv",
 "pyramidal -neuron"=>
  "Cluster_1--miscellaneous--pyramidal__neuron--study--wilcoxon.tsv",
 "somatomotor neuron "=>
  "Cluster_1--miscellaneous--somatomotor_neuron_--study--wilcoxon.tsv",
 "cholinergic (neuron)"=>
  "Cluster_1--miscellaneous--cholinergic__neuron_--study--wilcoxon.tsv"}

```
