### PR TITLE
Set z-score for plot tabs back (SCP-4785)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -280,7 +280,7 @@ export default function ExploreDisplayTabs({
             }
           </div>
         </div>
-        <div className="col-md-4 col-md-offset-1">
+        <div className="col-md-4 col-md-offset-1 send-element-back">
           <ul className="nav nav-tabs" role="tablist" data-analytics-name="explore-default">
             { enabledTabs.map(tabKey => {
               const label = tabList.find(({ key }) => key === tabKey).label

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -197,3 +197,7 @@
     display: inline-block;
   }
 }
+
+.send-element-back {
+	z-index: -2;
+}


### PR DESCRIPTION
While trying to reproduce the issues with heatmaps we saw today I noticed the dropdown mixes with the tabs, so this quick update to the CSS just pushes the tabs `Correlation, Dot plot, Heatmap` back so that the dropdown in the gene search will be over top.

Issue as seen on Staging:
![Screen Shot 2022-10-19 at 4 02 04 PM](https://user-images.githubusercontent.com/54322292/196801108-1c2467d9-936c-452c-94ed-c0e50b7d83f4.png)

After:
<screenshot coming>