### PR TITLE
Fixing bug with array indexing in zsh vs bash (SCP-4551)

### DIFF
--- a/bin/docker_utils.sh
+++ b/bin/docker_utils.sh
@@ -90,13 +90,18 @@ function get_matching_image_ids {
 
 # remove all but the most recent release image
 function prune_docker_artifacts {
+    INDEX=0
+    if [[ "$SHELL" = '/bin/zsh' ]]; then
+        echo "zsh detected, setting array index to 1"
+        INDEX=1
+    fi
     IMAGE_NAME="$1"
     # get all matching images, then pop off the first two as "current" and "rollback" images
     ALL_IMAGES=($(get_matching_image_ids $IMAGE_NAME))
-    RELEASE_IMAGE_ID="${ALL_IMAGES[1]}"
-    ALL_IMAGES=("${ALL_IMAGES[@]:1}") # remove first element and reindex
-    ROLLBACK_IMAGE_ID="${ALL_IMAGES[1]}"
-    ALL_IMAGES=("${ALL_IMAGES[@]:1}")
+    RELEASE_IMAGE_ID="${ALL_IMAGES[$INDEX]}"
+    ALL_IMAGES=("${ALL_IMAGES[@]:$INDEX}") # remove first element and reindex
+    ROLLBACK_IMAGE_ID="${ALL_IMAGES[$INDEX]}"
+    ALL_IMAGES=("${ALL_IMAGES[@]:$INDEX}")
     RELEASE_IMAGE_NAME=$(get_image_tag_from_id $RELEASE_IMAGE_ID)
     ROLLBACK_IMAGE_NAME=$(get_image_tag_from_id $ROLLBACK_IMAGE_ID)
     echo "Keeping $RELEASE_IMAGE_NAME as current, $ROLLBACK_IMAGE_NAME as rollback"


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug with the difference in array indexing between `bash` and `zsh` as seen on [this recent deployment](https://scp-jenkins.dsp-techops.broadinstitute.org/job/scp-deploy-development-to-staging/826/console) (scroll to the bottom):
```
### CLEANING UP SECRETS/OLD IMAGES ###
"docker image inspect" requires at least 1 argument.
See 'docker image inspect --help'.

Usage:  docker image inspect [OPTIONS] IMAGE [IMAGE...]

Display detailed information on one or more images
Keeping null as current,  as rollback
```
#### MANUAL TESTING
1. Pull branch and navigate to the `bin` directory in project source
2. Run `echo $SHELL` to get the value of your current shell
3. If you have `zsh`, then type `bash` to enter that shell
4. Follow steps from #1623 to confirm the cleanup script still works (note: you may have to load the script with `. docker_utils.sh` instead of `source docker_utils.sh`)