### PR TITLE
Adding missing dependency net- gems for mail LoadError issue (SCP-4576)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,8 @@ gem 'carrierwave-mongoid', :require => 'carrierwave/mongoid'
 gem 'uuid'
 gem 'vite_rails'
 gem 'net-smtp'
+gem 'net-imap'
+gem 'net-pop'
 
 # only enable TCell in deployed environments due to Chrome sec-ch-ua header issue
 group :production, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,6 +300,14 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.2.3)
     naturally (2.2.1)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
@@ -462,6 +470,7 @@ GEM
       sprockets (>= 3.0.0)
     ssrf_filter (1.0.7)
     stackprof (0.2.17)
+    strscan (3.0.4)
     swagger-blocks (3.0.0)
     sys-filesystem (1.4.1)
       ffi (~> 1.1)
@@ -550,6 +559,8 @@ DEPENDENCIES
   mongoid_rails_migrations
   naturally
   nested_form!
+  net-imap
+  net-pop
   net-smtp
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/lib/delayed_job_accessor.rb
+++ b/lib/delayed_job_accessor.rb
@@ -8,7 +8,9 @@ module DelayedJobAccessor
 
   # Classes allowed to dump handlers from using YAML.safe_load
   # This covers all recursive data structures inside IngestJob and UploadCleanupJob
-  SAFE_CLASS_LOADERS = [IngestJob, UploadCleanupJob, Symbol, BSON::ObjectId, BSON::Document, Time].freeze
+  SAFE_CLASS_LOADERS = [IngestJob, UploadCleanupJob, Symbol, BSON::ObjectId,
+                        BSON::Document, Time, Delayed::PerformableMethod, ActiveSupport::TimeWithZone,
+                        DifferentialExpressionParameters, ActiveModel::Errors].freeze
 
   # find a Delayed::Job instance of a particular class, and refine by an associated object
   #


### PR DESCRIPTION
#### BACKGROUND
After the Ruby 3.1 update, some gem updates have resulted in new requirements that were not visible until deployed to a remote environment.  There are differences in configurations that apparently only manifest in `staging` and possibly `production`.

#### CHANGES
For deployed environments, the 3 `net-` gems are required now to avoid `LoadError` issues when starting `DelayedJob`.  The `mail` gem appears to be the culprit.  There is an upcoming new release (2.8) that will hopefully address the issue, though interestingly their repository states that version 2.7 supports Ruby 3.1.  It may be that other dependencies in our codebase contribute to the issue.  It is unclear why this doesn't happen when booting in `development` or `test` environments, as the `action_mailer` configuration is the same.  There are obviously other issues at play.

#### MANUAL TESTING
It was possible to recreate the staging conditions locally outside of Docker with the following:
1. Pull this branch, ensure you're running Ruby 3.1.2
2. Go into the `Gemfile`, and comment out these two lines:
```
gem 'net-imap'
gem 'net-pop'
```
3. Run `bundle install`
4. Copy the contents of `config/environments/staging.rb` into `config/environments/development.rb`
5. Load secrets via `./rails_local_setup.rb && source config/secrets/.source_env.bash`
6. Run `bin/delayed_job start development --pool=default:6, --pool=cache:2` and confirm you get the following error:
```
`require': cannot load such file -- net/pop (LoadError)
```
7. Go back into the Gemfile, and undo step 2, then re-run `bundle install`
8. Restart `DelayedJob` with the command from step 6 and ensure you see processes launch:
```
delayed_job.0: process with pid 15834 started.
delayed_job.1: process with pid 15836 started.
delayed_job.2: process with pid 15838 started.
delayed_job.3: process with pid 15840 started.
delayed_job.4: process with pid 15842 started.
delayed_job.5: process with pid 15844 started.
delayed_job.6: process with pid 15846 started.
delayed_job.7: process with pid 15848 started.
```