### PR TITLE
Reducing false positives for Codecov integration (SCP-4502)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,3 +9,4 @@ coverage:
   project:
     default:
       threshold: 0.1%
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,8 +5,7 @@ comment:
   behavior: default
 coverage:
   status:
+    project:
+      default:
+        threshold: 0.1%
     patch: off
-  project:
-    default:
-      threshold: 0.1%
-

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,9 @@ codecov:
 comment:
   layout: "reach, diff, files"
   behavior: default
+coverage:
+  status:
+    patch: off
+  project:
+    default:
+      threshold: 0.1%


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update alters metrics for Codecov in an effort to reduce false positives on coverage calculations that fail PR checks.  The `patch` check has been disabled in favor of `project`, since global coverage is the published metric for this repository.  Additionally, an analysis of recently closed PRs with a failed Codecov check has shown that these failures were due to a drop in global coverage of ~0.05%.  The threshold for failing has now been increased to 0.1% to reduce these uninformative failed checks.

#### MANUAL TESTING
The checks section below should only display the `codecov/project` check, and it should pass since coverage is not affected by this update.