### PR TITLE
Use text/plain accept, content_type headers when deleting workspaces (SCP-4837)

### DIFF
--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -215,7 +215,7 @@ class FireCloudClient
 
     # set default headers, appending application identifier including hostname for disambiguation
     # allow for override of default application/json content_type and accept headers
-    headers = get_default_headers(content_override: opts[:content_override])
+    headers = get_default_headers(content_type: opts[:content_type])
 
     # if uploading a file, remove Content-Type/Accept headers to use default x-www-form-urlencoded type on POSTs
     if request_opts[:file_upload]
@@ -381,7 +381,7 @@ class FireCloudClient
   def delete_workspace(workspace_namespace, workspace_name)
     path = self.api_root + "/api/workspaces/#{uri_encode(workspace_namespace)}/#{uri_encode(workspace_name)}"
     # delete workspace endpoint throws 406 with JSON content_type, set to text/plain
-    process_firecloud_request(:delete, path, nil, { content_override: 'text/plain' })
+    process_firecloud_request(:delete, path, nil, { content_type: 'text/plain' })
   end
 
   # get the specified workspace ACL

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -214,7 +214,8 @@ class FireCloudClient
     Rails.logger.info "FireCloud API request (#{http_method.to_s.upcase}) #{path} with tracking identifier: #{self.tracking_identifier}"
 
     # set default headers, appending application identifier including hostname for disambiguation
-    headers = get_default_headers
+    # allow for override of default application/json content_type and accept headers
+    headers = get_default_headers(content_override: opts[:content_override])
 
     # if uploading a file, remove Content-Type/Accept headers to use default x-www-form-urlencoded type on POSTs
     if request_opts[:file_upload]
@@ -379,7 +380,8 @@ class FireCloudClient
   #   - +Hash+ message of status of workspace deletion
   def delete_workspace(workspace_namespace, workspace_name)
     path = self.api_root + "/api/workspaces/#{uri_encode(workspace_namespace)}/#{uri_encode(workspace_name)}"
-    process_firecloud_request(:delete, path)
+    # delete workspace endpoint throws 406 with JSON content_type, set to text/plain
+    process_firecloud_request(:delete, path, nil, { content_override: 'text/plain' })
   end
 
   # get the specified workspace ACL

--- a/lib/api_helpers.rb
+++ b/lib/api_helpers.rb
@@ -43,13 +43,16 @@ module ApiHelpers
 
   # get default HTTP headers for making requests
   #
+  # * *params*
+  #   - +content_type+ => Request Content-Type & Accept header value (defaults to application/json if not specified)
+  #
   # * *returns*
   #   - (Hash) => Hash of default HTTP headers, e.g. Authorization, Content-Type
-  def get_default_headers(content_override: nil)
+  def get_default_headers(content_type: nil)
     {
       'Authorization' => "Bearer #{self.valid_access_token['access_token']}",
-      'Accept' => content_override || 'application/json',
-      'Content-Type' => content_override || 'application/json',
+      'Accept' => content_type || 'application/json',
+      'Content-Type' => content_type || 'application/json',
       'x-app-id' => 'single-cell-portal',
       'x-domain-id' => "#{ENV['HOSTNAME']}"
     }

--- a/lib/api_helpers.rb
+++ b/lib/api_helpers.rb
@@ -45,11 +45,11 @@ module ApiHelpers
   #
   # * *returns*
   #   - (Hash) => Hash of default HTTP headers, e.g. Authorization, Content-Type
-  def get_default_headers
+  def get_default_headers(content_override: nil)
     {
       'Authorization' => "Bearer #{self.valid_access_token['access_token']}",
-      'Accept' => 'application/json',
-      'Content-Type' => 'application/json',
+      'Accept' => content_override || 'application/json',
+      'Content-Type' => content_override || 'application/json',
       'x-app-id' => 'single-cell-portal',
       'x-domain-id' => "#{ENV['HOSTNAME']}"
     }

--- a/test/integration/fire_cloud_client_test.rb
+++ b/test/integration/fire_cloud_client_test.rb
@@ -90,7 +90,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
   def test_override_default_headers
     headers = %w[Accept Content-Type]
     default_headers = @fire_cloud_client.get_default_headers
-    override_headers = @fire_cloud_client.get_default_headers(content_override: 'text/plain')
+    override_headers = @fire_cloud_client.get_default_headers(content_type: 'text/plain')
     headers.each do |header|
       assert_equal 'application/json', default_headers[header]
       assert_equal 'text/plain', override_headers[header]

--- a/test/integration/fire_cloud_client_test.rb
+++ b/test/integration/fire_cloud_client_test.rb
@@ -86,6 +86,17 @@ class FireCloudClientTest < ActiveSupport::TestCase
     end
   end
 
+  # test header overrides
+  def test_override_default_headers
+    headers = %w[Accept Content-Type]
+    default_headers = @fire_cloud_client.get_default_headers
+    override_headers = @fire_cloud_client.get_default_headers(content_override: 'text/plain')
+    headers.each do |header|
+      assert_equal 'application/json', default_headers[header]
+      assert_equal 'text/plain', override_headers[header]
+    end
+  end
+
   ##
   #
   # WORKSPACE TESTS


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This addresses a frequent silent error in CI where deleting a Terra workspace generates an `HTTP 406 Not Acceptable` error.  The root cause is that this endpoint now only accepts `text/plain` requests.  The deletes still happen, but the error pollutes logs, making debugging difficult.  Originally, this was addressed in https://github.com/broadinstitute/single_cell_portal_core/pull/1581 but this only silenced the error, and did not fix the underlying cause.

#### MANUAL TESTING
1. Pull branch and enter a Rails console session
2. Create a new Terra workspace:
```
client = FireCloudClient.new
project = FireCloudClient::PORTAL_NAMESPACE
name = "accept-header-#{SecureRandom.uuid}"
client.create_workspace(project, name)
```
3. Validate you can request the newly created workspace with`client.get_workspace(project, name)`
4. Delete the workspace and validate no `HTTP 406` error is thrown, and that you receive a message detailing when the bucket will be deleted:
```
client.delete_workspace(project, name)
=> "Your Google bucket fc-4911ea40-74bf-44ce-bd24-6db8761e931f will be deleted within 24h.  The workspace single-cell-portal-development:accept-header-83c6ea94-2fbd-4fbb-9d55-3ddad366d551 has been un-published."  
```