### PR TITLE
Changing default session timeout to 24h with configurable 15m opt-in (SCP-4627)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -638,24 +638,25 @@ function validateCandidateUpload(formId, filename, classSelector) {
     return true;
 }
 
-// toggle inline switch and submit associated AJAX form
+/**  toggle inline switch and submit associated AJAX form */
 function submitToggleForm(toggle) {
     flipToggleSwitch(toggle)
     const formId = $(toggle).data('form-id')
-    $(`#${formId}`).submit();
+    $(`#${formId}`).submit()
 }
 
-// change toggle display and update associated hidden form input
+/** change toggle display and update associated hidden form input */
 function flipToggleSwitch(toggle) {
-    const inputId = $(toggle).data('input-id')
-    const formField = $(`#${inputId}`);
+    const jqToggle = $(toggle)
+    const inputId = jqToggle.data('input-id')
+    const formField = $(`#${inputId}`)
     const enabled = formField.val() === 'true'
     const toggleState = enabled ? 'off' : 'on'
-    const newValue = enabled ? 'false' : 'true';
-    formField.val(newValue);
-    const toggleText = enabled ? `${$(toggle).data('label-off')}` : `${$(toggle).data('label-on')}`
+    const newValue = enabled ? 'false' : 'true'
+    formField.val(newValue)
+    const toggleText = jqToggle.data(`label-${toggleState}`)
     const newText = `${toggleText} <i class='fas fa-fw fa-toggle-${toggleState}'></i>`
-    $(toggle).html(newText)
+    jqToggle.html(newText)
 }
 
 // function to call Google Analytics whenever AJAX call is made

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -638,6 +638,26 @@ function validateCandidateUpload(formId, filename, classSelector) {
     return true;
 }
 
+// toggle inline switch and submit associated AJAX form
+function submitToggleForm(toggle) {
+    flipToggleSwitch(toggle)
+    const formId = $(toggle).data('form-id')
+    $(`#${formId}`).submit();
+}
+
+// change toggle display and update associated hidden form input
+function flipToggleSwitch(toggle) {
+    const inputId = $(toggle).data('input-id')
+    const formField = $(`#${inputId}`);
+    const enabled = formField.val() === 'true'
+    const toggleState = enabled ? 'off' : 'on'
+    const newValue = enabled ? 'false' : 'true';
+    formField.val(newValue);
+    const toggleText = enabled ? `${$(toggle).data('label-off')}` : `${$(toggle).data('label-on')}`
+    const newText = `${toggleText} <i class='fas fa-fw fa-toggle-${toggleState}'></i>`
+    $(toggle).html(newText)
+}
+
 // function to call Google Analytics whenever AJAX call is made
 // must be called manually from every AJAX success or js page render
 function gaTracker(id){

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -40,9 +40,9 @@ class ProfilesController < ApplicationController
 
   def update
     if @user.update(user_params)
-      @notice = 'Admin email subscription update successfully recorded.'
+      @notice = 'Account update successfully recorded.'
     else
-      @alert = "Unable to save admin email subscription settings: #{@user.errors.map(&:full_messages).join(', ')}"
+      @alert = "Unable to save account settings: #{@user.errors.map(&:full_messages).join(', ')}"
     end
   end
 
@@ -137,7 +137,7 @@ class ProfilesController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:admin_email_delivery)
+    params.require(:user).permit(:admin_email_delivery, :use_short_session)
   end
 
   def study_share_params

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,6 +8,7 @@ class ProfilesController < ApplicationController
   ##
 
   before_action :set_user
+  before_action :set_toggle_id, only: [:update, :update_study_subscription, :update_share_subscription]
   before_action do
     authenticate_user!
     check_profile_access
@@ -42,7 +43,7 @@ class ProfilesController < ApplicationController
     if @user.update(user_params)
       @notice = 'Account update successfully recorded.'
     else
-      @alert = "Unable to save account settings: #{@user.errors.map(&:full_messages).join(', ')}"
+      @alert = @user.errors.full_messages.join(', ')
     end
   end
 
@@ -53,8 +54,9 @@ class ProfilesController < ApplicationController
     if @study.update(default_options: opts.merge(deliver_emails: update))
       @notice = 'Study email subscription update successfully recorded.'
     else
-      @alert = "Unable to save study email subscription settings: #{@share.errors.map(&:full_messages).join(', ')}"
+      @alert = @share.errors.full_messages.join(', ')
     end
+    render action: :update
   end
 
   def update_share_subscription
@@ -63,8 +65,9 @@ class ProfilesController < ApplicationController
     if @share.update(deliver_emails: update)
       @notice = 'Study email subscription update successfully recorded.'
     else
-      @alert = "Unable to save study email subscription settings: #{@share.errors.map(&:full_messages).join(', ')}"
+      @alert = @share.errors.full_messages.join(', ')
     end
+    render action: :update
   end
 
   def update_firecloud_profile
@@ -116,6 +119,10 @@ class ProfilesController < ApplicationController
   # set the requested user account
   def set_user
     @user = User.find(params[:id])
+  end
+
+  def set_toggle_id
+    @toggle_id = params[:toggle_id]
   end
 
   # make sure the current user is the same as the requested profile

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,2 +1,11 @@
 module ProfilesHelper
+  # render an on/off toggle for inline forms on profile page
+  def render_toggle(form_id, input_id, boolean_field, text_array: %w[On Off])
+    toggle_state = boolean_field ? 'on' : 'off'
+    toggle_text = boolean_field ? text_array.first : text_array.last
+    content = "<span id='toggle_#{input_id}' class='btn btn-default user-toggle' data-form-id='#{form_id}' " \
+               "data-input-id='#{input_id}' data-label-on='#{text_array.first}' data-label-off='#{text_array.last}'>" \
+               "#{toggle_text} <i class='toggle-switch fa fa-fw fa-toggle-#{toggle_state}'></i></span>"
+    content.html_safe
+  end
 end

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -442,8 +442,7 @@ class PapiClient
     end
   end
 
-  # sanitizer for GCE label value (lowercase, alphanumeric with dash & underscore only, 64 characters)
-  # see https://cloud.google.com/compute/docs/labeling-resources#requirements for more info
+  # sanitizer for GCE label value (lowercase, alphanumeric with dash & underscore only)
   #
   # * *params*
   #   - +label+ (String, Symbol, Integer) => label value
@@ -451,7 +450,7 @@ class PapiClient
   # * *returns*
   #   - (String) => lowercase label with invalid characters removed
   def sanitize_label(label)
-    label.to_s.gsub(LABEL_SANITIZER, '_').downcase.truncate(64, omission: '')
+    label.to_s.gsub(LABEL_SANITIZER, '_').downcase
   end
 
   private

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -442,7 +442,8 @@ class PapiClient
     end
   end
 
-  # sanitizer for GCE label value (lowercase, alphanumeric with dash & underscore only)
+  # sanitizer for GCE label value (lowercase, alphanumeric with dash & underscore only, 64 characters)
+  # see https://cloud.google.com/compute/docs/labeling-resources#requirements for more info
   #
   # * *params*
   #   - +label+ (String, Symbol, Integer) => label value
@@ -450,7 +451,7 @@ class PapiClient
   # * *returns*
   #   - (String) => lowercase label with invalid characters removed
   def sanitize_label(label)
-    label.to_s.gsub(LABEL_SANITIZER, '_').downcase
+    label.to_s.gsub(LABEL_SANITIZER, '_').downcase.truncate(64, omission: '')
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,7 +131,7 @@ class User
     user
   end
 
-  # overwrite Timeoutable module to check for "opt-in" short session of 15 minutes
+  # override Timeoutable module to check for "opt-in" short session of 15 minutes
   def timeout_in
     use_short_session ? SHORT_SESSION_LENGTH : self.class.timeout_in
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User
   include Mongoid::Timestamps
   include FeatureFlaggable
 
+  SHORT_SESSION_LENGTH = 15.minutes.freeze
+
   ###
   #
   # SCOPES & FIELD DEFINITIONS
@@ -96,6 +98,7 @@ class User
   # default_value from the FeatureFlag should be used.  Accordingly, the helper method feature_flags_with_defaults
   # is provided
   field :feature_flags, type: Hash, default: {}
+  field :use_short_session, type: Boolean, default: false
 
   ###
   #
@@ -126,6 +129,11 @@ class User
       user.update(refresh_token: access_token.credentials.refresh_token)
     end
     user
+  end
+
+  # overwrite Timeoutable module to check for "opt-in" short session of 15 minutes
+  def timeout_in
+    use_short_session ? SHORT_SESSION_LENGTH : self.class.timeout_in
   end
 
   # generate an access token based on user's refresh token

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -4,7 +4,7 @@
 
 <div id="profile-tab-root">
   <ul class="nav nav-tabs" role="tablist" id="profile-tabs">
-    <li role="presentation" class="profile-nav active" id="profile-emails-nav"><a href="#profile-emails" data-toggle="tab">Email Delivery</a></li>
+    <li role="presentation" class="profile-nav active" id="profile-emails-nav"><a href="#profile-emails" data-toggle="tab">Preferences</a></li>
     <% if @profiles_available %>
       <li role="presentation" class="profile-nav" id="profile-firecloud-nav"><a href="#profile-firecloud" data-toggle="tab">Terra Profile</a></li>
     <% else %>
@@ -14,12 +14,34 @@
 
   <div class="tab-content top-pad">
     <div class="tab-pane active in" id="profile-emails" role="tabpanel">
+      <%= form_for(@user, url: update_profile_path, html: {class: 'form', id: 'update-user-session', data: {remote: true}}) do |f| %>
+        <div class="form-group">
+          <%= f.hidden_field :use_short_session %>
+          <% button_text = @user.use_short_session ? "15m <i class='fas fa-fw fa-toggle-on'></i>".html_safe : "24h <i class='fas fa-fw fa-toggle-off'></i>".html_safe %>
+          <h3>
+            Session length
+            <%= link_to button_text, '#/', class: 'btn btn-default user-toggle',
+                        data: { input_id: 'user_use_short_session', form_id: 'update-user-session' } %>
+          </h3>
+          <p class="help-block">
+            Toggles how long before you are signed out of your session.  The two options are 24 hours (default) or 15
+            minutes (recommended for shared workstations or compliance environments).</p>
+        </div>
+      <% end %>
+
       <%= form_for(@user, url: update_profile_path, html: {class: 'form', id: 'update-user-profile', data: {remote: true}}) do |f| %>
         <div class="form-group">
           <%= f.hidden_field :admin_email_delivery %>
           <% button_text = @user.admin_email_delivery ? "On <i class='fas fa-fw fa-toggle-on'></i>".html_safe : "Off <i class='fas fa-fw fa-toggle-off'></i>".html_safe %>
-          <h3>Admin email delivery <%= link_to button_text, '#/', class: 'btn btn-default', id: 'toggle-admin-emails' %></h3>
-          <p class="help-block">Use this toggle to determine whether or not you would like to receive information emails from Single Cell Portal adminsitrators (new feature announcements, unplanned site maintenance, general notices, etc.).</p>
+          <h3>
+            Admin email delivery
+            <%= link_to button_text, '#/', class: 'btn btn-default user-toggle',
+                        data: { input_id: 'user_admin_email_delivery', form_id: 'update-user-profile' } %>
+          </h3>
+          <p class="help-block">
+            Toggles whether or not you would like to receive information emails from Single Cell Portal adminsitrators
+            (new feature announcements, unplanned site maintenance, general notices, etc.).
+          </p>
         </div>
       <% end %>
 
@@ -102,35 +124,45 @@
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
 
     $('.toggle-share-subscription').click(function() {
-        var button = $(this);
-        var shareId = button.data('study-share-id');
-        var form = $('#share_subscription_' + shareId);
-        var deliverEmails = form.find("input[name='study_share[deliver_emails]']");
+        let button = $(this);
+        let shareId = button.data('study-share-id');
+        let form = $('#share_subscription_' + shareId);
+        let deliverEmails = form.find("input[name='study_share[deliver_emails]']");
         // toggle hidden form field
-        var newSub = deliverEmails.val() === 'true' ? 'false' : 'true';
+        let newSub = deliverEmails.val() === 'true' ? 'false' : 'true';
         console.log('changing subscription of share ' + shareId + ' to ' + newSub);
         deliverEmails.val(newSub);
         form.submit();
     });
 
     $('.toggle-study-subscription').click(function() {
-        var button = $(this);
-        var studyId = button.data('study-id');
-        var form = $('#study_subscription_' + studyId);
-        var deliverEmails = form.find("input[name='study[default_options][deliver_emails]']");
+        let button = $(this);
+        let studyId = button.data('study-id');
+        let form = $('#study_subscription_' + studyId);
+        let deliverEmails = form.find("input[name='study[default_options][deliver_emails]']");
         // toggle hidden form field
-        var newSub = deliverEmails.val() === 'true' ? 'false' : 'true';
+        let newSub = deliverEmails.val() === 'true' ? 'false' : 'true';
         console.log('changing subscription of share ' + studyId + ' to ' + newSub);
         deliverEmails.val(newSub);
         form.submit();
     });
 
-    $('#toggle-admin-emails').click(function() {
-        var deliverEmails = $('#user_admin_email_delivery');
-        var newSub =  deliverEmails.val() === 'true' ? 'false' : 'true';
-        console.log('changing admin email delivery to ' + newSub);
-        deliverEmails.val(newSub);
-        $('#update-user-profile').submit();
+    $('.user-toggle').click(function() {
+        let inputId = $(this).data('input-id')
+        let formId = $(this).data('form-id')
+        let formField = $("#" + inputId);
+        let value =  formField.val() === 'true' ? 'false' : 'true';
+        formField.val(value);
+        let toggleState = value === 'true' ? 'on' : 'off'
+        let toggleText
+        if (formField === 'user_admin_email_delivery') {
+          toggleText = value === 'true' ? 'On' : 'Off'
+        } else {
+          toggleText = value === 'true' ? '15m' : '24h'
+        }
+        let newText = `${toggleText} <i class='fas fa-fw fa-toggle-${toggleState}'></i>`
+        $(this).html(newText)
+        $("#" + formId).submit();
     });
 
     $(document).ready(function() {

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -33,7 +33,7 @@
           </h3>
           <p class="help-block">
             Toggles how long before you are signed out of your session.  The two options are 24 hours (default) or 15
-            minutes (recommended for shared workstations or compliance environments).</p>
+            minutes (recommended for shared workstations).</p>
         </div>
       <% end %>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -4,24 +4,32 @@
 
 <div id="profile-tab-root">
   <ul class="nav nav-tabs" role="tablist" id="profile-tabs">
-    <li role="presentation" class="profile-nav active" id="profile-emails-nav"><a href="#profile-emails" data-toggle="tab">Preferences</a></li>
+    <li role="presentation" class="profile-nav active" id="profile-emails-nav">
+      <a href="#profile-emails" data-toggle="tab">Preferences</a>
+    </li>
     <% if @profiles_available %>
-      <li role="presentation" class="profile-nav" id="profile-firecloud-nav"><a href="#profile-firecloud" data-toggle="tab">Terra Profile</a></li>
+      <li role="presentation" class="profile-nav" id="profile-firecloud-nav">
+        <a href="#profile-firecloud" data-toggle="tab">Terra Profile</a>
+      </li>
     <% else %>
-      <li role="presentation" class="profile-nav disabled" id="profile-firecloud-nav"><a href="#profile-firecloud" data-toggle="tooltip" title="FireCloud profiles are currently unavailable, please check back later.">Terra Profile</a></li>
+      <li role="presentation" class="profile-nav disabled" id="profile-firecloud-nav">
+        <a href="#profile-firecloud" data-toggle="tooltip"
+           title="FireCloud profiles are currently unavailable, please check back later.">Terra Profile</a>
+      </li>
     <% end %>
   </ul>
 
   <div class="tab-content top-pad">
     <div class="tab-pane active in" id="profile-emails" role="tabpanel">
-      <%= form_for(@user, url: update_profile_path, html: {class: 'form', id: 'update-user-session', data: {remote: true}}) do |f| %>
+      <%= form_for(@user, url: update_profile_path, html: {class: 'form', id: 'update-user-session',
+                                                           data: { remote: true }}) do |f| %>
+        <%= hidden_field_tag :toggle_id, "toggle_user_use_short_session" %>
         <div class="form-group">
           <%= f.hidden_field :use_short_session %>
-          <% button_text = @user.use_short_session ? "15m <i class='fas fa-fw fa-toggle-on'></i>".html_safe : "24h <i class='fas fa-fw fa-toggle-off'></i>".html_safe %>
-          <h3>
-            Session length
-            <%= link_to button_text, '#/', class: 'btn btn-default user-toggle',
-                        data: { input_id: 'user_use_short_session', form_id: 'update-user-session' } %>
+          <h3>Session length
+            <%= render_toggle(
+                  'update-user-session', 'user_use_short_session', @user.use_short_session, text_array: %w[15m 24h]
+                ) %>
           </h3>
           <p class="help-block">
             Toggles how long before you are signed out of your session.  The two options are 24 hours (default) or 15
@@ -29,14 +37,14 @@
         </div>
       <% end %>
 
-      <%= form_for(@user, url: update_profile_path, html: {class: 'form', id: 'update-user-profile', data: {remote: true}}) do |f| %>
+      <%= form_for(@user, url: update_profile_path, html: {class: 'form', id: 'update-user-profile',
+                                                           data: { remote: true }}) do |f| %>
+        <%= hidden_field_tag :toggle_id, "toggle_user_admin_email_delivery" %>
         <div class="form-group">
           <%= f.hidden_field :admin_email_delivery %>
-          <% button_text = @user.admin_email_delivery ? "On <i class='fas fa-fw fa-toggle-on'></i>".html_safe : "Off <i class='fas fa-fw fa-toggle-off'></i>".html_safe %>
           <h3>
             Admin email delivery
-            <%= link_to button_text, '#/', class: 'btn btn-default user-toggle',
-                        data: { input_id: 'user_admin_email_delivery', form_id: 'update-user-profile' } %>
+            <%= render_toggle('update-user-profile', 'user_admin_email_delivery', @user.admin_email_delivery) %>
           </h3>
           <p class="help-block">
             Toggles whether or not you would like to receive information emails from Single Cell Portal adminsitrators
@@ -47,8 +55,14 @@
 
       <h3>My study subscriptions</h3>
       <div class="bs-callout bs-callout-default">
-        <p>Use the table below to manage email delivery for all studies that are accessible to you.  You do not receive notification emails for studies when you make changes, only when others do.</p>
-        <p class="text-primary"><i class="fas fa-fw fa-info-circle"></i> Note: You will still receive emails with the results of parsing from files you upload, and automated emails from Terra on study sharing changes.</p>
+        <p>
+          Use the table below to manage email delivery for all studies that are accessible to you.  You do not receive
+          notification emails for studies when you make changes, only when others do.
+        </p>
+        <p class="text-primary">
+          <i class="fas fa-fw fa-info-circle"></i> Note: You will still receive emails with the results of parsing from
+          files you upload, and automated emails from Terra on study sharing changes.
+        </p>
       </div>
       <table class="table table-striped">
         <thead>
@@ -66,12 +80,20 @@
             <td><%= study.firecloud_project %></td>
             <td>Owner</td>
             <td>
-              <%= form_for(study, url: update_study_subscription_path(id: @user.id, study_id: study.id), html: {class: 'form-inline', id: "study_subscription_#{study.id}", data: {remote: true}}) do |f| %>
+              <%= form_for(study, url: update_study_subscription_path(id: @user.id, study_id: study.id),
+                           html: {class: 'form-inline', id: "study_subscription_#{study.id}",
+                                  data: {remote: true}}) do |f| %>
+                <%= hidden_field_tag :toggle_id, "toggle_study_default_options_deliver_emails_#{study.id}" %>
                 <div class="form-group">
                   <%= f.fields_for(:default_options) do |opts| %>
-                    <%= opts.hidden_field :deliver_emails, value: study.deliver_emails? %>
+                    <%= opts.hidden_field :deliver_emails?, value: study.deliver_emails?,
+                                          id: "study_default_options_deliver_emails_#{study.id}" %>
                   <% end %>
-                  <span class="btn btn-default toggle-study-subscription" data-study-id="<%= study.id %>"><%= study.deliver_emails? ? "On" : "Off" %> <i class="toggle-switch fa fa-fw fa-toggle-<%= study.deliver_emails? ? 'on' : 'off' %>"></i></span>
+                  <%= render_toggle(
+                        "study_subscription_#{study.id}",
+                        "study_default_options_deliver_emails_#{study.id}",
+                        study.deliver_emails?
+                      ) %>
                 </div>
               <% end %>
             </td>
@@ -84,10 +106,18 @@
             <td><%= share.firecloud_project %></td>
             <td><%= share.permission %></td>
             <td>
-              <%= form_for(share, url: update_share_subscription_path(id: @user.id, study_share_id: share.id), html: {class: 'form-inline', id: "share_subscription_#{share.id}", data: {remote: true}}) do |f| %>
+              <%= form_for(share, url: update_share_subscription_path(id: @user.id, study_share_id: share.id),
+                           html: {class: 'form-inline', id: "share_subscription_#{share.id}",
+                                  data: {remote: true}}) do |f| %>
+                <%= hidden_field_tag :toggle_id, "toggle_study_default_options_deliver_emails_#{study.id}" %>
                 <div class="form-group">
-                  <%= f.hidden_field :deliver_emails, value: share.deliver_emails %>
-                  <span class="btn btn-default toggle-share-subscription" data-study-share-id="<%= share.id %>"><%= share.deliver_emails ? "On" : "Off" %> <i class="toggle-switch fa fa-fw fa-toggle-<%= share.deliver_emails? ? 'on' : 'off' %>"></i></span>
+                  <%= f.hidden_field :deliver_emails, value: share.deliver_emails,
+                                     id: "study_default_options_deliver_emails_#{share.id}" %>
+                  <%= render_toggle(
+                        "share_subscription_#{share.id}",
+                        "study_default_options_deliver_emails_#{share.id}",
+                        share.deliver_emails
+                      ) %>
                 </div>
               <% end %>
             </td>
@@ -123,46 +153,8 @@
 
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
 
-    $('.toggle-share-subscription').click(function() {
-        let button = $(this);
-        let shareId = button.data('study-share-id');
-        let form = $('#share_subscription_' + shareId);
-        let deliverEmails = form.find("input[name='study_share[deliver_emails]']");
-        // toggle hidden form field
-        let newSub = deliverEmails.val() === 'true' ? 'false' : 'true';
-        console.log('changing subscription of share ' + shareId + ' to ' + newSub);
-        deliverEmails.val(newSub);
-        form.submit();
-    });
-
-    $('.toggle-study-subscription').click(function() {
-        let button = $(this);
-        let studyId = button.data('study-id');
-        let form = $('#study_subscription_' + studyId);
-        let deliverEmails = form.find("input[name='study[default_options][deliver_emails]']");
-        // toggle hidden form field
-        let newSub = deliverEmails.val() === 'true' ? 'false' : 'true';
-        console.log('changing subscription of share ' + studyId + ' to ' + newSub);
-        deliverEmails.val(newSub);
-        form.submit();
-    });
-
     $('.user-toggle').click(function() {
-        let inputId = $(this).data('input-id')
-        let formId = $(this).data('form-id')
-        let formField = $("#" + inputId);
-        let value =  formField.val() === 'true' ? 'false' : 'true';
-        formField.val(value);
-        let toggleState = value === 'true' ? 'on' : 'off'
-        let toggleText
-        if (formField === 'user_admin_email_delivery') {
-          toggleText = value === 'true' ? 'On' : 'Off'
-        } else {
-          toggleText = value === 'true' ? '15m' : '24h'
-        }
-        let newText = `${toggleText} <i class='fas fa-fw fa-toggle-${toggleState}'></i>`
-        $(this).html(newText)
-        $("#" + formId).submit();
+      submitToggleForm(this)
     });
 
     $(document).ready(function() {

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -8,13 +8,13 @@
       <a href="#profile-emails" data-toggle="tab">Preferences</a>
     </li>
     <% if @profiles_available %>
-      <li role="presentation" class="profile-nav" id="profile-firecloud-nav">
-        <a href="#profile-firecloud" data-toggle="tab">Terra Profile</a>
+      <li role="presentation" class="profile-nav" id="profile-terra-nav">
+        <a href="#profile-terra" data-toggle="tab">Terra Profile</a>
       </li>
     <% else %>
-      <li role="presentation" class="profile-nav disabled" id="profile-firecloud-nav">
-        <a href="#profile-firecloud" data-toggle="tooltip"
-           title="FireCloud profiles are currently unavailable, please check back later.">Terra Profile</a>
+      <li role="presentation" class="profile-nav disabled" id="profile-terra-nav">
+        <a href="#profile-terra" data-toggle="tooltip"
+           title="Terra profiles are currently unavailable, please check back later.">Terra Profile</a>
       </li>
     <% end %>
   </ul>
@@ -127,7 +127,7 @@
       </table>
     </div>
     <% if @profiles_available %>
-      <div class="tab-pane" id="profile-firecloud" role="tabpanel">
+      <div class="tab-pane" id="profile-terra" role="tabpanel">
         <% if current_user.registered_for_firecloud %>
           <%= render partial: 'user_firecloud_profile' %>
         <% else %>

--- a/app/views/profiles/update.js.erb
+++ b/app/views/profiles/update.js.erb
@@ -1,4 +1,5 @@
-if (<%= @notice.present? %>) {
+const isNoticePresent = <%= @notice.present? %>
+if (isNoticePresent) {
   // modal unnecessary as toggle has already changed
   console.log('<%= @notice %>')
 } else {

--- a/app/views/profiles/update.js.erb
+++ b/app/views/profiles/update.js.erb
@@ -1,3 +1,3 @@
-var button = $("#toggle-admin-emails");
-var newText = "<%= @user.admin_email_delivery ? "On <i class='fas fa-fw fa-toggle-on'></i>".html_safe : "Off <i class='fas fa-fw fa-toggle-off'></i>".html_safe %>";
-button.html(newText);
+if (<%= @alert.present? %>) {
+  alert('<%= @alert %>')
+}

--- a/app/views/profiles/update.js.erb
+++ b/app/views/profiles/update.js.erb
@@ -1,3 +1,15 @@
-if (<%= @alert.present? %>) {
-  alert('<%= @alert %>')
+if (<%= @notice.present? %>) {
+  // modal unnecessary as toggle has already changed
+  console.log('<%= @notice %>')
+} else {
+  // show error message
+  const errorMsg = '<%= @alert %>'
+  $('#generic-modal .modal-body').html(`<p class="text-danger text-center">${errorMsg}</p>`)
+  $('#generic-modal-spinner').remove('spinner-target')
+  $('#generic-modal-title').html('Unable to save profile settings')
+  $('#generic-modal-footer').remove()
+  $('#generic-modal').modal('show')
+  // reset toggle & form state
+  const toggleId = "<%= @toggle_id %>"
+  flipToggleSwitch($(`#${toggleId}`))
 }

--- a/app/views/profiles/update_share_subscription.js.erb
+++ b/app/views/profiles/update_share_subscription.js.erb
@@ -1,3 +1,0 @@
-var button = $("[data-study-share-id='<%= params[:study_share_id] %>']");
-var newText = "<%= @share.deliver_emails ? "On <i class='fas fa-fw fa-toggle-on'></i>".html_safe : "Off <i class='fas fa-fw fa-toggle-off'></i>".html_safe %>";
-button.html(newText);

--- a/app/views/profiles/update_study_subscription.js.erb
+++ b/app/views/profiles/update_study_subscription.js.erb
@@ -1,3 +1,0 @@
-var button = $("[data-study-id='<%= params[:study_id] %>']");
-var newText = "<%= @study.deliver_emails? ? "On <i class='fas fa-fw fa-toggle-on'></i>".html_safe : "Off <i class='fas fa-fw fa-toggle-off'></i>".html_safe %>";
-button.html(newText);

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -155,7 +155,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 30.minutes
+  config.timeout_in = 24.hours
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
#### BACKGROUND
The current timeout for session inactivity in SCP is 30 minutes, which was originally set as a compliance requirement.  We have since learned that this is not strictly necessary - Terra has a session timeout of 24 hours, for instance.  Increasing the timeout will allow for fewer user disruptions as they switch tasks and then come back to an active SCP window later.

#### CHANGES
This update increases the default timeout to 24 hours for all users.  In addition, there is a new "opt-in" timeout length of 15 minutes for users who do not want long sessions.  This can be useful for users with shared workstations.  This update also refines the inline form submission logic on the user profile page to be more consistent with shared functions, and reduces latency on updating the UI when toggling values (much longer in local development, but still a noticeable lag on production).  Lastly, it fixes broken code with rendering errors, and now only shows a modal if the profile update fails - successful saves have their state shown in the UI and as such do not require a "success" modal.

#### MANUAL TESTING (if desired)
1. Boot as normal and sign in
2. From the top-righthand menu, select "My profile"
3. Note that the default value for your session is now 24 hours
![Screen Shot 2023-01-18 at 1 14 08 PM](https://user-images.githubusercontent.com/729968/213261910-edc66b20-4039-43c1-a98a-e40f053a9dbc.png)
4. Open Chrome DevTools and go to the Javascript console
5. Back in the UI, toggle the Session length switch and note that the console reads `Account update successfully recorded.` after a few seconds, confirming that the save was successful.
6. Toggle any other switch and confirm you see similar messages
7. (Optional) to test error rendering, open `app/controllers/profiles_controller.rb` in your IDE and update lines 43-44 to read:
```
update_params = user_params.to_unsafe_hash.merge(email: 'foo')
if @user.update(update_params)
```
8. (Optional) toggle the Session length switch again, and confirm you see the following modal:
![Screen Shot 2023-01-18 at 1 14 25 PM](https://user-images.githubusercontent.com/729968/213261929-dc1bd46d-e31b-4755-8c30-6200238be56e.png)
9. (Optional) confirm that the Session length switch reverted back to its previous state