### PR TITLE
Update to fix persistence issue for add_override_viz_limit_annotation (SCP-4727)

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1220,7 +1220,7 @@ class Study
     updated_list = override_viz_limit_annotations
     updated_list.push(annotation_name)
     self.default_options[:override_viz_limit_annotations] = updated_list
-    self.save
+    self.save!
     # clear the cache so that explore data is fetched correctly
     CacheRemovalJob.new(accession).perform
   end


### PR DESCRIPTION
Overriding the visualization limit for annotation labels uses a convenience method available from the Rails Console.
Example for [staging SCP148](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP148): `study.add_override_viz_limit_annotation('CellType')`

The override currently only seems to apply to the in-memory instance of the Portal and the update is not saved to the database. Staging SCP148 in re-deployed instances of the staging server do not have the CellType annotation available (Except when CellType is set as the default annotation for the study, then the CellType annotation data is shown in the default plot BUT not shown in the Annotations dropdown as a selectable option).

This PR changes saving the override from self.save to self.save! to try and address the persistence issue.

No easy manual test in local dev per Jon. Will test on staging after merge to development.

This supports SCP-4727