### PR TITLE
Admin interface for managing A/B tests

### DIFF
--- a/app/controllers/ab_tests_controller.rb
+++ b/app/controllers/ab_tests_controller.rb
@@ -1,0 +1,56 @@
+class AbTestsController < ApplicationController
+  before_action do
+    authenticate_user!
+    authenticate_admin
+    set_feature_flag
+  end
+
+  before_action :set_ab_test, except: :create
+
+  def create
+    @feature_flag.build_ab_test.save! if @feature_flag.ab_test.nil?
+    redirect_to edit_feature_flag_ab_test_path
+  end
+
+  def edit; end
+
+  def update
+    if @ab_test.update(ab_test_params)
+      redirect_to edit_feature_flag_ab_test_path, notice: 'A/B test successfully updated'
+    else
+      render action: :edit
+    end
+  end
+
+  def destroy
+    @ab_test.destroy
+    redirect_to feature_flag_options_path, notice: 'A/B test successfully destroyed'
+  end
+
+  def add_to_group
+    # clear feature_flag_option first
+    current_user.remove_flag_option(@feature_flag.name)
+    # add user to A/B test group assignment
+    @assignment = @ab_test.assignment(current_user.metrics_uuid)
+    if @assignment.update(group_name: params[:group_name])
+      redirect_to edit_feature_flag_ab_test_path, notice: 'Successfully added to group'
+    else
+      redirect_to edit_feature_flag_ab_test_path,
+                  alert: "Could not add to group: #{@assignment.errors.full_messages.join(', ')}"
+    end
+  end
+
+  private
+
+  def set_feature_flag
+    @feature_flag = FeatureFlag.find_by(name: params[:name])
+  end
+
+  def set_ab_test
+    @ab_test = @feature_flag.ab_test
+  end
+
+  def ab_test_params
+    params.require(:ab_test).permit(:enabled, group_names: [])
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -191,7 +191,7 @@ class ApplicationController < ActionController::Base
 
   # load any enabled A/B test sessions for the current_user
   def set_ab_test_assignments
-    @ab_test_assignments = FeatureFlag.load_ab_test_assignments(request.cookies['user_id'])
+    @ab_test_assignments = AbTest.load_assignments(request.cookies['user_id'])
   end
 
   # merge in extra parameters on redirects as necessary

--- a/app/controllers/feature_flag_options_controller.rb
+++ b/app/controllers/feature_flag_options_controller.rb
@@ -23,7 +23,18 @@ class FeatureFlagOptionsController < ApplicationController
       options = feature_flag.feature_flag_options
       types = SEARCH_FIELDS_BY_MODEL.keys.map(&:classify)
       info = types.map { |name| { name => options.where(feature_flaggable_type: name).count } }.reduce({}, :merge)
-      info.merge!({ default_value: feature_flag.default_value, description: feature_flag.description })
+      ab_test = 'N/A'
+      ab_test_class = 'label-default'
+      if feature_flag.ab_test.present?
+        ab_test = feature_flag.ab_test_enabled? ? 'Enabled' : 'Disabled'
+        ab_test_class = feature_flag.ab_test_enabled? ? 'label-success' : 'label-danger'
+      end
+      info.merge!({
+                    default_value: feature_flag.default_value,
+                    description: feature_flag.description,
+                    ab_test:,
+                    ab_test_class:
+                  })
       @feature_flag_info[feature_flag.name] = info
     end
   end

--- a/app/controllers/feature_flag_options_controller.rb
+++ b/app/controllers/feature_flag_options_controller.rb
@@ -23,17 +23,14 @@ class FeatureFlagOptionsController < ApplicationController
       options = feature_flag.feature_flag_options
       types = SEARCH_FIELDS_BY_MODEL.keys.map(&:classify)
       info = types.map { |name| { name => options.where(feature_flaggable_type: name).count } }.reduce({}, :merge)
-      ab_test = 'N/A'
-      ab_test_class = 'label-default'
+      ab_test = nil
       if feature_flag.ab_test.present?
-        ab_test = feature_flag.ab_test_enabled? ? 'Enabled' : 'Disabled'
-        ab_test_class = feature_flag.ab_test_enabled? ? 'label-success' : 'label-danger'
+        ab_test = feature_flag.ab_test_enabled?
       end
       info.merge!({
                     default_value: feature_flag.default_value,
                     description: feature_flag.description,
                     ab_test:,
-                    ab_test_class:
                   })
       @feature_flag_info[feature_flag.name] = info
     end

--- a/app/controllers/feature_flag_options_controller.rb
+++ b/app/controllers/feature_flag_options_controller.rb
@@ -30,7 +30,7 @@ class FeatureFlagOptionsController < ApplicationController
       info.merge!({
                     default_value: feature_flag.default_value,
                     description: feature_flag.description,
-                    ab_test:,
+                    ab_test:
                   })
       @feature_flag_info[feature_flag.name] = info
     end

--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -1,7 +1,11 @@
 module StudiesHelper
   # formatted label for boolean values
   def get_boolean_label(field)
-    field ? "<span class='fas fa-check text-success'></span>".html_safe : "<span class='fas fa-times text-danger'></span>".html_safe
+    if field.nil?
+      "<span class='label label-default'>N/A</span>".html_safe
+    else
+      field ? "<span class='fas fa-check text-success'></span>".html_safe : "<span class='fas fa-times text-danger'></span>".html_safe
+    end
   end
 
   # formatted label for parse status of uploaded files

--- a/app/javascript/styles/_forms.scss
+++ b/app/javascript/styles/_forms.scss
@@ -228,3 +228,8 @@ hr.divider {
     }
   }
 }
+
+.large-checkbox {
+  width: 24px;
+  height: 24px;
+}

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -114,7 +114,7 @@ class MetricsService
     end
 
     # global tracking of A/B feature test groups
-    props.merge!({ abTests: FeatureFlag.load_ab_test_assignments(distinct_id) })
+    props.merge!({ abTests: AbTest.load_assignments(distinct_id) })
 
     post_body = {'event' => name, 'properties' => props}.to_json
 

--- a/app/models/ab_test.rb
+++ b/app/models/ab_test.rb
@@ -12,6 +12,10 @@ class AbTest
   field :group_names, type: Array, default: DEFAULT_GROUP_NAMES
   field :enabled, type: Boolean, default: false
 
+  validate :no_spaces_in_group_names
+  validate :two_groups?
+  after_save :unset_orphaned_groups
+
   def random_group
     group_names.sample
   end
@@ -20,11 +24,41 @@ class AbTest
     AbTestAssignment.find_or_create_by(feature_flag:, metrics_uuid:, ab_test: self)
   end
 
+  def user_count(group_name)
+    ab_test_assignments.where(group_name:).count
+  end
+
   # load A/B test assignments for all enabled A/B tests using a given metrics_uuid
   # filter out any instances where the FeatureFlagOption is set as this will skew results
   def self.load_assignments(metrics_uuid)
     return [] if metrics_uuid.nil?
 
     where(enabled: true).map { |ab_test| ab_test.assignment(metrics_uuid) }.reject(&:flag_override?).map(&:tag)
+  end
+
+  private
+
+  def no_spaces_in_group_names
+    invalid_names = group_names.map { |name| name.match(/\s/) }.compact
+    if invalid_names.any?
+      errors.add(:group_names,
+                 "cannot contain values with spaces: #{invalid_names.map {|n| "'#{n.string}'"}.join(',')}")
+    end
+  end
+
+  def two_groups?
+    if group_names.count < 2
+      errors.add(:group_names, 'must have at least two groups')
+    end
+  end
+
+  # remove any assignments to groups that have been removed
+  # users will automatically get reassigned to a new group on page load
+  def unset_orphaned_groups
+    assigned_groups = ab_test_assignments.pluck(:group_name).uniq
+    orphaned_groups = assigned_groups - group_names
+    if orphaned_groups.any?
+      ab_test_assignments.where(:group_name.in => orphaned_groups).delete_all
+    end
   end
 end

--- a/app/models/ab_test.rb
+++ b/app/models/ab_test.rb
@@ -1,0 +1,30 @@
+# holds groups names for running A/B UI tests
+# supports 2+ group assignments
+class AbTest
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  has_many :ab_test_assignments, dependent: :delete_all
+  belongs_to :feature_flag
+
+  DEFAULT_GROUP_NAMES = %w[control intervention].freeze
+
+  field :group_names, type: Array, default: DEFAULT_GROUP_NAMES
+  field :enabled, type: Boolean, default: false
+
+  def random_group
+    group_names.sample
+  end
+
+  def assignment(metrics_uuid)
+    AbTestAssignment.find_or_create_by(feature_flag:, metrics_uuid:, ab_test: self)
+  end
+
+  # load A/B test assignments for all enabled A/B tests using a given metrics_uuid
+  # filter out any instances where the FeatureFlagOption is set as this will skew results
+  def self.load_assignments(metrics_uuid)
+    return [] if metrics_uuid.nil?
+
+    where(enabled: true).map { |ab_test| ab_test.assignment(metrics_uuid) }.reject(&:flag_override?).map(&:tag)
+  end
+end

--- a/app/models/ab_test_assignment.rb
+++ b/app/models/ab_test_assignment.rb
@@ -1,23 +1,20 @@
 # reference document to map a user/metrics_uuid to a feature_flag A/B test group
 class AbTestAssignment
-  include Mongoid::Document
-  include Mongoid::Timestamps
+  include ::Mongoid::Document
+  include ::Mongoid::Timestamps
 
-  # use declarative labels so reports are clear what each group saw
-  GROUP_NAMES = %w[control intervention].freeze
   belongs_to :feature_flag
+  belongs_to :ab_test
   belongs_to :user, optional: true, foreign_key: :metrics_uuid, primary_key: :metrics_uuid
 
   field :metrics_uuid, type: String
   field :group_name, type: String
 
   validates :metrics_uuid, uniqueness: { scope: :feature_flag_id }, presence: true
-  validates :group_name, presence: true, inclusion: { in: GROUP_NAMES }
+  validates :group_name, presence: true
   before_validation :assign_group, on: :create
 
-  def self.random_group
-    rand.round.zero? ? GROUP_NAMES.first : GROUP_NAMES.last
-  end
+  delegate :random_group, to: :ab_test
 
   def tag
     "#{feature_flag.name.dasherize}-group-#{group_name}".downcase
@@ -32,6 +29,6 @@ class AbTestAssignment
   private
 
   def assign_group
-    self.group_name = self.class.random_group
+    self.group_name = random_group
   end
 end

--- a/app/models/ab_test_assignment.rb
+++ b/app/models/ab_test_assignment.rb
@@ -12,7 +12,7 @@ class AbTestAssignment
 
   validates :metrics_uuid, uniqueness: { scope: :feature_flag_id }, presence: true
   validates :group_name, presence: true
-  before_validation :assign_group, on: :create
+  before_validation :assign_group, on: :create, if: proc { group_name.blank? }
 
   delegate :random_group, to: :ab_test
 

--- a/app/views/ab_tests/_ab_test_form.html.erb
+++ b/app/views/ab_tests/_ab_test_form.html.erb
@@ -1,0 +1,86 @@
+<div id="ab-test-tab-root">
+  <ul class="nav nav-tabs" data-analytics-name="ab-test" id="ab-test-nav">
+    <li class="nav-item active"><a href="#ab-test-options" data-toggle="tab">Options</a></li>
+    <li class="nav-item"><a href="#ab-test-groups" data-toggle="tab">Group testing</a></li>
+  </ul>
+
+  <div class="tab-content">
+    <div class="tab-pane active in top-pad" id="ab-test-options">
+      <%= form_with(model: ab_test, url: update_feature_flag_ab_test_path, id: 'ab-test', class: 'form') do |form| %>
+        <% if ab_test.errors.any? %>
+          <div class="bs-callout bs-callout-danger" id="ab-test-errors-block">
+            <h2><%= pluralize(ab_test.errors.count, "error") %> prohibited this A/B test from being saved:</h2>
+
+            <ul>
+              <% ab_test.errors.each do |error| %>
+                <li><%= error.full_message %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+        <div class="form-group row">
+          <div class="col-md-3">
+            <%= form.label :enabled %><br />
+            <%= form.check_box :enabled, class: 'large-checkbox' %>
+            <p class="help-block">
+              Enabling this A/B test will automatically assign users to different groups when visting the portal.
+            </p>
+          </div>
+          <div class="col-md-4">
+            <%= form.label :group_names %><br />
+            <div id='ab-test-group-names-container'>
+              <% @ab_test.group_names.each do |name| %>
+                <%= render partial: 'ab_test_group_name_field',
+                           locals: { name: name, f: form, feature_flag: @feature_flag.name } %>
+              <% end %>
+            </div>
+            <%= link_to "<i class='fas fa-plus'></i> Add a group".html_safe, '#',
+                        class: 'btn btn-sm btn-default', id: 'add-ab-test-group' %>
+          </div>
+        </div>
+        <div class="form-group">
+          <%= form.submit 'Save', class: 'btn btn-success', id: 'save-ab-test' %>
+          <%= link_to "<i class='fas fa-trash'></i> Destroy".html_safe, destroy_feature_flag_ab_test_path,
+                      class: 'btn btn-danger', method: :delete, data: { confirm: 'Destroy this A/B test?' } %>
+        </div>
+
+        <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
+          $('#add-ab-test-group').on('click', () => {
+            $('#ab-test-group-names-container').append(
+              "<%= j(render partial: 'ab_test_group_name_field', locals: { name: '', f: form }) %>"
+            )
+          })
+
+          $('#ab-test').on('click', '.remove-group-name', (event) => {
+            if (confirm('Remove this group?')) {
+              $(event.target).closest('div.group-name-row').remove()
+            }
+          })
+        </script>
+      <% end %>
+    </div>
+    <div class="tab-pane top-pad" id="ab-test-groups">
+      <p class="help-block">
+        Configure your test group assignment to preview what each group will see.<br />
+        <strong>Note: this will remove any overrides you have in place for your account for this feature flag.</strong>
+      </p>
+      <%= form_tag(add_to_ab_test_group_path(name: @feature_flag.name)) do %>
+        <div class="form-group row">
+          <div class="col-md-3">
+            <%= label_tag 'Group name' %>
+            <%= select_tag :group_name,
+                           options_for_select(
+                             @ab_test.group_names, @ab_test.assignment(current_user.metrics_uuid).group_name
+                           ),
+                           class: 'form-control' %>
+          </div>
+        </div>
+        <div class="form-group row">
+          <div class="col-md-3">
+            <%= submit_tag 'Add to group', class: 'btn btn-sm btn-success' %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/ab_tests/_ab_test_group_name_field.html.erb
+++ b/app/views/ab_tests/_ab_test_group_name_field.html.erb
@@ -1,0 +1,13 @@
+<div class="form-group row group-name-row">
+  <div class="col-xs-8">
+    <%= f.text_field :group_names, name: 'ab_test[group_names][]', value: name, class: 'form-control group-name' %>
+  </div>
+  <div class="col-xs-2">
+    <%= link_to "<i class='fas fa-times'></i>".html_safe, '#', class: 'btn btn-sm btn-danger remove-group-name' %>
+
+  </div>
+  <div class="col-xs-2">
+    <% user_count = @ab_test.user_count(name)  %>
+    <h4><span class="label label-default"><%= user_count %> <%= 'user'.pluralize(user_count) %></span></h4>
+  </div>
+</div>

--- a/app/views/ab_tests/edit.html.erb
+++ b/app/views/ab_tests/edit.html.erb
@@ -1,0 +1,16 @@
+<h1>A/B test for '<%= @feature_flag.name %>'</h1>
+
+<% if @feature_flag.ab_test.nil? %>
+  <p class="help-block">No A/B test exists for this feature flag yet.</p>
+  <p>
+    <%= link_to "<i class='fas fa-plus'></i> Create A/B Test".html_safe,
+                 create_feature_flag_ab_test_path, method: :post, class: 'btn btn-primary' %>
+  </p>
+<% else %>
+  <%= render 'ab_test_form', ab_test: @ab_test %>
+<% end %>
+
+<p>
+  <%= link_to "<i class='fas fa-chevron-left'></i> Back".html_safe,
+              feature_flag_options_path, class: 'btn btn-warning' %>
+</p>

--- a/app/views/ab_tests/update.html.erb
+++ b/app/views/ab_tests/update.html.erb
@@ -1,0 +1,2 @@
+<h1>AbTests#update</h1>
+<p>Find me in app/views/ab_tests/update.html.erb</p>

--- a/app/views/feature_flag_options/index.html.erb
+++ b/app/views/feature_flag_options/index.html.erb
@@ -38,7 +38,8 @@
             <th>Enabled?</th>
             <th>Users</th>
             <th>Studies</th>
-            <th>Branding Groups</th>
+            <th>Collections</th>
+            <th>A/B Test</th>
           </tr>
         </thead>
         <tbody>
@@ -50,6 +51,10 @@
               <td><%= data[:User] %></td>
               <td><%= data[:Study] %></td>
               <td><%= data[:BrandingGroup] %></td>
+              <td>
+                <%= link_to "<i class='fas fa-cog'></i>".html_safe, edit_feature_flag_ab_test_path(name: flag_name), class: 'btn btn-default btn-sm' %>
+                <span class="label <%= data[:ab_test_class] %>"><%= data[:ab_test] %></span>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/feature_flag_options/index.html.erb
+++ b/app/views/feature_flag_options/index.html.erb
@@ -52,7 +52,7 @@
               <td><%= data[:Study] %></td>
               <td><%= data[:BrandingGroup] %></td>
               <td>
-                <%= link_to "<i class='fas fa-cog'></i>".html_safe, edit_feature_flag_ab_test_path(name: flag_name), class: 'btn btn-default btn-sm' %>
+                <%= link_to "<i class='fas fa-cog'></i>".html_safe, edit_feature_flag_ab_test_path(name: flag_name), class: 'btn btn-default btn-xs' %>
                 <span class="label <%= data[:ab_test_class] %>"><%= data[:ab_test] %></span>
               </td>
             </tr>

--- a/app/views/feature_flag_options/index.html.erb
+++ b/app/views/feature_flag_options/index.html.erb
@@ -53,7 +53,7 @@
               <td><%= data[:BrandingGroup] %></td>
               <td>
                 <%= link_to "<i class='fas fa-cog'></i>".html_safe, edit_feature_flag_ab_test_path(name: flag_name), class: 'btn btn-default btn-xs' %>
-                <span class="label <%= data[:ab_test_class] %>"><%= data[:ab_test] %></span>
+                <%= get_boolean_label data[:ab_test] %>
               </td>
             </tr>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,13 @@ Rails.application.routes.draw do
     resources :admin_configurations, path: 'admin'
     resources :preset_searches
 
+    # a/b test CMS
+    get 'feature_flags/:name/ab_test', to: 'ab_tests#edit', as: :edit_feature_flag_ab_test
+    post 'feature_flags/:name/ab_test', to: 'ab_tests#create', as: :create_feature_flag_ab_test
+    patch 'feature_flags/:name/ab_test/update', to: 'ab_tests#update', as: :update_feature_flag_ab_test
+    post 'feature_flags/:name/ab_test/add_to_group', to: 'ab_tests#add_to_group', as: :add_to_ab_test_group
+    delete 'feature_flags/:name/ab_test', to: 'ab_tests#destroy', as: :destroy_feature_flag_ab_test
+
     # feature flag option CMS
     get 'feature_flags', to: 'feature_flag_options#index', as: :feature_flag_options
     post 'feature_flags/find', to: 'feature_flag_options#find', as: :find_feature_flag_entity

--- a/test/controllers/ab_tests_controller_test.rb
+++ b/test/controllers/ab_tests_controller_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+describe AbTestsController do
+  it "must get edit" do
+    get ab_tests_edit_url
+    must_respond_with :success
+  end
+
+  it "must get update" do
+    get ab_tests_update_url
+    must_respond_with :success
+  end
+
+end

--- a/test/controllers/ab_tests_controller_test.rb
+++ b/test/controllers/ab_tests_controller_test.rb
@@ -1,14 +1,65 @@
-require "test_helper"
+require 'test_helper'
+require 'integration_test_helper'
+require 'includes_helper'
 
-describe AbTestsController do
-  it "must get edit" do
-    get ab_tests_edit_url
-    must_respond_with :success
+class AbTestsControllerTest < ActionDispatch::IntegrationTest
+
+  before(:all) do
+    @admin = FactoryBot.create(:admin_user, test_array: @@users_to_clean)
+    TosAcceptance.create(email: @admin.email)
+    @feature_flag = FeatureFlag.find_or_create_by!(name: 'ab_test_controller_test')
   end
 
-  it "must get update" do
-    get ab_tests_update_url
-    must_respond_with :success
+  setup do
+    sign_in @admin
+    auth_as_user @admin
   end
 
+  teardown do
+    @feature_flag.ab_test&.destroy
+    @feature_flag.reload
+    AbTestAssignment.destroy_all
+  end
+
+  test 'should create A/B test' do
+    post create_feature_flag_ab_test_path(name: @feature_flag.name)
+    follow_redirect!
+    assert_equal edit_feature_flag_ab_test_path(name: @feature_flag.name), path
+    assert @feature_flag.ab_test.present?
+  end
+
+  test 'should update A/B test' do
+    AbTest.create(feature_flag: @feature_flag)
+    groups = %w[control intervention combined]
+    update_params = {
+      ab_test: { enabled: true, group_names: groups }
+    }
+    patch update_feature_flag_ab_test_path(name: @feature_flag.name), params: update_params
+    follow_redirect!
+    ab_test = AbTest.find_by(feature_flag: @feature_flag)
+    assert ab_test.enabled
+    assert_equal groups, ab_test.group_names
+  end
+
+  test 'should destroy A/B test' do
+    AbTest.create(feature_flag: @feature_flag)
+    assert_not_nil @feature_flag.ab_test
+    delete destroy_feature_flag_ab_test_path(name: @feature_flag.name)
+    follow_redirect!
+    assert_nil AbTest.find_by(feature_flag: @feature_flag)
+  end
+
+  test 'should add user to A/B test group' do
+    ab_test = AbTest.create(feature_flag: @feature_flag)
+    assert_nil AbTestAssignment.find_by(feature_flag: @feature_flag, ab_test:, metrics_uuid: @admin.metrics_uuid)
+    ab_test.group_names.each do |group_name|
+      @admin.set_flag_option(@feature_flag.name, true) # test clearing out flag overrides
+      post add_to_ab_test_group_path(name: @feature_flag.name), params: { group_name: }
+      follow_redirect!
+      @admin.reload
+      assert_not @admin.flag_configured?(@feature_flag.name)
+      assignment = AbTestAssignment.find_by(feature_flag: @feature_flag, ab_test:, metrics_uuid: @admin.metrics_uuid)
+      assert_equal group_name, assignment.group_name
+    end
+  end
 end

--- a/test/controllers/ab_tests_controller_test.rb
+++ b/test/controllers/ab_tests_controller_test.rb
@@ -25,7 +25,7 @@ class AbTestsControllerTest < ActionDispatch::IntegrationTest
     post create_feature_flag_ab_test_path(name: @feature_flag.name)
     follow_redirect!
     assert_equal edit_feature_flag_ab_test_path(name: @feature_flag.name), path
-    assert @feature_flag.ab_test.present?
+    assert AbTest.find_by(feature_flag: @feature_flag).present?
   end
 
   test 'should update A/B test' do

--- a/test/models/ab_test_assignment_test.rb
+++ b/test/models/ab_test_assignment_test.rb
@@ -5,7 +5,12 @@ class AbTestAssignmentTest < ActiveSupport::TestCase
   before(:all) do
     @user = FactoryBot.create(:user, test_array: @@users_to_clean)
     @feature_flag = FeatureFlag.find_or_create_by!(name: 'explore_tab_default')
-    @session = AbTestAssignment.create(feature_flag: @feature_flag, user: @user)
+    @ab_test = AbTest.create(feature_flag: @feature_flag)
+    @assignment = @ab_test.assignment(@user.metrics_uuid)
+  end
+
+  teardown do
+    @user.feature_flag_options.destroy_all
   end
 
   after(:all) do
@@ -13,30 +18,27 @@ class AbTestAssignmentTest < ActiveSupport::TestCase
   end
 
   test 'should only create one session per flag per user' do
-    assert_equal @user.metrics_uuid, @session.metrics_uuid
-    assert_equal @user.id, @session.user.id
+    assert_equal @user.metrics_uuid, @assignment.metrics_uuid
+    assert_equal @user.id, @assignment.user.id
     assert_raise Mongoid::Errors::Validations do
-      AbTestAssignment.create!(feature_flag: @feature_flag, metrics_uuid: @user.metrics_uuid)
+      AbTestAssignment.create!(ab_test: @ab_test, feature_flag: @feature_flag, metrics_uuid: @user.metrics_uuid)
     end
   end
 
-  # we can't prove true random assignment, only that over a reasonable amount of iterations we would see a roughly
-  # equal distribution (±2%); for reference, SCP had ~2.5K unique Study overview users/week in 2022
-  test 'should distribute group assignments equally' do
-    groups = []
-    n = 2_500
-    distribution = (0.48..0.52)
-    n.times do
-      groups << AbTestAssignment.random_group
-    end
-    AbTestAssignment::GROUP_NAMES.map do |group|
-      percentage = groups.tally[group] / n.to_f
-      assert distribution.include?(percentage), "#{group}: #{percentage} was outside the ±2% distribution"
-    end
+  test 'should find ab test assigment by metrics uuid' do
+    loaded_assignment = @ab_test.assignment(@user.metrics_uuid)
+    assert_equal @assignment.metrics_uuid, loaded_assignment.metrics_uuid
+    assert_equal @assignment.id, loaded_assignment.id
   end
 
   test 'should set session tag' do
-    expected_name = "explore-tab-default-group-#{@session.group_name}"
-    assert_equal expected_name, @session.tag
+    expected_name = "explore-tab-default-group-#{@assignment.group_name}"
+    assert_equal expected_name, @assignment.tag
+  end
+
+  test 'should find flag override, if present' do
+    assert_not @assignment.flag_override?
+    @user.set_flag_option(@feature_flag.name, true)
+    assert @assignment.flag_override?
   end
 end

--- a/test/models/ab_test_test.rb
+++ b/test/models/ab_test_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class AbTestTest < ActiveSupport::TestCase
+
+  before(:all) do
+    @user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    @feature_flag = FeatureFlag.create(name: 'ab_test_flag')
+    # random number of group names from 2-5
+    limit = (2..5).to_a.sample
+    group_names = 1.upto(limit).map { |i| "name-#{i}" }
+    @ab_test = AbTest.create(feature_flag: @feature_flag, group_names:)
+  end
+
+  teardown do
+    @ab_test.update(enabled: false)
+    @user.feature_flag_options.destroy_all
+  end
+
+  after(:all) do
+    @feature_flag.destroy
+  end
+
+  # we can't prove true random assignment, only that over a reasonable amount of iterations we would see a roughly
+  # equal distribution (±2%); for reference, SCP had ~2.5K unique Study overview users/week in 2022
+  test 'should distribute group assignments equally' do
+    num_groups = @ab_test.group_names.size
+    slice = 1.0 / num_groups
+    groups = []
+    n = 5_000 # simulate average 2-week test
+
+    distribution = (slice - 0.02..slice + 0.02)
+    n.times do
+      groups << @ab_test.random_group
+    end
+    @ab_test.group_names.map do |group|
+      percentage = groups.tally[group] / n.to_f
+      assert distribution.include?(percentage),
+             "#{group}: #{percentage} was outside ±2% distribution for #{num_groups} groups (#{slice})"
+    end
+  end
+
+  test 'should load assignments for enabled tests' do
+    assert_empty AbTest.load_assignments(@user.metrics_uuid)
+    @ab_test.update(enabled: true)
+    assert_equal 1, AbTest.load_assignments(@user.metrics_uuid).size
+    # confirm flag override removes from groups
+    @user.set_flag_option(@feature_flag.name, true)
+    assert_empty AbTest.load_assignments(@user.metrics_uuid)
+  end
+end

--- a/test/models/feature_flag_option_test.rb
+++ b/test/models/feature_flag_option_test.rb
@@ -13,7 +13,6 @@ class FeatureFlagOptionTest < ActiveSupport::TestCase
 
   teardown do
     FeatureFlagOption.destroy_all
-    @feature_flag.update(enable_ab_test: false)
   end
 
   test 'should validate & persist feature_flag_option' do
@@ -61,13 +60,5 @@ class FeatureFlagOptionTest < ActiveSupport::TestCase
       feature_flaggable_id: @user.id.to_s
     }.with_indifferent_access
     assert_equal expected_attributes, option.form_attributes
-  end
-
-  test 'should remove user from A/B test if override is present' do
-    @feature_flag.update(enable_ab_test: true)
-    sessions = FeatureFlag.load_ab_test_assignments(@user.metrics_uuid)
-    assert_equal 1, sessions.size
-    @user.set_flag_option(@feature_flag.name, true)
-    assert_empty FeatureFlag.load_ab_test_assignments(@user.metrics_uuid)
   end
 end

--- a/test/models/feature_flag_test.rb
+++ b/test/models/feature_flag_test.rb
@@ -19,7 +19,7 @@ class FeatureFlagTest < ActiveSupport::TestCase
     FeatureFlagOption.destroy_all
     @user.reload
     @branding_group.reload
-    @feature_flag.update(enable_ab_test: false)
+    @feature_flag.ab_test&.destroy
   end
 
   after(:all) do
@@ -190,14 +190,9 @@ class FeatureFlagTest < ActiveSupport::TestCase
     assert_equal '1', updated_params[FeatureFlaggable::NESTED_FORM_KEY]['0'][:_destroy]
   end
 
-  test 'should load A/B test sessions if enabled' do
-    assert_empty FeatureFlag.load_ab_test_assignments(@user.metrics_uuid)
-    @feature_flag.update(enable_ab_test: true)
-    sessions = FeatureFlag.load_ab_test_assignments(@user.metrics_uuid)
-    assert_equal 1, sessions.size
-    # confirm no new entries are created when reloading sessions
-    new_sessions = FeatureFlag.load_ab_test_assignments(@user.metrics_uuid)
-    assert_equal sessions.size, new_sessions.size
-    assert_equal sessions.first, new_sessions.first
+  test 'should find enabled A/B test' do
+    assert_not @feature_flag.ab_test_enabled?
+    AbTest.create(feature_flag: @feature_flag, enabled: true)
+    assert @feature_flag.ab_test_enabled?
   end
 end


### PR DESCRIPTION
#### BACKGROUND
#1721 introduced a simple framework for running A/B tests.  However, that framework is limited to only 2 distinct groups (`control` and `intervention`), and enabling/disabling A/B tests can only be done through the Rails console.  Additionally, getting counts of users in each group could only be done through manual database queries or externally via Mixpanel reports.

#### CHANGES
This update adds the `AbTest` class to manage global configurations for individual A/B test instances, as well as an admin interface for configuring tests.  Admins can perform the following functions through a browser:

- Create new A/B test instances
- Enable/disable A/B test instances
- Configure group names, including adding addition groups
- See counts of user assignments
- Add their user account to specific groups to test UX changes
- Remove A/B test instances

When configuring group names:
- If an existing group is renamed, all users assigned to that group will have their assignment updated to reflect the new name
- If an existing group is removed, all users assigned to that group are randomly reassigned to new groups the next time they visit SCP

Short video highlighting main features:

https://user-images.githubusercontent.com/729968/218846293-418b2756-2282-4d8c-9025-c1d87aa2cba7.mov

#### MANUAL TESTING
1. Boot as normal and sign in
2. Go to the "Feature Flags" admin page from the profile menu
3. For any existing feature flag, click the gear icon under the "A/B Test" column
4. Click the "Create A/B Test" button
5. Once created, set the A/B test to be enabled to assign yourself to a given group
6. Use the "Group testing" tab to assign yourself to a different group and note that the user counts changed
7. Add a new group name and confirm you can assign yourself to that
8. Delete the A/B test to clean up all records