### PR TITLE
Fixing typo in share form toggle_id (SCP-4984)

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -109,7 +109,7 @@
               <%= form_for(share, url: update_share_subscription_path(id: @user.id, study_share_id: share.id),
                            html: {class: 'form-inline', id: "share_subscription_#{share.id}",
                                   data: {remote: true}}) do |f| %>
-                <%= hidden_field_tag :toggle_id, "toggle_study_default_options_deliver_emails_#{study.id}" %>
+                <%= hidden_field_tag :toggle_id, "toggle_study_default_options_deliver_emails_#{share.id}" %>
                 <div class="form-group">
                   <%= f.hidden_field :deliver_emails, value: share.deliver_emails,
                                      id: "study_default_options_deliver_emails_#{share.id}" %>


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a UI bug introduced in #1707 that prevents rendering the 'My Profile' page if you have had any studies shared with you.  Currently, this page will not load if you have any studies shared with your account.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Load any study you own, go to the "Settings" tab, click "Sharing" on the left, and share it with a different account you have access to
3. Sign out and then sign in with that other account
4. Click 'My profile' from the top-right nav menu and confirm the profile page loads