### PR TITLE
Wire up Rails to call to ingest-pipeline for Cluster data (SCP-4772)

### DIFF
--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -100,9 +100,7 @@ class FileParseService
       when 'AnnData'
         # gate ingest of AnnData using the feature flag 'ingest_anndata_file'
         do_anndata_file_ingest = FeatureFlaggable.feature_flags_for_instances(user, study)['ingest_anndata_file']
-        if do_anndata_file_ingest == false
-          Rails.logger.info "Aborting parse of AnnData file #{study_file.name} due to feature flag being #{do_anndata_file_ingest}"
-        else
+        if do_anndata_file_ingest == true
           # Currently assuming "Happy Path" and so the AnnData file will have clustering data
           # extract and parse clustering data
           job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_anndata, reparse: reparse,
@@ -113,6 +111,8 @@ class FileParseService
           # TODO extract and parse Metadata (SCP-4708)
           # TODO extract and parse Processed Exp Data (SCP-4709)
           # TODO extract and parse Raw Exp Data (SCP-4710)
+        else
+          Rails.logger.info "Aborting parse of AnnData file #{study_file.name} due to feature flag being #{do_anndata_file_ingest}"
         end
 
       end

--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -101,7 +101,6 @@ class FileParseService
         # gate ingest of AnnData using the feature flag 'ingest_anndata_file'
         do_anndata_file_ingest = FeatureFlaggable.feature_flags_for_instances(user, study)['ingest_anndata_file']
         if do_anndata_file_ingest == false
-          Rails.logger.info "Aborting parse of AnnData file 1 #{study_file}"
           Rails.logger.info "Aborting parse of AnnData file #{study_file.name} due to feature flag being #{do_anndata_file_ingest}"
         else
           # Currently assuming "Happy Path" and so the AnnData file will have clustering data

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -14,7 +14,7 @@ class IngestJob
 
   # valid ingest actions to perform
   VALID_ACTIONS = %i[
-    ingest_expression ingest_cluster ingest_cell_metadata subsample differential_expression render_expression_arrays
+    ingest_expression ingest_cluster ingest_cell_metadata subsample differential_expression render_expression_arrays ingest_anndata
   ].freeze
 
   # Mappings between actions & models (for cleaning up data on re-parses)
@@ -391,6 +391,13 @@ class IngestJob
       create_differential_expression_results
     when :image_pipeline
       set_has_image_cache
+    when :ingest_anndata
+      # currently extracting and ingesting only clustering data
+      # this will likely error until the DB inserts ingest job is done
+      set_cluster_point_count
+      set_study_default_options
+      launch_subsample_jobs
+      # TODO (SCP-4708)(SCP-4709)(SCP-4710) will duplicate a lot more from above 
     end
     set_study_initialized
   end
@@ -680,6 +687,8 @@ class IngestJob
           numAnnotationValues: annotation[:values]&.size
         }
       )
+    when :ingest_anndata
+      # AnnData file analytics TODO
     end
     job_props.with_indifferent_access
   end
@@ -772,6 +781,8 @@ class IngestJob
       message << "Gene-level files created: #{genes}"
     when :image_pipeline
       message << "Image Pipeline image rendering completed for \"#{params_object.cluster}\""
+    when :ingest_anndata
+      message << "AnnData file ingest has completed"
     end
     message
   end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -14,7 +14,7 @@ class IngestJob
 
   # valid ingest actions to perform
   VALID_ACTIONS = %i[
-    ingest_expression ingest_cluster ingest_cell_metadata subsample differential_expression render_expression_arrays ingest_anndata
+    ingest_expression ingest_cluster ingest_cell_metadata ingest_anndata subsample differential_expression render_expression_arrays
   ].freeze
 
   # Mappings between actions & models (for cleaning up data on re-parses)
@@ -397,7 +397,7 @@ class IngestJob
       set_cluster_point_count
       set_study_default_options
       launch_subsample_jobs
-      # TODO (SCP-4708)(SCP-4709)(SCP-4710) will duplicate a lot more from above 
+      # TODO (SCP-4708, SCP-4709, SCP-4710) will duplicate a lot more from above 
     end
     set_study_initialized
   end

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -25,7 +25,8 @@ class PapiClient
     ingest_subsample: ['Cluster'],
     differential_expression: ['Cluster'],
     render_expression_arrays: ['Cluster'],
-    image_pipeline: ['Cluster']
+    image_pipeline: ['Cluster'],
+    ingest_anndata: ['AnnData']
   }.freeze
 
   # jobs that require custom virtual machine types (e.g. more RAM, CPU)
@@ -327,6 +328,9 @@ class PapiClient
     when 'image_pipeline'
       # image_pipeline is node-based, so python command line to this point no longer applies
       command_line = 'node expression-scatter-plots.js'
+    when 'ingest_anndata'
+      # extract cluster data from AnnData file, currently hardcoding the obsm-keys
+      command_line +=  " --ingest-anndata --anndata-file #{study_file.gs_url} --extract-cluster --obsm-keys ['X_umap','X_tsne']"
     end
 
     # add optional command line arguments based on file type and action

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -320,6 +320,9 @@ class PapiClient
       end
     when 'ingest_cluster'
       command_line += " --cluster-file #{study_file.gs_url} --ingest-cluster"
+    when 'ingest_anndata'
+      # extract cluster data from AnnData file, currently hardcoding the obsm-keys
+      command_line +=  " --ingest-anndata --anndata-file #{study_file.gs_url} --extract-cluster --obsm-keys ['X_umap','X_tsne']"
     when 'ingest_subsample'
       metadata_file = study.metadata_file
       command_line += " --cluster-file #{study_file.gs_url} --cell-metadata-file #{metadata_file.gs_url} --subsample"
@@ -328,9 +331,6 @@ class PapiClient
     when 'image_pipeline'
       # image_pipeline is node-based, so python command line to this point no longer applies
       command_line = 'node expression-scatter-plots.js'
-    when 'ingest_anndata'
-      # extract cluster data from AnnData file, currently hardcoding the obsm-keys
-      command_line +=  " --ingest-anndata --anndata-file #{study_file.gs_url} --extract-cluster --obsm-keys ['X_umap','X_tsne']"
     end
 
     # add optional command line arguments based on file type and action

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -34,7 +34,7 @@ class StudyFile
 
 
   PARSEABLE_TYPES = ['Cluster', 'Coordinate Labels', 'Expression Matrix', 'MM Coordinate Matrix', '10X Genes File',
-                     '10X Barcodes File', 'Gene List', 'Metadata', 'Analysis Output']
+                     '10X Barcodes File', 'Gene List', 'Metadata', 'Analysis Output', 'AnnData']
   DISALLOWED_SYNC_TYPES = ['Fastq']
   UPLOAD_STATUSES = %w(new uploading uploaded)
   PARSE_STATUSES = %w(unparsed parsing parsed failed)

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.23.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.23.1'
 
     config.autoload_paths << Rails.root.join('lib')
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.22.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.23.0'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
Wire up the Rails side to call the new "extract cluster" ingest job from https://github.com/broadinstitute/scp-ingest-pipeline/pull/276 

This also makes use of the feature flag to gate AnnData file ingestion so make sure you follow the steps in this PR: https://github.com/broadinstitute/single_cell_portal_core/pull/1669 to utilize the flag

![Screen Shot 2022-11-15 at 4 07 01 PM](https://user-images.githubusercontent.com/54322292/202235220-9b9e087f-5fa2-4881-a79e-94d81de2bf37.png)


Open for review but will need to update the ingest-pipeline version with the small fix for the 2 dimensions check. In theory getting to the error `ValueError: Too few dimensions for visualization in obsm "X_umap", found 2, expected 2 or 3.` proves that the Rails logic is sound to get the ingest job to trigger. 

More tweaks will be needed as we iterate on this, but for the most basic wiring up of cluster data extraction wired into the rails logic this suffices. 

To test:
- pull this branch
- Make sure you've flipped your feature flag to 'true' for your user or your study for `ingest_anndata`
- go to a study you can upload to
- download this AnnData file: https://cellxgene.cziscience.com/collections/2902f08c-f83c-470e-a541-e463e25e5058
- upload that ^ file to your study 
- wait for the email, for now you will see this error `ValueError: Too few dimensions for visualization in obsm "X_umap", found 2, expected 2 or 3.`

To test that the feature flag works, flip it back to false and attempt to upload an AnnData file. Watch the rails terminal and you will see
 `Aborting parse of AnnData file <study_file.name> due to feature flag being false`
![Screen Shot 2022-11-15 at 3 54 40 PM](https://user-images.githubusercontent.com/54322292/202235066-a1b7fe9d-46f3-4d72-9e4f-e5d4e8948e28.png)

