### PR TITLE
Log Vite HMR, improving local performance diagnostics (SCP-4962)

### DIFF
--- a/app/javascript/components/explore/ExploreTabRouter.jsx
+++ b/app/javascript/components/explore/ExploreTabRouter.jsx
@@ -155,7 +155,6 @@ function buildQueryFromParams(exploreParams) {
       delete querySafeOptions[key]
     }
   })
-
   return stringifyQuery(querySafeOptions, paramSorter)
 }
 

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -39,6 +39,7 @@ let pendingEvents = [] // eslint-disable-line
 let bardDomain = ''
 const scpContext = getSCPContext()
 const env = scpContext.environment
+const devMode = scpContext.devMode
 const version = scpContext.version
 const isServiceWorkerCacheEnabled = scpContext.isServiceWorkerCacheEnabled
 let userId = ''
@@ -455,6 +456,12 @@ export function log(name, props = {}) {
     delete init['headers']['Authorization']
   } else {
     props['authenticated'] = true
+  }
+
+  if (env === 'development') {
+    // Log if developer is in Docker ("docker-compose").
+    // Helps analyze factors of local SCP page speed.
+    props['devMode'] = devMode
   }
 
   const body = {

--- a/app/javascript/lib/metrics-perf.js
+++ b/app/javascript/lib/metrics-perf.js
@@ -20,9 +20,9 @@ if (performance.setResourceTimingBufferSize) {
  * This helps assess if / why frontend development iteration is slow.
  */
 function logFrontendIteration(name, event) {
-  const logEvent = {type: event.type}
+  const logEvent = {'vite:type': event.type}
   if ('updates' in event) {
-    logEvent.path = event.updates[0].path
+    logEvent['vite:path'] = event.updates[0].path
   }
   log(name, logEvent)
 }

--- a/app/javascript/lib/metrics-perf.js
+++ b/app/javascript/lib/metrics-perf.js
@@ -4,15 +4,8 @@
 
 import { getTTFB, getFCP, getLCP, getFID, getCLS } from 'web-vitals'
 
-
 import { log } from './metrics-api'
-
-import { getSCPContext } from '~/providers/SCPContextProvider'
-const env = getSCPContext().environment
-
-// Jest breaks on `import.meta.hot`, so only import it in dev env
-const imhModule = env === 'development' ? await import('~/vite/import-meta-hot') : null
-const importMetaHot = imhModule ? imhModule.default : function() {return false}
+import importMetaHot from '~/vite/import-meta-hot'
 
 // Ensure we get perfTime metrics.  The number of `performance` browser API
 // entries can be low enough by default to cause some entries to be

--- a/app/javascript/lib/metrics-perf.js
+++ b/app/javascript/lib/metrics-perf.js
@@ -14,6 +14,37 @@ if (performance.setResourceTimingBufferSize) {
   performance.setResourceTimingBufferSize(500)
 }
 
+/**
+ * Log fast (beforeUpdate) and some slow (beforeFull) reloads to Mixpanel
+ *
+ * This helps assess if / why frontend development iteration is slow.
+ */
+function logFrontendIteration(name, event) {
+  const logEvent = {type: event.type}
+  if ('updates' in event) {
+    logEvent.path = event.updates[0].path
+  }
+  log(name, logEvent)
+}
+
+// Log hot module replacement (HMR) to Mixpanel
+// This helps measure "cache hit rate" for fast reload.
+if (import.meta.hot) {
+  const eventNames = [
+    'vite:beforeUpdate',
+    // 'vite:afterUpdate', // This and other disabled events might help later
+    'vite:beforeFullReload',
+    // 'vite:beforePrune',
+    // 'vite:invalidate',
+    // 'vite:error'
+  ]
+  eventNames.forEach(eventName => {
+    import.meta.hot.on(eventName, (event) => {
+      logFrontendIteration(eventName, event)
+    })
+  })
+}
+
 /** Client device memory, # CPUs, and Internet connection speed. */
 export const hardwareStats = getHardwareStats()
 /** we record the time taken by unexecuted steps as a very small negative number to make cumulative

--- a/app/javascript/lib/metrics-perf.js
+++ b/app/javascript/lib/metrics-perf.js
@@ -15,7 +15,7 @@ if (performance.setResourceTimingBufferSize) {
 }
 
 /**
- * Log fast (beforeUpdate) and some slow (beforeFull) reloads to Mixpanel
+ * Log fast (beforeUpdate) and some slow (beforeFullReload) reloads to Mixpanel
  *
  * This helps assess if / why frontend development iteration is slow.
  */

--- a/app/javascript/vite/import-meta-hot.js
+++ b/app/javascript/vite/import-meta-hot.js
@@ -1,0 +1,6 @@
+/**
+ * Jest breaks on `import.meta.hot`, so only import this in dev env
+ */
+export default function importMetaHot() {
+  return import.meta.hot
+}

--- a/app/javascript/vite/import-meta-hot.js
+++ b/app/javascript/vite/import-meta-hot.js
@@ -1,5 +1,5 @@
 /**
- * Jest breaks on `import.meta.hot`, so only import this in dev env
+ * Jest breaks on `import.meta.hot`, so enable mocking this in tests
  */
 export default function importMetaHot() {
   return import.meta.hot

--- a/test/js/setup-tests.js
+++ b/test/js/setup-tests.js
@@ -5,6 +5,11 @@ import 'jest-location-mock'
 
 configure({ adapter: new Adapter() })
 
+// Jest breaks on `import.meta.hot`, so mock it
+jest.mock('vite/import-meta-hot', () => {
+  return jest.fn(() => false)
+})
+
 import { setGlobalMockFlag, setMockOrigin } from 'lib/scp-api'
 
 setGlobalMockFlag(true)


### PR DESCRIPTION
Analytics and anecdotes report local SCP is notably slower than usual.  This logs new diagnostics to help us determine why.

### Overview <span id="overview"></span>
Previously, we logged a handful of events (e.g. `page:view:<page-name>`, `web-vitals`, `plot:scatter`) that are useful to assess the time it takes to fully load a page.  These apply to both [user-facing speed on production](https://mixpanel.com/s/3eow6w) and [frontend iteration speed on development](https://mixpanel.com/project/2085496/view/19055/app/boards#id=3346543).  

Now, we'll also log _partial reloads_ triggered by [hot module replacement (HMR) in Vite](https://vitejs.dev/guide/features.html#hot-module-replacement).  The new Mixpanel events are [`vite:update`](https://mixpanel.com/s/3RQRuS) for HMR and [`vite:beforeFullReload`](https://mixpanel.com/s/1T9ES7) for Vite-triggered full reload.  The <a href="#video">video</a> below concretely shows when they're logged.

Logging these events provides systematic data to answer questions like:

* Is local SCP slowing down because HMR is broken, or otherwise not being applied?
* If HMR is broken, exactly when did it break?
* Are full reloads (which are much slower than HMR) being triggered automatically by Vite, or manually?

The answers entail specific different tactics to speed up local SCP UI development.

### Impact <span id="impact"></span>
This logging is actionable.  For example, if working on a UI in an `appPath` where we expect HMR and:

* If HMR breaks (i.e., `vite:update` never gets logged), now we'll know more specifically when that happened, and thus have a better lead on what broke HMR -- e.g., maybe a recent PR.

* If Vite triggers non-HMR reload (i.e., `vite:beforeFullReload` is very common yet HMR gets logged elsewhere), then we can prioritize porting e.g. JS to JSX, further encourage in-browser iteration for style, verifying backend changes upstream of full UI change (e.g. look at API response change, not visual change), etc.

Periodically reviewing [local page speed analytics](https://mixpanel.com/project/2085496/view/19055/app/boards#id=3346543) -- maybe at least once a month in our daily 5-minute triage -- would help ensure we don't overlook this newly-surfaced frontend iteration speed data.  For example, if the "[Vite HMR (fast)](https://mixpanel.com/project/2085496/view/19055/app/boards#id=3346543&editor-card-id=%22report-37208128%22)" numbers go way down, we likely either A) aren't working on the home, upload, or study overview frontend, or B) have an important tooling bug -- i.e. Vite HMR is broken, misconfigured, or otherwise unused when it ought to be.

This also finishes wiring logging on whether local SCP is in Docker mode or not, e.g. it logs `devMode: "docker-compose"`.  This will help assess if Docker slows down local SCP page loads, and if so how much.

### Video <span id="video"></span>

https://user-images.githubusercontent.com/1334561/220686830-1fd8492f-f36e-4fec-aa5c-6626417218f5.mov


### Test <span id="test"></span>
To manually verify, follow steps from video above:
* Go to Study Overview, Home, or Upload page 
* Open DevTools Network panel
* Click "Preserve log", and filter requests to `bard method:POST`
* Add a `console.log` message to a file ending in `.jsx`, save it
* In DevTools Network panel, confirm `vite:beforeUpdate` event is logged to Bard and has a relevant `vite:path` property
* Add a `console.log` message to a file ending in `.js`, save it
* In Network panel, confirm `vite:beforeFullReload` event is logged to Bard
* In Network panel, confirm logged events set `devMode: "docker-compose"` property (added after making video)

### Further detail <span id="further-detail"></span>
[Slides](https://docs.google.com/presentation/d/1UoA9uZZjv6tDobx2VPDVAv-_PxCq9QJUf9rm-I-RGVg/edit) give more context, including local performance [milestones](https://docs.google.com/presentation/d/1UoA9uZZjv6tDobx2VPDVAv-_PxCq9QJUf9rm-I-RGVg/edit#slide=id.g20f5ae807d5_0_5), and [graphs](https://docs.google.com/presentation/d/1UoA9uZZjv6tDobx2VPDVAv-_PxCq9QJUf9rm-I-RGVg/edit#slide=id.g20f5ae807d5_0_10) showing ongoing systematic local slowdown.  SCP [demo presentation video](https://drive.google.com/file/d/1R8Qcv-aMmIG9ZEfQKtTJ_4I_Jymg2p2x/view?t=48s) and [feedback](https://drive.google.com/file/d/1R8Qcv-aMmIG9ZEfQKtTJ_4I_Jymg2p2x/view?t=24m08s) have further commentary.  

[Next steps](https://docs.google.com/presentation/d/1UoA9uZZjv6tDobx2VPDVAv-_PxCq9QJUf9rm-I-RGVg/edit#slide=id.g20fd9c0f94d_0_0) are also ticketed.  Per demo, I looked into logging Vite version, but didn't quickly find a robust way to do so.  (We can likely determine Vite version from the logged `scpVersion`.)

This satisfies SCP-4962.