### PR TITLE
Add tooltip for bulk correlation coefficient (SCP-4810)

### DIFF
--- a/app/javascript/components/visualization/PlotTitle.jsx
+++ b/app/javascript/components/visualization/PlotTitle.jsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 
 /** Renders a plot title for scatter plots */
 export default function PlotTitle({
@@ -6,6 +8,11 @@ export default function PlotTitle({
 }) {
   let content = cluster
   let detailContent = ''
+
+  const tooltipText =
+    `If this value looks different than what you expect given the plot,
+    the data may not be suited for correlation analysis and you should trust the plot`
+
   if (genes.length) {
     const geneList = genes.map(gene => {
       return <span className="badge" key={gene}>{gene}</span>
@@ -28,9 +35,19 @@ export default function PlotTitle({
     <span className="cluster-title">{content} </span>
     <span className="detail"> {detailContent} </span>
     { isCorrelatedScatter && !!correlation &&
+    <>
       <span className="correlation">
         Spearman rho = { Math.round(correlation * 1000) / 1000}
       </span>
+      <span
+        data-analytics-name="bulk-correlation-tooltip"
+        data-toggle="tooltip"
+        data-original-title={tooltipText}
+        style={{ marginLeft: '10px' }}
+      >
+        <FontAwesomeIcon className="action help-icon" icon={faInfoCircle} />
+      </span>
+    </>
     }
   </h5>
 }


### PR DESCRIPTION
This adds a caveat for the bulk correlation coefficient shown when a user searches two genes.

[Leyla notes](https://broadinstitute.slack.com/archives/CBEHTH601/p1667406055034149?thread_ts=1666891124.420599&cid=CBEHTH601) regarding a recent user support request concerning our bulk gene-gene correlation coefficient:
> there's a mismatch between the store that the correlation coefficient tells and the story that the plot itself tells. I expect that this situation will come up with other studies as well, so I think that we should add a tooltip or message to the spearman's rho result to say something like, "if this value looks different than what you'd expect given the plot, the data may not be suited for correlation analysis and you should trust the plot"

Here's how it looks:
<img width="1680" alt="Caveat_tooltip_bulk_correlation_coeffient__SCP_2022-11-03" src="https://user-images.githubusercontent.com/1334561/199736278-a8648445-788b-4fdd-95f6-5cecfc122666.png">

To test:
* Go to the synthetic study "Monkey correlations"
* Search two genes
* Hover over tooltip
* Confirm it matches screenshot

This satisfies SCP-4810.