### PR TITLE
Suppress logging Info level alerts to Sentry (SCP-4991)

### DIFF
--- a/app/javascript/lib/sentry-logging.js
+++ b/app/javascript/lib/sentry-logging.js
@@ -105,6 +105,9 @@ export function setupSentry() {
     // Sampling rate for transactions, which enrich Sentry events with traces
     tracesSampleRate: getIsSuppressedEnv() ? 0 : 1.0,
     beforeSend: event => {
+      if (event.level === 'info') {
+        return null
+      }
       if (getIsSuppressedEnv()) {
         return null
       }

--- a/test/js/metrics-api.test.js
+++ b/test/js/metrics-api.test.js
@@ -147,6 +147,14 @@ describe('Library for client-side usage analytics', () => {
     logToSentry({})
     const numDroppedWhenSuppressed = console.log.mock.calls.length - numDroppedInLowSampleWithResponse
     expect(numDroppedWhenSuppressed).toEqual(1)
+
+    // Nothing should be logged when level is info
+    jest
+      .spyOn(SCPContextProvider, 'getSCPContext')
+      .mockReturnValue({level: 'info'})
+    logToSentry({})
+    const numDroppedWhenInfo = console.log.mock.calls.length - numDroppedInLowSampleWithResponse
+    expect(numDroppedWhenInfo).toEqual(1)
   })
 
 })


### PR DESCRIPTION
During triage on 02/17/2023 we were alerted that we’d gone over our transaction quota limit. We saw some big spikes in our logging and further investigation revealed that a vast majority of these were Level:info items which we don’t actually care to track. Relevant slack thread: https://broadinstitute.slack.com/archives/CBEHTH601/p1676650562416579 

This PR stops sending events to Sentry of level "info" and adds a test to ensure that works.
