### PR TITLE
Show RNA and protein diagrams in related genes ideogram (SCP-4887)

### DIFF
--- a/app/javascript/components/visualization/RelatedGenesIdeogram.jsx
+++ b/app/javascript/components/visualization/RelatedGenesIdeogram.jsx
@@ -148,6 +148,9 @@ export default function RelatedGenesIdeogram({
 
   const verticalPad = 40 // Total top and bottom padding
 
+  // For Ideogram functionality only available for human
+  const showAdvanced = taxon === 'Homo sapiens'
+
   useEffect(() => {
     const ideoConfig = {
       container: '#related-genes-ideogram-container',
@@ -159,7 +162,9 @@ export default function RelatedGenesIdeogram({
       onClickAnnot,
       onPlotRelatedGenes,
       onWillShowAnnotTooltip,
-      showParalogNeighborhoods: taxon === 'Homo sapiens', // Works around bug in Ideogram 1.37.0, remove upon upgrade
+      showGeneStructureInTooltip: showAdvanced,
+      showProteinInTooltip: showAdvanced,
+      showParalogNeighborhoods: showAdvanced,
       onLoad() {
         // Handles edge case: when organism lacks chromosome-level assembly
         if (!genomeHasChromosomes()) {return}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "core-js": "^3.6.4",
     "exifreader": "4.6.0",
     "fflate": "^0.7.3",
-    "ideogram": "1.40.0",
+    "ideogram": "1.41.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.13.2",
     "morpheus-app": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6885,10 +6885,10 @@ identity-obj-proxy@^3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ideogram@1.40.0:
-  version "1.40.0"
-  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.40.0.tgz#23768f49d6b3351dceca5e5acc3ac1983c0f4ed4"
-  integrity sha512-mnLjBQryo/OuW0YHa1ipBw85mkscBuqvMBhTqfiWUtcDKSEcibM+11KmrAXWKeSFp/WLtMH1Hw11bRPLDlrexw==
+ideogram@1.41.0:
+  version "1.41.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.41.0.tgz#6bac8155c62dddee6df00a4dccb75329fd498522"
+  integrity sha512-+4ZTleo7aIsBBA/x5KRFJst3v5OX8arsaB1/1n2U/63mvyfEIdgdUC5jL5RycBx+DAlx+Io8cC2oVNKebFIIYA==
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"


### PR DESCRIPTION
This adds interactive RNA and protein diagrams to related genes ideogram.  It gives granular functional insight for genes.

### Overview 
Previously, tooltips shown upon hovering over a gene had only text: the gene's full name, genomic coordinates, and its relation to the searched gene.  Now, for protein-coding genes in human, diagrams are shown too.  Mature mRNA is at top, and aligned features in the corresponding protein are on bottom.  Hovering over parts of each diagram shows details, e.g. its length, and exon number or name.

#### Splice toggle
Clicking the scissors icon toggles the pre-mRNA into view.  While the _mature_ mRNA shown by default is basically equivalent to the cDNA molecule that is assayed in RNA-seq experiments, the pre-mRNA (i.e. preliminary mRNA) includes introns.

#### Alternative transcripts and isoforms
These diagrams exist for both canonical and alternative transcripts.  The [canonical transcript](https://useast.ensembl.org/info/genome/genebuild/canonical.html) is the default RNA transcript shown in traditional genome browsers.  Genes can also have other transcripts, e.g. due to alternative splicing or RNA editing.  These mRNA molecules and their corresponding proteins are often called "isoforms".  Different transcripts of the same gene are sometimes expressed in a cell type-specific manner.

### Use cases
These diagrams add value by giving granular functional insight and molecular references for genes.  For example:

* ***Easily learn more about what the gene does***.  Say you hover over a protein feature and see "GTP-binding domain".   Now you know the protein binds GTP!  Or maybe the protein feature notes it has kinase activity, and that's not deducible from the protein's full name.  Perhaps this helps you -- a biologist -- make other useful connections based on your scientific knowledge.  The new protein feature names convey key functional information about the gene you're looking at.

* ***Gauge known transcriptional complexity***.  Does your gene have 1 known transcript, or 10+?  Seeing many alternative transcripts in the "Transcripts" dropdown might warrant more care before assuming that your expression was due to the canonical transcript.

* ***Assess paralog similarity***.  Knowing that two genes are paralogs means knowing they are similar -- and now you can assess at a glance _how similar_ those genes are.  Does one gene have a much larger 3'-UTR?  Are their protein features basically the same, quite different, or somewhere in the middle?

There are potential future opportunities with sample data, e.g. integrating BAMs.  As is, though, these diagrams give unique and convenient biochemical context for genes.

Data on exons and transcripts comes from Ensembl, data on protein features comes from InterPro via Ensembl.

### <span id="video">Video</span>
Here's how it looks:

https://user-images.githubusercontent.com/1334561/212961840-1781d43f-9c1e-4bb3-95ec-2eb8c488aae7.mov

### Test
To manually verify:

1. **If local**, pull this branch, boot SCP via `bin/docker-compose-setup.sh`, navigate to a study that has human genes.  **If on staging**, Go to ["Human milk - differential expression"](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP303/human-milk-differential-expression#study-visualize) (SCP303).
2. Search for a gene
3. In related genes ideogram, hover over a gene
4. Confirm the tooltip shows RNA and protein diagrams
5. Play around with the new functionality, note anything that seems defective

Integrating this upstream Ideogram.js enhancement is a Developer's Choice Days project, tracked in SCP-4887.