### PR TITLE
Temporarily revert CSP for instant plot prototype (SCP-4583)

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -87,7 +87,7 @@ SecureHeaders::Configuration.default do |config|
     font_src: %w('self' data: https://fonts.googleapis.com https://fonts.google.com https://fonts.gstatic.com ),
     form_action: %w('self' https://accounts.google.com),
     connect_src: allowed_connect_sources,
-    img_src: %w('self' data: blob: https://www.google-analytics.com https://online.swagger.io res.cloudinary.com twemoji.maxcdn.com https://storage.googleapis.com),
+    img_src: %w('self' data: blob: https://www.google-analytics.com https://online.swagger.io res.cloudinary.com twemoji.maxcdn.com),
     manifest_src: %w('self'),
     object_src: %w('none'),
     script_src: %w('self' blob: 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' https://cdn.plot.ly https://cdn.datatables.net


### PR DESCRIPTION
The prototype in #1597 updated content security policy (CSP) without AppSec review, which was unintentional.  This reverts that until AppSec approves the change.  

That presumably will be OK, but worth a separate task given the lag, timelines, and scope of the work in that prior PR.  The main goal here is to not push that insufficiently reviewed security policy change to production.

To test:
* Go to a visualizable study
* Search a gene
* Click legend label
* Confirm above yields no obvious error

This relates to SCP-4583.  The CSP change will be handled separately in SCP-4626.