### PR TITLE
Bring back study usage page! (SCP-4616)

### DIFF
--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -112,9 +112,8 @@ module Api
             where_string: "\"#{@study.accession}\" in properties[\"studyAccessions\"]"
           }
         }
-
         responses = Parallel.map(usage_stats_params.keys) do |key|
-          response = MixpanelClient.fetch_segmentation_query(usage_stats_params[key])
+          response = MixpanelClient.fetch_segmentation_query(usage_stats_params[key][:event],usage_stats_params[key][:type], usage_stats_params[key][:where_string] )
         end
         usage_stats = {}
         usage_stats_params.keys.each_with_index do |key, index|

--- a/app/javascript/components/my-studies/MyStudiesPage.jsx
+++ b/app/javascript/components/my-studies/MyStudiesPage.jsx
@@ -199,7 +199,7 @@ function StudyActionLinks({ study }) {
 
   const actionList = <ul className="list-style-none-menu">
     <li><a href={`/single_cell/studies/${studyId}`}>Details</a></li>
-    <li><a href={`/single_cell/studies/${studyId}/usage_stats`}>Usage stats <sup className="alert-warning">NEW</sup></a></li>
+    <li><a href={`/single_cell/studies/${studyId}/usage_stats`}>Usage stats</a></li>
     <li><a href={`/single_cell/studies/${studyId}/edit`}>Study settings</a></li>
     <li><a href={`/single_cell/studies/${studyId}/edit`}>Edit name &amp; description</a></li>
     <li><a href={`/single_cell/studies/${studyId}/upload`}>Upload &amp; edit files</a></li>

--- a/app/javascript/components/my-studies/MyStudiesPage.jsx
+++ b/app/javascript/components/my-studies/MyStudiesPage.jsx
@@ -199,6 +199,7 @@ function StudyActionLinks({ study }) {
 
   const actionList = <ul className="list-style-none-menu">
     <li><a href={`/single_cell/studies/${studyId}`}>Details</a></li>
+    <li><a href={`/single_cell/studies/${studyId}/usage_stats`}>Usage stats <sup className="alert-warning">NEW</sup></a></li>
     <li><a href={`/single_cell/studies/${studyId}/edit`}>Study settings</a></li>
     <li><a href={`/single_cell/studies/${studyId}/edit`}>Edit name &amp; description</a></li>
     <li><a href={`/single_cell/studies/${studyId}/upload`}>Upload &amp; edit files</a></li>

--- a/app/lib/mixpanel_client.rb
+++ b/app/lib/mixpanel_client.rb
@@ -13,13 +13,14 @@ class MixpanelClient
 
   # see https://developer.mixpanel.com/reference/segmentation-query
   def self.fetch_segmentation_query(
-    event: nil,
-    from_date: '2020-10-01'.to_date,
-    to_date: Date.today,
-    unit: 'month',
-    type: 'unique',
-    where_string: '',
-    on_string: '')
+    event = nil,
+    type = 'unique',
+    where_string = '',
+    from_date = '2020-10-01'.to_date,
+    to_date = Date.today,
+    unit = 'month',
+    on_string = ''
+  )
 
     request = {
       method: 'GET',

--- a/app/views/site/_study_settings_form.html.erb
+++ b/app/views/site/_study_settings_form.html.erb
@@ -43,6 +43,9 @@
         <li>
           <%= scp_link_to "Study details", study_path(@study), class: " #{@study.url_safe_name}-sync details-button" %>
         </li>
+        <li>
+        <%= scp_link_to "Usage stats", usage_stats_study_path(@study), class: " #{@study.url_safe_name}-usage_stats usage-button" %>
+      </li>
       </ul>
     </div>
     <div class="col-md-10">


### PR DESCRIPTION
This adds back the links to the study usage page and restores the functionality

The fix ended up being super simple - apparently a small ruby syntax error? After barking up the wrong tree for a few days I did confirm Prod has the appropriate mixpanel secret and the mixpanel API works as expected and has had no updates since Devon added this feature.

To test
See this [PR](https://github.com/broadinstitute/single_cell_portal_core/pull/1479) about ensuring you've got the Env Variables loaded in your local
- pull this branch
- boot up a local server and sign into the portal
- navigate to a study and go to the study settings page
- click the usage link and wait for the page to actually load!

https://user-images.githubusercontent.com/54322292/218538304-46f94537-fc0f-452b-9305-c3f26e57df48.mov

