### PR TITLE
Updating to scp-ingest-pipeline:1.21.0 (SCP-4621)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.20.1'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.21.0'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
Updates to the latest version (`1.21.0`) of `scp-ingest-pipeilne` to address handling inserted documents during automatic MongoDB reconnection retries.  See associated [PR](https://github.com/broadinstitute/scp-ingest-pipeline/pull/271) for more details.