### PR TITLE
Adding labels to PAPI virtual machines (SCP-4700)

### DIFF
--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -582,6 +582,8 @@ class IngestJob
 
     trigger = study_file.remote_location.present? ?  'sync' : 'upload'
 
+    # retrieve pipeline metadata for VM information
+    vm_info = metadata.dig('pipeline', 'resources', 'virtualMachine')
     # Event properties to log to Mixpanel.
     # Mixpanel uses camelCase for props; snake_case would degrade Mixpanel UX.
     job_props = {
@@ -592,7 +594,9 @@ class IngestJob
       action: action,
       studyAccession: study.accession,
       trigger: trigger,
-      jobStatus: failed? ? 'failed' : 'success'
+      jobStatus: failed? ? 'failed' : 'success',
+      machineType: vm_info['machineType'],
+      bootDiskSizeGb: vm_info['bootDiskSizeGb']
     }
 
     case action

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -154,10 +154,7 @@ class PapiClient
   # * *return*
   #   - (Google::Apis::GenomicsV2alpha1::RunPipelineRequest)
   def create_run_pipeline_request_object(pipeline:, labels: {})
-    Google::Apis::GenomicsV2alpha1::RunPipelineRequest.new(
-      pipeline: pipeline,
-      labels: labels
-    )
+    Google::Apis::GenomicsV2alpha1::RunPipelineRequest.new(pipeline:, labels:)
   end
 
   # Create a pipeline object detailing all required information in order to run an ingest job
@@ -171,12 +168,7 @@ class PapiClient
   # * *return*
   #   - (Google::Apis::GenomicsV2alpha1::Pipeline)
   def create_pipeline_object(actions:, environment:, resources:, timeout: nil)
-    Google::Apis::GenomicsV2alpha1::Pipeline.new(
-      actions: actions,
-      environment: environment,
-      resources: resources,
-      timeout: timeout
-    )
+    Google::Apis::GenomicsV2alpha1::Pipeline.new(actions:, environment:, resources:, timeout:)
   end
 
   # Instantiate actions for pipeline, which holds command line actions, docker information,
@@ -242,7 +234,7 @@ class PapiClient
     Google::Apis::GenomicsV2alpha1::Resources.new(
       project_id: project,
       regions: regions,
-      virtual_machine: vm.nil? ? create_virtual_machine_object(labels: labels) : vm
+      virtual_machine: vm.nil? ? create_virtual_machine_object(labels:) : vm
     )
   end
 

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -30,11 +30,14 @@ class PapiClient
   # jobs that require custom virtual machine types (e.g. more RAM, CPU)
   CUSTOM_VM_ACTIONS = %i[differential_expression render_expression_arrays].freeze
 
+  # default GCE machine_type
+  DEFAULT_MACHINE_TYPE = 'n1-highmem-4'.freeze
+
   # Default constructor for PapiClient
   #
   # * *params*
   #   - +project+: (String) => GCP Project to use (can be overridden by other parameters)
-  #   - +project+: (Path) => Absolute filepath to service account credentials
+  #   - +service_account_credentials+: (Path) => Absolute filepath to service account credentials
   # * *return*
   #   - +PapiClient+
   def initialize(project = self.class.compute_project, service_account_credentials = self.class.get_primary_keyfile)
@@ -97,29 +100,26 @@ class PapiClient
   #   - (Google::Apis::AuthorizationError) => Authorization is required
   def run_pipeline(study_file:, user:, action:, params_object: nil)
     study = study_file.study
-    accession = study.accession
 
     # override default VM if required for this action
     if needs_custom_vm?(action)
-      custom_vm = create_virtual_machine_object(machine_type: params_object.machine_type)
+      labels = job_labels(
+        action: action, study: study, study_file: study_file, user: user, machine_type: params_object.machine_type
+      )
+      custom_vm = create_virtual_machine_object(machine_type: params_object.machine_type, labels: labels)
       resources = create_resources_object(regions: ['us-central1'], vm: custom_vm)
     else
-      resources = create_resources_object(regions: ['us-central1'])
+      labels = job_labels(action:, study:, study_file:, user:)
+      resources = create_resources_object(regions: ['us-central1'], labels: labels)
     end
 
-    command_line = get_command_line(study_file: study_file, action: action, user_metrics_uuid: user.metrics_uuid,
-                                    params_object: params_object)
-    labels = {
-      study_accession: accession,
-      user_id: user.id.to_s,
-      file_id: study_file.id.to_s,
-      action: action,
-      docker_image: AdminConfiguration.get_ingest_docker_image
-    }
+    user_metrics_uuid = user.metrics_uuid
+    command_line = get_command_line(study_file:, action:, user_metrics_uuid:, params_object:)
+
     environment = set_environment_variables
     action = create_actions_object(commands: command_line, environment: environment)
     pipeline = create_pipeline_object(actions: [action], environment: environment, resources: resources)
-    pipeline_request = create_run_pipeline_request_object(pipeline: pipeline, labels: labels)
+    pipeline_request = create_run_pipeline_request_object(pipeline:, labels:)
     Rails.logger.info "Request object sent to Google Pipelines API (PAPI), excluding 'environment' parameters:"
     sanitized_pipeline_request = pipeline_request.to_h[:pipeline].except(:environment)
     sanitized_pipeline_request[:actions] = sanitized_pipeline_request[:actions][0].except(:environment)
@@ -228,16 +228,17 @@ class PapiClient
   # Instantiate a resources object to tell where to run a pipeline
   #
   # * *params*
-  #   - regions: (Array<String>) => An array of GCP regions allowed for VM allocation
-  #   - vm: (Google::Apis::GenomicsV2alpha1::VirtualMachine) => Existing VM config to use, other than default
+  #   - +regions+: (Array<String>) => An array of GCP regions allowed for VM allocation
+  #   - +vm+: (Google::Apis::GenomicsV2alpha1::VirtualMachine) => Existing VM config to use, other than default
+  #   - +labels+ (Hash) => Key/value pairs of labels for VM
   #
   # * *return*
   #   - (Google::Apis::GenomicsV2alpha1::Resources)
-  def create_resources_object(regions:, vm: nil)
+  def create_resources_object(regions:, vm: nil, labels: {})
     Google::Apis::GenomicsV2alpha1::Resources.new(
       project_id: project,
       regions: regions,
-      virtual_machine: vm.nil? ? create_virtual_machine_object : vm
+      virtual_machine: vm.nil? ? create_virtual_machine_object(labels: labels) : vm
     )
   end
 
@@ -249,13 +250,18 @@ class PapiClient
   #   - +machine_type+ (String) => GCP VM machine type (defaults to 'n1-highmem-4': 4 CPU, 26GB RAM)
   #   - +boot_disk_size_gb+ (Integer) => Size of boot disk for VM, in gigabytes (defaults to 100GB)
   #   - +preemptible+ (Boolean) => Indication of whether VM can be preempted (defaults to false)
+  #   - +labels+ (Hash) => Key/value pairs of labels for VM
   # * *return*
   #   - (Google::Apis::GenomicsV2alpha1::VirtualMachine)
-  def create_virtual_machine_object(machine_type: 'n1-highmem-4', boot_disk_size_gb: 300, preemptible: false)
+  def create_virtual_machine_object(machine_type: DEFAULT_MACHINE_TYPE,
+                                    boot_disk_size_gb: 300,
+                                    preemptible: false,
+                                    labels: {})
     virtual_machine = Google::Apis::GenomicsV2alpha1::VirtualMachine.new(
       machine_type: machine_type,
       preemptible: preemptible,
       boot_disk_size_gb: boot_disk_size_gb,
+      labels: labels,
       service_account: Google::Apis::GenomicsV2alpha1::ServiceAccount.new(email: issuer, scopes: GOOGLE_SCOPES)
     )
     # assign correct network/sub-network if specified
@@ -356,6 +362,52 @@ class PapiClient
       end
     end
     opts
+  end
+
+  # set labels for pipeline request/virtual machine
+  #
+  # * *params*
+  #   - +action+ (String, Symbol) => action being executed
+  #   - +study+ (Study) => parent study of file
+  #   - +study_file+ (StudyFile) => File to be ingested/processed
+  #   - +user+ (User) => user requesting action
+  #   - +machine_type+ (String) => GCE machine type
+  #   - +boot_disk_size_gb+ (Integer) => size of boot disk, in GB
+  #
+  # * *returns*
+  #   - (Hash)
+  def job_labels(action:, study:, study_file:, user:, machine_type: DEFAULT_MACHINE_TYPE, boot_disk_size_gb: 300)
+    {
+      study_accession: study.accession,
+      user_id: user.id.to_s,
+      filename: study_file.upload_file_name,
+      action: label_for_action(action),
+      docker_image: AdminConfiguration.get_ingest_docker_image,
+      environment: Rails.env,
+      file_type: study_file.file_type,
+      machine_type: machine_type,
+      boot_disk_size_gb: boot_disk_size_gb
+    }
+  end
+
+  # shorthand label for action
+  #
+  # * *params*
+  #   - +action+ (String) => original action
+  #
+  # * *returns*
+  #   - (String) => label for action, condensing all ingest actions to 'ingest'
+  def label_for_action(action)
+    case action.to_s
+    when /ingest/
+      'ingest_pipeline'
+    when /differential/
+      'differential_expression'
+    when 'render_expression_arrays'
+      'image_pipeline'
+    else
+      action
+    end
   end
 
   private

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -401,7 +401,7 @@ class PapiClient
     when /differential/
       'differential_expression'
     when 'render_expression_arrays'
-      'image_pipeline'
+      'data_cache_pipeline'
     else
       action
     end

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -96,8 +96,17 @@ class IngestJobTest < ActiveSupport::TestCase
       events: [
         { timestamp: now.to_s },
         { timestamp: (now + 1.minute).to_s }
-      ]
+      ],
+      pipeline: {
+        resources: {
+          virtualMachine: {
+            machineType: 'n1-highmem-4',
+            bootDiskSizeGb: 300
+          }
+        }
+      }
     }.with_indifferent_access
+    mock.expect :metadata, mock_metadata
     mock.expect :metadata, mock_metadata
     mock.expect :error, nil
 
@@ -116,7 +125,9 @@ class IngestJobTest < ActiveSupport::TestCase
         jobStatus: 'success',
         numGenes: @basic_study.genes.count,
         is_raw_counts: false,
-        numCells: num_cells
+        numCells: num_cells,
+        machineType: 'n1-highmem-4',
+        bootDiskSizeGb: 300
       }.with_indifferent_access
 
       job_analytics = job.get_job_analytics
@@ -132,8 +143,17 @@ class IngestJobTest < ActiveSupport::TestCase
       events: [
         { timestamp: now.to_s },
         { timestamp: (now + 2.minutes).to_s }
-      ]
+      ],
+      pipeline: {
+        resources: {
+          virtualMachine: {
+            machineType: 'n1-highmem-4',
+            bootDiskSizeGb: 300
+          }
+        }
+      }
     }.with_indifferent_access
+    mock.expect :metadata, mock_metadata
     mock.expect :metadata, mock_metadata
     mock.expect :error, { code: 1, message: 'mock message' } # simulate error
 
@@ -149,7 +169,9 @@ class IngestJobTest < ActiveSupport::TestCase
         jobStatus: 'failed',
         numCells: 0,
         is_raw_counts: false,
-        numGenes: 0
+        numGenes: 0,
+        machineType: 'n1-highmem-4',
+        bootDiskSizeGb: 300
       }.with_indifferent_access
 
       job_analytics = job.get_job_analytics

--- a/test/models/papi_client_test.rb
+++ b/test/models/papi_client_test.rb
@@ -238,16 +238,17 @@ class PapiClientTest < ActiveSupport::TestCase
 
   test 'should set labels for job' do
     labels = @client.job_labels(action: :ingest_cluster, study: @study, study_file: @cluster_file, user: @user)
+    ingest_tag = AdminConfiguration.get_ingest_docker_image_attributes[:tag].gsub(/\./, '_')
     expected_labels = {
-      study_accession: @study.accession,
+      study_accession: @study.accession.downcase,
       user_id: @user.id.to_s,
-      filename: @cluster_file.upload_file_name,
+      filename: 'cluster_txt',
       action: 'ingest_pipeline',
-      docker_image: AdminConfiguration.get_ingest_docker_image,
+      docker_image: ingest_tag,
       environment: 'test',
-      file_type: 'Cluster',
+      file_type: 'cluster',
       machine_type: PapiClient::DEFAULT_MACHINE_TYPE,
-      boot_disk_size_gb: 300
+      boot_disk_size_gb: '300'
     }
     assert_equal expected_labels, labels
   end

--- a/test/models/papi_client_test.rb
+++ b/test/models/papi_client_test.rb
@@ -252,4 +252,18 @@ class PapiClientTest < ActiveSupport::TestCase
     }
     assert_equal expected_labels, labels
   end
+
+  test 'should get correct label for action' do
+    PapiClient::FILE_TYPES_BY_ACTION.keys.select { |k| k =~ /ingest/ }.each do |action|
+      assert_equal 'ingest_pipeline', @client.label_for_action(action)
+    end
+    assert_equal 'differential_expression', @client.label_for_action('differential_expression')
+    assert_equal 'image_pipeline', @client.label_for_action('render_expression_arrays')
+    assert_equal 'foo', @client.label_for_action('foo')
+  end
+
+  test 'should sanitize label' do
+    assert_equal 'foo_bar', @client.sanitize_label('FOO&bar')
+    assert_equal 'n1-highcpu-96', @client.sanitize_label('n1-highcpu-96')
+  end
 end

--- a/test/models/papi_client_test.rb
+++ b/test/models/papi_client_test.rb
@@ -258,7 +258,7 @@ class PapiClientTest < ActiveSupport::TestCase
       assert_equal 'ingest_pipeline', @client.label_for_action(action)
     end
     assert_equal 'differential_expression', @client.label_for_action('differential_expression')
-    assert_equal 'image_pipeline', @client.label_for_action('render_expression_arrays')
+    assert_equal 'data_cache_pipeline', @client.label_for_action('render_expression_arrays')
     assert_equal 'foo', @client.label_for_action('foo')
   end
 


### PR DESCRIPTION
#### BACKGROUND
The Google Cloud Platform billing dashboard allows SCP team members to get detailed information about the cost of various assets that are a part of SCP core infrastructure (VMs, disks, etc).  However, these costs are rolled up by resource type (compute CPU/RAM, cloud storage, egress, etc.) and do not provide adequate granularity to determine how much is being spent on specific actions in SCP, such as file parsing, differential expression computation, or Image Pipeline activities.

#### CHANGES
This update adds labels to virtual machines created in PAPI, which will allow us to filter billing reports based on these key/value pairs.  The following labels will be added to every VM and pipeline request:
- `study_accession`: accession of study
- `user_id`: MongDB ID of user requesting action
- `filename`: name of primary file being processed
- `action`: summary label for action: `ingest_pipeline`, `differential_expression`, or `image_pipeline`
- `docker_image`: version tag of the `scp-ingest-pipeline` Docker image
- `environment`: the Rails environment this job was launched in: `development`, `test`, `staging`, or `production`
-  `file_type`: SCP file type of primary file
- `machine_type`: GCE machine type, e.g. `n1-highmem-4`
- `boot_disk_size_gb`: size of the boot disk provisioned for VM (usually 300GB)

Note: due to restrictions on label formatting, the values provided for these keys can only contain lowercase alphanumeric characters, plus dashes: `-` and underscores: `_`.  This means that values like study accessions will appear slightly different - `scp1234` instead of `SCP1234`, and `expression_matrix` instead of `Expression Matrix`.

#### MANUAL TESTING
1. Locally, boot as normal and sign in
2. In a separate terminal, start DelayedJob: 
```
./rails_local_setup.rb && source config/secrets/.source_env.bash && bin/rails jobs:work
```
3. Upload a parseable file to any study - cluster, metadata, or expression matrix
4. In `development.log`, note that labels have been applied to the virtual machine:
```
Request object sent to Google Pipelines API (PAPI), excluding 'environment' parameters:
---
...

:resources:
  :project_id: broad-singlecellportal-bistlin
  :regions:
  - us-central1
  :virtual_machine:
    :boot_disk_size_gb: 300
    :labels:
      :study_accession: scp72
      :user_id: 6033f4a8e2413917a1d0ddcd
      :filename: expression_matrix_example_txt
      :action: ingest_pipeline
      :docker_image: '1_22_0'
      :environment: development
      :file_type: expression_matrix
      :machine_type: n1-highmem-4
      :boot_disk_size_gb: '300'
    :machine_type: n1-highmem-4
    :preemptible: false
```
5. In a separate browser tab, go to your developer specific GCP console (e.g. `broad-singlecellportal-{username}`), and open the Compute Engine panel
6. Look for the `google-pipelines-worker` VM and click on that entry
7. Note under the `Labels` section, the same labels have been applied to the VM:
![Screen Shot 2022-10-12 at 2 29 26 PM](https://user-images.githubusercontent.com/729968/195426845-df36cf2f-f84b-4f2d-a453-1e1610e7f394.png)

Note: you will not be able to see these labels yet in the billing reports section, as charges do not roll up until the following day.  However, you should be able to filter on any of these labels the day after running these tests.