### PR TITLE
Fixing Explore tab rendering for AnnData files (SCP-4894)

### DIFF
--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -13,7 +13,7 @@ class ClusterVizService
 
   # helper method to load all possible cluster groups for a study
   def self.load_cluster_group_options(study)
-    non_spatial_file_ids = StudyFile.where(study: study, :is_spatial.ne => true, file_type: 'Cluster').pluck(:id)
+    non_spatial_file_ids = study.clustering_files.where(is_spatial: false).pluck(:id)
     ClusterGroup.where(study: study, :study_file_id.in => non_spatial_file_ids).pluck(:name)
   end
 
@@ -50,8 +50,7 @@ class ClusterVizService
   # the clusters
   def self.load_spatial_options(study)
     # grab all the spatial files for this study
-    spatial_file_info = StudyFile.where(study: study, is_spatial: true, file_type: 'Cluster')
-                                 .pluck(:name, :spatial_cluster_associations)
+    spatial_file_info = study.clustering_files.where(is_spatial: true).pluck(:name, :spatial_cluster_associations)
     # now grab any non spatial cluster files for the study that had ids specified in the spatial_cluster_associations above
     # and put them in an id=>name hash
     associated_clusters = StudyFile.where(study: study, :id.in => spatial_file_info.map{ |si| si[1] }.flatten.uniq)

--- a/app/lib/reports_service.rb
+++ b/app/lib/reports_service.rb
@@ -66,8 +66,10 @@ class ReportsService
         study_hash[study_id][:admin_owned] = 'N/A' # account for nil by casting to boolean
       end
 
-      metadata_files = StudyFile.where(file_type: 'Metadata', queued_for_deletion: false, study_id: study_id)
-                                .pluck(:use_metadata_convention, :created_at)
+      metadata_files = StudyFile.any_of(
+        { file_type: 'Metadata' },
+        { file_type: 'AnnData', 'ann_data_file_info.has_metadata' => true }
+      ).where(queued_for_deletion: false, study_id: study_id).pluck(:use_metadata_convention, :created_at)
       metadata_files.each do |convention, created_at|
         study_hash[study_id][:metadata_convention] = !!convention # account for nil by casting to boolean
         study_hash[study_id][:metadata_file_created] = created_at

--- a/app/lib/summary_stats_utils.rb
+++ b/app/lib/summary_stats_utils.rb
@@ -33,7 +33,10 @@ class SummaryStatsUtils
     {
       all: studies.count,
       public: public.count,
-      compliant: StudyFile.where(file_type: 'Metadata', use_metadata_convention: true, :study_id.in => public).count
+      compliant: StudyFile.any_of(
+        { file_type: 'Metadata' },
+        { file_type: 'AnnData', 'ann_data_file_info.has_metadata' => true }
+      ).where(use_metadata_convention: true, :study_id.in => public).count
     }
   end
 
@@ -43,7 +46,7 @@ class SummaryStatsUtils
     one_week_ago = today - 1.weeks
     user_count = User.where(:last_sign_in_at.gte => one_week_ago, :last_sign_in_at.lt => today)
                      .or(:current_sign_in_at.gte => one_week_ago, :current_sign_in_at.lt => today).count
-    {count: user_count, description: "Count of bleturning users from #{one_week_ago} to #{today}"}
+    {count: user_count, description: "Count of returning users from #{one_week_ago} to #{today}"}
   end
 
   # perform a sanity check to look for any missing files in remote storage

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -154,7 +154,7 @@ class IngestJob
       # expression matrices currently cannot be ingested in parallel due to constraints around validating cell names
       # this block ensures that all other matrices have all cell names ingested and at least one gene entry, which
       # ensures the matrix has validated
-      other_matrix_files = StudyFile.where(study_id: study.id, file_type: /Matrix/, :id.ne => study_file.id)
+      other_matrix_files = study.expression_matrices.where(:id.ne => study_file.id)
       # only check other matrix files of the same type, as this is what will be checked when validating
       similar_matrix_files = other_matrix_files.select {|matrix| matrix.is_raw_counts_file? == study_file.is_raw_counts_file?}
       similar_matrix_files.each do |matrix_file|
@@ -383,7 +383,7 @@ class IngestJob
       # update search facets if convention data
       if study_file.use_metadata_convention
         SearchFacet.delay.update_all_facet_filters
-      end      
+      end
       launch_differential_expression_jobs unless study_file.is_anndata?
       set_anndata_file_info if study_file.is_anndata?
     when :ingest_expression
@@ -602,7 +602,7 @@ class IngestJob
 
   # launch appropriate downstream jobs once an AnnData file successfully extracts "fragment" files
   def launch_anndata_subparse_jobs
-    
+
     params_object.attribute_as_array(:extract).each do |extract|
       case extract
       when 'cluster'

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1445,7 +1445,7 @@ class Study
   def clustering_files
     study_files.any_of(
       { file_type: 'Cluster' },
-      { 'ann_data_file_info.has_clusters' => true }
+      { file_type: 'AnnData', 'ann_data_file_info.has_clusters' => true }
     )
   end
 
@@ -1468,7 +1468,7 @@ class Study
   def expression_matrices
     study_files.any_of(
       { :file_type.in => ['Expression Matrix', 'MM Coordinate Matrix'] },
-      { 'ann_data_file_info.has_expression' => true }
+      { file_type: 'AnnData', 'ann_data_file_info.has_expression' => true }
     )
   end
 
@@ -1481,7 +1481,7 @@ class Study
   def metadata_file
     study_files.any_of(
       { file_type: 'Metadata' },
-      { 'ann_data_file_info.has_metadata' => true }
+      { file_type: 'AnnData', 'ann_data_file_info.has_metadata' => true }
     ).first
   end
 

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -914,8 +914,9 @@ class StudyFile
       StudyFile.where(:id.in => study_file_ids, queued_for_deletion: false)
     when :processed
       # lazy-load all other expression matrices in study
-      processed_matrices = StudyFile.where(study_id: study.id, file_type: /Matrix/, queued_for_deletion: false,
-                                         :id.ne => id, 'expression_file_info.is_raw_counts' => false)
+      processed_matrices = study.expression_matrices.where(queued_for_deletion: false, :id.ne => id).any_of(
+        { 'expression_file_info.is_raw_counts' => false }, { 'ann_data_file_info.has_raw_counts' => false }
+      )
       processed_matrices.select { |matrix| matrix&.expression_file_info&.raw_counts_associations&.include?(id.to_s) }
     else
       [] # nil-safe return w/ no association type specified

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -49,8 +49,9 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
   setup do
     sign_in_and_update @user
-    @convention_accessions = StudyFile.where(file_type: 'Metadata', use_metadata_convention: true)
-                                      .map { |f| f.study.accession }.flatten
+    @convention_accessions = StudyFile.any_of(
+      { file_type: 'Metadata' }, { file_type: 'AnnData', 'ann_data_file_info.has_metadata' => true }
+    ).where(use_metadata_convention: true).map { |f| f.study.accession }.flatten
   end
 
   # reset known commonly used objects to initial states to prevent failures breaking other tests

--- a/test/api/visualization/explore_controller_test.rb
+++ b/test/api/visualization/explore_controller_test.rb
@@ -130,8 +130,4 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
     execute_http_request(:get, cluster_options_api_v1_study_explore_path('SCP1234567'))
     assert_equal 404, response.status
   end
-
-  test 'should show AnnData files as visualizable' do
-
-  end
 end

--- a/test/api/visualization/explore_controller_test.rb
+++ b/test/api/visualization/explore_controller_test.rb
@@ -130,4 +130,8 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
     execute_http_request(:get, cluster_options_api_v1_study_explore_path('SCP1234567'))
     assert_equal 404, response.status
   end
+
+  test 'should show AnnData files as visualizable' do
+
+  end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug where the Explore tab did not render the Scatter pane when data was parsed from AnnData files.  The issue was that our queries for clustering names only took into account files of type `Cluster`.

#### MANUAL TESTING
1. Boot as normal 
2. If you do not have a study with a parsed AnnData file, download and ingest [`compliant_pbmc3K.h5ad`](https://github.com/broadinstitute/single_cell_portal_core/files/10362369/compliant_pbmc3K.h5ad.zip) (from #1698)
3. Navigate to that study and validate that you can see data (shown below is the `X_umap` cluster w/ `louvain` annotation)
![Screen Shot 2023-01-11 at 10 13 24 AM](https://user-images.githubusercontent.com/729968/211842881-19c9142e-5e16-4f2c-825a-83eeeca1b163.png)
