### PR TITLE
Updating to scp-ingest-pipeline:1.23.3 (SCP-4831)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.23.2'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.23.3'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates to `scp-ingest-pipeline:1.23.3` in order to fully support extracting clustering data from `AnnData` files.  See https://github.com/broadinstitute/single_cell_portal_core/pull/1689 for more info.

#### MANUAL TESTING
Not necessary given https://github.com/broadinstitute/single_cell_portal_core/pull/1689 has already merged, though you can re-run those steps (minus step 3) if you like.