### PR TITLE
Adding differential expression info to reports_service.rb (SCP-4829)

### DIFF
--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -11,7 +11,7 @@ module Api
         report_name = params[:report_name].to_sym
         response.headers['Content-Disposition'] = "attachment; filename=#{report_name}_data.tsv"
         begin
-          render plain: ReportsService.get_report_data(report_name)
+          render plain: ReportsService.get_report_data(report_name, view_context: params[:view_context])
         rescue ArgumentError => e
           render json: { error: e.message }, status: :bad_request
         end

--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -61,6 +61,11 @@ class DifferentialExpressionResult
     StudyFile.find(matrix_file_id)
   end
 
+  # name of associated matrix file
+  def matrix_file_name
+    matrix_file.upload_file_name
+  end
+
   # associated clustering file
   def cluster_file
     cluster_group.study_file

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -21,6 +21,15 @@
           </td>
         </tr>
       <% end %>
+      <tr>
+        <td>Differential Expression Results</td>
+        <td>Breakdown of differential expression results</td>
+        <td>
+          <%= link_to 'View', '#', class: 'btn btn-primary view-report', id: 'view-de-data',
+                      data: {'loading-text' => 'Loading... ', toggle: 'button' } %>
+          <%= link_to 'Export', api_v1_report_url('differential_expression'), class: 'btn btn-default' %>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -34,7 +43,8 @@
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
   const reportTarget = $('#report-table')
   const REPORTS = {
-    'view-study-data': '<%= api_v1_report_url('studies') %>'
+    'view-study-data': '<%= api_v1_report_url('studies') %>',
+    'view-de-data': '<%= api_v1_report_url('differential_expression', view_context: true) %>'
   }
   let table
   $('.view-report').on('click', function(event) {
@@ -60,7 +70,8 @@
         })
         table = reportTarget.dataTable({
           columns: columns,
-          data: lines
+          data: lines,
+          order: [[1, 'asc']]
         })
       }
     })

--- a/test/api/reports_controller_test.rb
+++ b/test/api/reports_controller_test.rb
@@ -19,22 +19,26 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
                       cell_input: {
                         x: [1, 4, 6],
                         y: [7, 5, 3],
-                        cells: %w[A B C]
+                        cells: %w[A B C D]
                       },
-                      annotation_input: [{ name: 'foo', type: 'group', values: %w[bar bar baz] }])
+                      annotation_input: [{ name: 'foo', type: 'group', values: %w[bar bar baz baz] }])
 
     FactoryBot.create(:metadata_file,
                       name: 'metadata.txt',
                       study: @study,
-                      cell_input: %w[A B C],
+                      cell_input: %w[A B C D],
                       annotation_input: [
-                        { name: 'species', type: 'group', values: %w[dog cat dog] },
-                        { name: 'disease', type: 'group', values: %w[none none measles] }
+                        { name: 'species', type: 'group', values: %w[dog cat dog cat] },
+                        { name: 'disease', type: 'group', values: %w[none none measles measles] }
                       ])
-    FactoryBot.create(:study_file,
+    matrix = FactoryBot.create(:study_file,
                       name: 'dense.txt',
                       file_type: 'Expression Matrix',
                       study: @study)
+    DifferentialExpressionResult.create(
+      study: @study, cluster_group: @study.cluster_groups.by_name('clusterA.txt'), matrix_file_id: matrix.id,
+      annotation_name: 'disease', annotation_scope: 'study', observed_values: %w[none measles]
+    )
   end
 
   teardown do
@@ -62,5 +66,12 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     execute_http_request(:get, api_v1_report_path('studies'), user: @admin_user)
     assert_equal 200, response.status
     assert response.body.starts_with?("accession\tcreated_at\tcell_count")
+  end
+
+  test 'can fetch differential expression report' do
+    sign_in_and_update @admin_user
+    execute_http_request(:get, api_v1_report_path('differential_expression'), user: @admin_user)
+    assert_equal 200, response.status
+    assert response.body.starts_with?("accession\tcreated_at\tcluster_name\tannotation_identifier")
   end
 end

--- a/test/models/differential_expression_result_test.rb
+++ b/test/models/differential_expression_result_test.rb
@@ -127,6 +127,7 @@ class DifferentialExpressionResultTest  < ActiveSupport::TestCase
     assert_equal @raw_matrix, @species_result.matrix_file
     assert_equal @metadata_file, @species_result.annotation_file
     assert_equal @cluster_file, @species_result.cluster_file
+    assert_equal @raw_matrix.upload_file_name, @species_result.matrix_file_name
   end
 
   test 'should clean up files on destroy' do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds information about differential expression results to the "Study Data" report, as well as adding a new report that contains detailed information about all available DE results in a given instance.  While we report DE ingest jobs to [Mixpanel](https://mixpanel.com/project/2120588/view/19059/app/dashboards#id=3292575&editor-card-id=%22report-34696797%22), this will not reflect if results or files are deleted.  Adding these reports to SCP will give team members the ability to get accurate snapshots of DE results, and also create manual longitudinal reports elsewhere.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Go to the [Reports](https://localhost:3000/single_cell/reports) page
3. Click the "View" button on the Study data report, and ensure that there is a column for `de_results` listed as seen below
![Screen Shot 2022-11-17 at 3 43 43 PM](https://user-images.githubusercontent.com/729968/202555706-757a9bc8-cc0e-422c-a923-e3a97caab329.png)
4. Click the "View" button on the "Differential expression" report, and ensure that it loads with information about any local DE results
![Screen Shot 2022-11-17 at 3 44 11 PM](https://user-images.githubusercontent.com/729968/202555801-2d7ec8e0-273b-449c-b34f-5d9fbf6cb2da.png)
5. Click the "Export" button for either report and confirm a tsv file is downloaded