### PR TITLE
Add delay for setting active trace label (SCP-4604)

### DIFF
--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
@@ -60,6 +60,19 @@ function LegendEntry({
 
   // clicking the label will either hide the trace, or pop up a color picker
   const entryClickFunction = showColorControls ? () => setShowColorPicker(true) : toggleSelection
+  // clicking the label will either hide the trace, or pop up a color picker
+
+  let scatterHoverHandle
+  let scatterHoverId
+  // do not trigger `setActiveTraceLabel()` immediately to prevent triggers on scroll
+  const scatterHoverHandler = (label, currentSelectCheck) => {
+    clearTimeout(scatterHoverHandle)
+    scatterHoverHandle = setTimeout(() => {
+      if (scatterHoverHandle && currentSelectCheck()) {
+        setActiveTraceLabel(label)
+      }
+    }, 10000)
+  }
   return (
     <>
       <div
@@ -67,9 +80,19 @@ function LegendEntry({
         role="button"
         onClick={entryClickFunction}
         onMouseEnter={() => {
-          setActiveTraceLabel(label)
+          scatterHoverId = label
+          scatterHoverHandler(
+            label,
+            () => label === scatterHoverId
+          )
         }}
-        onMouseLeave={() => setActiveTraceLabel(null)}
+        onMouseLeave={() => {
+          scatterHoverId=''
+          scatterHoverHandler(
+            null,
+            () => '' === scatterHoverId
+          )
+        }}
       >
         <div className="scatter-legend-icon" style={iconStyle}>
           { showColorControls && <FontAwesomeIcon icon={faPalette} title="Change the color for this label"/> }

--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
@@ -60,7 +60,6 @@ function LegendEntry({
 
   // clicking the label will either hide the trace, or pop up a color picker
   const entryClickFunction = showColorControls ? () => setShowColorPicker(true) : toggleSelection
-  // clicking the label will either hide the trace, or pop up a color picker
 
   let scatterHoverHandle
   let scatterHoverId


### PR DESCRIPTION
This is to address the laggy scrolling of the scatter plot legend for studies with very long lists of labels.

Write up here: https://docs.google.com/document/d/1kA5E2_OnS9yQcIADUeOSkT5g05Yt5cEhQYJxsfzO1gY/edit of approach to looking into performance of such studies and proposed options.

TLDR: The lagginess of scrolling the legend list appeared to be caused by the hover functionality that would be triggered as a user scrolled down the list since their mouse would be hovering as it went triggering re-draws of the plot. This fix adds delay so that the hover functionality of bringing labels to the front of the plot won't be triggered on every single hover during a scroll.


To test:
- You need a really big study. I copied the one from Staging here: https://singlecell-staging.broadinstitute.org/single_cell/study/SCP149/5k-unqiue-u19-multi-cell-type-merged-labels#study-visualize
- Try scrolling that study in staging ^ to see the before behavior
- Pull this branch and start up your local server and navigate to your really big study
- Try scrolling the legend and observe the lagginess is fixed.

Before:

https://user-images.githubusercontent.com/54322292/195439794-c804fb16-583c-491a-a339-0cf25bccca5e.mov


After:

https://user-images.githubusercontent.com/54322292/195439577-f45f6545-39f5-4dfc-a86e-8cbfa01b22f9.mov


