### PR TITLE
Ignore common/stop words when constructing Azul queries (SCP-4531)

### DIFF
--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -29,7 +29,7 @@ class HcaAzulClient
   }.freeze
 
   # list of words that are common among Azul filter values that result in too many matches
-  # this can cause HTTP 413 Payload Too Large or HTTP 413 URI Too Long errors when executing
+  # this can cause HTTP 413 Payload Too Large or HTTP 414 URI Too Long errors when executing
   # search requests in Azul
   COMMON_AZUL_TERMS = %w[cell cells human single-cell reveals sequencing rna-seq analysis atlas rna disease].freeze
 
@@ -308,7 +308,8 @@ class HcaAzulClient
     query
   end
 
-  # find matching facets based on keyword list, to be passed to :format_query_from_facets
+  # find matching facets based on keyword list along with filters that contain items from term_list
+  # to be passed to :format_query_from_facets
   # since Azul does not support keyword searching, we must find a match for a corresponding facet and treat this as
   # the search request
   # will ignore very common/short words, including known stop words (see StudySearchService::STOP_WORDS)

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -216,6 +216,12 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should ignore common/stop words when creating queries' do
+    ignored_terms = HcaAzulClient::IGNORED_WORDS.sample(5)
+    facets = @hca_azul_client.format_facet_query_from_keyword(ignored_terms)
+    assert_empty facets
+  end
+
   test 'should merge query objects' do
     expected_query = {
       sampleDisease: {


### PR DESCRIPTION
#### BACKGROUND
A common error found during triage is one received from Azul when attempting to convert a keyword search into something that Azul will accept.  For certain common terms, the amount of matches found are so great that Azul throws an `HTTP Payload Too Large` error since the query string payload can be over 8K.

#### CHANGES
This leverages similar work done for [rejecting stop words](https://github.com/broadinstitute/single_cell_portal_core/pull/1357) in SCP-based searches.  In addition to ignoring those words when finding matches for possible entries in Azul, a short list of exceedingly common terms found in Azul filter values are also filtered out before finding any possible hits.  These include terms like `cell`, `rna`, `sequencing`, etc., as well as any terms less than 3 characters long.  While these terms may be relevant in some cases, the amount of matches that they return are such that no query can ever be performed against Azul if they are included.  It is worth noting that if they are included in a quoted string (e.g. "B cell"), then that will be honored as a distinct term.

It is worth noting that this does not address the related issue of large compound queries not returning results from Azul.  This is due to the fact that Azul does not natively support keyword searching, and providing a large list of terms - or commonly found ones - will always result in a query with no intersection as Azul only support `AND` logic across facets.  The above work is solely to mitigate the HTTP 413 error by constraining possible matches.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Enter the following query in the text search box: `Tumor and immune reprogramming during immunotherapy in advanced renal cell carcinoma` (no quotes)
3. Confirm the search request completes and some SCP-based result are found, such as the `Human HIV and Tuberculosis, blood study` synthetic study
4. In `development.log`, confirm that a search was performed against Azul with something similar to the below object (will depend on facets in your local instance and how recently they've been updated against Azul) and that no error was thrown:
```
Executing Azul project query with: {"organ"=>{"is"=>["adrenal gland", "renal system"]}, "sampleDisease"=>{"is"=>["breast adenocarcinoma", "breast carcinoma", "breast ductal adenocarcinoma", "breast lobular carcinoma", "carcinoma of floor of mouth", "carcinoma of supraglottis", "diffuse gastric adenocarcinoma", "endometrioid adenocarcinoma", "hepatocellular carcinoma", "invasive breast carcinoma", "invasive ductal breast carcinoma", "laryngeal carcinoma", "luminal B breast carcinoma", "non-small cell lung carcinoma", "oral cavity carcinoma", "pancreatic adenosquamous carcinoma", "squamous cell carcinoma of buccal mucosa", "tonsil carcinoma"]}, "libraryConstructionApproach"=>{"is"=>["10x immune profiling"]}, "selectedCellType"=>{"is"=>["cd4neg cd45pos immune cell"]}, "organPart"=>{"is"=>["renal medulla", "renal pelvis"]}}
...
Found 0 results in Azul
```