### PR TITLE
Remove unused docker artifacts after successful deployment (SCP-4551)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ to log in with their Google accounts.  To do so:
   * Click 'Create Credentials' > 'OAuth Client ID'
   * Select 'Web Application', and provide a name
   * For 'Authorized Javascript Origins', enter the following:
-    * `https://(your hostname)/single_cell`
+    * `https://(your hostname)`
   * For 'Authorized redirect URIs', enter the following:
     * `https://(your hostname)/single_cell/users/auth/google_oauth2/callback`
-    * `	https://(your hostname)/single_cell/api/swagger_docs/oauth2`
+    * `https://(your hostname)/single_cell/api/v1/oauth2_redirect`
   * Save the client id
   * You will also want to create a second OAuth Client ID to use in local development, using `localhost` as the hostname
 

--- a/bin/docker_utils.sh
+++ b/bin/docker_utils.sh
@@ -80,3 +80,37 @@ function ensure_container_running {
     done
     echo "$RUNNING"
 }
+
+# get all matching images, will return image IDs in the order of most recent first
+function get_matching_image_ids {
+    IMAGE_NAME="$1"
+    IMAGES=$(docker images | grep -F $IMAGE_NAME | awk '{ print $3 }')
+    echo $IMAGES
+}
+
+# remove all but the most recent release image
+function prune_docker_artifacts {
+    IMAGE_NAME="$1"
+    # get all matching images, then pop the first entry off
+    ALL_IMAGES=($(get_matching_image_ids $IMAGE_NAME))
+    RELEASE_IMAGE_ID="${ALL_IMAGES[1]}"
+    ALL_IMAGES=("${ALL_IMAGES[@]:1}")
+    RELEASE_IMAGE_NAME=$(get_image_tag_from_id $RELEASE_IMAGE_ID)
+    echo "Keeping $RELEASE_IMAGE_NAME image as most recent"
+    for IMAGE in $ALL_IMAGES; do
+        IMAGE_TAG=$(get_image_tag_from_id $IMAGE)
+        echo "Removing obsolete image $IMAGE_TAG"
+        docker rmi $IMAGE
+    done
+    # prune unused image layers and volumes
+    echo "pruning orphaned image layers"
+    docker image prune --force
+    echo "pruning orphaned volumes"
+    docker volume prune --force
+}
+
+# use docker inspect to get an image tag from ID
+function get_image_tag_from_id {
+    IMAGE_ID="$1"
+    echo $(docker image inspect $IMAGE_ID | jq '.[0].RepoTags[0]')
+}

--- a/bin/docker_utils.sh
+++ b/bin/docker_utils.sh
@@ -91,12 +91,15 @@ function get_matching_image_ids {
 # remove all but the most recent release image
 function prune_docker_artifacts {
     IMAGE_NAME="$1"
-    # get all matching images, then pop the first entry off
+    # get all matching images, then pop off the first two as "current" and "rollback" images
     ALL_IMAGES=($(get_matching_image_ids $IMAGE_NAME))
     RELEASE_IMAGE_ID="${ALL_IMAGES[1]}"
+    ALL_IMAGES=("${ALL_IMAGES[@]:1}") # remove first element and reindex
+    ROLLBACK_IMAGE_ID="${ALL_IMAGES[1]}"
     ALL_IMAGES=("${ALL_IMAGES[@]:1}")
     RELEASE_IMAGE_NAME=$(get_image_tag_from_id $RELEASE_IMAGE_ID)
-    echo "Keeping $RELEASE_IMAGE_NAME image as most recent"
+    ROLLBACK_IMAGE_NAME=$(get_image_tag_from_id $ROLLBACK_IMAGE_ID)
+    echo "Keeping $RELEASE_IMAGE_NAME as current, $ROLLBACK_IMAGE_NAME as rollback"
     for IMAGE in $ALL_IMAGES; do
         IMAGE_TAG=$(get_image_tag_from_id $IMAGE)
         echo "Removing obsolete image $IMAGE_TAG"
@@ -112,5 +115,5 @@ function prune_docker_artifacts {
 # use docker inspect to get an image tag from ID
 function get_image_tag_from_id {
     IMAGE_ID="$1"
-    echo $(docker image inspect $IMAGE_ID | jq '.[0].RepoTags[0]')
+    echo $(docker image inspect $IMAGE_ID | jq '.[0].RepoTags[0]' | sed r/\"//g)
 }

--- a/bin/remote_deploy.sh
+++ b/bin/remote_deploy.sh
@@ -83,7 +83,7 @@ function main {
     if [[ $(get_http_status_code $PORTAL_HOMEPAGE) != "200" ]] ; then exit_with_error_message "Portal still not available at $PORTAL_HOMEPAGE after 6 minutes, deployment failed" ; fi
     echo "### CLEANING UP SECRETS/OLD IMAGES ###"
     rm $PORTAL_SECRETS_PATH
-    docker image prune --force
+    prune_docker_artifacts $DOCKER_IMAGE_NAME
     echo "### DEPLOYMENT COMPLETED ###"
 }
 

--- a/bin/remote_deploy.sh
+++ b/bin/remote_deploy.sh
@@ -80,9 +80,10 @@ function main {
 		    sleep 15
 		    if [[ $(get_http_status_code $PORTAL_HOMEPAGE) = "200" ]]; then echo "DEBUG: hooray, got a 200 back from $PORTAL_HOMEPAGE";break 2; fi
     done
-    if [[ $(get_http_status_code $PORTAL_HOMEPAGE) != "200" ]] ; then exit_with_error_message "Portal still not available at $PORTAL_HOMEPAGE after 3 minutes, deployment failed" ; fi
-    echo "### Cleaning up ###"
+    if [[ $(get_http_status_code $PORTAL_HOMEPAGE) != "200" ]] ; then exit_with_error_message "Portal still not available at $PORTAL_HOMEPAGE after 6 minutes, deployment failed" ; fi
+    echo "### CLEANING UP SECRETS/OLD IMAGES ###"
     rm $PORTAL_SECRETS_PATH
+    docker image prune --force
     echo "### DEPLOYMENT COMPLETED ###"
 }
 


### PR DESCRIPTION
#### BACKGROUND
There is currently no automation to clean up unused Docker images/layers/volumes on deployed hosts.  As such, over time disks fill up and eventually lead to [broken deployments](https://scp-jenkins.dsp-techops.broadinstitute.org/job/scp-deploy-development-to-staging/823/console).

#### CHANGES
This update adds automation to remove any unused Docker images, as well as local volumes no longer associated with a running container.  A recent manual cleanup removed ~21 GiB of unused images & volumes on our staging server.  The two most recent images will be kept - the first is the current image in use, and the second is a rollback candidate, if needed.

This PR also contains a documentation fix regarding OAuth client IDs as defined in SCP-4686 (incorrect JavaScript origins/redirects).

#### MANUAL TESTING
The easiest way to test this is to manually pull several copies of our main Docker image and then run the cleanup command directly:
1. Start Docker and run the following commands to pull 3 copies of our Docker image:
    * `docker pull gcr.io/broad-singlecellportal-staging/single-cell-portal:1.25.0`
    * `docker pull gcr.io/broad-singlecellportal-staging/single-cell-portal:1.24.0`    
    * `docker pull gcr.io/broad-singlecellportal-staging/single-cell-portal:1.23.0`
2. Navigate to the `bin` directory inside the project source directory
3. Load the `docker_utils.sh` script with `source docker_utils.sh`
4. Run `prune_docker_artifacts 'gcr.io/broad-singlecellportal-staging/single-cell-portal'` and confirm that it removes the `1.23.0` image, keeping both `1.25.0` and `1.24.0`
5. Run `docker volume ls` and confirm there are no volumes left
6. Rerun `prune_docker_artifacts 'gcr.io/broad-singlecellportal-staging/single-cell-portal'` and confirm that no images are deleted