### PR TITLE
Use Ruby 3.1 with Passenger (SCP-4576)

### DIFF
--- a/lib/delayed_job_accessor.rb
+++ b/lib/delayed_job_accessor.rb
@@ -10,7 +10,7 @@ module DelayedJobAccessor
   # This covers all recursive data structures inside IngestJob and UploadCleanupJob
   SAFE_CLASS_LOADERS = [IngestJob, UploadCleanupJob, Symbol, BSON::ObjectId,
                         BSON::Document, Time, Delayed::PerformableMethod, ActiveSupport::TimeWithZone,
-                        DifferentialExpressionParameters, ActiveModel::Errors].freeze
+                        DifferentialExpressionParameters, ActiveModel::Errors, SearchFacet].freeze
 
   # find a Delayed::Job instance of a particular class, and refine by an associated object
   #

--- a/webapp.conf
+++ b/webapp.conf
@@ -53,7 +53,7 @@ server {
     proxy_read_timeout	300;
 
     # If this is a Ruby app, specify a Ruby version:
-    passenger_ruby	/usr/bin/ruby2.6;
+    passenger_ruby	/usr/bin/ruby3.1;
     # For Ruby 2.0
     # passenger_ruby /usr/bin/ruby2.0;
     # For Ruby 1.9.3 (you can ignore the "1.9.1" suffix)


### PR DESCRIPTION
#### BACKGROUND & CHANGES
When updating to Ruby 3.1.2, we neglected to point Passenger (application server) at the updated Ruby version.  Since local development is done primarily outside of Docker, this wasn't discovered until the Ruby 3.1 update was pushed to staging.

#### MANUAL TESTING
1. Pull this branch and ensure Docker is running locally
2. Rebuild the Docker image from the project root with:
```
docker build -t gcr.io/broad-singlecellportal-staging/single-cell-portal:development .
```
3. Run the following command from the project root directory:
```
bin/load_env_secrets.sh -p secret/kdux/scp/development/$(whoami)/scp_config.json \
                        -r secret/kdux/scp/development/$(whoami)/read_only_service_account.json \
                        -s secret/kdux/scp/development/$(whoami)/scp_service_account.json \
                        -v development
```
4. Ensure the home page comes up (eventually), or look for the following log statements in the terminal:
```
[ N 2022-08-10 17:30:18.6935 248/T1 age/Wat/WatchdogMain.cpp:1373 ]: Starting Passenger watchdog...
[ N 2022-08-10 17:30:18.7153 251/T1 age/Cor/CoreMain.cpp:1340 ]: Starting Passenger core...
[ N 2022-08-10 17:30:18.7182 251/T1 age/Cor/CoreMain.cpp:256 ]: Passenger core running in multi-application mode.
[ N 2022-08-10 17:30:18.7445 251/T1 age/Cor/CoreMain.cpp:1015 ]: Passenger core online, PID 251
[ N 2022-08-10 17:30:21.3018 251/T5 age/Cor/SecurityUpdateChecker.h:519 ]: Security update check: no update found (next check in 24 hours)
```