### PR TITLE
Restrict automated differential expression jobs to cell type annotations (SCP-4953)

### DIFF
--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -267,15 +267,30 @@ class IngestJobTest < ActiveSupport::TestCase
       :metadata_file, name: 'metadata.txt', study: study, cell_input: %w[A B C],
       annotation_input: [
         { name: 'species', type: 'group', values: %w[dog cat dog] },
-        { name: 'disease', type: 'group', values: %w[none none measles] }
+        { name: 'disease', type: 'group', values: %w[none none measles] },
+        {
+          name: 'cell_type__ontology_label',
+          type: 'group',
+          values: ['B cell', 'T cell', 'B cell', ]
+        },
+        {
+          name: 'cell_type',
+          type: 'group',
+          values: %w[CL_0000236 CL_0000084 CL_0000236]
+        },
+        {
+          name: 'cell_type__custom',
+          type: 'group',
+          values: %w[ImmN Hb-VC ImmN]
+        }
       ])
     job = IngestJob.new(study:)
     job_mock = Minitest::Mock.new
-    3.times do
+    2.times do
       job_mock.expect(:push_remote_and_launch_ingest, Delayed::Job.new)
     end
     mock = Minitest::Mock.new
-    3.times do
+    2.times do
       mock.expect(:delay, job_mock)
     end
     IngestJob.stub :new, mock do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update restricts the cases in which an automated differential expression job is launched to only annotations that are a cell type analog of some kind.  Previously, the restrictions for annotations were that they had to be group-based with between 2 and 250 unique values.  Now, we check the name of the annotation against the regular expression `/cell.*type/i` as well.  It should be noted that this is only for automated jobs - it is still possible to run differential expression jobs manually via the `DifferentialExpressionService.run_differential_expression_job` method.  This update is in service of two issues: 1) reducing the amount of "churn" in the form of needless differential expression jobs that end up getting deleted when the parent file is removed, and 2) restrict automated jobs to annotations that we believe are of higher relevance for differential expression analysis.  User interviews have indicated that cell type is a good candidate to begin with.  As we move forward, we may find other annotations (like Seurat clustering, for example) that may also be good proxies.

A check of the production database showed a count of 6941 for annotations matching our current rules.  Adding in the cell type restriction drops that to 661, a reduction of over 90%.

#### MANUAL TESTING
Note: if you do not have the `Human milk - differential expression` study loaded, you can download the [metadata file](https://console.cloud.google.com/storage/browser/_details/broad-singlecellportal-public/test/studies/SCP1671/MIT_milk_study_metadata.csv.gz;tab=live_object?project=broad-singlecellportal) and ingest it locally in a new study (we don't need clustering/expression for this test)
1. Pull branch and enter a Rails console session
2. Load the `Human milk - differential expression` study
```
study = Study.find_by(name: 'Human milk - differential expression')
```
3. Find all eligible annotations for the above study and confirm you only get back `General_Celltype` and `cell_type__ontology_label`
```
 DifferentialExpressionService.find_eligible_annotations(study)
=> 
[{:annotation_name=>"General_Celltype", :annotation_scope=>"study"},                                
 {:annotation_name=>"cell_type__ontology_label", :annotation_scope=>"study"}]
```