### PR TITLE
Patch for bug in Explore Tab after multi gene search and annotation & consensus toggling (SCP-4800)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -368,7 +368,7 @@ function RawScatterPlot({
 
   // Fetches plot data then draws it, upon load or change of any data parameter
   useEffect(() => {
-    /** */
+    /** retrieve and process data */
     async function getData() {
       setIsLoading(true)
 

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -181,9 +181,12 @@ function RawScatterPlot({
       isSplitLabelArrays: isSplitLabelArrays ?? scatter.isSplitLabelArrays,
       isRefGroup: isRG
     })
+    // debugger
     if (isRG) {
       setCountsByLabel(labelCounts)
     }
+
+    //EMiLY the traces here are legit and coming thru not undefined in teh debug
 
     return traces
   }
@@ -200,16 +203,20 @@ function RawScatterPlot({
 
 
   /** Fetch cached data from bucket, use it to draw *interactive* gene expression scatter plot */
-  function renderBucketData(fetchMethod, expressionParams, dataPath) {
-    fetchBucketFile(bucketId, dataPath).then(async response => {
-      const expressionArray = await response.json()
+  async function renderBucketData(fetchMethod, expressionParams, dataPath) {
+    try {
+      const bucketFileDataResp = await fetchBucketFile(bucketId, dataPath)
+      const expressionArray = await bucketFileDataResp.json()
       expressionParams.expressionArray = expressionArray
-      fetchMethod(expressionParams).then(processScatterPlot).catch(error => {
-        setIsLoading(false)
-        setShowError(true)
-        setError(error)
-      })
-    })
+
+      const response = await fetchMethod(expressionParams)
+      processScatterPlot(response)
+    } catch (error) {
+      debugger
+      setIsLoading(false)
+      // setShowError(true)
+      // setError(error)
+    }
   }
 
   /** Draw static image of gene expression scatter plot */
@@ -322,11 +329,12 @@ function RawScatterPlot({
   function processScatterPlot(clusterResponse=null) {
     let [scatter, perfTimes] =
       (clusterResponse ? clusterResponse : [scatterData, null])
-
+      debugger
     scatter = updateScatterLayout(scatter)
     const layout = scatter.layout
 
     const plotlyTraces = updateCountsAndGetTraces(scatter)
+    console.log('plotlyTraces:', plotlyTraces)
 
     const startTime = performance.now()
 
@@ -370,74 +378,168 @@ function RawScatterPlot({
 
   // Fetches plot data then draws it, upon load or change of any data parameter
   useEffect(() => {
-    setIsLoading(true)
+    /** */
+    async function getData() {
+      setIsLoading(true)
 
-    let expressionArray
+      let expressionArray
 
-    const fetchMethod = dataCache ? dataCache.fetchCluster : fetchCluster
+      // const fetchMethod = dataCache ? dataCache.fetchCluster : fetchCluster
 
-    // use an image and/or data cache if one has been provided, otherwise query scp-api directly
-    if (
-      flags?.progressive_loading && isGeneExpression(genes, isCorrelatedScatter) && !isAnnotatedScatter &&
-      !scatterData
-    ) {
-      const urlSafeCluster = cluster.replaceAll('+', 'pos').replace(/\W/g, '_')
-      const gene = genes[0]
-      const stem = '_scp_internal/cache/expression_scatter/'
-      const leaf = `${urlSafeCluster}/${gene}`
+      // use an image and/or data cache if one has been provided, otherwise query scp-api directly
+      if (
+        flags?.progressive_loading && isGeneExpression(genes, isCorrelatedScatter) && !isAnnotatedScatter &&
+        !scatterData
+      ) {
+        console.log('inside this if')
+        const urlSafeCluster = cluster.replaceAll('+', 'pos').replace(/\W/g, '_')
+        const gene = genes[0]
+        const stem = '_scp_internal/cache/expression_scatter/'
+        const leaf = `${urlSafeCluster}/${gene}`
 
-      // TODO (SCP-4839): Instrument more bucket cache analytics, then remove line below
-      // window.t0 = Date.now()
+        // TODO (SCP-4839): Instrument more bucket cache analytics, then remove line below
+        // window.t0 = Date.now()
 
-      const imagePath = `${stem}images/${leaf}.webp`
-      const dataPath = `${stem}data/${leaf}.json`
+        const imagePath = `${stem}images/${leaf}.webp`
+        const dataPath = `${stem}data/${leaf}.json`
 
-      const expressionParams = {
-        studyAccession,
-        cluster,
-        annotation: annotation ? annotation : '',
-        subsample,
-        consensus,
-        genes,
-        isAnnotatedScatter,
-        isCorrelatedScatter
-      }
-
-      fetchBucketFile(bucketId, imagePath).then(async response => {
-        const imageCacheHit = response.ok
-
-        // Draw plot as static image first, if it's cached
-        if (imageCacheHit) {
-          await drawPlotImage(response)
+        const expressionParams = {
+          studyAccession,
+          cluster,
+          annotation: annotation ? annotation : '',
+          subsample,
+          consensus,
+          genes,
+          isAnnotatedScatter,
+          isCorrelatedScatter
         }
 
-        // Then make it interactive, using gene expression scatter plot data array from GCS bucket
-        renderBucketData(fetchMethod, expressionParams, dataPath)
+        fetchBucketFile(bucketId, imagePath).then(async response => {
+          const imageCacheHit = response.ok
 
-        // TODO (SCP-4839): Instrument more bucket cache analytics, then remove console log below
-        // console.log(`Image render took ${ Date.now() - window.t0}`)
-        // Add imageCacheHit boolean to perfTime object here
-      })
-    } else {
-      fetchMethod({
-        studyAccession,
-        cluster,
-        annotation: annotation ? annotation : '',
-        subsample,
-        consensus,
-        genes,
-        isAnnotatedScatter,
-        isCorrelatedScatter,
-        expressionArray
-      }).then(processScatterPlot).catch(error => {
-        setIsLoading(false)
-        setShowError(true)
-        setError(error)
-      })
+          // Draw plot as static image first, if it's cached
+          if (imageCacheHit) {
+            await drawPlotImage(response)
+          }
+
+          // Then make it interactive, using gene expression scatter plot data array from GCS bucket
+          await renderBucketData(fetchMethod, expressionParams, dataPath)
+
+          // TODO (SCP-4839): Instrument more bucket cache analytics, then remove console log below
+          // console.log(`Image render took ${ Date.now() - window.t0}`)
+          // Add imageCacheHit boolean to perfTime object here
+        })
+      } else {
+        try {
+          const respData = await fetchCluster({
+            studyAccession,
+            cluster,
+            annotation: annotation ? annotation : '',
+            subsample,
+            consensus,
+            genes,
+            isAnnotatedScatter,
+            isCorrelatedScatter,
+            expressionArray
+          })
+          processScatterPlot(respData)
+        } catch (error) {
+          debugger
+          setIsLoading(false)
+          setShowError(true)
+          setError(error)
+        }
+      }
     }
-  }, [cluster, annotation.name, subsample, consensus, genes.join(','), isAnnotatedScatter])
+    getData()
+  }, [cluster, annotation.name, subsample, genes.join(','), isAnnotatedScatter, consensus])
+
+  // Fetches plot data then draws it, upon load or change of any data parameter
+  useEffect(() => {
+    /** */
+    async function getData() {
+      setIsLoading(true)
+
+      let expressionArray
+
+      const fetchMethod = dataCache ? dataCache.fetchCluster : fetchCluster
+
+      // use an image and/or data cache if one has been provided, otherwise query scp-api directly
+      if (
+        flags?.progressive_loading && isGeneExpression(genes, isCorrelatedScatter) && !isAnnotatedScatter &&
+        !scatterData
+      ) {
+        console.log('inside this if')
+        const urlSafeCluster = cluster.replaceAll('+', 'pos').replace(/\W/g, '_')
+        const gene = genes[0]
+        const stem = '_scp_internal/cache/expression_scatter/'
+        const leaf = `${urlSafeCluster}/${gene}`
+
+        // TODO (SCP-4839): Instrument more bucket cache analytics, then remove line below
+        // window.t0 = Date.now()
+
+        const imagePath = `${stem}images/${leaf}.webp`
+        const dataPath = `${stem}data/${leaf}.json`
+
+        const expressionParams = {
+          studyAccession,
+          cluster,
+          annotation: annotation ? annotation : '',
+          subsample,
+          consensus,
+          genes,
+          isAnnotatedScatter,
+          isCorrelatedScatter
+        }
+
+        fetchBucketFile(bucketId, imagePath).then(async response => {
+          const imageCacheHit = response.ok
+
+          // Draw plot as static image first, if it's cached
+          if (imageCacheHit) {
+            await drawPlotImage(response)
+          }
+
+          // Then make it interactive, using gene expression scatter plot data array from GCS bucket
+          await renderBucketData(fetchMethod, expressionParams, dataPath)
+
+          // TODO (SCP-4839): Instrument more bucket cache analytics, then remove console log below
+          // console.log(`Image render took ${ Date.now() - window.t0}`)
+          // Add imageCacheHit boolean to perfTime object here
+        })
+      } else {
+        try {
+          const respData = await fetchMethod({
+            studyAccession,
+            cluster,
+            annotation: annotation ? annotation : '',
+            subsample,
+            consensus,
+            genes,
+            isAnnotatedScatter,
+            isCorrelatedScatter,
+            expressionArray
+          })
+          processScatterPlot(respData)
+        } catch (error) {
+          debugger
+          setIsLoading(false)
+          setShowError(true)
+          setError(error)
+        }
+      }
+    }
+    getData()
+  }, [cluster, annotation.name, subsample, genes.join(','), isAnnotatedScatter])
+
+
+
+
 
   useUpdateEffect(() => {
+    debugger
+//EMILY would be surprised if it's in here
+
     // Don't update if graph hasn't loaded
     if (scatterData && !isLoading) {
       scatterData.customColors = customColors

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -420,7 +420,7 @@ function RawScatterPlot({
         })
       } else {
         try {
-          // attempt to fetch the data using the cache if that exists
+          // attempt to fetch the data, this will use the cache if available
           const respData1 = await fetchMethod({
             studyAccession,
             cluster,
@@ -436,7 +436,7 @@ function RawScatterPlot({
           if (respData1[0]?.data?.annotations?.length) {
             processScatterPlot(respData1)
           } else {
-            // if the cache data was missing the necessary info make an api call
+            // if the data was missing the necessary info, make an api call
             const respData = await fetchCluster({
               studyAccession,
               cluster,

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -369,7 +369,7 @@ function RawScatterPlot({
   // Fetches plot data then draws it, upon load or change of any data parameter
   useEffect(() => {
     /** retrieve and process data */
-    async function getData() {
+    async function fetchData() {
       setIsLoading(true)
 
       let expressionArray
@@ -457,7 +457,7 @@ function RawScatterPlot({
         }
       }
     }
-    getData()
+    fetchData()
   }, [cluster, annotation.name, subsample, genes.join(','), isAnnotatedScatter, consensus])
 
   useUpdateEffect(() => {


### PR DESCRIPTION
There is an issue with the data available in the ExploreTab when a user performs a multi-gene search and then attempts to toggle between Annotations and Consensus mechanisms. This results in a few errors mostly like "Cannot read properties of undefined (reading 'reduce')" from the plots attempting to update but not having good data to complete. I believe there are a few issues involved here around stale state and data however, this would require substantial refactor work of how these multiple plots and inputs interact. 

Instead here I am suggesting two updates that I believe patches this bug. 

The main section that is causing this issue comes from the `UseEffect` that is called when any plot data parameter updates.  Included in this `UseEffect` is a fetch to retrieve data. 

1. This fetch was previously called utilizing the javascript Promise construct of `.then()` but I am changing to use the construct of `await` instead. `.then()` and `await` are similar in that they are used to handle the result of a Promise however, a key difference is that `.then()` does not block the current execution (is more truly asynchronous) while `await` does block. In this case the fetch is being used to retrieve data and the next action is using this data, so it would be best to block and wait for this data to finish resolving before continuing. This is achieved using `await`. 

2. Retry on failure of good data. The fetch of the data in this `UseEffect` attempts to use the cached data if available, however in case this does not return good data I have added a "retry" to call the API for the data. Future work could certainly include digging into the cache code to fix any possibility of "bad" data from this, however, I believe this will be much more involved and I think it is best to have a fallback to the API data which, presumably, is the source of truth, in general.


To test: 
- Pull this branch and boot up a local server
- You do not need to sign in, navigate to a study with multiple genes and go to the explore tab
- Search for two genes
- Use the "Collapse by" menu and collapse to Mean or Median
- Change the annotation
- Now use the "Collapse by" menu again and choose whichever (mean or median) you hadn't chose before
- This should not result in an error
- Feel free to continue playing around with toggling annotations and consensus mechanisms to ensure no error comes up.
- Compare to Staging or Prod following these same steps to see the bug

Example error
![Screen Shot 2023-02-03 at 3 32 03 PM](https://user-images.githubusercontent.com/54322292/216705196-be63b3f1-cc23-44cb-9d6c-4adbf29f085e.png)
