### PR TITLE
Refine retry logic for Google Cloud Storage API calls (SCP-4730)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ gem 'vite_rails'
 gem 'net-smtp'
 gem 'net-imap'
 gem 'net-pop'
+gem 'exponential-backoff'
 
 # only enable TCell in deployed environments due to Chrome sec-ch-ua header issue
 group :production, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,7 @@ GEM
     easy_diff (1.0.0)
     erubi (1.10.0)
     execjs (2.7.0)
+    exponential-backoff (0.0.4)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.1.0)
@@ -560,6 +561,7 @@ DEPENDENCIES
   delayed_job
   delayed_job_mongoid
   devise
+  exponential-backoff
   factory_bot_rails
   flamegraph
   font-awesome-sass!

--- a/app/models/data_repo_client.rb
+++ b/app/models/data_repo_client.rb
@@ -79,11 +79,11 @@ class DataRepoClient
       context = " encountered when requesting '#{path}', attempt ##{current_retry}"
       log_message = "#{e.message}: #{e.http_body}; #{context}"
       Rails.logger.error log_message
-      retry_time = retry_count * ApiHelpers::RETRY_INTERVAL
-      sleep(retry_time)
       # only retry if status code indicates a possible temporary error, and we are under the retry limit and
       # not calling a method that is blocked from retries
       if should_retry?(e.http_code) && retry_count < ApiHelpers::MAX_RETRY_COUNT
+        retry_time = retry_interval_for(current_retry)
+        sleep(retry_time)
         process_api_request(http_method, path, payload: payload, retry_count: current_retry)
       else
         # we have reached our retry limit or the response code indicates we should not retry

--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -55,10 +55,22 @@ class DifferentialExpressionResult
     end
   end
 
-  ## STUDY FILE GETTERS
+  def info
+    { study_accession:, cluster_name:, annotation_name:, annotation_scope:, observed_values:, matrix_file_name: }
+  end
+
+  def self.report
+    all.map(&:info).group_by { |entry| entry.delete(:study_accession) }
+  end
+
+  ## GETTERS
   # associated raw count matrix
   def matrix_file
     StudyFile.find(matrix_file_id)
+  end
+
+  def matrix_file_name
+    matrix_file.upload_file_name
   end
 
   # associated clustering file
@@ -74,6 +86,10 @@ class DifferentialExpressionResult
     when 'cluster'
       cluster_file
     end
+  end
+
+  def study_accession
+    study.accession
   end
 
   # compute the relative path inside a GCS bucket of a DE output file for a given label

--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -55,22 +55,10 @@ class DifferentialExpressionResult
     end
   end
 
-  def info
-    { study_accession:, cluster_name:, annotation_name:, annotation_scope:, observed_values:, matrix_file_name: }
-  end
-
-  def self.report
-    all.map(&:info).group_by { |entry| entry.delete(:study_accession) }
-  end
-
-  ## GETTERS
+  ## STUDY FILE GETTERS
   # associated raw count matrix
   def matrix_file
     StudyFile.find(matrix_file_id)
-  end
-
-  def matrix_file_name
-    matrix_file.upload_file_name
   end
 
   # associated clustering file
@@ -86,10 +74,6 @@ class DifferentialExpressionResult
     when 'cluster'
       cluster_file
     end
-  end
-
-  def study_accession
-    study.accession
   end
 
   # compute the relative path inside a GCS bucket of a DE output file for a given label

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -1297,8 +1297,7 @@ class FireCloudClient
   # * *return*
   #   - Object depends on method, can be one of the following: +Google::Cloud::Storage::Bucket+, +Google::Cloud::Storage::File+,
   #     +Google::Cloud::Storage::FileList+, +Boolean+, +File+, or +String+
-
-  def execute_gcloud_method(method_name, retry_count=0, *params)
+  def execute_gcloud_method(method_name, retry_count = 0, *params)
     begin
       self.send(method_name, *params)
     rescue => e
@@ -1316,7 +1315,7 @@ class FireCloudClient
                                                                  retry_count: current_retry, params: params})
         end
         Rails.logger.info "Retry count exceeded calling #{method_name} with #{params.join(', ')}: #{e.message}"
-        raise RuntimeError, e.message
+        raise e.message # raise implicitly creates RuntimeError
       end
     end
   end

--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -71,11 +71,11 @@ class HcaAzulClient
       context = " encountered when requesting '#{path}', attempt ##{current_retry}"
       log_message = "#{e.message}: #{e.http_body}; #{context}"
       Rails.logger.error log_message
-      retry_time = retry_count * ApiHelpers::RETRY_INTERVAL
-      sleep(retry_time)
       # only retry if status code indicates a possible temporary error, and we are under the retry limit and
       # not calling a method that is blocked from retries
       if should_retry?(e.http_code) && retry_count < ApiHelpers::MAX_RETRY_COUNT
+        retry_time = retry_interval_for(current_retry)
+        sleep(retry_time)
         process_api_request(http_method, path, payload: payload, retry_count: current_retry)
       else
         # we have reached our retry limit or the response code indicates we should not retry

--- a/test/integration/data_repo_client_test.rb
+++ b/test/integration/data_repo_client_test.rb
@@ -10,8 +10,10 @@ class DataRepoClientTest < ActiveSupport::TestCase
     @filename = 'pulmonary-fibrosis-human-lung-10XV2.loom' # name of above file
     @drs_file_id = "drs://#{DataRepoClient::REPOSITORY_HOSTNAME}/v1_#{@snapshot_id}_#{@file_id}" # computed DRS id
     bucket_id = 'datarepo-dev-54946186-bucket'
+    project_name = 'datarepo-dev-0f9f0d44'
     @gs_url = "gs://#{bucket_id}/#{@dataset_id}/#{@file_id}/#{@filename}" # computed GS url
-    @https_url = "https://www.googleapis.com/storage/v1/b/#{bucket_id}/o/#{@dataset_id}%2F#{@file_id}%2F#{@filename}?alt=media"
+    @https_url = "https://www.googleapis.com/storage/v1/b/#{bucket_id}/o/" \
+                 "#{@dataset_id}%2F#{@file_id}%2F#{@filename}?userProject=#{project_name}&alt=media"
   end
 
   # skip a test if the TDR API is not up (since it is their dev instance there is no uptime guarantee)


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update refines the logic on how/when API calls to Google Cloud Storage are retried.  Previously, `4xx` errors would be retried with staggered backoffs when none of these calls had a chance of ever succeeding based on parameters/state.  This leads to situations where the UI can hang for 3-4 minutes with no obvious indication of what is happening.  Now, only error codes in the `502-4` range are ever retried, and all other errors will exit immediately and continue through normal error handling/reporting.

This update also adds exponential backoff and jitter via the `exponential-backoff` gem to better handle potential load/thundering herd  issues.  Lastly, it fixes a newly broken test in `DataRepoClientTest` due to an upstream change.

#### MANUAL TESTING
The easiest way to test this is via the Rails console:
1. Pull branch and enter a Rails console session
2. Run the following snippet to simulate a `4xx` level error and confirm the error returns immediately:
```
ApplicationController.firecloud_client.execute_gcloud_method(:get_workspace_file, 0, 'foo', 'bar.txt')
```
3. In `development.log`, note the following error message only appears once, and that the message denotes `Retry count exceeded`:
```
Suppressing error reporting to Sentry: Google::Cloud::PermissionDeniedError:forbidden: default-service-account@broad-singlecellportal-bistlin.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket., context: {:method_name=>:get_workspace_file, :retry_count=>1, :params=>["foo", "bar.txt"]}
Retry count exceeded calling get_workspace_file with foo, bar.txt: forbidden: default-service-account@broad-singlecellportal-bistlin.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket.
```