### PR TITLE
Move exact study name matches to top of search results (SCP-4674)

### DIFF
--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -79,6 +79,12 @@ class RequestUtils
     SANITIZER.sanitize(inputs).encode(Encoding.find('ASCII-8BIT'), invalid: :replace, undef: :replace)
   end
 
+  # convert a string into a format for matching
+  # will strip non-word characters and extraneous whitespace and downcase to make matching easier
+  def self.format_text_for_match(text)
+    text.split.map { |term| term.downcase.gsub(/\W/, '') }.reject(&:blank?).join(' ')
+  end
+
   # takes a comma-delimited string of ids (e.g. StudyFile ids) and returns an array of ids
   # raises Argument error if any of the strings are not valid ids
   def self.validate_id_list(id_list_string)

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -492,8 +492,11 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should reorder results for exact name match' do
-    studies = Api::V1::SearchController.promote_exact_match(@other_study.name,[@study, @other_study])
+    studies, match_data = Api::V1::SearchController.promote_exact_match(@other_study.name,
+                                                                        [@study, @other_study],
+                                                                        {})
     assert_equal @other_study.accession, studies.first.accession
+    assert_equal 1, match_data.with_indifferent_access['numResults:scp:exactTitle']
   end
 
   test 'should return initialized studies first in empty search' do

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -470,6 +470,32 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_value, sanitized_filter
   end
 
+  test 'should return study name exact match first without quotes' do
+    studies = []
+    5.times do
+      studies << FactoryBot.create(:detached_study,
+                                   name_prefix: "Search Promotion Test #{SecureRandom.uuid}",
+                                   public: true,
+                                   user: @user,
+                                   initialized: false,
+                                   test_array: @@studies_to_clean)
+    end
+    studies.each do |study|
+      detail = study.build_study_detail
+      detail.full_description = '<p>This is the description.</p>'
+      detail.save!
+    end
+    study_name = studies.sample.name
+    execute_http_request(:get, api_v1_search_path(type: 'study', terms: study_name))
+    assert_response :success
+    assert_equal study_name, json['studies'].first['name']
+  end
+
+  test 'should reorder results for exact name match' do
+    studies = Api::V1::SearchController.promote_exact_match(@other_study.name,[@study, @other_study])
+    assert_equal @other_study.accession, studies.first.accession
+  end
+
   test 'should return initialized studies first in empty search' do
     execute_http_request(:get, api_v1_search_path(type: 'study'))
     assert_response :success

--- a/test/integration/lib/request_utils_test.rb
+++ b/test/integration/lib/request_utils_test.rb
@@ -52,6 +52,12 @@ class RequestUtilsTest < ActiveSupport::TestCase
                  "Did not correctly sanitize characters from list; #{invalid_output} != #{sanitized_invalid_list}"
   end
 
+  test 'should format text for matching' do
+    search_string = '   ThiS iS a long %%  STRING with non\  word ... charaCTers    iN   It !!!!   '
+    expected_string = 'this is a long string with non word characters in it'
+    assert_equal expected_string, RequestUtils.format_text_for_match(search_string)
+  end
+
   test 'should format file path for os' do
     path = 'path/to/some/file.txt'
     unix_os_list = ['Mac OS X', 'macOSX', 'Generic Linux', 'Android', 'iOS (iPhone)']


### PR DESCRIPTION
#### BACKGROUND
Text-based searches us `OR` logic when entering multiple terms, but quoted strings are treated as a single entity.  However, most users when searching by the title of a paper/study do not think to quote the search, expecting the highest-relevance match would be the entry with the same name.  This is not always the case, and can leave the study the user was looking for buried in pages or results.

#### CHANGES
This update now attempts to match the entire search string against the names of studies in the results array, and promotes that match to the first entry, if found.  The logic for matching will be case-insensitive and ignore non-word characters to make it more permissive.  Using [`Enumerable#partition`](https://ruby-doc.org/core-3.1.2/Enumerable.html#method-i-partition) chained to [`Array#flatten`](https://ruby-doc.org/core-3.1.2/Array.html#method-i-flatten) will exit silently if no match is found.

#### MANUAL TESTING
1. Boot as normal
2. Once studies load on the home page, copy the exact title of one of the entries that is not the first result (e.g. `Male Mouse Brain`)
3. Paste the name into the search box without quoting
4. Confirm that study returns first