### PR TITLE
Enforce redirects after login to correct SCP hostname (SCP-4655)

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -34,7 +34,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       end
       if TosAcceptance.accepted?(@user)
         MetricsService.merge_identities_in_mixpanel(@user, cookies)
-        requested_path = request.env['omniauth.origin'] || site_path
+        # validate that the Referer header has not been manipulated
+        requested_path = set_omniauth_redirect(request, @user) || site_path
         redirect_to requested_path, alert: @alert
       else
         redirect_to accept_tos_path(@user.id), alert: @alert
@@ -57,6 +58,26 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         error_message = "Invalid scope requested in OAuth callback: #{scope_name}, not in: #{configured_scopes}"
         raise SecurityError.new(error_message)
       end
+    end
+  end
+
+  # validate omniauth.origin is redirecting to same host
+  # will allow redirect if hostnames match, otherwise will return nil to force redirect to home page
+  def set_omniauth_redirect(request, user)
+    begin
+      hostname = URI.parse(request.env['omniauth.origin']).hostname
+      if hostname == ENV['HOSTNAME']
+        request.env['omniauth.origin']
+      else
+        Rails.logger.error "Invalid origin: #{request.env['omniauth.origin']} requested, redirecting to home page"
+        nil
+      end
+    rescue URI::InvalidURIError, NoMethodError => e
+      # we can't use RequestUtils.log_exception as this isn't a handled request exception
+      Rails.logger.error "Error processing omniauth.origin: (#{e.class.name}) #{e.message}"
+      ErrorTracker.report_exception(e, user, request.params)
+      MetricsService.report_error(e, request, user, nil)
+      nil
     end
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -66,9 +66,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # malicious redirects are logged as SecurityError in Sentry/Mixpanel
   def set_omniauth_redirect(request, user)
     begin
-      hostname = URI.parse(request.env['omniauth.origin']).hostname
-      return nil if hostname.nil? # no referrer set, so default logic applies
+      return nil if request.env['omniauth.origin'].nil? # no referrer set, so default logic applies
 
+      hostname = URI.parse(request.env['omniauth.origin']).hostname
       if hostname == ENV['HOSTNAME']
         request.env['omniauth.origin']
       else

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -67,6 +67,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def set_omniauth_redirect(request, user)
     begin
       hostname = URI.parse(request.env['omniauth.origin']).hostname
+      return nil if hostname.nil? # no referrer set, so default logic applies
+
       if hostname == ENV['HOSTNAME']
         request.env['omniauth.origin']
       else


### PR DESCRIPTION
#### BACKGROUND
A recent pentest of staging uncovered a vulnerability where a malicious actor can intercept the OAuth request and replace the `Referer` header, which will cause the redirect after login to proceed to the newly specified host, rather than SCP.

#### CHANGES
This update adds a validation method that will ensure the requested hostname is the same as the current instance.  If it is, it will allow the redirect specified in `request.env['omniauth.orgin']`, which stores the record of the last page the user was on (if present).  If the hostnames do not match, then a `SecurityError` is raised and logged, then the user is redirected back to the home page.

#### MANUAL TESTING
Testing this feature requires installing a plugin to allow you to manipulate request headers in your browser.  For Chrome, I recommend [Modify Header Value](https://mybrowseraddon.com/modify-header-value.html).  Once installed, you can add a rule to modify the `Referer` header to an external domain on requests to `localhost`:
![Screen Shot 2022-10-20 at 1 46 09 PM](https://user-images.githubusercontent.com/729968/197021049-52b6fe85-3f4c-4630-aff2-34840d7c7da2.png)
1. Pull branch and boot as normal
2. Using `Modify Header Value` (or similar plugin), configure your browser to modify the `Referer` header to be `https://www.google.com`
3. Once enabled, open any study page to load the Study Overview
4. Now sign in as normal, and validate that you've been redirected to the home page (instead of the previous page)
5. In `development.log`, note the message that the external hostname was not allowed, and that a `SecurityError` would have been logged to Sentry/Mixpanel:
```
Invalid origin: www.google.com requested, does not match localhost
Suppressing error reporting to Sentry: SecurityError:Invalid origin: www.google.com requested, does not match localhost
Reporting error analytics to mixpanel for (SecurityError) Invalid origin: www.google.com requested, does not match localhost
```