### PR TITLE
Log error with counting trace labels to Sentry and Mixpanel (SCP-4801)

### DIFF
--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -8,7 +8,7 @@ import _find from 'lodash/find'
 import _remove from 'lodash/remove'
 import $ from 'jquery'
 import { getDefaultProperties } from '@databiosphere/bard-client'
-import { logJSFetchExceptionToSentry, logJSFetchErrorToSentry } from '~/lib/sentry-logging'
+import { logJSFetchExceptionToSentry, logJSFetchErrorToSentry, logToSentry } from '~/lib/sentry-logging'
 
 import { getAccessToken } from '~/providers/UserProvider'
 import { getBrandingGroup } from '~/lib/scp-api'
@@ -322,11 +322,13 @@ export function logMenuChange(event) {
 }
 
 /**
- * Log front-end error (e.g. uncaught ReferenceError)
+ * Log front-end error (e.g. uncaught ReferenceError) to both Sentry and Mixpanel
  */
-export function logError(text, details = {}) {
-  const props = { text, ...details }
+export function logError(text, error = {}) {
+  const props = { text, error }
   log('error', props)
+
+  logToSentry(error)
 }
 
 /**

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -324,8 +324,8 @@ export function logMenuChange(event) {
 /**
  * Log front-end error (e.g. uncaught ReferenceError)
  */
-export function logError(text) {
-  const props = { text }
+export function logError(text, details = {}) {
+  const props = { text, ...details }
   log('error', props)
 }
 

--- a/app/javascript/lib/plot.js
+++ b/app/javascript/lib/plot.js
@@ -1,6 +1,5 @@
 import { UNSPECIFIED_ANNOTATION_NAME } from '~/lib/cluster-utils'
 import { log, logError } from '~/lib/metrics-api'
-import {logToSentry} from '~/lib/sentry-logging'
 
 // Default plot colors, combining ColorBrewer sets 1-3 with tweaks to yellows.
 const colorBrewerList = [
@@ -303,8 +302,8 @@ function countValues(array) {
       return acc
     }, {})
   } catch (error) {
-    logToSentry(error)
-    logError('Error counting values for trace array', { error: error.message })
+    // This will log to both Mixpanel and Sentry
+    logError('Error counting values for trace array', error)
   }
 }
 

--- a/app/javascript/lib/plot.js
+++ b/app/javascript/lib/plot.js
@@ -1,5 +1,6 @@
 import { UNSPECIFIED_ANNOTATION_NAME } from '~/lib/cluster-utils'
-import { log } from '~/lib/metrics-api'
+import { log, logError } from '~/lib/metrics-api'
+import {logToSentry} from '~/lib/sentry-logging'
 
 // Default plot colors, combining ColorBrewer sets 1-3 with tweaks to yellows.
 const colorBrewerList = [
@@ -295,11 +296,16 @@ PlotUtils.getLegendSortedLabels = function(countsByLabel) {
  * didn't have to do this.  See https://github.com/plotly/plotly.js/issues/5612
 */
 function countValues(array) {
-  return array.reduce((acc, curr) => {
-    acc[curr] ||= 0
-    acc[curr] += 1
-    return acc
-  }, {})
+  try {
+    return array.reduce((acc, curr) => {
+      acc[curr] ||= 0
+      acc[curr] += 1
+      return acc
+    }, {})
+  } catch (error) {
+    logToSentry(error)
+    logError('Error counting values for trace array', { error: error.message })
+  }
 }
 
 /**


### PR DESCRIPTION
We uncovered a bug that can occur when switching between annotations and "collapse by" methods after a user has searched a few genes in study. This adds logging to both Sentry and Mixpanel so that we can understand the user impact better and also have visibility if this occurs again in the future after we fix the bug.

To test:
- Pull this branch
- Start up your local host
- Navigate to a study on the portal that is visualizable with at least 3 searchable genes
- Open up dev tools
- Perform a search for 3 genes in the explore tab
- Change the annotation
- Select "Mean" from the "Collapse by" drop down menu
- You should see the error appear in the UI and if you go to the console you will see the error report to Sentry has been suppressed and going over to the Network tab you should find an event to Mixpanel to log the error


<img width="750" alt="Screen Shot 2022-10-27 at 1 32 33 PM" src="https://user-images.githubusercontent.com/54322292/198359823-ea9cd754-4234-4c05-80a9-126755c3b62b.png">
<img width="1143" alt="Screen Shot 2022-10-27 at 1 32 22 PM" src="https://user-images.githubusercontent.com/54322292/198359832-23a02c0b-3835-4c48-bf45-d7cb6531a19c.png">
