### PR TITLE
Convert all request params into hex digest for API caching (SCP-4654)

### DIFF
--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -17,29 +17,24 @@ class RequestUtils
   # Cache path methods
   ##
 
+  # get a unique cache path for an individual request
+  # will result in paths with fixed lengths, such as
+  # _single_cell_api_v1_clusters_SCP1234_f6c41dbf8f1760d7dc1b36a3db7c05ec56049a0bdc54644639005c0e41bd7490
   def self.get_cache_path(request_path, url_params)
     # transform / into _ to avoid encoding as %2f
     sanitized_path = sanitize_value_for_cache(request_path)
-    # remove unwanted parameters from cache_key, as well as empty values
-    # this simplifies base key into smaller value, e.g. _single_cell_api_v1_studies_SCP123_explore_
-    # parameters must also be sorted by name to ensure cache paths are idempotent
-    params_key = url_params.reject {|name, value| CACHE_PATH_EXCLUDE_LIST.include?(name) || value.empty?}.sort_by {|k,v| k}.
-      map do |parameter_name, parameter_value|
-      if parameter_name == 'genes'
-        "#{parameter_name}_#{construct_gene_list_hash(parameter_value)}"
-      else
-        "#{parameter_name}_#{sanitize_value_for_cache(parameter_value).split.join('_')}"
-      end
-    end
-    [sanitized_path, params_key].join('_')
+    digest_key = construct_params_digest(url_params)
+    [sanitized_path, digest_key].join('_')
   end
 
-  # create a unique hex digest of a list of genes for use in get_cache_key
-  # this prevents long gene list queries from being split in the middle due to maximum filename length limits
+  # create a unique hex digest for a hash of request parameters
+  # parameters are sorted to ensure idempotency of resulting digest, which is critical for cache management
+  # this prevents long parameter lists from being split in the middle due to maximum filename length limits
   # and resulting in invalid % encoding issue when trying to clear selected cache entries
-  def self.construct_gene_list_hash(query_list)
-    genes = query_list.split(',').map {|gene| gene.strip.gsub(/(%|\/)/, '')}.sort.join
-    Digest::SHA256.hexdigest genes
+  def self.construct_params_digest(params)
+    sorted_params = params.reject { |name, value| CACHE_PATH_EXCLUDE_LIST.include?(name) || value.empty? }
+                          .sort_by { |key, _| key }.flatten
+    Digest::SHA256.hexdigest sorted_params.join
   end
 
   ##

--- a/test/integration/lib/request_utils_test.rb
+++ b/test/integration/lib/request_utils_test.rb
@@ -86,4 +86,31 @@ class RequestUtilsTest < ActiveSupport::TestCase
       assert RequestUtils.static_asset_error?(asset_error)
     end
   end
+
+  test 'should set reproducible cache path on viz API requests' do
+    path = '/single_cell/api/v1/clusters/SCP1234'
+    parameters = {
+      annotation_name: 'cell_type__ontology_label',
+      annotation_scope: 'study',
+      annotation_type: 'group',
+      cluster_name: 'All Cells UMAP',
+      fields: 'coordinates,cells,annotation',
+      subsample: 'all',
+      study_id: 'SCP1234'
+    }
+    expected_digest = '14ea419f44c73ecaf4740526bf7e8c5a54f48b850c197567a3356ae47577c07d'
+    expected_path = "_single_cell_api_v1_clusters_SCP1234_#{expected_digest}"
+    assert_equal expected_path, RequestUtils.get_cache_path(path, parameters)
+    # reorder parameters to ensure idempotency
+    new_params = {
+      annotation_type: 'group',
+      subsample: 'all',
+      annotation_scope: 'study',
+      cluster_name: 'All Cells UMAP',
+      fields: 'coordinates,cells,annotation',
+      study_id: 'SCP1234',
+      annotation_name: 'cell_type__ontology_label'
+    }
+    assert_equal expected_path, RequestUtils.get_cache_path(path, new_params)
+  end
 end

--- a/test/integration/lib/request_utils_test.rb
+++ b/test/integration/lib/request_utils_test.rb
@@ -88,25 +88,25 @@ class RequestUtilsTest < ActiveSupport::TestCase
   end
 
   test 'should set reproducible cache path on viz API requests' do
-    path = '/single_cell/api/v1/clusters/SCP1234'
+    path = '/single_cell/api/v1/clusters/SCP1234/UMAP'
     parameters = {
       annotation_name: 'cell_type__ontology_label',
       annotation_scope: 'study',
       annotation_type: 'group',
-      cluster_name: 'All Cells UMAP',
+      cluster_name: 'UMAP',
       fields: 'coordinates,cells,annotation',
       subsample: 'all',
       study_id: 'SCP1234'
     }
-    expected_digest = '14ea419f44c73ecaf4740526bf7e8c5a54f48b850c197567a3356ae47577c07d'
-    expected_path = "_single_cell_api_v1_clusters_SCP1234_#{expected_digest}"
+    expected_digest = '50122a95a87f2ffa6be253a216f662388988c2e61e530e8d9423b8c97b7c1d60'
+    expected_path = "_single_cell_api_v1_clusters_SCP1234_UMAP_#{expected_digest}"
     assert_equal expected_path, RequestUtils.get_cache_path(path, parameters)
     # reorder parameters to ensure idempotency
     new_params = {
       annotation_type: 'group',
       subsample: 'all',
       annotation_scope: 'study',
-      cluster_name: 'All Cells UMAP',
+      cluster_name: 'UMAP',
       fields: 'coordinates,cells,annotation',
       study_id: 'SCP1234',
       annotation_name: 'cell_type__ontology_label'


### PR DESCRIPTION
#### BACKGROUND
Visualization API responses are cached for better performance, and each response encodes its parameters into a unique key to allow for easy clearing of caches.  Request parameters are included as plain text in the cache path to help generate this unique key.  This can give rise to errors when clearing caches where certain parameter values are URL-encoded (e.g. `%2f` for `/`), but then those strings would be split inside the percent expression due to filename length limits in linux.  This can cause the `CacheRemovalJob` to throw errors such as `invalid %-encoding` or `invalid byte sequence in UTF-8`.

#### CHANGES
This update now collects and sorts all request parameters and then computes a hex digest of those values to append onto the end of the request path.  This retains the uniqueness of cache entries while remaining deterministic, and results in cache paths that are fairly consistent in length.  For instance, a cache path before this change would look something like this:
```
_single_cell_api_v1_studies_SCP63_clusters_cluster_tsv_annotation_name_biosample_id_annotation_scope_study_annotation_type_group_cluster_name_cluster_tsv_fields_coordinates_cells_annotation_subsample_all
```
Now, this path is condensed into the following:
```
_single_cell_api_v1_studies_SCP63_clusters_cluster_tsv_8621f4a717a3a3fa4aaa58b596c6ee950d1aaac6d1c257bbe7235ed96e7cf8fa
```
Since the study accession is still present, we can continue clearing caches as we always have as this is the only request parameter that we use when determining which entries to remove.  

#### MANUAL TESTING
1. Boot as normal and ensure that request caching is turned on (run `bin/rails dev:cache` in the terminal until you see the message `Development mode is now being cached.`)
2. Load any study with visualizations enabled, and select various clusters/annotations, making sure to toggle back and forth between several values so that some are requested more than once
3. Confirm new requests have messages in `development.log` like the following:
```
Writing to API cache: _single_cell_api_v1_studies_SCP75_clusters_Cluster_1_5f129e12e78bbb214391f9ba4dfd31bc9f538cc0b3fdb9db27d9cf389c19d9e1
```
4. Issuing the same request again should show as a hit in the cache and that execution halts and renders immediately:
```
Reading from API cache: _single_cell_api_v1_studies_SCP75_clusters_Cluster_1_5f129e12e78bbb214391f9ba4dfd31bc9f538cc0b3fdb9db27d9cf389c19d9e1
Filter chain halted as :check_api_cache! rendered or redirected
```