### PR TITLE
Ignore hiddenTraces for geneExpression (SCP-4487)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -164,7 +164,7 @@ function RawScatterPlot({
       isCorrelatedScatter,
       scatterColor,
       editedCustomColors,
-      hiddenTraces,
+      hiddenTraces: isGeneExpression(genes, isCorrelatedScatter) ? [] : hiddenTraces,
       scatter,
       activeTraceLabel,
       expressionFilter,


### PR DESCRIPTION
Currently in Prod if you hide an item in the legend then do a gene search the resulting Gene Expression plot is just a blue blob. (or if you refresh the page post gene search and post legend hide). This was caused by including the hidden traces in the plotting of the Gene Expression plot, so this work essentially just ignores hidden traces for such plots.

To see the broken behavior:
- Click this link: https://singlecell-staging.broadinstitute.org/single_cell/study/SCP319/reproducing-scp1837?genes=E030013I19Rik&hiddenTraces=B%20cells#study-visualize
![Screen Shot 2022-09-06 at 1 05 19 PM](https://user-images.githubusercontent.com/54322292/188697166-95000372-c02e-46d0-9b56-794c0af6d5c6.png)

- Or if you'd like to create the issue yourself, follow the steps below and you will see a blue blob rather than the Gene Exp. plot

To test the fix:
- Pull this branch
- start up your local env
- go to any study that has a visualized Scatter plot
- click any entry on the legend
- search any valid gene
- observe the Gene Exp. plot renders.
![Screen Shot 2022-09-06 at 1 07 53 PM](https://user-images.githubusercontent.com/54322292/188697590-50be0256-f1e1-4b55-8515-d447c2c02f48.png)
