### PR TITLE
Launch image pipeline jobs on successful render_expression_arrays job (SCP-4743)

### DIFF
--- a/app/lib/image_pipeline_service.rb
+++ b/app/lib/image_pipeline_service.rb
@@ -10,9 +10,10 @@ class ImagePipelineService
   # :run_render_expression_arrays_job
   #
   # * *params*
-  #   - +study+        (Study) => study to generate images in
-  #   - +cluster_file+ (StudyFile) => clustering file to use as source for cell names
-  #   - +user+         (User) => associated user (for email notifications)
+  #   - +study+                (Study) => study to generate images in
+  #   - +cluster_file+         (StudyFile) => clustering file to use as source for cell names
+  #   - +user+                 (User) => associated user (for email notifications)
+  #   - +data_cache_perftime+ (Integer) => runtime of :render_expression_arrays job, for reporting
   #
   # * *yields*
   #   - (IngestJob) => image_pipeline job in PAPI
@@ -22,10 +23,10 @@ class ImagePipelineService
   #
   # * *raises*
   #   - (ArgumentError) => if requested parameters do not validate
-  def self.run_image_pipeline_job(study, cluster_file, user: nil)
+  def self.run_image_pipeline_job(study, cluster_file, user: nil, data_cache_perftime:)
     validate_study(study)
     requested_user = user || study.user
-    params_object = create_image_pipeline_parameters_object(study, cluster_file)
+    params_object = create_image_pipeline_parameters_object(study, cluster_file, data_cache_perftime)
     submit_job(study:, cluster_file:, requested_user:, params_object:)
   end
 
@@ -118,18 +119,21 @@ class ImagePipelineService
   # create a ImagePipelineParameters object to pass to IngestJob
   #
   # * *params*
-  #   - +study+        (Study) => study to generate images in
-  #   - +cluster_file+ (StudyFile) => clustering file to use as source for cell names
+  #   - +study+                (Study) => study to generate images in
+  #   - +cluster_file+         (StudyFile) => clustering file to use as source for cell names
+  #   - +data_cache_perftime+ (Integer) => runtime of :render_expression_arrays job, for reporting
   #
   # * *returns*
   #   - (ImagePipelineParameters) => parameters object
   #
   # * *raises*
   #   - (ArgumentError) => if requested parameters do not validate
-  def self.create_image_pipeline_parameters_object(study, cluster_file)
+  def self.create_image_pipeline_parameters_object(study, cluster_file, data_cache_perftime)
     validate_study_file(cluster_file, :cluster_file)
     cluster_name = ClusterGroup.find_by(study: study, study_file: cluster_file)&.name
-    ImagePipelineParameters.new(accession: study.accession, bucket: study.bucket_id, cluster: cluster_name)
+    ImagePipelineParameters.new(
+      accession: study.accession, bucket: study.bucket_id, cluster: cluster_name, data_cache_perftime:
+    )
   end
 
   # validate a study is a candidate for image pipeline jobs

--- a/app/models/image_pipeline_parameters.rb
+++ b/app/models/image_pipeline_parameters.rb
@@ -9,9 +9,11 @@ class ImagePipelineParameters
   # cores: number of cores to use in processing images (defaults to available cores - 1)
   # docker_image: image pipeline docker image to use
   # machine_type: GCE machine type, see Parameterizable::GOOGLE_VM_MACHINE_TYPES
-  attr_accessor :accession, :bucket, :cluster, :environment, :cores, :docker_image, :machine_type
+  # data_cache_perftime: total runtime (in ms) of upstream :render_expression_arrays job
+  attr_accessor :accession, :bucket, :cluster, :environment, :cores, :docker_image, :machine_type,
+                :data_cache_perftime
 
-  validates :accession, :bucket, :cluster, :environment, :cores, presence: true
+  validates :accession, :bucket, :cluster, :environment, :cores, :data_cache_perftime, presence: true
   validates :machine_type, inclusion: Parameterizable::GCE_MACHINE_TYPES
   validates :environment, inclusion: %w[development test staging production]
   validates :docker_image, format: { with: Parameterizable::GCR_URI_REGEXP }

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -389,6 +389,8 @@ class IngestJob
       set_subsampling_flags
     when :differential_expression
       create_differential_expression_results
+    when :render_expression_arrays
+      launch_image_pipeline_job
     when :image_pipeline
       set_has_image_cache
     when :ingest_anndata
@@ -397,7 +399,7 @@ class IngestJob
       set_cluster_point_count
       set_study_default_options
       launch_subsample_jobs
-      # TODO (SCP-4708, SCP-4709, SCP-4710) will duplicate a lot more from above 
+      # TODO (SCP-4708, SCP-4709, SCP-4710) will duplicate a lot more from above
     end
     set_study_initialized
   end
@@ -534,6 +536,12 @@ class IngestJob
       matrix_file_id: matrix_file.id
     )
     de_result.save
+  end
+
+  # launch an image pipeline job once :render_expression_arrays completes
+  def launch_image_pipeline_job
+    Rails.logger.info "Launching image_pipeline job in #{study.accession} for cluster file: #{study_file.name}"
+    ImagePipelineService.run_image_pipeline_job(study, study_file, user:)
   end
 
   # set flags to denote when a cluster has image data

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -631,7 +631,7 @@ class IngestJob
     # Event properties to log to Mixpanel.
     # Mixpanel uses camelCase for props; snake_case would degrade Mixpanel UX.
     job_props = {
-      perfTime: get_total_runtime_ms, # Latency in milliseconds
+      perfTime: job_perftime, # Latency in milliseconds
       fileName: study_file.name,
       fileType: file_type,
       fileSize: study_file.upload_file_size,

--- a/test/integration/lib/image_pipeline_service_test.rb
+++ b/test/integration/lib/image_pipeline_service_test.rb
@@ -59,7 +59,7 @@ class ImagePipelineServiceTest < ActiveSupport::TestCase
     mock.expect(:delay, job_mock)
     IngestJob.stub :new, mock do
       ApplicationController.firecloud_client.stub :workspace_file_exists?, true do
-        ImagePipelineService.run_image_pipeline_job(@study, @cluster_file)
+        ImagePipelineService.run_image_pipeline_job(@study, @cluster_file, data_cache_perftime: 120_000)
       end
     end
   end
@@ -117,7 +117,7 @@ class ImagePipelineServiceTest < ActiveSupport::TestCase
 
   test 'should create image pipeline parameters object' do
     ApplicationController.firecloud_client.stub :workspace_file_exists?, true do
-      params = ImagePipelineService.create_image_pipeline_parameters_object(@study, @cluster_file)
+      params = ImagePipelineService.create_image_pipeline_parameters_object(@study, @cluster_file, 120_000)
       assert params.valid?
       assert_equal @cluster_file.name, params.cluster
       assert_equal @study.bucket_id, params.bucket

--- a/test/models/image_pipeline_parameters_test.rb
+++ b/test/models/image_pipeline_parameters_test.rb
@@ -6,7 +6,8 @@ class ImagePipelineParametersTest < ActiveSupport::TestCase
       accession: 'SCP1234',
       cluster: 'UMAP',
       bucket: 'test_bucket',
-      environment: 'test'
+      environment: 'test',
+      data_cache_perftime: 120_000
     }
     @pipeline_params = ImagePipelineParameters.new(@params)
   end
@@ -15,7 +16,7 @@ class ImagePipelineParametersTest < ActiveSupport::TestCase
     assert @pipeline_params.valid?
     invalid = ImagePipelineParameters.new(environment: 'foo', machine_type: 'bar', docker_image: 'blah')
     assert_not invalid.valid?
-    assert_equal %i[accession bucket cluster cores docker_image environment machine_type],
+    assert_equal %i[accession bucket cluster cores data_cache_perftime docker_image environment machine_type],
                  invalid.errors.attribute_names.sort
 
     # test overriding defaults


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update automates launching `image_pipeline` jobs after successful completion of `render_expression_array` jobs via `ImagePipelineService`.  Initial launching of jobs not automated, but launching the first job will automatically create and queue the second job on completion.

#### MANUAL TESTING
Note: the `image_pipeline` job will fail due to limitations of not being able to communicate back to `localhost` to query the API.  This will not be the case in deployed environments.

1. Pull branch and start `Delayed::Job` with `./rails_local_setup.rb && source config/secrets/.source_env.bash && bin/rails jobs:work`
2. Enter a Rails console session, and load any study that has clustering & expression files with the same cell names, such as the synthetic study `Murine vision and HIV with arrays`:
```
study = Study.find_by(name: "Murine vision and HIV with arrays")
cluster_file = study.cluster_ordinations_files.first
matrix_file = study.expression_matrices.first
```
3. Launch the `render_expression_arrays` job:
```
ImagePipelineService.run_render_expression_arrays_job(study, cluster_file, matrix_file)
```
4. In `development.log`, note the job launches in PAPI:
```
Remote found for cluster.tsv:6261a3fb94ec8fe535ac00a4, launching Ingest job
Request object sent to Google Pipelines API (PAPI), excluding 'environment' parameters:
---
:actions:
  :commands:
  - python
  - ingest_pipeline.py
  - "--study-id"
  - 6261a3e394ec8fe535ac009a
  - "--study-file-id"
  - 6261a3fb94ec8fe535ac00a4
  - "--user-metrics-uuid"
  - f775823b-94f7-46af-b1c7-789582efaa18
  - render_expression_arrays
  - "--cluster-file"
  - gs://fc-3005f029-745a-43dd-b26d-cafdef3ad017/cluster.tsv
  - "--cluster-name"
  - cluster.tsv
  - "--matrix-file-path"
  - gs://fc-3005f029-745a-43dd-b26d-cafdef3ad017/expression_matrix.tsv
  - "--matrix-file-type"
  - dense
  - "--render-expression-arrays"
...
```
5. After 1-2 minutes, note that the job completes and automatically launches the `image_pipeline` job:
```
Ingest run initiated: projects/broad-singlecellportal-bistlin/operations/13856765342766917132, queueing Ingest poller
...

IngestJob poller: projects/broad-singlecellportal-bistlin/operations/13856765342766917132 is done!
IngestJob poller: projects/broad-singlecellportal-bistlin/operations/13856765342766917132 status: Completed
Launching image_pipeline job in SCP63 for cluster file: cluster.tsv
...

Remote found for cluster.tsv:6261a3fb94ec8fe535ac00a4, launching Ingest job
Request object sent to Google Pipelines API (PAPI), excluding 'environment' parameters:
---
:actions:
  :commands:
  - node
  - expression-scatter-plots.js
  - "--accession"
  - SCP63
  - "--bucket"
  - fc-3005f029-745a-43dd-b26d-cafdef3ad017
  - "--cluster"
  - cluster.tsv
  - "--environment"
  - development
  - "--cores"
  - '95'
  :flags: []
  :image_uri: gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_e2992be5b
  :labels: {}
  :timeout: {}
...
```