### PR TITLE
Add AnnData Ingestible and AnnData Reference file types

### DIFF
--- a/app/javascript/components/upload/AnnDataStep.jsx
+++ b/app/javascript/components/upload/AnnDataStep.jsx
@@ -4,11 +4,12 @@ import AnnDataFileForm from './AnnDataFileForm'
 import { AddFileButton } from './form-components'
 
 const DEFAULT_NEW_ANNDATA_FILE = {
-  file_type: 'AnnData',
+  file_type: 'AnnData Reference',
   options: {}
 }
 
-const AnnDataFileFilter = file => ['AnnData'].includes(file.file_type)
+const AnnDataFileTypes = ['AnnData Reference', 'AnnData Ingestible']
+const AnnDataFileFilter = file => AnnDataFileTypes.includes(file.file_type)
 
 export default {
   title: 'AnnData (.h5ad)',
@@ -20,6 +21,7 @@ export default {
 
 /** Renders a form for uploading one or more AnnData files */
 function AnnDataForm({
+  serverState,
   formState,
   addNewFile,
   updateFile,
@@ -27,9 +29,22 @@ function AnnDataForm({
   deleteFile
 }) {
   const AnnDataFiles = formState.files.filter(AnnDataFileFilter)
+  const featureFlagState = serverState.feature_flags
+  console.log('featureflagstate:', featureFlagState)
+  console.log('featureflagstate ingest_anndata:', featureFlagState?.ingest_anndata_file)
+
+  // if the feature flag is flipped to ingest the AnnData file update the file_type
+  let NEW_ANNDATA_FILE = DEFAULT_NEW_ANNDATA_FILE
+  if (featureFlagState?.ingest_anndata_file) {
+    NEW_ANNDATA_FILE = {
+      file_type: 'AnnData Ingestible',
+      options: {}
+    }
+  }
+
   useEffect(() => {
     if (AnnDataFiles.length === 0) {
-      addNewFile(DEFAULT_NEW_ANNDATA_FILE)
+      addNewFile(NEW_ANNDATA_FILE)
     }
   }, [AnnDataFiles.length])
 
@@ -54,10 +69,10 @@ function AnnDataForm({
         updateFile={updateFile}
         saveFile={saveFile}
         deleteFile={deleteFile}
-        annDataFileTypes={['AnnData']}
+        annDataFileTypes={AnnDataFileTypes}
         bucketName={formState.study.bucket_id}
         isInitiallyExpanded={AnnDataFiles.length === 1}/>
     })}
-    <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_ANNDATA_FILE}/>
+    <AddFileButton addNewFile={addNewFile} newFileTemplate={NEW_ANNDATA_FILE}/>
   </div>
 }

--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -249,7 +249,7 @@ const plainTextExtensions = ['.txt', '.tsv', '.text', '.csv']
 const mtxExtensions = ['.mtx', '.mm', '.txt', '.text']
 const imageExtensions = ['.jpeg', '.jpg', '.png', '.bmp']
 const miscExtensions = ['.txt', '.text', '.tsv', '.csv', '.jpg', '.jpeg', '.png', '.pdf',
-  '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.zip', '.loom', '.ipynb']
+  '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.zip', '.loom', '.ipynb', '.h5', '.h5ad', '.hdf5']
 const sequenceExtensions = ['.fq', '.fastq', '.fq.tar.gz', '.fastq.tar.gz', '.fq.gz', '.fastq.gz', '.bam']
 const baiExtensions = ['.bai']
 const annDataExtensions = ['.h5', '.h5ad', '.hdf5']

--- a/app/javascript/lib/validation/validate-file.js
+++ b/app/javascript/lib/validation/validate-file.js
@@ -61,7 +61,7 @@ async function validateLocalFile(file, studyFile, allStudyFiles=[], allowedFileE
 
   let issuesObj
 
-  const noContentValidationFileTypes = ['Seurat', 'AnnData', 'Other', 'Documentation']
+  const noContentValidationFileTypes = ['Seurat', 'AnnData Reference', 'AnnData Ingestible', 'Other', 'Documentation']
 
   const studyFileType = studyFile.file_type
 

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -24,7 +24,7 @@ class StudyFile
   # constants, used for statuses and file types
   STUDY_FILE_TYPES = ['Cluster', 'Coordinate Labels' ,'Expression Matrix', 'MM Coordinate Matrix', '10X Genes File',
                       '10X Barcodes File', 'Gene List', 'Metadata', 'Fastq', 'BAM', 'BAM Index', 'Documentation',
-                      'Other', 'Analysis Output', 'Ideogram Annotations', 'Image', 'AnnData', 'Seurat'].freeze
+                      'Other', 'Analysis Output', 'Ideogram Annotations', 'Image', 'AnnData Reference', 'AnnData Ingestible', 'Seurat'].freeze
   CUSTOM_FILE_TYPE_NAMES = {
     'MM Coordinate Matrix' => 'Sparse matrix (.mtx)',
     'Expression Matrix' => 'Dense matrix',

--- a/test/js/upload-wizard/file-info-responses.js
+++ b/test/js/upload-wizard/file-info-responses.js
@@ -462,7 +462,7 @@ export const ANNDATA_FILE = {
   created_at: '2021-11-15T18:31:41.598Z',
   data_dir: '71e1a89e5c5d9300aabd0e757d1b569eb66644872b40bcbb720e2b39bc7e3822',
   description: '',
-  file_type: 'H5ad',
+  file_type: 'AnnData Reference',
   human_data: false,
   is_spatial: false,
   name: 'anndata.h5ad',


### PR DESCRIPTION
We currently allow users to upload AnnData files to SCP. These are more of a reference type file (more akin to the Miscellaneous file types) than the ingestible file types. Once we add the ability to ingest AnnData files any AnnData files already on SCP will cause issues and could break our new requirements. To fix this issue and allow users to continue to upload reference style AnnData files while we build out and test the ingestible AnnData upload this PR introduces two new distinct AnnData file_types.

`AnnData reference` file_type will be used for all the existing AnnData files on SCP, so there is a migration script to move those. Also when the feature flag for `ingest_anndata_file` is flipped to false this will be the assigned file_type

`AnnData ingestible` file_type will be used for testing and for the future when we allow users to ingest AnnData files. This will be the assigned file_type when the feature flag is true.

This means all AnnData will still be housed under the same section in the UI wizard and in the future we can employ the tactic used in the Miscellaneous section to allow users to choose `ingestible` or `reference` 