### PR TITLE
Restore stack traces, add Sentry logging for React errors (SCP-4799)

### DIFF
--- a/app/javascript/components/visualization/GeneListHeatmap.jsx
+++ b/app/javascript/components/visualization/GeneListHeatmap.jsx
@@ -25,7 +25,7 @@ function RawGeneListHeatmap({
     heatmapRowCentering,
     geneList: geneListName
   })
-  const { ErrorComponent, setShowError, setErrorContent } = useErrorMessage()
+  const { ErrorComponent, setShowError, setError } = useErrorMessage()
   // we can't render until we know what the cluster is, since morpheus requires the annotation name
   // so don't try until we've received this, unless we're showing a Gene List
   const canRender = !!geneListName && geneLists.length
@@ -55,7 +55,7 @@ function RawGeneListHeatmap({
       rowCentering: heatmapRowCentering,
       sortColumns: false,
       setShowError,
-      setErrorContent,
+      setError,
       colorMin,
       colorMax
     })

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -53,7 +53,7 @@ function RawScatterPlot({
   const [scatterData, setScatterData] = useState(null)
   // array of trace names (strings) to show in the graph
   const [graphElementId] = useState(_uniqueId('study-scatter-'))
-  const { ErrorComponent, setShowError, setErrorContent } = useErrorMessage()
+  const { ErrorComponent, setShowError, setError } = useErrorMessage()
   const [activeTraceLabel, setActiveTraceLabel] = useState(null)
   // map of label name to color hex codes, for any labels the user has picked a color for
   const [editedCustomColors, setEditedCustomColors] = useState({})
@@ -101,7 +101,6 @@ function RawScatterPlot({
 
   /** updates whether pipe-delimited label values should be split */
   function updateIsSplitLabelArrays(value) {
-    // console.log('split the array', value)
     updateExploreParams({ isSplitLabelArrays: value })
   }
 
@@ -310,7 +309,7 @@ function RawScatterPlot({
     let [scatter, perfTimes] =
       (clusterResponse ? clusterResponse : [scatterData, null])
 
-    scatter = updateScatterLayout(scatter)
+    scatter = null // updateScatterLayout(scatter)
     const layout = scatter.layout
 
     const plotlyTraces = updateCountsAndGetTraces(scatter)
@@ -379,10 +378,10 @@ function RawScatterPlot({
       genes,
       isAnnotatedScatter,
       isCorrelatedScatter
-    }).then(processScatterPlot).catch(err => {
+    }).then(processScatterPlot).catch(error => {
       setIsLoading(false)
-      setErrorContent([`${err}`])
       setShowError(true)
+      setError(error)
     })
   }, [cluster, annotation.name, subsample, consensus, genes.join(','), isAnnotatedScatter])
 

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -309,7 +309,7 @@ function RawScatterPlot({
     let [scatter, perfTimes] =
       (clusterResponse ? clusterResponse : [scatterData, null])
 
-    scatter = null // updateScatterLayout(scatter)
+    scatter = updateScatterLayout(scatter)
     const layout = scatter.layout
 
     const plotlyTraces = updateCountsAndGetTraces(scatter)

--- a/app/javascript/components/visualization/StudyViolinPlot.jsx
+++ b/app/javascript/components/visualization/StudyViolinPlot.jsx
@@ -37,7 +37,7 @@ function RawStudyViolinPlot({
   // array of gene names as they are listed in the study itself
   const [studyGeneNames, setStudyGeneNames] = useState([])
   const [graphElementId] = useState(_uniqueId('study-violin-'))
-  const { ErrorComponent, setShowError, setErrorContent } = useErrorMessage()
+  const { ErrorComponent, setShowError, setError } = useErrorMessage()
 
   /** renders received expression data from the server */
   function renderData([results, perfTimes]) {
@@ -80,7 +80,7 @@ function RawStudyViolinPlot({
       consensus
     ).then(renderData).catch(error => {
       Plotly.purge(graphElementId)
-      setErrorContent(error.message)
+      setError(error)
       setShowError(true)
       setIsLoading(false)
     })

--- a/app/javascript/lib/error-message.jsx
+++ b/app/javascript/lib/error-message.jsx
@@ -1,41 +1,48 @@
 import React, { useState, useEffect } from 'react'
-import { log } from '~/lib/metrics-api'
+import { logError } from '~/lib/metrics-api'
 
 /**
   * Hook for enabling the conditional display an error message.
   * In the event of an error, the returned ErrorComponent can be placed in the component's markup,
-  * and will be displayed with the content from setErrorContent if setShowError is called with true.
+  * and will be displayed with the error message from setError if setShowError is called with true.
   */
 export default function useErrorMessage() {
   const [showError, setShowError] = useState(false)
-  const [errorContent, setErrorContent] = useState('')
+  const [error, setError] = useState(null)
+
+  const errorContent = `${error}`
 
   let ErrorComponent = <></>
   if (showError) {
-    ErrorComponent = <div className="alert-danger text-center error-boundary">
-      { errorContent }
-    </div>
+    ErrorComponent =
+      <div className="alert-danger text-center error-boundary">
+        { errorContent }
+      </div>
   }
   useEffect(() => {
     if (showError) {
-      log('error-message', { text: errorContent })
+      logError(errorContent, error)
     }
-  }, [errorContent])
+  }, [error])
   return {
-    showError, setShowError, setErrorContent, ErrorComponent
+    showError, setShowError, setError, ErrorComponent
   }
 }
 
-/** handler for morpheus errors that catches the error from an empty gene search to
-    replace it with a more useful display and error message. */
-export function morpheusErrorHandler($target, setShowError, setErrorContent) {
+/**
+ * Handler for Morpheus errors that catches the error from an empty gene search to
+ * replace it with a more useful display and error message.
+ */
+export function morpheusErrorHandler($target, setShowError, setError) {
   return err => {
-    // this is a brittle check, but morpheus doesn't give us any visibility into what error occured,
+    // This is a brittle check, but Morpheus doesn't give us any visibility into what error occured,
     // other than that there was an error processing the results returned
     if (err[0].includes('genes') && err[0].includes('opening')) {
       setShowError(true)
-      setErrorContent('The gene search returned no results for this study')
-      // there doesn't seem to be any way to stop the morpheus dialog from popping up,
+      const text = 'The gene search returned no results for this study'
+      const error = { message: text }
+      setError(error)
+      // There doesn't seem to be any way to stop the Morpheus dialog from popping up,
       // so we do the next best thing and destroy it immediately
       // see https://github.com/cmap/morpheus.js/blob/master/src/ui/heat_map.js:607
       setTimeout(() => $target.find('.modal').remove(), 0)

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -322,11 +322,13 @@ export function logMenuChange(event) {
 }
 
 /**
- * Log front-end error (e.g. uncaught ReferenceError) to both Sentry and Mixpanel
+ * Log JS error (e.g. uncaught ReferenceError) to console, Sentry, and Mixpanel
  */
 export function logError(text, error = {}) {
+  console.error(error.message)
+
   const props = { text, error }
-  log('error', props)
+  log('error', props) // Log to Mixpanel
 
   logToSentry(error)
 }

--- a/app/javascript/lib/morpheus-heatmap.js
+++ b/app/javascript/lib/morpheus-heatmap.js
@@ -5,7 +5,7 @@ import { morpheusErrorHandler } from '~/lib/error-message'
 /** Render Morpheus heatmap */
 export function renderHeatmap({
   target, expressionValuesURL, annotationCellValuesURL, annotationName,
-  fit, rowCentering, sortColumns=true, setShowError, setErrorContent, genes, colorMin, colorMax
+  fit, rowCentering, sortColumns=true, setShowError, setError, genes, colorMin, colorMax
 }) {
   const $target = $(target)
   $target.empty()
@@ -14,7 +14,7 @@ export function renderHeatmap({
     dataset: expressionValuesURL,
     el: $target,
     menu: null,
-    error: morpheusErrorHandler($target, setShowError, setErrorContent),
+    error: morpheusErrorHandler($target, setShowError, setError),
     colorScheme: {
       scalingMode: rowCentering !== '' ? 'fixed' : 'relative',
       stepped: false

--- a/app/javascript/lib/sentry-logging.js
+++ b/app/javascript/lib/sentry-logging.js
@@ -70,7 +70,7 @@ function printSuppression(errorObj, reason) {
 function getIsSuppressedEnv() {
   const env = getSCPContext().environment
   // Return `false` if manually locally testing Sentry logging
-  return ['development', 'test'].includes(env)
+  return false // ['development', 'test'].includes(env)
 }
 
 /**
@@ -83,7 +83,7 @@ function getIsSuppressedEnv() {
  * @return {Array} two-element array: [whether logging should occur, why if not]
  */
 export function logToSentry(error, useThrottle = false, sampleRate = 0.05) {
-  const isThrottled = useThrottle && Math.random() >= sampleRate
+  const isThrottled = false // useThrottle && Math.random() >= sampleRate
 
   if (getIsSuppressedEnv() || isThrottled) {
     const reason = isThrottled ? 'throttle' : 'environment'

--- a/app/javascript/lib/sentry-logging.js
+++ b/app/javascript/lib/sentry-logging.js
@@ -70,7 +70,7 @@ function printSuppression(errorObj, reason) {
 function getIsSuppressedEnv() {
   const env = getSCPContext().environment
   // Return `false` if manually locally testing Sentry logging
-  return false // ['development', 'test'].includes(env)
+  return ['development', 'test'].includes(env)
 }
 
 /**
@@ -83,7 +83,7 @@ function getIsSuppressedEnv() {
  * @return {Array} two-element array: [whether logging should occur, why if not]
  */
 export function logToSentry(error, useThrottle = false, sampleRate = 0.05) {
-  const isThrottled = false // useThrottle && Math.random() >= sampleRate
+  const isThrottled = useThrottle && Math.random() >= sampleRate
 
   if (getIsSuppressedEnv() || isThrottled) {
     const reason = isThrottled ? 'throttle' : 'environment'


### PR DESCRIPTION
This fixes observability bugs that blocked much JavaScript error debugging.  It also improves error logging consistency.

Previously:

* JavaScript stack traces were unavailable when a JS error was encountered in a React component. 
 Only the top-level error message was displayed in the UI.  Now, the same error is shown in the UI, _and_ the full error stack trace is printed to the browser's console.  This traces the error's execution path, with files, line numbers, etc.  These traces had been available some time ago; this restores them.

* Such errors were not logged to Sentry.  Now they are.   They were only logged to Mixpanel, which also had the downside of using an idiosyncratic `error-message` event name.  Now, this Mixpanel logging for JS errors in React components uses the same event name -- `error` -- as other error logging in JS (like e.g. [#1656](https://github.com/broadinstitute/single_cell_portal_core/pull/1656)) and [in Ruby on Rails](https://mixpanel.com/s/3Ywrz).  Mixpanel Lexicon reports the conventional "error" event is used in 8 Mixpanel queries, whereas the prior React-specific "error-message" event was used in none.  So I'm not concerned we're breaking analytics.

Here's an example stack trace:
<img width="1680" alt="Restored_stack_trace_for_JS_error_in_React_component__SCP_2022-11-16" src="https://user-images.githubusercontent.com/1334561/202302745-eea6ba31-1a9c-4fb6-81e1-b7c098e89f61.png">

To test:
1. Change line 312 of ScatterPlot.jsx to `scatter = null // updateScatterLayout(scatter)`
2. Go to a Study Overview page that has visualizations
3. Open DevTools, go to Console Panel
4. Note JS error stack trace, like one in screenshot
5. Undo step 1

This satisfies SCP-4799.