### PR TITLE
Temporarily enforce limit of 50 genes on all expression-based visualizations (SCP-4766)

### DIFF
--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -9,6 +9,7 @@ module Api
         before_action :set_current_api_user!
         before_action :set_study
         before_action :check_study_view_permission
+        before_action :check_gene_limit
         before_action :check_api_cache!
         after_action :write_api_cache!
 
@@ -158,6 +159,17 @@ module Api
           end
 
           render plain: expression_data, status: 200
+        end
+
+        # enforce a limit on number of genes allowed for visualization requests
+        # see StudySearchService::MAX_GENE_SEARCH
+        def check_gene_limit
+          return true if params[:genes].blank?
+
+          # render 422 if more than MAX_GENE_SEARCH as request fails internal validation
+          if params[:genes].split(',').size > StudySearchService::MAX_GENE_SEARCH
+            render json: { error: StudySearchService::MAX_GENE_SEARCH_MSG }, status: :unprocessable_entity
+          end
         end
       end
     end

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -169,7 +169,7 @@ module Api
           # render 422 if more than MAX_GENE_SEARCH as request fails internal validation
           num_genes = params[:genes].split(',').size
           if num_genes > StudySearchService::MAX_GENE_SEARCH
-            MetricsService.log('search-too-many-genes', {numGenes: num_genes})
+            MetricsService.log('search-too-many-genes', { numGenes: num_genes }, current_api_user)
             render json: { error: StudySearchService::MAX_GENE_SEARCH_MSG }, status: :unprocessable_entity
           end
         end

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -167,7 +167,9 @@ module Api
           return true if params[:genes].blank?
 
           # render 422 if more than MAX_GENE_SEARCH as request fails internal validation
-          if params[:genes].split(',').size > StudySearchService::MAX_GENE_SEARCH
+          num_genes = params[:genes].split(',').size
+          if num_genes > StudySearchService::MAX_GENE_SEARCH
+            MetricsService.log('search-too-many-genes', {numGenes: num_genes})
             render json: { error: StudySearchService::MAX_GENE_SEARCH_MSG }, status: :unprocessable_entity
           end
         end

--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -61,6 +61,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
     } else if (newGeneArray && newGeneArray.length) {
       const genesToSearch = newGeneArray.map(g => g.value)
       if (genesToSearch.length > window.MAX_GENE_SEARCH) {
+        log('search-too-many-genes', {numGenes: genesToSearch.length})
         setShowTooManyGenesModal(true)
       } else {
         if (event) { // this was not a 'clear'

--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -36,6 +36,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
     * and the current text the user is typing (inputText) */
   const [geneArray, setGeneArray] = useState(enteredGeneArray)
   const [showEmptySearchModal, setShowEmptySearchModal] = useState(false)
+  const [showTooManyGenesModal, setShowTooManyGenesModal] = useState(false)
 
   const [notPresentGenes, setNotPresentGenes] = useState(new Set([]))
   const [showNotPresentGeneChoice, setShowNotPresentGeneChoice] = useState(false)
@@ -59,11 +60,15 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
       setShowNotPresentGeneChoice(true)
     } else if (newGeneArray && newGeneArray.length) {
       const genesToSearch = newGeneArray.map(g => g.value)
-      if (event) { // this was not a 'clear'
-        const trigger = event.type // 'click' or 'submit'
-        logStudyGeneSearch(genesToSearch, trigger, speciesList)
+      if (genesToSearch.length > window.MAX_GENE_SEARCH) {
+        setShowTooManyGenesModal(true)
+      } else {
+        if (event) { // this was not a 'clear'
+          const trigger = event.type // 'click' or 'submit'
+          logStudyGeneSearch(genesToSearch, trigger, speciesList)
+        }
+        searchGenes(genesToSearch)
       }
-      searchGenes(genesToSearch)
     } else {
       setShowEmptySearchModal(true)
     }
@@ -218,7 +223,15 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
         Invalid Search - Please remove &quot;{Array.from(notPresentGenes).join('", "')}&quot; from gene search.
         </Modal.Body>
       </Modal>
-
+      <Modal
+        show={showTooManyGenesModal}
+        onHide={() => {setShowTooManyGenesModal(false)}}
+        animation={false}
+        bsSize='small'>
+        <Modal.Body className="text-center">
+          {window.MAX_GENE_SEARCH_MSG}
+        </Modal.Body>
+      </Modal>
     </form>
   )
 }

--- a/bin/docker-compose-setup.sh
+++ b/bin/docker-compose-setup.sh
@@ -41,6 +41,7 @@ done
 echo "### SETTING UP ENVIRONMENT ###"
 ./rails_local_setup.rb --docker-paths
 source config/secrets/.source_env.bash
+rm tmp/pids/*.pid
 echo "### STARTING SERVICES ###"
 VITE_FRONTEND_SERVICE_WORKER_CACHE="$VITE_FRONTEND_SERVICE_WORKER_CACHE" \
 docker-compose -f docker-compose-dev.yaml up $DETACHED

--- a/test/api/visualization/expression_controller_test.rb
+++ b/test/api/visualization/expression_controller_test.rb
@@ -94,4 +94,13 @@ class ExpressionControllerTest < ActionDispatch::IntegrationTest
     }), user: @user)
     assert_equal 400, response.status # 400 since study is not visualizable
   end
+
+  test "should prevent searches over #{StudySearchService::MAX_GENE_SEARCH} genes" do
+    genes = 1.upto(100).map { |i| "Gene_#{i}" }.join(',')
+    sign_in_and_update @user
+    execute_http_request(:get, api_v1_study_expression_path(
+      @basic_study, 'heatmap', { cluster: 'clusterA.txt', genes: genes }
+    ), user: @user)
+    assert_response :unprocessable_entity
+  end
 end


### PR DESCRIPTION
#### BACKGROUND
Several recent outages on our production SCP instance have shown that expression-based visualizations with large lists of requested genes place disproportionate levels of CPU load on the server, as compared to single gene or non-expression based visualizations.  These requests take much longer to complete than others, and cause worker processes to be tied up, which cause other requests to pend in a queue.  This eventually results in `nginx` responding `502` as the queue fills up, and the entire instance becomes unavailable as the load balancer shunts traffic away.

#### CHANGES
This update reintroduces a historical limit of 50 genes for all multi-gene expression visualizations.  This is enforced both client- and server-side.  The server-side check will respond `422` when failing this validation as the request is formed correctly but cannot be processed for internal validation reasons.  Client-side, the UI will simply prevent submitting the search and show a small modal notifying the user of the limit on gene searches for performance reasons.

In addition, this adds a small cleanup step to `bin/docker-compose-setup.sh` to remove orphaned `.pid` files that may not have been cleaned up when restarting existing containers.

#### MANUAL TESTING
1. Boot as normal and load any study that has more than 50 genes, such as the example study `Human milk - differential expression`
2. Go into the Explore tab, and then enter a search for larger than 50 genes.  If using the above study, you can enter the gene list below, otherwise you can get the list of gene names available for the study from the `explore` API response under the `uniqueGenes` key:
```
Traf3,Yes1,Mapkap1,Crem,Myo19,Plagl1,Fhod3,Pnpla7,Ank2,Ccdc74a,Evi5,Lekr1,Epn2,Rbfox2,Mtmr3,Ppig,Lhpp,Sik2,Strn3,Pax6,Rbm25,Dock9,Dock6,Irf7,Mtf2,Dst,Snap25,Syt7,Eya1,Snph,Zfand4,Zbtb20,Pdlim5,Fam196a,Pde9a,Inf2,Adrbk1,Dock3,G2e3,Trit1,Lrrfip1,Dcun1d2,U2af1,Inpp4a,Smim19,Ngdn,Phka1,Dhx30,Cep192,Cdan1,Mef2d
```
3. Execute the search, and validate that you see the following modal:
![Screen Shot 2022-10-20 at 5 03 44 PM](https://user-images.githubusercontent.com/729968/197057809-8edfe063-e2cf-470d-8571-5ec3d40825b0.png)
4. Open the Swagger API for the [dotplot visualization endpoint](https://localhost:3000/single_cell/api/v1#/Visualization/study_visualization_expression_show)
5. Enter the accession of the above study, select `heatmap` for the `data_type`, and then paste in your gene list under `genes` and submit
6. Confirm the response code is `422` with the same error message as above:
```
{
  "error": "For performance reasons, gene search is limited to 50 genes. Please use multiple searches to view more genes."
}
```