### PR TITLE
Run Rails asset jobs as app user (SCP-4821)

### DIFF
--- a/rails_startup.bash
+++ b/rails_startup.bash
@@ -24,10 +24,10 @@ if [[ $PASSENGER_APP_ENV = "production" ]] || [[ $PASSENGER_APP_ENV = "staging" 
 then
     echo "*** PRECOMPILING ASSETS ***"
     export NODE_OPTIONS="--max-old-space-size=4096"
-    # precompiled assets are read-only therefore no need to run as app user and sidesteps permission issues
-    bin/rails NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV assets:clobber
-    bin/rails NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV vite:clobber
-    bin/rails NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV assets:precompile
+    sudo chown app:app ./node_modules/.yarn-integrity
+    sudo -E -u app -H bin/rails NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV assets:clobber
+    sudo -E -u app -H bin/rails NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV vite:clobber
+    sudo -E -u app -H bin/rails NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV assets:precompile
     echo "*** COMPLETED ***"
 fi
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug in deployed environments where running tasks as `root` breaks file permissions for logs & cache directories that cause deployments to fail.

#### MANUAL TESTING
Since this only manifests on deployed instances, this cannot be tested locally as file permissions are handled differently in Docker Desktop.  However, [this hotfix deployment](https://scp-jenkins.dsp-techops.broadinstitute.org/job/scp-deploy-hotfix-to-staging/102/console) to staging with an updated Docker image shows that the changes to `rails_startup.bash` corrected the issue.  Further permission errors should not be seen on production as the affected branch was never deployed beyond staging.