### PR TITLE
Fix custom color setting buggyness (SCP-4684)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -126,7 +126,7 @@ function RawScatterPlot({
   }, [editedCustomColors])
 
   /** Save any changes to the legend colors */
-  const saveCustomColors = async newColors => {
+  async function saveCustomColors(newColors) {
     const colorObj = {}
     // read the annotation name off of scatterData to ensure it's the real name, and not '' or '_default'
     colorObj[scatterData?.annotParams?.name] = newColors

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -57,6 +57,7 @@ function RawScatterPlot({
   const [activeTraceLabel, setActiveTraceLabel] = useState(null)
   // map of label name to color hex codes, for any labels the user has picked a color for
   const [editedCustomColors, setEditedCustomColors] = useState({})
+  const [customColors, setCustomColors] = useState({})
 
   const isRefGroup = getIsRefGroup(scatterData?.annotParams?.type, genes, isCorrelatedScatter)
 
@@ -116,13 +117,21 @@ function RawScatterPlot({
     return scatter
   }
 
+  /** redraw the plot when editedCustomColors changes */
+  useEffect(() => {
+    if (editedCustomColors && Object.keys(editedCustomColors).length > 0) {
+      const plotlyTraces = document.getElementById(graphElementId).data
+      Plotly.react(graphElementId, plotlyTraces, scatterData.layout)
+    }
+  }, [editedCustomColors])
+
   /** Save any changes to the legend colors */
-  async function saveCustomColors(newColors) {
+  const saveCustomColors = async newColors => {
     const colorObj = {}
     // read the annotation name off of scatterData to ensure it's the real name, and not '' or '_default'
-    colorObj[scatterData.annotParams.name] = newColors
+    colorObj[scatterData?.annotParams?.name] = newColors
     const newFileObj = {
-      _id: scatterData.clusterFileId,
+      _id: scatterData?.clusterFileId,
       custom_color_updates: colorObj
     }
     setIsLoading(true)
@@ -136,9 +145,10 @@ function RawScatterPlot({
       const newScatterData = Object.assign({}, scatterData, {
         customColors: response.cluster_file_info?.custom_colors[scatterData.annotParams.name] ?? {}
       })
-      setEditedCustomColors({})
       setIsLoading(false)
       setScatterData(newScatterData)
+      setCustomColors({ ...newColors })
+      setEditedCustomColors({ ...newColors })
     } catch (error) {
       Store.addNotification(failureNotification(<span>Error saving colors<br/>{error}</span>))
       setIsLoading(false)
@@ -181,6 +191,7 @@ function RawScatterPlot({
   function concludeRender(scatter) {
     if (scatter) {
       setScatterData(scatter)
+      setCustomColors(scatter.customColors)
     }
     setShowError(false)
     setIsLoading(false)
@@ -373,11 +384,10 @@ function RawScatterPlot({
     })
   }, [cluster, annotation.name, subsample, consensus, genes.join(','), isAnnotatedScatter])
 
-  // Handles custom scatter legend updates
-  const customColors = scatterData?.customColors ?? {}
   useUpdateEffect(() => {
     // Don't update if graph hasn't loaded
     if (scatterData && !isLoading) {
+      scatterData.customColors = customColors
       const plotlyTraces = updateCountsAndGetTraces(scatterData)
       Plotly.react(graphElementId, plotlyTraces, scatterData.layout)
     }
@@ -486,9 +496,10 @@ function RawScatterPlot({
             updateHiddenTraces={updateHiddenTraces}
             editedCustomColors={editedCustomColors}
             setEditedCustomColors={setEditedCustomColors}
+            setCustomColors={setCustomColors}
+            saveCustomColors={saveCustomColors}
             customColors={customColors}
             enableColorPicking={canEdit}
-            saveCustomColors={saveCustomColors}
             activeTraceLabel={activeTraceLabel}
             setActiveTraceLabel={setActiveTraceLabel}
             hasArrayLabels={scatterData.hasArrayLabels}

--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
@@ -3,7 +3,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPalette, faExternalLinkAlt, faTimes, faSearch } from '@fortawesome/free-solid-svg-icons'
 import Modal from 'react-bootstrap/lib/Modal'
 import { HexColorPicker, HexColorInput } from 'react-colorful'
-import _cloneDeep from 'lodash/cloneDeep'
 import Button from 'react-bootstrap/lib/Button'
 import { getFeatureFlagsWithDefaults } from '~/providers/UserProvider'
 
@@ -67,7 +66,9 @@ function LegendEntry({
         className={`scatter-legend-row ${shownClass}`}
         role="button"
         onClick={entryClickFunction}
-        onMouseEnter={() => setActiveTraceLabel(label)}
+        onMouseEnter={() => {
+          setActiveTraceLabel(label)
+        }}
         onMouseLeave={() => setActiveTraceLabel(null)}
       >
         <div className="scatter-legend-icon" style={iconStyle}>
@@ -142,10 +143,10 @@ function getShowHideEnabled(hiddenTraces, countsByLabel) {
 /** Component for custom legend for scatter plots */
 export default function ScatterPlotLegend({
   name, height, countsByLabel, correlations, hiddenTraces,
-  updateHiddenTraces, customColors, editedCustomColors, setEditedCustomColors,
-  enableColorPicking=false, saveCustomColors, activeTraceLabel, setActiveTraceLabel,
+  updateHiddenTraces, customColors, editedCustomColors, setEditedCustomColors, setCustomColors,
+  enableColorPicking=false, activeTraceLabel, setActiveTraceLabel,
   splitLabelArrays, setSplitLabelArrays, hasArrayLabels,
-  externalLink
+  externalLink, saveCustomColors
 }) {
   // is the user currently in color-editing mode
   const [showColorControls, setShowColorControls] = useState(false)
@@ -167,9 +168,8 @@ export default function ScatterPlotLegend({
 
   /** updates the user picked color for the given label.  does *not* save change to the server */
   function updateEditedCustomColors(label, color) {
-    const newColors = _cloneDeep(editedCustomColors)
-    newColors[label] = color
-    setEditedCustomColors(newColors)
+    editedCustomColors[label] = color
+    setEditedCustomColors({ ...editedCustomColors })
   }
 
   /** resets any unsaved changes to user colors */
@@ -179,19 +179,18 @@ export default function ScatterPlotLegend({
   }
 
   /** resets any unsaved changes to user colors and clears custom colors */
-  function resetColors() {
+  async function resetColors() {
     setEditedCustomColors({})
-    saveCustomColors({})
+    await saveCustomColors({})
     setShowColorControls(false)
   }
 
   /** save the colors to the server */
-  function saveColors() {
+  async function saveColors() {
     // merge the user picked colors with existing custom colors so previously saved values are preserved
-    const colorsToSave = _cloneDeep(customColors)
-    Object.assign(colorsToSave, editedCustomColors)
+    const colorsToSave = Object.assign(customColors, editedCustomColors)
+    await saveCustomColors(colorsToSave)
     setShowColorControls(false)
-    saveCustomColors(colorsToSave)
   }
 
   /** collect general information when a user's mouse enters the legend  */

--- a/test/js/explore/scatter-tab.test.js
+++ b/test/js/explore/scatter-tab.test.js
@@ -51,7 +51,8 @@ const MOCK_CLUSTER_RESPONSE = {
   },
   subsample: 'all',
   consensus: null,
-  externalLink: { url: '', title: '', description: '' }
+  externalLink: { url: '', title: '', description: '' },
+  customColors: {}
 }
 
 const CACHE_PERF_PARAMS = {


### PR DESCRIPTION
TLDR: All buttons (cancel, OK, save, reset) work (both client and server side) and you do not have to hover to trigger the color update


We noticed a few bugs with setting custom colors in scatter plots, including the Cancel and Save buttons not working to set the colors in the UI and needing to hover over the legend labels to trigger the updated-but-not-saved colors to update.

This PR is fixing all the weird buggy-ness for typical custom coloring. 


To test:
- Pull this branch
- Boot up local dev as usual and log in
- Go to a study that has visualizations 
- Click Customize Colors 
- Try all variations of changing colors on labels, clicking OK or Cancel in the modal and clicking Save, Cancel, and Reset to Defaults in the customize color sections. Confirm that the colors update as you would expect. And confirm that refreshing persists Saved colors but does not persist unsaved colors.

BEFORE BUGS:

https://user-images.githubusercontent.com/54322292/193067370-75e802ab-3f18-44ef-b405-bcde08eb322a.mov


https://user-images.githubusercontent.com/54322292/193067467-f1844064-284d-49dc-a2b1-30a86c5730f1.mov

AFTER:

https://user-images.githubusercontent.com/54322292/193068726-c5470d67-2e4a-491f-8ae2-8da08f028830.mov


