### PR TITLE
Updating to Ruby 3.1.2 (SCP-4576)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use SCP base Rails image, configure only project-specific items here
-FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:2.1.0
+FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:2.1.1
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-3.1.2'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:2.1.0
 
 # Set ruby version
-RUN bash -lc 'rvm --default use ruby-2.6.10'
+RUN bash -lc 'rvm --default use ruby-3.1.2'
 RUN bash -lc 'rvm rvmrc warning ignore /home/app/webapp/Gemfile'
 
 # Set up project dir, install gems, set up script to migrate database and precompile static assets on run

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.10'
+ruby '3.1.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '6.1.6.1'
@@ -28,7 +28,7 @@ gem 'sdoc', group: :doc
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
-gem 'bootsnap', '>= 1.4.4', require: false
+gem 'bootsnap', require: false
 gem 'minitest-rails'
 gem 'minitest-reporters'
 
@@ -74,6 +74,7 @@ gem 'carrierwave', '~> 2.0'
 gem 'carrierwave-mongoid', :require => 'carrierwave/mongoid'
 gem 'uuid'
 gem 'vite_rails'
+gem 'net-smtp'
 
 # only enable TCell in deployed environments due to Chrome sec-ch-ua header issue
 group :production, :staging do
@@ -82,7 +83,6 @@ end
 
 group :development, :test do
   # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'debase'
   gem 'test-unit'
   gem 'brakeman', :require => false
   gem 'factory_bot_rails'

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'sdoc', group: :doc
 # gem 'capistrano-rails', group: :development
 
 gem 'bootsnap', require: false
+gem 'minitest', '5.15.0'
 gem 'minitest-rails'
 gem 'minitest-reporters'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,12 +98,12 @@ GEM
     autoprefixer-rails (10.2.4.0)
       execjs
     bcrypt (3.1.16)
-    bootsnap (1.7.5)
-      msgpack (~> 1.0)
+    bootsnap (1.13.0)
+      msgpack (~> 1.2)
     brakeman (5.0.1)
     brotli (0.4.0)
     browser (5.3.1)
-    bson (4.12.0)
+    bson (4.15.0)
     bson_ext (1.5.1)
     builder (3.2.4)
     byebug (11.1.3)
@@ -129,9 +129,6 @@ GEM
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     daemons (1.4.0)
-    debase (0.2.4.1)
-      debase-ruby_core_source (>= 0.10.2)
-    debase-ruby_core_source (0.10.12)
     declarative (0.0.20)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)
@@ -145,7 +142,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    digest-crc (0.6.3)
+    digest (3.1.0)
+    digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
     docile (1.3.5)
     domain_name (0.5.20190701)
@@ -159,65 +157,67 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
-    faraday (0.17.4)
+    faraday (0.17.5)
       multipart-post (>= 1.2, < 3)
     ffi (1.15.5)
     flamegraph (0.9.5)
+    gems (1.2.0)
     gibberish (2.1.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    google-api-client (0.50.0)
-      addressable (~> 2.5, >= 2.5.1)
-      googleauth (~> 0.9)
-      httpclient (>= 2.8.1, < 3.0)
-      mini_mime (~> 1.0)
-      representable (~> 3.0)
-      retriable (>= 2.0, < 4.0)
-      rexml
-      signet (~> 0.12)
-    google-apis-bigquery_v2 (0.9.0)
+    google-api-client (0.53.0)
       google-apis-core (~> 0.1)
-    google-apis-core (0.3.0)
+      google-apis-generator (~> 0.1)
+    google-apis-bigquery_v2 (0.37.0)
+      google-apis-core (>= 0.7, < 2.a)
+    google-apis-core (0.7.0)
       addressable (~> 2.5, >= 2.5.1)
-      googleauth (~> 0.14)
-      httpclient (>= 2.8.1, < 3.0)
+      googleauth (>= 0.16.2, < 2.a)
+      httpclient (>= 2.8.1, < 3.a)
       mini_mime (~> 1.0)
       representable (~> 3.0)
-      retriable (>= 2.0, < 4.0)
+      retriable (>= 2.0, < 4.a)
       rexml
-      signet (~> 0.14)
       webrick
-    google-apis-iamcredentials_v1 (0.3.0)
-      google-apis-core (~> 0.1)
-    google-apis-storage_v1 (0.3.0)
-      google-apis-core (~> 0.1)
-    google-cloud-bigquery (1.31.0)
+    google-apis-discovery_v1 (0.11.0)
+      google-apis-core (>= 0.7, < 2.a)
+    google-apis-generator (0.9.0)
+      activesupport (>= 5.0)
+      gems (~> 1.2)
+      google-apis-core (>= 0.7, < 2.a)
+      google-apis-discovery_v1 (~> 0.5)
+      thor (>= 0.20, < 2.a)
+    google-apis-iamcredentials_v1 (0.13.0)
+      google-apis-core (>= 0.7, < 2.a)
+    google-apis-storage_v1 (0.17.0)
+      google-apis-core (>= 0.7, < 2.a)
+    google-cloud-bigquery (1.39.0)
       concurrent-ruby (~> 1.0)
       google-apis-bigquery_v2 (~> 0.1)
-      google-cloud-core (~> 1.2)
-      googleauth (~> 0.9)
+      google-cloud-core (~> 1.6)
+      googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
     google-cloud-core (1.6.0)
       google-cloud-env (~> 1.0)
       google-cloud-errors (~> 1.0)
-    google-cloud-env (1.5.0)
-      faraday (>= 0.17.3, < 2.0)
-    google-cloud-errors (1.1.0)
-    google-cloud-storage (1.31.0)
-      addressable (~> 2.5)
+    google-cloud-env (1.6.0)
+      faraday (>= 0.17.3, < 3.0)
+    google-cloud-errors (1.2.0)
+    google-cloud-storage (1.38.0)
+      addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-iamcredentials_v1 (~> 0.1)
-      google-apis-storage_v1 (~> 0.1)
-      google-cloud-core (~> 1.2)
-      googleauth (~> 0.9)
+      google-apis-storage_v1 (~> 0.17.0)
+      google-cloud-core (~> 1.6)
+      googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
-    googleauth (0.16.2)
-      faraday (>= 0.17.3, < 2.0)
+    googleauth (1.2.0)
+      faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
-      signet (~> 0.14)
+      signet (>= 0.16, < 2.a)
     hashie (4.1.0)
     http-accept (1.7.0)
     http-cookie (1.0.3)
@@ -239,7 +239,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.5.1)
-    jwt (2.2.3)
+    jwt (2.4.1)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -259,7 +259,7 @@ GEM
     mime-types-data (3.2021.0225)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    minitest (5.15.0)
+    minitest (5.16.2)
     minitest-hooks (1.5.0)
       minitest (> 5.3)
     minitest-rails (6.1.0)
@@ -270,11 +270,12 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mongo (2.14.0)
-      bson (>= 4.8.2, < 5.0.0)
-    mongoid (7.2.2)
-      activemodel (>= 5.1, < 6.2)
+    mongo (2.18.1)
+      bson (>= 4.14.1, < 5.0.0)
+    mongoid (7.5.1)
+      activemodel (>= 5.1, < 7.1, != 7.0.0)
       mongo (>= 2.10.5, < 3.0.0)
+      ruby2_keywords (~> 0.0.5)
     mongoid-compatibility (0.5.1)
       activesupport
       mongoid (>= 2.0)
@@ -294,11 +295,17 @@ GEM
       mongoid (>= 4.0.0)
       rails (>= 4.2.0)
       railties (>= 4.2.0)
-    msgpack (1.4.2)
+    msgpack (1.5.4)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    multipart-post (2.1.1)
+    multipart-post (2.2.3)
     naturally (2.2.1)
+    net-protocol (0.1.3)
+      timeout
+    net-smtp (0.3.1)
+      digest
+      net-protocol
+      timeout
     netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.13.8-x86_64-darwin)
@@ -327,12 +334,12 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
-    os (1.1.1)
+    os (1.1.4)
     parallel (1.20.1)
     parser (3.0.1.1)
       ast (~> 2.4.1)
     power_assert (2.0.0)
-    public_suffix (4.0.6)
+    public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -381,7 +388,7 @@ GEM
       ffi (~> 1.0)
     rdoc (6.3.1)
     regexp_parser (2.1.1)
-    representable (3.1.1)
+    representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
@@ -416,6 +423,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    ruby2_keywords (0.0.5)
     ruby_native_statistics (0.10.1)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
@@ -433,9 +441,9 @@ GEM
     secure_headers (6.3.2)
     sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
-    signet (0.15.0)
-      addressable (~> 2.3)
-      faraday (>= 0.17.3, < 2.0)
+    signet (0.17.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
     simplecov (0.21.2)
@@ -467,9 +475,10 @@ GEM
     tilt (2.0.10)
     time_difference (0.5.0)
       activesupport
-    trailblazer-option (0.1.1)
+    timeout (0.3.0)
+    trailblazer-option (0.1.2)
     truncate_html (0.9.3)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unf (0.1.4)
@@ -500,10 +509,11 @@ GEM
 PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
-  bootsnap (>= 1.4.4)
+  bootsnap
   bootstrap-sass!
   brakeman
   browser
@@ -513,7 +523,6 @@ DEPENDENCIES
   carrierwave-mongoid
   coffee-rails
   daemons
-  debase
   delayed_job
   delayed_job_mongoid
   devise
@@ -540,6 +549,7 @@ DEPENDENCIES
   mongoid_rails_migrations
   naturally
   nested_form!
+  net-smtp
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   parallel
@@ -573,7 +583,7 @@ DEPENDENCIES
   will_paginate_mongoid
 
 RUBY VERSION
-   ruby 2.6.10p210
+   ruby 3.1.2p20
 
 BUNDLED WITH
-   2.2.24
+   2.3.19

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,7 +259,7 @@ GEM
     mime-types-data (3.2021.0225)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    minitest (5.16.2)
+    minitest (5.15.0)
     minitest-hooks (1.5.0)
       minitest (> 5.3)
     minitest-rails (6.1.0)
@@ -540,6 +540,7 @@ DEPENDENCIES
   jquery-rails
   listen
   memory_profiler
+  minitest (= 5.15.0)
   minitest-hooks
   minitest-rails
   minitest-reporters

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -1,28 +1,40 @@
 # Developing on SCP without a Docker container
 
-Developing on SCP without a Docker container, while less robust, opens up some faster development paradigms, including live css/js reloading, faster build times, and byebug debugging in rails.
+Developing on SCP without a Docker container, while less robust, opens up some faster development paradigms, including 
+live css/js reloading, faster build times, and byebug debugging in rails.
 
 ## SETUP
 
-1.  Run `ruby -v` to ensure Ruby 2.6.10 is installed on your local machine.  If not, [install rbenv](https://github.com/rbenv/rbenv#installation) (via `brew install rbenv` if on macOS) then `rbenv init` to set up rbenv in your shell. Then close out terminal and reopen and run `rbenv install 2.6.10`. (version is current as of 06/27/2022)
-2.  Run `bundler -v` to ensure Bundler is installed.  If not, `gem install bundler`.
-3.  Run `node -v` to ensure Node is installed. If not, install via https://nodejs.org/en/download/
-4.  Run `yarn -v` to ensure Yarn is installed. If not, install via `brew install yarn`
-5.  `cd` to where you have the `single_cell_portal_core` Git repo checked out.
-6.  Run `bundle install`
-7.  Run `yarn install`
-8.  Run `ruby rails_local_setup.rb $BROAD_USERNAME`, where $BROAD_USERNAME is a something like eweitz -- this creates a file in config/secrets with commands to export needed environment variables
-9.  Run the source command the script outputs -- this will export those needed variables into the current shell
-10.  Add config/local_ssl/localhost.crt to your system's trusted certificates. On macOS, you can drag this file into the keychain access app, use the "System" keychain, and the "Certificates" category. Then you will likely need to open the newly added certificate in the keychain access app and update the "Trust" setting to be "Always Trust" rather than "Use System Defaults".
-11.  Run `rails s`
-12.  If you're developing JS, for hot module replacement and live reload, in a separate terminal, run `bin/vite dev`
+1. Run `ruby -v` to ensure Ruby 3.1.2 is installed on your local machine.  If not, [install rbenv](https://github.com/rbenv/rbenv#installation) 
+(via `brew install rbenv` if on macOS) then `rbenv init` to set up rbenv in your shell. Then close out terminal and reopen 
+and run `rbenv install 3.1.2`. (version is current as of 08/09/2022)
+2. Run `bundler -v` to ensure Bundler is installed.  If not, `gem install bundler`.
+3. Run `node -v` to ensure Node is installed. If not, install via https://nodejs.org/en/download/
+4. Run `yarn -v` to ensure Yarn is installed. If not, install via `brew install yarn`
+5. `cd` to where you have the `single_cell_portal_core` Git repo checked out.
+6. Run `bundle install`
+7. Run `yarn install`
+8. Run `./rails_local_setup.rb` to will write out required variables into an shell env file (using your Broad username 
+to determine which `vault` paths to read from).
+9. Run the source command the script outputs -- this will export those needed variables into the current shell
+10. Add `config/local_ssl/localhost.crt` to your system's trusted certificates. On macOS, you can drag this file into the 
+keychain access app, use the "System" keychain, and the "Certificates" category. Then you will likely need to open the 
+newly added certificate in the keychain access app and update the "Trust" setting to be "Always Trust" rather than "Use 
+System Defaults".
+11. Run `rails s`
+12. If you're developing JS, for hot module replacement and live reload, in a separate terminal, run `bin/vite dev`
 13. If you are working on functionality that involves delayed jobs, like uploading data:
     * In another terminal, run the source command output in step 7
     * run `rails jobs:work`
-14.  You're all set!  You can now go to https://localhost:3000 and see the website.
+14. You're all set!  You can now go to https://localhost:3000 and see the website.
 
 ## REGULAR DEVELOPMENT
-Adding `source <<path-to-single-cell-portal-core>>/config/secrets/.source_env.bash` to your .bash_profile will source the secrets read from vault to each new shell, saving you the trouble of rerunning the setup process every time you open a new shell.
+Adding `source <<path-to-single-cell-portal-core>>/config/secrets/.source_env.bash` to your .bash_profile will source the 
+secrets read from vault to each new shell, saving you the trouble of rerunning the setup process every time you open a 
+new shell.  
+
+NOTE: If you ever use the `bin/run_tests.sh` script locally, this will write out and delete any shell env files 
+after completion.  You will need to run `./ruby_local_setup.rb` again to repopulate them.
 
 ## KNOWN ISSUES
 1. Developing outside the docker container inherently runs more risk that your code will not work in the docker environment in staging/production.  BE CAREFUL.  If your changes are non-trivial, confirm your changes work in the containerized deploy before committing (ESPECIALLY changes involving package.json and/or the Gemfile)

--- a/app/controllers/api/v1/bulk_download_controller.rb
+++ b/app/controllers/api/v1/bulk_download_controller.rb
@@ -446,7 +446,7 @@ module Api
       # can be 'all', or a single directory (with specified file_type as well)
       def self.find_matching_directories(directory_name, file_type, accession)
         study = Study.find_by(accession: accession)
-        sanitized_dirname = URI.decode(directory_name)
+        sanitized_dirname = CGI.unescape(directory_name)
         case sanitized_dirname.downcase
         when 'nodirs'
           []

--- a/app/controllers/api/v1/metadata_schemas_controller.rb
+++ b/app/controllers/api/v1/metadata_schemas_controller.rb
@@ -86,7 +86,7 @@ module Api
           response_type = 'application/json'
         end
 
-        if File.exists?(schema_pathname)
+        if File.exist?(schema_pathname)
           send_file schema_pathname, type: response_type, filename: schema_filename
         else
           head 404 and return

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,7 +45,7 @@ module ApplicationHelper
   # create javascript-safe url with parameters
   def javascript_safe_url(url)
     # remove utf8=✓& from url to avoid formatting errors
-    URI.decode(url.gsub(/utf8=%E2%9C%93&/, '')).html_safe
+    CGI.unescape(url.gsub(/utf8=%E2%9C%93&/, '')).html_safe
   end
 
   # construct nav menu breadcrumbs

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -76,7 +76,7 @@ class RequestUtils
   # strips out unsafe characters that break rendering notices/modals
   def self.sanitize_search_terms(terms)
     inputs = terms.is_a?(Array) ? terms.join(',') : terms.to_s
-    SANITIZER.sanitize(inputs).encode!(Encoding.find('ASCII-8BIT'), invalid: :replace, undef: :replace)
+    SANITIZER.sanitize(inputs).encode(Encoding.find('ASCII-8BIT'), invalid: :replace, undef: :replace)
   end
 
   # takes a comma-delimited string of ids (e.g. StudyFile ids) and returns an array of ids

--- a/app/lib/user_asset_service.rb
+++ b/app/lib/user_asset_service.rb
@@ -24,7 +24,7 @@ class UserAssetService
   # * *yields*
   #   - +Google::Cloud::Storage+
   def self.storage_service
-    @@storage_service ||= Google::Cloud::Storage.new(keyfile: self.get_primary_keyfile)
+    @@storage_service ||= Google::Cloud::Storage.new(credentials: self.get_primary_keyfile)
   end
 
   # get storage driver access token

--- a/app/lib/user_asset_service.rb
+++ b/app/lib/user_asset_service.rb
@@ -68,7 +68,7 @@ class UserAssetService
   # * *returns*
   #   - +Array<String>+ => Array of filenames
   def self.get_directory_entries(pathname = Dir.pwd)
-    Dir.exists?(pathname) ? Dir.entries(pathname).keep_if {|entry| !entry.start_with?('.')} : []
+    Dir.exist?(pathname) ? Dir.entries(pathname).keep_if {|entry| !entry.start_with?('.')} : []
   end
 
   # get a list of all local assets; can scope by asset type
@@ -202,7 +202,7 @@ class UserAssetService
   def self.create_download_directory(pathname)
     parent_dir = Pathname.new(pathname).parent
     fullpath = RAILS_PUBLIC_PATH.join(parent_dir)
-    FileUtils.mkdir_p(fullpath) unless Dir.exists?(fullpath)
+    FileUtils.mkdir_p(fullpath) unless Dir.exist?(fullpath)
     fullpath
   end
 

--- a/app/models/analysis_metadatum.rb
+++ b/app/models/analysis_metadatum.rb
@@ -78,7 +78,7 @@ class AnalysisMetadatum
   def definition_schema
     begin
       # check for local copy first
-      if File.exists?(self.definition_filepath)
+      if File.exist?(self.definition_filepath)
         existing_schema = File.read(self.definition_filepath)
         JSON.parse(existing_schema)
       else

--- a/app/models/data_repo_client.rb
+++ b/app/models/data_repo_client.rb
@@ -37,14 +37,14 @@ class DataRepoClient
   def initialize(service_account = self.class.get_read_only_keyfile)
     # GCS storage driver attributes
     storage_attr = {
-      project: self.class.compute_project,
+      project_id: self.class.compute_project,
       timeout: 3600,
-      keyfile: service_account
+      credentials: service_account
     }
 
     self.service_account_credentials = service_account
     self.access_token = self.class.generate_access_token(service_account)
-    self.storage = Google::Cloud::Storage.new(storage_attr)
+    self.storage = Google::Cloud::Storage.new(**storage_attr)
     self.expires_at = Time.zone.now + self.access_token['expires_in']
     self.api_root = BASE_URL
   end

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -91,19 +91,19 @@ class FireCloudClient
       # instantiate Google Cloud Storage driver to work with files in workspace buckets
       # if no keyfile is present, use environment variables
       storage_attr = {
-          project: PORTAL_NAMESPACE,
-          timeout: 3600
+        project_id: PORTAL_NAMESPACE,
+        timeout: 3600
       }
 
       if !service_account.blank?
-        storage_attr.merge!(keyfile: service_account)
+        storage_attr.merge!(credentials: service_account)
         self.service_account_credentials = service_account
       end
 
       self.access_token = self.class.generate_access_token(service_account)
       self.project = PORTAL_NAMESPACE
 
-      self.storage = Google::Cloud::Storage.new(storage_attr)
+      self.storage = Google::Cloud::Storage.new(**storage_attr)
 
       # set expiration date of token
       self.expires_at = Time.zone.now + self.access_token['expires_in']
@@ -119,16 +119,16 @@ class FireCloudClient
       # use user-defined project instead of portal default
       # if no keyfile is present, use environment variables
       storage_attr = {
-          project: project,
+          project_id: project,
           timeout: 3600
       }
 
       if !service_account.blank?
-        storage_attr.merge!(keyfile: service_account)
+        storage_attr.merge!(credentials: service_account)
         self.service_account_credentials = service_account
       end
 
-      self.storage = Google::Cloud::Storage.new(storage_attr)
+      self.storage = Google::Cloud::Storage.new(**storage_attr)
     end
     # set FireCloud API base url
     self.api_root = BASE_URL
@@ -162,11 +162,11 @@ class FireCloudClient
   #   - +Google::Cloud::Storage+ instance
   def refresh_storage_driver(project_name=PORTAL_NAMESPACE)
     storage_attr = {
-        project: project_name,
+        project_id: project_name,
         timeout: 3600
     }
     if !ENV['SERVICE_ACCOUNT_KEY'].blank?
-      storage_attr.merge!(keyfile: self.class.get_primary_keyfile)
+      storage_attr.merge!(credentials: self.class.get_primary_keyfile)
     end
     new_storage = Google::Cloud::Storage.new(storage_attr)
     self.storage = new_storage

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -1399,7 +1399,7 @@ class FireCloudClient
   #   - +Google::Cloud::Storage::File+
   def create_workspace_file(workspace_bucket_id, filepath, filename, opts={})
     bucket = self.get_workspace_bucket(workspace_bucket_id)
-    bucket.create_file filepath, filename, **opts
+    bucket.create_file(filepath, filename, **opts)
   end
 
   # copy a file to a new location in a workspace bucket
@@ -1415,7 +1415,7 @@ class FireCloudClient
   #   - +Google::Cloud::Storage::File+
   def copy_workspace_file(workspace_bucket_id, filename, destination_name, opts={})
     file = self.get_workspace_file(workspace_bucket_id, filename)
-    file.copy destination_name, **opts
+    file.copy(destination_name, **opts)
   end
 
   # delete a file to a workspace bucket

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -168,7 +168,7 @@ class FireCloudClient
     if !ENV['SERVICE_ACCOUNT_KEY'].blank?
       storage_attr.merge!(credentials: self.class.get_primary_keyfile)
     end
-    new_storage = Google::Cloud::Storage.new(storage_attr)
+    new_storage = Google::Cloud::Storage.new(**storage_attr)
     self.storage = new_storage
     new_storage
   end
@@ -1352,7 +1352,7 @@ class FireCloudClient
   #   - +Google::Cloud::Storage::File::List+
   def get_workspace_files(workspace_bucket_id, opts={})
     bucket = self.get_workspace_bucket(workspace_bucket_id)
-    bucket.files(opts)
+    bucket.files(**opts)
   end
 
   # retrieve single study_file in a GCP bucket of a workspace
@@ -1399,7 +1399,7 @@ class FireCloudClient
   #   - +Google::Cloud::Storage::File+
   def create_workspace_file(workspace_bucket_id, filepath, filename, opts={})
     bucket = self.get_workspace_bucket(workspace_bucket_id)
-    bucket.create_file filepath, filename, opts
+    bucket.create_file filepath, filename, **opts
   end
 
   # copy a file to a new location in a workspace bucket
@@ -1415,7 +1415,7 @@ class FireCloudClient
   #   - +Google::Cloud::Storage::File+
   def copy_workspace_file(workspace_bucket_id, filename, destination_name, opts={})
     file = self.get_workspace_file(workspace_bucket_id, filename)
-    file.copy destination_name, opts
+    file.copy destination_name, **opts
   end
 
   # delete a file to a workspace bucket
@@ -1490,7 +1490,7 @@ class FireCloudClient
       # return newly-opened file (will need to check content type before attempting to parse)
       local
     else
-      file.download end_path, opts
+      file.download end_path, **opts
     end
   end
 
@@ -1521,7 +1521,7 @@ class FireCloudClient
   #   - +String+ signed URL
   def generate_signed_url(workspace_bucket_id, filename, opts={})
     file = self.get_workspace_file(workspace_bucket_id, filename)
-    file.signed_url(opts)
+    file.signed_url(**opts)
   end
 
   # generate an api url to directly load a file from GCS via client-side JavaScript
@@ -1555,7 +1555,7 @@ class FireCloudClient
     # makes sure directory ends with '/', otherwise append to prevent spurious matches
     directory += '/' unless directory.last == '/'
     opts.merge!(prefix: directory)
-    self.get_workspace_files(workspace_bucket_id, opts)
+    self.get_workspace_files(workspace_bucket_id, **opts)
   end
 
   #######

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1673,7 +1673,7 @@ class Study
   # make data directory after study creation is successful
   # this is now a public method so that we can use it whenever remote files are downloaded to validate that the directory exists
   def make_data_dir
-    unless Dir.exists?(self.data_store_path)
+    unless Dir.exist?(self.data_store_path)
       FileUtils.mkdir_p(self.data_store_path)
     end
   end
@@ -2055,7 +2055,7 @@ class Study
 
   # remove data directory on delete
   def remove_data_dir
-    if Dir.exists?(self.data_store_path)
+    if Dir.exist?(self.data_store_path)
       FileUtils.rm_rf(self.data_store_path)
     end
   end

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1024,7 +1024,7 @@ class StudyFile
   def remove_local_copy
     Rails.logger.info "Removing local copy of #{self.upload_file_name}"
     Dir.chdir(self.study.data_store_path)
-    if Dir.exists?(self.id.to_s)
+    if Dir.exist?(self.id.to_s)
       Rails.logger.info "Removing upload directory for #{self.upload_file_name} at #{Dir.pwd}/#{self.id.to_s}"
       FileUtils.rm_rf(self.id.to_s)
     elsif File.exists?(self.bucket_location)

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -756,11 +756,11 @@ class StudyFile
 
   def local_location
     path = Rails.root.join(self.study.data_store_path, self.download_location)
-    if File.exists?(path)
+    if File.exist?(path)
       path
     else
       path = Rails.root.join(self.study.data_store_path, self.bucket_location)
-      File.exists?(path) ? path : nil
+      File.exist?(path) ? path : nil
     end
   end
 
@@ -920,7 +920,7 @@ class StudyFile
   # determine a file's content type by reading the first 2 bytes and comparing to known magic numbers
   def determine_content_type
     location = File.join(self.study.data_store_path, self.download_location)
-    if !File.exists?(location)
+    if !File.exist?(location)
       location = File.join(self.study.data_store_path, self.bucket_location)
     end
     signature = File.open(location).read(2)
@@ -1027,7 +1027,7 @@ class StudyFile
     if Dir.exist?(self.id.to_s)
       Rails.logger.info "Removing upload directory for #{self.upload_file_name} at #{Dir.pwd}/#{self.id.to_s}"
       FileUtils.rm_rf(self.id.to_s)
-    elsif File.exists?(self.bucket_location)
+    elsif File.exist?(self.bucket_location)
       Rails.logger.info "Removing local copy at #{Dir.pwd}/#{self.bucket_location}"
       File.delete(self.bucket_location)
     end

--- a/app/models/user_annotation.rb
+++ b/app/models/user_annotation.rb
@@ -388,7 +388,7 @@ class UserAnnotation
         study_file = cluster.study_file
         # make new subdirectory for file
         subdir = File.join(study.data_store_path, study_file.id)
-        if !Dir.exists?(subdir)
+        if !Dir.exist?(subdir)
           FileUtils.mkdir_p(subdir)
         end
         new_file = File.new(study_file.upload.path, 'w+')

--- a/bin/cycle_logs.rb
+++ b/bin/cycle_logs.rb
@@ -13,7 +13,7 @@ all_logs = Dir.entries("log").keep_if {|l| !l.start_with?('.')}
 4.downto(1) do |i|
   if i == 4
     all_logs.select {|l| l =~ /#{i}/}.each do |log|
-      File.exists?("log/#{log}") ? File.delete("log/#{log}") : next
+      File.exist?("log/#{log}") ? File.delete("log/#{log}") : next
     end
   else
     all_logs.select {|l| l =~ /#{i}/}.each do |log|
@@ -24,7 +24,7 @@ all_logs = Dir.entries("log").keep_if {|l| !l.start_with?('.')}
       else
         basename = log_parts.first
       end
-      File.exists?("log/#{basename}.#{i}.log") ? File.rename("log/#{basename}.#{i}.log", "log/#{basename}.#{i + 1}.log") : next
+      File.exist?("log/#{basename}.#{i}.log") ? File.rename("log/#{basename}.#{i}.log", "log/#{basename}.#{i + 1}.log") : next
     end
   end
 end
@@ -37,7 +37,7 @@ all_logs.select {|l| l.split('.').last == 'log'}.each do |log|
   else
     basename = log_parts.first
   end
-  if File.exists?("log/#{basename}.log")
+  if File.exist?("log/#{basename}.log")
     FileUtils.cp("log/#{basename}.log", "log/#{basename}.1.log")
     File.delete("log/#{basename}.log")
   end

--- a/bin/cycle_logs.rb
+++ b/bin/cycle_logs.rb
@@ -44,7 +44,7 @@ all_logs.select {|l| l.split('.').last == 'log'}.each do |log|
 end
 
 # blow away any nginx access & error logs
-if Dir.exists?('log/nginx')
+if Dir.exist?('log/nginx')
   Dir.chdir('log/nginx')
   nginx_logs = Dir.entries(".").keep_if {|l| !l.start_with?('.')}
   nginx_logs.each do |log|

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -8,18 +8,3 @@ Delayed::Worker.default_queue_name = :default
 if Rails.env.test? || Rails.env.development? # save a little time in testing/dev
   Delayed::Worker.sleep_delay = 5 # seconds
 end
-
-# Fixing class loader issues with delayed_job, for Rails 5
-# from https://stackoverflow.com/questions/4705867/rails-doesnt-load-classes-on-deserializing-yaml-marshal-objects
-module Psych::Visitors
-  ToRuby.class_eval do
-    def resolve_class(klassname)
-      begin
-        class_loader.load klassname
-      rescue ArgumentError
-        require_dependency klassname.underscore
-        klassname.constantize
-      end
-    end
-  end
-end

--- a/db/migrate/20181004151831_auto_populate_species_info.rb
+++ b/db/migrate/20181004151831_auto_populate_species_info.rb
@@ -2,7 +2,7 @@ class AutoPopulateSpeciesInfo < Mongoid::Migration
   def self.up
     admin_user = User.where(admin: true).first
     path = Rails.root.join('lib', 'assets', 'default_species_assemblies.txt')
-    if File.exists?(path) && admin_user.present?
+    if File.exist?(path) && admin_user.present?
       Taxon.parse_from_file(path, admin_user)
     end
   end

--- a/lib/api_helpers.rb
+++ b/lib/api_helpers.rb
@@ -116,6 +116,6 @@ module ApiHelpers
   # * *returns*
   #   - +String+ => URI-encoded parameter
   def uri_encode(parameter)
-    URI.escape(parameter)
+    CGI.escape(parameter)
   end
 end

--- a/lib/api_helpers.rb
+++ b/lib/api_helpers.rb
@@ -55,7 +55,7 @@ module ApiHelpers
   #   - +String+ of concatenated query params
   def merge_query_options(opts={})
     return nil if opts.blank?
-    '?' + opts.reject {|k,v| v.blank?}.to_a.map {|k,v| uri_encode("#{k}=#{v}")}.join('&')
+    '?' + opts.reject {|k,v| k.blank? || v.blank?}.to_a.map {|k,v| "#{uri_encode(k)}=#{uri_encode(v)}"}.join('&')
   end
 
   # handle a RestClient::Response object
@@ -116,6 +116,6 @@ module ApiHelpers
   # * *returns*
   #   - +String+ => URI-encoded parameter
   def uri_encode(parameter)
-    CGI.escape(parameter)
+    CGI.escape(parameter.to_s)
   end
 end

--- a/lib/delayed_job_accessor.rb
+++ b/lib/delayed_job_accessor.rb
@@ -8,7 +8,7 @@ module DelayedJobAccessor
 
   # Classes allowed to dump handlers from using YAML.safe_load
   # This covers all recursive data structures inside IngestJob and UploadCleanupJob
-  SAFE_CLASS_LOADERS = [IngestJob, UploadCleanupJob, Symbol, BSON::ObjectId, Time].freeze
+  SAFE_CLASS_LOADERS = [IngestJob, UploadCleanupJob, Symbol, BSON::ObjectId, BSON::Document, Time].freeze
 
   # find a Delayed::Job instance of a particular class, and refine by an associated object
   #

--- a/lib/delayed_job_accessor.rb
+++ b/lib/delayed_job_accessor.rb
@@ -4,7 +4,11 @@ module DelayedJobAccessor
 
   # Classes allowed to access jobs from the queue
   # only applies to job classes that queue jobs in the future (DeleteQueueJob, CacheRemovalJob are run on demand)
-  ALLOWED_JOB_TYPES = [IngestJob, UploadCleanupJob]
+  ALLOWED_JOB_TYPES = [IngestJob, UploadCleanupJob].freeze
+
+  # Classes allowed to dump handlers from using YAML.safe_load
+  # This covers all recursive data structures inside IngestJob and UploadCleanupJob
+  SAFE_CLASS_LOADERS = [IngestJob, UploadCleanupJob, Symbol, BSON::ObjectId, Time].freeze
 
   # find a Delayed::Job instance of a particular class, and refine by an associated object
   #
@@ -35,7 +39,7 @@ module DelayedJobAccessor
   # * *returns*
   #   - (Struct) => Struct representing original queued task
   def self.dump_job_handler(job)
-    YAML.load(job.handler)
+    YAML.safe_load(job.handler, permitted_classes: SAFE_CLASS_LOADERS, aliases: true)
   end
 
   # match a job handler to the specified object instance

--- a/lib/generic_profiler.rb
+++ b/lib/generic_profiler.rb
@@ -227,7 +227,7 @@ class GenericProfiler
   # create scratch dir for profiling results
   def self.make_profile_dir(report_dir)
     reports_basepath = Rails.root.join(PROFILE_BASEDIR, report_dir)
-    FileUtils.mkdir_p(reports_basepath) unless Dir.exists?(reports_basepath)
+    FileUtils.mkdir_p(reports_basepath) unless Dir.exist?(reports_basepath)
     reports_basepath
   end
 

--- a/test/Dockerfile-test
+++ b/test/Dockerfile-test
@@ -1,6 +1,10 @@
 # use SCP base Rails image, configure only project-specific items here
 FROM gcr.io/broad-singlecellportal-staging/single-cell-portal:development
 
+# Set ruby version as this may have changed
+RUN bash -lc 'rvm --default use ruby-3.1.2'
+RUN bash -lc 'rvm rvmrc warning ignore /home/app/webapp/Gemfile'
+
 # run any gem/package updates that may have been introduced by this PR
 WORKDIR /home/app/webapp
 COPY Gemfile /home/app/webapp/Gemfile

--- a/test/integration/data_repo_client_test.rb
+++ b/test/integration/data_repo_client_test.rb
@@ -85,7 +85,7 @@ class DataRepoClientTest < ActiveSupport::TestCase
     assert_equal expected_query, @data_repo_client.merge_query_options(opts)
     # ensure params are uri-encoded
     new_opts = { one: 'foo', two: 'bar bing' }
-    expected_encoded_query = '?one=foo&two=bar%20bing'
+    expected_encoded_query = '?one=foo&two=bar+bing'
     assert_equal expected_encoded_query, @data_repo_client.merge_query_options(new_opts)
   end
 

--- a/test/integration/lib/user_asset_service_test.rb
+++ b/test/integration/lib/user_asset_service_test.rb
@@ -10,7 +10,7 @@ class UserAssetServiceTest < ActiveSupport::TestCase
   # only intended for use in a CI environment
   def populate_test_data
     UserAssetService::ASSET_PATHS_BY_TYPE.values.each do |asset_path|
-      unless Dir.exists?(asset_path)
+      unless Dir.exist?(asset_path)
         FileUtils.mkdir_p(asset_path)
       end
       entries = UserAssetService.get_directory_entries(asset_path)
@@ -52,7 +52,7 @@ class UserAssetServiceTest < ActiveSupport::TestCase
 
   # move a file and clean up src copy, creating directories as needed
   def move_file(source, new_folder, filename)
-    FileUtils.mkdir_p new_folder unless Dir.exists?(new_folder)
+    FileUtils.mkdir_p new_folder unless Dir.exist?(new_folder)
     destination = "#{new_folder}/#{filename}"
     FileUtils.mv source, destination
   end

--- a/test/lib/generic_profiler_test.rb
+++ b/test/lib/generic_profiler_test.rb
@@ -57,7 +57,7 @@ class GenericProfilerTest < ActiveSupport::TestCase
     profile_results = GenericProfiler.profile(AnnotationVizService, :get_selected_annotation, SecureRandom.hex(4), @basic_study)
     assert profile_results.any?
     profile_results.each do |profile_path|
-      assert File.exists? profile_path
+      assert File.exist? profile_path
     end
   end
 
@@ -65,7 +65,7 @@ class GenericProfilerTest < ActiveSupport::TestCase
     profile_results = GenericProfiler.profile_clustering(@basic_study.accession)
     assert profile_results.any?
     profile_results.each do |profile_path|
-      assert File.exists? profile_path
+      assert File.exist? profile_path
     end
   end
 
@@ -75,7 +75,7 @@ class GenericProfilerTest < ActiveSupport::TestCase
     violin_results = GenericProfiler.profile_expression(@basic_study.accession, genes: gene_name)
     assert violin_results.any?
     violin_results.each do |profile_path|
-      assert File.exists? profile_path
+      assert File.exist? profile_path
     end
 
     # test heatmap
@@ -83,7 +83,7 @@ class GenericProfilerTest < ActiveSupport::TestCase
     heatmap_results = GenericProfiler.profile_expression(@basic_study.accession, genes: gene_names, plot_type: 'heatmap')
     assert heatmap_results.any?
     heatmap_results.each do |profile_path|
-      assert File.exists? profile_path
+      assert File.exist? profile_path
     end
   end
 
@@ -94,7 +94,7 @@ class GenericProfilerTest < ActiveSupport::TestCase
     GenericProfiler.write_args_list(test_dir, random_seed, *args)
     filename = "#{random_seed}_arguments.txt"
     args_filepath = Rails.root.join(GenericProfiler::PROFILE_BASEDIR, test_dir, filename)
-    assert File.exists?(args_filepath)
+    assert File.exist?(args_filepath)
     args_file = File.open(args_filepath).read
     assert args_file.include?(@basic_study.name)
     assert args_file.include?('"some value"')

--- a/test/ui_test_helper.rb
+++ b/test/ui_test_helper.rb
@@ -325,7 +325,7 @@ class Test::Unit::TestCase
       # give browser 5 seconds to initiate download
       sleep(5)
       # make sure file was actually downloaded
-      file_exists = Dir.entries($download_dir).select {|f| f =~ /#{basename}/}.size >= 1 || File.exists?(File.join($download_dir, basename))
+      file_exists = Dir.entries($download_dir).select {|f| f =~ /#{basename}/}.size >= 1 || File.exist?(File.join($download_dir, basename))
       assert file_exists, "did not find downloaded file: #{basename} in #{Dir.entries($download_dir).join(', ')}"
 
       # delete matching files

--- a/test/ui_test_suite.rb
+++ b/test/ui_test_suite.rb
@@ -83,7 +83,7 @@ if !File.exists?($chromedriver_path)
   puts "No Chromedriver binary found at #{$chromedriver_path}"
   puts $usage
   exit(1)
-elsif !Dir.exists?($download_dir)
+elsif !Dir.exist?($download_dir)
   puts "No download directory found at #{$download_dir}"
   puts $usage
   exit(1)


### PR DESCRIPTION
#### BACKGROUND
Ruby 2.6.10 has been [declared end of life](https://www.ruby-lang.org/en/downloads/branches/) as of April 12, 2022.  This means no more security patches will be issued, and therefore we must transition onto a newer version of Ruby.  Moving to 3.x+ will afford us at least 3 years of maintenance before we need to migrate to a newer version of Ruby.

#### CHANGES
The default Ruby for SCP is now pinned at [3.1.2](https://rubyreferences.github.io/rubychanges/3.1.html), which is the most recent release of 3.1, and the most recent supported by our Docker image.  The most notable new feature is the [omission of hash literals/keyword arguments](https://rubyreferences.github.io/rubychanges/3.1.html#values-in-hash-literals-and-keyword-arguments-can-be-omitted) if the variable & literal are the same.  This means that `{ foo: foo, bar: bar }` can be written as `{ foo: , bar: }`, both as a literal and as keyword arguments (kwargs).  A side effect of this is that we should always use parentheses when invoking methods with kwargs, such as `my_method(positional_arg, first_kwarg: , second_kwarg: )`, and any method that accepts a `Hash` of kwargs will need to explicitly deconstruct them with the double splat (`**`) operator.

All other local changes are related to gem/library updates, or retiring deprecated methods (such as `URI.escape`).

**NOTE: all new PRs based off of `development` will need to use Ruby 3.1.2 once this is merged.**

#### MANUAL TESTING
1. Before starting, make sure you can install Ruby 3.1.2 with your local Ruby version manager
2. Pull this branch, and run `bundle install` from the project root
3. Once the install completes, boot the server as normal
    * Note: you may need to manually specify the version of Ruby to load in your shell, depending on how you manage Ruby installations.  For RMV, this is `rvm use 3.1.2`, and rbenv is `rbenv shell 3.1.2`.
4. Confirm the home page loads as normal and no errors (except for deprecation warnings) appear in the logs.
