### PR TITLE
Handle docker cleanup for development tag (SCP-4551)

### DIFF
--- a/bin/build_image.sh
+++ b/bin/build_image.sh
@@ -4,7 +4,7 @@
 # cleans up untagged images after push when overwriting tags
 # meant to be run as part of Jenkins deployment, but can be used as standalone to build/push specified image
 # TODO (SCP-4494): Add this script to corresponding Jenkins jobs
-THIS_DIR="$(cd "$(dirname "$0")"; pwd)"
+THIS_DIR="$(cd "$(dirname -- "$0")"; pwd)"
 
 # common libraries
 . $THIS_DIR/bash_utils.sh

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -4,7 +4,7 @@
 # can also roll back a broken deployment by calling with -R, and optionally -t OFFSET
 # to increase the amount of releases to roll back to
 
-THIS_DIR="$(cd "$(dirname "$0")"; pwd)"
+THIS_DIR="$(cd "$(dirname -- "$0")"; pwd)"
 
 # common libraries
 . $THIS_DIR/bash_utils.sh

--- a/bin/docker_utils.sh
+++ b/bin/docker_utils.sh
@@ -96,20 +96,27 @@ function prune_docker_artifacts {
         INDEX=1
     fi
     IMAGE_NAME="$1"
-    # get all matching images, then pop off the first two as "current" and "rollback" images
-    ALL_IMAGES=($(get_matching_image_ids $IMAGE_NAME))
-    RELEASE_IMAGE_ID="${ALL_IMAGES[$INDEX]}"
-    ALL_IMAGES=("${ALL_IMAGES[@]:$INDEX}") # remove first element and reindex
-    ROLLBACK_IMAGE_ID="${ALL_IMAGES[$INDEX]}"
-    ALL_IMAGES=("${ALL_IMAGES[@]:$INDEX}")
-    RELEASE_IMAGE_NAME=$(get_image_tag_from_id $RELEASE_IMAGE_ID)
-    ROLLBACK_IMAGE_NAME=$(get_image_tag_from_id $ROLLBACK_IMAGE_ID)
-    echo "Keeping $RELEASE_IMAGE_NAME as current, $ROLLBACK_IMAGE_NAME as rollback"
-    for IMAGE in $ALL_IMAGES; do
-        IMAGE_TAG=$(get_image_tag_from_id $IMAGE)
-        echo "Removing obsolete image $IMAGE_TAG"
-        docker rmi $IMAGE
-    done
+    CURRENT_TAG="$2"
+    # if the current tag is 'development', don't attempt to remove any images by name as they are all the same tag
+    # docker image prune will handle any necessary cleanup in this case
+    if [[ "$CURRENT_TAG" -ne "development" ]]; then
+        # get all matching images, then pop off the first two as "current" and "rollback" images
+        ALL_IMAGES=($(get_matching_image_ids $IMAGE_NAME))
+        RELEASE_IMAGE_ID="${ALL_IMAGES[$INDEX]}"
+        ALL_IMAGES=("${ALL_IMAGES[@]:$INDEX}") # remove first element and reindex
+        ROLLBACK_IMAGE_ID="${ALL_IMAGES[$INDEX]}"
+        ALL_IMAGES=("${ALL_IMAGES[@]:$INDEX}")
+        RELEASE_IMAGE_NAME=$(get_image_tag_from_id $RELEASE_IMAGE_ID)
+        ROLLBACK_IMAGE_NAME=$(get_image_tag_from_id $ROLLBACK_IMAGE_ID)
+        echo "Keeping $RELEASE_IMAGE_NAME as current, $ROLLBACK_IMAGE_NAME as rollback"
+        for IMAGE in $ALL_IMAGES; do
+            IMAGE_TAG=$(get_image_tag_from_id $IMAGE)
+            echo "Removing obsolete image $IMAGE_TAG"
+            docker rmi $IMAGE
+        done
+    else
+        echo "Current tag is $CURRENT_TAG, skipping manual image cleanup of $IMAGE_NAME"
+    fi
     # prune unused image layers and volumes
     echo "pruning orphaned image layers"
     docker image prune --force

--- a/bin/extract_vault_secrets.sh
+++ b/bin/extract_vault_secrets.sh
@@ -3,7 +3,7 @@
 # load secrets from Vault for running/deploying SCP docker container
 
 # defaults
-THIS_DIR="$(cd "$(dirname "$0")"; pwd)"
+THIS_DIR="$(cd "$(dirname -- "$0")"; pwd)"
 DOCKER_IMAGE_FOR_VAULT_CLIENT='vault:1.1.3'
 export VAULT_ADDR
 export JENKINS_VAULT_TOKEN_PATH

--- a/bin/manual_deployment_config.sh
+++ b/bin/manual_deployment_config.sh
@@ -3,7 +3,7 @@
 # Extract secrets from vault and copy to remote host. Only to be used as a manual process to
 # migrate secrets in the case of a failed deployment.
 
-THIS_DIR="$(cd "$(dirname "$0")"; pwd)"
+THIS_DIR="$(cd "$(dirname -- "$0")"; pwd)"
 
 # common libraries
 . $THIS_DIR/bash_utils.sh

--- a/bin/remote_deploy.sh
+++ b/bin/remote_deploy.sh
@@ -83,7 +83,7 @@ function main {
     if [[ $(get_http_status_code $PORTAL_HOMEPAGE) != "200" ]] ; then exit_with_error_message "Portal still not available at $PORTAL_HOMEPAGE after 6 minutes, deployment failed" ; fi
     echo "### CLEANING UP SECRETS/OLD IMAGES ###"
     rm $PORTAL_SECRETS_PATH
-    prune_docker_artifacts $DOCKER_IMAGE_NAME
+    prune_docker_artifacts "$DOCKER_IMAGE_NAME" "$VERSION_TAG"
     echo "### DEPLOYMENT COMPLETED ###"
 }
 

--- a/bin/remote_deploy.sh
+++ b/bin/remote_deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-THIS_DIR="$(cd "$(dirname "$0")"; pwd)"
+THIS_DIR="$(cd "$(dirname -- "$0")"; pwd)"
 
 # common libraries
 . $THIS_DIR/bash_utils.sh


### PR DESCRIPTION
#### BACKGROUND & CHANGES
#1623 introduced logic to automatically clean up any obsolete/unused Docker artifacts after successful deployments.  However, in the staging environment, all Docker images are tagged with `development`, which caused [problems](https://scp-jenkins.dsp-techops.broadinstitute.org/job/scp-deploy-development-to-staging/830/console
) when trying to run the automated cleanups.  This update skips the manual image removal portion of the cleanup as `docker image prune` will handle removing any recently untagged image layers.  In addition, this update addresses issues with the difference in behavior between `zsh` and `bash` by standardizing the `prune_docker_artifacts` method to only operate in `bash` as this is what the default shell is on our deployed hosts.  Lastly, this also fixes issues with source/imports in `bash` when testing locally.

#### MANUAL TESTING
1. Pull branch and navigate to the `bin` directory in project source
2. Pull the `development` tag via `docker pull gcr.io/broad-singlecellportal-staging/single-cell-portal:development`
3. Run `source docker_utils.sh` and confirm you get no errors
4. Determine what your shell is by running `echo $SHELL`
    * If you are running `zsh`, confirm that the script exits correctly by running step 4 and seeing the message `zsh detected, exiting as this function only operates on bash shells`
    * Next, run the following code to enter and configure a `bash` session:
    ```
    bash
    SHELL=/bin/bash
    source docker_utils.sh
    ```
5. Run `prune_docker_artifacts "gcr.io/broad-singlecellportal-staging/single-cell-portal" "development"` (note we are passing in an image tag now, which will be passed to `remote_deploy.sh` during a deployment by Jenkins)
6. Note the following message in the console:
```
% prune_docker_artifacts "gcr.io/broad-singlecellportal-staging/single-cell-portal" "development"
Skipping manual image cleanup of gcr.io/broad-singlecellportal-staging/single-cell-portal:development; not enough versions present
pruning orphaned image layers
...
```