### PR TITLE
Relax public requirement for DE, remove automation on study update (SCP-4716)

### DIFF
--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -287,7 +287,6 @@ class DifferentialExpressionService
   #   - (ArgumentError) => If requested study is not eligible for DE
   def self.validate_study(study)
     raise ArgumentError, 'Requested study does not exist' if study.nil?
-    raise ArgumentError, "#{study.accession} is not public" unless study.public?
     raise ArgumentError, "#{study.accession} cannot view cluster plots" unless study.can_visualize_clusters?
   end
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update removes the `public` requirement for studies to be eligible for differential expression, and also removes the check for eligibility on study updates.  Eligibility will now only be checked on successful file parse, and results generated automatically if a study meets requirements.

#### MANUAL TESTING
1. Boot as normal
2. Open a rails console session, and using the study you created from #1660, delete the differential expression results:
```
study = Study.find_by(accession: <accession of your study>)
study.differential_expression_results.map(&:destroy)
```
3. Back in the UI, sign in and load the above study
4. Go to the study settings tab and update the visibility from public to private
5. In `development.log`, note that the save completes and there are no log messages about launching new DE jobs