### PR TITLE
Ensure cache dir permissions before compiling static assets (SCP-4844)

### DIFF
--- a/rails_startup.bash
+++ b/rails_startup.bash
@@ -24,7 +24,9 @@ if [[ $PASSENGER_APP_ENV = "production" ]] || [[ $PASSENGER_APP_ENV = "staging" 
 then
     echo "*** PRECOMPILING ASSETS ***"
     export NODE_OPTIONS="--max-old-space-size=4096"
+    # ensure file permissions don't interfere with compiling assets
     sudo chown app:app ./node_modules/.yarn-integrity
+    sudo chown -R app:app /home/app/webapp/tmp/cache
     sudo -E -u app -H bin/rails NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV assets:clobber
     sudo -E -u app -H bin/rails NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV vite:clobber
     sudo -E -u app -H bin/rails NODE_ENV=production RAILS_ENV=$PASSENGER_APP_ENV assets:precompile


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes an issue discovered on a [recent deployment](https://scp-jenkins.dsp-techops.broadinstitute.org/job/scp-deploy-master-to-production/118/console) where directories owned by `root` could not be removed when attempting to clear asset caches and recompile.  Now, the `tmp/cache` directory will have `chown` recursively applied to ensure everything is owned by the `app` user.  That being said, this particular error only occurred once on each host (staging & production), and repeated deployments to staging have succeeded without this update.  This step is more preventative than actually addressing a known bug.  Also, the operation only takes 2-3 seconds to complete and will not substantively impact deployment times.

#### MANUAL TESTING
Since this only happens on deployments, and Docker Desktop for Mac uses different file system drivers than Ubuntu, it is not possible to test this locally.