### PR TITLE
Increase search relevance, address HTTP errors by splitting keyword searches in Azul (SCP-4531)

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -36,7 +36,10 @@ jobs:
           # TODO: (SCP-4496): Move production-related GCR images out of staging project
           DOCKER_IMAGE_NAME="gcr.io/broad-singlecellportal-staging/single-cell-portal"
           # add ci- prefix to avoid post-merge build failing due to missing GITHUB_HEAD_REF
-          DOCKER_IMAGE_TAG="ci-$GITHUB_HEAD_REF-$GITHUB_SHA"
+          # and strip any slashes from GITHUB_HEAD_REF to avoid 'invalid reference format' error with tag
+          # this will happen on dependabot PRs
+          SAFE_HEAD_REF=$(echo $GITHUB_HEAD_REF | sed -e 's/\//_/g')
+          DOCKER_IMAGE_TAG="ci-$SAFE_HEAD_REF-$GITHUB_SHA"
           docker build -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG -f test/Dockerfile-test .
           bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json \
                                   -s secret/kdux/scp/staging/scp_service_account.json \

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -304,7 +304,7 @@ module Api
               metadata_weight = @metadata_matches.dig(study.accession, :facet_search_weight).to_i
               -(study.search_weight(@term_list)[:total] + metadata_weight)
             else
-              -study[:term_matches][:total]
+              -study[:term_search_weight]
             end
           end
         when :accession

--- a/app/controllers/api/v1/study_search_results_objects.rb
+++ b/app/controllers/api/v1/study_search_results_objects.rb
@@ -84,7 +84,8 @@ module Api
             gene_count: 0,
             study_url: '#',
             file_information: study[:file_information],
-            term_matches: @term_list
+            term_matches: study[:term_matches],
+            term_search_weight: study[:term_search_weight]
           }
           if @studies_by_facet.present?
             # faceted search was run, so append filter matches

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -57,7 +57,8 @@ class AzulSearchService
         created_at: submission_date, # for sorting purposes
         view_count: 0, # for sorting purposes
         facet_matches: {},
-        term_matches: {},
+        term_matches: [],
+        term_search_weight: 0,
         file_information: [
           {
             project_id: project_id,

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -75,8 +75,12 @@ class AzulSearchService
       result[:facet_matches] = get_facet_matches(entry_hash, merged_facets)
       if terms
         # only store result if we get a text match on project name/description
-        result[:term_matches] = get_search_term_weights(result, terms)
-        results[short_name] = result if result.dig(:term_matches, :total) > 0
+        match_info = get_search_term_weights(result, terms)
+        if match_info[:total] > 0
+          result[:term_matches] = match_info[:terms].keys
+          result[:term_search_weight] = match_info[:total]
+          results[short_name] = result
+        end
       else
         results[short_name] = result
       end

--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -39,7 +39,9 @@ class AzulSearchService
 
     merged_facets = merge_facet_lists(selected_facets, terms_to_facets)
     Rails.logger.info "Executing Azul project query with: #{query_json}"
-    project_results = client.projects(query: query_json)
+    # determine if this is a normal faceted search (1 request), or term-based (split into separate requests and join)
+    search_method = terms_to_facets ? :projects_by_facet : :projects
+    project_results = client.send(search_method, query: query_json)
     project_results['hits'].each do |entry|
       entry_hash = entry.with_indifferent_access
       submission_date = entry_hash[:dates].first[:submissionDate]

--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -29,7 +29,7 @@ class HcaAzulClient
   }.freeze
 
   # list of words that are common among Azul filter values that result in too many matches
-  # this can cause HTTP 413 Payload Too Large or HTTP 413 URI Too Long errors when executing
+  # this can cause HTTP 413 Payload Too Large or HTTP 414 URI Too Long errors when executing
   # search requests in Azul
   COMMON_AZUL_TERMS = %w[cell cells human single-cell reveals sequencing rna-seq analysis atlas rna disease].freeze
 
@@ -308,7 +308,8 @@ class HcaAzulClient
     query
   end
 
-  # find matching facets based on keyword list, to be passed to :format_query_from_facets
+  # find matching facets based on keyword list along with filters that contain items from term_list
+  # to be passed to :format_query_from_facets
   # since Azul does not support keyword searching, we must find a match for a corresponding facet and treat this as
   # the search request
   # will ignore very common/short words, including known stop words (see StudySearchService::STOP_WORDS)

--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -194,7 +194,7 @@ class HcaAzulClient
   def projects_by_facet(catalog: nil, query: {}, size: MAX_RESULTS)
     all_results = { 'hits' => [], 'project_ids' => [] }
     isolated_queries = query.each_pair.map { |facet, filters| { facet => filters } }
-    Rails.logger.info "Splitting above query into #{isolated_queries.size} requests and joinging results"
+    Rails.logger.info "Splitting above query into #{isolated_queries.size} requests and joining results"
     Parallel.map(isolated_queries, in_threads: isolated_queries.size) do |project_query|
       results = projects(catalog: catalog, query: project_query, size: size)
       results['hits'].each do |result|

--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -179,7 +179,7 @@ class HcaAzulClient
     process_api_request(:get, path)
   end
 
-  # simulate a keyword-search by splitting project queries on facet and joining results
+  # simulate OR logic by splitting project queries on facet and joining results
   #
   # * *params*
   #   - +catalog+ (String) => HCA catalog name (optional)
@@ -194,6 +194,7 @@ class HcaAzulClient
   def projects_by_facet(catalog: nil, query: {}, size: MAX_RESULTS)
     all_results = { 'hits' => [], 'project_ids' => [] }
     isolated_queries = query.each_pair.map { |facet, filters| { facet => filters } }
+    Rails.logger.info "Splitting above query into #{isolated_queries.size} requests and joinging results"
     Parallel.map(isolated_queries, in_threads: isolated_queries.size) do |project_query|
       results = projects(catalog: catalog, query: project_query, size: size)
       results['hits'].each do |result|

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -216,6 +216,12 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should ignore common/stop words when creating queries' do
+    ignored_terms = HcaAzulClient::IGNORED_WORDS.sample(5)
+    facets = @hca_azul_client.format_facet_query_from_keyword(ignored_terms)
+    assert_empty facets
+  end
+
   test 'should merge query objects' do
     expected_query = {
       sampleDisease: {

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -114,6 +114,29 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     assert_equal 1, projects.size
   end
 
+  test 'should similate OR logic by splitting project queries' do
+    # TODO: convert other tests to use mocks to avoid Azul instability/lack of idempotency due to changing data
+    hiv_json = File.open('test/test_data/azul/disease_hiv.json').read
+    disease_response = JSON.parse(hiv_json).with_indifferent_access
+    homo_sapiens_json = File.open('test/test_data/azul/species_homo_sapiens.json').read
+    species_response = JSON.parse(homo_sapiens_json).with_indifferent_access
+    mock = Minitest::Mock.new
+    mock.expect(:code, 200)
+    mock.expect(:body, species_response) # body is called twice in ApiHelpers#handle_response
+    mock.expect(:body, species_response)
+    mock.expect(:code, 200)
+    mock.expect(:body, disease_response)
+    mock.expect(:body, disease_response)
+    RestClient::Request.stub :execute, mock do
+      # NOTE: :size here means _per facet_, not total
+      projects = @hca_azul_client.projects_by_facet(query: @query_json, size: 1)
+      assert_equal 2, projects['hits'].size
+      assert_equal %w[0fd8f918-62d6-4b8b-ac35-4c53dd601f71 53c53cd4-8127-4e12-bc7f-8fe1610a715c],
+                   projects['project_ids'].sort
+      mock.verify
+    end
+  end
+
   test 'should get one project' do
     skip_if_api_down
     project = @hca_azul_client.project(@project_id)

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -116,9 +116,9 @@ class HcaAzulClientTest < ActiveSupport::TestCase
 
   test 'should similate OR logic by splitting project queries' do
     # TODO: convert other tests to use mocks to avoid Azul instability/lack of idempotency due to changing data
-    hiv_json = File.open('test/test_data/azul/disease_hiv.json').read
+    hiv_json = File.open(Rails.root.join('test/test_data/azul/disease_hiv.json')).read
     disease_response = JSON.parse(hiv_json).with_indifferent_access
-    homo_sapiens_json = File.open('test/test_data/azul/species_homo_sapiens.json').read
+    homo_sapiens_json = File.open(Rails.root.join('test/test_data/azul/species_homo_sapiens.json')).read
     species_response = JSON.parse(homo_sapiens_json).with_indifferent_access
     mock = Minitest::Mock.new
     mock.expect(:code, 200)

--- a/test/test_data/azul/disease_hiv.json
+++ b/test/test_data/azul/disease_hiv.json
@@ -1,0 +1,346 @@
+{
+  "hits": [
+    {
+      "protocols": [
+        {
+          "workflow": [
+            "optimus_post_processing_v1.0.0",
+            "optimus_v4.2.3"
+          ]
+        },
+        {
+          "libraryConstructionApproach": [
+            "10X 3' v2 sequencing"
+          ],
+          "nucleicAcidSource": [
+            "single cell"
+          ]
+        },
+        {
+          "instrumentManufacturerModel": [
+            "Illumina HiSeq 2500"
+          ],
+          "pairedEnd": [
+            false
+          ]
+        }
+      ],
+      "entryId": "0fd8f918-62d6-4b8b-ac35-4c53dd601f71",
+      "sources": [
+        {
+          "sourceId": "bbc476e1-5f7a-47fd-aaab-1a5bcd461b16",
+          "sourceSpec": "tdr:datarepo-76169feb:snapshot/hca_prod_0fd8f91862d64b8bac354c53dd601f71__20220110_dcp2_20220114_dcp12:/0"
+        }
+      ],
+      "projects": [
+        {
+          "projectId": "0fd8f918-62d6-4b8b-ac35-4c53dd601f71",
+          "projectTitle": "An Atlas of Immune Cell Exhaustion in HIV-Infected Individuals Revealed by Single-Cell Transcriptomics.",
+          "projectShortname": "ImmuneCellExhaustianHIV",
+          "laboratory": [
+            "Department of Medicine, Division of Infectious Diseases",
+            "Department of Pediatrics, Division of Genetics, Institute for Genomic Medicine, Program in Immunology"
+          ],
+          "estimatedCellCount": 43731,
+          "projectDescription": "The effects of HIV infection on immune cell exhaustion at the transcriptomic level was investigated by analyzing single-cell RNA sequencing of peripheral blood mononuclear cells from four healthy subjects (37,847 cells) and six HIV-infected donors (28,610 cells).",
+          "contributors": [
+            {
+              "institution": "EMBL-EBI",
+              "contactName": "Ami,,Day",
+              "projectRole": "data curator",
+              "laboratory": null,
+              "correspondingContributor": false,
+              "email": null
+            },
+            {
+              "institution": "University of California San Diego",
+              "contactName": "Kriti,,Agrawal",
+              "projectRole": null,
+              "laboratory": "Department of Pediatrics, Division of Genetics, Institute for Genomic Medicine, Program in Immunology",
+              "correspondingContributor": false,
+              "email": null
+            },
+            {
+              "institution": "University of California San Diego",
+              "contactName": "Tariq,M,Rana",
+              "projectRole": null,
+              "laboratory": "Department of Pediatrics, Division of Genetics, Institute for Genomic Medicine, Program in Immunology",
+              "correspondingContributor": true,
+              "email": "trana@ucsd.edu"
+            },
+            {
+              "institution": "University of California San Diego",
+              "contactName": "Qiong,,Zhang",
+              "projectRole": null,
+              "laboratory": "Department of Pediatrics, Division of Genetics, Institute for Genomic Medicine, Program in Immunology",
+              "correspondingContributor": false,
+              "email": null
+            },
+            {
+              "institution": "University of California San Diego",
+              "contactName": "Maile Ann Young,,Karris",
+              "projectRole": null,
+              "laboratory": "Department of Medicine, Division of Infectious Diseases",
+              "correspondingContributor": false,
+              "email": null
+            },
+            {
+              "institution": "University of California San Diego",
+              "contactName": "Shaobo,,Wang",
+              "projectRole": null,
+              "laboratory": "Department of Pediatrics, Division of Genetics, Institute for Genomic Medicine, Program in Immunology",
+              "correspondingContributor": false,
+              "email": null
+            },
+            {
+              "institution": "University of California San Diego",
+              "contactName": "Hui,,Hui",
+              "projectRole": null,
+              "laboratory": "Department of Pediatrics, Division of Genetics, Institute for Genomic Medicine, Program in Immunology",
+              "correspondingContributor": false,
+              "email": null
+            }
+          ],
+          "publications": [
+            {
+              "publicationTitle": "An atlas of immune cell exhaustion in HIV-infected individuals revealed by single-cell transcriptomics.",
+              "officialHcaPublication": false,
+              "publicationUrl": "https://doi.org/10.1080/22221751.2020.1826361",
+              "doi": "10.1080/22221751.2020.1826361"
+            }
+          ],
+          "supplementaryLinks": [
+            null
+          ],
+          "accessions": [
+            {
+              "namespace": "geo_series",
+              "accession": "GSE157829"
+            },
+            {
+              "namespace": "insdc_project",
+              "accession": "SRP282057"
+            },
+            {
+              "namespace": "insdc_study",
+              "accession": "PRJNA662927"
+            }
+          ],
+          "accessible": true
+        }
+      ],
+      "samples": [
+        {
+          "sampleEntityType": [
+            "specimens"
+          ],
+          "effectiveOrgan": [
+            "blood"
+          ],
+          "id": [
+            "SAMN16100343",
+            "SAMN16100344",
+            "SAMN16100345",
+            "SAMN16100346"
+          ],
+          "organ": [
+            "blood"
+          ],
+          "organPart": [
+            null
+          ],
+          "disease": [
+            "HIV infectious disease"
+          ],
+          "preservationMethod": [
+            null
+          ],
+          "source": [
+            "specimen_from_organism"
+          ]
+        }
+      ],
+      "specimens": [
+        {
+          "id": [
+            "SAMN16100343",
+            "SAMN16100344",
+            "SAMN16100345",
+            "SAMN16100346"
+          ],
+          "organ": [
+            "blood"
+          ],
+          "organPart": [
+            null
+          ],
+          "disease": [
+            "HIV infectious disease"
+          ],
+          "preservationMethod": [
+            null
+          ],
+          "source": [
+            "specimen_from_organism"
+          ]
+        }
+      ],
+      "cellLines": [
+
+      ],
+      "donorOrganisms": [
+        {
+          "id": [
+            "donor_PID_168",
+            "donor_PID_471",
+            "donor_PID_529",
+            "donor_PID_630"
+          ],
+          "donorCount": 4,
+          "developmentStage": [
+            "human adult stage"
+          ],
+          "genusSpecies": [
+            "Homo sapiens"
+          ],
+          "organismAge": [
+            {
+              "value": "36.0",
+              "unit": "year"
+            },
+            {
+              "value": "58.0",
+              "unit": "year"
+            },
+            {
+              "value": "59.0",
+              "unit": "year"
+            },
+            {
+              "value": "60.0",
+              "unit": "year"
+            }
+          ],
+          "organismAgeRange": [
+            [
+              1135296000.0,
+              1135296000.0
+            ],
+            [
+              1829088000.0,
+              1829088000.0
+            ],
+            [
+              1860624000.0,
+              1860624000.0
+            ],
+            [
+              1892160000.0,
+              1892160000.0
+            ]
+          ],
+          "biologicalSex": [
+            "male"
+          ],
+          "disease": [
+            "HIV infectious disease"
+          ]
+        }
+      ],
+      "organoids": [
+
+      ],
+      "cellSuspensions": [
+        {
+          "organ": [
+            "blood"
+          ],
+          "organPart": [
+            null
+          ],
+          "selectedCellType": [
+            null
+          ],
+          "totalCells": null
+        }
+      ],
+      "dates": [
+        {
+          "aggregateLastModifiedDate": "2021-09-30T17:37:46.691000Z",
+          "aggregateSubmissionDate": "2021-03-19T12:13:31.447000Z",
+          "aggregateUpdateDate": "2021-09-30T17:37:46.691000Z",
+          "lastModifiedDate": "2021-09-30T17:37:46.691000Z",
+          "submissionDate": "2021-03-19T12:13:31.447000Z",
+          "updateDate": "2021-09-30T17:37:46.691000Z"
+        }
+      ],
+      "fileTypeSummaries": [
+        {
+          "count": 124,
+          "fileSource": [
+            null
+          ],
+          "totalSize": 106183323408,
+          "matrixCellCount": null,
+          "format": "fastq.gz",
+          "isIntermediate": null,
+          "contentDescription": [
+            "DNA sequence"
+          ]
+        },
+        {
+          "count": 4,
+          "fileSource": [
+            "DCP/2 Analysis"
+          ],
+          "totalSize": 4560503185,
+          "matrixCellCount": null,
+          "format": "loom",
+          "isIntermediate": true,
+          "contentDescription": [
+            "Count Matrix"
+          ]
+        },
+        {
+          "count": 1,
+          "fileSource": [
+            "DCP/2 Analysis"
+          ],
+          "totalSize": 677616697,
+          "matrixCellCount": null,
+          "format": "loom",
+          "isIntermediate": false,
+          "contentDescription": [
+            "Count Matrix"
+          ]
+        },
+        {
+          "count": 4,
+          "fileSource": [
+            "DCP/2 Analysis"
+          ],
+          "totalSize": 84883220489,
+          "matrixCellCount": null,
+          "format": "bam",
+          "isIntermediate": null,
+          "contentDescription": [
+            null
+          ]
+        },
+        {
+          "count": 1,
+          "fileSource": [
+            "GEO"
+          ],
+          "totalSize": 122654720,
+          "matrixCellCount": null,
+          "format": "tar",
+          "isIntermediate": false,
+          "contentDescription": [
+            "Matrix"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/test_data/azul/species_homo_sapiens.json
+++ b/test/test_data/azul/species_homo_sapiens.json
@@ -1,0 +1,331 @@
+{
+  "hits": [
+    {
+      "protocols": [
+        {
+          "workflow": [
+            "optimus_post_processing_v1.0.0",
+            "optimus_v4.2.3"
+          ]
+        },
+        {
+          "libraryConstructionApproach": [
+            "10X v2 sequencing"
+          ],
+          "nucleicAcidSource": [
+            "single cell"
+          ]
+        },
+        {
+          "instrumentManufacturerModel": [
+            "Illumina NextSeq 500"
+          ],
+          "pairedEnd": [
+            false
+          ]
+        }
+      ],
+      "entryId": "53c53cd4-8127-4e12-bc7f-8fe1610a715c",
+      "sources": [
+        {
+          "sourceId": "ccc0d8c3-ac34-44bb-9bb0-55e9ab67d858",
+          "sourceSpec": "tdr:datarepo-9e63ca34:snapshot/hca_prod_53c53cd481274e12bc7f8fe1610a715c__20220117_dcp2_20220307_dcp14:/0"
+        }
+      ],
+      "projects": [
+        {
+          "projectId": "53c53cd4-8127-4e12-bc7f-8fe1610a715c",
+          "projectTitle": "A Cellular Anatomy of the Normal Adult Human Prostate and Prostatic Urethra",
+          "projectShortname": "ProstateCellAtlas",
+          "laboratory": [
+            "Human Cell Atlas Data Coordination Platform",
+            "Strand Lab"
+          ],
+          "estimatedCellCount": 108700,
+          "projectDescription": "A comprehensive cellular anatomy of normal human prostate is essential for solving the cellular origins of benign prostatic hyperplasia and prostate cancer. The tools used to analyze the contribution of individual cell types are not robust. We provide a cellular atlas of the young adult human prostate and prostatic urethra using an iterative process of single-cell RNA sequencing (scRNA-seq) and flow cytometry on ∼98,000 cells taken from different anatomical regions. Immunohistochemistry with newly derived cell type-specific markers revealed the distribution of each epithelial and stromal cell type on whole mounts, revising our understanding of zonal anatomy. Based on discovered cell surface markers, flow cytometry antibody panels were designed to improve the purification of each cell type, with each gate confirmed by scRNA-seq. The molecular classification, anatomical distribution, and purification tools for each cell type in the human prostate create a powerful resource for experimental design in human prostate disease.",
+          "contributors": [
+            {
+              "institution": "UC Santa Cruz",
+              "contactName": "Rachel,A,Schwartz",
+              "projectRole": "data curator",
+              "laboratory": "Human Cell Atlas Data Coordination Platform",
+              "correspondingContributor": false,
+              "email": "rachelschwartz@ucsc.edu"
+            },
+            {
+              "institution": "UC Santa Cruz",
+              "contactName": "Parisa,,Nejad",
+              "projectRole": "data curator",
+              "laboratory": "Human Cell Atlas Data Coordination Platform",
+              "correspondingContributor": false,
+              "email": "pnejad@ucsc.edu"
+            },
+            {
+              "institution": "UT Southwestern",
+              "contactName": "Gervaise,H,Henry",
+              "projectRole": "computational scientist",
+              "laboratory": "Strand Lab",
+              "correspondingContributor": true,
+              "email": "gervaise.henry@utsouthwestern.edu"
+            },
+            {
+              "institution": "UC Santa Cruz",
+              "contactName": "William,,Sullivan",
+              "projectRole": "data curator",
+              "laboratory": "Human Cell Atlas Data Coordination Platform",
+              "correspondingContributor": false,
+              "email": "wisulliv@ucsc.edu"
+            }
+          ],
+          "publications": [
+            {
+              "publicationTitle": "A Cellular Anatomy of the Normal Adult Human Prostate and Prostatic Urethra",
+              "officialHcaPublication": false,
+              "publicationUrl": "https://www.cell.com/cell-reports/fulltext/S2211-1247(18)31877-1?_returnURL=https%3A%2F%2Flinkinghub.elsevier.com%2Fretrieve%2Fpii%2FS2211124718318771%3Fshowall%3Dtrue",
+              "doi": "10.1016/j.celrep.2018.11.086"
+            }
+          ],
+          "supplementaryLinks": [
+            "https://doi.org/10.25548/W-R8CM;  https://git.biohpc.swmed.edu/StrandLab/sc-TissueMapper_Pr; http://strandlab.net/analysis.php"
+          ],
+          "accessions": [
+            {
+              "namespace": "geo_series",
+              "accession": "GSE117403"
+            }
+          ],
+          "accessible": true
+        }
+      ],
+      "samples": [
+        {
+          "sampleEntityType": [
+            "specimens"
+          ],
+          "effectiveOrgan": [
+            "prostate gland"
+          ],
+          "id": [
+            "D17PrPz",
+            "D17PrTz",
+            "D27PrPz",
+            "D27PrTz",
+            "D35PrPz",
+            "D35PrTz"
+          ],
+          "organ": [
+            "prostate gland"
+          ],
+          "organPart": [
+            "peripheral zone of prostate",
+            "transition zone of prostate"
+          ],
+          "disease": [
+            "normal"
+          ],
+          "preservationMethod": [
+            "fresh"
+          ],
+          "source": [
+            "specimen_from_organism"
+          ]
+        }
+      ],
+      "specimens": [
+        {
+          "id": [
+            "D17PrPz",
+            "D17PrTz",
+            "D27PrPz",
+            "D27PrTz",
+            "D35PrPz",
+            "D35PrTz"
+          ],
+          "organ": [
+            "prostate gland"
+          ],
+          "organPart": [
+            "peripheral zone of prostate",
+            "transition zone of prostate"
+          ],
+          "disease": [
+            "normal"
+          ],
+          "preservationMethod": [
+            "fresh"
+          ],
+          "source": [
+            "specimen_from_organism"
+          ]
+        }
+      ],
+      "cellLines": [
+
+      ],
+      "donorOrganisms": [
+        {
+          "id": [
+            "D17",
+            "D27",
+            "D35"
+          ],
+          "donorCount": 3,
+          "developmentStage": [
+            "human adult stage"
+          ],
+          "genusSpecies": [
+            "Homo sapiens"
+          ],
+          "organismAge": [
+            {
+              "value": "25.0",
+              "unit": "year"
+            },
+            {
+              "value": "29.0",
+              "unit": "year"
+            },
+            {
+              "value": "31.0",
+              "unit": "year"
+            }
+          ],
+          "organismAgeRange": [
+            [
+              788400000.0,
+              788400000.0
+            ],
+            [
+              914544000.0,
+              914544000.0
+            ],
+            [
+              977616000.0,
+              977616000.0
+            ]
+          ],
+          "biologicalSex": [
+            "male"
+          ],
+          "disease": [
+            "normal"
+          ]
+        }
+      ],
+      "organoids": [
+
+      ],
+      "cellSuspensions": [
+        {
+          "organ": [
+            "prostate gland"
+          ],
+          "organPart": [
+            "peripheral zone of prostate",
+            "transition zone of prostate"
+          ],
+          "selectedCellType": [
+            "basal cell of prostate epithelium",
+            "epithelial cell of prostate",
+            "fibroblast of connective tissue of prostate",
+            "luminal cell of prostate epithelium",
+            "prostate epithelial cell",
+            "prostate stromal cell",
+            "smooth muscle cell of prostate"
+          ],
+          "totalCells": 108701
+        }
+      ],
+      "dates": [
+        {
+          "aggregateLastModifiedDate": "2021-09-30T17:38:55.685000Z",
+          "aggregateSubmissionDate": "2021-05-13T22:14:48.756000Z",
+          "aggregateUpdateDate": "2021-09-30T17:38:55.685000Z",
+          "lastModifiedDate": "2021-09-30T17:38:55.685000Z",
+          "submissionDate": "2021-05-13T22:14:48.756000Z",
+          "updateDate": "2021-09-30T17:38:55.685000Z"
+        }
+      ],
+      "fileTypeSummaries": [
+        {
+          "count": 32,
+          "fileSource": [
+            null
+          ],
+          "totalSize": 371800015176,
+          "matrixCellCount": null,
+          "format": "fastq.gz",
+          "isIntermediate": null,
+          "contentDescription": [
+            "DNA sequence"
+          ]
+        },
+        {
+          "count": 16,
+          "fileSource": [
+            "DCP/2 Analysis"
+          ],
+          "totalSize": 22068537401,
+          "matrixCellCount": null,
+          "format": "loom",
+          "isIntermediate": true,
+          "contentDescription": [
+            "Count Matrix"
+          ]
+        },
+        {
+          "count": 16,
+          "fileSource": [
+            "DCP/2 Analysis"
+          ],
+          "totalSize": 384697792085,
+          "matrixCellCount": null,
+          "format": "bam",
+          "isIntermediate": null,
+          "contentDescription": [
+            null
+          ]
+        },
+        {
+          "count": 3,
+          "fileSource": [
+            "GEO"
+          ],
+          "totalSize": 475803421,
+          "matrixCellCount": null,
+          "format": "mtx.gz",
+          "isIntermediate": false,
+          "contentDescription": [
+            "Matrix"
+          ]
+        },
+        {
+          "count": 6,
+          "fileSource": [
+            "GEO"
+          ],
+          "totalSize": 1232335,
+          "matrixCellCount": null,
+          "format": "tsv.gz",
+          "isIntermediate": false,
+          "contentDescription": [
+            "Matrix"
+          ]
+        },
+        {
+          "count": 1,
+          "fileSource": [
+            "DCP/2 Analysis"
+          ],
+          "totalSize": 1528939804,
+          "matrixCellCount": null,
+          "format": "loom",
+          "isIntermediate": false,
+          "contentDescription": [
+            "Count Matrix"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
#### BACKGROUND
Due to how the logic of simulating keyword searches in Azul is implemented in SCP, we often run into an issue with some keywords resulting in very large compound query objects due to the amount of matches given for possible hits.  This will then result in an `HTTP 413 Payload Too Large` or `HTTP 414 URI Too Long` error from Azul, and no results are returned to the user.  Furthermore, even if the request does go through, usually no results are returned at all due to the fact that Azul does not natively support keyword based search only supports `AND` logic across facets, as opposed to `OR` logic which is expected of any keyword-based search.

#### CHANGES
This update addresses both issues by taking the compound query object created from the keyword search and splitting out each facet into a separate search, and then joining the results after.  The search requests are parallelized in separate threads to reduce overall latency.  Furthermore, all common stop words (stored in `StudySearchService::STOP_WORDS`) and the terms `cell` and `cells` are now ignored when attempting to find possible matches, as are any terms shorter than 3 characters.  This mirrors functionality in SCP-based searches, and removes many spurious matches due to the preponderance of the term `cell`, as well as partial string matches on single/double characters.  Note: quoted phrases such as `"B cell"` are still honored and treated as a single term.  This update also fixes a subtle bug with search term highlighting were actual matches were not being properly passed from the API to the UI.

It should be noted that a very large keyword search could result in slow load times for search results, especially if pagination is required.  This should be monitored in MixPanel to ascertain whether or not more performance tuning is required.  Limited testing has shown that the performance is roughly on par with current facet-based searches in Azul.

This update also addresses a recently found issue with `dependabot` PRs not being able to run CI due to a problem in formatting the Docker image tag.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Enter the following query in the text search box: `Tumor and immune reprogramming during immunotherapy in advanced renal cell carcinoma` (no quotes)
3. Confirm the search executes and returns HCA results, such as [The immune cell atlas of human neuroblastoma](https://data.humancellatlas.org/explore/projects/8f630e0f-6bf9-4a04-9754-02533152a954)
4. In `development.log`, note the following logging statements regarding query splitting:
```
Started GET "/single_cell/api/v1/search?type=study&page=1&terms=Tumor%20and%20immune%20reprogramming%20during%20immunotherapy%20in%20advanced%20renal%20cell%20carcinoma" for 127.0.0.1 at 2022-09-08 12:47:44 -0400
Processing by Api::V1::SearchController#index as JSON
  Parameters: {"type"=>"study", "page"=>"1", "terms"=>"Tumor and immune reprogramming during immunotherapy in advanced renal cell carcinoma", "search"=>{}}
Performing keyword-based search using ["Tumor", "immune", "reprogramming", "immunotherapy", "advanced", "renal", "cell", "carcinoma"]
Found 21 studies in keyword search: ["SCP24", "SCP68", "SCP53", "SCP15", "SCP69", "SCP17", "SCP66", "SCP18", "SCP13", "SCP61", "SCP55", "SCP25", "SCP21", "SCP63", "SCP22", "SCP64", "SCP14", "SCP47", "SCP36", "SCP58", "SCP67"]
Executing Azul project query with: {"organ"=>{"is"=>["tumor", "Immune system", "immune organ", "immune system", "adrenal gland", "renal system"]}, "sampleDisease"=>{"is"=>["autoimmune encephalitis", "Abnormal renal physiology", "end stage renal failure", "breast adenocarcinoma", "breast carcinoma", "breast ductal adenocarcinoma", "breast lobular carcinoma", "carcinoma of floor of mouth", "carcinoma of supraglottis", "diffuse gastric adenocarcinoma", "endometrioid adenocarcinoma", "hepatocellular carcinoma", "invasive breast carcinoma", "invasive ductal breast carcinoma", "laryngeal carcinoma", "luminal B breast carcinoma", "non-small cell lung carcinoma", "oral cavity carcinoma", "pancreatic adenosquamous carcinoma", "pancreatic ductal adenocarcinoma", "squamous cell carcinoma of buccal mucosa", "tonsil carcinoma"]}, "libraryConstructionApproach"=>{"is"=>["10x immune profiling"]}, "selectedCellType"=>{"is"=>["cd4neg cd45pos immune cell"]}, "organPart"=>{"is"=>["renal medulla", "renal pelvis"]}}
Splitting above query into 5 requests and joining results
```
5. Run a search for `"B cell"` (with quotes) and note that the HCA project [Single-cell analysis of human B cell maturation predicts how antibody class switching shapes selection dynamics](https://data.humancellatlas.org/explore/projects/24d0dbbc-54eb-4904-8141-934d26f1c936) is still returned (same as production)
6. Sign into [production](https://singlecell.broadinstitute.org/single_cell) and run a search for `pulmonary fibrosis lung`, noting that no HCA results are returned (you can page through if you want, but there should not be any due to compound query)
7. Run the same search locally and note the top 3 hits are all HCA and highly relevant:
    * [Single-Cell Transcriptomic Analysis of Human Lung Provides Insights into the Pathobiology of Pulmonary Fibrosis](https://data.humancellatlas.org/explore/projects/daf9d982-7ce6-43f6-ab51-272577290606)
    * [Single-cell RNA-sequencing reveals profibrotic roles of distinct epithelial and mesenchymal lineages in pulmonary fibrosis](https://data.humancellatlas.org/explore/projects/c1a9a93d-d9de-4e65-9619-a9cec1052eaa)
    * [Single Cell RNA-seq reveals ectopic and aberrant lung resident cell populations in Idiopathic Pulmonary Fibrosis](https://data.humancellatlas.org/explore/projects/c16a754f-5da3-46ed-8c1e-6426af2ef625)