### PR TITLE
Accept additional file extensions for AnnData ingest (Ingest release 1.20.1)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.20.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.20.1'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
update production to use ingest release 1.20.1

- see scp-ingest-pipeline PR [Accept additional file extensions for AnnData ingest](https://github.com/broadinstitute/scp-ingest-pipeline/pull/266)

This update supports SCP-4557.