### PR TITLE
Fix broken explore response on missing cluster for DE result (SCP-4834)

### DIFF
--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -200,10 +200,10 @@ class AnnotationVizService
   def self.differential_expression_menu_opts(study)
     study.differential_expression_results.map do |diff_exp_result|
       {
-        cluster_name: diff_exp_result.cluster_group.name, # use current name, not cached name
+        cluster_name: diff_exp_result.cluster_group&.name,
         annotation_name: diff_exp_result.annotation_name,
         annotation_scope: diff_exp_result.annotation_scope,
-        select_options: diff_exp_result.select_options # to_a turns Hash into nested array of arrays for select opts
+        select_options: diff_exp_result.select_options
       }
     end
   end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -339,6 +339,7 @@ class IngestJob
       log_error_messages
       log_to_mixpanel # log before queuing file for deletion to preserve properties
       # don't delete files or notify users if this is a 'special action', like DE or image pipeline jobs
+      subject = "Error: #{study_file.file_type} file: '#{study_file.upload_file_name}' parse has failed"
       unless special_action?
         create_study_file_copy
         study_file.update(parse_status: 'failed')
@@ -349,7 +350,6 @@ class IngestJob
             ApplicationController.firecloud_client.delete_workspace_file(study.bucket_id, bundled_file.bucket_location)
           end
         end
-        subject = "Error: #{study_file.file_type} file: '#{study_file.upload_file_name}' parse has failed"
         user_email_content = generate_error_email_body
         SingleCellMailer.notify_user_parse_fail(user.email, subject, user_email_content, study).deliver_now
       end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a case where the explore response throws an error when a `DifferentialExpressionResult` exists for a study but the associated `ClusterGroup` object is no longer present.  The cause of this case is still undetermined - possibly a race condition on deletes or another unrelated error - but the result is that the study becomes unusable as the explore response gates all visualization requests.  The user would see a spinner that never goes away, and no visualizations can be launched.  By nil-safing `cluster_group&.name`, this will return `null` as the name, allowing execution to continue.  Since that cluster no longer exists, it cannot be visualized anyway.  In a case where somehow it does still exist (perhaps re-parsed, but the existing result wasn't deleted, so reference is invalid), returning `null` will cause the Differential Expression button not to render, preventing any broken visualizations.

Also, this update fixes an unrelated bug with admin email delivery for "special action" jobs (DE, Image Pipeline) when the ingest job fails due to the email subject not being set.  This was discovered while attempting to discern the cause of the original DE error.

#### MANUAL TESTING
1. Boot as normal, sign in, and load any study with DE results
2. Open a Rails console session in a separate terminal, and load the above study
3. Take the first DE result, and unset the cluster association (preserving the ID so you can reset it later)
```
accession = <accession of study>
study = Study.find_by(accession:)
result = study.differential_expression_results.first
cluster_group_id = result.cluster_group_id
result.cluster_group_id = nil
result.save(validate: false)
```
4. Back in the portal, refresh the page, then load the cluster/annotation from the above result and validate that the Differential Expression button doesn't render
5. Back in the console, reset the association:
```
result.update(cluster_group_id:)
```
6. Back in the portal, refresh the page again, and confirm you can now load the missing DE result