### PR TITLE
Fix `usermod` hang on deployments (SCP-4579)

### DIFF
--- a/rails_startup.bash
+++ b/rails_startup.bash
@@ -69,6 +69,9 @@ then
     echo "*** MAKING tmp/pids DIR ***"
     sudo -E -u app -H mkdir -p /home/app/webapp/tmp/pids || { echo "FAILED to create ./tmp/pids/" >&2; exit 1; }
     echo "*** COMPLETED ***"
+else
+  # ensure group write permission bit is correct for pids dir, otherwise delayed_job won't start
+  sudo chmod g+w /home/app/webapp/tmp/pids
 fi
 echo "*** STARTING DELAYED_JOB for $PASSENGER_APP_ENV env ***"
 rm tmp/pids/delayed_job.*.pid

--- a/set_user_permissions.bash
+++ b/set_user_permissions.bash
@@ -3,10 +3,6 @@ if [[ $PASSENGER_APP_ENV = "production" ]] || [[ $PASSENGER_APP_ENV = "staging" 
 then
 	set -e # fail on any error
 
-	echo '*** SETTING UID AND GID TO MATCH HOST VOLUMES ***'
-	TARGET_UID=$(stat -c "%u" /home/app/webapp)
-	echo '-- Setting app user to use uid '$TARGET_UID
-	usermod -o -u $TARGET_UID app || true
 	TARGET_GID=$(stat -c "%g" /home/app/webapp)
 	echo '-- Setting app group to use gid '$TARGET_GID
 	groupmod -o -g $TARGET_GID app || true

--- a/test/Dockerfile-test
+++ b/test/Dockerfile-test
@@ -12,6 +12,7 @@ COPY Gemfile.lock /home/app/webapp/Gemfile.lock
 COPY package.json /home/app/webapp/package.json
 COPY yarn.lock /home/app/webapp/yarn.lock
 RUN chmod a+w /home/app/webapp/yarn.lock
+RUN chmod a+w /home/app/webapp/node_modules/.yarn-integrity
 
-RUN bundle install
+RUN yarn install
 RUN sudo -E -u app -H yarn install


### PR DESCRIPTION
#### BACKGROUND
Since SCP mounts local filesystems into a container when running in Dockerized mode, managing file permissions becomes an issue on ubuntu machines as we need to match the user/group ID of the `app` user to that of the host filesystem to allow read/write operations.  Previously, this operation completed relatively quickly as everything on the host filesystem already matched, but since #1552 it has slowed down significantly since `usermod` will recursively apply the new user ID to the pre-compiled `node_modules` directory tree inside the container.  This can take upwards of 2 minutes to complete.

#### CHANGES
Since the user and group permissions inside the SCP directory structure are uniform (at least in places where writes are necessary), this update removes the `usermod` call in `set_user_permissions.bash` startup script and instead only calls `groupmod`.  This executes immediately, and confers the necessary read/write permissions to the `app` user.  A test deployment to staging reduce the downtime on a deployment from roughly 4.5m to about 75 seconds.

#### MANUAL TESTING
1. Pull this branch and ensure Docker is running on your machine
2. Build the new Docker image locally with the `groupmod` tag via:
```
docker build -t gcr.io/broad-singlecellportal-staging/single-cell-portal:groupmod .
```
3. Boot your local instance in Dockerized mode in the `staging` environment to ensure `set_user_permissions.bash` executes:
```
bin/load_env_secrets.sh -p secret/kdux/scp/development/$(whoami)/scp_config.json \
                        -r secret/kdux/scp/development/$(whoami)/read_only_service_account.json \
                        -s secret/kdux/scp/development/$(whoami)/scp_service_account.json \
                        -e staging -v groupmod
```
4. Once the portal starts, you will see the message `### BOOTING PORTAL IN 'staging' MODE WITH DOCKER IMAGE VERSION groupmod-test`, and then will disconnect as the container starts in detached mode.
5. Run `docker logs -f single_cell`, and verify that you see that `01_set_user_permissions.bash` has already executed and the startup has moved forward without hanging:
```
*** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
*** Running /etc/my_init.d/01_set_user_permissions.bash...
-- Setting app group to use gid 0
*** Running /etc/my_init.d/02_generate_dh_parameters.bash...
...
```
6. Press `CTRL^C`, and then run `docker stop single_cell && docker rm single_cell` to stop and remove the container