### PR TITLE
Track DE feature globally in Mixpanel (SCP-4717)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -56,7 +56,9 @@ function annotHasDe(exploreInfo, exploreParams) {
   const flags = getFeatureFlagsWithDefaults()
   if (!flags?.differential_expression_frontend || !exploreInfo) {
     // set isDEEnabled to false since user cannot see DE results, so we don't want to skew usage data
-    window.SCP.isDEEnabled = false
+    if (window.SCP) {
+      window.SCP.isDEEnabled = false
+    }
     return false
   }
 

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -55,6 +55,8 @@ const tabList = [
 function annotHasDe(exploreInfo, exploreParams) {
   const flags = getFeatureFlagsWithDefaults()
   if (!flags?.differential_expression_frontend || !exploreInfo) {
+    // set isDEEnabled to false since user cannot see DE results, so we don't want to skew usage data
+    window.SCP.isDEEnabled = false
     return false
   }
 

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -55,7 +55,7 @@ const tabList = [
 function annotHasDe(exploreInfo, exploreParams) {
   const flags = getFeatureFlagsWithDefaults()
   if (!flags?.differential_expression_frontend || !exploreInfo) {
-    // set isDEEnabled to false since user cannot see DE results, so we don't want to skew usage data
+    // set isDifferentialExpressionEnabled to false as user cannot see DE results, even if present for annotation
     if (window.SCP) {
       window.SCP.isDEEnabled = false
     }

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -57,7 +57,7 @@ function annotHasDe(exploreInfo, exploreParams) {
   if (!flags?.differential_expression_frontend || !exploreInfo) {
     // set isDifferentialExpressionEnabled to false as user cannot see DE results, even if present for annotation
     if (window.SCP) {
-      window.SCP.isDEEnabled = false
+      window.SCP.isDifferentialExpressionEnabled = false
     }
     return false
   }

--- a/app/javascript/components/explore/ExploreView.jsx
+++ b/app/javascript/components/explore/ExploreView.jsx
@@ -29,7 +29,9 @@ function RoutableExploreTab({ studyAccession }) {
     const exploreResponse = await fetchExplore(studyAccession)
     setExploreInfo(exploreResponse)
     // set window.SCP.isDEEnabled so that we can track DE visibility globally
-    window.SCP.isDEEnabled = exploreResponse.differentialExpression.length > 0
+    if (window.SCP) {
+      window.SCP.isDEEnabled = exploreResponse.differentialExpression.length > 0
+    }
     // after the explore info is received, fetch the user-specific study data, but do it
     // after a timeout to ensure the visualization data gets fetched first
     window.setTimeout(async () => {

--- a/app/javascript/components/explore/ExploreView.jsx
+++ b/app/javascript/components/explore/ExploreView.jsx
@@ -28,9 +28,9 @@ function RoutableExploreTab({ studyAccession }) {
   async function loadStudyData() {
     const exploreResponse = await fetchExplore(studyAccession)
     setExploreInfo(exploreResponse)
-    // set window.SCP.isDEEnabled so that we can track differential expression visibility globally
+    // set window.SCP.isDifferentialExpressionEnabled so that we can track differential expression visibility globally
     if (window.SCP) {
-      window.SCP.isDEEnabled = exploreResponse.differentialExpression.length > 0
+      window.SCP.isDifferentialExpressionEnabled = exploreResponse.differentialExpression.length > 0
     }
     // after the explore info is received, fetch the user-specific study data, but do it
     // after a timeout to ensure the visualization data gets fetched first

--- a/app/javascript/components/explore/ExploreView.jsx
+++ b/app/javascript/components/explore/ExploreView.jsx
@@ -28,6 +28,8 @@ function RoutableExploreTab({ studyAccession }) {
   async function loadStudyData() {
     const exploreResponse = await fetchExplore(studyAccession)
     setExploreInfo(exploreResponse)
+    // set window.SCP.isDEEnabled so that we can track DE visibility globally
+    window.SCP.isDEEnabled = exploreResponse.differentialExpression.length > 0
     // after the explore info is received, fetch the user-specific study data, but do it
     // after a timeout to ensure the visualization data gets fetched first
     window.setTimeout(async () => {

--- a/app/javascript/components/explore/ExploreView.jsx
+++ b/app/javascript/components/explore/ExploreView.jsx
@@ -28,7 +28,7 @@ function RoutableExploreTab({ studyAccession }) {
   async function loadStudyData() {
     const exploreResponse = await fetchExplore(studyAccession)
     setExploreInfo(exploreResponse)
-    // set window.SCP.isDEEnabled so that we can track DE visibility globally
+    // set window.SCP.isDEEnabled so that we can track differential expression visibility globally
     if (window.SCP) {
       window.SCP.isDEEnabled = exploreResponse.differentialExpression.length > 0
     }

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -392,6 +392,13 @@ function getTabProperty() {
  * @param {Object} props
  */
 export function log(name, props = {}) {
+  let isDEEnabled // track DE globally
+  if ('isDEEnabled' in props) {
+    isDEEnabled = props.isDEEnabled
+  } else {
+    isDEEnabled = !!window.SCP?.isDEEnabled
+  }
+
   props = Object.assign(props, {
     appId: 'single-cell-portal',
     appPath: getAnalyticsPageName(),
@@ -399,6 +406,7 @@ export function log(name, props = {}) {
     env,
     logger: 'app-frontend',
     scpVersion: version,
+    isDEEnabled,
     isServiceWorkerCacheEnabled
   }, getDefaultProperties())
 

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -392,11 +392,11 @@ function getTabProperty() {
  * @param {Object} props
  */
 export function log(name, props = {}) {
-  let isDEEnabled // track differential expression visibility globally
-  if ('isDEEnabled' in props) {
-    isDEEnabled = props.isDEEnabled
+  let isDifferentialExpressionEnabled // track differential expression visibility globally
+  if ('isDifferentialExpressionEnabled' in props) {
+    isDifferentialExpressionEnabled = props.isDifferentialExpressionEnabled
   } else {
-    isDEEnabled = !!window.SCP?.isDEEnabled
+    isDifferentialExpressionEnabled = !!window.SCP?.isDifferentialExpressionEnabled
   }
 
   props = Object.assign(props, {
@@ -406,7 +406,7 @@ export function log(name, props = {}) {
     env,
     logger: 'app-frontend',
     scpVersion: version,
-    isDEEnabled,
+    isDifferentialExpressionEnabled,
     isServiceWorkerCacheEnabled
   }, getDefaultProperties())
 

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -392,7 +392,7 @@ function getTabProperty() {
  * @param {Object} props
  */
 export function log(name, props = {}) {
-  let isDEEnabled // track DE globally
+  let isDEEnabled // track differential expression visibility globally
   if ('isDEEnabled' in props) {
     isDEEnabled = props.isDEEnabled
   } else {


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds the global `isDEEnabled` property to all front-end Mixpanel events.  This will allow us to create a variety of reports/funnels related to differential expression usage by users.  For instance, rather than having to manually curate a list of study accessions to know which studies have DE results, we can simply add a filter for `isDEEnabled: true`.  Similarly, we can chain this event with another for the `click:button` event where the text is `Differential expression`, and add a conversion criterion of `studyAccession` remaining the same.  This will then give us users who visited a study that has DE results available and then interacted with the DE feature without leaving that study.

Some things worth noting:
1. We are tracking this at the study level since of the 106 studies that have DE results available, 96 have results for the default annotation (90%).  Furthermore, 48 (45%) have `cell_type` as the default annotation (or some analog of that).  Given this prevalence, it does not seem necessary to track DE enablement at the plot or annotation level, as this may grossly overcount users.
2. Even though the above studies have DE results available, this does _not_ necessarily mean that users can see them.  Given the current feature flag state for `differential_expression_frontend`, we are opting in DE at the study level.  Right now, only 39 studies have DE enabled.  In order for this to have better signal, we may want to revisit this decision.
3. This feature _does_ take into account whether or not a user is able to see DE results.  For instance, if a study has not opted into DE, `isDEEnabled` is `false`.

#### MANUAL TESTING
1. Boot as normal and visit any study with DE results that you can view
2. Open DevTools > Network and filter for `event` requests
3. Click on the "Explore" tab, and find the corresponding Mixpanel event, noting that `isDEEnabled` is `true`
![Screen Shot 2022-12-15 at 10 10 48 AM](https://user-images.githubusercontent.com/729968/207907932-9ecf6f9f-d0d2-46c9-8f76-f511ce8cc196.png)
4. Click the "Differential expression" button, and find the corresponding Mixpanel event, noting that `isDEEnabled` is `true`
![Screen Shot 2022-12-15 at 10 11 14 AM](https://user-images.githubusercontent.com/729968/207907958-ce33802e-a696-46be-8c26-7ed44407ce8c.png)
