### PR TITLE
Remove AnnData/Seurat file FF and migrate misc files to new type (SCP-4567, SCP-4732)

### DIFF
--- a/app/javascript/components/upload/UploadWizard.jsx
+++ b/app/javascript/components/upload/UploadWizard.jsx
@@ -75,7 +75,7 @@ export function RawUploadWizard({ studyAccession, name }) {
     NON_VISUALIZABLE_STEPS.splice(0, 0, AnnDataStep)
   }
 
-  if ( !STEPS.includes(SeuratStep)) {
+  if (!STEPS.includes(SeuratStep)) {
     STEPS.splice(9, 0, SeuratStep)
     NON_VISUALIZABLE_STEPS.splice(1, 0, SeuratStep)
   }

--- a/app/javascript/components/upload/UploadWizard.jsx
+++ b/app/javascript/components/upload/UploadWizard.jsx
@@ -69,14 +69,13 @@ export function RawUploadWizard({ studyAccession, name }) {
 
   const allowReferenceImageUpload = serverState?.feature_flags?.reference_image_upload
 
-  const allowAnnDataAndSeuratFileUploads = serverState?.feature_flags?.upload_seurat_and_anndata
 
-  if (allowAnnDataAndSeuratFileUploads && !STEPS.includes(AnnDataStep)) {
+  if (!STEPS.includes(AnnDataStep)) {
     STEPS.splice(8, 0, AnnDataStep)
     NON_VISUALIZABLE_STEPS.splice(0, 0, AnnDataStep)
   }
 
-  if (allowAnnDataAndSeuratFileUploads && !STEPS.includes(SeuratStep)) {
+  if ( !STEPS.includes(SeuratStep)) {
     STEPS.splice(9, 0, SeuratStep)
     NON_VISUALIZABLE_STEPS.splice(1, 0, SeuratStep)
   }

--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -249,12 +249,11 @@ const plainTextExtensions = ['.txt', '.tsv', '.text', '.csv']
 const mtxExtensions = ['.mtx', '.mm', '.txt', '.text']
 const imageExtensions = ['.jpeg', '.jpg', '.png', '.bmp']
 const miscExtensions = ['.txt', '.text', '.tsv', '.csv', '.jpg', '.jpeg', '.png', '.pdf',
-  '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.zip', '.loom', '.h5an',
-  '.ipynb', '.Rda', '.rda']
+  '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.zip', '.loom', '.ipynb']
 const sequenceExtensions = ['.fq', '.fastq', '.fq.tar.gz', '.fastq.tar.gz', '.fq.gz', '.fastq.gz', '.bam']
 const baiExtensions = ['.bai']
-const annDataExtensions = ['.h5', '.h5ad', 'h5ad1', '.hdf5']
-const seuratExtensions = ['.Rds', '.rds', '.seuratdata', '.h5seurat', '.seuratdisk']
+const annDataExtensions = ['.h5', '.h5ad', '.hdf5']
+const seuratExtensions = ['.Rds', '.rds', '.seuratdata', '.h5seurat', '.seuratdisk', '.Rda', '.rda']
 
 export const FileTypeExtensions = {
   plainText: plainTextExtensions.concat(plainTextExtensions.map(ext => `${ext}.gz`)),

--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -249,8 +249,8 @@ const plainTextExtensions = ['.txt', '.tsv', '.text', '.csv']
 const mtxExtensions = ['.mtx', '.mm', '.txt', '.text']
 const imageExtensions = ['.jpeg', '.jpg', '.png', '.bmp']
 const miscExtensions = ['.txt', '.text', '.tsv', '.csv', '.jpg', '.jpeg', '.png', '.pdf',
-  '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.zip', '.loom', '.h5', '.h5ad', '.h5an',
-  '.ipynb', '.Rda', '.rda', '.Rds', '.rds']
+  '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.zip', '.loom', '.h5an',
+  '.ipynb', '.Rda', '.rda']
 const sequenceExtensions = ['.fq', '.fastq', '.fq.tar.gz', '.fastq.tar.gz', '.fq.gz', '.fastq.gz', '.bam']
 const baiExtensions = ['.bai']
 const annDataExtensions = ['.h5', '.h5ad', 'h5ad1', '.hdf5']

--- a/db/migrate/20221006124530_retire_anndata_and_seurat_feature_flag.rb
+++ b/db/migrate/20221006124530_retire_anndata_and_seurat_feature_flag.rb
@@ -1,13 +1,9 @@
   class RetireAnndataAndSeuratFeatureFlag < Mongoid::Migration
     def self.up
       FeatureFlag.retire_feature_flag('upload_seurat_and_anndata')
-      FeatureFlag.retire_feature_flag('upload_seurat_and_anndata')
     end
   
     def self.down
-      FeatureFlag.create!(name: 'upload_seurat_and_anndata',
-                          default_value: true,
-                          description: 'allow AnnData and seurat file uploads in the upload wizard')
       FeatureFlag.create!(name: 'upload_seurat_and_anndata',
                           default_value: false,
                           description: 'allow AnnData and seurat file uploads in the upload wizard')

--- a/db/migrate/20221006124530_retire_anndata_and_seurat_feature_flag.rb
+++ b/db/migrate/20221006124530_retire_anndata_and_seurat_feature_flag.rb
@@ -1,0 +1,16 @@
+  class RetireAnndataAndSeuratFeatureFlag < Mongoid::Migration
+    def self.up
+      FeatureFlag.retire_feature_flag('upload_seurat_and_anndata')
+      FeatureFlag.retire_feature_flag('upload_seurat_and_anndata')
+    end
+  
+    def self.down
+      FeatureFlag.create!(name: 'upload_seurat_and_anndata',
+                          default_value: true,
+                          description: 'allow AnnData and seurat file uploads in the upload wizard')
+      FeatureFlag.create!(name: 'upload_seurat_and_anndata',
+                          default_value: false,
+                          description: 'allow AnnData and seurat file uploads in the upload wizard')
+    end
+  end
+  

--- a/db/migrate/20221006132730_update_misc_file_type_for_anndata_and_seurat.rb
+++ b/db/migrate/20221006132730_update_misc_file_type_for_anndata_and_seurat.rb
@@ -1,0 +1,15 @@
+  class UpdateMiscFileTypeForAnndataAndSeurat < Mongoid::Migration
+    def self.up
+      # For AnnData
+      StudyFile.where(:file_type.in => ['Other', 'Documentation', 'Analysis Output'], upload_file_name: /\.(h5ad|h5)$/).update_all(file_type: 'AnnData')
+      
+      # For Seurat
+      StudyFile.where(:file_type.in => ['Documentation', 'Other', 'Analysis Output'], upload_file_name: /\.(rds|Rdata)$/).update_all(file_type: 'Seurat')
+
+    end
+  
+    def self.down
+      # intentially left blank
+    end
+  end
+  

--- a/db/migrate/20221006132730_update_misc_file_type_for_anndata_and_seurat.rb
+++ b/db/migrate/20221006132730_update_misc_file_type_for_anndata_and_seurat.rb
@@ -4,7 +4,7 @@
       StudyFile.where(:file_type.in => ['Other', 'Documentation', 'Analysis Output'], upload_file_name: /\.(h5ad|h5)$/).update_all(file_type: 'AnnData')
       
       # For Seurat
-      StudyFile.where(:file_type.in => ['Documentation', 'Other', 'Analysis Output'], upload_file_name: /\.(rds|Rdata)$/).update_all(file_type: 'Seurat')
+      StudyFile.where(:file_type.in => ['Documentation', 'Other', 'Analysis Output'], upload_file_name: /\.(rda|Rda|rds|Rds|Rdata$/).update_all(file_type: 'Seurat')
 
     end
   


### PR DESCRIPTION
TLDR: Remove AnnData/Seurat file upload FF and migrate misc files to their new appropriate type


- Misc file types like `Other` and `Documentation` will no longer accept `'.Rds', '.rds'` or `'.h5', '.h5ad'`

- `AnnData` and `Seurat` file upload sections in the wizard will not be feature flagged anymore and will be GA

- Any file uploaded in the categories` 'Other', 'Documentation',` or ` 'Analysis Output'` that end in `h5ad` or `h5` are migrated to type `AnnData` and those ending in `rds` or `Rdata` will migrate to type `'Seurat'`



To Test:
1. BEFORE pulling this branch
2. Get together an `.rds` and a `.h5ad` files to test with, I used this study in HCA which has an `.rds` and a `.h5ad` file to download https://data.humancellatlas.org/explore/projects/83f5188e-3bf7-4956-9544-cea4f8997756/get-curl-command
3. Start up your local server `./rails_local_setup.rb && source config/secrets/.source_env.bash && rails s`
4. Open up localhost in a browser and sign in
5. Navigate to a study you own and go to the upload wizard
6. Start the rails job uploads by opening another terminal and running `./rails_local_setup.rb && source config/secrets/.source_env.bash && bin/rails jobs:work`
7. Upload the `.rds` file and a `.h5ad` files to the `misc` file section choosing either 'Other' or 'Documentation' for the file type. 
8. Once that has completed open up another terminal window and start up a rails console with `rails c` 
9. In the console run `StudyFile.where(upload_file_name: /\.(h5ad)$/).pluck(:file_type)` This will print out the file types of any files ending in `.h5ad` and run `StudyFile.where(upload_file_name: /\.(rds)$/).pluck(:file_type)` to get any `.rds` ending files. You should see 'Other' or 'Documentation' at this point
![Screen Shot 2022-10-07 at 11 16 23 AM](https://user-images.githubusercontent.com/54322292/194589691-4c6262c2-67ff-4f8f-a4b1-db31c237ba88.png)



1. NOW Pull this branch
2. Kill the local server you've got running
3. Open up a new terminal window  and run the DB migration `bin/rails db:migrate`
5. Start up your local server
8. Open up localhost and sign in
10. Navigate to the same study you just uploaded to and go to the wizard
11. Observe that you should see now the `AnnData` and `Seurat` sections in the wizard
12. In the rails console rerun these commands `StudyFile.where(upload_file_name: /\.(h5ad)$/).pluck(:file_type)` and run `StudyFile.where(upload_file_name: /\.(rds)$/).pluck(:file_type)` and observe that the filetypes are now `Seurat` and `AnnData` as appropriate
![Screen Shot 2022-10-07 at 11 22 58 AM](https://user-images.githubusercontent.com/54322292/194590625-9a7a0620-ce29-40d6-bfcc-5af25e06f5c8.png)


----------------------------------------------------------------
Interesting note is any invalid files that were in misc section did not migrate
![Screen Shot 2022-10-06 at 5 13 58 PM](https://user-images.githubusercontent.com/54322292/194420971-a9e9b1ad-f757-45ad-bd34-8f8657f3c3e7.png)



