### PR TITLE
Adding information modal about differential expression results (SCP-4813)

### DIFF
--- a/app/javascript/components/explore/DifferentialExpressionModal.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionModal.jsx
@@ -1,0 +1,44 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
+import React, { useState } from 'react'
+import Modal from 'react-bootstrap/lib/Modal'
+import { closeModal } from '~/components/search/controls/SearchPanel'
+
+export default function DifferentialExpressionModal() {
+  const [showDeModal, setShowDeModal] = useState(false)
+  const deModalContent = (
+    <div>
+      <p>These are exploratory results calculated automatically by SCP, not the study owner. Any discrepancies between
+        these results and an associated publication may be because it benefits from methods different from SCP's.
+        These results are intended purely as an aid in exploring this dataset.&nbsp;
+        <a href="https://singlecell.zendesk.com/hc/en-us/articles/6059411840027"
+           target="_blank" data-analytics-name="differential-expression-docs">
+          Learn more
+        </a> about how these results are computed.</p>
+    </div>
+  )
+
+  const deModalHelpLink = (
+    <a onClick={() => setShowDeModal(true)} data-analytics-name="de-info-help" className='de-info-help-icon'>
+      <FontAwesomeIcon className="action help-icon" icon={faInfoCircle} />
+    </a>
+  )
+
+  return (
+    <>
+      { deModalHelpLink }
+      <Modal
+        id="de-info-modal"
+        show={showDeModal}
+        onHide={() => closeModal(setShowDeModal)}
+        animation={false}>
+        <Modal.Header>
+          <h4 className="text-center">Exploratory differential expression</h4>
+        </Modal.Header>
+        <Modal.Body>
+          { deModalContent }
+        </Modal.Body>
+      </Modal>
+    </>
+  )
+}

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -54,7 +54,8 @@ export default function DifferentialExpressionPanel({
   const deModalContent = (
     <div>
       <p>These are exploratory results calculated automatically by SCP, not the study owner. Any discrepancies between
-        these results and an associated publication may be because it benefits from methods different from SCP's. These results are intended purely as an aid in exploring this dataset.&nbsp;
+        these results and an associated publication may be because it benefits from methods different from SCP's.
+        These results are intended purely as an aid in exploring this dataset.&nbsp;
         <a href="https://singlecell.zendesk.com/hc/en-us/articles/6059411840027"
            target="_blank" data-analytics-name="differential-expression-docs">
           Learn more

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -54,12 +54,11 @@ export default function DifferentialExpressionPanel({
   const deModalContent = (
     <div>
       <p>These are exploratory results calculated automatically by SCP, not the study owner. Any discrepancies between
-        these results and an associated publication may be because it benefits from different methods than the ones that
-        SCP uses. They are intended purely as an aid in exploring this dataset.&nbsp;
+        these results and an associated publication may be because it benefits from methods different from SCP's. These results are intended purely as an aid in exploring this dataset.&nbsp;
         <a href="https://singlecell.zendesk.com/hc/en-us/articles/6059411840027"
            target="_blank" data-analytics-name="differential-expression-docs">
-          Read more
-        </a> to learn about how these results are computed.</p>
+          Learn more
+        </a> about how these results are computed.</p>
     </div>
   )
 
@@ -103,7 +102,7 @@ export default function DifferentialExpressionPanel({
             onHide={() => closeModal(setShowDeModal)}
             animation={false}>
             <Modal.Header>
-              <h4 className="text-center">Learn about SCP exploratory differential gene expression analysis</h4>
+              <h4 className="text-center">Exploratory differential expression</h4>
             </Modal.Header>
             <Modal.Body>
               { deModalContent }

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowLeft, faInfoCircle } from '@fortawesome/free-solid-svg-icons'
+import { Button, Popover, OverlayTrigger } from 'react-bootstrap'
 
 import DifferentialExpressionGroupPicker from '~/components/visualization/controls/DifferentialExpressionGroupPicker'
 import { logSearchFromDifferentialExpression } from '~/lib/search-metrics'
@@ -48,6 +49,15 @@ export default function DifferentialExpressionPanel({
     setChecked(newChecked)
   }
 
+  const dePopover = (
+    <Popover id="de-info-popover" title="Learn about SCP DE genes analysis">
+      These are exploratory results calculated automatically by SCP, not the study owner. Any discrepancies between
+      these results and an associated publication may be because this dataset benefits from different methods than the
+      ones that SCP uses.  They are intended purely as an aid in exploring this dataset. Click the info icon to learn
+      more about these results are computed.
+    </Popover>
+  )
+
   return (
     <>
       <DifferentialExpressionGroupPicker
@@ -75,17 +85,19 @@ export default function DifferentialExpressionPanel({
             data-original-title="Download all DE genes data for this group"
           >
             <FontAwesomeIcon icon={faDownload}/></a> */}
-          <a href="https://singlecell.zendesk.com/hc/en-us/articles/6059411840027"
-            target="_blank"
-            data-analytics-name="differential-expression-docs"
-            // style={{ 'marginLeft': '10px' }} // Dev placeholder for when download is enable
-            data-toggle="tooltip"
-            data-original-title="Learn about SCP DE genes analysis"
-          >
-            <FontAwesomeIcon
-              className="action help-icon" icon={faInfoCircle}
-            />
-          </a>
+          {
+            <OverlayTrigger placement="left" trigger={['hover', 'focus']} overlay={dePopover}>
+              <a href="https://singlecell.zendesk.com/hc/en-us/articles/6059411840027"
+                 target="_blank"
+                 data-analytics-name="differential-expression-docs"
+                // style={{ 'marginLeft': '10px' }} // Dev placeholder for when download is enable
+              >
+                <FontAwesomeIcon
+                  className="action help-icon" icon={faInfoCircle}
+                />
+              </a>
+            </OverlayTrigger>
+          }
         </span>
         <table data-testid="differential-expression-table" className="table table-terra table-scp-compact">
           <thead>

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -54,7 +54,7 @@ export default function DifferentialExpressionPanel({
       These are exploratory results calculated automatically by SCP, not the study owner. Any discrepancies between
       these results and an associated publication may be because this dataset benefits from different methods than the
       ones that SCP uses.  They are intended purely as an aid in exploring this dataset. Click the info icon to learn
-      more about these results are computed.
+      more about how these results are computed.
     </Popover>
   )
 

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -2,7 +2,8 @@
 import React, { useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowLeft, faInfoCircle } from '@fortawesome/free-solid-svg-icons'
-import { Popover, OverlayTrigger } from 'react-bootstrap'
+import Modal from 'react-bootstrap/lib/Modal'
+import { closeModal } from '~/components/search/controls/SearchPanel'
 
 import DifferentialExpressionGroupPicker from '~/components/visualization/controls/DifferentialExpressionGroupPicker'
 import { logSearchFromDifferentialExpression } from '~/lib/search-metrics'
@@ -42,6 +43,7 @@ export default function DifferentialExpressionPanel({
 
   const [checked, setChecked] = useState(initChecked(deGenes))
   const [deFileUrl, setDeFileUrl] = useState(null)
+  const [showDeModal, setShowDeModal] = useState(false)
 
   /** Check radio button such that changing group unchecks all buttons */
   function changeRadio(event) {
@@ -49,13 +51,22 @@ export default function DifferentialExpressionPanel({
     setChecked(newChecked)
   }
 
-  const dePopover = (
-    <Popover id="de-info-popover" title="Learn about SCP DE genes analysis">
-      These are exploratory results calculated automatically by SCP, not the study owner. Any discrepancies between
-      these results and an associated publication may be because this dataset benefits from different methods than the
-      ones that SCP uses.  They are intended purely as an aid in exploring this dataset. Click the info icon to learn
-      more about how these results are computed.
-    </Popover>
+  const deModalContent = (
+    <div>
+      <p>These are exploratory results calculated automatically by SCP, not the study owner. Any discrepancies between
+        these results and an associated publication may be because it benefits from different methods than the ones that
+        SCP uses. They are intended purely as an aid in exploring this dataset.&nbsp;
+        <a href="https://singlecell.zendesk.com/hc/en-us/articles/6059411840027"
+           target="_blank" data-analytics-name="differential-expression-docs">
+          Read more
+        </a> to learn about how these results are computed.</p>
+    </div>
+  )
+
+  const deModalHelpLink = (
+    <a onClick={() => setShowDeModal(true)} data-analytics-name="de-info-help">
+      <FontAwesomeIcon className="action help-icon" icon={faInfoCircle} />
+    </a>
   )
 
   return (
@@ -85,19 +96,19 @@ export default function DifferentialExpressionPanel({
             data-original-title="Download all DE genes data for this group"
           >
             <FontAwesomeIcon icon={faDownload}/></a> */}
-          {
-            <OverlayTrigger placement="left" trigger={['hover', 'focus']} overlay={dePopover}>
-              <a href="https://singlecell.zendesk.com/hc/en-us/articles/6059411840027"
-                 target="_blank"
-                 data-analytics-name="differential-expression-docs"
-                // style={{ 'marginLeft': '10px' }} // Dev placeholder for when download is enable
-              >
-                <FontAwesomeIcon
-                  className="action help-icon" icon={faInfoCircle}
-                />
-              </a>
-            </OverlayTrigger>
-          }
+          { deModalHelpLink }
+          <Modal
+            id="de-info-modal"
+            show={showDeModal}
+            onHide={() => closeModal(setShowDeModal)}
+            animation={false}>
+            <Modal.Header>
+              <h4 className="text-center">Learn about SCP exploratory differential gene expression analysis</h4>
+            </Modal.Header>
+            <Modal.Body>
+              { deModalContent }
+            </Modal.Body>
+          </Modal>
         </span>
         <table data-testid="differential-expression-table" className="table table-terra table-scp-compact">
           <thead>

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -2,8 +2,7 @@
 import React, { useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowLeft, faInfoCircle } from '@fortawesome/free-solid-svg-icons'
-import Modal from 'react-bootstrap/lib/Modal'
-import { closeModal } from '~/components/search/controls/SearchPanel'
+import DifferentialExpressionModal from '~/components/explore/DifferentialExpressionModal'
 
 import DifferentialExpressionGroupPicker from '~/components/visualization/controls/DifferentialExpressionGroupPicker'
 import { logSearchFromDifferentialExpression } from '~/lib/search-metrics'
@@ -43,31 +42,12 @@ export default function DifferentialExpressionPanel({
 
   const [checked, setChecked] = useState(initChecked(deGenes))
   const [deFileUrl, setDeFileUrl] = useState(null)
-  const [showDeModal, setShowDeModal] = useState(false)
 
   /** Check radio button such that changing group unchecks all buttons */
   function changeRadio(event) {
     const newChecked = initChecked(deGenes, event.target.value)
     setChecked(newChecked)
   }
-
-  const deModalContent = (
-    <div>
-      <p>These are exploratory results calculated automatically by SCP, not the study owner. Any discrepancies between
-        these results and an associated publication may be because it benefits from methods different from SCP's.
-        These results are intended purely as an aid in exploring this dataset.&nbsp;
-        <a href="https://singlecell.zendesk.com/hc/en-us/articles/6059411840027"
-           target="_blank" data-analytics-name="differential-expression-docs">
-          Learn more
-        </a> about how these results are computed.</p>
-    </div>
-  )
-
-  const deModalHelpLink = (
-    <a onClick={() => setShowDeModal(true)} data-analytics-name="de-info-help">
-      <FontAwesomeIcon className="action help-icon" icon={faInfoCircle} />
-    </a>
-  )
 
   return (
     <>
@@ -96,19 +76,7 @@ export default function DifferentialExpressionPanel({
             data-original-title="Download all DE genes data for this group"
           >
             <FontAwesomeIcon icon={faDownload}/></a> */}
-          { deModalHelpLink }
-          <Modal
-            id="de-info-modal"
-            show={showDeModal}
-            onHide={() => closeModal(setShowDeModal)}
-            animation={false}>
-            <Modal.Header>
-              <h4 className="text-center">Exploratory differential expression</h4>
-            </Modal.Header>
-            <Modal.Body>
-              { deModalContent }
-            </Modal.Body>
-          </Modal>
+          <DifferentialExpressionModal />
         </span>
         <table data-testid="differential-expression-table" className="table table-terra table-scp-compact">
           <thead>

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowLeft, faInfoCircle } from '@fortawesome/free-solid-svg-icons'
-import { Button, Popover, OverlayTrigger } from 'react-bootstrap'
+import { Popover, OverlayTrigger } from 'react-bootstrap'
 
 import DifferentialExpressionGroupPicker from '~/components/visualization/controls/DifferentialExpressionGroupPicker'
 import { logSearchFromDifferentialExpression } from '~/lib/search-metrics'

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -34,6 +34,7 @@ import { getFeatureFlagsWithDefaults } from '~/providers/UserProvider'
 import DifferentialExpressionPanel, { DifferentialExpressionPanelHeader } from './DifferentialExpressionPanel'
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger'
 import Tooltip from 'react-bootstrap/lib/Tooltip'
+import DifferentialExpressionModal from '~/components/explore/DifferentialExpressionModal'
 
 const tabList = [
   { key: 'loading', label: 'loading...' },
@@ -516,14 +517,19 @@ export default function ExploreDisplayTabs({
                 }
                 {isDifferentialExpressionEnabled &&
                 <>
-                  <button
-                    className="btn btn-primary"
-                    onClick={() => {
-                      setShowDifferentialExpressionPanel(true)
-                      setShowDeGroupPicker(true)
-                    }}
-                  >Differential expression</button>
-                  <br/><br/>
+                  <div className="row de-modal-row-wrapper">
+                    <div className="col-xs-12 de-modal-row">
+                      <button
+                        className="btn btn-primary"
+                        onClick={() => {
+                          setShowDifferentialExpressionPanel(true)
+                          setShowDeGroupPicker(true)
+                        }}
+                      >Differential expression</button>
+                      <DifferentialExpressionModal />
+                    </div>
+
+                  </div>
                 </>
                 }
                 <SubsampleSelector

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -84,7 +84,7 @@
 		border-radius: 5px;
 		margin-top: 4rem;
 		margin-bottom: -9rem;
-		
+
 	}
 	label {
 		font-weight: normal;
@@ -197,3 +197,15 @@
     display: inline-block;
   }
 }
+
+.de-modal-row-wrapper {
+	position: relative;
+	top: -15px;
+	.de-modal-row {
+		a.de-info-help-icon {
+			margin-left: 10px;
+			vertical-align: middle;
+		}
+	}
+}
+


### PR DESCRIPTION
#### BACKGROUND & CHANGEs
This update adds a small informational modal to the info circle icon in the differential expression UX.  This will contain brief explanatory text about what they are intended for, as well as linking to more comprehensive documentation.

Demo:

https://user-images.githubusercontent.com/729968/202243892-f090f873-28e2-40bd-900f-bcf33e5edfa1.mov

#### MANUAL TESTING
1. Boot as normal and load any study with differential expression results
2. Confirm the info circle icon shows next to the `Differential Expression` button, and clicking it opens the modal
3. Select an annotation, then once the table loads, click the info circle icon again
4. Confirm the modal loads as seen above, and the link to documentation opens in a new tab