### PR TITLE
Access staging web server from Image Pipeline PAPI (SCP-4666)

### DIFF
--- a/image-pipeline/expression-scatter-plots.js
+++ b/image-pipeline/expression-scatter-plots.js
@@ -257,28 +257,25 @@ async function configureIntercepts(page) {
 /** CPU-level wrapper to make images for a sub-list of genes */
 async function processScatterPlotImages(genes, context) {
   const { accession, preamble, origin } = context
-  // const browser = await puppeteer.launch()
-  let browser
 
+  // Set up Puppeteer Chrome browser
   const pptrArgs = [
     '--ignore-certificate-errors',
     '--no-sandbox'
   ]
-
   // Map staging domain name to staging internal IP address on PAPI
   if (process.env?.IS_PAPI) {
     const dnsEntry = `${stagingHost.domainName} ${stagingHost.ip}`
     pptrArgs.push(`--host-rules=MAP ${dnsEntry}`)
   }
-
-  // Cert args needed for localhost; doesn't hurt in other environments
+  const pptrArgsObj = { acceptInsecureCerts: true, args: pptrArgs }
   if (values.debug) {
-    browser = await puppeteer.launch({
-      headless: false, devtools: true, acceptInsecureCerts: true, args: pptrArgs
-    })
-  } else {
-    browser = await puppeteer.launch({ acceptInsecureCerts: true, args: pptrArgs })
+    pptrArgsObj.headless = false
+    pptrArgsObj.devtools = true
   }
+
+  const browser = await puppeteer.launch(pptrArgsObj)
+
   const page = await browser.newPage()
   // Set user agent to Chrome "9000".
   // Bard client crudely parses UA, so custom raw user agents are infeasible.

--- a/image-pipeline/expression-scatter-plots.js
+++ b/image-pipeline/expression-scatter-plots.js
@@ -133,7 +133,7 @@ async function makeExpressionScatterPlotImage(gene, page, preamble) {
   // without needing to call GCS client library's bucket.upload on each file.
   // Ideally there would be a GCS client library equivalent of those commands,
   // but brief research found none.
-  const toFilePath = `images/expression_scatter${debugNonce}/${webpFileName}`
+  const toFilePath = `cache/expression_scatter/images/${debugNonce}${webpFileName}`
   uploadToBucket(imagePath, toFilePath, preamble)
 
   return
@@ -321,7 +321,7 @@ async function processScatterPlotImages(genes, context) {
   //   clip: clipDimensions,
   //   omitBackground: true
   // })
-  // const toFilePath = `images/expression_scatter${debugNonce}/${webpFileName}`
+  // const toFilePath = `cache/expression_scatter/images/{debugNonce}${webpFileName}`
   // uploadToBucket(imagePath, toFilePath, preamble)
 
   await page.waitForSelector('.gene-keyword-search input')
@@ -548,7 +548,7 @@ const { values, numCPUs, origin, stagingHost } = await parseCliArgs()
 
 let debugNonce = ''
 if (values['debug'] || values['debug-headless']) {
-  debugNonce = `_debug${ nonce}`
+  debugNonce = `_debug${ nonce}/`
 }
 
 let imagesDir

--- a/image-pipeline/expression-scatter-plots.js
+++ b/image-pipeline/expression-scatter-plots.js
@@ -360,11 +360,18 @@ async function parseCliArgs() {
   const numCPUs = values.cores ? parseInt(values.cores) : os.cpus().length / 2 - 1
   print(`Number of CPUs to be used on this client: ${numCPUs}`)
 
+
+  // Internal IP address for https://singlecell-staging.broadinstitute.org
+  // Reference: singlecell-01 in
+  // https://console.cloud.google.com/compute/instances?project=broad-singlecellportal-staging
+  // This allows PAPI to access the staging web app server, which is
+  // otherwise blocked per firewall / GCP Cloud Armor.
+  const stagingOrigin = '10.128.0.5'
+
   // TODO (SCP-4564): Document how to adjust network rules to use staging
   const originsByEnvironment = {
     'development': 'https://localhost:3000',
-    // Internal IP address for https://singlecell-staging.broadinstitute.org
-    'staging': '10.128.0.5',
+    'staging': stagingOrigin,
     'production': 'https://singlecell.broadinstitute.org'
   }
   const environment = values.environment || 'development'

--- a/image-pipeline/expression-scatter-plots.js
+++ b/image-pipeline/expression-scatter-plots.js
@@ -258,7 +258,7 @@ async function configureIntercepts(page) {
 async function processScatterPlotImages(genes, context) {
   const { accession, preamble, origin } = context
 
-  // Set up Puppeteer Chrome browser
+  // Set up Puppeteer Chromium browser
   const pptrArgs = [
     '--ignore-certificate-errors',
     '--no-sandbox'
@@ -390,14 +390,14 @@ async function parseCliArgs() {
   // https://console.cloud.google.com/compute/instances?project=broad-singlecellportal-staging
   // This allows PAPI to access the staging web app server, which is
   // otherwise blocked per firewall / GCP Cloud Armor.
-  const stagingIP = '10.128.0.5'
+  const stagingIP = process.env?.STAGING_INTERNAL_IP
   const stagingDomainName = 'singlecell-staging.broadinstitute.org'
   const stagingHost = { ip: stagingIP, domainName: stagingDomainName }
 
-  // TODO (SCP-4564): Document how to adjust network rules to use staging
+  // TODO (SCP-4564): Document how to adjust network rules to use staging locally
   const originsByEnvironment = {
     'development': 'https://localhost:3000',
-    'staging': 'https://singlecell-staging.broadinstitute.org',
+    'staging': `https://${ stagingDomainName}`,
     'production': 'https://singlecell.broadinstitute.org'
   }
   const environment = values.environment || 'development'
@@ -405,7 +405,7 @@ async function parseCliArgs() {
 
   // Set origin for use in standalone fetch, which lacks Puppeteer host map
   const isStagingPAPI = environment === 'staging' && process.env?.IS_PAPI
-  const fetchOrigin = isStagingPAPI ? `https://${ stagingHost.ip}` : origin
+  const fetchOrigin = isStagingPAPI ? `https://${ stagingIP}` : origin
 
   return { values, numCPUs, origin, stagingHost, fetchOrigin }
 }
@@ -446,7 +446,7 @@ async function run() {
 
   let json
   try {
-    // json = JSON.parse(text)
+    // json = JSON.parse(text) // Helpful to debug errors
     json = await response.json()
   } catch (error) {
     console.log('Failed to fetch:')

--- a/image-pipeline/expression-scatter-plots.js
+++ b/image-pipeline/expression-scatter-plots.js
@@ -363,7 +363,8 @@ async function parseCliArgs() {
   // TODO (SCP-4564): Document how to adjust network rules to use staging
   const originsByEnvironment = {
     'development': 'https://localhost:3000',
-    'staging': 'https://singlecell-staging.broadinstitute.org',
+    // Internal IP address for https://singlecell-staging.broadinstitute.org
+    'staging': '10.128.0.5',
     'production': 'https://singlecell.broadinstitute.org'
   }
   const environment = values.environment || 'development'

--- a/image-pipeline/expression-scatter-plots.js
+++ b/image-pipeline/expression-scatter-plots.js
@@ -133,7 +133,7 @@ async function makeExpressionScatterPlotImage(gene, page, preamble) {
   // without needing to call GCS client library's bucket.upload on each file.
   // Ideally there would be a GCS client library equivalent of those commands,
   // but brief research found none.
-  const toFilePath = `images/expression_scatter/${webpFileName}`
+  const toFilePath = `images/expression_scatter_eweitz/${webpFileName}`
   uploadToBucket(imagePath, toFilePath, preamble)
 
   return
@@ -367,8 +367,9 @@ async function parseCliArgs() {
   // This allows PAPI to access the staging web app server, which is
   // otherwise blocked per firewall / GCP Cloud Armor.
   const stagingIP = '10.128.0.5'
-  const stagingDomainName = 'https://singlecell-staging.broadinstitute.org'
-  const stagingOrigin = process.env?.IS_PAPI ? stagingIP : stagingDomainName
+  const stagingDomainName = 'singlecell-staging.broadinstitute.org'
+  const isPAPI = process.env?.IS_PAPI
+  const stagingOrigin = `https://${isPAPI ? stagingIP : stagingDomainName}`
 
   // TODO (SCP-4564): Document how to adjust network rules to use staging
   const originsByEnvironment = {


### PR DESCRIPTION
This enables scalability development for Image Pipeline.  It also improves logging and output file organization.

### Impact
[Previously](https://github.com/broadinstitute/single_cell_portal_core/pull/1628), Image Pipeline could only run without PAPI and locally, or with PAPI on production.   _Now, Image Pipeline can run with PAPI on staging._  This lets us develop and test scalability.  Without scalability, Image Pipeline delivers no user value: it's only viable if it produces expression scatter plot images for _all_ (often ~30k) genes in a cluster.

### Technical summary
#### Networking
The [staging web server is firewalled](https://console.cloud.google.com/net-security/securitypolicies/details/singlecell-staging-policy?project=broad-singlecellportal-staging&tab=rules), unlike local development and external production environments.  Without custom firewall exceptions, staging can't be accessed via its external IP address, which the familiar staging domain name ([singlecell-staging.broadinstitute.org](https://singlecell-staging.broadinstitute.org)) maps to by default.  PAPI instances use a wide range of random IP addresses by default, so firewall exceptions are not a feasible solution.

So we now use staging's internal IP address to access staging on PAPI.  When we fetch SCP API data directly via Node, the staging URL now uses this internal IP address directly.  This is enabled by specifying the `--network` and `--subnetwork` via PAPI CLI arguments.

When we fetch SCP web pages via Puppeteer, however, we use the internal IP address indirectly -- by passing the `--host-rules` switch to the Chromium browser instance.  That acts like a run-time [`hosts`](https://en.wikipedia.org/wiki/Hosts_(file)) file, overriding the default [DNS](https://en.wikipedia.org/wiki/Domain_Name_System) map of domain names to IP addresses.  Using the domain name is necessary to avoid content security policy (CSP) errors when loading staging web pages to render screenshots of gene expression scatter plots.

#### Logging
Observability was also enhanced.  Now:
* Logs begin uploading earlier, for faster first peeks
* Log file paths in `--debug` or `--debug-headless` logs include a timestamp, for easier tracing that's not overwritten
* Log file (and output image) paths now have a more reusable structure, which aligns with upcoming data file path
* Completion status and total run time are recorded within the log file itself

### Manual test
0a. Ensure you can read from Vault:
```
vault login -method=github token=`~/bin/git-vault-token`
```

0b.  Ensure you're on the staging GCP project
```
gcloud config set project broad-singlecellportal-staging
```

0c. Execute steps 1-4 from test instructions in #1619

1. Pull secrets from Vault (new: second file):
> `vault read secret/kdux/scp/staging/scp_service_account.json -format=json | jq .data > /tmp/scp_service_account_staging.json; vault read secret/kdux/scp/staging/scp_config.json -format=json | jq .data > /tmp/scp_config_staging.json`

2. Make secrets accessible as environment variables (new: `GCP_NETWORK_NAME`, `STAGING_INTERNAL_IP`):
> `SA_EMAIL_ADDRESS=$(cat /tmp/scp_service_account_staging.json | jq -r .client_email); GCP_NETWORK=$(cat /tmp/scp_config_staging.json | jq -r .GCP_NETWORK_NAME); STAGING_INTERNAL_IP=$(cat /tmp/scp_config_staging.json | jq -r .APP_INTERNAL_IP);`

3. Run Image Pipeline with PAPI on staging (new: `--env-vars`, `IS_PAPI=1`, `--network` and `--subnetwork`):
> `gcloud alpha genomics pipelines run --regions us-east1 --env-vars="STAGING_INTERNAL_IP=$STAGING_INTERNAL_IP" --command-line 'IS_PAPI=1 NODE_TLS_REJECT_UNAUTHORIZED=0 node expression-scatter-plots.js --accession="SCP303" --environment="staging" --cores="1" --debug-headless; # human milk DE pilot' --docker-image gcr.io/broad-singlecellportal-staging/image-pipeline:0.0.1_f6e1698d1 --service-account-email $SA_EMAIL_ADDRESS --network $GCP_NETWORK --subnetwork $GCP_NETWORK # Command to run Image Pipeline on PAPI`

4. Manually copy your run's operation ID from above output, e.g. "15137633979837466304" in below:
```
Running [projects/broad-singlecellportal-staging/operations/15137633979837466304].
```

6. Watch for your PAPI run to complete: replace "15137633979837466304" with your value from previous step
> `OPERATION_ID=15137633979837466304; gcloud alpha genomics operations wait ${OPERATION_ID}; tput bel; gcloud alpha genomics operations describe ${OPERATION_ID} | grep exitStatus; tput bel`

7. Confirm your exit status code is 0, e.g.:
```
Waiting for [projects/broad-singlecellportal-staging/operations/15137633979837466304]...done.                                                                                                                                                
      exitStatus: 0
```

8. Confirm output images are written in latest debug output directory at: 
[broad-singlecellportal-staging-testing-data/_scp_internal/cache/expression_scatter/images](https://console.cloud.google.com/storage/browser/broad-singlecellportal-staging-testing-data/_scp_internal/cache/expression_scatter/images)

9. Confirm output log is written at `expression_scatter_images__<timestamp for your PAPI run>.txt` at:
[broad-singlecellportal-staging-testing-data/_scp_internal/parse_logs](https://console.cloud.google.com/storage/browser/broad-singlecellportal-staging-testing-data/_scp_internal/parse_logs)

This satisfies SCP-4666.