### PR TITLE
Nil-safe StudyFileBundle methods, add test coverage (SCP-4993)

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1534,7 +1534,7 @@ class Study
       bams << {
           'name' => bam_file.name,
           'url' => bam_file.api_url,
-          'indexUrl' => bam_file.bundled_files.first.api_url,
+          'indexUrl' => bam_file.bundled_file_by_type('BAM Index')&.api_url,
           'genomeAssembly' => bam_file.genome_assembly_name,
           'genomeAnnotation' => bam_file.genome_annotation
       }

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1531,10 +1531,12 @@ class Study
     bams = []
 
     bam_files.each do |bam_file|
+      next unless bam_file.has_completed_bundle?
+
       bams << {
           'name' => bam_file.name,
           'url' => bam_file.api_url,
-          'indexUrl' => bam_file.bundled_file_by_type('BAM Index')&.api_url,
+          'indexUrl' => bam_file.study_file_bundle.bundled_file_by_type('BAM Index')&.api_url,
           'genomeAssembly' => bam_file.genome_assembly_name,
           'genomeAnnotation' => bam_file.genome_annotation
       }

--- a/app/models/study_file_bundle.rb
+++ b/app/models/study_file_bundle.rb
@@ -139,7 +139,7 @@ class StudyFileBundle
 
   # child/dependent files in this bundle
   def bundled_files
-    self.study_files.where(:id.ne => self.parent.id)
+    self.study_files.where(:id.ne => self.parent&.id)
   end
 
   def file_types

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -172,7 +172,7 @@
                   '</button>' +
                   '</span>' +
                   '</div>' +
-                  '<div style="font-size: 16px">Valid for one use within ' + countdownValue + ' minutes.  Paste into Mac/Linux/Unix terminal and execute to download.<br/><br/>' + 
+                  '<div style="font-size: 16px">Valid for one use within ' + countdownValue + ' minutes.  Paste into Mac/Linux/Unix terminal and execute to download.<br/><br/>' +
                   'If a certificate validation error occurs, adding the "-k" option will skip certificate validation.<br/>  e.g. `curl -k "https://singlecell...."`</div>'
               );
             }
@@ -212,7 +212,7 @@
           <% end %>
         </td>
         <td>
-          <% if study_file.file_type == 'BAM' %>
+          <% if study_file.file_type == 'BAM' && study_file.has_completed_bundle? %>
             <%= render partial: '/site/genome/browse_igv_link', locals: {study_file: study_file} %>
           <% end %>
         </td>

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -259,7 +259,7 @@
                 <% end %>
               </td>
               <td>
-                <% if file.file_type == 'BAM' %>
+                <% if file.file_type == 'BAM' && file.has_completed_bundle? %>
                   <%= render partial: '/site/genome/browse_igv_link', locals: {study_file: file} %>
                 <% end %>
               </td>

--- a/test/integration/lib/file_parse_service_test.rb
+++ b/test/integration/lib/file_parse_service_test.rb
@@ -69,7 +69,8 @@ class FileParseServiceTest < ActiveSupport::TestCase
     cluster_bundle = cluster.study_file_bundle
     assert cluster_bundle.present?, "Did not create study file bundle for cluster file w/ coordinate labels present"
     assert cluster_bundle.completed?, "Did not mark cluster bundle completed"
-    assert cluster_bundle.bundled_files.first == coordinate_labels, "Did not correctly return labels file from bundle"
+    assert cluster_bundle.bundled_file_by_type('Coordinate Labels') == coordinate_labels,
+           'Did not correctly return labels file from bundle'
   end
 
   test 'should clean up ingest artifacts after one month' do

--- a/test/models/study_file_bundle_test.rb
+++ b/test/models/study_file_bundle_test.rb
@@ -1,0 +1,110 @@
+require 'test_helper'
+
+class StudyFileBundleTest < ActiveSupport::TestCase
+
+  before(:all) do
+    @user = FactoryBot.create(:admin_user, test_array: @@users_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                               name_prefix: 'StudyFileBundle Test',
+                               user: @user,
+                               test_array: @@studies_to_clean)
+    @matrix = FactoryBot.create(:study_file,
+                                name: 'matrix.mtx',
+                                study: @study,
+                                file_type: 'MM Coordinate Matrix',
+                                parse_status: 'parsed',
+                                status: 'uploaded',
+                                expression_file_info: {
+                                  is_raw_counts: false,
+                                  library_preparation_protocol: 'Drop-seq',
+                                  biosample_input_type: 'Whole cell',
+                                  modality: 'Proteomic'
+                                })
+    @genes = FactoryBot.create(:study_file,
+                               name: 'genes.txt',
+                               study: @study,
+                               status: 'uploaded',
+                               file_type: '10X Genes File')
+    @barcodes = FactoryBot.create(:study_file,
+                                  name: 'barcodes.txt',
+                                  study: @study,
+                                  status: 'uploaded',
+                                  file_type: '10X Barcodes File')
+
+    @bundle = StudyFileBundle.new(study: @study, bundle_type: @matrix.file_type)
+    @bundle.add_files(@matrix, @genes, @barcodes)
+    @bundle.save!
+    @cluster_file = FactoryBot.create(:cluster_file,
+                                      name: 'cluster.txt',
+                                      parse_status: 'parsed',
+                                      status: 'uploaded',
+                                      study: @study)
+    @coordinate_file = FactoryBot.create(:study_file,
+                                         study: @study,
+                                         name: 'labels.txt',
+                                         parse_status: 'parsed',
+                                         status: 'uploaded',
+                                         file_type: 'Coordinate Labels')
+  end
+
+  teardown do
+    @cluster_file.update(status: 'uploaded')
+    @study.study_file_bundles.where(bundle_type: 'Cluster').delete_all
+  end
+
+  test 'should find completed bundle' do
+    assert @bundle.completed?
+    assert @matrix.has_completed_bundle?
+  end
+
+  test 'should find parent and bundled files' do
+    assert_equal @matrix.id, @bundle.parent.id
+    assert_equal %w[genes.txt barcodes.txt], @bundle.bundled_files.pluck(:name)
+    assert @matrix.is_bundle_parent?
+  end
+
+  test 'should determine that all files should bundle' do
+    [@matrix, @genes, @barcodes].each do |study_file|
+      assert study_file.should_bundle?
+    end
+    assert_not @cluster_file.should_bundle?
+  end
+
+  test 'should handle incomplete bundles safely until completed' do
+    new_bundle = StudyFileBundle.new(study: @study, bundle_type: 'Cluster')
+    assert_not new_bundle.completed?
+    assert_nil new_bundle.parent
+    new_bundle.add_files(@cluster_file)
+    assert_not new_bundle.completed?
+    assert_equal @cluster_file.id, new_bundle.parent.id
+    assert_empty new_bundle.bundled_files.to_a
+    new_bundle.add_files(@coordinate_file)
+    assert new_bundle.completed?
+    assert_equal [@coordinate_file], new_bundle.bundled_files.to_a
+  end
+
+  test 'should check upload status for completion' do
+    @cluster_file.update(status: 'new')
+    incomplete_bundle = StudyFileBundle.new(study: @study, bundle_type: 'Cluster')
+    incomplete_bundle.add_files(@cluster_file, @coordinate_file)
+    assert_not incomplete_bundle.completed?
+  end
+
+  test 'should find bundled files by type' do
+    [@genes, @barcodes].each do |bundled_file|
+      assert_equal bundled_file, @bundle.bundled_file_by_type(bundled_file.file_type)
+    end
+  end
+
+  test 'should get file types' do
+    expected = [@matrix, @genes, @barcodes].map(&:file_type).sort
+    assert_equal expected, @bundle.original_file_types.sort
+    assert_equal expected, @bundle.file_types.sort
+  end
+
+  test 'should generate file list' do
+    files = [@matrix, @genes, @barcodes]
+    expected = files.map { |file| { name: file.name, file_type: file.file_type }.with_indifferent_access }
+    assert_equal expected, StudyFileBundle.generate_file_list(files)
+  end
+end

--- a/test/models/study_file_bundle_test.rb
+++ b/test/models/study_file_bundle_test.rb
@@ -105,6 +105,6 @@ class StudyFileBundleTest < ActiveSupport::TestCase
   test 'should generate file list' do
     files = [@matrix, @genes, @barcodes]
     expected = files.map { |file| { name: file.name, file_type: file.file_type }.with_indifferent_access }
-    assert_equal expected, StudyFileBundle.generate_file_list(files)
+    assert_equal expected, StudyFileBundle.generate_file_list(*files)
   end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds appropriate nil-safe handling to various `StudyFileBundle` methods for accessing parent/child files.  This is to address errors when accessing the [sync](https://broad-institute.sentry.io/issues/3628114971/events/eb0edfc569974955ad27faada933a276/?project=1424198) or [Study overview](https://broad-institute.sentry.io/issues/3946595309/events/abfa7baa929e4402a1188dd21af0d607/?project=1424198) pages caused by incomplete/inconsistent bundle objects.  In addition, BAM files without associated indexes will no longer show the "Browse in IGV" button but will still be available for download.  Lastly, this adds basic unit tests for `StudyFileBundle` which was lacking coverage.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Create a new study and upload `test/test_data/fixed_neurons_6days_2000_possorted_genome_bam_test_data.bam` as a BAM file (species/assembly don't matter, pick whatever is available)
3. Once the file has pushed to the bucket, navigate to the Study overview and confirm it loads
4. Click the Download tab and note that there is no "Browse in IGV" button
5. Navigate back to My studies and click Sync for this study
6. Confirm the page loads without error