### PR TITLE
Expand failed upload query to account for nil status (SCP-4482)

### DIFF
--- a/app/models/upload_cleanup_job.rb
+++ b/app/models/upload_cleanup_job.rb
@@ -82,8 +82,8 @@ class UploadCleanupJob < Struct.new(:study, :study_file, :retry_count)
   def self.find_and_remove_failed_uploads
     date_threshold = 1.day.ago.in_time_zone
     # make sure to exclude links to external sequence data with human_fastq_url: nil
-    failed_uploads = StudyFile.where(status: 'uploading', generation: nil, :created_at.lte => date_threshold,
-                                     human_fastq_url: nil, parse_status: 'unparsed')
+    failed_uploads = StudyFile.where(:status.in => ['uploading', nil], generation: nil, :created_at.lte => date_threshold,
+                                     human_fastq_url: nil, :parse_status.in => ['unparsed', nil])
     failed_uploads.each do |study_file|
       # final sanity check - see if there is a file in the bucket of the same size
       # this might happen if the post-upload action to update 'status' fails for some reason


### PR DESCRIPTION
#### BACKGROUND
The job that runs periodically to detect and remove failed/partial uploads has a corner case where some failed uploads are ignored due to missing status values.  This results in partial files remaining on disk and potentially filling up the volume unless they are manually removed.

#### CHANGES
This update accounts for `nil` values in the `status` and `parse_status` fields that would cause the query to ignore some files.  It is unclear how exactly these values were set to `nil`, but handling them in the cleanup process addresses the stated issue.

#### MANUAL TESTING
1. Pull branch and enter a new Rails console session
2. Ensure you have no files queued for deletion with `StudyFile.delete_queued_files`
3. Simulate a failed upload that has bad status values with the following commands:
```
study = Study.last
filename = 'mock_study_doc_upload.txt'
file = File.open(Rails.root.join('test', 'test_data', filename))
bad_upload = StudyFile.create!(name: filename, study: study, file_type: 'Other', upload: file, status: nil, created_at: 1.week.ago.in_time_zone, parse_status: nil, generation: nil)
file.close
```
4. Run the cleanup job and confirm that the file is queued for deletion:
```
UploadCleanupJob.find_and_remove_failed_uploads
StudyFile.where(queued_for_deletion: true).count
=> 1
```