### PR TITLE
Truncate all GCP resource labels to 63 characters (SCP-4931)

### DIFF
--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -442,7 +442,7 @@ class PapiClient
     end
   end
 
-  # sanitizer for GCE label value (lowercase, alphanumeric with dash & underscore only, 64 characters)
+  # sanitizer for GCE label value (lowercase, alphanumeric with dash & underscore only, 63 characters)
   # see https://cloud.google.com/compute/docs/labeling-resources#requirements for more info
   #
   # * *params*
@@ -451,7 +451,7 @@ class PapiClient
   # * *returns*
   #   - (String) => lowercase label with invalid characters removed
   def sanitize_label(label)
-    label.to_s.gsub(LABEL_SANITIZER, '_').downcase[0...64]
+    label.to_s.gsub(LABEL_SANITIZER, '_').downcase[0...63]
   end
 
   private

--- a/test/models/papi_client_test.rb
+++ b/test/models/papi_client_test.rb
@@ -274,7 +274,7 @@ class PapiClientTest < ActiveSupport::TestCase
     # test length truncation
     long_label = SecureRandom.alphanumeric(128)
     sanitized_label = @client.sanitize_label(long_label)
-    assert_equal 64, sanitized_label.chars.size
-    assert_equal long_label.downcase.truncate(64, omission: ''), sanitized_label
+    assert_equal 63, sanitized_label.chars.size
+    assert_equal long_label.downcase.truncate(63, omission: ''), sanitized_label
   end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a bug where filenames longer than 63 characters result in an invalid GCP resource label. This prevents the file from being ingested as the job cannot be queued due to `Google::Apis::ClientError:badRequest: Error: validating pipeline: invalid VM label value` being thrown.  This is not recoverable unless the user shortens the filename, which is completely opaque to the end user.  All resource labels are now truncated at 63 characters.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Go to the upload wizard for any study
3. Open a new terminal window, navigate to project source, and run the following command to create a cluster file with a filename longer than 63 characters:
```
cp test/test_data/cluster_example.txt ~/Desktop/$(openssl rand -hex 40).txt
```
4. Upload this new file as a clustering file, confirm the job queues in PAPI, and that you can see the truncated filename as a label on the virtual machine in `development.log`:
```
Request object sent to Google Pipelines API (PAPI), excluding 'environment' parameters:
---
:actions:
  :commands:
  - python
  - ingest_pipeline.py
...

  :virtual_machine:
    :boot_disk_size_gb: 300
    :labels:
      :study_accession: scp52
      :user_id: 6033f4a8e2413917a1d0ddcd
      :filename: d8bfeb07f0299f75ed260e8adcf14279a24b87d224f93ed50ade9bddad56f6a
      :action: ingest_pipeline
...

Ingest run initiated: projects/broad-singlecellportal-bistlin/operations/10279437626310948347, queueing Ingest poller

```