### PR TITLE
A/B test for showing Explore tab by default (SCP-4671)

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -160,6 +160,12 @@ class SiteController < ApplicationController
     set_study_permissions(@study.detached?)
     set_study_default_options
     set_study_download_options
+
+    # decide what tab to show by default for this user
+    # normally we would do this in React but the tab display is in the Rails HTML view
+    # we need to check server-side since we have to account for @study.can_visualize? as well
+    @explore_tab_default = @study.can_visualize? &&
+                           AbTest.override_for_feature?('explore_tab_default', request.cookies['user_id'])
   end
 
   def record_download_acceptance

--- a/app/models/ab_test.rb
+++ b/app/models/ab_test.rb
@@ -50,7 +50,7 @@ class AbTest
   # will consider flag default state, possible user overrides, and A/B test state
   #
   # * *params*
-  #   - +flag_name+ (String)      => name of feature_flag
+  #   - +flag_name+ (String)     => name of feature_flag
   #   - +metrics_uuid+ (UUID)    => value of cookies['user_id'] for current user
   #   - +groups+ (Array<String>) => array of groups that qualify to override UX (default: 'intervention')
   #

--- a/app/models/ab_test.rb
+++ b/app/models/ab_test.rb
@@ -39,6 +39,35 @@ class AbTest
     where(enabled: true).map { |ab_test| ab_test.assignment(metrics_uuid) }.reject(&:flag_override?).map(&:tag)
   end
 
+  # determine if assignment for metrics_uuid qualifies for showing an updated feature
+  def override_feature?(metrics_uuid, groups: [])
+    return false unless enabled
+
+    groups.include? assignment(metrics_uuid).group_name
+  end
+
+  # determine what state a potential feature_flag and metrics_uuid combine to show
+  # will consider flag default state, possible user overrides, and A/B test state
+  #
+  # * *params*
+  #   - +flag_name+ (String)      => name of feature_flag
+  #   - +metrics_uuid+ (UUID)    => value of cookies['user_id'] for current user
+  #   - +groups+ (Array<String>) => array of groups that qualify to override UX (default: 'intervention')
+  #
+  # * *returns*
+  #   - (Boolean) => T/F if current merged state constitutes an updated UX
+  def self.override_for_feature?(flag_name, metrics_uuid, groups: %w[intervention])
+    user = User.find_by(metrics_uuid:)
+    feature_flag = FeatureFlag.find_by(name: flag_name)
+    # return false if flag isn't found or A/B test is not enabled
+    return false if feature_flag.blank? || !feature_flag.ab_test_enabled?
+
+    # FeatureFlaggable#merged_value_for will check the state of feature_flag default and any user overrides
+    # if that is false, then fall back to checking if user group assignment constitutes an override to the normal UX
+    ab_test = feature_flag.ab_test
+    FeatureFlaggable.merged_value_for(feature_flag.name, user) || ab_test.override_feature?(metrics_uuid, groups:)
+  end
+
   private
 
   # ensure consistent group name formatting - all lowercase word characters (plus dashes)

--- a/app/views/site/_study_tabs_nav.html.erb
+++ b/app/views/site/_study_tabs_nav.html.erb
@@ -1,27 +1,61 @@
 <ul class="nav nav-tabs"  data-analytics-name="study-overview" role="tablist" id="study-tabs">
-  <li role="presentation" class="study-nav active" id="study-summary-nav"><a href="#study-summary" data-toggle="tab">Summary <i class="far fa-fw fa-file-alt"></i></a></li>
+  <li role="presentation" class="study-nav <%= @explore_tab_default ? nil : ' active' %>" id="study-summary-nav">
+    <a href="#study-summary" data-toggle="tab">Summary <i class="far fa-fw fa-file-alt"></i></a>
+  </li>
   <% if @study.can_visualize? %>
-    <li role="presentation" class="study-nav" id="study-visualize-nav"><a href="#study-visualize" data-toggle="tab">Explore <i class="fas fa-fw fa-eye"></i></a></li>
+    <li role="presentation" class="study-nav <%= @explore_tab_default ? ' active' : nil %>" id="study-visualize-nav">
+      <a href="#study-visualize" data-toggle="tab">Explore <i class="fas fa-fw fa-eye"></i></a>
+    </li>
   <% else %>
-    <li role="presentation" class="study-nav disabled" id="study-visualize-nav"><a href="#study-visualize" data-toggle="tooltip" title="This study has no data to view">Explore <i class="fas fa-fw fa-eye"></i></a></li>
+    <li role="presentation" class="study-nav disabled" id="study-visualize-nav">
+      <a href="#study-visualize" data-toggle="tooltip" title="This study has no data to view">
+        Explore <i class="fas fa-fw fa-eye"></i>
+      </a>
+    </li>
   <% end %>
   <% if @study.detached %>
-    <li role="presentation" class="study-nav disabled" id="study-download-nav"><a href="#study-download" data-toggle="tooltip" title="Downloads are disabled for this study - cannot load workspace">Download <i class="fas fa-fw fa-download"></i></a></li>
+    <li role="presentation" class="study-nav disabled" id="study-download-nav">
+      <a href="#study-download" data-toggle="tooltip"
+         title="Downloads are disabled for this study - cannot load workspace">
+        Download <i class="fas fa-fw fa-download"></i>
+      </a>
+    </li>
     <% if @user_can_edit %>
-     <li role="presentation" class="study-nav disabled" id="study-settings-nav"><a href="#study-settings" data-toggle="tooltip" title="Edits are been disabled for this study - cannot load workspace">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
+     <li role="presentation" class="study-nav disabled" id="study-settings-nav">
+       <a href="#study-settings" data-toggle="tooltip"
+          title="Edits are been disabled for this study - cannot load workspace">
+         Settings <i class="fas fa-fw fa-cogs"></i>
+       </a>
+     </li>
     <% end %>
   <% else %>
     <% if @user_can_download %>
-      <li role="presentation" class="study-nav" id="study-download-nav"><a href="#study-download" data-toggle="tab">Download <i class="fas fa-fw fa-download"></i></a></li>
+      <li role="presentation" class="study-nav" id="study-download-nav">
+        <a href="#study-download" data-toggle="tab">Download <i class="fas fa-fw fa-download"></i>
+        </a>
+      </li>
     <% else %>
-      <li role="presentation" class="study-nav disabled" id="study-download-nav"><a href="#study-download" data-toggle="tooltip" title="Please sign in to download data">Download <i class="fas fa-fw fa-download"></i></a></li>
+      <li role="presentation" class="study-nav disabled" id="study-download-nav">
+        <a href="#study-download" data-toggle="tooltip" title="Please sign in to download data">
+          Download <i class="fas fa-fw fa-download"></i>
+        </a>
+      </li>
     <% end %>
-    <li role="presentation" class="study-nav hidden" id="study-analysis-nav"><a href="#study-analysis" data-toggle="tab">Analysis <i class="fas fa-fw fa-tasks"></i></a></li>
+    <li role="presentation" class="study-nav hidden" id="study-analysis-nav">
+      <a href="#study-analysis" data-toggle="tab">Analysis <i class="fas fa-fw fa-tasks"></i></a>
+    </li>
     <% if @allow_firecloud_access && @user_can_edit %>
       <% if @allow_edits %>
-        <li role="presentation" class="study-nav" id="study-settings-nav"><a href="#study-settings" data-toggle="tab">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
+        <li role="presentation" class="study-nav" id="study-settings-nav">
+          <a href="#study-settings" data-toggle="tab">Settings <i class="fas fa-fw fa-cogs"></i></a>
+        </li>
       <% else %>
-        <li role="presentation" class="study-nav disabled" id="study-settings-nav"><a href="#study-settings" data-toggle="tooltip" title="Study workspaces are currently unavailable - please try again later.">Settings <i class="fas fa-fw fa-cogs"></i></a></li>
+        <li role="presentation" class="study-nav disabled" id="study-settings-nav">
+          <a href="#study-settings" data-toggle="tooltip"
+             title="Study workspaces are currently unavailable - please try again later.">
+            Settings <i class="fas fa-fw fa-cogs"></i>
+          </a>
+        </li>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/site/study.html.erb
+++ b/app/views/site/study.html.erb
@@ -4,10 +4,10 @@
 <div id="tab-root">
   <%= render :partial => 'study_tabs_nav' %>
   <div class="tab-content top-pad">
-    <div class="tab-pane active in" id="study-summary" role="tabpanel">
+    <div class="tab-pane <%= @explore_tab_default ? nil : ' active in' %>" id="study-summary" role="tabpanel">
       <%= render partial: 'study_description_view' %>
     </div>
-    <div class="tab-pane" id="study-visualize" role="tabpanel">
+    <div class="tab-pane <%= @explore_tab_default ? 'active in' : nil %>" id="study-visualize" role="tabpanel">
       <% if @study.can_visualize? %>
         <%= render partial: 'study_visualize' %>
       <% end %>

--- a/db/migrate/20230215152445_add_feature_flag_for_explore_tab_ab_test.rb
+++ b/db/migrate/20230215152445_add_feature_flag_for_explore_tab_ab_test.rb
@@ -1,0 +1,11 @@
+class AddFeatureFlagForExploreTabAbTest < Mongoid::Migration
+  def self.up
+    FeatureFlag.create!(name: 'explore_tab_default',
+                        default_value: false,
+                        description: 'show the explore tab in study overview by default')
+  end
+
+  def self.down
+    FeatureFlag.find_by(name: 'explore_tab_default')&.destroy
+  end
+end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
Now that we have a framework for running A/B tests, we can perform our first test by making the Explore tab the default active tab for some users and run the comparison in Mixpanel.  This update adds the convenience method `AbTest.override_for_feature?` to handle the business logic of determining when a particular user should see an updated UX.

The following checks are performed sequentially with the given outcomes ("current" is the Summary tab, "updated" is Explore tab):
1. If the `FeatureFlag` doesn't exist or the A/B test is not enabled, the user sees the current UX
2. The merged state of the `FeatureFlag` and any user overrides is checked - if either are `true` then the user will see the updated UX
3. The group assignment is checked for the `metrics_uuid` for this current user, and if they are assigned to the `intervention` group, they see the updated UX

This logic will apply to all subsequent A/B tests as well. Since we will always need to add code to handle the actual switching of the UX, this is a good example of how this framework makes that simpler.  Outside of the A/B test infrastructure (which ideally does not need to be updated moving forward), there is only the server-side logic of checking which tab to render by default:

`site_controller.rb`:
```
@explore_tab_default = @study.can_visualize? &&
                       AbTest.override_for_feature?('explore_tab_default', request.cookies['user_id'])
```

And then the front-end code to switch the active tabs:

`_study_tabs_nav.html.erb:`
```
<li role="presentation" class="study-nav <%= @explore_tab_default ? nil : ' active' %>" id="study-summary-nav">
```

`study.html.erb:`
```
<div class="tab-pane <%= @explore_tab_default ? nil : ' active in' %>" id="study-summary" role="tabpanel">
```

#### MANUAL TESTING
1. Boot normally with `bin/docker-compose-setup.sh` to start all services and run the migration to create the necessary feature flag
2. Sign in and go to the "[Feature flags](https://localhost:3000/single_cell/feature_flags)" page
3. Next to `explore_tab_default`, click the gear icon to configure the A/B test
4. Click "Create A/B Test"
5. Click the checkbox to enable the test and assign yourself to a particular group and save
6. In another tab, navigate to any study, and observe the following:
    - if you are in the `control` group, you see the "Summary" tab 
    - if you are in the `intervention` group, you see the "Explore" tab
7. Open the DevTools panel in Chrome, go to the network tab and refresh the page.  You should see an event for `page:view:site-study` and your `abTests` value should be `explore-tab-default-group-{name}`, where `name` is either `control` or `intervention`
![Screen Shot 2023-02-16 at 12 09 45 PM](https://user-images.githubusercontent.com/729968/219437872-fd344f77-c102-460c-b813-796c4968cf5d.png)

7. Back in the A/B test config page, click the `Group testing` tab and assign yourself to the other group
9. Back in the study page, refresh and confirm that you see the other tab by default, and in the corresponding Mixpanel event, your `abTests` assignment has changed as well