### PR TITLE
Allow study editors to specify override_viz_limit_annotations (SCP-4739)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -140,6 +140,9 @@ class ApplicationController < ActionController::Base
         @default_cluster_annotations['Cannot Display'] << @default_cluster&.formatted_cell_annotation(cell_annotation)
       end
     end
+    # set array of viz override values, always showing current selections first
+    invalid_annotation_names = @default_cluster_annotations['Cannot Display'].map(&:first)
+    @viz_override_annotations = @study.override_viz_limit_annotations + invalid_annotation_names
     # initialize reviewer access object
     @reviewer_access = @study.reviewer_access.present? ? @study.reviewer_access : @study.build_reviewer_access
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -141,7 +141,7 @@ class ApplicationController < ActionController::Base
       end
     end
     # set array of viz override values, always showing current selections first
-    invalid_annotation_names = @default_cluster_annotations['Cannot Display'].map(&:first)
+    invalid_annotation_names = @default_cluster_annotations['Cannot Display'].map(&:first).sort
     @viz_override_annotations = @study.override_viz_limit_annotations + invalid_annotation_names
     # initialize reviewer access object
     @reviewer_access = @study.reviewer_access.present? ? @study.reviewer_access : @study.build_reviewer_access

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -726,13 +726,17 @@ class SiteController < ApplicationController
   # permit parameters for updating studies on study settings tab (smaller list than in studies controller)
   def study_params
     params.require(:study).permit(:name, :description, :public, :embargo, :cell_count,
-                                  :default_options => [:cluster, :annotation, :color_profile, :expression_label, :deliver_emails,
-                                                       :cluster_point_size, :cluster_point_alpha, :cluster_point_border, :precomputed_heatmap_label],
+                                  :default_options => [:cluster, :annotation, :color_profile, :expression_label,
+                                                       :deliver_emails, :cluster_point_size, :cluster_point_alpha,
+                                                       :cluster_point_border, :precomputed_heatmap_label,
+                                                       override_viz_limit_annotations: []],
                                   study_shares_attributes: [:id, :_destroy, :email, :permission],
                                   study_detail_attributes: [:id, :full_description],
                                   reviewer_access_attributes: [:id, :expires_at],
-                                  authors_attributes: [:id, :first_name, :last_name, :email, :institution, :corresponding, :orcid, :_destroy],
-                                  publications_attributes: [:id, :title, :journal, :citation, :url, :pmcid, :preprint, :_destroy],
+                                  authors_attributes: [:id, :first_name, :last_name, :email, :institution,
+                                                       :corresponding, :orcid, :_destroy],
+                                  publications_attributes: [:id, :title, :journal, :citation, :url, :pmcid,
+                                                            :preprint, :_destroy],
                                   external_resources_attributes: [:id, :_destroy, :title, :description, :url],
     )
   end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -991,8 +991,9 @@ class StudiesController < ApplicationController
   end
 
   def default_options_params
-    params.require(:study_default_options).permit(:cluster, :annotation, :color_profile, :expression_label, :cluster_point_size,
-                                                  :cluster_point_alpha, :cluster_point_border, :precomputed_heatmap_label)
+    params.require(:study_default_options).permit(:cluster, :annotation, :color_profile, :expression_label,
+                                                  :cluster_point_size, :cluster_point_alpha, :cluster_point_border,
+                                                  :precomputed_heatmap_label, override_viz_limit_annotations: [])
   end
 
   def set_file_types

--- a/app/javascript/styles/_forms.scss
+++ b/app/javascript/styles/_forms.scss
@@ -210,3 +210,21 @@
 hr.divider {
   border-top: 1px solid #AAA;
 }
+
+#default-study-options-form {
+  ul.multi-checkbox {
+    padding-inline-start: 0;
+    padding: 4px;
+    max-height: 90px;
+    overflow-y: scroll;
+    background-color: white;
+    border-radius: 4px;
+    li {
+      list-style-type: none;
+      width: 100%;
+      input[type='checkbox'] {
+        margin-right: 4px;
+      }
+    }
+  }
+}

--- a/app/views/layouts/_multiselect_checkbox_field.html.erb
+++ b/app/views/layouts/_multiselect_checkbox_field.html.erb
@@ -1,0 +1,10 @@
+<ul class="multi-checkbox">
+  <% options.each do |annotation_name| %>
+    <li>
+      <%= form.check_box :override_viz_limit_annotations, {
+        multiple: true, checked: overrides.include?(annotation_name)
+      }, annotation_name, nil %>
+      <%= annotation_name %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/site/_study_settings_viz.html.erb
+++ b/app/views/site/_study_settings_viz.html.erb
@@ -38,7 +38,9 @@
         </div>
         <div class="col-sm-4">
           <%= opts.label :override_viz_limit_annotations, "Annotation display override <i class='fas fa-info-circle' data-toggle='tooltip' title='Select annotations from the list to allow showing groups with only 1 or more than #{CellMetadatum::GROUP_VIZ_THRESHOLD.last} values' ></i>".html_safe %><br />
-          <%= opts.select :override_viz_limit_annotations, options_for_select(@viz_override_annotations, @study.override_viz_limit_annotations), { include_blank: 'Select all that apply...', include_hidden: false } , class: 'form-control', multiple: true %>
+          <%= render partial: '/layouts/multiselect_checkbox_field', locals: {
+            form: opts, options: @viz_override_annotations, overrides: @study.override_viz_limit_annotations
+          } %>
         </div>
       </div>
       <div class="form-group row">

--- a/app/views/site/_study_settings_viz.html.erb
+++ b/app/views/site/_study_settings_viz.html.erb
@@ -36,6 +36,10 @@
           <%= opts.label :color_profile, "Default color profile <i class='fas fa-info-circle' title='Default color profile for numeric annotations and expression plots' data-toggle='tooltip'></i>".html_safe %><br />
           <%= opts.select :color_profile, options_for_select(SiteController::COLORSCALE_THEMES, @study.default_color_profile), {include_blank: 'N/A'} , class: 'form-control' %>
         </div>
+        <div class="col-sm-4">
+          <%= opts.label :override_viz_limit_annotations, "Annotation display override <i class='fas fa-info-circle' data-toggle='tooltip' title='Select annotations from the list to allow showing groups with only 1 or more than #{CellMetadatum::GROUP_VIZ_THRESHOLD.last} values' ></i>".html_safe %><br />
+          <%= opts.select :override_viz_limit_annotations, options_for_select(@viz_override_annotations, @study.override_viz_limit_annotations), { include_blank: 'Select all that apply...', include_hidden: false } , class: 'form-control', multiple: true %>
+        </div>
       </div>
       <div class="form-group row">
         <div class="col-sm-12">

--- a/app/views/site/_study_settings_viz.html.erb
+++ b/app/views/site/_study_settings_viz.html.erb
@@ -37,10 +37,12 @@
       </div>
       <div class="form-group row">
         <div class="col-sm-6">
-          <%= opts.label :override_viz_limit_annotations, "Annotation display override <i class='fas fa-info-circle' data-toggle='tooltip' title='Select annotations from the list to allow showing groups with only 1 or more than #{CellMetadatum::GROUP_VIZ_THRESHOLD.last} values' ></i>".html_safe %><br />
-          <%= render partial: '/layouts/multiselect_checkbox_field', locals: {
-            form: opts, options: @viz_override_annotations, overrides: @study.override_viz_limit_annotations
-          } %>
+          <% if @viz_override_annotations.any? %>
+            <%= opts.label :override_viz_limit_annotations, "Add undisplayed annotations (>200 or single value) to dropdown" %><br />
+            <%= render partial: '/layouts/multiselect_checkbox_field', locals: {
+              form: opts, options: @viz_override_annotations, overrides: @study.override_viz_limit_annotations
+            } %>
+          <% end %>
         </div>
       </div>
       <div class="form-group row">

--- a/app/views/site/_study_settings_viz.html.erb
+++ b/app/views/site/_study_settings_viz.html.erb
@@ -16,6 +16,10 @@
           <%= opts.label :annotation, 'Default annotation' %><br />
           <%= opts.select :annotation, grouped_options_for_select(@default_cluster_annotations, @study.default_annotation), {},class: 'form-control' %>
         </div>
+        <div class="col-sm-4">
+          <%= opts.label :color_profile, "Default color profile <i class='fas fa-info-circle' title='Default color profile for numeric annotations and expression plots' data-toggle='tooltip'></i>".html_safe %><br />
+          <%= opts.select :color_profile, options_for_select(SiteController::COLORSCALE_THEMES, @study.default_color_profile), {include_blank: 'N/A'} , class: 'form-control' %>
+        </div>
       </div>
       <div class="form-group row">
         <div class="col-sm-4">
@@ -32,11 +36,7 @@
         </div>
       </div>
       <div class="form-group row">
-        <div class="col-sm-4">
-          <%= opts.label :color_profile, "Default color profile <i class='fas fa-info-circle' title='Default color profile for numeric annotations and expression plots' data-toggle='tooltip'></i>".html_safe %><br />
-          <%= opts.select :color_profile, options_for_select(SiteController::COLORSCALE_THEMES, @study.default_color_profile), {include_blank: 'N/A'} , class: 'form-control' %>
-        </div>
-        <div class="col-sm-4">
+        <div class="col-sm-6">
           <%= opts.label :override_viz_limit_annotations, "Annotation display override <i class='fas fa-info-circle' data-toggle='tooltip' title='Select annotations from the list to allow showing groups with only 1 or more than #{CellMetadatum::GROUP_VIZ_THRESHOLD.last} values' ></i>".html_safe %><br />
           <%= render partial: '/layouts/multiselect_checkbox_field', locals: {
             form: opts, options: @viz_override_annotations, overrides: @study.override_viz_limit_annotations

--- a/app/views/studies/_study_default_options_form.html.erb
+++ b/app/views/studies/_study_default_options_form.html.erb
@@ -23,10 +23,8 @@
           <%= f.select :annotation, grouped_options_for_select(@default_cluster_annotations, @study.default_annotation), {}, class: 'form-control' %>
         </div>
         <div class="col-sm-4">
-          <%= f.label :override_viz_limit_annotations, "Annotation display override <i class='fas fa-info-circle' data-toggle='tooltip' title='Select annotations from the list to allow showing groups with only 1 or more than #{CellMetadatum::GROUP_VIZ_THRESHOLD.last} values' ></i>".html_safe %><br />
-          <%= render partial: '/layouts/multiselect_checkbox_field', locals: {
-            form: f, options: @viz_override_annotations, overrides: @study.override_viz_limit_annotations
-          } %>
+          <%= f.label :color_profile, "Default Color Profile <i class='fas fa-info-circle' title='The default color profile only applies to the selected annotation (if the type is numeric)' data-toggle='tooltip'></i>".html_safe %><br />
+          <%= f.select :color_profile, options_for_select(SiteController::COLORSCALE_THEMES, @study.default_color_profile), {include_blank: 'N/A'} , class: 'form-control' %>
         </div>
       </div>
       <div class="form-group row">
@@ -44,17 +42,11 @@
         </div>
       </div>
       <div class="form-group row">
-        <div class="col-sm-4">
-          <%= f.label :color_profile, "Default Color Profile <i class='fas fa-info-circle' title='The default color profile only applies to the selected annotation (if the type is numeric)' data-toggle='tooltip'></i>".html_safe %><br />
-          <%= f.select :color_profile, options_for_select(SiteController::COLORSCALE_THEMES, @study.default_color_profile), {include_blank: 'N/A'} , class: 'form-control' %>
-        </div>
-        <div class="col-sm-4">
-          <%= f.label :cluster_point_border, 'Show Cluster Point Borders?' %><br />
-          <%= f.select :cluster_point_border, options_for_select([['Yes', true],['No', false]], @study.show_cluster_point_borders?) , {}, class: 'form-control' %>
-        </div>
-        <div class="col-sm-4">
-          <%= f.label :cluster_point_alpha, "Cluster Point Opacity <i class='fas fa-fw fa-question-circle' data-toggle='tooltip' title='Global value for the transparency (alpha) of all cluster points.  Only values between 0 and 1 are accepted.'></i>".html_safe %><br />
-          <%= f.number_field :cluster_point_alpha, value: @study.default_cluster_point_alpha, in: 0.0..1.0, step: 0.05, class: 'form-control' %>
+        <div class="col-sm-6">
+          <%= f.label :override_viz_limit_annotations, "Annotation display override <i class='fas fa-info-circle' data-toggle='tooltip' title='Select annotations from the list to allow showing groups with only 1 or more than #{CellMetadatum::GROUP_VIZ_THRESHOLD.last} values' ></i>".html_safe %><br />
+          <%= render partial: '/layouts/multiselect_checkbox_field', locals: {
+            form: f, options: @viz_override_annotations, overrides: @study.override_viz_limit_annotations
+          } %>
         </div>
       </div>
       <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">

--- a/app/views/studies/_study_default_options_form.html.erb
+++ b/app/views/studies/_study_default_options_form.html.erb
@@ -43,10 +43,12 @@
       </div>
       <div class="form-group row">
         <div class="col-sm-6">
-          <%= f.label :override_viz_limit_annotations, "Annotation display override <i class='fas fa-info-circle' data-toggle='tooltip' title='Select annotations from the list to allow showing groups with only 1 or more than #{CellMetadatum::GROUP_VIZ_THRESHOLD.last} values' ></i>".html_safe %><br />
-          <%= render partial: '/layouts/multiselect_checkbox_field', locals: {
-            form: f, options: @viz_override_annotations, overrides: @study.override_viz_limit_annotations
-          } %>
+          <% if @viz_override_annotations.any? %>
+            <%= f.label :override_viz_limit_annotations, "Add undisplayed annotations (>200 or single value) to dropdown" %><br />
+            <%= render partial: '/layouts/multiselect_checkbox_field', locals: {
+              form: f, options: @viz_override_annotations, overrides: @study.override_viz_limit_annotations
+            } %>
+          <% end %>
         </div>
       </div>
       <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">

--- a/app/views/studies/_study_default_options_form.html.erb
+++ b/app/views/studies/_study_default_options_form.html.erb
@@ -22,6 +22,10 @@
           <%= f.label :annotation, 'Default Annotation' %><br />
           <%= f.select :annotation, grouped_options_for_select(@default_cluster_annotations, @study.default_annotation), {}, class: 'form-control' %>
         </div>
+        <div class="col-sm-4">
+          <%= f.label :override_viz_limit_annotations, "Annotation display override <i class='fas fa-info-circle' data-toggle='tooltip' title='Select annotations from the list to allow showing groups with only 1 or more than #{CellMetadatum::GROUP_VIZ_THRESHOLD.last} values' ></i>".html_safe %><br />
+          <%= f.select :override_viz_limit_annotations, options_for_select(@viz_override_annotations, @study.override_viz_limit_annotations), { include_blank: 'Select all that apply...', include_hidden: false } , class: 'form-control', multiple: true %>
+        </div>
       </div>
       <div class="form-group row">
         <div class="col-sm-4">

--- a/app/views/studies/_study_default_options_form.html.erb
+++ b/app/views/studies/_study_default_options_form.html.erb
@@ -24,7 +24,9 @@
         </div>
         <div class="col-sm-4">
           <%= f.label :override_viz_limit_annotations, "Annotation display override <i class='fas fa-info-circle' data-toggle='tooltip' title='Select annotations from the list to allow showing groups with only 1 or more than #{CellMetadatum::GROUP_VIZ_THRESHOLD.last} values' ></i>".html_safe %><br />
-          <%= f.select :override_viz_limit_annotations, options_for_select(@viz_override_annotations, @study.override_viz_limit_annotations), { include_blank: 'Select all that apply...', include_hidden: false } , class: 'form-control', multiple: true %>
+          <%= render partial: '/layouts/multiselect_checkbox_field', locals: {
+            form: f, options: @viz_override_annotations, overrides: @study.override_viz_limit_annotations
+          } %>
         </div>
       </div>
       <div class="form-group row">


### PR DESCRIPTION
#### BACKGROUND
The admin-only feature `Study#add_override_viz_limit_annotation` allows admins to specify annotations that do not meet our visualization criteria (2..200 values) as "visualizable" for a given study.  These values are stored in the `study.default_options` hash.  However, updating any visualization defaults through the study settings forms will not persist this value as it is not present in the form.

#### CHANGES
This update adds those values to the forms as a multi-select with checkboxes, allowing the study editor to specify annotations without admin intervention.  This also fixes the persistence bug when saving other values as it will always be passed with form data.

Screenshot of new form control:
![Screen Shot 2022-10-05 at 1 50 15 PM](https://user-images.githubusercontent.com/729968/194128008-14dc6ab7-265b-4535-a53a-8047f58e8bed.png)

#### MANUAL TESTING
1. Boot as normal and sign in
2. If you don't already have it in your local instance, populate the synthetic study `Mouse stomach cells and GERD, with over 200 cell types` by running the following in the Rails console (you'll need DelayedJob running to launch the parse job): 
```
SyntheticStudyPopulator.populate('mouse_multilabel')
```
3. Load the `Mouse stomach cells and GERD` study and open the Settings -> View options tab
4. For `Annotation display override`, select the `manylabel_field` field and one other, then save
5. Open the Explore tab and confirm you can select `manylabel_field` and the other option you specified
6. Go back to the View options tab, and change the default annotation to `manylabel_field`
7. Go back to the Explore tab and confirm this is now the default annotation, and that `manylabel_field` and the other annotation are still selectable