### PR TITLE
Create exitStatus field for Mixpanel (SCP-4948)

### DIFF
--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -154,7 +154,7 @@ class IngestJob
       # expression matrices currently cannot be ingested in parallel due to constraints around validating cell names
       # this block ensures that all other matrices have all cell names ingested and at least one gene entry, which
       # ensures the matrix has validated
-      other_matrix_files = StudyFile.where(study_id: study.id, file_type: /Matrix/, :id.ne => study_file.id)
+      other_matrix_files = study.expression_matrices.where(:id.ne => study_file.id)
       # only check other matrix files of the same type, as this is what will be checked when validating
       similar_matrix_files = other_matrix_files.select {|matrix| matrix.is_raw_counts_file? == study_file.is_raw_counts_file?}
       similar_matrix_files.each do |matrix_file|

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -154,7 +154,7 @@ class IngestJob
       # expression matrices currently cannot be ingested in parallel due to constraints around validating cell names
       # this block ensures that all other matrices have all cell names ingested and at least one gene entry, which
       # ensures the matrix has validated
-      other_matrix_files = study.expression_matrices.where(:id.ne => study_file.id)
+      other_matrix_files = StudyFile.where(study_id: study.id, file_type: /Matrix/, :id.ne => study_file.id)
       # only check other matrix files of the same type, as this is what will be checked when validating
       similar_matrix_files = other_matrix_files.select {|matrix| matrix.is_raw_counts_file? == study_file.is_raw_counts_file?}
       similar_matrix_files.each do |matrix_file|
@@ -271,6 +271,22 @@ class IngestJob
     events.map {|event| event['description']}
   end
 
+  # Get the exit code for the pipeline, if present
+  #
+  # * *returns*
+  #   - (Integer or Nil::NilClass) => integer status code or nil (if still running)
+  def exit_code
+    return nil unless done?
+
+    events.each do |event|
+      status = event.dig('details', 'exitStatus')
+      return status.to_i if status
+    end
+    nil # catch-all
+  end
+
+
+
   # Reconstruct the command line from the pipeline actions
   #
   # * *returns*
@@ -383,7 +399,7 @@ class IngestJob
       # update search facets if convention data
       if study_file.use_metadata_convention
         SearchFacet.delay.update_all_facet_filters
-      end
+      end      
       launch_differential_expression_jobs unless study_file.is_anndata?
       set_anndata_file_info if study_file.is_anndata?
     when :ingest_expression
@@ -602,7 +618,7 @@ class IngestJob
 
   # launch appropriate downstream jobs once an AnnData file successfully extracts "fragment" files
   def launch_anndata_subparse_jobs
-
+    
     params_object.attribute_as_array(:extract).each do |extract|
       case extract
       when 'cluster'
@@ -716,7 +732,8 @@ class IngestJob
       trigger: trigger,
       jobStatus: failed? ? 'failed' : 'success',
       machineType: vm_info['machineType'],
-      bootDiskSizeGb: vm_info['bootDiskSizeGb']
+      bootDiskSizeGb: vm_info['bootDiskSizeGb'],
+      exitStatus: exit_code #takes integer value from exit_code method
     }
 
     case action

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -733,7 +733,7 @@ class IngestJob
       jobStatus: failed? ? 'failed' : 'success',
       machineType: vm_info['machineType'],
       bootDiskSizeGb: vm_info['bootDiskSizeGb'],
-      exitStatus: exit_code #takes integer value from exit_code method
+      exitStatus: exit_code # integer exit code from PAPI, e.g. `137` for out of memory (OOM)
     }
 
     case action

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -95,7 +95,7 @@ class IngestJobTest < ActiveSupport::TestCase
     mock_metadata = {
       events: [
         { timestamp: now.to_s },
-        { timestamp: (now + 1.minute).to_s }
+        { timestamp: (now + 1.minute).to_s, details: { exitStatus: 0 } }
       ],
       pipeline: {
         resources: {
@@ -108,7 +108,9 @@ class IngestJobTest < ActiveSupport::TestCase
     }.with_indifferent_access
     mock.expect :metadata, mock_metadata
     mock.expect :metadata, mock_metadata
+    mock.expect :metadata, mock_metadata
     mock.expect :error, nil
+    mock.expect :done?, true
 
     cells = @basic_study.expression_matrix_cells(@basic_study_exp_file)
     num_cells = cells.present? ? cells.count : 0
@@ -127,7 +129,8 @@ class IngestJobTest < ActiveSupport::TestCase
         is_raw_counts: false,
         numCells: num_cells,
         machineType: 'n1-highmem-4',
-        bootDiskSizeGb: 300
+        bootDiskSizeGb: 300,
+        exitStatus: 0
       }.with_indifferent_access
 
       job_analytics = job.get_job_analytics
@@ -142,7 +145,7 @@ class IngestJobTest < ActiveSupport::TestCase
     mock_metadata = {
       events: [
         { timestamp: now.to_s },
-        { timestamp: (now + 2.minutes).to_s }
+        { timestamp: (now + 2.minutes).to_s, details: { exitStatus: 1 } }
       ],
       pipeline: {
         resources: {
@@ -155,7 +158,10 @@ class IngestJobTest < ActiveSupport::TestCase
     }.with_indifferent_access
     mock.expect :metadata, mock_metadata
     mock.expect :metadata, mock_metadata
+    mock.expect :metadata, mock_metadata
     mock.expect :error, { code: 1, message: 'mock message' } # simulate error
+    mock.expect :done?, true
+
 
     ApplicationController.papi_client.stub :get_pipeline, mock do
       expected_outputs = {
@@ -171,7 +177,8 @@ class IngestJobTest < ActiveSupport::TestCase
         is_raw_counts: false,
         numGenes: 0,
         machineType: 'n1-highmem-4',
-        bootDiskSizeGb: 300
+        bootDiskSizeGb: 300,
+        exitStatus: 1
       }.with_indifferent_access
 
       job_analytics = job.get_job_analytics


### PR DESCRIPTION
Adds a field to Mixpanel reports that will have an exitStatus, meaning a 0 if all works as expected and a 1 or specific error code if there was a failure 