### PR TITLE
Ensure proper naming in destructure to avoid TypeError (SCP-4624)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -354,7 +354,7 @@ export default function ExploreDisplayTabs({
                   {...{
                     studyAccession,
                     exploreParamsWithDefaults,
-                    updateExploreParams,
+                    updateExploreParamsWithDefaults: updateExploreParams,
                     exploreInfo,
                     isGeneList,
                     isGene,

--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -64,7 +64,7 @@ export default function ScatterTab({
             <ScatterPlot
               {...{
                 studyAccession, plotPointsSelected, isCellSelecting, updateScatterColor,
-                countsByLabel, setCountsByLabel, updateExploreParamsWithDefaults
+                countsByLabel, setCountsByLabel, updateExploreParams: updateExploreParamsWithDefaults
               }}
               {...params}
               dataCache={dataCache}


### PR DESCRIPTION
Fixing a bug where clicking a label in the legend resulted in a `TypeError: y is not a function`

To test:
- Go to staging and go to any study that is visualizable
- Open the browser console and click on any label in the legend for the plot
- Observe an error appear in the console and the points not toggling
- Pull this branch and boot up local 
- Go to any study that is visualizable
- Open the browser console and click on any label in the legend for the plot
- Observe that the points toggle as expected and no error appears
<img width="388" alt="Screen Shot 2022-08-26 at 3 24 52 PM" src="https://user-images.githubusercontent.com/54322292/187039697-0fd699ae-ada3-40da-a3d3-d7447e891240.png">

