### PR TITLE
Enable Image Pipeline to run via PAPI (SCP-4639)

### DIFF
--- a/image-pipeline/.dockerignore
+++ b/image-pipeline/.dockerignore
@@ -1,0 +1,11 @@
+# Ignore Node runtime assets
+node_modules/
+
+# Ignore editor configuration
+.idea/
+.vscode/
+
+# Ignore other detritus
+*.log
+.DS_Store
+.git/

--- a/image-pipeline/Dockerfile
+++ b/image-pipeline/Dockerfile
@@ -1,0 +1,40 @@
+# Dockerfile for SCP Image Pipeline
+#
+# PREREQUISITES
+# Run the following command to register gcloud as a Docker credential helper:
+# gcloud auth configure-docker
+
+# TODO:
+# ^ Put this in a Bash script
+
+# Use a managed base image from Google.  It is continually updated for
+# security fixes (thus the "latest" tag).
+# https://github.com/GoogleContainerTools/base-images-docker/tree/master/ubuntu
+FROM marketplace.gcr.io/google/ubuntu2004:latest
+
+# RUN echo "Uncomment to clear cached layers below this statement (2020-01-07-0947)"
+
+# Install Node
+ENV NODE_VERSION=18.6.0
+RUN apt install -y curl
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+ENV NVM_DIR=/root/.nvm
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+RUN node --version
+RUN npm --version
+RUN npm install -g yarn
+
+# Copy contents of this directory into the Docker image
+# (See .Dockerignore for omitted files)
+COPY . image-pipeline
+
+WORKDIR /image-pipeline
+
+# Install JS dependencies
+RUN yarn install
+
+WORKDIR /image-pipeline
+CMD ["node", "expression-scatter-plots", "--help"]

--- a/image-pipeline/Dockerfile
+++ b/image-pipeline/Dockerfile
@@ -16,6 +16,14 @@ FROM marketplace.gcr.io/google/ubuntu2004:latest
 
 # Install Node
 ENV NODE_VERSION=18.6.0
+RUN apt-get update \
+    && apt-get install -y wget gnupg \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
 RUN apt install -y curl
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm

--- a/image-pipeline/expression-scatter-plots.js
+++ b/image-pipeline/expression-scatter-plots.js
@@ -28,7 +28,7 @@ const options = {
 }
 const { values } = parseArgs({ args, options })
 
-const timeoutMinutes = 10 // 0.75
+const timeoutMinutes = 0.75
 
 // Candidates for CLI argument
 // CPU count on Intel i7 is 1/2 of reported, due to hyperthreading
@@ -341,6 +341,7 @@ async function processScatterPlotImages(genes, context) {
     // Helpful for local development iterations
     const humanMilkDePilotAccessions = ['SCP138', 'SCP303', 'SCP1671'] // dev, staging, prod
     if (humanMilkDePilotAccessions.includes(accession) && gene === 'A1BG-AS1') {
+      print('Encountered debug stop gene, exiting', preamble)
       process.exit()
     }
   }

--- a/image-pipeline/expression-scatter-plots.js
+++ b/image-pipeline/expression-scatter-plots.js
@@ -339,9 +339,10 @@ async function processScatterPlotImages(genes, context) {
     print(`Expression plot time for gene ${gene}: ${expressionPlotPerfTime} ms`, preamble)
 
     // Helpful for local development iterations
-    // if (accession === 'SCP138' && gene === 'A1BG-AS1') {
-    //   exit()
-    // }
+    const humanMilkDePilotAccessions = ['SCP138', 'SCP303', 'SCP1671'] // dev, staging, prod
+    if (humanMilkDePilotAccessions.includes(accession) && gene === 'A1BG-AS1') {
+      process.exit()
+    }
   }
 
   await browser.close()

--- a/image-pipeline/expression-scatter-plots.js
+++ b/image-pipeline/expression-scatter-plots.js
@@ -22,7 +22,8 @@ const options = {
   'accession': { type: 'string' }, // SCP accession
   'cluster': { type: 'string' }, // Name of clustering
   'cores': { type: 'string' }, // Number of CPU cores to use. Default: all - 1
-  'debug': { type: 'boolean' }, // Whether to show browser UI and DevTools
+  'debug': { type: 'boolean' }, // Whether to show browser UI and exit early
+  'debug-headless': { type: 'boolean' }, // Whether to exit early; for PAPI debugging
   'environment': { type: 'string' }, // development, staging, or production
   'json-dir': { type: 'string' } // Path to expression arrays; for development
 }
@@ -340,7 +341,10 @@ async function processScatterPlotImages(genes, context) {
 
     // Helpful for local development iterations
     const humanMilkDePilotAccessions = ['SCP138', 'SCP303', 'SCP1671'] // dev, staging, prod
-    if (humanMilkDePilotAccessions.includes(accession) && gene === 'A1BG-AS1') {
+    if (
+      (values['debug'] || values['debug-headless']) &&
+      humanMilkDePilotAccessions.includes(accession) && gene === 'A1BG-AS1'
+    ) {
       print('Encountered debug stop gene, exiting', preamble)
       process.exit()
     }

--- a/image-pipeline/expression-scatter-plots.js
+++ b/image-pipeline/expression-scatter-plots.js
@@ -294,10 +294,10 @@ async function processScatterPlotImages(genes, context) {
   // Cert args needed for localhost; doesn't hurt in other environments
   if (values.debug) {
     browser = await puppeteer.launch({
-      headless: false, devtools: true, acceptInsecureCerts: true, args: ['--ignore-certificate-errors']
+      headless: false, devtools: true, acceptInsecureCerts: true, args: ['--ignore-certificate-errors', '--no-sandbox']
     })
   } else {
-    browser = await puppeteer.launch({ acceptInsecureCerts: true, args: ['--ignore-certificate-errors'] })
+    browser = await puppeteer.launch({ acceptInsecureCerts: true, args: ['--ignore-certificate-errors', '--no-sandbox'] })
   }
   const page = await browser.newPage()
   await page.setViewport({


### PR DESCRIPTION
This lets Image Pipeline run on the Google Cloud Genomics Pipelines API (PAPI), like our [Ingest Pipeline](https://github.com/broadinstitute/scp-ingest-pipeline).

[Previously](https://github.com/broadinstitute/single_cell_portal_core/pull/1616), Image Pipeline could not leverage our solution for horizontal compute beyond a single machine; now it can.  That's a step towards generating ~100k images per study, which is needed to quickly visualize gene expression scatter plots for large datasets.

This adds a new Docker runtime environment, [uploaded](https://console.cloud.google.com/gcr/images/broad-singlecellportal-staging/global/image-pipeline?project=broad-singlecellportal-staging) to Google Cloud Registry (GCR), and run via PAPI.  

Notable differences in Image vs. Ingest Docker images:
* Image Pipeline runs Ubuntu 20.04, not 18.04
* Linux dependencies focus on Puppeteer and JavaScript, not Python

There's more to do on this line of infrastructure.  Next steps are to A) enable running this against our staging web server, for scalable non-production runs; and B) upload data (images, logs) to a bucket via [`@google-cloud/storage`](https://www.npmjs.com/package/@google-cloud/storage) [as a file](https://github.com/googleapis/nodejs-storage/blob/main/samples/uploadFile.js) or perhaps [from memory](https://github.com/googleapis/nodejs-storage/blob/main/samples/uploadFromMemory.js).  The scope here was to show we can run Puppeteer on Docker in PAPI, and that's done.

To test:
* Authenticate gcloud on terminal: `gcloud auth login`
* Confirm you're auth'd with your Broad account.  (Your Broad username should display instead of "eweitz".): 
```
gcloud auth list | grep "*"
*       eweitz@broadinstitute.org
```
* Put staging credentials in a local temporary directory: 
> `vault read secret/kdux/scp/staging/scp_service_account.json -format=json | jq .data > /tmp/scp_service_account_staging.json`
* Define the service account (SA) email address:
```
SA_EMAIL_ADDRESS=$(cat /tmp/scp_service_account_staging.json | jq -r .client_email)
```
* Run Image Pipeline via PAPI:
> `gcloud alpha genomics pipelines run --regions us-east1 --command-line 'export NODE_NO_WARNINGS=1; export NODE_TLS_REJECT_UNAUTHORIZED=0; node expression-scatter-plots.js --accession="SCP1671" --environment="production" --cores="1" --debug-headless; # human milk DE pilot' --docker-image gcr.io/broad-singlecellportal-staging/image-pipeline:0.0.1_c97a4d87e --service-account-email $SA_EMAIL_ADDRESS # Command to run Image Pipeline on PAPI`
* Confirm above command outputs a status including an operation ID (mine here is "6805090987568553570"):
```
Running [projects/broad-singlecellportal-staging/operations/6805090987568553570].
```
* Wait for job to complete, then describe its run metadata, replacing my operation ID with yours from above step:
> `OPERATION_ID=6805090987568553570; gcloud alpha genomics operations wait ${OPERATION_ID}; tput bel; gcloud alpha genomics operations describe ${OPERATION_ID} | grep exitStatus; tput bel`
* The `tput bel` bell should sound a note of completion within 3 minutes
* Confirm PAPI job succeeded; you should see:
```
exitStatus: 0
```

This test runs against production services to make two gene expression scatter plots.  Future work will let us generally run against services on staging rather than production for this kind of manual smoke test.  (Our development environments are local and not on the cloud, so PAPI can't reach our development SCP web app instances.)

The Image Pipeline Puppeteer includes a unique version string in user agent, letting us filter out noisy events from Mixpanel via `browser_version equals 9000`.  I've updated our ["Internal users" Mixpanel cohort](https://mixpanel.com/s/3uhQ6v) to do this, so internal humans _and_ internal puppets are excluded with our standard "Team is not Internal users" filter.

This satisfies SCP-4639.