### PR TITLE
Fix JavaScript heap OOM errors on `assets:precompile` (SCP-4768)

### DIFF
--- a/rails_startup.bash
+++ b/rails_startup.bash
@@ -24,8 +24,10 @@ if [[ $PASSENGER_APP_ENV = "production" ]] || [[ $PASSENGER_APP_ENV = "staging" 
 then
     echo "*** PRECOMPILING ASSETS ***"
     export NODE_OPTIONS="--max-old-space-size=4096"
-    sudo -E -u app -H bundle exec rake NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV SECRET_KEY_BASE=$SECRET_KEY_BASE assets:clean
-    sudo -E -u app -H bundle exec rake NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV SECRET_KEY_BASE=$SECRET_KEY_BASE assets:precompile
+    # precompiled assets are read-only therefore no need to run as app user and sidesteps permission issues
+    bin/rails NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV assets:clobber
+    bin/rails NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV vite:clobber
+    bin/rails NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV assets:precompile
     echo "*** COMPLETED ***"
 fi
 
@@ -61,7 +63,7 @@ chown app:app /home/app/.cron_env
 echo "*** COMPLETED ***"
 
 echo "*** RUNNING PENDING MIGRATIONS ***"
-sudo -E -u app -H bin/rake RAILS_ENV=$PASSENGER_APP_ENV db:migrate
+sudo -E -u app -H bin/rails RAILS_ENV=$PASSENGER_APP_ENV db:migrate
 echo "*** COMPLETED ***"
 
 if [[ ! -d /home/app/webapp/tmp/pids ]]
@@ -81,11 +83,11 @@ echo "*/15 * * * * . /home/app/.cron_env ; /home/app/webapp/bin/job_monitor.rb -
 echo "*** COMPLETED ***"
 
 echo "*** REINDEXING DATABASE ***"
-sudo -E -u app -H bin/bundle exec rake RAILS_ENV=$PASSENGER_APP_ENV db:mongoid:create_indexes
+sudo -E -u app -H bin/rails RAILS_ENV=$PASSENGER_APP_ENV db:mongoid:create_indexes
 echo "*** COMPLETED ***"
 
 echo "*** ADDING CRONTAB TO REINDEX DATABASE ***"
-(crontab -u app -l ; echo "@daily . /home/app/.cron_env ; cd /home/app/webapp/; bin/bundle exec rake RAILS_ENV=$PASSENGER_APP_ENV db:mongoid:create_indexes >> /home/app/webapp/log/cron_out.log 2>&1") | crontab -u app -
+(crontab -u app -l ; echo "@daily . /home/app/.cron_env ; cd /home/app/webapp/; bin/rails RAILS_ENV=$PASSENGER_APP_ENV db:mongoid:create_indexes >> /home/app/webapp/log/cron_out.log 2>&1") | crontab -u app -
 echo "*** COMPLETED ***"
 
 if [[ $PASSENGER_APP_ENV = "development" ]]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,8 @@ export default defineConfig({
     'chunkSizeWarningLimit': 4096,
     'rollupOptions': {
       'output': {
+        // Safely split out especially large third-party libraries
+        // Fuller explanation: https://github.com/broadinstitute/single_cell_portal_core/pull/1668
         'manualChunks': {
           'morpheus-app': ['morpheus-app'],
           'plotly.js-dist': ['plotly.js-dist'],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,18 @@ export default defineConfig({
       jsxRuntime: 'classic'
     })
   ],
+  'build': {
+    'chunkSizeWarningLimit': 4096,
+    'rollupOptions': {
+      'output': {
+        'manualChunks': {
+          'morpheus-app': ['morpheus-app'],
+          'plotly.js-dist': ['plotly.js-dist'],
+          'igv': ['@single-cell-portal/igv']
+        }
+      }
+    }
+  },
   'server': {
     'hmr': {
       'host': '127.0.0.1',


### PR DESCRIPTION
#### BACKGROUND
This update fixes a persistent issue on production deployments where precompiling static assets results in a `JavaScript heap out of memory` fatal error that prevents asset compilation.  The previous workaround was to manually allocate more memory via `export NODE_OPTIONS="--max-old-space-size=8192"` (a 2x increase from what we have now) and then rerun `bin/rails assets:precompile`.  This workaround does not scale as a solution since the amount of precompiled JS will only ever increase, and eventually we will have to allocate yet more memory to "fix" the problem again.

#### CHANGES
The primary issue at play was the size of rendered source maps after transformation was complete.  The main `application.js.map` source map is an eye-popping 24MiB uncompressed once compiled.  We could have fixed the issue by not rendering source maps, but that would have drastic implications for debugging production errors.  Instead of allocating more RAM, this update leverages the `build.rollupOptions.output.manualChunks` option for `vite` to manually split out several of the largest modules into separate chunks.  The three modules selected were Plotly, Morpheus, and IGV - as visualization libraries, they all have numerous dependencies, and as such their source maps tended to be the largest.  Also, as visualization libraries, their integrations tend to be tightly sandboxed, and splitting them out separately seemed safer than selecting other core libraries like `react` or `jquery`.  Below are chunk sizes after manual splitting:
```
../../public/vite/assets/morpheus-app.762bf82d.js                     637.17 KiB / gzip: 161.69 KiB
../../public/vite/assets/morpheus-app.762bf82d.js.map                 1545.50 KiB
../../public/vite/assets/igv.ac4b5e95.js                              725.02 KiB / gzip: 221.10 KiB
../../public/vite/assets/igv.ac4b5e95.js.map                          2598.75 KiB
../../public/vite/assets/application.d345a34e.js                      1443.73 KiB / gzip: 459.17 KiB
../../public/vite/assets/application.d345a34e.js.map                  6915.91 KiB
../../public/vite/assets/plotly.3d1d3db3.js                           3565.81 KiB / gzip: 1084.32 KiB
../../public/vite/assets/plotly.3d1d3db3.js.map                       13626.94 KiB
```

In addition, this update runs `vite clobber` and `assets:clobber` on deployment to ensure proper cleanup of static assets, as inspection of deployed hosts has shown that there are some assets persisting from as far back as 2020.  Lastly, this standardizes on `bin/rails` over `bundle exec rake` in all startup tasks for consistency & reproducibility.

#### MANUAL TESTING
1. Pull branch and run the following from project root to setup & clean your environment:
```
./rails_local_setup.rb
source config/secrets/.source_env.bash
bin/rails assets:clobber
bin/vite clobber
export NODE_OPTIONS="--max-old-space-size=4096" # this is to mimic memory allocation inside Docker
```
2. In your IDE, open `config/vite.json` and delete the entire block for `development` to prevent `vite` from autobuilding later
3. Back in the terminal, run `bin/rails assets:precompile` and confirm it succeeds (you can ignore the warnings about `this` in modules)
4. Start the development server with `bin/rails s` without starting the vite dev server
5. Pull up the home page and confirm it loads without issues
6. Sign in and navigate to the `Male mouse brain` synthetic study
7. Open the explore tab, and interact with the scatter plots, confirming they all load
8. Run a search for a single gene and confirm violin plots load, as well as the Related genes Ideogram
9. Search for two genes and confirm the correlation plot, dot plot, and heatmap all load
10. Click the `Genome` tab and confirm IGV loads without error