### PR TITLE
Remove the links to study usage (SCP-4972)

### DIFF
--- a/app/javascript/components/my-studies/MyStudiesPage.jsx
+++ b/app/javascript/components/my-studies/MyStudiesPage.jsx
@@ -199,7 +199,6 @@ function StudyActionLinks({ study }) {
 
   const actionList = <ul className="list-style-none-menu">
     <li><a href={`/single_cell/studies/${studyId}`}>Details</a></li>
-    <li><a href={`/single_cell/studies/${studyId}/usage_stats`}>Usage stats <sup className="alert-warning">NEW</sup></a></li>
     <li><a href={`/single_cell/studies/${studyId}/edit`}>Study settings</a></li>
     <li><a href={`/single_cell/studies/${studyId}/edit`}>Edit name &amp; description</a></li>
     <li><a href={`/single_cell/studies/${studyId}/upload`}>Upload &amp; edit files</a></li>

--- a/app/views/site/_study_settings_form.html.erb
+++ b/app/views/site/_study_settings_form.html.erb
@@ -43,9 +43,6 @@
         <li>
           <%= scp_link_to "Study details", study_path(@study), class: " #{@study.url_safe_name}-sync details-button" %>
         </li>
-        <li>
-          <%= scp_link_to "Usage stats", usage_stats_study_path(@study), class: " #{@study.url_safe_name}-usage_stats usage-button" %>
-        </li>
       </ul>
     </div>
     <div class="col-md-10">


### PR DESCRIPTION
The Study Usage page is broken and we have a ticket to fix it https://broadworkbench.atlassian.net/browse/SCP-4616?atlOrigin=eyJpIjoiZjAxYjllNDI4ZWExNDRjNTg0ZWU0ZGQ5Nzg5OTY3ZjMiLCJwIjoiaiJ9 for now lets remove the links to it so it doesn't cause confusion when the page never loads for users.

See the screenshots for before and after
To test
- pull this branch and start up a local environment
- sign in and go to a studys setting page - note no study usage link
- go to My Studies section and when you click the 3 dots next to a study note no study usage link


![Screen Shot 2023-02-03 at 10 29 28 AM](https://user-images.githubusercontent.com/54322292/216648345-6475e8e7-b043-473a-b665-763319745614.png)
![Screen Shot 2023-02-03 at 10 29 11 AM](https://user-images.githubusercontent.com/54322292/216648342-3d7cb2ca-d221-4b47-95f5-cf5088074716.png)


![Screen Shot 2023-02-03 at 10 29 37 AM](https://user-images.githubusercontent.com/54322292/216648349-aa590c58-be5f-49a5-b2c9-40fcacd9f8fc.png)
![Screen Shot 2023-02-03 at 10 26 12 AM](https://user-images.githubusercontent.com/54322292/216648338-e8dab5cb-2348-4c80-8c8d-8ba7f282ce33.png)
