### PR TITLE
Update metrics_service log to handle nil user (SCP-4797)

### DIFF
--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -169,7 +169,7 @@ module Api
           # render 422 if more than MAX_GENE_SEARCH as request fails internal validation
           num_genes = params[:genes].split(',').size
           if num_genes > StudySearchService::MAX_GENE_SEARCH
-            MetricsService.log('search-too-many-genes', { numGenes: num_genes }, current_api_user)
+            MetricsService.log('search-too-many-genes', { numGenes: num_genes }, current_api_user, request:)
             render json: { error: StudySearchService::MAX_GENE_SEARCH_MSG }, status: :unprocessable_entity
           end
         end

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -108,7 +108,7 @@ class MetricsService
     if user.present? && user.registered_for_firecloud
       props.merge!({ authenticated: true, registeredForTerra: user.registered_for_firecloud })
     else
-      props.merge!({ authenticated: user.present?, distinct_id: request.cookies['user_id'] })
+      props.merge!({ authenticated: user.present?, distinct_id: user.get_metrics_uuid })
     end
 
     post_body = {'event' => name, 'properties' => props}.to_json

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -34,11 +34,13 @@ class MetricsService
   end
 
   def self.get_default_headers(user)
-    access_token = user.token_for_api_call
-    {
-      'Authorization' => "Bearer #{access_token.present? ? access_token.dig('access_token') : nil }",
-      'Content-Type' => 'application/json'
-    }
+    headers = { 'Content-Type' => 'application/json'}
+    if user.present?
+      access_token = user.token_for_api_call
+      headers.merge!({
+        'Authorization' => "Bearer #{access_token.present? ? access_token.dig('access_token') : nil }",
+      })
+    end
   end
 
   # Merges unauth’d and auth’d user identities in Mixpanel via Bard
@@ -90,28 +92,23 @@ class MetricsService
   # @param {String} name Name of the event
   # @param {Hash} props Properties associated with the event
   # @param {User} user User model object
-  def self.log(name, props={}, user)
+  def self.log(name, props={}, user=nil)
     Rails.logger.info "#{Time.zone.now}: Logging analytics to Mixpanel for event name: #{name}"
 
     props.merge!({
       appId: 'single-cell-portal',
       env: Rails.env,
-      registeredForTerra: user.registered_for_firecloud,
       logger: 'app-backend'
     })
 
     headers = get_default_headers(user)
 
-    access_token = user.token_for_api_call
-    user_id = user.get_metrics_uuid
-
-    if access_token.nil? || !user.registered_for_firecloud
-      # User is unauthenticated / unregistered / anonymous
-      props['distinct_id'] = user_id
-      headers.delete('Authorization')
-      props['authenticated'] = false
+    # configure properties/headers depending on user presence
+    # only pass user token if user is registered for Terra to avoid 4xx/5xx errors
+    if user.present? && user.registered_for_firecloud
+      props.merge!({ authenticated: true, registeredForTerra: user.registered_for_firecloud })
     else
-      props['authenticated'] = true
+      props.merge!({ authenticated: user.present?, distinct_id: request.cookies['user_id'] })
     end
 
     post_body = {'event' => name, 'properties' => props}.to_json
@@ -177,15 +174,12 @@ class MetricsService
       props.merge!({studyAccession: study.accession})
     end
 
-    headers = {
-      'Content-Type' => 'application/json'
-    }
+    headers = get_default_headers(user)
 
     # configure properties/headers depending on user presence
     # only pass user token if user is registered for Terra to avoid 4xx/5xx errors
     if user.present? && user.registered_for_firecloud
       props.merge!({ authenticated: true, registeredForTerra: user.registered_for_firecloud })
-      headers.merge!({'Authorization' => "Bearer #{user.token_for_api_call.dig('access_token')}"})
     else
       props.merge!({ authenticated: user.present?, distinct_id: request.cookies['user_id'] })
     end

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -35,12 +35,13 @@ class MetricsService
 
   def self.get_default_headers(user)
     headers = { 'Content-Type' => 'application/json'}
-    if user.present?
+    if user.present? && user.registered_for_firecloud && user.token_for_api_call.present?
       access_token = user.token_for_api_call
       headers.merge!({
-        'Authorization' => "Bearer #{access_token.present? ? access_token.dig('access_token') : nil }",
+        'Authorization' => "Bearer #{access_token.dig(:access_token)}",
       })
     end
+    return headers
   end
 
   # Merges unauth’d and auth’d user identities in Mixpanel via Bard
@@ -108,7 +109,7 @@ class MetricsService
     if user.present? && user.registered_for_firecloud
       props.merge!({ authenticated: true, registeredForTerra: user.registered_for_firecloud })
     else
-      props.merge!({ authenticated: user.present?, distinct_id: user.get_metrics_uuid })
+      props.merge!({ authenticated: false, distinct_id: user.get_metrics_uuid, registeredForTerra: false })
     end
 
     post_body = {'event' => name, 'properties' => props}.to_json

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -110,7 +110,7 @@ class MetricsService
       props.merge!({ authenticated: true, registeredForTerra: user.registered_for_firecloud })
     else
       distinct_id = user&.get_metrics_uuid || request&.cookies['user_id']
-      props.merge!({ authenticated: false, distinct_id: distinct_id, registeredForTerra: false })
+      props.merge!({ authenticated: false, registeredForTerra: false,  distinct_id: distinct_id })
     end
 
     post_body = {'event' => name, 'properties' => props}.to_json

--- a/test/integration/lib/metrics_service_test.rb
+++ b/test/integration/lib/metrics_service_test.rb
@@ -134,9 +134,6 @@ class MetricsServiceTest < ActiveSupport::TestCase
 
     mock = Minitest::Mock.new
 
-    puts('expected:', expected_args)
-    puts('result:', mock)
-
     mock.expect :call, mock, [expected_args]
 
     RestClient::Request.stub :execute, mock do

--- a/test/integration/lib/metrics_service_test.rb
+++ b/test/integration/lib/metrics_service_test.rb
@@ -31,15 +31,15 @@ class MetricsServiceTest < ActiveSupport::TestCase
     expected_output_props = input_props.merge({
       appId: "single-cell-portal",
       env: "test",
-      registeredForTerra: true,
-      authenticated: true
+      authenticated: true,
+      registeredForTerra: true
     })
 
     # As input into RestClient::Request.execute.
     # These expected arguments are the main thing we are testing.
     expected_args = {
       url: "https://terra-bard-dev.appspot.com/api/event",
-      headers: {'Authorization' => "Bearer ", "Content-Type" => "application/json"},
+      headers: {"Content-Type" => "application/json", 'Authorization' => "Bearer #{@user.token_for_api_call.dig(:access_token)}"},
       payload: {event: event, properties: expected_output_props}.to_json,
       method: "POST"
     }
@@ -68,7 +68,7 @@ class MetricsServiceTest < ActiveSupport::TestCase
     # These expected arguments are the main thing we are testing.
     expected_args = {
       url: "https://terra-bard-dev.appspot.com/api/identify",
-      headers: {"Authorization" => "Bearer ", "Content-Type" => "application/json"},
+      headers: {"Authorization" => "Bearer #{@user.token_for_api_call.dig(:access_token)}", "Content-Type" => "application/json"},
       payload: {anonId: anon_id}.to_json,
       method: "POST"
     }
@@ -133,6 +133,10 @@ class MetricsServiceTest < ActiveSupport::TestCase
     }
 
     mock = Minitest::Mock.new
+
+    puts('expected:', expected_args)
+    puts('result:', mock)
+
     mock.expect :call, mock, [expected_args]
 
     RestClient::Request.stub :execute, mock do
@@ -197,9 +201,9 @@ class MetricsServiceTest < ActiveSupport::TestCase
       {
         appId: "single-cell-portal",
         env: "test",
-        registeredForTerra: false,
+        authenticated: false,
         distinct_id: unregistered_user.metrics_uuid,
-        authenticated: false
+        registeredForTerra: false
       }
     )
 

--- a/test/integration/lib/metrics_service_test.rb
+++ b/test/integration/lib/metrics_service_test.rb
@@ -199,8 +199,8 @@ class MetricsServiceTest < ActiveSupport::TestCase
         appId: "single-cell-portal",
         env: "test",
         authenticated: false,
-        distinct_id: unregistered_user.metrics_uuid,
-        registeredForTerra: false
+        registeredForTerra: false,
+        distinct_id: unregistered_user.metrics_uuid
       }
     )
 


### PR DESCRIPTION
This prevents the errors we are seeing in Sentry related to an unregistered user trying to search 50+ genes on a study. Previously the function MetricsService.log() did not handle `nil` users appropriately. This update utilizes the pattern set in MetricsService.report_error() to handle both logged in and not logged in users. Also this updates the function `get_default_headers()` to conditionally handle not signed in users as well.

Note - It seemed like the way `get_default_headers()` was designed was to sometimes produce Authentication headers that were blank, seemingly for ease of testing? I'm not sure, I couldn't sort out why we'd want to do that, so I updated it to only add real Auth bearer token headers and not add Auth headers if the user is not registered rather than adding and removing as was previously done and updated the tests to handle actual Auth bearer tokens. But please let me know if I'm missing something there.

To test:
- Pull this branch
- Boot up your local server
- Navigate to [swagger](https://localhost:3000/single_cell/api/v1#/Visualization/study_visualization_expression_show)
- Add a study accession for a public study in your local that has 50+ genes you can search
- Set the `data_type` to `heatmap` 
- Add 50+ genes to the gene search input
- Execute
- You should see no 500 error in the results on the Swagger page, you can also further confirm this by opening up `development.log` 
- To see the broken behavior do these same steps using the `development` branch and you will see an error like:

> registeredForTerra: user.registered_for_firecloud,
> single_cell       |                               ^^^^^^^^^^^^^^^^^^^^^^^^^ excluded from capture: DSN not set
> single_cell       |   
> single_cell       | NoMethodError (undefined method `registered_for_firecloud' for nil:NilClass


Before:
![Screen Shot 2022-11-07 at 3 22 14 PM](https://user-images.githubusercontent.com/54322292/200597961-cf0c33aa-89c8-47ba-a22c-83615e1d71d5.png)

After:
![Screen Shot 2022-11-08 at 10 02 15 AM](https://user-images.githubusercontent.com/54322292/200599409-0b5c42cb-9a17-421c-9cd2-8e2728579272.png)

