### PR TITLE
Add more info to the error logging for failed fetches (SCP-4548)

### DIFF
--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -409,14 +409,15 @@ export function log(name, props = {}) {
   init = Object.assign(init, body)
 
   if ('SCP' in window || metricsApiMock) {
-    fetch(`${bardDomain}/api/event/`, init).then(response => {
+    const url = `${bardDomain}/api/event/`
+    fetch(url, init).then(response => {
       // log failed attempts to connect with Bard to Sentry
       if (!response.ok) {
         logJSFetchExceptionToSentry(response, 'Error in fetch response when logging event to Bard', true)
       }
     // log errored attempts to connect with Bard to Sentry
     }).catch(error => {
-      logJSFetchErrorToSentry(error, 'Error in JavaScript when logging event to Bard', true)
+      logJSFetchErrorToSentry(error, 'Error in JavaScript when logging event to Bard', true, url, init)
     })
   }
 }

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -352,7 +352,7 @@ export async function fetchBucketFile(bucketName, fileName, maxBytes=null, mock=
     return response
   // log errored attempts to access google storage to Sentry
   }).catch(error => {
-    logJSFetchErrorToSentry(error, 'Error in JavaScript when connecting to Google storage')
+    logJSFetchErrorToSentry(error, 'Error in JavaScript when connecting to Google storage', url, init)
   })
 
   return response

--- a/app/javascript/lib/sentry-logging.js
+++ b/app/javascript/lib/sentry-logging.js
@@ -28,14 +28,24 @@ export function logJSFetchExceptionToSentry(response, titleInfo = '', useThrottl
 }
 
 /**
- * Log an exception to Sentry for failed JS fetch executions
- * i.e. fetches that fail and error
+ * Log an error to Sentry for failed JS fetch executions
  *
- * @param {Object} response - the response object from a failed JS fetch call
+ * @param {Object} error - the error object from a failed JS fetch call
  * @param {String} titleInfo - extra info for the title of the Sentry event
  * @param {Boolean} useThrottle - whether to apply clientside rate limit throttling
+ * @param {String} url - the url used in the fetch request that failed
+ * @param {Object} init - the init object sent in the fetch request that failed
+
  */
-export function logJSFetchErrorToSentry(error, titleInfo = '', useThrottle = false) {
+export function logJSFetchErrorToSentry(error, titleInfo = '', useThrottle = false, url = '', init = {}) {
+  // add details from the error to the 'error info' object that will be logged in Sentry
+  Sentry.setContext('error info', {
+    message: error.message,
+    cause: error.cause,
+    attemptedUrl: url,
+    initObj: init
+  })
+
   const errorObj = new Error(`${error}: ${titleInfo}`)
   logToSentry(errorObj, useThrottle)
 }


### PR DESCRIPTION
Increase the information sent to Sentry when a fetch request fails in the JS code. This pretty much only occurs for connecting to Bard or Google resources (though we've only seen this from Bard fetches). This adds extra context to the Sentry log which will hopefully help us diagnose these issues in the future. 

To test:
- Pull this branch
- Edit line 73 in sentry-logging.js to return false
- Edit line 86 in sentry-logging.jsto `1` to not throttle any requests
- Load home page
- Open DevTools in browser
- Go to the Network tab and find an `event` request and right click on it
- Block the request URL 
![Screen Shot 2022-08-03 at 2 54 24 PM](https://user-images.githubusercontent.com/54322292/182687811-e433b6ca-a5fc-4ffe-80eb-7c7f507f055d.png)
- mouse around the site, until you see in the Network tab something like `?sentry_key=a713dcf8bbce...`
- click on that and check out the request payload where you should see something like below:
![Screen Shot 2022-08-03 at 2 54 47 PM](https://user-images.githubusercontent.com/54322292/182687794-4e9c8365-900a-4e2d-9008-0a0969f89af5.png)

Which is showing the contexts now includes error info