### PR TITLE
Refactor study sync logic into `StudySyncService` (SCP-3121)

### DIFF
--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -531,146 +531,35 @@ module Api
       end
 
       def sync_study
-        @study_files = @study.study_files.valid
-        @study_files.each {|study_file| study_file.build_expression_file_info if study_file.expression_file_info.nil?}
-        @directories = @study.directory_listings.to_a
-        # keep a list of what we expect to be
-        @files_by_dir = {}
-        @synced_study_files = []
-        @synced_directories = []
-        @unsynced_files = []
-        @unsynced_directories = @study.directory_listings.unsynced
-        @permissions_changed = []
-
-        # get a list of workspace submissions so we know what directories to ignore
-        @submission_ids = ApplicationController.firecloud_client.get_workspace_submissions(@study.firecloud_project, @study.firecloud_workspace).map {|s| s['submissionId']}
+        @study_files = @study.study_files.available
+        @study_files.each { |study_file| study_file.build_expression_file_info if study_file.expression_file_info.nil? }
 
         # first sync permissions if necessary
         begin
-          portal_permissions = @study.local_acl
-          firecloud_permissions = ApplicationController.firecloud_client.get_workspace_acl(@study.firecloud_project, @study.firecloud_workspace)
-          firecloud_permissions['acl'].each do |user, permissions|
-            # skip project owner permissions, they aren't relevant in this context
-            # also skip the readonly service account
-            if permissions['accessLevel'] =~ /OWNER/i || (ApplicationController.read_only_firecloud_client.present? && user == ApplicationController.read_only_firecloud_client.issuer)
-              next
-            else
-              # determine whether permissions are incorrect or missing completely
-              if !portal_permissions.has_key?(user)
-                new_share = @study.study_shares.build(email: user,
-                                                      permission: StudyShare::PORTAL_ACL_MAP[permissions['accessLevel']],
-                                                      firecloud_project: @study.firecloud_project,
-                                                      firecloud_workspace: @study.firecloud_workspace,
-
-                                                      )
-                # skip validation as we don't wont to set the acl in FireCloud as it already exists
-                new_share.save(validate: false)
-                @permissions_changed << new_share
-              elsif portal_permissions[user] != StudyShare::PORTAL_ACL_MAP[permissions['accessLevel']] && user != @study.user.email
-                # share exists, but permissions are wrong
-                share = @study.study_shares.detect {|s| s.email == user}
-                share.update(permission: StudyShare::PORTAL_ACL_MAP[permissions['accessLevel']])
-                @permissions_changed << share
-              else
-                # permissions are correct, skip
-                next
-              end
-            end
-          end
-
-          # now check to see if there have been permissions removed in FireCloud that need to be removed on the portal side
-          new_study_permissions = @study.study_shares.to_a
-          new_study_permissions.each do |share|
-            if firecloud_permissions['acl'][share.email].nil?
-              logger.info "#{Time.zone.now}: removing #{share.email} access to #{@study.name} via sync - no longer in FireCloud acl"
-              share.delete
-            end
-          end
+          @permissions_changed = StudySyncService.update_shares_from_acl(@study)
         rescue => e
-          logger.error "#{Time.zone.now}: error syncing ACLs in workspace bucket #{@study.firecloud_workspace} due to error: #{e.message}"
-          render json: {error: "Unable to sync with workspace ACL: #{view_context.simple_format(e.message)}"}, status: 500
+          ErrorTracker.report_exception(e, current_user, @study, params)
+          MetricsService.report_error(e, request, current_user, @study)
+          logger.error "Error syncing ACLs in workspace bucket #{@study.firecloud_workspace} due to error: #{e.message}"
+          redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
+                      alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}.  #{SCP_SUPPORT_EMAIL}" and return
         end
 
         # begin determining sync status with study_files and primary or other data
         begin
-          # create a map of file extension to use for creating directory_listings of groups of 10+ files of the same type
-          @file_extension_map = {}
-          workspace_files = ApplicationController.firecloud_client.execute_gcloud_method(:get_workspace_files, 0, @study.bucket_id)
-          # see process_workspace_bucket_files in private methods for more details on syncing
-          process_workspace_bucket_files(workspace_files)
-          while workspace_files.next?
-            workspace_files = workspace_files.next
-            process_workspace_bucket_files(workspace_files)
-          end
+          @unsynced_files = StudySyncService.process_all_remotes(@study)
         rescue => e
-          ErrorTracker.report_exception(e, current_api_user, @study, params.to_unsafe_hash)
-          MetricsService.report_error(e, request, current_api_user, @study)
-          logger.error "Error syncing files in workspace bucket #{@study.firecloud_workspace} due to error: #{e.message}"
-          render json: {error: "Unable to sync with workspace bucket: #{view_context.simple_format(e.message)}"}, status: 500
+          ErrorTracker.report_exception(e, current_user, @study, params)
+          MetricsService.report_error(e, request, current_user, @study)
+          logger.error "#{Time.zone.now}: error syncing files in workspace bucket #{@study.firecloud_workspace} due to error: #{e.message}"
+          redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
+                      alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}.  #{SCP_SUPPORT_EMAIL}" and return
         end
 
-        files_to_remove = []
+        # refresh study state before continuing as new records may have been inserted
+        @study.reload
 
-        # before saving unsynced directories, make a pass to check if there were any files that ended up as study_files
-        # that should have been in a directory (might happen due to cutoff in files.next when iterating)
-        @unsynced_files.each do |study_file|
-          file_ext = DirectoryListing.file_extension(study_file.name)
-          directory = DirectoryListing.get_folder_name(study_file.name)
-          # check unsynced directories first, then existing directories
-          existing_dir = (@unsynced_directories + @directories).detect {|dir| dir.name == directory && dir.file_type == file_ext}
-          if !existing_dir.nil?
-            # we have a matching directory, so that means this file should be added to it
-            file_entry = {'name' => study_file.name, 'size' => study_file.upload_file_size, 'generation' => study_file.generation}
-            files_to_remove << study_file.generation
-            unless existing_dir.files.include?(file_entry)
-              existing_dir.files << file_entry
-            end
-          end
-        end
-
-        # now remove files that we found that were supposed to be in directory_listings
-        @unsynced_files.delete_if {|file| files_to_remove.include?(file.generation)}
-
-        # now check against latest list of files by directory vs. what was just found to see if we are missing anything and
-        # add directory to unsynced list. also check if an existing directory is now 'orphaned' because it was moved and
-        # store that reference for removal after the check is complete
-        orphaned_directories = []
-        @directories.each do |directory|
-          synced = true
-          if @files_by_dir[directory.name].present?
-            directory.files.each do |file|
-              if @files_by_dir[directory.name].detect {|f| f['generation'].to_s == file['generation'].to_s}.nil?
-                synced = false
-                directory.files.delete(file)
-              else
-                next
-              end
-            end
-            # if no longer synced, check if already in the list and remove as files list has changed
-            if !synced
-              @unsynced_directories.delete_if {|dir| dir.name == directory.name}
-              @unsynced_directories << directory
-            elsif directory.sync_status
-              @synced_directories << directory
-            end
-          else
-            # directory did not exist in @files_by_dir, so this directory_listing is orphaned and should be removed
-            orphaned_directories << directory
-          end
-        end
-
-        # remove orphaned directories
-        orphaned_directories.each do |orphan|
-          orphan.destroy
-        end
-
-        # provisionally save unsynced directories so we don't have to pass huge arrays of filenames/sizes in the form
-        # users clicking "don't sync" actually delete entries
-        @unsynced_directories.each do |directory|
-          directory.save
-        end
-
-        # reload unsynced directories to remove any that were orphaned
+        @synced_directories = @study.directory_listings.are_synced
         @unsynced_directories = @study.directory_listings.unsynced
 
         # split directories into primary data types and 'others'
@@ -678,12 +567,13 @@ module Api
         @unsynced_other_dirs = @unsynced_directories.select {|dir| !DirectoryListing::PRIMARY_DATA_TYPES.include?(dir.file_type)}
 
         # now determine if we have study_files that have been 'orphaned' (cannot find a corresponding bucket file)
-        @orphaned_study_files = @study_files - @synced_study_files
-        @available_files = @unsynced_files.map {|f| {name: f.name, generation: f.generation, size: f.upload_file_size}}
+        @orphaned_study_files = StudySyncService.find_orphaned_files(@study)
+        @available_files = @unsynced_files.map { |f| { name: f.name, generation: f.generation, size: f.upload_file_size } }
+        @synced_study_files = @study.study_files.valid - @orphaned_study_files
 
         # now remove any 'bundled' files from @synced_study_files so we can render them inside their parent file's form
-        bundled_file_ids = @study.study_file_bundles.map {|bundle| bundle.bundled_files.to_a.map(&:id)}.flatten
-        @synced_study_files.delete_if {|file| bundled_file_ids.include?(file.id)}
+        bundled_file_ids = @study.study_file_bundles.map { |bundle| bundle.bundled_files.to_a.map(&:id) }.flatten
+        @synced_study_files.delete_if { |file| bundled_file_ids.include?(file.id) }
       end
 
       swagger_path '/studies/{id}/manifest' do

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -558,22 +558,16 @@ module Api
 
         # refresh study state before continuing as new records may have been inserted
         @study.reload
-
         @synced_directories = @study.directory_listings.are_synced
         @unsynced_directories = @study.directory_listings.unsynced
 
         # split directories into primary data types and 'others'
-        @unsynced_primary_data_dirs = @unsynced_directories.select {|dir| DirectoryListing::PRIMARY_DATA_TYPES.include?(dir.file_type)}
-        @unsynced_other_dirs = @unsynced_directories.select {|dir| !DirectoryListing::PRIMARY_DATA_TYPES.include?(dir.file_type)}
+        @unsynced_primary_data_dirs, @unsynced_other_dirs = StudySyncService.load_unsynced_directories(@study)
 
         # now determine if we have study_files that have been 'orphaned' (cannot find a corresponding bucket file)
         @orphaned_study_files = StudySyncService.find_orphaned_files(@study)
-        @available_files = @unsynced_files.map { |f| { name: f.name, generation: f.generation, size: f.upload_file_size } }
-        @synced_study_files = @study.study_files.valid - @orphaned_study_files
-
-        # now remove any 'bundled' files from @synced_study_files so we can render them inside their parent file's form
-        bundled_file_ids = @study.study_file_bundles.map { |bundle| bundle.bundled_files.to_a.map(&:id) }.flatten
-        @synced_study_files.delete_if { |file| bundled_file_ids.include?(file.id) }
+        @available_files = StudySyncService.set_available_files(@unsynced_files)
+        @synced_study_files = StudySyncService.set_synced_files(@study, @orphaned_study_files)
       end
 
       swagger_path '/studies/{id}/manifest' do

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -98,61 +98,12 @@ class StudiesController < ApplicationController
 
   # allow a user to sync files uploaded outside the portal into a workspace bucket with an existing study
   def sync_study
-    @study_files = @study.study_files.valid
-    @study_files.each {|study_file| study_file.build_expression_file_info if study_file.expression_file_info.nil?}
-    @directories = @study.directory_listings.to_a
-    # keep a list of what we expect to be
-    @files_by_dir = {}
-    @synced_study_files = []
-    @synced_directories = []
-    @unsynced_files = []
-    @unsynced_directories = @study.directory_listings.unsynced
-    @permissions_changed = []
+    @study_files = @study.study_files.available
+    @study_files.each { |study_file| study_file.build_expression_file_info if study_file.expression_file_info.nil? }
 
-    # get a list of workspace submissions so we know what directories to ignore
-    @submission_ids = ApplicationController.firecloud_client.get_workspace_submissions(@study.firecloud_project, @study.firecloud_workspace).map {|s| s['submissionId']}
-
-    # first sync permissions if necessary
+     # first sync permissions if necessary
     begin
-      portal_permissions = @study.local_acl
-      firecloud_permissions = ApplicationController.firecloud_client.get_workspace_acl(@study.firecloud_project, @study.firecloud_workspace)
-      firecloud_permissions['acl'].each do |user, permissions|
-        # skip project owner permissions, they aren't relevant in this context
-        # also skip the readonly service account
-        if permissions['accessLevel'] =~ /OWNER/i || (ApplicationController.read_only_firecloud_client.present? && user == ApplicationController.read_only_firecloud_client.issuer)
-          next
-        else
-          # determine whether permissions are incorrect or missing completely
-          if !portal_permissions.has_key?(user)
-            new_share = @study.study_shares.build(email: user,
-                                                  permission: StudyShare::PORTAL_ACL_MAP[permissions['accessLevel']],
-                                                  firecloud_project: @study.firecloud_project,
-                                                  firecloud_workspace: @study.firecloud_workspace,
-
-            )
-            # skip validation as we don't wont to set the acl in FireCloud as it already exists
-            new_share.save(validate: false)
-            @permissions_changed << new_share
-          elsif portal_permissions[user] != StudyShare::PORTAL_ACL_MAP[permissions['accessLevel']] && user != @study.user.email
-            # share exists, but permissions are wrong
-            share = @study.study_shares.detect {|s| s.email == user}
-            share.update(permission: StudyShare::PORTAL_ACL_MAP[permissions['accessLevel']])
-            @permissions_changed << share
-          else
-            # permissions are correct, skip
-            next
-          end
-        end
-      end
-
-      # now check to see if there have been permissions removed in FireCloud that need to be removed on the portal side
-      new_study_permissions = @study.study_shares.to_a
-      new_study_permissions.each do |share|
-        if firecloud_permissions['acl'][share.email].nil?
-          logger.info "#{Time.zone.now}: removing #{share.email} access to #{@study.name} via sync - no longer in FireCloud acl"
-          share.delete
-        end
-      end
+      @permissions_changed = StudySyncService.update_shares_from_acl(@study)
     rescue => e
       ErrorTracker.report_exception(e, current_user, @study, params)
       MetricsService.report_error(e, request, current_user, @study)
@@ -163,15 +114,7 @@ class StudiesController < ApplicationController
 
     # begin determining sync status with study_files and primary or other data
     begin
-      # create a map of file extension to use for creating directory_listings of groups of 10+ files of the same type
-      @file_extension_map = {}
-      workspace_files = ApplicationController.firecloud_client.execute_gcloud_method(:get_workspace_files, 0, @study.bucket_id)
-      # see process_workspace_bucket_files in private methods for more details on syncing
-      process_workspace_bucket_files(workspace_files)
-      while workspace_files.next?
-        workspace_files = workspace_files.next
-        process_workspace_bucket_files(workspace_files)
-      end
+      @unsynced_files = StudySyncService.process_all_remotes(@study)
     rescue => e
       ErrorTracker.report_exception(e, current_user, @study, params)
       MetricsService.report_error(e, request, current_user, @study)
@@ -180,79 +123,10 @@ class StudiesController < ApplicationController
                   alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}.  #{SCP_SUPPORT_EMAIL}" and return
     end
 
-    files_to_remove = []
+    # refresh study state before continuing as new records may have been inserted
+    @study.reload
 
-    # before saving unsynced directories, make a pass to check if there were any files that ended up as study_files
-    # that should have been in a directory (might happen due to cutoff in files.next when iterating)
-    @unsynced_files.each do |study_file|
-      file_ext = DirectoryListing.file_extension(study_file.name)
-      directory = DirectoryListing.get_folder_name(study_file.name)
-      # check unsynced directories first, then existing directories
-      existing_dir = (@unsynced_directories + @directories).detect {|dir| dir.name == directory && dir.file_type == file_ext}
-      if !existing_dir.nil?
-        # we have a matching directory, so that means this file should be added to it
-        file_entry = {'name' => study_file.name, 'size' => study_file.upload_file_size, 'generation' => study_file.generation}
-        files_to_remove << study_file.generation
-        unless existing_dir.files.include?(file_entry)
-          existing_dir.files << file_entry
-        end
-      end
-    end
-
-    # now remove files that we found that were supposed to be in directory_listings
-    @unsynced_files.delete_if {|file| files_to_remove.include?(file.generation)}
-
-    # now check against latest list of files by directory vs. what was just found to see if we are missing anything and
-    # add directory to unsynced list. also check if an existing directory is now 'orphaned' because it was moved and
-    # store that reference for removal after the check is complete.  we make a list of files to remove and then take
-    # them out at the end as removing them from the list mid-iteration will skip the next file accidentally
-    orphaned_directories = []
-    @directories.each do |directory|
-      synced = true
-      if @files_by_dir[directory.name].present?
-        remove_from_dir = []
-        directory.files.each do |file|
-          if @files_by_dir[directory.name].detect {|f| f['generation'].to_i == file['generation'].to_i}.nil?
-            synced = false
-            remove_from_dir << file
-          else
-            next
-          end
-        end
-        # if no longer synced, check if already in the list and remove as files list has changed
-        if !synced
-          directory.sync_status = false
-          # remove files that are no longer present
-          remove_from_dir.each do |remove|
-            directory.files.delete(remove)
-          end
-          @unsynced_directories.delete_if {|dir| dir.name == directory.name}
-          if directory.files.any?
-            @unsynced_directories << directory
-          else
-            orphaned_directories << directory # queue for deletion as this directory is empty now
-          end
-        elsif directory.sync_status
-          @synced_directories << directory
-        end
-      else
-        # directory did not exist in @files_by_dir, so this directory_listing is orphaned and should be removed
-        orphaned_directories << directory
-      end
-    end
-
-    # remove orphaned directories
-    orphaned_directories.each do |orphan|
-      orphan.destroy
-    end
-
-    # provisionally save unsynced directories so we don't have to pass huge arrays of filenames/sizes in the form
-    # users clicking "don't sync" actually delete entries
-    @unsynced_directories.each do |directory|
-      directory.save
-    end
-
-    # reload unsynced directories to remove any that were orphaned
+    @synced_directories = @study.directory_listings.are_synced
     @unsynced_directories = @study.directory_listings.unsynced
 
     # split directories into primary data types and 'others'
@@ -260,12 +134,13 @@ class StudiesController < ApplicationController
     @unsynced_other_dirs = @unsynced_directories.select {|dir| !DirectoryListing::PRIMARY_DATA_TYPES.include?(dir.file_type)}
 
     # now determine if we have study_files that have been 'orphaned' (cannot find a corresponding bucket file)
-    @orphaned_study_files = @study_files - @synced_study_files
-    @available_files = @unsynced_files.map {|f| {name: f.name, generation: f.generation, size: f.upload_file_size}}
+    @orphaned_study_files = StudySyncService.find_orphaned_files(@study)
+    @available_files = @unsynced_files.map { |f| { name: f.name, generation: f.generation, size: f.upload_file_size } }
+    @synced_study_files = @study.study_files.valid - @orphaned_study_files
 
     # now remove any 'bundled' files from @synced_study_files so we can render them inside their parent file's form
-    bundled_file_ids = @study.study_file_bundles.map {|bundle| bundle.bundled_files.to_a.map(&:id)}.flatten
-    @synced_study_files.delete_if {|file| bundled_file_ids.include?(file.id)}
+    bundled_file_ids = @study.study_file_bundles.map { |bundle| bundle.bundled_files.to_a.map(&:id) }.flatten
+    @synced_study_files.delete_if { |file| bundled_file_ids.include?(file.id) }
   end
 
   # sync outputs from a specific submission

--- a/app/lib/study_sync_service.rb
+++ b/app/lib/study_sync_service.rb
@@ -22,7 +22,7 @@ class StudySyncService
     new_study_permissions = study.study_shares.to_a
     new_study_permissions.each do |share|
       if firecloud_permissions.dig('acl', share.email).nil?
-        Rails.logger.info "#{Time.zone.now}: removing #{share.email} access to #{@study.name} via sync - no longer in FireCloud acl"
+        Rails.logger.info "removing #{share.email} access to #{study.name} via sync - no longer in Terra acl"
         share.delete
       end
     end

--- a/app/lib/study_sync_service.rb
+++ b/app/lib/study_sync_service.rb
@@ -207,7 +207,7 @@ class StudySyncService
   #   - (Array<Google::Cloud::Storage::File>) => filtered list of remote files
   def self.remove_synced_files(study, files)
     files_to_remove = files.select do |file|
-      study.study_files.valid.detect { |f| f.generation.to_i == file.generation }
+      study.study_files.valid.detect { |f| f.generation.to_s == file.generation.to_s }
     end.map(&:generation)
     files.delete_if { |f| files_to_remove.include?(f.generation) || f.name.start_with?('parse_logs') }
   end

--- a/app/lib/study_sync_service.rb
+++ b/app/lib/study_sync_service.rb
@@ -167,11 +167,11 @@ class StudySyncService
     files.each do |file|
       file_type = DirectoryListing.file_type_from_extension(file.name)
       directory_name = DirectoryListing.get_folder_name(file.name)
-      remote = { 'name' => file.name, 'size' => file.size, 'generation' => file.generation }
+      remote = { 'name' => file.name, 'size' => file.size, 'generation' => file.generation.to_s }
       existing_dir = DirectoryListing.find_by(study_id: study.id, name: directory_name, file_type: file_type)
       if existing_dir.nil?
         study.directory_listings.create(name: directory_name, file_type: file_type, files: [remote], sync_status: false)
-      elsif existing_dir.files.detect { |f| f['generation'].to_i == file.generation }.nil?
+      elsif existing_dir.files.detect { |f| f['generation'].to_s == file.generation.to_s }.nil?
         existing_dir.files << remote
         existing_dir.sync_status = false
         existing_dir.save
@@ -208,8 +208,8 @@ class StudySyncService
   def self.remove_synced_files(study, files)
     files_to_remove = files.select do |file|
       study.study_files.valid.detect { |f| f.generation.to_s == file.generation.to_s }
-    end.map(&:generation)
-    files.delete_if { |f| files_to_remove.include?(f.generation) || f.name.start_with?('parse_logs') }
+    end.map { |f| f.generation.to_s }
+    files.delete_if { |f| files_to_remove.include?(f.generation.to_s) || f.name.start_with?('parse_logs') }
   end
 
   # remove files that have been added to directory listings from list to process

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -17,7 +17,11 @@ class DeleteQueueJob < Struct.new(:object)
       end
       # mark for deletion, rename study to free up old name for use, and restrict access by removing owner
       new_name = "DELETE-#{object.data_dir}"
-      object.update!(public: false, name: new_name, url_safe_name: new_name)
+      # set various attributes to hide study while it is queued for deletion
+      # also free up name/workspace to be used again immediately
+      # validate: false is used to prevent validations from blocking update
+      object.assign_attributes(public: false, name: new_name, url_safe_name: new_name, firecloud_workspace: new_name)
+      object.save(validate: false)
     when 'StudyFile'
       file_type = object.file_type
       study = object.study

--- a/app/models/study_share.rb
+++ b/app/models/study_share.rb
@@ -222,6 +222,8 @@ class StudyShare
 
 	# revoke FireCloud workspace access on share deletion, will email owner on fail to manually remove sharing as we can't do a validation on destroy
 	def revoke_firecloud_acl
+		return true if Rails.env.test? # ignore in test environment
+
 		begin
 			unless self.permission == 'Reviewer'
 				acl = ApplicationController.firecloud_client.create_workspace_acl(self.email, 'NO ACCESS')

--- a/test/integration/lib/study_sync_service_test.rb
+++ b/test/integration/lib/study_sync_service_test.rb
@@ -21,7 +21,8 @@ class StudySyncServiceTest < ActiveSupport::TestCase
                                     user: @user,
                                     test_array: @@studies_to_clean)
     bucket = ApplicationController.firecloud_client.get_workspace_bucket(@full_study.bucket_id)
-    bucket.create_file 'test/test_data/metadata_example.txt', 'metadata_example.txt'
+    metadata_file = File.open(Rails.root.join('test/test_data/metadata_example.txt'))
+    bucket.create_file metadata_file, 'metadata_example.txt'
   end
 
   test 'should process all remotes' do

--- a/test/integration/lib/study_sync_service_test.rb
+++ b/test/integration/lib/study_sync_service_test.rb
@@ -11,6 +11,7 @@ class StudySyncServiceTest < ActiveSupport::TestCase
     @study_file = FactoryBot.create(:cluster_file,
                                     name: 'cluster_1.txt.gz',
                                     remote_location: 'cluster_1.txt.gz',
+                                    generation: '12345',
                                     study: @study)
   end
 
@@ -75,5 +76,112 @@ class StudySyncServiceTest < ActiveSupport::TestCase
     mock.expect(:download, plain_bytes, [{ range: 0..1, skip_decompress: true }])
     assert_not StudySyncService.gzipped?(mock)
     mock.verify
+  end
+
+  test 'should CRUD shares from workspace ACL' do
+    other_user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    workspace_acl = {
+      acl: {
+        'mock-scp-owner-group@firecloud.org' =>
+          { accessLevel: 'OWNER', canCompute: true, canShare: true, pending: false },
+        @user.email =>
+          { accessLevel: 'WRITER', canCompute: true, canShare: true, pending: false },
+        other_user.email =>
+          { accessLevel: 'WRITER', canCompute: true, canShare: true, pending: false },
+        ApplicationController.read_only_firecloud_client.issuer =>
+          { accessLevel: 'READER', canCompute: true, canShare: true, pending: false }
+      }
+    }.with_indifferent_access
+    mock = Minitest::Mock.new
+    mock.expect(:get_workspace_acl, workspace_acl, [@study.firecloud_project, @study.firecloud_workspace])
+    ApplicationController.stub :firecloud_client, mock do
+      new_shares = StudySyncService.update_shares_from_acl(@study)
+      assert new_shares.detect { |share| share.email == other_user.email && share.permission == 'Edit' }.present?
+      mock.verify
+    end
+  end
+
+  test 'should process all remote files' do
+
+  end
+
+  test 'should create directory listings from remotes' do
+
+  end
+
+  test 'should remove submission outputs from list' do
+    submission_id = SecureRandom.uuid
+    submissions = [{ submissionId: submission_id }.with_indifferent_access]
+    api_mock = Minitest::Mock.new
+    api_mock.expect(:get_workspace_submissions, submissions, [@study.firecloud_project, @study.firecloud_workspace])
+    files = []
+    5.times do
+      mock = Minitest::Mock.new
+      generation = SecureRandom.uuid
+      mock.expect(:name, "#{submission_id}/outputs/#{SecureRandom.uuid}.txt")
+      mock.expect(:generation, generation)
+      mock.expect(:generation, generation)
+      files << mock
+    end
+    study_file_mock = Minitest::Mock.new
+    study_file_mock.expect(:name, 'matrix.tsv')
+    generation = '1234567890123456'
+    study_file_mock.expect(:generation, generation) # study file will only check generation once
+    files << study_file_mock
+    ApplicationController.stub :firecloud_client, api_mock do
+      expected_files = StudySyncService.remove_submission_outputs(@study, files)
+      api_mock.verify
+      assert_equal expected_files, [study_file_mock]
+      files.each(&:verify)
+    end
+  end
+
+  test 'should remove synced files from list' do
+    synced_mock = Minitest::Mock.new
+    unsynced_mock = Minitest::Mock.new
+    unsynced_generation = SecureRandom.uuid
+    # an unsynced file will call :generation twice and then :name, whereas a synced file will call :generation 3 times
+    # this is due to how the block evaluates in :remove_synced_files
+    unsynced_mock.expect(:generation, unsynced_generation)
+    unsynced_mock.expect(:generation, unsynced_generation)
+    unsynced_mock.expect(:name, 'matrix.tsv')
+    synced_mock.expect(:generation, @study_file.generation)
+    synced_mock.expect(:generation, @study_file.generation)
+    synced_mock.expect(:generation, @study_file.generation)
+    files = [synced_mock, unsynced_mock]
+    unsynced_files = StudySyncService.remove_synced_files(@study, files)
+    assert_equal unsynced_files, [unsynced_mock]
+    synced_mock.verify
+    unsynced_mock.verify
+  end
+
+  test 'should remove directory files from list' do
+    dir_files = []
+    all_files = []
+    10.times do
+      dir_mock = Minitest::Mock.new
+      generation = SecureRandom.uuid
+      dir_mock.expect(:generation, generation)
+      dir_mock.expect(:generation, generation)
+      dir_files << dir_mock
+      all_files << dir_mock
+    end
+    file_mock = Minitest::Mock.new
+    generation = SecureRandom.uuid
+    file_mock.expect(:generation, generation)
+    all_files << file_mock
+    non_dir_files = StudySyncService.remove_directory_files(dir_files, all_files)
+    assert_equal non_dir_files, [file_mock]
+    all_files.map(&:verify)
+  end
+
+  test 'should find orphaned files' do
+    mock = Minitest::Mock.new
+    mock.expect(:workspace_file_exists?, false,[@study.bucket_id, @study_file.bucket_location])
+    ApplicationController.stub :firecloud_client, mock do
+      orphaned = StudySyncService.find_orphaned_files(@study)
+      assert_equal [@study_file], orphaned
+      mock.verify
+    end
   end
 end

--- a/test/models/search_facet_test.rb
+++ b/test/models/search_facet_test.rb
@@ -223,7 +223,8 @@ class SearchFacetTest < ActiveSupport::TestCase
       mock.verify
       disease_facet.reload
       assert_empty disease_facet.find_filter_matches(disease_keyword)
-      assert_equal cancers, disease_facet.find_filter_matches(disease_keyword, filter_list: :filters_with_external)
+      assert_equal cancers.sort,
+                   disease_facet.find_filter_matches(disease_keyword, filter_list: :filters_with_external).sort
     end
   end
 


### PR DESCRIPTION
#### BACKGROUND
With the separation of the API from the more "traditional" Rails controllers, this created areas of the codebase that were prone to duplication.  To address this, separate service libraries were created that could be referenced from both places so that there is only codepath that is exercised, regardless of how many times it is referenced.  This can be seen in practice with classes such as `ClusterVizService`, `ExpressionVizService`, and `FileParseService`.

#### CHANGES
The `StudySyncService` class now handles all main sync functionality, and is referenced in both `StudiesController` and `Api::V1::StudiesController`.  These controllers now only contain code to set the various variables needed for their associated views, and the actual business logic of synchronizing a study with a Terra workspace only lives in `StudySyncService`.  It also now has much more extensive test coverage than the existing controllers had, since the majority of these new helper methods can be tested directly using mocks/stubbing, rather than a full integration test done at the HTTP request level.  Also, this service class is simpler than the preexisting code as it does not rely on the in-memory data structures that the older code utilized for tracking state.

#### MANUAL TESTING
1. Sign into Terra, and create a new workspace in your default development Terra billing project
2. Click the "Open bucket in browser" link under "Cloud Information"
3. Upload several files from `test/test_data` (it doesn't matter which files, just that you upload more than one)
4. Pull this branch, boot as normal and then sign in
5. Click "Create a study" in the top menu bar, and then select "Yes" for **Use an existing workspace**, and put in the name of the workspace for **Existing Terra workspace** (make sure you select the correct Terra billing project as well)
6. Click "Save study", and validate that the sync page loads eventually
7. Validate that the files you uploaded show up in the page as unsynced files

_Note: it is not required that you save the files or parse them as none of that logic has been altered as a part of this PR._