### PR TITLE
Integration for static image creation jobs into `ImagePipelineService` (SCP-4756)

### DIFF
--- a/app/controllers/api/v1/visualization/explore_controller.rb
+++ b/app/controllers/api/v1/visualization/explore_controller.rb
@@ -154,6 +154,7 @@ module Api
             clusterGroupNames: ClusterVizService.load_cluster_group_options(study),
             spatialGroups: spatial_group_options,
             differentialExpression: AnnotationVizService.differential_expression_menu_opts(study),
+            hasImageData: study.cluster_groups.where(has_image_data: true).pluck(:name),
             imageFiles: image_options,
             clusterPointAlpha: study.default_cluster_point_alpha,
             colorProfile: study.default_color_profile,

--- a/app/controllers/api/v1/visualization/explore_controller.rb
+++ b/app/controllers/api/v1/visualization/explore_controller.rb
@@ -154,7 +154,7 @@ module Api
             clusterGroupNames: ClusterVizService.load_cluster_group_options(study),
             spatialGroups: spatial_group_options,
             differentialExpression: AnnotationVizService.differential_expression_menu_opts(study),
-            hasImageData: study.cluster_groups.where(has_image_data: true).pluck(:name),
+            hasImageCache: study.cluster_groups.where(has_image_cache: true).pluck(:name),
             imageFiles: image_options,
             clusterPointAlpha: study.default_cluster_point_alpha,
             colorProfile: study.default_color_profile,

--- a/app/lib/image_pipeline_service.rb
+++ b/app/lib/image_pipeline_service.rb
@@ -6,12 +6,13 @@ class ImagePipelineService
     matrix_file: ['Expression Matrix', 'MM Coordinate Matrix']
   }.freeze
 
-  # launch a job to generate static images using array artifacts generated from :run_render_expression_arrays_job
-  # #
+  # launch a job to generate cache of static images using array artifacts generated from
+  # :run_render_expression_arrays_job
+  #
   # * *params*
-  #   - +study+       (Study) => study to generate images in
+  #   - +study+        (Study) => study to generate images in
   #   - +cluster_file+ (StudyFile) => clustering file to use as source for cell names
-  #   - +user+        (User) => associated user (for email notifications)
+  #   - +user+         (User) => associated user (for email notifications)
   #
   # * *yields*
   #   - (IngestJob) => image_pipeline job in PAPI
@@ -31,10 +32,10 @@ class ImagePipelineService
   # launch a job to generate expression array artifacts to be used downstream by image pipeline
   #
   # * *params*
-  #   - +study+       (Study) => study to generate data in
+  #   - +study+        (Study) => study to generate data in
   #   - +cluster_file+ (StudyFile) => clustering file to use as source for cell names
   #   - +matrix_file+  (StudyFile) => processed expression matrix to use as source for expression values
-  #   - +user+        (User) => associated user (for email notifications)
+  #   - +user+         (User) => associated user (for email notifications)
   #
   # * *yields*
   #   - (IngestJob) => render_expression_arrays job in PAPI
@@ -55,9 +56,9 @@ class ImagePipelineService
   #
   # * *params*
   #   - +study+          (Study) => study to launch job for
-  #   - +cluster_file+    (StudyFile) => clustering file to use as source for cell names
+  #   - +cluster_file+   (StudyFile) => clustering file to use as source for cell names
   #   - +requested_user+ (User) => associated user (for email notifications)
-  #   - +params_object+  (Multiple) => parameters object, e.g. ImagePipelineParameters
+  #   - +params_object+  (ImagePipelineParameters, RenderExpressionArrayParameters) => parameters object
   #
   # * *yields*
   #   - (IngestJob) => render_expression_arrays job in PAPI
@@ -117,7 +118,7 @@ class ImagePipelineService
   # create a ImagePipelineParameters object to pass to IngestJob
   #
   # * *params*
-  #   - +study+       (Study) => study to generate images in
+  #   - +study+        (Study) => study to generate images in
   #   - +cluster_file+ (StudyFile) => clustering file to use as source for cell names
   #
   # * *returns*
@@ -150,7 +151,7 @@ class ImagePipelineService
   #
   # * *params*
   #   - +study_file+  (StudyFile) => study file to validate
-  #   - +param_name+ (String, Symbol) => name of parameter being validated
+  #   - +param_name+  (String, Symbol) => name of parameter being validated
   #
   # * *raises*
   #   - (ArgumentError) => if study file does not validate

--- a/app/lib/image_pipeline_service.rb
+++ b/app/lib/image_pipeline_service.rb
@@ -6,13 +6,35 @@ class ImagePipelineService
     matrix_file: ['Expression Matrix', 'MM Coordinate Matrix']
   }.freeze
 
+  # launch a job to generate static images using array artifacts generated from :run_render_expression_arrays_job
+  # #
+  # * *params*
+  #   - +study+       (Study) => study to generate images in
+  #   - +cluster_file+ (StudyFile) => clustering file to use as source for cell names
+  #   - +user+        (User) => associated user (for email notifications)
+  #
+  # * *yields*
+  #   - (IngestJob) => image_pipeline job in PAPI
+  #
+  # * *returns*
+  #   - (Boolean) => True if job queues successfully
+  #
+  # * *raises*
+  #   - (ArgumentError) => if requested parameters do not validate
+  def self.run_image_pipeline_job(study, cluster_file, user: nil)
+    validate_study(study)
+    requested_user = user || study.user
+    params_object = create_image_pipeline_parameters_object(study, cluster_file)
+    submit_job(study:, cluster_file:, requested_user:, params_object:)
+  end
+
   # launch a job to generate expression array artifacts to be used downstream by image pipeline
   #
   # * *params*
-  #   - +study+ (Study) => study to generate data in
+  #   - +study+       (Study) => study to generate data in
   #   - +cluster_file+ (StudyFile) => clustering file to use as source for cell names
-  #   - +matrix_file+ (StudyFile) => processed expression matrix to use as source for expression values
-  #   - +user+ (User) => associated user (for email notifications)
+  #   - +matrix_file+  (StudyFile) => processed expression matrix to use as source for expression values
+  #   - +user+        (User) => associated user (for email notifications)
   #
   # * *yields*
   #   - (IngestJob) => render_expression_arrays job in PAPI
@@ -23,17 +45,37 @@ class ImagePipelineService
   # * *raises*
   #   - (ArgumentError) => if requested parameters do not validate
   def self.run_render_expression_arrays_job(study, cluster_file, matrix_file, user: nil)
-    raise ArgumentError, 'invalid study' unless study.is_a?(Study)
-
+    validate_study(study)
     requested_user = user || study.user
     params_object = create_expression_parameters_object(cluster_file, matrix_file)
+    submit_job(study:, cluster_file:, requested_user:, params_object:)
+  end
+
+  # generic job submission handler
+  #
+  # * *params*
+  #   - +study+          (Study) => study to launch job for
+  #   - +cluster_file+    (StudyFile) => clustering file to use as source for cell names
+  #   - +requested_user+ (User) => associated user (for email notifications)
+  #   - +params_object+  (Multiple) => parameters object, e.g. ImagePipelineParameters
+  #
+  # * *yields*
+  #   - (IngestJob) => render_expression_arrays job in PAPI
+  #
+  # * *returns*
+  #   - (Boolean) => True if job queues successfully
+  #
+  # * *raises*
+  #   - (ArgumentError) => if requested parameters do not validate
+  def self.submit_job(study:, cluster_file:, requested_user:, params_object:)
     if params_object.valid?
       job = IngestJob.new(study: study, study_file: cluster_file, user: requested_user,
-                          action: :render_expression_arrays, params_object: params_object)
+                          action: params_object.action_name, params_object: params_object)
       job.delay.push_remote_and_launch_ingest
       true
     else
-      raise ArgumentError, "job parameters failed to validate: #{params_object.errors.full_messages}"
+      raise ArgumentError,
+            "#{params_object.action_name} job parameters failed to validate: #{params_object.errors.full_messages}"
     end
   end
 
@@ -41,7 +83,7 @@ class ImagePipelineService
   #
   # * *params*
   #   - +cluster_file+ (StudyFile) => clustering file to use as source for cell names
-  #   - +matrix_file+ (StudyFile) => processed expression matrix to use as source for expression values
+  #   - +matrix_file+  (StudyFile) => processed expression matrix to use as source for expression values
   #
   # * *returns*
   #   - (RenderExpressionArraysParameters) => parameters object
@@ -72,12 +114,45 @@ class ImagePipelineService
     RenderExpressionArraysParameters.new(parameters)
   end
 
+  # create a ImagePipelineParameters object to pass to IngestJob
+  #
+  # * *params*
+  #   - +study+       (Study) => study to generate images in
+  #   - +cluster_file+ (StudyFile) => clustering file to use as source for cell names
+  #
+  # * *returns*
+  #   - (ImagePipelineParameters) => parameters object
+  #
+  # * *raises*
+  #   - (ArgumentError) => if requested parameters do not validate
+  def self.create_image_pipeline_parameters_object(study, cluster_file)
+    validate_study_file(cluster_file, :cluster_file)
+    cluster_name = ClusterGroup.find_by(study: study, study_file: cluster_file)&.name
+    ImagePipelineParameters.new(
+      accession: study.accession, bucket: study.bucket_id,
+      cluster: cluster_name, environment: Rails.env.to_s, cores: '92'
+    )
+  end
+
+  # validate a study is a candidate for image pipeline jobs
+  #
+  # * *params*
+  #   - +study+ (Study) => study to validate, must be public and have clustering/expression data
+  #
+  # * *raises*
+  #   - (ArgumentError) => if study does not meet requirements
+  def self.validate_study(study)
+    raise ArgumentError, 'invalid study, must be public' unless study.is_a?(Study) && study.public
+    raise ArgumentError, 'study does not have clustering data' unless study.has_cluster_data?
+    raise ArgumentError, 'study does not have expression data' unless study.has_expression_data?
+  end
+
   # validate a study file for use in render_expression_arrays
   # must be a StudyFile instance that has been pushed to the workspace bucket (does not need to be parsed)
   # MM Coordinate Matrix files must also have completed bundle (genes/barcodes files)
   #
   # * *params*
-  #   - +study_file+ (StudyFile) => study file to validate
+  #   - +study_file+  (StudyFile) => study file to validate
   #   - +param_name+ (String, Symbol) => name of parameter being validated
   #
   # * *raises*

--- a/app/lib/image_pipeline_service.rb
+++ b/app/lib/image_pipeline_service.rb
@@ -128,10 +128,7 @@ class ImagePipelineService
   def self.create_image_pipeline_parameters_object(study, cluster_file)
     validate_study_file(cluster_file, :cluster_file)
     cluster_name = ClusterGroup.find_by(study: study, study_file: cluster_file)&.name
-    ImagePipelineParameters.new(
-      accession: study.accession, bucket: study.bucket_id,
-      cluster: cluster_name, environment: Rails.env.to_s, cores: '92'
-    )
+    ImagePipelineParameters.new(accession: study.accession, bucket: study.bucket_id, cluster: cluster_name)
   end
 
   # validate a study is a candidate for image pipeline jobs

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -26,6 +26,9 @@ class ClusterGroup
   field :subsampled, type: Boolean, default: false
   field :is_subsampling, type: Boolean, default: false
 
+  # denotes when image_pipeline has been run for this cluster_group
+  field :has_image_data, type: Boolean, default: false
+
   validates_uniqueness_of :name, scope: :study_id
   validates_presence_of :name, :cluster_type
   validates_format_of :name, with: ValidationTools::URL_PARAM_SAFE,

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -27,7 +27,7 @@ class ClusterGroup
   field :is_subsampling, type: Boolean, default: false
 
   # denotes when image_pipeline has been run for this cluster_group
-  field :has_image_data, type: Boolean, default: false
+  field :has_image_cache, type: Boolean, default: false
 
   validates_uniqueness_of :name, scope: :study_id
   validates_presence_of :name, :cluster_type

--- a/app/models/concerns/parameterizable.rb
+++ b/app/models/concerns/parameterizable.rb
@@ -6,7 +6,7 @@ module Parameterizable
   # regular expression to validate GS url format
   GS_URL_REGEXP = %r{\Ags://}
 
-  # regular expression to match GCI URI format
+  # regular expression to match GCR URI format
   # faster than checking repository for image presence, has no upstream dependencies
   # format as gcr.io/google-project/docker-image:version
   # google-project: 6-30 alphanumeric characters, plus dash (-)

--- a/app/models/concerns/parameterizable.rb
+++ b/app/models/concerns/parameterizable.rb
@@ -4,7 +4,25 @@ module Parameterizable
   extend ActiveSupport::Concern
 
   # regular expression to validate GS url format
-  GS_URL_REGEXP = %r{\Ags://}.freeze
+  GS_URL_REGEXP = %r{\Ags://}
+
+  # regular expression to match GCI URI format
+  # faster than checking repository for image presence, has no upstream dependencies
+  # format as gcr.io/google-project/docker-image:version
+  # google-project: 6-30 alphanumeric characters, plus dash (-)
+  # docker-image: 4-128 alphanumeric characters, plus dash (-) and periods (.)
+  # version: standard semantic versioning (x.y.z), plus extra alphanumerics after last digit for commit SHA
+  GCR_URI_REGEXP = %r{gcr.io/[\w-]{6,30}/[\w.-]{4,128}+:\d+\.\d+\.\d+\w*}
+
+  # acceptable Google N-machine types
+  # https://cloud.google.com/compute/docs/general-purpose-machines
+  GCE_MACHINE_TYPES = %w[n1 n2].map do |family|
+    %w[standard highmem highcpu].map do |series|
+      [2, 4, 8, 16, 32, 64, 96].map do |cores|
+        [family, series, cores].join('-')
+      end
+    end
+  end.flatten.freeze
 
   # convert attribute name into CLI-formatted option
   def self.to_cli_opt(param_name)
@@ -16,7 +34,7 @@ module Parameterizable
   def to_options_array
     options_array = []
     attributes.each do |attr_name, value|
-      options_array += [Parameterizable.to_cli_opt(attr_name), "#{value}"] if value.present?
+      options_array += [Parameterizable.to_cli_opt(attr_name), value.to_s] if value.present?
     end
     options_array << self.class::PARAMETER_NAME if defined? self.class::PARAMETER_NAME
     options_array

--- a/app/models/concerns/parameterizable.rb
+++ b/app/models/concerns/parameterizable.rb
@@ -18,7 +18,13 @@ module Parameterizable
     attributes.each do |attr_name, value|
       options_array += [Parameterizable.to_cli_opt(attr_name), "#{value}"] if value.present?
     end
-    options_array << self.class::PARAMETER_NAME
+    options_array << self.class::PARAMETER_NAME if defined? self.class::PARAMETER_NAME
     options_array
+  end
+
+  # name of ingest action
+  # example: RenderExpressionArraysParameters => :render_expression_arrays
+  def action_name
+    self.class.name.gsub(/Parameters/, '').underscore.to_sym
   end
 end

--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -3,10 +3,6 @@ class DifferentialExpressionParameters
   include ActiveModel::Model
   include Parameterizable
 
-  # acceptable Google N1 machine types
-  # https://cloud.google.com/compute/docs/general-purpose-machines#n1-high-memory
-  GOOGLE_VM_MACHINE_TYPES = [2, 4, 8, 16, 32, 64, 96].map { |i| "n1-highmem-#{i}" }.freeze
-
   # name of Ingest Pipeline CLI parameter that invokes correct parser
   PARAMETER_NAME = '--differential-expression'.freeze
 
@@ -29,7 +25,7 @@ class DifferentialExpressionParameters
             format: { with: Parameterizable::GS_URL_REGEXP, message: 'is not a valid GS url' }
   validates :annotation_scope, inclusion: %w[cluster study]
   validates :matrix_file_type, inclusion: %w[dense mtx]
-  validates :machine_type, inclusion: GOOGLE_VM_MACHINE_TYPES
+  validates :machine_type, inclusion: Parameterizable::GCE_MACHINE_TYPES
   validates :gene_file, :barcode_file,
             presence: true,
             format: {

--- a/app/models/image_pipeline_parameters.rb
+++ b/app/models/image_pipeline_parameters.rb
@@ -2,9 +2,20 @@ class ImagePipelineParameters
   include ActiveModel::Model
   include Parameterizable
 
+  # accession: study accession
+  # bucket: GCS bucket name
+  # cluster: name of ClusterGroup object
+  # environment: Rails environment
+  # cores: number of cores to use in processing images (defaults to available cores - 1)
+  # docker_image: image pipeline docker image to use
+  # machine_type: GCE machine type, see Parameterizable::GOOGLE_VM_MACHINE_TYPES
   attr_accessor :accession, :bucket, :cluster, :environment, :cores, :docker_image, :machine_type
 
   validates :accession, :bucket, :cluster, :environment, :cores, presence: true
+  validates :machine_type, inclusion: Parameterizable::GCE_MACHINE_TYPES
+  validates :environment, inclusion: %w[development test staging production]
+  validates :docker_image, format: { with: Parameterizable::GCR_URI_REGEXP }
+  validate :machine_has_cores?
 
   # default values for all jobs
   PARAM_DEFAULTS = {
@@ -14,8 +25,15 @@ class ImagePipelineParameters
 
   def initialize(attributes = {})
     super
+    @environment ||= Rails.env.to_s
     @docker_image ||= PARAM_DEFAULTS[:docker_image]
     @machine_type ||= PARAM_DEFAULTS[:machine_type]
+    @cores ||= machine_type_cores - 1
+  end
+
+  # available cores by machine_type
+  def machine_type_cores
+    machine_type.split('-').last.to_i
   end
 
   # default attributes hash
@@ -23,5 +41,14 @@ class ImagePipelineParameters
     {
       accession:, bucket:, cluster:, environment:, cores:
     }.with_indifferent_access
+  end
+
+  private
+
+  # ensure requested cores supported by machine_type, reserving 1 for OS
+  def machine_has_cores?
+    if cores + 1 > machine_type_cores || cores < 1
+      errors.add(:cores, "(#{cores}) not supported by machine_type: #{machine_type}")
+    end
   end
 end

--- a/app/models/image_pipeline_parameters.rb
+++ b/app/models/image_pipeline_parameters.rb
@@ -1,0 +1,27 @@
+class ImagePipelineParameters
+  include ActiveModel::Model
+  include Parameterizable
+
+  attr_accessor :accession, :bucket, :cluster, :environment, :cores, :docker_image, :machine_type
+
+  validates :accession, :bucket, :cluster, :environment, :cores, presence: true
+
+  # default values for all jobs
+  PARAM_DEFAULTS = {
+    docker_image: 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_e2992be5b',
+    machine_type: 'n1-highcpu-96'
+  }.freeze
+
+  def initialize(attributes = {})
+    super
+    @docker_image ||= PARAM_DEFAULTS[:docker_image]
+    @machine_type ||= PARAM_DEFAULTS[:machine_type]
+  end
+
+  # default attributes hash
+  def attributes
+    {
+      accession:, bucket:, cluster:, environment:, cores:
+    }.with_indifferent_access
+  end
+end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -380,7 +380,7 @@ class IngestJob
     when :differential_expression
       create_differential_expression_results
     when :image_pipeline
-      set_has_image_data
+      set_has_image_cache
     end
     set_study_initialized
   end
@@ -512,10 +512,10 @@ class IngestJob
   end
 
   # set flags to denote when a cluster has image data
-  def set_has_image_data
+  def set_has_image_cache
     Rails.logger.info "Setting image_pipeline flags in #{study.accession} for cluster: #{study_file.name}"
     cluster_group = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
-    cluster_group.update(has_image_data: true) if cluster_group.present?
+    cluster_group.update(has_image_cache: true) if cluster_group.present?
   end
 
   # set corresponding is_differential_expression_enabled flags on annotations

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -28,7 +28,7 @@ class IngestJob
   # non-standard job actions where data is not being read from a file to insert into MongoDB
   # these jobs usually process files and write objects back to the bucket, and as such have special pre/post-processing
   # steps that need to be accounted for
-  SPECIAL_ACTIONS = %i[differential_expression render_expression_arrays].freeze
+  SPECIAL_ACTIONS = %i[differential_expression render_expression_arrays image_pipeline].freeze
 
   # Name of pipeline submission running in GCP (from [PapiClient#run_pipeline])
   attr_accessor :pipeline_name
@@ -379,6 +379,8 @@ class IngestJob
       set_subsampling_flags
     when :differential_expression
       create_differential_expression_results
+    when :image_pipeline
+      set_has_image_data
     end
     set_study_initialized
   end
@@ -507,6 +509,13 @@ class IngestJob
       matrix_file_id: matrix_file.id
     )
     de_result.save
+  end
+
+  # set flags to denote when a cluster has image data
+  def set_has_image_data
+    Rails.logger.info "Setting image_pipeline flags in #{study.accession} for cluster: #{study_file.name}"
+    cluster_group = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
+    cluster_group.update(has_image_data: true) if cluster_group.present?
   end
 
   # set corresponding is_differential_expression_enabled flags on annotations
@@ -743,6 +752,8 @@ class IngestJob
       genes = Gene.where(study_id: study.id, study_file_id: matrix.id).count
       message << "Image Pipeline data pre-rendering completed for \"#{params_object.cluster_name}\""
       message << "Gene-level files created: #{genes}"
+    when :image_pipeline
+      message << "Image Pipeline image rendering completed for \"#{params_object.cluster}\""
     end
     message
   end

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -121,7 +121,9 @@ class PapiClient
     command_line = get_command_line(study_file:, action:, user_metrics_uuid:, params_object:)
 
     environment = set_environment_variables
-    action = create_actions_object(commands: command_line, environment: environment)
+    action = create_actions_object(
+      commands: command_line, environment: environment, image_uri: params_object&.docker_image
+    )
     pipeline = create_pipeline_object(actions: [action], environment: environment, resources: resources)
     pipeline_request = create_run_pipeline_request_object(pipeline:, labels:)
     Rails.logger.info "Request object sent to Google Pipelines API (PAPI), excluding 'environment' parameters:"
@@ -184,15 +186,16 @@ class PapiClient
   #   - +image_uri+: (String) => GCR Docker image to pull, defaults to AdminConfiguration.get_ingest_docker_image
   #   - +labels+: (Hash) => Hash of labels to associate with the action
   #   - +timeout+: (String) => Maximum runtime of action
+  #   - +image_uri+: (String) => Override for docker image URI
   #
   #  * *return*
   #   - (Google::Apis::GenomicsV2alpha1::Action)
-  def create_actions_object(commands: [], environment: {}, flags: [], labels: {}, timeout: nil)
+  def create_actions_object(commands: [], environment: {}, flags: [], labels: {}, timeout: nil, image_uri: nil)
     Google::Apis::GenomicsV2alpha1::Action.new(
       commands: commands,
       environment: environment,
       flags: flags,
-      image_uri: AdminConfiguration.get_ingest_docker_image,
+      image_uri: image_uri || AdminConfiguration.get_ingest_docker_image,
       labels: labels,
       timeout: timeout
     )

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -228,7 +228,7 @@ class PapiClient
       'BARD_HOST_URL' => Rails.application.config.bard_host_url
     }
     if action == :image_pipeline
-      vars.merge({ 'IS_PAPI' => '1', 'NODE_TLS_REJECT_UNAUTHORIZED' => '0' })
+      vars.merge({ 'IS_PAPI' => '1', 'STAGING_INTERNAL_IP' => ENV['APP_INTERNAL_IP'] })
     else
       vars
     end

--- a/test/api/visualization/explore_controller_test.rb
+++ b/test/api/visualization/explore_controller_test.rb
@@ -121,6 +121,16 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
     assert_equal false, json['canEdit']
   end
 
+  test 'should get clusters with image cache' do
+    cluster_name = 'clusterA.txt'
+    cluster = @basic_study.cluster_groups.by_name(cluster_name)
+    cluster.update(has_image_cache: true)
+    @basic_study.reload
+    sign_in_and_update @user
+    execute_http_request(:get, api_v1_study_explore_path(@basic_study))
+    assert_response :success
+    assert_includes json['hasImageCache'], cluster_name
+  end
 
   test 'should handle invalid study id' do
     sign_in_and_update @user

--- a/test/integration/lib/image_pipeline_service_test.rb
+++ b/test/integration/lib/image_pipeline_service_test.rb
@@ -123,7 +123,8 @@ class ImagePipelineServiceTest < ActiveSupport::TestCase
       assert_equal @study.bucket_id, params.bucket
       assert_equal @study.accession, params.accession
       assert_equal Rails.env.to_s, params.environment
-      assert_equal
+      assert_equal 95, params.cores
+      assert_equal ImagePipelineParameters::PARAM_DEFAULTS[:docker_image], params.docker_image
     end
   end
 

--- a/test/integration/lib/image_pipeline_service_test.rb
+++ b/test/integration/lib/image_pipeline_service_test.rb
@@ -18,10 +18,13 @@ class ImagePipelineServiceTest < ActiveSupport::TestCase
                                         modality: 'Proteomic'
                                       },
                                       upload_file_size: 10.megabytes)
+    @pten_gene = FactoryBot.create(:gene_with_expression,
+                                   name: 'PTEN',
+                                   study_file: @dense_matrix,
+                                   expression_input: [['A', 0],['B', 3],['C', 1.5]])
     @cluster_file = FactoryBot.create(:cluster_file,
                                       name: 'cluster.txt',
                                       study: @study)
-
     @sparse_matrix = FactoryBot.create(:expression_file,
                                        name: 'matrix.mtx',
                                        file_type: 'MM Coordinate Matrix',
@@ -49,6 +52,18 @@ class ImagePipelineServiceTest < ActiveSupport::TestCase
     bundle.add_files(@sparse_matrix, @genes_file, @barcodes_file)
   end
 
+  test 'should launch image pipeline job' do
+    job_mock = Minitest::Mock.new
+    job_mock.expect(:push_remote_and_launch_ingest, Delayed::Job.new)
+    mock = Minitest::Mock.new
+    mock.expect(:delay, job_mock)
+    IngestJob.stub :new, mock do
+      ApplicationController.firecloud_client.stub :workspace_file_exists?, true do
+        ImagePipelineService.run_image_pipeline_job(@study, @cluster_file)
+      end
+    end
+  end
+
   test 'should launch render expression arrays job for all matrix types' do
     [@dense_matrix, @sparse_matrix].each do |matrix_file|
       job_mock = Minitest::Mock.new
@@ -66,7 +81,24 @@ class ImagePipelineServiceTest < ActiveSupport::TestCase
     end
   end
 
-  test 'should validate parameters' do
+  test 'should validate parameters for images pipeline jobs' do
+    # wrong data types
+    assert_raise ArgumentError do
+      ImagePipelineService.run_image_pipeline_job({}, {})
+    end
+
+    # passing matrix as cluster file
+    assert_raise ArgumentError do
+      ImagePipelineService.run_image_pipeline_job(@study, @dense_matrix)
+    end
+
+    # should fail because file is not in bucket
+    assert_raise ArgumentError do
+      ImagePipelineService.run_image_pipeline_job(@study, @cluster_file)
+    end
+  end
+
+  test 'should validate parameters for expression array jobs' do
     # wrong data types
     assert_raise ArgumentError do
       ImagePipelineService.run_render_expression_arrays_job({}, {}, {})
@@ -83,7 +115,19 @@ class ImagePipelineServiceTest < ActiveSupport::TestCase
     end
   end
 
-  test 'should create parameters object' do
+  test 'should create image pipeline parameters object' do
+    ApplicationController.firecloud_client.stub :workspace_file_exists?, true do
+      params = ImagePipelineService.create_image_pipeline_parameters_object(@study, @cluster_file)
+      assert params.valid?
+      assert_equal @cluster_file.name, params.cluster
+      assert_equal @study.bucket_id, params.bucket
+      assert_equal @study.accession, params.accession
+      assert_equal Rails.env.to_s, params.environment
+      assert_equal
+    end
+  end
+
+  test 'should create expression array parameters object' do
     [@dense_matrix, @sparse_matrix].each do |matrix_file|
       ApplicationController.firecloud_client.stub :workspace_file_exists?, true do
         params = ImagePipelineService.create_expression_parameters_object(@cluster_file, matrix_file)

--- a/test/models/image_pipeline_parameters_test.rb
+++ b/test/models/image_pipeline_parameters_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class ImagePipelineParametersTest < ActiveSupport::TestCase
+  before(:all) do
+    @params = {
+      accession: 'SCP1234',
+      cluster: 'UMAP',
+      bucket: 'test_bucket',
+      environment: 'test',
+      cores: '4'
+    }
+    @pipeline_params = ImagePipelineParameters.new(@params)
+  end
+
+  test 'should instantiate and validate parameters' do
+    assert @pipeline_params.valid?
+    invalid = ImagePipelineParameters.new
+    assert_not invalid.valid?
+    assert_equal invalid.attributes.keys.sort, invalid.errors.errors.map { |e| e.attribute.to_s }.sort
+
+    # test overriding defaults
+    fake_image = 'gcr.io/repository/image:version'
+    new_params = ImagePipelineParameters.new(@params.merge(cores: '12', docker_image: fake_image))
+    assert new_params.valid?
+    assert_equal fake_image, new_params.docker_image
+    assert_equal '12', new_params.cores
+  end
+
+  test 'should format render expression array parameters for python cli' do
+    options_array = @pipeline_params.to_options_array
+    @pipeline_params.attributes.each do |name, value|
+      expected_name = Parameterizable.to_cli_opt(name)
+      assert_includes options_array, expected_name
+      assert_includes options_array, value
+    end
+  end
+end

--- a/test/models/image_pipeline_parameters_test.rb
+++ b/test/models/image_pipeline_parameters_test.rb
@@ -6,32 +6,51 @@ class ImagePipelineParametersTest < ActiveSupport::TestCase
       accession: 'SCP1234',
       cluster: 'UMAP',
       bucket: 'test_bucket',
-      environment: 'test',
-      cores: '4'
+      environment: 'test'
     }
     @pipeline_params = ImagePipelineParameters.new(@params)
   end
 
   test 'should instantiate and validate parameters' do
     assert @pipeline_params.valid?
-    invalid = ImagePipelineParameters.new
+    invalid = ImagePipelineParameters.new(environment: 'foo', machine_type: 'bar', docker_image: 'blah')
     assert_not invalid.valid?
-    assert_equal invalid.attributes.keys.sort, invalid.errors.errors.map { |e| e.attribute.to_s }.sort
+    assert_equal %i[accession bucket cluster cores docker_image environment machine_type],
+                 invalid.errors.attribute_names.sort
 
     # test overriding defaults
-    fake_image = 'gcr.io/repository/image:version'
-    new_params = ImagePipelineParameters.new(@params.merge(cores: '12', docker_image: fake_image))
+    fake_image = 'gcr.io/repository/image:0.1.2'
+    new_params = ImagePipelineParameters.new(@params.merge(cores: 12, docker_image: fake_image))
     assert new_params.valid?
     assert_equal fake_image, new_params.docker_image
-    assert_equal '12', new_params.cores
+    assert_equal 12, new_params.cores
   end
 
-  test 'should format render expression array parameters for python cli' do
+  test 'should ensure core count does not exceed requested machine type' do
+    assert @pipeline_params.cores.to_i < @pipeline_params.machine_type_cores.to_i
+    bad_params = ImagePipelineParameters.new(@params.merge(cores: 128))
+    assert_not bad_params.valid?
+    assert_equal %i[cores], bad_params.errors.attribute_names
+  end
+
+  test 'should get cores from machine type' do
+    assert_equal 95, @pipeline_params.cores
+    assert_equal 96, @pipeline_params.machine_type_cores
+    custom_machine_type = ImagePipelineParameters.new(@params.merge(machine_type: 'n1-standard-12'))
+    assert_equal 11, custom_machine_type.cores
+    assert_equal 12, custom_machine_type.machine_type_cores
+    # this will fail to validate, but shows that a bad machine_type doesn't throw any other errors
+    bad_machine = ImagePipelineParameters.new(@params.merge(machine_type: 'foo'))
+    assert_equal(-1, bad_machine.cores)
+    assert_equal 0, bad_machine.machine_type_cores
+  end
+
+  test 'should format image pipeline array parameters for cli' do
     options_array = @pipeline_params.to_options_array
     @pipeline_params.attributes.each do |name, value|
       expected_name = Parameterizable.to_cli_opt(name)
       assert_includes options_array, expected_name
-      assert_includes options_array, value
+      assert_includes options_array, value.to_s # gotcha as cores is converted to string for command line
     end
   end
 end

--- a/test/models/papi_client_test.rb
+++ b/test/models/papi_client_test.rb
@@ -121,7 +121,7 @@ class PapiClientTest < ActiveSupport::TestCase
     assert_equal @client.project, env_vars['GOOGLE_PROJECT_ID']
     image_pipeline_vars = @client.set_environment_variables(action: :image_pipeline)
     assert_equal '1', image_pipeline_vars['IS_PAPI']
-    assert_equal '0', image_pipeline_vars['NODE_TLS_REJECT_UNAUTHORIZED']
+    assert_includes image_pipeline_vars.keys, 'STAGING_INTERNAL_IP'
   end
 
   test 'should create virtual machine config' do

--- a/test/models/papi_client_test.rb
+++ b/test/models/papi_client_test.rb
@@ -119,6 +119,9 @@ class PapiClientTest < ActiveSupport::TestCase
     assert env_vars.keys.include? 'MONGODB_USERNAME'
     assert env_vars.keys.include? 'GOOGLE_PROJECT_ID'
     assert_equal @client.project, env_vars['GOOGLE_PROJECT_ID']
+    image_pipeline_vars = @client.set_environment_variables(action: :image_pipeline)
+    assert_equal '1', image_pipeline_vars['IS_PAPI']
+    assert_equal '0', image_pipeline_vars['NODE_TLS_REJECT_UNAUTHORIZED']
   end
 
   test 'should create virtual machine config' do
@@ -216,7 +219,7 @@ class PapiClientTest < ActiveSupport::TestCase
     regions = %w[us-central1]
     labels = @client.job_labels(
       action: :differential_expression, study: @study, study_file: @cluster_file, user: @user,
-      machine_type: de_params.machine_type
+      params_object: de_params
     )
     machine_type = de_params.machine_type
     custom_vm = @client.create_virtual_machine_object(machine_type:, labels:)
@@ -237,14 +240,17 @@ class PapiClientTest < ActiveSupport::TestCase
   end
 
   test 'should set labels for job' do
-    labels = @client.job_labels(action: :ingest_cluster, study: @study, study_file: @cluster_file, user: @user)
+    labels = @client.job_labels(
+      action: :ingest_cluster, study: @study, study_file: @cluster_file, user: @user, params_object: nil
+    )
     ingest_tag = AdminConfiguration.get_ingest_docker_image_attributes[:tag].gsub(/\./, '_')
     expected_labels = {
       study_accession: @study.accession.downcase,
       user_id: @user.id.to_s,
       filename: 'cluster_txt',
       action: 'ingest_pipeline',
-      docker_image: ingest_tag,
+      docker_image: 'scp-ingest-pipeline',
+      docker_tag: ingest_tag,
       environment: 'test',
       file_type: 'cluster',
       machine_type: PapiClient::DEFAULT_MACHINE_TYPE,

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,7 +237,7 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-string-parser@^7.18.10", "@babel/helper-string-parser@^7.19.4":
+"@babel/helper-string-parser@^7.19.4":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
   integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
@@ -280,7 +280,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.18.10", "@babel/parser@^7.18.11", "@babel/parser@^7.19.6", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0":
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.18.10", "@babel/parser@^7.19.6", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0":
   version "7.19.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.6.tgz#b923430cb94f58a7eae8facbffa9efd19130e7f8"
   integrity sha512-h1IUp81s2JYJ3mRkdxJgs4UvmSsRvDrx5ICSJbPvtWYv5i1nTBGcBpnog+89rAFMwvvru6E5NUHdBe01UeSzYA==


### PR DESCRIPTION
#### BACKGROUND
As part of work towards improving the performance of expression-based plots, the work completed in #1619 and #1650 needs to be able to be launched from Rails in order to eventually automate the entire process of generating static images for single-gene expression plots.

#### CHANGES
This update adds the convenience method `ImagePipelineService.run_image_pipeline_job` to allow the launching of jobs to generate static images from previously rendered expression array artifacts.  This follows the existing paradigms of creating a parameter class (`ImagePipelineParameters`) and launching/polling jobs via `PapiClient` and `IngestJob`.  This will also update the state of the `ClusterGroup` object referenced in the job to denote that static images have been generated for this instance via the `has_image_data` field (exposed as `hasImageData` in the explore API response).

This also updates the labeling of virtual machines in PAPI to correctly denote the docker image & tag used for jobs, since Image Pipeline does not use the `scp-ingest-pipeline` Docker image.

#### MANUAL TESTING
Due to design/architectural limitations, it is not possible to fully test the end-to-end integration locally as jobs running in PAPI cannot connect back to your local instance.  Therefore, it is only possible to test the jobs can be launched - they will eventually fail, but we can validate the integration of launching the jobs.  In deployed environments such as `staging` and `production`, these jobs would be able to succeed eventually.
1. Pull branch and start `DelayedJob` (it is not necessary to start the server)
2. In a separate terminal, enter a Rails console session
3. Load any study with clustering data, such as the `Human raw counts` study:
```
study = Study.find_by(name: 'Human raw counts')
cluster_file = study.cluster_ordinations_files.first
```
4. Launch the job and note it returns true, meaning a job was queued:
```
ImagePipelineService.run_image_pipeline_job(study, cluster_file)
=> true
```
5. In `development.log`, note the submission to PAPI, and that the labels show `image_pipeline` for `action`, `image-pipeline` for `docker_image`, and `0_1_0_e2992be5b` for the version tag.
```
Request object sent to Google Pipelines API (PAPI), excluding 'environment' parameters:
---
:actions:
  :commands:
  - node
  - expression-scatter-plots.js
  - "--accession"
  - SCP79
  - "--bucket"
  - fc-e35ffb0e-480c-4ff6-bcc7-5c823910c95a
  - "--cluster"
  - raw1_human_5k_cells_80_genes.cluster_3D.txt
  - "--environment"
  - development
  - "--cores"
  - '95'
  :flags: []
  :image_uri: gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_e2992be5b
  :labels: {}
  :timeout: {}
:resources:
  :project_id: broad-singlecellportal-bistlin
  :regions:
  - us-central1
  :virtual_machine:
    :boot_disk_size_gb: 300
    :labels:
      :study_accession: scp79
      :user_id: 6033f4a8e2413917a1d0ddcd
      :filename: raw1_human_5k_cells_80_genes_cluster_3d_txt
      :action: :image_pipeline
      :docker_image: image-pipeline
      :docker_tag: 0_1_0_e2992be5b
      :environment: development
      :file_type: cluster
      :machine_type: n1-highcpu-96
      :boot_disk_size_gb: '300'
    :machine_type: n1-highcpu-96
    :preemptible: false
    :service_account:
      :email: default-service-account@broad-singlecellportal-bistlin.iam.gserviceaccount.com
      :scopes:
      - https://www.googleapis.com/auth/cloud-platform
    :network:
      :name: singlecell-network
      :subnetwork: singlecell-network
:timeout: {}
```