### PR TITLE
Ignore case when filtering terms for Azul (SCP-4673)

### DIFF
--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -350,7 +350,7 @@ class HcaAzulClient
   #   - (Array<Hash>) => Array of facet objects to be fed to :format_query_from_facets
   def format_facet_query_from_keyword(term_list = [])
     matching_facets = []
-    sanitized_terms = (term_list - IGNORED_WORDS).reject { |t| t.size < 3 }
+    sanitized_terms = filter_term_list(term_list)
     sanitized_terms.each do |term|
       facets = SearchFacet.find_facets_from_term(term)
       next if facets.empty?
@@ -439,6 +439,17 @@ class HcaAzulClient
     validate_catalog_name(catalog)
     delimiter = api_path.include?('?') ? '&' : '?'
     "#{api_path}#{delimiter}catalog=#{catalog}"
+  end
+
+  # filter irrelevant terms from keyword query to increase relevance of search
+  #
+  # * *params*
+  #   - +term_list+ (Array) => list of terms to filter
+  #
+  # * *returns*
+  #   - (Array) => filtered list of terms
+  def filter_term_list(term_list)
+    (term_list.map(&:downcase) - IGNORED_WORDS).reject { |t| t.size < 3 }
   end
 
   private

--- a/test/integration/hca_azul_client_test.rb
+++ b/test/integration/hca_azul_client_test.rb
@@ -245,6 +245,14 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     assert_empty facets
   end
 
+  test 'should filter common/stop words from term lists' do
+    ignored_terms = HcaAzulClient::IGNORED_WORDS.sample(5)
+    assert_empty @hca_azul_client.filter_term_list(ignored_terms)
+    assert_empty @hca_azul_client.filter_term_list(ignored_terms.map(&:capitalize)) # case sensitivity
+    good_terms = %w[cancer brain human]
+    assert_equal good_terms, @hca_azul_client.filter_term_list(good_terms)
+  end
+
   test 'should merge query objects' do
     expected_query = {
       sampleDisease: {


### PR DESCRIPTION
#### BACKGROUND & CHANGES
Changes introduced in #1614 resulted in a corner case where terms that should have been ignored for queries in Azul were not filtered due to case sensitivity, resulting in `HTTP 413` errors again.  This update now converts all search terms to lower case before filtering.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Run a search for `Cell atlas of aqueous humor outflow pathways in eyes of humans and four model species provides insight into glaucoma pathogenesis`
3. Confirm the request succeeds and [Single-cell RNA-Seq Investigation of Foveal and Peripheral Expression in the Human Retina](https://data.humancellatlas.org/explore/projects/4bec484d-ca7a-47b4-8d48-8830e06ad6db) is returned from Azul
4. In `development.log`, note the query for Azul does not contain `Cell`:
```
Executing Azul project query with: {"sampleDisease"=>{"is"=>["glaucoma", "glaucoma (disease)"]}}
```