### PR TITLE
Update instructions for Terra Terms of Service (SCP-4929)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -167,8 +167,9 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # Kludge to fix problem with signed-in users not having accepted Terra Terms of Service
-  # Details: https://broadworkbench.atlassian.net/browse/SCP-4929
+  # Temporary sub-optimal fix for signed-in users not having accepted Terra Terms of Service
+  # Context: https://broadworkbench.atlassian.net/browse/SCP-4929
+  # TODO (SCP-4971): intercept API calls that need end-user credentials, and handle this at that level
   def check_terra_tos_acceptance
     if user_signed_in? && current_user.must_accept_terra_tos? && request.path != exceptions_terra_tos_path
       redirect_to exceptions_terra_tos_path and return

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  before_action :check_terra_tos_acceptance
   before_action :get_download_quota
   before_action :get_deployment_notification
   before_action :set_selected_branding_group
@@ -163,6 +164,14 @@ class ApplicationController < ActionController::Base
   def set_selected_branding_group
     if params[:scpbr].present?
       @selected_branding_group = BrandingGroup.find_by(name_as_id: params[:scpbr])
+    end
+  end
+
+  # Kludge to fix problem with signed-in users not having accepted Terra Terms of Service
+  # Details: https://broadworkbench.atlassian.net/browse/SCP-4929
+  def check_terra_tos_acceptance
+    if user_signed_in? && current_user.must_accept_terra_tos? && request.path != exceptions_terra_tos_path
+      redirect_to exceptions_terra_tos_path and return
     end
   end
 

--- a/app/controllers/exceptions_controller.rb
+++ b/app/controllers/exceptions_controller.rb
@@ -12,4 +12,6 @@ class ExceptionsController < ApplicationController
       end
     end
   end
+
+  def terra_tos; end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -28,9 +28,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @alert = nil
       # check if user needs to accept updated Terra ToS
       if @user.must_accept_terra_tos?
-        @alert = 'Terra has updated their Terms of Service.  Please visit ' \
-                 "<a href='https://app.terra.bio' target='_blank'>Terra</a> to accept the updated terms.  Some " \
-                 'features may not function correctly until you do so.'
+        redirect_to exceptions_terra_tos_path and return
       end
       if TosAcceptance.accepted?(@user)
         MetricsService.merge_identities_in_mixpanel(@user, cookies)

--- a/app/views/exceptions/render_error.html.erb
+++ b/app/views/exceptions/render_error.html.erb
@@ -6,6 +6,7 @@
         <p class="lead text-center">This error has been reported to support staff. If you require immediate assistance,
           please send an email to <%= mail_to 'scp-support@broadinstitute.zendesk.com', 'scp-support@broadinstitute.zendesk.com' %>
         </p>
+        <p>Please also ensure you have accepted the <a href='https://app.terra.bio/#terms-of-service' target='_blank'>Terra Terms of Service</a>.</p>
       </div>
     </div>
   </div>

--- a/app/views/exceptions/terra_tos.html
+++ b/app/views/exceptions/terra_tos.html
@@ -9,8 +9,8 @@
           <ol>
             <li>Go to <a href='https://app.terra.bio' target='_blank'>Terra</a>.</li>
             <li>Log in with your Google account.</li>
-            <li><i>After you have logged in on Terra</i> the <a href='https://app.terra.bio#terms-of-service' target='_blank'>Terra Terms of Service</a> will load.</li>
-            <li>In Terra, click "ACCEPT" for the new Terms.  Note: there is also an "AGREE" button at the very bottom of the page about cookies.  You will need to click "ACCEPT" on the form in the middle of the page; the cookie agreement is separate.</li>
+            <li><i>After you have logged in on Terra</i>, the <a href='https://app.terra.bio#terms-of-service' target='_blank'>Terra Terms of Service</a> will load.</li>
+            <li>In Terra, click "ACCEPT" for the new Terms.  Note: there is also an "AGREE" button at the very bottom of the page about cookies.  You will need to click "ACCEPT" terms on the form in the middle of the page; agreeing to cookies is not needed to use Single Cell Portal.</li>
             <li>In SCP, click the Single Cell Portal icon at top left of the page to go to the home page.  You can now use Single Cell Portal.</li>
           </ol>
         </p>

--- a/app/views/exceptions/terra_tos.html
+++ b/app/views/exceptions/terra_tos.html
@@ -1,0 +1,20 @@
+<div class="container-fluid" id="wrap">
+  <div class="row section-pad" id="main-body">
+    <div class="col-md-12">
+      <div class="bs-callout bs-callout-danger">
+        <h3 class="text-danger text-center">Required action</h3>
+        <p class="lead text-center">
+          Terra has updated their Terms of Service.  Please accept the new <a href='https://app.terra.bio' target='_blank'>Terra Terms of Service</a>.  Single
+          Cell Portal will not work properly until you do so.  You can accept the new Terra Terms of Service like so:
+          <ol>
+            <li>Go to <a href='https://app.terra.bio' target='_blank'>Terra</a>.</li>
+            <li>Log in with your Google account.</li>
+            <li><i>After you have logged in on Terra</i> the <a href='https://app.terra.bio#terms-of-service' target='_blank'>Terra Terms of Service</a> will load.</li>
+            <li>In Terra, click "ACCEPT" for the new Terms.  Note: there is also an "AGREE" button at the very bottom of the page about cookies.  You will need to click "ACCEPT" on the form in the middle of the page; the cookie agreement is separate.</li>
+            <li>In SCP, click the Single Cell Portal icon at top left of the page to go to the home page.  You can now use Single Cell Portal.</li>
+          </ol>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -293,6 +293,9 @@ Rails.application.routes.draw do
     get '*a/igv.css.map', to: -> (env) { [204, {}, ['']] }
     get 'igv.css.map', to: -> (env) { [204, {}, ['']] }
 
+
+    get 'terra_tos', to: 'exceptions#terra_tos', as: 'exceptions_terra_tos'
+
     root to: 'site#index'
     end
   get 'igv.css.map', to: -> (env) { [204, {}, ['']] }

--- a/test/integration/tos_acceptance_test.rb
+++ b/test/integration/tos_acceptance_test.rb
@@ -19,28 +19,30 @@ class TosAcceptanceTest < ActionDispatch::IntegrationTest
   end
 
   test 'should record user tos action' do
-    # first log in and validate that the user is redirected to the ToS page
-    get site_path
-    follow_redirect!
-    assert path == accept_tos_path(@test_user.id),
-           "Did not redirect to terms of service path, current path is #{path}"
-    # first deny ToS and validate that user gets signed out
-    post record_tos_action_path(id: @test_user.id, tos: {action: 'deny'})
-    follow_redirect!
-    user_accepted = TosAcceptance.accepted?(@test_user)
-    assert_not user_accepted, "Did not record user denial, acceptance shows: #{user_accepted}"
-    assert controller.current_user.nil?, "Did not sign out user, current_user is #{controller.current_user}"
-    # now accept ToS
-    sign_in @test_user
-    post record_tos_action_path(id: @test_user.id, tos: {action: 'accept'})
-    follow_redirect!
-    user_accepted = TosAcceptance.accepted?(@test_user)
-    assert user_accepted, "Did not record user acceptance, acceptance shows: #{user_accepted}"
-    assert controller.current_user == @test_user,
-           "Did not preserve sign in, current user is not #{@test_user.email}"
-    # now get another page and validate that redirect is no longer being enforced
-    get site_path
-    assert path == site_path, "Redirect still being enforced, expected path to be #{site_path} but found #{path}"
+    @test_user.stub :must_accept_terra_tos?, false do
+      # first log in and validate that the user is redirected to the ToS page
+      get site_path
+      follow_redirect!
+      assert path == accept_tos_path(@test_user.id),
+             "Did not redirect to terms of service path, current path is #{path}"
+      # first deny ToS and validate that user gets signed out
+      post record_tos_action_path(id: @test_user.id, tos: {action: 'deny'})
+      follow_redirect!
+      user_accepted = TosAcceptance.accepted?(@test_user)
+      assert_not user_accepted, "Did not record user denial, acceptance shows: #{user_accepted}"
+      assert controller.current_user.nil?, "Did not sign out user, current_user is #{controller.current_user}"
+      # now accept ToS
+      sign_in @test_user
+      post record_tos_action_path(id: @test_user.id, tos: {action: 'accept'})
+      follow_redirect!
+      user_accepted = TosAcceptance.accepted?(@test_user)
+      assert user_accepted, "Did not record user acceptance, acceptance shows: #{user_accepted}"
+      assert controller.current_user == @test_user,
+             "Did not preserve sign in, current user is not #{@test_user.email}"
+      # now get another page and validate that redirect is no longer being enforced
+      get site_path
+      assert path == site_path, "Redirect still being enforced, expected path to be #{site_path} but found #{path}"
+    end
   end
 end
 


### PR DESCRIPTION
This refines instructions for accepting updated Terra Terms of Service.  It clarifies steps in a non-obvious critical user story.

### Impact
Some users might not be able to use Single Cell Portal, if they do not closely read a Terms of Service UI and ascertain a few non-obvious steps <a href="#details">detailed below</a>.  Errors began flaring up yesterday (2023-02-01), and [today (2023-02-02) it has affected 24 users](https://broad-institute.sentry.io/issues/3869811457/?project=1424198&query=is%3Aunresolved&referrer=issue-stream) -- around 3% of the day's daily visitors.  There is a workaround, noted [in Zendesk](https://broadinstitute.zendesk.com/agent/tickets/303184).  

So likely < 3% of daily users experiece a severe form of this problem.

### Problem details <span id="details"/>
Previously, if a user had registered for SCP and Terra and then Terra updated the Terms of Service, we would show the user an error modal that generically directed them to Terra.  However, to accept the Terra Terms of Service, the user must be signed in on Terra -- not just signed in on SCP.  The common case seems to be that users are signed in on SCP but not Terra.  

So the user must ascertain that they must sign in, then they must ascertain how to get to the Terms of Service UI, then click "ACCEPT" for the Terms -- a button that is physically close to an unrelated "AGREE" button for cookies.  A few SCP team members independently had trouble with this UX flow, and a user reported trouble on 2023-02-02.

### Fix
Now, that scenario will bring such users to an error page with clearer, more explicitly instructions that account for a frequent case -- where the user is signed in on SCP _but not Terra_.  The instructions have the user sign in _on Terra_, click "ACCEPT" (not "AGREE"!), etc.

Here's how it looks:

<img width="884" alt="Updated_Terra_Terms_of_Service_handling__SCP_2023-02-03" src="https://user-images.githubusercontent.com/1334561/216633265-66fef3a6-f337-42cd-9058-dfcecc556d90.png">



Jon and I paired on this; he navigated, I drove.

To test:
At most one person should test this pre-merge, one person post-merge, one person post-production-deployment.
* This likely isn't feasible to manually verify unless you previous have a "special account", i.e. an account registered for SCP and Terra, but have not yet accepted the Terra Terms of Service as updated in January 2023.
* If you have such an account and want to verify pre-merge, then pull this branch locally
* Go to your local SCP in your web browser
* Sign in with your special account
* Confirm you see https://localhost:3000/single_cell/terra_tos
* Go through steps there
* Confirm your local SCP loads any page as expected

This satisfies SCP-4929.  For more context, see [internal Slack discussion](https://broadinstitute.slack.com/archives/CBEHTH601/p1675373810829689).