### PR TITLE
Add feature flag for future use to gate AnnData ingest (SCP-4773)

### DIFF
--- a/db/migrate/20221110110837_add_feature_flag_for_ingesting_anndata.rb
+++ b/db/migrate/20221110110837_add_feature_flag_for_ingesting_anndata.rb
@@ -1,0 +1,21 @@
+class AddFeatureFlagForIngestingAnndata < Mongoid::Migration
+    # mirror of FeatureFlag.rb, so this migration won't error if that class is renamed/altered
+    class FeatureFlagMigrator
+      include Mongoid::Document
+      store_in collection: 'feature_flags'
+      field :name, type: String
+      field :default_value, type: Boolean, default: false
+      field :description, type: String
+    end
+  
+    def self.up
+      FeatureFlagMigrator.create!(name: 'add_feature_flag_for_ingesting_anndata',
+                                  default_value: false,
+                                  description: 'Feature flag to allow annData ingest or not')
+    end
+  
+    def self.down
+      FeatureFlagMigrator.find_by(name: 'add_feature_flag_for_ingesting_anndata').destroy
+    end
+  end
+  

--- a/db/migrate/20221110160637_feature_flag_for_ingesting_anndata.rb
+++ b/db/migrate/20221110160637_feature_flag_for_ingesting_anndata.rb
@@ -1,4 +1,4 @@
-class AddFeatureFlagForIngestingAnndata < Mongoid::Migration
+class FeatureFlagForIngestingAnndata < Mongoid::Migration
     # mirror of FeatureFlag.rb, so this migration won't error if that class is renamed/altered
     class FeatureFlagMigrator
       include Mongoid::Document
@@ -9,13 +9,13 @@ class AddFeatureFlagForIngestingAnndata < Mongoid::Migration
     end
   
     def self.up
-      FeatureFlagMigrator.create!(name: 'add_feature_flag_for_ingesting_anndata',
+      FeatureFlagMigrator.create!(name: 'ingest_anndata_file',
                                   default_value: false,
-                                  description: 'Feature flag to allow annData ingest or not')
+                                  description: 'allow AnnData files to ingest or not')
     end
   
     def self.down
-      FeatureFlagMigrator.find_by(name: 'add_feature_flag_for_ingesting_anndata').destroy
+      FeatureFlagMigrator.find_by(name: 'ingest_anndata_file').destroy
     end
   end
   


### PR DESCRIPTION
Add a feature flag defaulted to false that we can use for gating ingesting AnnData files.

This is necessary to support https://broadworkbench.atlassian.net/browse/SCP-4706 

Testing:
There is not real functionality added with this subtask but you can run the migration script to see the new flag.
- Pull this branch
- Open up terminal and run `bin/rails db:migrate`
- Start a server and open up localhost
- Navigate to the Feature Flags list page: https://localhost:3000/single_cell/feature_flags and see the new feature flag

![Screen Shot 2022-11-10 at 3 45 30 PM](https://user-images.githubusercontent.com/54322292/201202472-0b6288c7-ffdc-4636-b82f-52d647b9cc85.png)


