### PR TITLE
Add the necessary wiring for Appcues events to go to Mixpanel (SCP-4659)

### DIFF
--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -98,6 +98,8 @@ export function logClick(event) {
     // https://docs.appcues.com/article/161-javascript-api
     window.Appcues.track('Click Event')
     window.Appcues.on('all', (eventName, event) => {
+      // Event prop building borrowed from Terra UI
+      // https://github.com/DataBiosphere/terra-ui/pull/2463/files
       const eventProps = {
         'appcues.flowId': event.flowId,
         'appcues.flowName': event.flowName,

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -94,38 +94,7 @@ export function logClick(event) {
   }
 
   if (window.Appcues) {
-    // Logs Appcues public events to Mixpanel
-    // https://docs.appcues.com/article/161-javascript-api
-    window.Appcues.track('Click Event')
-    window.Appcues.on('all', (eventName, event) => {
-      // Event prop building borrowed from Terra UI
-      // https://github.com/DataBiosphere/terra-ui/pull/2463/files
-      const eventProps = {
-        'appcues.flowId': event.flowId,
-        'appcues.flowName': event.flowName,
-        'appcues.flowType': event.flowType,
-        'appcues.flowVersion': event.flowVersion,
-        'appcues.id': event.id,
-        'appcues.interaction.category': event.interaction?.category,
-        'appcues.interaction.destination': event.interaction?.destination,
-        'appcues.interaction.element': event.interaction?.element,
-        'appcues.interaction.fields': JSON.stringify(event.interaction?.fields),
-        'appcues.interaction.formId': event.interaction?.formId,
-        'appcues.interaction.text': event.interaction?.text, // not documented by Appcues, but observed and useful
-        'appcues.interactionType': event.interactionType,
-        'appcues.localeId': event.localeId,
-        'appcues.localeName': event.localeName,
-        'appcues.name': event.name,
-        'appcues.sessionId': event.sessionId,
-        'appcues.stepChildId': event.stepChildId,
-        'appcues.stepChildNumber': event.stepChildNumber,
-        'appcues.stepId': event.stepId,
-        'appcues.stepNumber': event.stepNumber,
-        'appcues.stepType': event.stepType,
-        'appcues.timestamp': event.timestamp
-      }
-      log(eventName, eventProps)
-    })
+    logAppcuesClicks()
   }
 
   // we use closest() so we don't lose clicks on, e.g. icons within a link/button
@@ -139,6 +108,43 @@ export function logClick(event) {
   } else if (target.closest('.log-click').length > 0) {
     logClickOther(target.closest('.log-click')[0])
   }
+}
+
+/**
+ * Logs Appcues public events to Mixpanel
+ * https://docs.appcues.com/article/161-javascript-api
+ *
+ * Event prop building borrowed from Terra UI
+ * https://github.com/DataBiosphere/terra-ui/pull/2463/files
+ */
+function logAppcuesClicks() {
+  window.Appcues.on('all', (eventName, event) => {
+    const eventProps = {
+      'appcues.flowId': event.flowId,
+      'appcues.flowName': event.flowName,
+      'appcues.flowType': event.flowType,
+      'appcues.flowVersion': event.flowVersion,
+      'appcues.id': event.id,
+      'appcues.interaction.category': event.interaction?.category,
+      'appcues.interaction.destination': event.interaction?.destination,
+      'appcues.interaction.element': event.interaction?.element,
+      'appcues.interaction.fields': JSON.stringify(event.interaction?.fields),
+      'appcues.interaction.formId': event.interaction?.formId,
+      'appcues.interaction.text': event.interaction?.text, // not documented by Appcues, but observed and useful
+      'appcues.interactionType': event.interactionType,
+      'appcues.localeId': event.localeId,
+      'appcues.localeName': event.localeName,
+      'appcues.name': event.name,
+      'appcues.sessionId': event.sessionId,
+      'appcues.stepChildId': event.stepChildId,
+      'appcues.stepChildNumber': event.stepChildNumber,
+      'appcues.stepId': event.stepId,
+      'appcues.stepNumber': event.stepNumber,
+      'appcues.stepType': event.stepType,
+      'appcues.timestamp': event.timestamp
+    }
+    log(eventName, eventProps)
+  })
 }
 
 /** Log clicks on SVG element of analytics interest */

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -144,6 +144,7 @@ function logAppcuesClicks() {
       'appcues.timestamp': event.timestamp
     }
     log(eventName, eventProps)
+    log('appcues:event', eventProps)
   })
 }
 

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -93,7 +93,38 @@ export function logClick(event) {
     return
   }
 
-  window.Appcues && window.Appcues.track('Click Event')
+  if (window.Appcues) {
+    // Logs Appcues public events to Mixpanel
+    // https://docs.appcues.com/article/161-javascript-api
+    window.Appcues.track('Click Event')
+    window.Appcues.on('all', (eventName, event) => {
+      const eventProps = {
+        'appcues.flowId': event.flowId,
+        'appcues.flowName': event.flowName,
+        'appcues.flowType': event.flowType,
+        'appcues.flowVersion': event.flowVersion,
+        'appcues.id': event.id,
+        'appcues.interaction.category': event.interaction?.category,
+        'appcues.interaction.destination': event.interaction?.destination,
+        'appcues.interaction.element': event.interaction?.element,
+        'appcues.interaction.fields': JSON.stringify(event.interaction?.fields),
+        'appcues.interaction.formId': event.interaction?.formId,
+        'appcues.interaction.text': event.interaction?.text, // not documented by Appcues, but observed and useful
+        'appcues.interactionType': event.interactionType,
+        'appcues.localeId': event.localeId,
+        'appcues.localeName': event.localeName,
+        'appcues.name': event.name,
+        'appcues.sessionId': event.sessionId,
+        'appcues.stepChildId': event.stepChildId,
+        'appcues.stepChildNumber': event.stepChildNumber,
+        'appcues.stepId': event.stepId,
+        'appcues.stepNumber': event.stepNumber,
+        'appcues.stepType': event.stepType,
+        'appcues.timestamp': event.timestamp
+      }
+      log(eventName, eventProps)
+    })
+  }
 
   // we use closest() so we don't lose clicks on, e.g. icons within a link/button
   // (and we have to use $.closest since IE still doesn't have built-in support for it)


### PR DESCRIPTION
Adding the necessary wiring to get Appcues events to Mixpanel.
Relevant slack threads: https://broadinstitute.slack.com/archives/CBEHTH601/p1662649411099869 and https://broadinstitute.slack.com/archives/CBEHTH601/p1662742945836799

To test:
- pull this branch
- Head over to Appcues Studio here: https://studio.appcues.com/journeys/f4e48214-3684-4aa0-b62e-dd5b30e6b915/conditions
- This flow is a copy of our prod flow and is only enabled on localhost, currently enabled to everytime you go to the explore tab of study SCP60. If you don't have an SCP60 update the allowed URL/pages to include a study you do have access to or feel free to remove the study specific option. IMPORTANT - DO NOT REMOVE the "single_cell/study" "#study-visualize" filters as this is what keeps this from showing on Terra localhost (and I was told folks get fussy if Appcues start popping up over there)
- Once the appcues flow is configured boot up the portal and go to your study in localhost
- Observe the appcue pop up and look for events in the network tab titled like "`Flow started`, `flow skipped`
- Or look in Mixpanel dev version and see events come through for Appcues

![Screen Shot 2022-09-09 at 3 39 42 PM](https://user-images.githubusercontent.com/54322292/189434243-cf33146c-4ce6-42ed-93b0-b9af8cd9ffea.png)

![Screen Shot 2022-09-09 at 3 42 20 PM](https://user-images.githubusercontent.com/54322292/189434264-b44538a5-3b8d-4765-94b0-d89899f444e4.png)
