### PR TITLE
Constrain possible test user email values in CI (SCP-4910)

### DIFF
--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -2,6 +2,7 @@
 # Rough performance timing in local (non-dockerized) development suggests that crating a user
 # using this factory takes ~0.1 seconds
 FactoryBot.define do
+  random_num = rand(1..100)
   factory :user do
     transient do
       random_seed { SecureRandom.alphanumeric(4).upcase }
@@ -9,13 +10,15 @@ FactoryBot.define do
       # this enables easy managing of a central list of objects to be cleaned up by a test suite
       test_array { nil }
     end
-    email { "test.user.#{random_seed}@test.edu" }
+    # https://github.com/thoughtbot/factory_bot/blob/main/GETTING_STARTED.md#sequences
+    sequence(:email, random_num) { |n| "test.user.#{n}@test.edu" }
     uid { rand(10000..99999) }
     password { "test_password" }
     metrics_uuid { SecureRandom.uuid }
     after(:create) do |user, evaluator|
       if evaluator.test_array
         evaluator.test_array.push(user)
+        puts "email: #{user.email}"
       end
       TosAcceptance.create(email: user.email)
     end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -2,7 +2,6 @@
 # Rough performance timing in local (non-dockerized) development suggests that crating a user
 # using this factory takes ~0.1 seconds
 FactoryBot.define do
-  random_num = rand(1..100)
   factory :user do
     transient do
       random_seed { SecureRandom.alphanumeric(4).upcase }
@@ -11,14 +10,13 @@ FactoryBot.define do
       test_array { nil }
     end
     # https://github.com/thoughtbot/factory_bot/blob/main/GETTING_STARTED.md#sequences
-    sequence(:email, random_num) { |n| "test.user.#{n}@test.edu" }
+    sequence(:email) { |n| "test.user.#{n}@test.edu" }
     uid { rand(10000..99999) }
     password { "test_password" }
     metrics_uuid { SecureRandom.uuid }
     after(:create) do |user, evaluator|
       if evaluator.test_array
         evaluator.test_array.push(user)
-        puts "email: #{user.email}"
       end
       TosAcceptance.create(email: user.email)
     end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
A recent review of a user cleanup process in SAM (Terra's workspace identity & access management service) found that SCP has been creating test user accounts with the email pattern of  `test.user.#{random_seed}@test.edu`, where `random_seed` is a 4-character alphanumeric string.  This means there could be over 1.6M different possible values for the email address (36^4 = 1,679,616).  Over the last several years, this has led to ~34K fake email accounts being invited to their "all users" Google group, despite the accounts not existing, and removing these accounts from the group resulted in upstream Google quota rate limits for SAM.  In an effort to avoid this moving forward, we've been asked to constrain the number of possible email values.  

This update will change the pattern to `test.user.#{n}@test.edu`, where `n` is an incrementing integer starting at `1`.  There are currently `109` calls from `FactoryBot` to create a user (though not all of them will make it to Terra as some are local mocks only).