### PR TITLE
Fix the gaps that were unintentionally added to top of pages (SCP-4605)

### DIFF
--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -24,7 +24,7 @@ label {
 }
 
 .section-pad {
-  margin-top: 50px;
+  margin-top: 20px;
   margin-bottom: 20px;
 }
 
@@ -186,7 +186,7 @@ label {
 }
 
 #main-banner {
-  margin-top: 50px;
+  margin-top: 30px;
   background-image: url('../../assets/images/SCP-Header-resize.png');
   background-repeat: no-repeat;
   background-position: right bottom;


### PR DESCRIPTION
Fix the gapping that was accidentally added with the unique page title PR

- Pull this branch
- Open up localhost
- See there is no gap at the top of the page for the home page or study overview pages
- Compare to staging to see the gap

