### PR TITLE
Wire up the ingest for 'reference AnnData' files (SCP-4838)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,4 +55,3 @@ Style/ConditionalAssignment:
 
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
-  EnforcedShorthandSyntax: consistent

--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -2,7 +2,7 @@ import _get from 'lodash/get'
 import React from 'react'
 
 export const PARSEABLE_TYPES = ['Cluster', 'Coordinate Labels', 'Expression Matrix', 'MM Coordinate Matrix',
-  '10X Genes File', '10X Barcodes File', 'Gene List', 'Metadata', 'Analysis Output']
+  '10X Genes File', '10X Barcodes File', 'Gene List', 'Metadata', 'Analysis Output', 'AnnData']
 
 const EXPRESSION_INFO_TYPES = ['Expression Matrix', 'MM Coordinate Matrix']
 

--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -28,8 +28,7 @@ class FileParseService
       self.create_bundle_from_file_options(study_file, study)
       case study_file.file_type
       when 'Cluster'
-        job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_cluster, reparse: reparse,
-                            persist_on_fail: persist_on_fail)
+        job = IngestJob.new(study:, study_file:, user:, action: :ingest_cluster, reparse:, persist_on_fail:)
         job.delay.push_remote_and_launch_ingest
         # check if there is a coordinate label file waiting to be parsed
         # must reload study_file object as associations have possibly been updated
@@ -38,25 +37,23 @@ class FileParseService
           study_file.bundled_files.each do |coordinate_file|
             # pre-emptively set parse_status to prevent initialize_coordinate_label_data_arrays from failing due to race condition
             study_file.update(parse_status: 'parsing')
-            study.delay.initialize_coordinate_label_data_arrays(coordinate_file, user, {reparse: reparse})
+            study.delay.initialize_coordinate_label_data_arrays(coordinate_file, user, { reparse: })
           end
         end
       when 'Coordinate Labels'
         if study_file.has_completed_bundle?
-          ParseUtils.delay.initialize_coordinate_label_data_arrays(study, study_file, user, {reparse: reparse})
+          ParseUtils.delay.initialize_coordinate_label_data_arrays(study, study_file, user, { reparse: })
         else
           return self.missing_bundled_file(study_file)
         end
       when 'Expression Matrix'
-        job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_expression, reparse: reparse,
-                            persist_on_fail: persist_on_fail)
+        job = IngestJob.new(study:, study_file:, user:, action: :ingest_expression, reparse:, persist_on_fail:)
         job.delay.push_remote_and_launch_ingest
       when 'MM Coordinate Matrix'
         study_file.reload
         if study_file.has_completed_bundle?
           study_file.bundled_files.update_all(parse_status: 'parsing')
-          job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_expression, reparse: reparse,
-                              persist_on_fail: persist_on_fail)
+          job = IngestJob.new(study:, study_file:, user:, action: :ingest_expression, reparse:, persist_on_fail:)
           job.delay.push_remote_and_launch_ingest
         else
           study.delay.send_to_firecloud(study_file) if study_file.is_local?
@@ -70,8 +67,7 @@ class FileParseService
           bundle = study_file.study_file_bundle
           matrix = bundle.parent
           bundle.study_files.update_all(parse_status: 'parsing')
-          job = IngestJob.new(study: study, study_file: matrix, user: user, action: :ingest_expression, reparse: reparse,
-                              persist_on_fail: persist_on_fail)
+          job = IngestJob.new(study:, study_file: matrix, user:, action: :ingest_expression, reparse:, persist_on_fail:)
           job.delay.push_remote_and_launch_ingest
         else
           return self.missing_bundled_file(study_file)
@@ -86,8 +82,7 @@ class FileParseService
             studyFileName: study_file.name
           }, user)
         end
-        job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_cell_metadata, reparse: reparse,
-                            persist_on_fail: persist_on_fail)
+        job = IngestJob.new(study:, study_file:, user:, action: :ingest_cell_metadata, reparse:, persist_on_fail:)
         job.delay.push_remote_and_launch_ingest
       when 'Analysis Output'
         case @study_file.options[:analysis_name]
@@ -99,20 +94,18 @@ class FileParseService
           Rails.logger.info "Aborting parse of #{@study_file.name} as #{@study_file.file_type} in study #{@study.name}; not applicable"
         end
       when 'AnnData'
-        # gate full ingest of an AnnData file using the feature flag 'ingest_anndata_file'
+        # enable / disable full ingest of AnnData files using the feature flag 'ingest_anndata_file'
         if do_anndata_file_ingest
           # Currently assuming "Happy Path" and so the AnnData file will have clustering data
           # extract and parse clustering data
-          job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_anndata, reparse: reparse,
-          persist_on_fail: persist_on_fail)
+          job = IngestJob.new(study:, study_file:, user:, action: :ingest_anndata, reparse:, persist_on_fail:)
           # Future consideration about whether to do all in one job likely in (SCP-4754)
           # TODO extract and parse Metadata (SCP-4708)
           # TODO extract and parse Processed Exp Data (SCP-4709)
           # TODO extract and parse Raw Exp Data (SCP-4710)
         else
           # launch an ingest job for parsing a reference AnnData file
-          job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_anndata_reference, reparse: reparse,
-          persist_on_fail: persist_on_fail)
+          job = IngestJob.new(study:, study_file:, user:, action: :ingest_anndata_reference, reparse:, persist_on_fail:)
         end
         job.delay.push_remote_and_launch_ingest
       end

--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -100,7 +100,7 @@ class FileParseService
         end
       when 'AnnData'
         # gate full ingest of an AnnData file using the feature flag 'ingest_anndata_file'
-        if do_anndata_file_ingest == true
+        if do_anndata_file_ingest
           # Currently assuming "Happy Path" and so the AnnData file will have clustering data
           # extract and parse clustering data
           job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_anndata, reparse: reparse,

--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -99,27 +99,25 @@ class FileParseService
           Rails.logger.info "Aborting parse of #{@study_file.name} as #{@study_file.file_type} in study #{@study.name}; not applicable"
         end
       when 'AnnData'
-        # gate ingest of AnnData using the feature flag 'ingest_anndata_file'
+        # gate full ingest of an AnnData file using the feature flag 'ingest_anndata_file'
         if do_anndata_file_ingest == true
           # Currently assuming "Happy Path" and so the AnnData file will have clustering data
           # extract and parse clustering data
           job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_anndata, reparse: reparse,
           persist_on_fail: persist_on_fail)
-          job.delay.push_remote_and_launch_ingest
-
           # Future consideration about whether to do all in one job likely in (SCP-4754)
           # TODO extract and parse Metadata (SCP-4708)
           # TODO extract and parse Processed Exp Data (SCP-4709)
           # TODO extract and parse Raw Exp Data (SCP-4710)
         else
-          Rails.logger.info "Aborting parse of AnnData file #{study_file.name} due to feature flag being #{do_anndata_file_ingest}"
+          # launch an ingest job for parsing a reference AnnData file
+          job = IngestJob.new(study: study, study_file: study_file, user: user, action: :ingest_anndata_reference, reparse: reparse,
+          persist_on_fail: persist_on_fail)
         end
+        job.delay.push_remote_and_launch_ingest
+      end
 
-      end
-      # If the AnnData ingest feature flag is false don't update the parse status since no ingest job was initiated
-      unless study_file.file_type == 'AnnData' && !do_anndata_file_ingest
-        study_file.update(parse_status: 'parsing')
-      end
+      study_file.update(parse_status: 'parsing')
       changes = ["Study file added: #{study_file.upload_file_name}"]
       if study.study_shares.any?
         SingleCellMailer.share_update_notification(study, changes, user).deliver_now

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -14,7 +14,7 @@ class IngestJob
 
   # valid ingest actions to perform
   VALID_ACTIONS = %i[
-    ingest_expression ingest_cluster ingest_cell_metadata ingest_anndata subsample differential_expression render_expression_arrays
+    ingest_expression ingest_cluster ingest_cell_metadata ingest_anndata ingest_anndata_reference subsample differential_expression render_expression_arrays
   ].freeze
 
   # Mappings between actions & models (for cleaning up data on re-parses)

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -299,9 +299,14 @@ class PapiClient
   def get_command_line(study_file:, action:, user_metrics_uuid:, params_object: nil)
     validate_action_by_file(action, study_file)
     study = study_file.study
+    stringified_action = action.to_s
     command_line = "python ingest_pipeline.py --study-id #{study.id} --study-file-id #{study_file.id} " \
-                   "--user-metrics-uuid #{user_metrics_uuid} #{action}"
-    case action.to_s
+                   "--user-metrics-uuid #{user_metrics_uuid}"
+    unless stringified_action == 'ingest_anndata_reference'
+      command_line += " #{action}"
+    end
+
+    case stringified_action
     when 'ingest_expression'
       if study_file.file_type == 'Expression Matrix'
         command_line += " --matrix-file #{study_file.gs_url} --matrix-file-type dense"
@@ -325,8 +330,8 @@ class PapiClient
         # extract cluster data from AnnData file, currently hardcoding the obsm-keys
         command_line +=  " --ingest-anndata --anndata-file #{study_file.gs_url} --extract-cluster --obsm-keys ['X_umap','X_tsne']"
     when 'ingest_anndata_reference'
-        command_line = "python ingest_pipeline.py --study-id #{study.id} --study-file-id #{study_file.id} " \
-        "--user-metrics-uuid #{user_metrics_uuid} ingest_anndata --ingest-anndata --anndata-file #{study_file.gs_url}"
+      # ingest_anndata_reference is not a command that ingest pipeline recognizes so use ingest_anndata as the action
+        command_line += " ingest_anndata --ingest-anndata --anndata-file #{study_file.gs_url}"
     when 'ingest_subsample'
       metadata_file = study.metadata_file
       command_line += " --cluster-file #{study_file.gs_url} --cell-metadata-file #{metadata_file.gs_url} --subsample"

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -26,7 +26,8 @@ class PapiClient
     differential_expression: ['Cluster'],
     render_expression_arrays: ['Cluster'],
     image_pipeline: ['Cluster'],
-    ingest_anndata: ['AnnData']
+    ingest_anndata: ['AnnData'],
+    ingest_anndata_reference: ['AnnData']
   }.freeze
 
   # jobs that require custom virtual machine types (e.g. more RAM, CPU)
@@ -321,8 +322,11 @@ class PapiClient
     when 'ingest_cluster'
       command_line += " --cluster-file #{study_file.gs_url} --ingest-cluster"
     when 'ingest_anndata'
-      # extract cluster data from AnnData file, currently hardcoding the obsm-keys
-      command_line +=  " --ingest-anndata --anndata-file #{study_file.gs_url} --extract-cluster --obsm-keys ['X_umap','X_tsne']"
+        # extract cluster data from AnnData file, currently hardcoding the obsm-keys
+        command_line +=  " --ingest-anndata --anndata-file #{study_file.gs_url} --extract-cluster --obsm-keys ['X_umap','X_tsne']"
+    when 'ingest_anndata_reference'
+        command_line = "python ingest_pipeline.py --study-id #{study.id} --study-file-id #{study_file.id} " \
+        "--user-metrics-uuid #{user_metrics_uuid} ingest_anndata --ingest-anndata --anndata-file #{study_file.gs_url}"
     when 'ingest_subsample'
       metadata_file = study.metadata_file
       command_line += " --cluster-file #{study_file.gs_url} --cell-metadata-file #{metadata_file.gs_url} --subsample"

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.23.1'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.23.2'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
This adds the wiring on the Rails side to call the ingest job that does the very basic check on AnnData files uploaded as reference files. Previously these files were not being parsed at all, just uploaded.


To test:
- Pull this branch and boot up a rails server and the delayed job worker
- Open up localhost
- Make sure your feature flag for `ingest_anndata_file` is set to false
- go to a study you can upload data to
- upload an AnnData file
- observe that the file uploads and the parsing status appears then you should receive an email that says the file finished parsing
- If you want to further confirm check out the study details page to see the file and it's parsed status
![Screen Shot 2022-11-29 at 5 07 20 PM](https://user-images.githubusercontent.com/54322292/204659078-2c21446f-b181-41fb-9c75-1bf7678d2aa3.png)


![Screen Shot 2022-11-21 at 3 46 05 PM](https://user-images.githubusercontent.com/54322292/204659422-0de58434-80be-4f7e-8636-b7ef522f3e28.png)

![Screen Shot 2022-11-29 at 5 07 42 PM](https://user-images.githubusercontent.com/54322292/204659442-b1fd7a29-9da9-471d-ae5e-f8749399ae36.png)

