### PR TITLE
Stop automatic retries of 503s in Azul (SCP-4592)

### DIFF
--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -106,6 +106,11 @@ class HcaAzulClient
     handle_response(response)
   end
 
+  # FROM SCP-4592: Temporarily disable automatic retries while we investigate the rise in 503 errors from Azul
+  def should_retry?(code)
+    false
+  end
+
   ##
   # API endpoint bindings
   ##

--- a/lib/api_helpers.rb
+++ b/lib/api_helpers.rb
@@ -8,6 +8,12 @@ module ApiHelpers
   # interval for retry backoff on request retries
   RETRY_INTERVAL = Rails.env.test? ? 0 : 15
 
+  # known good HTTP status codes
+  OK_STATUS_CODES = [200, 201, 202, 204, 206].freeze
+
+  # 50x error codes that are acceptable to retry
+  RETRY_STATUS_CODES = [502, 503, 504].freeze
+
   # get default HTTP headers for making requests
   #
   # * *returns*
@@ -30,7 +36,7 @@ module ApiHelpers
   # * *return*
   #   - +Boolean+ of whether or not response is a known 'OK' response
   def ok?(code)
-    [200, 201, 202, 204, 206].include?(code)
+    OK_STATUS_CODES.include?(code)
   end
 
   # determine if request should be retried based on response code, and will retry if necessary
@@ -43,7 +49,7 @@ module ApiHelpers
   # * *return*
   #   - +Boolean+ of whether or not response code indicates a retry should be executed
   def should_retry?(code)
-    code.nil? || [502, 503, 504].include?(code)
+    code.nil? || RETRY_STATUS_CODES.include?(code)
   end
 
   # merge hash of options into single URL query string, will reject query params with empty values

--- a/test/integration/fire_cloud_client_test.rb
+++ b/test/integration/fire_cloud_client_test.rb
@@ -458,6 +458,12 @@ class FireCloudClientTest < ActiveSupport::TestCase
     assert !final_emails.include?(@test_email), "Did not successfully remove #{@test_email} from list of billing project members: #{emails.join(', ')}"
   end
 
+  def test_should_retry_error_codes
+    ApiHelpers::RETRY_STATUS_CODES.each do |code|
+      assert @fire_cloud_client.should_retry?(code)
+    end
+  end
+
   ##
   #
   # GCS TESTS

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -272,4 +272,10 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     assert @hca_azul_client.query_too_large?(query)
     assert_not @hca_azul_client.query_too_large?({ project: { is: accession_list.take(10) } })
   end
+
+  test 'should not retry any error status code' do
+    ApiHelpers::RETRY_STATUS_CODES.each do |code|
+      assert_not @hca_azul_client.should_retry?(code)
+    end
+  end
 end


### PR DESCRIPTION
#### BACKGROUND
Single Cell Portal went offline for ~1 minute yesterday due to the `nginx` request queue filling up.  This was caused by multiple upstream requests to Azul returning `503`, which were then automatically retried.  In addition, users were paging through large result sets on the homepage, which continued to issue requests to Azul, which also returned `503`.  Eventually the portal stop accepting new requests when the load balancer saw that `nginx` was not responding.  This was quickly fixed by bouncing passenger, but the possibility of this happening again still remains.

#### CHANGES
Now any non "ok" status code returned from Azul will not be retried.  It is not completely clear why we have seen an uptick in `503` responses.  One theory is that it is caused by an interdependency on Terra Data Repo, where many HCA datasets are deposited.  There is some evidence to suggest that `503` responses from TDR get shipped back to Azul, and then passed to SCP.  Below is an error from the logs during yesterday's brief downtime:
```
503 Service Unavailable: {"Code":"ServiceUnavailableError","Message":"No response from https://data.terra.bio/api/repository/v1/snapshots?offset=200&limit=200&sort=created_date&direction=asc within 5.0 seconds"};  encountered when requesting 'https://service.azul.data.humancellatlas.org/index/projects?
```
It could also be that we are overwhelming Azul with the number of requests we are issuing, though previous conversations with the Azul team led us to believe this would not be an issue.  More investigation is warranted before we re-enable retries when querying Azul.

#### MANUAL TESTING
Since the very nature of a `503` response is transient, it is very difficult to simulate this.  However, it is fairly easy to get a `502` by requesting a very large number of results from Azul:
1. Pull branch and enter a rails console session with: 
```
./rails_local_setup.rb && source config/secrets/.source_env.bash && bin/rails c
```
2. Open `development.log` in the Console app (or a text editor)
3. In the Rails console, run the following query to generate a `502`:
```
client = HcaAzulClient.new
client.project(size: 300)
```
4. Confirm that `502 Bad Gateway (RestClient::BadGateway)` is returned
5. In `development.log`, confirm that no additional requests were issued:
```
HCA Azul API request (GET) https://service.azul.data.humancellatlas.org/index/projects?filters=%7B%7D&size=300
502 Bad Gateway: {"message": "Internal server error"};  encountered when requesting 'https://service.azul.data.humancellatlas.org/index/projects?filters=%7B%7D&size=300', attempt #1
Suppressing error reporting to Sentry: RestClient::BadGateway:502 Bad Gateway, context: {:method=>:get, :url=>"https://service.azul.data.humancellatlas.org/index/projects?filters=%7B%7D&size=300", :payload=>nil, :retry_count=>0}
Retry count exceeded when requesting 'https://service.azul.data.humancellatlas.org/index/projects?filters=%7B%7D&size=300' - 502 Bad Gateway
```