### PR TITLE
Adding local dev setup via docker-compose (SCP-4777)

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,11 +339,10 @@ To create an admin user account:
 Developing on SCP without a Docker container, while less robust, opens up some faster development paradigms, including live css/js reloading, faster build times, and byebug debugging in rails.  See [Non-containerized development README](./NON_CONTAINERIZED_DEV_README.md) for instructions
 
 ## HYBRID DOCKER LOCAL DEVELOPMENT
-It is possible for Broad Institute team members to develop locally using Docker with a 'hybrid' setup that merges the 
-speed of developing outside the container with the ease of using Docker for package/gem management.  This allows using 
-`vite` for hot module replacement (HMR) along with all the other features of native Rails development, but uses 
-`docker-compose` to build and deploy containers locally.  Both containers are built off of the 
-`single-cell-portal:development` Docker image referenced above.
+SCP team members can develop locally using Docker with a 'hybrid' setup that merges the speed of developing outside the 
+container with the ease of using Docker for package/gem management.  This allows using `vite` for hot module replacement 
+(HMR) along with all the other features of native Rails development, but uses `docker-compose` to build and deploy 
+containers locally.  Both containers are built off of the `single-cell-portal:development` Docker image referenced above.
 
 This setup will behave almost exactly like developing 
 outside of the container - you can edit files in your IDE and have them updated in the container in real time, and any 
@@ -354,8 +353,8 @@ reduce this latency by rebuilding the `single-cell-portal:development` Docker im
 [building the Docker image](#pullingbuilding-the-docker-image) above for more information.
 
 ### USING DOCKER COMPOSE LOCALLY
-To leverage this setup, there are two shell scripts for both setup and cleanup, respectively.  To start the local 
-instance, run:
+To leverage this setup, there are two shell scripts for setup and cleanup, respectively.  To start the local instance, 
+run:
 
     bin/docker-compose-setup.sh
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ will need to create a Terra project that will own all the workspaces created in 
 
 ## RUNNING THE CONTAINER
 
+Note: If you are developing locally and would like to leverage the hybrid Docker/local setup, see the section below on
+[HYBRID DOCKER LOCAL DEVELOPMENT](#hybrid-docker-local-development).
+
 Once the image has successfully built, all registration/configuration steps have been completed, use the following command
 to start the container:
 
@@ -334,6 +337,40 @@ To create an admin user account:
 
 ## DEVELOPING OUTSIDE THE CONTAINER
 Developing on SCP without a Docker container, while less robust, opens up some faster development paradigms, including live css/js reloading, faster build times, and byebug debugging in rails.  See [Non-containerized development README](./NON_CONTAINERIZED_DEV_README.md) for instructions
+
+## HYBRID DOCKER LOCAL DEVELOPMENT
+It is possible for Broad Institute team members to develop locally using Docker with a 'hybrid' setup that merges the 
+speed of developing outside the container with the ease of using Docker for package/gem management.  This allows using 
+`vite` for hot module replacement (HMR) along with all the other features of native Rails development, but uses 
+`docker-compose` to build and deploy containers locally.  Both containers are built off of the 
+`single-cell-portal:development` Docker image referenced above.
+
+This setup will behave almost exactly like developing 
+outside of the container - you can edit files in your IDE and have them updated in the container in real time, and any 
+JS/CSS changes will automatically reload thanks to HMR without any page refresh.  The startup process (minus any 
+`docker pull` latency) should only take 20-30s, though if you update any JS dependencies it can take 2-3 minutes to run 
+`yarn install` on boot depending on how constrained your local Docker installation is in terms of CPU/RAM.  You can 
+reduce this latency by rebuilding the `single-cell-portal:development` Docker image locally.  See the section on 
+[building the Docker image](#pullingbuilding-the-docker-image) above for more information.
+
+### USING DOCKER COMPOSE LOCALLY
+To leverage this setup, there are two shell scripts for both setup and cleanup, respectively.  To start the local 
+instance, run:
+
+    bin/docker-compose-setup.sh
+
+This will pull all necessary secrets from `vault` and write env files to pass to Docker, then create two containers 
+locally: `single_cell` (application server), and `single_cell_vite` (vite dev server). Both containers will install 
+their dependencies automatically if you have updated any gems or JS packages and then start their required services.  In 
+addition to the Rails server, the `single_cell` container will run any required migrations and start `Delayed::Job` on 
+startup.  Both containers can be stopped by pressing `Ctrl-C`.
+
+To clean up the Docker environment, run:
+
+    bin/docker-compose-cleanup.sh
+
+This will remove both containers, their dependent volumes, and reset any local configuration files to their non-Dockerized 
+format.
 
 ## UPDATING JAVASCRIPT PEER/INDIRECT DEPENDENCIES
 Since `yarn` does not automatically upgrade peer/indirect dependencies automatically (it will only update packages declared 

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ speed of developing outside the container with the ease of using Docker for pack
 This setup will behave almost exactly like developing 
 outside of the container - you can edit files in your IDE and have them updated in the container in real time, and any 
 JS/CSS changes will automatically reload thanks to HMR without any page refresh.  The startup process (minus any 
-`docker pull` latency) should only take 20-30s, though if you update any JS dependencies it can take 2-3 minutes to run 
+`docker pull` latency) should only take ~30s, though if you update any JS dependencies it can take 2-3 minutes to run 
 `yarn install` on boot depending on how constrained your local Docker installation is in terms of CPU/RAM.  You can 
 reduce this latency by rebuilding the `single-cell-portal:development` Docker image locally.  See the section on 
 [building the Docker image](#pullingbuilding-the-docker-image) above for more information.
@@ -363,9 +363,16 @@ This will pull all necessary secrets from `vault` and write env files to pass to
 locally: `single_cell` (application server), and `single_cell_vite` (vite dev server). Both containers will install 
 their dependencies automatically if you have updated any gems or JS packages and then start their required services.  In 
 addition to the Rails server, the `single_cell` container will run any required migrations and start `Delayed::Job` on 
-startup.  Both containers can be stopped by pressing `Ctrl-C`.
+startup.  Both containers can be stopped by pressing `Ctrl-C`.  This will not remove either container, and they can both 
+be restarted with the same command.
 
-To clean up the Docker environment, run:
+You can also start these containers headlessly by passing `-d`.  This runs the same startup commands, but will not 
+attach `STDOUT` from the containers to the terminal.  When using this option, note that it will take between 30-60 
+seconds before the portal instance is available at `https://localhost:3000/single_cell`.
+
+    bin/docker-compose-setup.sh -d
+
+To stop both services and clean up the Docker environment, run:
 
     bin/docker-compose-cleanup.sh
 

--- a/app/javascript/providers/SCPContextProvider.jsx
+++ b/app/javascript/providers/SCPContextProvider.jsx
@@ -1,5 +1,6 @@
 // JS variables wrapped in double underscores are defined in version.txt
 const version = (typeof __SCP_VERSION__ !== 'undefined') ? __SCP_VERSION__ : null
+const devMode = (typeof __DEV_MODE__ !== 'undefined') ? __DEV_MODE__ : null
 
 // Set by running the following in terminal in local SCP instance:
 // VITE_FRONTEND_SERVICE_WORKER_CACHE="true" bin/vite dev
@@ -10,6 +11,7 @@ export function getSCPContext() {
   if (window.SCP) {
     window.SCP.version = version
     window.SCP.isServiceWorkerCacheEnabled = isServiceWorkerCacheEnabled
+    window.SCP.devMode = devMode
     return window.SCP
   }
   return {
@@ -17,6 +19,7 @@ export function getSCPContext() {
     environment: 'test',
     analyticsPageName: 'test-noname',
     version,
-    isServiceWorkerCacheEnabled
+    isServiceWorkerCacheEnabled,
+    devMode
   }
 }

--- a/bin/docker-compose-cleanup.sh
+++ b/bin/docker-compose-cleanup.sh
@@ -1,4 +1,8 @@
 #! /bin/sh
+
+# docker-compose-cleanup.sh
+# stop/remove all containers/volumes created by docker-compose and revert environment config files
+
 echo "### REMOVING CONTAINERS/VOLUMES ###"
 docker-compose -f docker-compose-dev.yaml down
 docker volume prune --force

--- a/bin/docker-compose-cleanup.sh
+++ b/bin/docker-compose-cleanup.sh
@@ -5,6 +5,8 @@
 # More context: https://github.com/broadinstitute/single_cell_portal_core#hybrid-docker-local-development
 
 echo "### REMOVING CONTAINERS/VOLUMES ###"
+# set VITE_FRONTEND_SERVICE_WORKER_CACHE to silence warnings from docker-compose
+VITE_FRONTEND_SERVICE_WORKER_CACHE="$VITE_FRONTEND_SERVICE_WORKER_CACHE" \
 docker-compose -f docker-compose-dev.yaml down
 docker volume prune --force
 rm tmp/pids/*.pid

--- a/bin/docker-compose-cleanup.sh
+++ b/bin/docker-compose-cleanup.sh
@@ -2,6 +2,7 @@
 
 # docker-compose-cleanup.sh
 # stop/remove all containers/volumes created by docker-compose and revert environment config files
+# More context: https://github.com/broadinstitute/single_cell_portal_core#hybrid-docker-local-development
 
 echo "### REMOVING CONTAINERS/VOLUMES ###"
 docker-compose -f docker-compose-dev.yaml down

--- a/bin/docker-compose-cleanup.sh
+++ b/bin/docker-compose-cleanup.sh
@@ -2,9 +2,6 @@
 echo "### REMOVING CONTAINERS/VOLUMES ###"
 docker-compose -f docker-compose-dev.yaml down
 docker volume prune --force
-PID_PATH=tmp/pids/server.pid
-if [[ -f "$PID_PATH" ]]; then
-  rm $PID_PATH
-fi
+rm tmp/pids/*.pid
 echo "### REVERTING ENVIRONMENT ###"
 ./rails_local_setup.rb

--- a/bin/docker-compose-cleanup.sh
+++ b/bin/docker-compose-cleanup.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+echo "### REMOVING CONTAINERS/VOLUMES ###"
+docker-compose -f docker-compose-dev.yaml down
+docker volume prune --force
+PID_PATH=tmp/pids/server.pid
+if [[ -f "$PID_PATH" ]]; then
+  rm $PID_PATH
+fi
+echo "### REVERTING ENVIRONMENT ###"
+./rails_local_setup.rb

--- a/bin/docker-compose-setup.sh
+++ b/bin/docker-compose-setup.sh
@@ -2,6 +2,7 @@
 
 # docker-compose-setup.sh
 # bring up local development environment via docker-compose
+# More context: https://github.com/broadinstitute/single_cell_portal_core#hybrid-docker-local-development
 
 usage=$(
 cat <<EOF

--- a/bin/docker-compose-setup.sh
+++ b/bin/docker-compose-setup.sh
@@ -8,15 +8,23 @@ usage=$(
 cat <<EOF
 $0 [OPTION]
 -d   run docker-compose in detached mode (default is attatched to terminal STDOUT)
+-c   enable VITE_FRONTEND_SERVICE_WORKER_CACHE (default is disabled)
 -h   print this text
 EOF
 )
 
-DETACHED="no"
-while getopts "dh" OPTION; do
+DETACHED=""
+VITE_FRONTEND_SERVICE_WORKER_CACHE="false"
+while getopts "dch" OPTION; do
 case $OPTION in
   d)
-    DETACHED="yes"
+    echo "### SETTING DETACHED ###"
+    DETACHED="--detach"
+    echo "### PLEASE ALLOW 30s ONCE SERVICES START BEFORE ISSUING REQUESTS ###"
+    ;;
+  c)
+    echo "### ENABLING VITE_FRONTEND_SERVICE_WORKER_CACHE ###"
+    VITE_FRONTEND_SERVICE_WORKER_CACHE="true"
     ;;
   h)
   	echo "$usage"
@@ -33,11 +41,6 @@ done
 echo "### SETTING UP ENVIRONMENT ###"
 ./rails_local_setup.rb --docker-paths
 source config/secrets/.source_env.bash
-if [[ "$DETACHED" = "yes" ]]; then
-  echo "### SERVICES STARTING IN DETACHED MODE ###"
-  docker-compose -f docker-compose-dev.yaml up --detach
-  echo "### please wait 60s before issuing requests to localhost:3000 ###"
-else
-  echo "### STARTING SERVICES ###"
-  docker-compose -f docker-compose-dev.yaml up
-fi
+echo "### STARTING SERVICES ###"
+VITE_FRONTEND_SERVICE_WORKER_CACHE="$VITE_FRONTEND_SERVICE_WORKER_CACHE" \
+docker-compose -f docker-compose-dev.yaml up $DETACHED

--- a/bin/docker-compose-setup.sh
+++ b/bin/docker-compose-setup.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 echo "### SETTING UP ENVIRONMENT ###"
-./rails_local_setup.rb -d
+./rails_local_setup.rb --docker-paths
 source config/secrets/.source_env.bash
 echo "### STARTING SERVICES ###"
 docker-compose -f docker-compose-dev.yaml up

--- a/bin/docker-compose-setup.sh
+++ b/bin/docker-compose-setup.sh
@@ -1,6 +1,42 @@
 #! /bin/sh
+
+# docker-compose-setup.sh
+# bring up local development environment via docker-compose
+
+usage=$(
+cat <<EOF
+$0 [OPTION]
+-d   run docker-compose in detached mode (default is attatched to terminal STDOUT)
+-h   print this text
+EOF
+)
+
+DETACHED="no"
+while getopts "dh" OPTION; do
+case $OPTION in
+  d)
+    DETACHED="yes"
+    ;;
+  h)
+  	echo "$usage"
+  	exit 0
+  	;;
+  *)
+  	echo "unrecognized option"
+  	echo "$usage"
+  	exit 1
+  	;;
+  esac
+done
+
 echo "### SETTING UP ENVIRONMENT ###"
 ./rails_local_setup.rb --docker-paths
 source config/secrets/.source_env.bash
-echo "### STARTING SERVICES ###"
-docker-compose -f docker-compose-dev.yaml up
+if [[ "$DETACHED" = "yes" ]]; then
+  echo "### SERVICES STARTING IN DETACHED MODE ###"
+  docker-compose -f docker-compose-dev.yaml up --detach
+  echo "### please wait 60s before issuing requests to localhost:3000 ###"
+else
+  echo "### STARTING SERVICES ###"
+  docker-compose -f docker-compose-dev.yaml up
+fi

--- a/bin/docker-compose-setup.sh
+++ b/bin/docker-compose-setup.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+echo "### SETTING UP ENVIRONMENT ###"
+./rails_local_setup.rb -d
+source config/secrets/.source_env.bash
+echo "### STARTING SERVICES ###"
+docker-compose -f docker-compose-dev.yaml up

--- a/config/vite.json
+++ b/config/vite.json
@@ -8,7 +8,8 @@
     "autoBuild": true,
     "publicOutputDir": "vite-dev",
     "port": 3036,
-    "host": "127.0.0.1"
+    "host": "127.0.0.1",
+    "devServerConnectTimeout": 1.0
   },
   "test": {
     "autoBuild": true,

--- a/db/migrate/20221006132730_update_misc_file_type_for_anndata_and_seurat.rb
+++ b/db/migrate/20221006132730_update_misc_file_type_for_anndata_and_seurat.rb
@@ -2,14 +2,13 @@
     def self.up
       # For AnnData
       StudyFile.where(:file_type.in => ['Other', 'Documentation', 'Analysis Output'], upload_file_name: /\.(h5ad|h5)$/).update_all(file_type: 'AnnData')
-      
+
       # For Seurat
-      StudyFile.where(:file_type.in => ['Documentation', 'Other', 'Analysis Output'], upload_file_name: /\.(rda|Rda|rds|Rds|Rdata$/).update_all(file_type: 'Seurat')
+      StudyFile.where(:file_type.in => ['Documentation', 'Other', 'Analysis Output'], upload_file_name: /\.(rda|Rda|rds|Rds|Rdata$)/).update_all(file_type: 'Seurat')
 
     end
-  
+
     def self.down
       # intentially left blank
     end
   end
-  

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -8,12 +8,7 @@ services:
       - vite
     env_file:
       - config/secrets/.source_env.bash
-    command:
-      - /bin/bash
-      - -c
-      - |
-        bundle install
-        bin/rails s
+    entrypoint: ./rails-dev-entrypoint.sh
     ports:
       - 3000:3000
       - 3001:3001
@@ -26,12 +21,7 @@ services:
   vite:
     container_name: single_cell_vite
     image: gcr.io/broad-singlecellportal-staging/single-cell-portal:development
-    command:
-      - /bin/bash
-      - -c
-      - |
-        yarn install
-        bin/vite dev
+    entrypoint: ./vite-dev-entrypoint.sh
     environment:
       RAILS_ENV: development
       VITE_RUBY_HOST: 0.0.0.0

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -1,0 +1,43 @@
+services:
+  app:
+    container_name: single_cell
+    image: gcr.io/broad-singlecellportal-staging/single-cell-portal:development
+    environment:
+      VITE_RUBY_HOST: vite
+    depends_on:
+      - vite
+    env_file:
+      - config/secrets/.source_env.bash
+    command:
+      - /bin/bash
+      - -c
+      - |
+        bundle install
+        bin/rails s
+    ports:
+      - 3000:3000
+      - 3001:3001
+    expose:
+      - 27017
+    volumes:
+      - .:/home/app/webapp
+      - type: volume
+        target: /home/app/webapp/node_modules
+  vite:
+    container_name: single_cell_vite
+    image: gcr.io/broad-singlecellportal-staging/single-cell-portal:development
+    command:
+      - /bin/bash
+      - -c
+      - |
+        yarn install
+        bin/vite dev
+    environment:
+      RAILS_ENV: development
+      VITE_RUBY_HOST: 0.0.0.0
+    ports:
+      - 3036:3036
+    volumes:
+      - .:/home/app/webapp
+      - type: volume
+        target: /home/app/webapp/node_modules

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -25,6 +25,8 @@ services:
     environment:
       RAILS_ENV: development
       VITE_RUBY_HOST: 0.0.0.0
+      VITE_FRONTEND_SERVICE_WORKER_CACHE: "${VITE_FRONTEND_SERVICE_WORKER_CACHE}"
+      VITE_DEV_MODE: "\"docker-compose\"" # extra quotes are to encode as JSON string value
     ports:
       - 3036:3036
     volumes:

--- a/rails-dev-entrypoint.sh
+++ b/rails-dev-entrypoint.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+bundle install
+bin/rails db:migrate
+bin/delayed_job start development --pool=default:6, --pool=cache:2
+bin/rails s

--- a/rails_local_setup.rb
+++ b/rails_local_setup.rb
@@ -5,11 +5,9 @@ require 'optparse'
 
 # Set up the environment for doing local development/testing outside of Docker
 # will export all secrets from vault for the current user and create configuration files
-#
 # can also be run to print 'dockerized' paths to use inside of Docker for hybrid setup
-# run ./rails_local_setup.rb -d and then docker-compose -f docker-compose-dev.yaml up
 #
-# usage: ruby rails_local_setup.rb [-e, --environment ENVIRONMENT] [-u, --username USERNAME]
+# usage: ./rails_local_setup.rb [-e, --environment ENVIRONMENT] [-u, --username USERNAME] [-d, --docker-paths]
 
 # defaults
 username = `whoami`.chomp

--- a/rails_local_setup.rb
+++ b/rails_local_setup.rb
@@ -6,11 +6,15 @@ require 'optparse'
 # Set up the environment for doing local development/testing outside of Docker
 # will export all secrets from vault for the current user and create configuration files
 #
+# can also be run to print 'dockerized' paths to use inside of Docker for hybrid setup
+# run ./rails_local_setup.rb -d and then docker-compose -f docker-compose-dev.yaml up
+#
 # usage: ruby rails_local_setup.rb [-e, --environment ENVIRONMENT] [-u, --username USERNAME]
 
 # defaults
 username = `whoami`.chomp
 environment = 'development'
+output_dir = "#{File.expand_path('.')}/config"
 
 # options parsing
 OptionParser.new do |opts|
@@ -25,6 +29,10 @@ OptionParser.new do |opts|
   opts.on("-e", "--environment ENVIRONMENT", String, "Set the rails environment (defaults to #{environment})") do |e|
     environment = e.strip
     puts "ENVIRONMENT: #{environment}"
+  end
+
+  opts.on('-d', '--docker-paths', 'Use Dockerized paths for configurations (for running inside Docker)') do |d|
+    output_dir = '/home/app/webapp/config'
   end
 
   opts.on("-h", "--help", "Prints this help") do
@@ -47,6 +55,7 @@ mongo_user_path = "#{base_vault_path}/mongo/user"
 # defaults
 PASSENGER_APP_ENV = environment
 CONFIG_DIR = File.expand_path('.') + "/config"
+
 
   # load raw secrets from vault
 puts 'Processing secret parameters from Vault'
@@ -72,13 +81,13 @@ service_account_hash = JSON.parse(service_account_string)['data']
 File.open("#{CONFIG_DIR}/.scp_service_account.json", 'w') { |file| file.write(service_account_hash.to_json) }
 puts "Setting google cloud project: #{service_account_hash['project_id']}"
 source_file_string += "export GOOGLE_CLOUD_PROJECT=#{service_account_hash['project_id']}\n"
-source_file_string += "export SERVICE_ACCOUNT_KEY=#{CONFIG_DIR}/.scp_service_account.json\n"
+source_file_string += "export SERVICE_ACCOUNT_KEY=#{output_dir}/.scp_service_account.json\n"
 
 puts 'Processing readonly service account info'
 readonly_string = `vault read -format=json #{read_only_service_account_path}`
 readonly_hash = JSON.parse(readonly_string)['data']
 File.open("#{CONFIG_DIR}/.read_only_service_account.json", 'w') { |file| file.write(readonly_hash.to_json) }
-source_file_string += "export READ_ONLY_SERVICE_ACCOUNT_KEY=#{CONFIG_DIR}/.read_only_service_account.json\n"
+source_file_string += "export READ_ONLY_SERVICE_ACCOUNT_KEY=#{output_dir}/.read_only_service_account.json\n"
 
 File.open("#{CONFIG_DIR}/secrets/.source_env.bash", 'w') { |file| file.write(source_file_string) }
 

--- a/vite-dev-entrypoint.sh
+++ b/vite-dev-entrypoint.sh
@@ -1,4 +1,8 @@
 #! /bin/sh
 
+# set SCP_VERSION to current branch name + short commit SHA
+# e.g. my-feature-branch:f4e377a60
+SCP_VERSION="$(git branch --show-current):$(git rev-parse --short HEAD)"
+
 yarn install
-bin/vite dev
+SCP_VERSION="\"$SCP_VERSION\"" bin/vite dev

--- a/vite-dev-entrypoint.sh
+++ b/vite-dev-entrypoint.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 yarn install
-bin/vite dev
+VITE_DEV_MODE="\"docker-compose\"" VITE_FRONTEND_SERVICE_WORKER_CACHE="true" bin/vite dev

--- a/vite-dev-entrypoint.sh
+++ b/vite-dev-entrypoint.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 yarn install
-VITE_DEV_MODE="\"docker-compose\"" VITE_FRONTEND_SERVICE_WORKER_CACHE="true" bin/vite dev
+bin/vite dev

--- a/vite-dev-entrypoint.sh
+++ b/vite-dev-entrypoint.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+yarn install
+bin/vite dev

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,8 @@ export default defineConfig({
   'server': {
     'hmr': {
       'host': '127.0.0.1',
-      'protocol': 'ws'
+      'protocol': 'ws',
+      'timeout': 1.0
     }
   }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ const version = readFileSync('version.txt', { encoding: 'utf8' })
 
 export default defineConfig({
   'define': {
-    '__SCP_VERSION__': version,
+    '__SCP_VERSION__': process.env.SCP_VERSION ? process.env.SCP_VERSION : version,
     '__FRONTEND_SERVICE_WORKER_CACHE__': process.env.VITE_FRONTEND_SERVICE_WORKER_CACHE,
     '__DEV_MODE__': process.env.VITE_DEV_MODE
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,8 @@ const version = readFileSync('version.txt', { encoding: 'utf8' })
 export default defineConfig({
   'define': {
     '__SCP_VERSION__': version,
-    '__FRONTEND_SERVICE_WORKER_CACHE__': process.env.VITE_FRONTEND_SERVICE_WORKER_CACHE
+    '__FRONTEND_SERVICE_WORKER_CACHE__': process.env.VITE_FRONTEND_SERVICE_WORKER_CACHE,
+    '__DEV_MODE__': process.env.VITE_DEV_MODE
   },
   'plugins': [
     // inject plugin needs to be first

--- a/yarn.lock
+++ b/yarn.lock
@@ -2847,10 +2847,10 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@xmldom/xmldom@^0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.3.tgz#beaf980612532aa9a3004aff7e428943aeaa0711"
-  integrity sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==
+"@xmldom/xmldom@^0.7.5":
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.6.tgz#6f55073fa73e65776bd85826958b98c8cd1457b5"
+  integrity sha512-HHXP9hskkFQHy8QxxUXkS7946FFIhYVfGqsk0WLwllmexN9x/+R4UBLvurHEuyXRfVEObVR8APuQehykLviwSQ==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -7244,7 +7244,7 @@ jest-environment-enzyme@^7.1.2:
   resolved "https://registry.yarnpkg.com/jest-environment-enzyme/-/jest-environment-enzyme-7.1.2.tgz#4561f26a719e8e87ce8c9a6d3f540a92663ba8d5"
   integrity sha512-3tfaYAzO7qZSRrv+srQnfK16Vu5XwH/pHi8FpoqSHjKKngbHzXf7aBCBuWh8y3w0OtknHRfDMFrC60Khj+g1hA==
   dependencies:
-    jest-environment-jsdom "^26.0.0"
+    jest-environment-jsdom "^24.0.0"
 
 jest-environment-jsdom@^26.0.0, jest-environment-jsdom@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
#### BACKGROUND
Although SCP is built and deployed via Docker, SCP team members historically develop outside of Docker as using it locally has significant costs both in setup/boot time and overall performance.  Additionally, features such as hot module replacement (HMR) via the `vite` dev server do not work in our current Docker setup.  The drawback is that this requires developers to install packages/gems directly on their machines, and updates to machine hardware (e.g. Macintosh M1 chips) can cause serious issues that require extensive workarounds.  Any gains in performance are then lost as developers spend hours - or days - just getting their environments working.  These kinds of issues are exactly what Docker was designed to address.

#### CHANGES
This update adds a local Dockerized setup for SCP development via `docker-compose` and some helper shell scripts.  This setup retains all of the performance and ease-of-use advantages of native Rails development (like HMR) without the need to install anything locally other than Docker.  It leverages existing work for [pre-built Docker images](#1552) to create a small local network that runs the portal Rails application and Vite dev server in side-by-side containers.  Additionally, this contains two helper shell scripts to both setup/launch the services (bin/docker-compose-setup.sh), as well as tear down and revert configurations back to the native development setup (bin/docker-compose-cleanup.sh).  The `docker-compose-dev.yaml` file also automates installing any package/gem updates, so that any local changes are automatically incorporated on boot.   Furthermore, no manual changes to configurations are required to use this.  The helper scripts automate any config file updates, and `docker-compose` handles all networking/port mapping.  This makes it possible to switch back and forth between Dockerized and non-Dockerized with a few shell commands.

This also updates an apparent typo in a regular expression in the latest migration that prevented it from running locally (though it appeared to run fine on staging, so it is unclear why it failed locally).

#### MANUAL TESTING
1. Pull this branch and ensure Docker is running
2. For improved boot time, pull the latest copy of the development image: 
```
docker pull gcr.io/broad-singlecellportal-staging/single-cell-portal:development
```
3. Start the services with `bin/docker-compose-setup.sh`
4. The helper script will initialize the environment and then start both services.  You will know that it is done when you see both of the following log messages in the terminal:

Server running:
```
single_cell       | => Booting Puma
single_cell       | => Rails 6.1.6.1 application starting in development 
single_cell       | => Run `bin/rails server --help` for more startup options
single_cell       | Puma starting in single mode...
single_cell       | * Puma version: 5.6.4 (ruby 3.1.2-p20) ("Birdie's Version")
single_cell       | *  Min threads: 5
single_cell       | *  Max threads: 5
single_cell       | *  Environment: development
single_cell       | *          PID: 1
single_cell       | * Listening on http://127.0.0.1:3001
single_cell       | * Listening on ssl://0.0.0.0:3000?cert=/home/app/webapp/config/certs/localhost.crt&key=/home/app/webapp/config/certs/localhost.key&verify_mode=none
single_cell       | Use Ctrl-C to stop
```
Vite dev server running:
```
single_cell_vite  | [5/5] Building fresh packages...
single_cell_vite  | success Saved lockfile.
single_cell_vite  | Done in 12.97s.
single_cell_vite  | 
single_cell_vite  |   vite v2.9.13 dev server running at:
single_cell_vite  | 
single_cell_vite  |   > Local:    http://localhost:3036/vite-dev/
single_cell_vite  |   > Network:  http://172.23.0.2:3036/vite-dev/
single_cell_vite  | 
single_cell_vite  |   ready in 2733ms.
single_cell_vite  | 
```
5. Open the home page in a browser tab and confirm that it loads successfully
6. To confirm HMR is working, open `app/javascript/styles/_global.scss` and on line 10 change `background-color` to `#000`
7. Back in the UI, confirm the background changes to black without needing to reload the page (it make take a few seconds to pick up the change and recompile)
8. In the terminal, press `Ctrl-C` to stop the server, then run `bin/docker-compose-cleanup.sh` to remove the containers and volumes and revert `config/secrets/.source_env.bash` back to its original state
