### PR TITLE
Fix stuck 'return to cluster view' tooltip (SCP-4633)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -32,6 +32,8 @@ import LoadingSpinner from '~/lib/LoadingSpinner'
 import { log } from '~/lib/metrics-api'
 import { getFeatureFlagsWithDefaults } from '~/providers/UserProvider'
 import DifferentialExpressionPanel, { DifferentialExpressionPanelHeader } from './DifferentialExpressionPanel'
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger'
+import Tooltip from 'react-bootstrap/lib/Tooltip'
 
 const tabList = [
   { key: 'loading', label: 'loading...' },
@@ -265,14 +267,16 @@ export default function ExploreDisplayTabs({
               allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}
               isLoading={!exploreInfo}
               speciesList={exploreInfo ? exploreInfo.taxonNames : []}/>
-            { (isGene || isGeneList || hasIdeogramOutputs) && // show if this is gene search || gene list
-              <button className="action fa-lg"
-                onClick={() => searchGenes([])}
-                title="Return to cluster view"
-                data-toggle="tooltip"
-                data-analytics-name="back-to-cluster-view">
-                <FontAwesomeIcon icon={faArrowLeft}/>
-              </button>
+            { // show if this is gene search || gene list
+              (isGene || isGeneList || hasIdeogramOutputs) &&
+                <OverlayTrigger placement='top' overlay={
+                  <Tooltip id='back-to-cluster-view'>{'Return to cluster view'}</Tooltip>
+                }>
+                  <button className="action fa-lg"
+                    onClick={() => searchGenes([])}>
+                    <FontAwesomeIcon icon={faArrowLeft}/>
+                  </button>
+                </OverlayTrigger>
             }
           </div>
         </div>


### PR DESCRIPTION
Switch the tooltip for the "Return to cluster view" button to use the Overlay/Tooltip style. 

As far as I can see we use two main tooltip patterns in the code, one is using Overlay/Tooltip and one is adding `data-toggle="tooltip"` to buttons. 

Previously the button was using the `toggle="tooltip"` version and it was not handling the dismissal of the tooltip once the button disappeared upon clicking the button. This likely could have been sorted out using the different `trigger` options offered by this [bootstrap tooltip](https://getbootstrap.com/docs/4.0/components/tooltips/) however, I have generally found more success working with the other tooltip option we use from [react-bootstrap](https://react-bootstrap.github.io/components/overlays/) so I switched it to use this style.

The fix is that the tooltip is dismissed when the button is removed from the page upon clicking the button.

To test:
- Pull the branch
- Fire up a local instance
- Go to any study that has visualizable plots
- Search for any gene
- Then click the left arrow to clear out that search and observe that the tooltip goes away when the button does.

Before - see how the tooltip is stuck to the page even if you switch to the overview tab
<img width="790" alt="Screen Shot 2022-09-08 at 12 59 05 PM" src="https://user-images.githubusercontent.com/54322292/189182140-fd1104c6-b9eb-4cf8-a793-95c39991e034.png">

After - the screenshot doesn't show but the mouse is hovering over the arrow button
<img width="1074" alt="Screen Shot 2022-09-08 at 12 59 19 PM (2)" src="https://user-images.githubusercontent.com/54322292/189182169-87570f39-7bb1-4688-9e5a-497a97ad00ab.png">

After - the button has been dismissed and the tooltip went away as well
![Screen Shot 2022-09-08 at 12 59 36 PM](https://user-images.githubusercontent.com/54322292/189182275-06908fa0-6767-4d1e-a754-49a4735c5c21.png)
