### PR TITLE
Update cookie comment to reflect that Appcues relies on user_id cookie as well (SCP-4620)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,7 @@
       window.SCP.featuredSpace = 'covid19'
       <% end %>
 
-      // Set the unique cookie for tracking user IDs in GA.  Also used in Mixpanel.
+      // Set the unique cookie for tracking user IDs in GA.  Also used in Mixpanel and Appcues.
       // This is not personally identifiable, lasts for 1 year or until cleared.
       if ( typeof Cookies.get('user_id') === 'undefined' ) {
         Cookies.set('user_id', '<%= user_signed_in? ? current_user.get_metrics_uuid : SecureRandom.uuid %>', {expires: 365})


### PR DESCRIPTION
We are using the `user_id` cookie to send to Appcues as the identifier for unique users. This cookie item is set to expire after 1 year. Therefore we don't need another cookie for our un-auth'd users to avoid Appcues overload, since if they are using the same device they will have the same cookie for 1 year (provided they do not refresh their cookies, which even if we did instrument another Appcues specific cookie that would be blown away too). This is just to update the comment above setting the `user_id` cookie to indicate its used by Appcues as well, so if we ever change that expiration we are aware it will affect Appcues as well.

