### PR TITLE
Silence reporting routing errors to Mixpanel/Sentry (SCP-4085, SCP-4252)

### DIFF
--- a/test/integration/lib/request_utils_test.rb
+++ b/test/integration/lib/request_utils_test.rb
@@ -84,6 +84,7 @@ class RequestUtilsTest < ActiveSupport::TestCase
     assert_not RequestUtils.static_asset_error?(error)
     paths = [
       'No route matches [GET] "/apple-touch-icon-precomposed.png"',
+      'No route matches [GET] "/static/img/logo.1a41f6387d69.svg"',
       'No route matches [GET] "/single_cell/packs/foo.js"',
       'No route matches [GET] "/single_cell/assets/does-not-exist.css"'
     ]


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a logic bug that prevented silencing `ActionController::RoutingError` exceptions, causing them to be reported upstream, which then resulted in `RestClient::BadRequest` errors when attempting to log to Bard.  There have been over [5400 instances](https://sentry.io/organizations/broad-institute/issues/3510199835/events/89091297b6214588a8fab05ded5a45e9/?environment=production&project=1424198&query=is%3Aunresolved&sort=freq&statsPeriod=24h) of this particular issue in the last two months alone (Sentry does not have a record before that).  These errors are largely caused by regular security scans of all applications running on the `broadinstitute.org` domain looking for known exploits.  Since Rails will respond `404` to any request path that is not defined in the `config/routes.rb` file, almost all of these error reports are spurious.  They should not be logged as they are not actionable and use up bandwidth in subscription quotas.

#### MANUAL TESTING
1. Boot as normal
2. In a browser tab, go to `https://localhost:3000/single_cell/api/v1/does-not-exist`, and confirm you get the following response:
```
{
  "error":"No route matches [GET] \"/single_cell/api/v1/does-not-exist\"",
  "error_class":"ActionController::RoutingError",
  "source":"/Users/bistline/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-6.1.6.1/lib/action_dispatch/middleware/debug_exceptions.rb:33:in `call'"
}
```
3. In the terminal, note the stack trace, and confirm you do not see any messages about Sentry/Mixpanel like the following:
```
Suppressing error reporting to Sentry: ActionController::RoutingError:No route matches [GET] "/single_cell/api/v1/foobar", context: ...
Reporting error analytics to mixpanel for (ActionController::RoutingError) No route matches [GET] "/single_cell/api/v1/foobar"
```