### PR TITLE
Show "Differential expression" button whenever study has DE results (SCP-4954)

### DIFF
--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -242,16 +242,19 @@ export default function DifferentialExpressionPanel({
 
 /** Top matter for differential expression panel shown at right in Explore tab */
 export function DifferentialExpressionPanelHeader({
-  setDeGenes, setDeGroup, setShowDifferentialExpressionPanel
+  setDeGenes, setDeGroup, setShowDifferentialExpressionPanel, setShowUpstreamDifferentialExpressionPanel, isUpstream
 }) {
+
+  const title = isUpstream ? 'Differentially expressed genes' : 'Datasets with DE results'
   return (
     <>
-      <span>Differentially expressed genes</span>
+      <span>{title}</span>
       <button className="action fa-lg"
         onClick={() => {
           setDeGenes(null)
           setDeGroup(null)
           setShowDifferentialExpressionPanel(false)
+          setShowUpstreamDifferentialExpressionPanel(false)
         }}
         title="Exit differential expression panel"
         data-analytics-name="differential-expression-panel-exit">

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -242,23 +242,14 @@ export default function DifferentialExpressionPanel({
 
 /** Top matter for differential expression panel shown at right in Explore tab */
 export function DifferentialExpressionPanelHeader({
-  setDeGenes, setDeGroup, setShowDifferentialExpressionPanel, setShowUpstreamDifferentialExpressionPanel, isUpstream
+  setDeGenes, setDeGroup, setShowDifferentialExpressionPanel, setShowUpstreamDifferentialExpressionPanel, isUpstream,
+  cluster, annotation
 }) {
 
-  const title = isUpstream ? 'Find differential expression' : 'Differential expression'
-  console.log('isUpstream', isUpstream)
+  const title = 'Differential expression'
   return (
     <>
       <span>{title}</span>
-      {isUpstream &&
-        <>
-        <br/><br/>
-        <p className="de-nondefault-explainer">
-          That clustering and annotation have no DE results.
-          Select an option below to explore differential expression.
-        </p>
-        </>
-      }
       <button className="action fa-lg"
         onClick={() => {
           setDeGenes(null)
@@ -270,6 +261,27 @@ export function DifferentialExpressionPanelHeader({
         data-analytics-name="differential-expression-panel-exit">
         <FontAwesomeIcon icon={faArrowLeft}/>
       </button>
+      {isUpstream &&
+        <>
+        <div className="de-nondefault-explainer">
+          No DE results for:
+          <br/><br/>
+          <ul className="no-de-summary">
+            <li>
+              <span className="bold">Clustering</span><br/>
+              {cluster}
+            </li>
+            <br/>
+            <li>
+              <span className="bold">Annotation</span><br/>
+              {annotation.name}
+            </li>
+          </ul>
+          <br/>
+          Explore DE results in:
+        </div>
+        </>
+      }
     </>
   )
 }

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -114,9 +114,6 @@ export default function DifferentialExpressionPanel({
   exploreInfo, exploreParamsWithDefaults, setShowDeGroupPicker, setDeGenes, setDeGroup,
   countsByLabel, numRows=15
 }) {
-
-  console.log('exploreInfo', exploreInfo)
-  console.log('exploreParamsWithDefaults', exploreParamsWithDefaults)
   const clusterName = exploreParamsWithDefaults?.cluster
   const bucketId = exploreInfo?.bucketId
   const annotation = getAnnotationObject(exploreParamsWithDefaults, exploreInfo)
@@ -246,10 +243,9 @@ export function DifferentialExpressionPanelHeader({
   cluster, annotation
 }) {
 
-  const title = 'Differential expression'
   return (
     <>
-      <span>{title}</span>
+      <span>Differential expression</span>
       <button className="action fa-lg"
         onClick={() => {
           setDeGenes(null)

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -250,6 +250,15 @@ export function DifferentialExpressionPanelHeader({
   return (
     <>
       <span>{title}</span>
+      {isUpstream &&
+        <>
+        <br/><br/>
+        <p className="de-nondefault-explainer">
+          That clustering and annotation have no DE results.
+          Select an option below to explore differential expression.
+        </p>
+        </>
+      }
       <button className="action fa-lg"
         onClick={() => {
           setDeGenes(null)

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -245,7 +245,7 @@ export function DifferentialExpressionPanelHeader({
   setDeGenes, setDeGroup, setShowDifferentialExpressionPanel, setShowUpstreamDifferentialExpressionPanel, isUpstream
 }) {
 
-  const title = isUpstream ? 'Differentially expressed genes' : 'Datasets with DE results'
+  const title = isUpstream ? 'Find differential expression' : 'Differential expression'
   return (
     <>
       <span>{title}</span>

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -246,6 +246,7 @@ export function DifferentialExpressionPanelHeader({
 }) {
 
   const title = isUpstream ? 'Find differential expression' : 'Differential expression'
+  console.log('isUpstream', isUpstream)
   return (
     <>
       <span>{title}</span>

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -36,7 +36,7 @@ function initChecked(deGenes, checkedGene) {
   return checked
 }
 
-function DownloadButton({bucketId, deFilePath}) {
+function DownloadButton({ bucketId, deFilePath }) {
   return (
     <a className="de-download-button"
       onClick={async () => {await downloadBucketFile(bucketId, deFilePath)}}
@@ -54,57 +54,57 @@ function DifferentialExpressionTable({
 }) {
   return (
     <>
-    <table className="de-table table table-terra table-scp-compact">
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>
-            <span className="glossary" data-toggle="tooltip" data-original-title="Log (base 2) of fold change">
+      <table className="de-table table table-terra table-scp-compact">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>
+              <span className="glossary" data-toggle="tooltip" data-original-title="Log (base 2) of fold change">
               log<sub>2</sub>(FC)
-            </span>
-          </th>
-          <th>
-            <span className="glossary" data-toggle="tooltip" data-original-title="p-value adjusted with Benjamini-Hochberg FDR correction">
+              </span>
+            </th>
+            <th>
+              <span className="glossary" data-toggle="tooltip" data-original-title="p-value adjusted with Benjamini-Hochberg FDR correction">
               Adj. p-value
-            </span>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        {genesToShow.map((deGene, i) => {
-          return (
-            <tr className="de-gene-row" key={i}>
-              <td>
-                <label
-                  title="Click to view gene expression.  Arrow down (↓) and up (↑) to quickly scan."
-                ><input
-                    type="radio"
-                    checked={checked[deGene.name]}
-                    data-analytics-name="selected-gene-differential-expression"
-                    value={deGene.name}
-                    onClick={event => {
-                      searchGenes([deGene.name])
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {genesToShow.map((deGene, i) => {
+            return (
+              <tr className="de-gene-row" key={i}>
+                <td>
+                  <label
+                    title="Click to view gene expression.  Arrow down (↓) and up (↑) to quickly scan."
+                  ><input
+                      type="radio"
+                      checked={checked[deGene.name]}
+                      data-analytics-name="selected-gene-differential-expression"
+                      value={deGene.name}
+                      onClick={event => {
+                        searchGenes([deGene.name])
 
-                      // Log this search to Mixpanel
-                      const rank = i
-                      logSearchFromDifferentialExpression(
-                        event, deGene, species, rank,
-                        clusterName, annotation.name
-                      )
+                        // Log this search to Mixpanel
+                        const rank = i
+                        logSearchFromDifferentialExpression(
+                          event, deGene, species, rank,
+                          clusterName, annotation.name
+                        )
 
-                      changeRadio(event)
-                    }}/>
-                  {deGene.name}</label></td>
-              <td>{deGene.log2FoldChange}</td>
-              <td>{deGene.pvalAdj}</td>
-            </tr>)
-        })}
-      </tbody>
-    </table>
-    <a href="https://forms.gle/qPGH5J9oFkurpbD76" target="_blank" title="Take a 1 minute survey">
+                        changeRadio(event)
+                      }}/>
+                    {deGene.name}</label></td>
+                <td>{deGene.log2FoldChange}</td>
+                <td>{deGene.pvalAdj}</td>
+              </tr>)
+          })}
+        </tbody>
+      </table>
+      <a href="https://forms.gle/qPGH5J9oFkurpbD76" target="_blank" title="Take a 1 minute survey">
       Help improve this new feature
-    </a>
-  </>
+      </a>
+    </>
   )
 }
 
@@ -155,7 +155,7 @@ export default function DifferentialExpressionPanel({
     // results in the DE table.
     clearTimeout(delayedDETableLogTimeout.current)
     delayedDETableLogTimeout.current = setTimeout(() => {
-      const otherProps = {trigger}
+      const otherProps = { trigger }
       const genes = [newSearchedGene]
       logDifferentialExpressionTableSearch(genes, species, otherProps)
     }, 1000)
@@ -171,9 +171,8 @@ export default function DifferentialExpressionPanel({
       filteredGenes = deGenes.filter(d => d.name.toLowerCase().includes(lowerCaseSearchedGene))
     }
 
-    if (deGenes) filteredGenes = filteredGenes.slice(0, numRows)
+    if (deGenes) {filteredGenes = filteredGenes.slice(0, numRows)}
     setGenesToShow(filteredGenes)
-
   }, [deGenes, searchedGene])
 
   return (
@@ -205,7 +204,7 @@ export default function DifferentialExpressionPanel({
             autoComplete="off"
             placeholder="Find a gene" // Consensus per demo, to distinguish from main "Search genes" in same UI
             value={searchedGene}
-            onChange={(event) => updateSearchedGene(event.target.value, 'keydown')}
+            onChange={event => updateSearchedGene(event.target.value, 'keydown')}
             data-analytics-name="differential-expression-search"
           />
           { showClear && <Button
@@ -242,7 +241,6 @@ export function DifferentialExpressionPanelHeader({
   setDeGenes, setDeGroup, setShowDifferentialExpressionPanel, setShowUpstreamDifferentialExpressionPanel, isUpstream,
   cluster, annotation
 }) {
-
   return (
     <>
       <span>Differential expression</span>
@@ -259,23 +257,23 @@ export function DifferentialExpressionPanelHeader({
       </button>
       {isUpstream &&
         <>
-        <div className="de-nondefault-explainer">
+          <div className="de-nondefault-explainer">
           No DE results for:
-          <br/><br/>
-          <ul className="no-de-summary">
-            <li>
-              <span className="bold">Clustering</span><br/>
-              {cluster}
-            </li>
+            <br/><br/>
+            <ul className="no-de-summary">
+              <li>
+                <span className="bold">Clustering</span><br/>
+                {cluster}
+              </li>
+              <br/>
+              <li>
+                <span className="bold">Annotation</span><br/>
+                {annotation.name}
+              </li>
+            </ul>
             <br/>
-            <li>
-              <span className="bold">Annotation</span><br/>
-              {annotation.name}
-            </li>
-          </ul>
-          <br/>
           Explore DE results in:
-        </div>
+          </div>
         </>
       }
     </>

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -114,6 +114,9 @@ export default function DifferentialExpressionPanel({
   exploreInfo, exploreParamsWithDefaults, setShowDeGroupPicker, setDeGenes, setDeGroup,
   countsByLabel, numRows=15
 }) {
+
+  console.log('exploreInfo', exploreInfo)
+  console.log('exploreParamsWithDefaults', exploreParamsWithDefaults)
   const clusterName = exploreParamsWithDefaults?.cluster
   const bucketId = exploreInfo?.bucketId
   const annotation = getAnnotationObject(exploreParamsWithDefaults, exploreInfo)

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -545,6 +545,7 @@ export default function ExploreDisplayTabs({
                 setDeGroup={setDeGroup}
                 setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
                 setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
+                isUpstream={showUpstreamDifferentialExpressionPanel}
               />
             }
           </div>

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -24,7 +24,7 @@ import Heatmap from '~/components/visualization/Heatmap'
 import GeneListHeatmap from '~/components/visualization/GeneListHeatmap'
 import GenomeView from './GenomeView'
 import ImageTab from './ImageTab'
-import { getAnnotationValues, getDefaultSpatialGroupsForCluster } from '~/lib/cluster-utils'
+import { getAnnotationValues, getShownAnnotation, getDefaultSpatialGroupsForCluster } from '~/lib/cluster-utils'
 import RelatedGenesIdeogram from '~/components/visualization/RelatedGenesIdeogram'
 import InferCNVIdeogram from '~/components/visualization/InferCNVIdeogram'
 import useResizeEffect from '~/hooks/useResizeEffect'
@@ -54,7 +54,7 @@ const tabList = [
 /** Determine if currently selected cluster has differential expression outputs available */
 function getClusterHasDe(exploreInfo, exploreParams) {
   const flags = getFeatureFlagsWithDefaults()
-  if (!flags?.differential_expression_frontend || !exploreInfo) return false
+  if (!flags?.differential_expression_frontend || !exploreInfo) {return false}
   let clusterHasDe = false
   const annotList = exploreInfo.annotationList
   let selectedCluster
@@ -74,7 +74,7 @@ function getClusterHasDe(exploreInfo, exploreParams) {
 }
 
 function getAnnotationsWithDE(exploreInfo, exploreParams) {
-  if (!exploreInfo) return false
+  if (!exploreInfo) {return false}
 
   let annotsWithDe = []
   const annotList = exploreInfo.annotationList
@@ -231,6 +231,8 @@ export default function ExploreDisplayTabs({
   if (exploreInfo) {
     hasSpatialGroups = exploreInfo.spatialGroups.length > 0
   }
+
+  const shownAnnotation = getShownAnnotation(exploreParamsWithDefaults.annotation, annotationList)
 
   /** in the event a component takes an action which updates the list of annotations available
     * e.g. by creating a user annotation, this updates the list */
@@ -546,7 +548,7 @@ export default function ExploreDisplayTabs({
                 setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
                 isUpstream={showUpstreamDifferentialExpressionPanel}
                 cluster={exploreParamsWithDefaults.cluster}
-                annotation={exploreParamsWithDefaults.annotation}
+                annotation={shownAnnotation}
               />
             }
           </div>
@@ -569,7 +571,7 @@ export default function ExploreDisplayTabs({
                 <AnnotationSelector
                   annotationList={annotationList}
                   cluster={exploreParamsWithDefaults.cluster}
-                  annotation={exploreParamsWithDefaults.annotation}
+                  shownAnnotation={shownAnnotation}
                   updateClusterParams={updateClusterParams}/>
                 { shownTab === 'scatter' && <CreateAnnotation
                   isSelecting={isCellSelecting}
@@ -659,7 +661,7 @@ export default function ExploreDisplayTabs({
               exploreParamsWithDefaults={exploreParamsWithDefaults}
               exploreInfo={exploreInfo}
               clusterName={exploreParamsWithDefaults.cluster}
-              annotation={exploreParamsWithDefaults.annotation}
+              annotation={shownAnnotation}
               setShowDeGroupPicker={setShowDeGroupPicker}
               setDeGenes={setDeGenes}
               setDeGroup={setDeGroup}
@@ -673,8 +675,8 @@ export default function ExploreDisplayTabs({
             <>
               <ClusterSelector
                 annotationList={getAnnotationsWithDE(exploreInfo, exploreParams)}
-                cluster={""}
-                annotation={""}
+                cluster={''}
+                annotation={''}
                 updateClusterParams={updateClusterParams}
                 hasSelection={false}
                 spatialGroups={exploreInfo ? exploreInfo.spatialGroups : []}/>
@@ -682,15 +684,15 @@ export default function ExploreDisplayTabs({
             }
             {clusterHasDe &&
               <AnnotationSelector
-              annotationList={getAnnotationsWithDE(exploreInfo, exploreParams)}
-              cluster={exploreParamsWithDefaults.cluster}
-              annotation={null}
-              updateClusterParams={updateClusterParams}
-              hasSelection={false}
-              setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
-              setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
-            />
-          }
+                annotationList={getAnnotationsWithDE(exploreInfo, exploreParams)}
+                cluster={exploreParamsWithDefaults.cluster}
+                shownAnnotation={shownAnnotation}
+                updateClusterParams={updateClusterParams}
+                hasSelection={false}
+                setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
+                setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
+              />
+            }
           </>
           }
         </div>

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -36,6 +36,8 @@ import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger'
 import Tooltip from 'react-bootstrap/lib/Tooltip'
 import DifferentialExpressionModal from '~/components/explore/DifferentialExpressionModal'
 
+const flags = getFeatureFlagsWithDefaults()
+
 const tabList = [
   { key: 'loading', label: 'loading...' },
   { key: 'scatter', label: 'Scatter' },
@@ -53,7 +55,7 @@ const tabList = [
 
 /** Determine if currently selected cluster has differential expression outputs available */
 function getClusterHasDe(exploreInfo, exploreParams) {
-  if (!exploreInfo) return false
+  if (!flags?.differential_expression_frontend || !exploreInfo) return false
   let clusterHasDe = false
   const annotList = exploreInfo.annotationList
   let selectedCluster
@@ -106,11 +108,10 @@ function getAnnotationsWithDE(exploreInfo, exploreParams) {
 
 /** Determine if currently selected annotation has differential expression outputs available */
 function getAnnotHasDe(exploreInfo, exploreParams) {
-  const flags = getFeatureFlagsWithDefaults()
   if (!flags?.differential_expression_frontend || !exploreInfo) {
-    // set annotHasDe to false as user cannot see DE results, even if present for annotation
+    // set isDifferentialExpressionEnabled to false as user cannot see DE results, even if present for annotation
     if (window.SCP) {
-      window.SCP.annotHasDe = false
+      window.SCP.isDifferentialExpressionEnabled = false
     }
     return false
   }
@@ -166,16 +167,16 @@ export default function ExploreDisplayTabs({
   const [currentPointsSelected, setCurrentPointsSelected] = useState(null)
 
   // Differential expression settings
+
+  const studyHasDe = flags?.differential_expression_frontend && exploreInfo?.differentialExpression.length > 0
   const annotHasDe = getAnnotHasDe(exploreInfo, exploreParams)
+  const clusterHasDe = getClusterHasDe(exploreInfo, exploreParams)
+
   const [, setShowDeGroupPicker] = useState(false)
   const [deGenes, setDeGenes] = useState(null)
   const [deGroup, setDeGroup] = useState(null)
   const [showDifferentialExpressionPanel, setShowDifferentialExpressionPanel] = useState(deGenes !== null)
   const [showUpstreamDifferentialExpressionPanel, setShowUpstreamDifferentialExpressionPanel] = useState(deGenes !== null)
-
-  const studyHasDe = exploreInfo?.differentialExpression.length > 0
-
-  const clusterHasDe = getClusterHasDe(exploreInfo, exploreParams)
 
   // Hash of trace label names to the number of points in that trace
   const [countsByLabel, setCountsByLabel] = useState(null)

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -72,6 +72,35 @@ function getClusterHasDe(exploreInfo, exploreParams) {
   return clusterHasDe
 }
 
+function getAnnotationsWithDE(exploreInfo, exploreParams) {
+  if (!exploreInfo) return false
+
+  let annotsWithDe = []
+  const annotList = exploreInfo.annotationList
+  let selectedCluster
+  if (exploreParams?.cluster) {
+    selectedCluster = exploreParams.cluster
+  } else {
+    selectedCluster = annotList.default_cluster
+  }
+
+  annotsWithDe = exploreInfo.differentialExpression.filter(deItem => {
+    return (
+      deItem.cluster_name === selectedCluster
+    )
+  }).map(annot => {
+    return {
+      cluster_name: annot.cluster_name,
+      name: annot.annotation_name,
+      scope: annot.annotation_scope,
+      type: 'group'
+    }
+  })
+
+  console.log('annotsWithDe', annotsWithDe)
+  return {annotations: annotsWithDe}
+}
+
 /** Determine if currently selected annotation has differential expression outputs available */
 function getAnnotHasDe(exploreInfo, exploreParams) {
   const flags = getFeatureFlagsWithDefaults()
@@ -499,7 +528,7 @@ export default function ExploreDisplayTabs({
         </div>
         <div className={showViewOptionsControls ? 'col-md-2 ' : 'hidden'}>
           <div className="view-options-toggle">
-            {!showDifferentialExpressionPanel &&
+            {!showDifferentialExpressionPanel && !showUpstreamDifferentialExpressionPanel &&
               <>
                 <FontAwesomeIcon className="fa-lg" icon={faCog}/> OPTIONS
                 <button className="action"
@@ -510,11 +539,12 @@ export default function ExploreDisplayTabs({
                 </button>
               </>
             }
-            {showDifferentialExpressionPanel &&
+            {(showDifferentialExpressionPanel || showUpstreamDifferentialExpressionPanel) &&
               <DifferentialExpressionPanelHeader
                 setDeGenes={setDeGenes}
                 setDeGroup={setDeGroup}
                 setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
+                setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
               />
             }
           </div>
@@ -652,10 +682,11 @@ export default function ExploreDisplayTabs({
             </>
             }
             <AnnotationSelector
-              annotationList={annotationList}
+              annotationList={getAnnotationsWithDE(exploreInfo, exploreParams)}
               cluster={exploreParamsWithDefaults.cluster}
-              annotation={exploreParamsWithDefaults.annotation}
-              updateClusterParams={updateClusterParams}/>
+              annotation={null}
+              updateClusterParams={updateClusterParams}
+              hasSelection={false}/>
           </>
           }
         </div>

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -544,6 +544,8 @@ export default function ExploreDisplayTabs({
                 setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
                 setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
                 isUpstream={showUpstreamDifferentialExpressionPanel}
+                cluster={exploreParamsWithDefaults.cluster}
+                annotation={exploreParamsWithDefaults.annotation}
               />
             }
           </div>

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -169,12 +169,23 @@ export default function ExploreDisplayTabs({
   const [, setShowDeGroupPicker] = useState(false)
   const [deGenes, setDeGenes] = useState(null)
   const [deGroup, setDeGroup] = useState(null)
-  const [showDifferentialExpressionPanel, setShowDifferentialExpressionPanel] = useState(deGenes !== null)
-  const [showUpstreamDifferentialExpressionPanel, setShowUpstreamDifferentialExpressionPanel] = useState(deGenes !== null)
+  const [showDifferentialExpressionPanel, setShowDifferentialExpressionPanel] = useState(deGenes !== null || exploreParams.pickDeGroup)
+  const [showUpstreamDifferentialExpressionPanel, setShowUpstreamDifferentialExpressionPanel] = useState(deGenes !== null || !exploreParams.pickDeGroup)
 
   const studyHasDe = exploreInfo?.differentialExpression.length > 0
 
   const clusterHasDe = getClusterHasDe(exploreInfo, exploreParams)
+
+
+  // if (exploreParams.pickDeGroup) {
+  //   console.log('')
+  //   console.log('pickDeGroup is true!')
+  //   setShowUpstreamDifferentialExpressionPanel(false)
+  //   setShowDifferentialExpressionPanel(true)
+  //   setShowDeGroupPicker(true)
+  // }
+  console.log('showDifferentialExpressionPanel', showDifferentialExpressionPanel)
+  console.log('showUpstreamDifferentialExpressionPanel', showUpstreamDifferentialExpressionPanel)
 
   console.log('studyHasDe', studyHasDe)
   console.log('clusterHasDe', clusterHasDe)
@@ -269,6 +280,8 @@ export default function ExploreDisplayTabs({
     // also, unset any gene lists as we're about to re-render the explore tab and having gene list selected will show
     // the wrong tabs
     const updateParams = { geneList: '', ideogramFileId: '' }
+
+    if (newParams.pickDeGroup) updateParams.pickDeGroup = true
     const clusterParamNames = ['cluster', 'annotation', 'subsample', 'spatialGroups']
     clusterParamNames.forEach(param => {
       updateParams[param] = param in newParams ? newParams[param] : exploreParamsWithDefaults[param]
@@ -285,6 +298,7 @@ export default function ExploreDisplayTabs({
       updateParams.hiddenTraces = []
     }
 
+    console.log('updateParams', updateParams)
     updateExploreParams(updateParams)
   }
 

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -153,8 +153,6 @@ export default function ExploreDisplayTabs({
   studyAccession, exploreInfo, setExploreInfo, exploreParams, updateExploreParams,
   clearExploreParams, exploreParamsWithDefaults, routerLocation
 }) {
-  console.log('exploreInfo', exploreInfo)
-  console.log('exploreParams', exploreParams)
   const [, setRenderForcer] = useState({})
   const [dataCache] = useState(createCache())
   // tracks whether the view options controls are open or closed
@@ -169,27 +167,12 @@ export default function ExploreDisplayTabs({
   const [, setShowDeGroupPicker] = useState(false)
   const [deGenes, setDeGenes] = useState(null)
   const [deGroup, setDeGroup] = useState(null)
-  const [showDifferentialExpressionPanel, setShowDifferentialExpressionPanel] = useState(deGenes !== null || exploreParams.pickDeGroup)
-  const [showUpstreamDifferentialExpressionPanel, setShowUpstreamDifferentialExpressionPanel] = useState(deGenes !== null || !exploreParams.pickDeGroup)
+  const [showDifferentialExpressionPanel, setShowDifferentialExpressionPanel] = useState(deGenes !== null)
+  const [showUpstreamDifferentialExpressionPanel, setShowUpstreamDifferentialExpressionPanel] = useState(deGenes !== null)
 
   const studyHasDe = exploreInfo?.differentialExpression.length > 0
 
   const clusterHasDe = getClusterHasDe(exploreInfo, exploreParams)
-
-
-  // if (exploreParams.pickDeGroup) {
-  //   console.log('')
-  //   console.log('pickDeGroup is true!')
-  //   setShowUpstreamDifferentialExpressionPanel(false)
-  //   setShowDifferentialExpressionPanel(true)
-  //   setShowDeGroupPicker(true)
-  // }
-  console.log('showDifferentialExpressionPanel', showDifferentialExpressionPanel)
-  console.log('showUpstreamDifferentialExpressionPanel', showUpstreamDifferentialExpressionPanel)
-
-  console.log('studyHasDe', studyHasDe)
-  console.log('clusterHasDe', clusterHasDe)
-  console.log('annotHasDe', annotHasDe)
 
   // Hash of trace label names to the number of points in that trace
   const [countsByLabel, setCountsByLabel] = useState(null)
@@ -281,7 +264,6 @@ export default function ExploreDisplayTabs({
     // the wrong tabs
     const updateParams = { geneList: '', ideogramFileId: '' }
 
-    if (newParams.pickDeGroup) updateParams.pickDeGroup = true
     const clusterParamNames = ['cluster', 'annotation', 'subsample', 'spatialGroups']
     clusterParamNames.forEach(param => {
       updateParams[param] = param in newParams ? newParams[param] : exploreParamsWithDefaults[param]
@@ -298,7 +280,6 @@ export default function ExploreDisplayTabs({
       updateParams.hiddenTraces = []
     }
 
-    console.log('updateParams', updateParams)
     updateExploreParams(updateParams)
   }
 
@@ -662,7 +643,7 @@ export default function ExploreDisplayTabs({
             </button>
           </>
           }
-          {showDifferentialExpressionPanel && countsByLabel &&
+          {showDifferentialExpressionPanel && countsByLabel && annotHasDe &&
           <>
             <DifferentialExpressionPanel
               deGroup={deGroup}
@@ -701,7 +682,10 @@ export default function ExploreDisplayTabs({
               cluster={exploreParamsWithDefaults.cluster}
               annotation={null}
               updateClusterParams={updateClusterParams}
-              hasSelection={false}/>
+              hasSelection={false}
+              setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
+              setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
+            />
           </>
           }
         </div>

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -36,8 +36,6 @@ import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger'
 import Tooltip from 'react-bootstrap/lib/Tooltip'
 import DifferentialExpressionModal from '~/components/explore/DifferentialExpressionModal'
 
-const flags = getFeatureFlagsWithDefaults()
-
 const tabList = [
   { key: 'loading', label: 'loading...' },
   { key: 'scatter', label: 'Scatter' },
@@ -55,6 +53,7 @@ const tabList = [
 
 /** Determine if currently selected cluster has differential expression outputs available */
 function getClusterHasDe(exploreInfo, exploreParams) {
+  const flags = getFeatureFlagsWithDefaults()
   if (!flags?.differential_expression_frontend || !exploreInfo) return false
   let clusterHasDe = false
   const annotList = exploreInfo.annotationList
@@ -108,6 +107,7 @@ function getAnnotationsWithDE(exploreInfo, exploreParams) {
 
 /** Determine if currently selected annotation has differential expression outputs available */
 function getAnnotHasDe(exploreInfo, exploreParams) {
+  const flags = getFeatureFlagsWithDefaults()
   if (!flags?.differential_expression_frontend || !exploreInfo) {
     // set isDifferentialExpressionEnabled to false as user cannot see DE results, even if present for annotation
     if (window.SCP) {
@@ -167,7 +167,7 @@ export default function ExploreDisplayTabs({
   const [currentPointsSelected, setCurrentPointsSelected] = useState(null)
 
   // Differential expression settings
-
+  const flags = getFeatureFlagsWithDefaults()
   const studyHasDe = flags?.differential_expression_frontend && exploreInfo?.differentialExpression.length > 0
   const annotHasDe = getAnnotHasDe(exploreInfo, exploreParams)
   const clusterHasDe = getClusterHasDe(exploreInfo, exploreParams)

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -97,8 +97,6 @@ function getAnnotationsWithDE(exploreInfo, exploreParams) {
 
   const clustersWithDe = Array.from(new Set(annotsWithDe.map(a => a.cluster_name)))
 
-  console.log('annotsWithDe', annotsWithDe)
-
   return {
     clusters: clustersWithDe,
     annotations: annotsWithDe,
@@ -136,8 +134,6 @@ function getAnnotHasDe(exploreInfo, exploreParams) {
       deItem.annotation_scope === selectedAnnot.scope
     )
   })
-
-  console.log('in getAnnotHasDe, annotHasDe', annotHasDe)
 
   return annotHasDe
 }
@@ -180,7 +176,6 @@ export default function ExploreDisplayTabs({
   const studyHasDe = exploreInfo?.differentialExpression.length > 0
 
   const clusterHasDe = getClusterHasDe(exploreInfo, exploreParams)
-  console.log('clusterHasDe', clusterHasDe)
 
   // Hash of trace label names to the number of points in that trace
   const [countsByLabel, setCountsByLabel] = useState(null)
@@ -235,9 +230,6 @@ export default function ExploreDisplayTabs({
   if (exploreInfo) {
     hasSpatialGroups = exploreInfo.spatialGroups.length > 0
   }
-
-  console.log('annotHasDe', annotHasDe)
-  console.log('countsByLabel', countsByLabel)
 
   /** in the event a component takes an action which updates the list of annotations available
     * e.g. by creating a user annotation, this updates the list */
@@ -593,7 +585,8 @@ export default function ExploreDisplayTabs({
                   <div className="row de-modal-row-wrapper">
                     <div className="col-xs-12 de-modal-row">
                       <button
-                        className="btn btn-primary"
+                        className=
+                          {`btn btn-primary differential-expression${annotHasDe ? '' : '-nondefault'}`}
                         onClick={() => {
                           if (annotHasDe) {
                             setShowDifferentialExpressionPanel(true)

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -85,9 +85,7 @@ function getAnnotationsWithDE(exploreInfo, exploreParams) {
   }
 
   annotsWithDe = exploreInfo.differentialExpression.filter(deItem => {
-    return (
-      deItem.cluster_name === selectedCluster
-    )
+    return deItem
   }).map(annot => {
     return {
       cluster_name: annot.cluster_name,
@@ -97,8 +95,10 @@ function getAnnotationsWithDE(exploreInfo, exploreParams) {
     }
   })
 
+  const clustersWithDe = Array.from(new Set(annotsWithDe.map(a => a.cluster_name)))
+
   console.log('annotsWithDe', annotsWithDe)
-  return {annotations: annotsWithDe}
+  return {clusters: clustersWithDe, annotations: annotsWithDe}
 }
 
 /** Determine if currently selected annotation has differential expression outputs available */
@@ -131,6 +131,8 @@ function getAnnotHasDe(exploreInfo, exploreParams) {
       deItem.annotation_scope === selectedAnnot.scope
     )
   })
+
+  console.log('in getAnnotHasDe, annotHasDe', annotHasDe)
 
   return annotHasDe
 }
@@ -173,6 +175,7 @@ export default function ExploreDisplayTabs({
   const studyHasDe = exploreInfo?.differentialExpression.length > 0
 
   const clusterHasDe = getClusterHasDe(exploreInfo, exploreParams)
+  console.log('clusterHasDe', clusterHasDe)
 
   // Hash of trace label names to the number of points in that trace
   const [countsByLabel, setCountsByLabel] = useState(null)
@@ -227,6 +230,9 @@ export default function ExploreDisplayTabs({
   if (exploreInfo) {
     hasSpatialGroups = exploreInfo.spatialGroups.length > 0
   }
+
+  console.log('annotHasDe', annotHasDe)
+  console.log('countsByLabel', countsByLabel)
 
   /** in the event a component takes an action which updates the list of annotations available
     * e.g. by creating a user annotation, this updates the list */
@@ -587,7 +593,7 @@ export default function ExploreDisplayTabs({
                           if (annotHasDe) {
                             setShowDifferentialExpressionPanel(true)
                             setShowDeGroupPicker(true)
-                          } else if (clusterHasDe) {
+                          } else if (studyHasDe) {
                             setShowUpstreamDifferentialExpressionPanel(true)
                           }
                         }}
@@ -665,16 +671,12 @@ export default function ExploreDisplayTabs({
             {!clusterHasDe &&
             <>
               <ClusterSelector
-                annotationList={annotationList}
-                cluster={exploreParamsWithDefaults.cluster}
-                annotation={exploreParamsWithDefaults.annotation}
+                annotationList={getAnnotationsWithDE(exploreInfo, exploreParams)}
+                cluster={""}
+                annotation={""}
                 updateClusterParams={updateClusterParams}
+                hasSelection={false}
                 spatialGroups={exploreInfo ? exploreInfo.spatialGroups : []}/>
-              {hasSpatialGroups &&
-              <SpatialSelector allSpatialGroups={exploreInfo.spatialGroups}
-                spatialGroups={exploreParamsWithDefaults.spatialGroups}
-                updateSpatialGroups={spatialGroups => updateClusterParams({ spatialGroups })}/>
-              }
             </>
             }
             <AnnotationSelector

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -98,7 +98,12 @@ function getAnnotationsWithDE(exploreInfo, exploreParams) {
   const clustersWithDe = Array.from(new Set(annotsWithDe.map(a => a.cluster_name)))
 
   console.log('annotsWithDe', annotsWithDe)
-  return {clusters: clustersWithDe, annotations: annotsWithDe}
+
+  return {
+    clusters: clustersWithDe,
+    annotations: annotsWithDe,
+    subsample_thresholds: exploreInfo.annotationList.subsample_thresholds
+  }
 }
 
 /** Determine if currently selected annotation has differential expression outputs available */
@@ -679,7 +684,8 @@ export default function ExploreDisplayTabs({
                 spatialGroups={exploreInfo ? exploreInfo.spatialGroups : []}/>
             </>
             }
-            <AnnotationSelector
+            {clusterHasDe &&
+              <AnnotationSelector
               annotationList={getAnnotationsWithDE(exploreInfo, exploreParams)}
               cluster={exploreParamsWithDefaults.cluster}
               annotation={null}
@@ -688,6 +694,7 @@ export default function ExploreDisplayTabs({
               setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
               setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
             />
+          }
           </>
           }
         </div>

--- a/app/javascript/components/explore/ExploreTabRouter.jsx
+++ b/app/javascript/components/explore/ExploreTabRouter.jsx
@@ -43,7 +43,6 @@ function updateExploreParams(newOptions, wasUserSpecified=true) {
   const search = location.search
   const currentParams = buildExploreParamsFromQuery(search)
   const mergedOpts = Object.assign({}, currentParams, newOptions)
-  console.log('mergedOpts', mergedOpts)
   if (wasUserSpecified) {
     // this is just default params being fetched from the server, so don't change the url
     Object.keys(newOptions).forEach(key => {
@@ -98,7 +97,6 @@ function buildExploreParamsFromQuery(query) {
   } else {
     exploreParams.spatialGroups = queryParams.spatialGroups ? queryParams.spatialGroups.split(',') : []
   }
-  exploreParams.pickDeGroup = queryParams.pickDeGroup === 'true' ? true : null
   exploreParams.genes = geneParamToArray(queryParams.genes)
   exploreParams.geneList = queryParams.geneList ? queryParams.geneList : ''
   exploreParams.heatmapRowCentering = queryParams.heatmapRowCentering ?
@@ -131,7 +129,6 @@ function buildQueryFromParams(exploreParams) {
     cluster: exploreParams.cluster,
     annotation: getIdentifierForAnnotation(exploreParams.annotation),
     subsample: exploreParams.subsample,
-    pickDeGroup: exploreParams.pickDeGroup,
     genes: geneArrayToParam(exploreParams.genes),
     consensus: exploreParams.consensus,
     geneList: exploreParams.geneList,

--- a/app/javascript/components/explore/ExploreTabRouter.jsx
+++ b/app/javascript/components/explore/ExploreTabRouter.jsx
@@ -43,6 +43,7 @@ function updateExploreParams(newOptions, wasUserSpecified=true) {
   const search = location.search
   const currentParams = buildExploreParamsFromQuery(search)
   const mergedOpts = Object.assign({}, currentParams, newOptions)
+  console.log('mergedOpts', mergedOpts)
   if (wasUserSpecified) {
     // this is just default params being fetched from the server, so don't change the url
     Object.keys(newOptions).forEach(key => {
@@ -97,6 +98,7 @@ function buildExploreParamsFromQuery(query) {
   } else {
     exploreParams.spatialGroups = queryParams.spatialGroups ? queryParams.spatialGroups.split(',') : []
   }
+  exploreParams.pickDeGroup = queryParams.pickDeGroup === 'true' ? true : null
   exploreParams.genes = geneParamToArray(queryParams.genes)
   exploreParams.geneList = queryParams.geneList ? queryParams.geneList : ''
   exploreParams.heatmapRowCentering = queryParams.heatmapRowCentering ?
@@ -129,6 +131,7 @@ function buildQueryFromParams(exploreParams) {
     cluster: exploreParams.cluster,
     annotation: getIdentifierForAnnotation(exploreParams.annotation),
     subsample: exploreParams.subsample,
+    pickDeGroup: exploreParams.pickDeGroup,
     genes: geneArrayToParam(exploreParams.genes),
     consensus: exploreParams.consensus,
     geneList: exploreParams.geneList,

--- a/app/javascript/components/upload/ExpandableFileForm.jsx
+++ b/app/javascript/components/upload/ExpandableFileForm.jsx
@@ -111,7 +111,7 @@ export function SaveDeleteButtons({ file, saveFile, deleteFile, validationMessag
     return <div className="text-center">
       <div className="validation-error"><FontAwesomeIcon icon={faTimes}/> Parse failed</div>
       <div className="detail">Check your email for details - this file will be removed from the server.</div>
-      <button className="terra-secondary-btn" onClick={() => deleteFile(file)}>Ok</button>
+      <button className="terra-secondary-btn" onClick={() => deleteFile(file)}>OK</button>
     </div>
   }
   return <div className="flexbox-align-center button-panel">

--- a/app/javascript/components/visualization/controls/AnnotationSelector.jsx
+++ b/app/javascript/components/visualization/controls/AnnotationSelector.jsx
@@ -7,21 +7,21 @@ import { annotationKeyProperties, getMatchedAnnotation, clusterSelectStyle } fro
 /** takes the server response and returns annotation options suitable for react-select */
 function getAnnotationOptions(annotationList, clusterName) {
   return [{
-    label: 'Study Wide',
+    label: 'Study wide',
     options: annotationList.annotations
       .filter(annot => annot.scope === 'study').map(annot => annotationKeyProperties(annot))
   }, {
-    label: 'Cluster-Based',
+    label: 'Cluster-based',
     options: annotationList.annotations
       .filter(annot => annot.cluster_name === clusterName && annot.scope === 'cluster')
       .map(annot => annotationKeyProperties(annot))
   }, {
-    label: 'User-Based',
+    label: 'User-based',
     options: annotationList.annotations
       .filter(annot => annot.cluster_name === clusterName && annot.scope === 'user')
       .map(annot => annotationKeyProperties(annot))
   }, {
-    label: 'Cannot Display',
+    label: 'Cannot display',
     options: annotationList.annotations
       .filter(annot => annot.scope === 'invalid' && (annot.cluster_name == clusterName || !annot.cluster_name))
       .map(annot => annotationKeyProperties(annot))

--- a/app/javascript/components/visualization/controls/AnnotationSelector.jsx
+++ b/app/javascript/components/visualization/controls/AnnotationSelector.jsx
@@ -44,7 +44,9 @@ export default function AnnotationControl({
   cluster,
   annotation,
   updateClusterParams,
-  hasSelection=true
+  hasSelection=true,
+  setShowDifferentialExpressionPanel,
+  setShowUpstreamDifferentialExpressionPanel
 }) {
   if (!annotationList) {
     annotationList = { default_cluster: null, default_annotation: null, annotations: [] }
@@ -87,7 +89,9 @@ export default function AnnotationControl({
             getOptionLabel={annotation => annotation.name}
             getOptionValue={annotation => annotation.scope + annotation.name + annotation.cluster_name}
             onChange={newAnnotation => {
-              updateClusterParams({ annotation: newAnnotation, pickDeGroup: true })
+              updateClusterParams({ annotation: newAnnotation })
+              setShowDifferentialExpressionPanel(true)
+              setShowUpstreamDifferentialExpressionPanel(false)
             }}
             styles={clusterSelectStyle}/>
         }

--- a/app/javascript/components/visualization/controls/AnnotationSelector.jsx
+++ b/app/javascript/components/visualization/controls/AnnotationSelector.jsx
@@ -83,9 +83,9 @@ export default function AnnotationControl({
         }
         {!hasSelection &&
           <Select
-            menuIsOpen={!hasSelection}
+            menuIsOpen={true}
             options={annotationOptions}
-            data-analytics-name="annotation-select"
+            data-analytics-name="annotation-select-differential-expression"
             getOptionLabel={annotation => annotation.name}
             getOptionValue={annotation => annotation.scope + annotation.name + annotation.cluster_name}
             onChange={newAnnotation => {

--- a/app/javascript/components/visualization/controls/AnnotationSelector.jsx
+++ b/app/javascript/components/visualization/controls/AnnotationSelector.jsx
@@ -86,7 +86,9 @@ export default function AnnotationControl({
             data-analytics-name="annotation-select"
             getOptionLabel={annotation => annotation.name}
             getOptionValue={annotation => annotation.scope + annotation.name + annotation.cluster_name}
-            onChange={newAnnotation => updateClusterParams({ annotation: newAnnotation })}
+            onChange={newAnnotation => {
+              updateClusterParams({ annotation: newAnnotation, pickDeGroup: true })
+            }}
             styles={clusterSelectStyle}/>
         }
       </label>

--- a/app/javascript/components/visualization/controls/AnnotationSelector.jsx
+++ b/app/javascript/components/visualization/controls/AnnotationSelector.jsx
@@ -4,8 +4,6 @@ import _clone from 'lodash/clone'
 import Select from '~/lib/InstrumentedSelect'
 import { annotationKeyProperties, getMatchedAnnotation, clusterSelectStyle } from '~/lib/cluster-utils'
 
-const noneSelected = 'Select annotation'
-
 /** takes the server response and returns annotation options suitable for react-select */
 function getAnnotationOptions(annotationList, clusterName) {
   return [{

--- a/app/javascript/components/visualization/controls/AnnotationSelector.jsx
+++ b/app/javascript/components/visualization/controls/AnnotationSelector.jsx
@@ -4,6 +4,8 @@ import _clone from 'lodash/clone'
 import Select from '~/lib/InstrumentedSelect'
 import { annotationKeyProperties, getMatchedAnnotation, clusterSelectStyle } from '~/lib/cluster-utils'
 
+const noneSelected = 'Select annotation'
+
 /** takes the server response and returns annotation options suitable for react-select */
 function getAnnotationOptions(annotationList, clusterName) {
   return [{
@@ -41,7 +43,8 @@ export default function AnnotationControl({
   annotationList,
   cluster,
   annotation,
-  updateClusterParams
+  updateClusterParams,
+  hasSelection=true
 }) {
   if (!annotationList) {
     annotationList = { default_cluster: null, default_annotation: null, annotations: [] }
@@ -49,27 +52,43 @@ export default function AnnotationControl({
 
   const annotationOptions = getAnnotationOptions(annotationList, cluster)
 
-  const shownAnnotation = _clone(annotation)
-  // for user annotations, we have to match the given id to a name to show the name in the dropdown
-  if (annotation && annotation.scope === 'user') {
-    const matchedAnnotation = getMatchedAnnotation(annotation, annotationList)
-    if (matchedAnnotation) {
-      shownAnnotation.name = matchedAnnotation.name
-      shownAnnotation.id = matchedAnnotation.id
+  let shownAnnotation
+  if (hasSelection) {
+    shownAnnotation = _clone(annotation)
+    // for user annotations, we have to match the given id to a name to show the name in the dropdown
+    if (annotation && annotation.scope === 'user') {
+      const matchedAnnotation = getMatchedAnnotation(annotation, annotationList)
+      if (matchedAnnotation) {
+        shownAnnotation.name = matchedAnnotation.name
+        shownAnnotation.id = matchedAnnotation.id
+      }
     }
   }
 
   return (
     <div className="form-group">
       <label className="labeled-select">Annotation
-        <Select options={annotationOptions}
-          data-analytics-name="annotation-select"
-          value={shownAnnotation}
-          isOptionDisabled={annotation => annotation.isDisabled}
-          getOptionLabel={annotation => annotation.name}
-          getOptionValue={annotation => annotation.scope + annotation.name + annotation.cluster_name}
-          onChange={newAnnotation => updateClusterParams({ annotation: newAnnotation })}
-          styles={clusterSelectStyle}/>
+        {hasSelection &&
+          <Select
+            options={annotationOptions}
+            data-analytics-name="annotation-select"
+            value={shownAnnotation}
+            isOptionDisabled={annotation => annotation.isDisabled}
+            getOptionLabel={annotation => annotation.name}
+            getOptionValue={annotation => annotation.scope + annotation.name + annotation.cluster_name}
+            onChange={newAnnotation => updateClusterParams({ annotation: newAnnotation })}
+            styles={clusterSelectStyle}/>
+        }
+        {!hasSelection &&
+          <Select
+            menuIsOpen={!hasSelection}
+            options={annotationOptions}
+            data-analytics-name="annotation-select"
+            getOptionLabel={annotation => annotation.name}
+            getOptionValue={annotation => annotation.scope + annotation.name + annotation.cluster_name}
+            onChange={newAnnotation => updateClusterParams({ annotation: newAnnotation })}
+            styles={clusterSelectStyle}/>
+        }
       </label>
     </div>
   )

--- a/app/javascript/components/visualization/controls/AnnotationSelector.jsx
+++ b/app/javascript/components/visualization/controls/AnnotationSelector.jsx
@@ -1,8 +1,7 @@
 import React from 'react'
-import _clone from 'lodash/clone'
 
 import Select from '~/lib/InstrumentedSelect'
-import { annotationKeyProperties, getMatchedAnnotation, clusterSelectStyle } from '~/lib/cluster-utils'
+import { annotationKeyProperties, clusterSelectStyle } from '~/lib/cluster-utils'
 
 /** takes the server response and returns annotation options suitable for react-select */
 function getAnnotationOptions(annotationList, clusterName) {
@@ -40,7 +39,7 @@ function getAnnotationOptions(annotationList, clusterName) {
 export default function AnnotationControl({
   annotationList,
   cluster,
-  annotation,
+  shownAnnotation,
   updateClusterParams,
   hasSelection=true,
   setShowDifferentialExpressionPanel,
@@ -51,19 +50,6 @@ export default function AnnotationControl({
   }
 
   const annotationOptions = getAnnotationOptions(annotationList, cluster)
-
-  let shownAnnotation
-  if (hasSelection) {
-    shownAnnotation = _clone(annotation)
-    // for user annotations, we have to match the given id to a name to show the name in the dropdown
-    if (annotation && annotation.scope === 'user') {
-      const matchedAnnotation = getMatchedAnnotation(annotation, annotationList)
-      if (matchedAnnotation) {
-        shownAnnotation.name = matchedAnnotation.name
-        shownAnnotation.id = matchedAnnotation.id
-      }
-    }
-  }
 
   return (
     <div className="form-group">

--- a/app/javascript/components/visualization/controls/ClusterSelector.jsx
+++ b/app/javascript/components/visualization/controls/ClusterSelector.jsx
@@ -71,8 +71,8 @@ export default function ClusterSelector({
       {!hasSelection &&
         <Select
           menuIsOpen={true}
+          placeholder="Select..."
           options={clusterOptions}
-          value={{ label: 'Select cluster...', value: 'Select cluster...' }}
           data-analytics-name="cluster-select-differential-expression"
           onChange={newCluster => {
             updateClusterParams({

--- a/app/javascript/components/visualization/controls/ClusterSelector.jsx
+++ b/app/javascript/components/visualization/controls/ClusterSelector.jsx
@@ -49,11 +49,6 @@ export default function ClusterSelector({
 
   const clusterOptions = getClusterOptions(annotationList, spatialGroups)
 
-  console.log('in ClusterSelector, annotationList')
-  console.log(annotationList)
-  console.log('in ClusterSelector, clusterOptions')
-  console.log(clusterOptions)
-
   return (
     <div className="form-group">
       <label className="labeled-select">Clustering

--- a/app/javascript/components/visualization/controls/ClusterSelector.jsx
+++ b/app/javascript/components/visualization/controls/ClusterSelector.jsx
@@ -40,7 +40,8 @@ export default function ClusterSelector({
   spatialGroups,
   cluster,
   annotation,
-  updateClusterParams
+  updateClusterParams,
+  hasSelection=true
 }) {
   if (!annotationList) {
     annotationList = { default_cluster: null, default_annotation: null, annotations: [] }
@@ -48,12 +49,36 @@ export default function ClusterSelector({
 
   const clusterOptions = getClusterOptions(annotationList, spatialGroups)
 
+  console.log('in ClusterSelector, annotationList')
+  console.log(annotationList)
+  console.log('in ClusterSelector, clusterOptions')
+  console.log(clusterOptions)
+
   return (
     <div className="form-group">
       <label className="labeled-select">Clustering
-        <Select options={clusterOptions}
-          value={{ label: cluster, value: cluster }}
-          data-analytics-name="cluster-select"
+        {hasSelection &&
+          <Select options={clusterOptions}
+            value={{ label: cluster, value: cluster }}
+            data-analytics-name="cluster-select"
+            onChange={newCluster => updateClusterParams({
+              annotation: annotationKeyProperties(getDefaultAnnotationForCluster(
+                annotationList,
+                newCluster.value,
+                annotation
+              )),
+              cluster: newCluster.value,
+              subsample: getDefaultSubsampleForCluster(annotationList, newCluster.value)
+            })}
+            styles={clusterSelectStyle}
+          />
+      }
+      {!hasSelection &&
+        <Select
+          menuIsOpen={true}
+          options={clusterOptions}
+          value={{ label: 'Select cluster...', value: 'Select cluster...' }}
+          data-analytics-name="cluster-select-differential-expression"
           onChange={newCluster => updateClusterParams({
             annotation: annotationKeyProperties(getDefaultAnnotationForCluster(
               annotationList,
@@ -62,9 +87,10 @@ export default function ClusterSelector({
             )),
             cluster: newCluster.value,
             subsample: getDefaultSubsampleForCluster(annotationList, newCluster.value)
-          })}
-          styles={clusterSelectStyle}
-        />
+        })}
+        styles={clusterSelectStyle}
+      />
+      }
       </label>
     </div>
   )

--- a/app/javascript/components/visualization/controls/ClusterSelector.jsx
+++ b/app/javascript/components/visualization/controls/ClusterSelector.jsx
@@ -79,15 +79,17 @@ export default function ClusterSelector({
           options={clusterOptions}
           value={{ label: 'Select cluster...', value: 'Select cluster...' }}
           data-analytics-name="cluster-select-differential-expression"
-          onChange={newCluster => updateClusterParams({
-            annotation: annotationKeyProperties(getDefaultAnnotationForCluster(
-              annotationList,
-              newCluster.value,
-              annotation
-            )),
-            cluster: newCluster.value,
-            subsample: getDefaultSubsampleForCluster(annotationList, newCluster.value)
-        })}
+          onChange={newCluster => {
+            updateClusterParams({
+              annotation: annotationKeyProperties(getDefaultAnnotationForCluster(
+                annotationList,
+                newCluster.value,
+                annotation
+              )),
+              cluster: newCluster.value,
+              subsample: getDefaultSubsampleForCluster(annotationList, newCluster.value)
+            })
+          }}
         styles={clusterSelectStyle}
       />
       }

--- a/app/javascript/components/visualization/controls/CreateAnnotation.jsx
+++ b/app/javascript/components/visualization/controls/CreateAnnotation.jsx
@@ -246,7 +246,7 @@ function CreateAnnotation({
         <Modal.Footer>
           <button className="btn btn-md btn-primary" onClick={() => {
             setShowResponseModal(false)
-          }}>Ok</button>
+          }}>OK</button>
         </Modal.Footer>
       </Modal>
     </div>

--- a/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
+++ b/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
@@ -16,8 +16,6 @@ function getSimpleOptions(stringArray) {
   return stringArray.map(assignLabelsAndValues)
 }
 
-const nonAlphaNumericRegex = /\W/g
-
 /**
  * Transform raw TSV text into array of differential expression gene objects
  */
@@ -25,8 +23,8 @@ function parseDeFile(tsvText) {
   const deGenes = []
   const tsvLines = tsvText.split(newlineRegex)
   for (let i = 1; i < tsvLines.length; i++) {
-    const tsvLine = tsvLines[i];
-    if (tsvLine === '') continue
+    const tsvLine = tsvLines[i]
+    if (tsvLine === '') {continue}
     // Each element in this array is DE data for the gene in this row
     const [
       index, // eslint-disable-line

--- a/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
+++ b/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
@@ -112,7 +112,6 @@ export default function DifferentialExpressionGroupPicker({
     setDeGenes(deGenes)
   }
 
-  console.log('deGroup', deGroup)
   return (
     <>
       {!deGenes &&

--- a/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
+++ b/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
@@ -112,6 +112,7 @@ export default function DifferentialExpressionGroupPicker({
     setDeGenes(deGenes)
   }
 
+  console.log('deGroup', deGroup)
   return (
     <>
       {!deGenes &&

--- a/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
+++ b/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
@@ -89,6 +89,11 @@ export default function DifferentialExpressionGroupPicker({
   countsByLabel, deObjects, setDeFilePath
 }) {
   let groups = getLegendSortedLabels(countsByLabel)
+
+  console.log('deObjects', deObjects)
+  console.log('groups', groups)
+  console.log('clusterName', clusterName)
+  console.log('annotation', annotation)
   groups = groups.filter(group => {
     const deOption = getMatchingDeOption(deObjects, group, clusterName, annotation)
     return deOption !== undefined

--- a/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
+++ b/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
@@ -89,11 +89,6 @@ export default function DifferentialExpressionGroupPicker({
   countsByLabel, deObjects, setDeFilePath
 }) {
   let groups = getLegendSortedLabels(countsByLabel)
-
-  console.log('deObjects', deObjects)
-  console.log('groups', groups)
-  console.log('clusterName', clusterName)
-  console.log('annotation', annotation)
   groups = groups.filter(group => {
     const deOption = getMatchingDeOption(deObjects, group, clusterName, annotation)
     return deOption !== undefined

--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -1,8 +1,7 @@
 /** Utility functions for parsing cluster and annotation parameters from the server
  *  These live in a separate utility because multiple endpoints (explore, cluster, etc..)
  *  return annotationLists of the same basic structure */
-
-import { ParseException } from './validation/shared-validation'
+import _clone from 'lodash/clone'
 
 /** custom styling for cluster control-style select */
 export const clusterSelectStyle = {
@@ -20,7 +19,6 @@ export const emptyDataParams = {
 }
 
 export const UNSPECIFIED_ANNOTATION_NAME = '--Unspecified--'
-const GROUP_VIZ_THRESHOLD_MAX = 200
 
 /** takes the server response and returns subsample default subsample for the cluster */
 export function getDefaultSubsampleForCluster(annotationList, clusterName) {
@@ -148,8 +146,8 @@ export function getAnnotationValues(annotation, annotationList) {
   return []
 }
 
-/** finds the matching entry in the all annotation list for the specified annotation */
-export function getMatchedAnnotation(annotation, annotationList) {
+/** Find matching entry in annotation list for specified annotation */
+function getMatchedAnnotation(annotation, annotationList) {
   if (annotationList && annotationList.annotations) {
     const matchedAnnotation = annotationList.annotations.find(a => {
       return (a.name === annotation.name || a.id === annotation.name) &&
@@ -159,4 +157,18 @@ export function getMatchedAnnotation(annotation, annotationList) {
     return matchedAnnotation
   }
   return null
+}
+
+/** Get display value for annotation drop-down menu, including user annotations */
+export function getShownAnnotation(annotation, annotationList) {
+  const shownAnnotation = _clone(annotation)
+  // for user annotations, we have to match the given id to a name to show the name in the dropdown
+  if (annotation && annotation.scope === 'user') {
+    const matchedAnnotation = getMatchedAnnotation(annotation, annotationList)
+    if (matchedAnnotation) {
+      shownAnnotation.name = matchedAnnotation.name
+      shownAnnotation.id = matchedAnnotation.id
+    }
+  }
+  return shownAnnotation
 }

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -211,15 +211,20 @@ function getEventPropsWithTabsApplied(target, props, eventName) {
   return { eventName, updatedProps }
 }
 
-/**
- * Log click on link, i.e. anchor (<a ...) tag
- */
-export function logClickLink(target) {
-  const props = {
+/** Get text / name, classes, and ID for target element */
+function getStandardClickProps(target) {
+  return {
     text: getNameForClickTarget(target),
     classList: getClassListAsArray(target),
     id: target.id
   }
+}
+
+/**
+ * Log click on link, i.e. anchor (<a ...) tag
+ */
+export function logClickLink(target) {
+  const props = getStandardClickProps(target)
   // Check if target is a tab that's not a part of a menu
   const { eventName, updatedProps } = getEventPropsWithTabsApplied(target, props, 'click:link')
   log(eventName, updatedProps)
@@ -229,11 +234,7 @@ export function logClickLink(target) {
  * Log click on button, e.g. for pagination, "Apply", etc.
  */
 function logClickButton(target) {
-  const props = {
-    text: getNameForClickTarget(target),
-    classList: getClassListAsArray(target),
-    id: target.id
-  }
+  const props = getStandardClickProps(target)
   const { eventName, updatedProps } = getEventPropsWithTabsApplied(target, props, 'click:button')
   log(eventName, updatedProps)
 

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -229,7 +229,11 @@ export function logClickLink(target) {
  * Log click on button, e.g. for pagination, "Apply", etc.
  */
 function logClickButton(target) {
-  const props = { text: getNameForClickTarget(target) }
+  const props = {
+    text: getNameForClickTarget(target),
+    classList: getClassListAsArray(target),
+    id: target.id
+  }
   const { eventName, updatedProps } = getEventPropsWithTabsApplied(target, props, 'click:button')
   log(eventName, updatedProps)
 

--- a/app/javascript/styles/_differentialExpression.scss
+++ b/app/javascript/styles/_differentialExpression.scss
@@ -64,3 +64,7 @@
   margin-top: 16px;
   font-weight: normal;
 }
+
+.no-de-summary {
+  padding-left: 10px
+}

--- a/app/javascript/styles/_differentialExpression.scss
+++ b/app/javascript/styles/_differentialExpression.scss
@@ -59,3 +59,8 @@
   box-shadow: none;
   outline: none;
 }
+
+.de-nondefault-explainer {
+  margin-top: 16px;
+  font-weight: normal;
+}

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -90,7 +90,7 @@
     border: 1px solid #bbb;
     border-radius: 5px;
     margin-top: 4rem;
-    margin-bottom: -9rem;
+    margin-bottom: -8rem;
 
   }
 

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -44,6 +44,10 @@ label {
   color: #c9302c;
 }
 
+.bold {
+  font-weight: bold;
+}
+
 .sc-navbar {
   a {
     color: white !important;

--- a/test/js/explore/differential-expression-panel.test.js
+++ b/test/js/explore/differential-expression-panel.test.js
@@ -92,4 +92,5 @@ describe('Differential expression panel', () => {
     fireEvent.change(input, { target: { value: 'SO' } })
     expect(deTable.querySelectorAll('.de-gene-row')).toHaveLength(1)
   })
+
 })

--- a/test/js/explore/explore-display-tabs.test.js
+++ b/test/js/explore/explore-display-tabs.test.js
@@ -18,7 +18,8 @@ jest.mock('components/visualization/InferCNVIdeogram', () => {
 })
 
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import * as UserProvider from '~/providers/UserProvider'
 import ExploreDisplayTabs, { getEnabledTabs } from 'components/explore/ExploreDisplayTabs'
 import {
   exploreInfo as exploreInfoDe,
@@ -290,6 +291,12 @@ describe('explore tabs are activated based on study info and parameters', () => 
   })
 
   it('shows "Differential expression" button when clustering (but not current annotation) has DE results', async () => {
+    jest
+      .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
+      .mockReturnValue({
+        differential_expression_frontend: true
+      })
+
     const {container} = render((
       <ExploreDisplayTabs
         studyAccession={"SCP123"}

--- a/test/js/explore/explore-display-tabs.test.js
+++ b/test/js/explore/explore-display-tabs.test.js
@@ -17,7 +17,13 @@ jest.mock('components/visualization/InferCNVIdeogram', () => {
   }
 })
 
-import { getEnabledTabs } from 'components/explore/ExploreDisplayTabs'
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import ExploreDisplayTabs, { getEnabledTabs } from 'components/explore/ExploreDisplayTabs'
+import {
+  exploreInfo as exploreInfoDe,
+  exploreParams as exploreParamsDe
+} from './explore-tab-de-integration.test-data'
 import '@testing-library/jest-dom/extend-expect'
 
 // mock explore info from a study
@@ -281,5 +287,19 @@ describe('explore tabs are activated based on study info and parameters', () => 
     }
 
     expect(expectedResults).toEqual(getEnabledTabs(exploreInfo, exploreParams))
+  })
+
+  it('shows "Differential expression" button when clustering (but not current annotation) has DE results', async () => {
+    const {container} = render((
+      <ExploreDisplayTabs
+        studyAccession={"SCP123"}
+        exploreParams={exploreParamsDe}
+        exploreParamsWithDefaults={exploreParamsDe}
+        exploreInfo={exploreInfoDe}
+      />
+    ))
+
+    const deButton = container.querySelector('.differential-expression-nondefault')
+    expect(deButton).toHaveTextContent('Differential expression')
   })
 })

--- a/test/js/explore/explore-tab-de-integration.test-data.js
+++ b/test/js/explore/explore-tab-de-integration.test-data.js
@@ -1,0 +1,863 @@
+/**
+ * @fileoverview: Data for high-level unit test for DE button display logic (SCP-4954)
+ */
+
+export const exploreParams = {
+  "userSpecified": {
+      "annotation": true,
+      "cluster": true,
+      "spatialGroups": true,
+      "subsample": true
+  },
+  "cluster": "All Cells UMAP",
+  "annotation": {
+      "name": "biosample_id",
+      "type": "group",
+      "scope": "study"
+  },
+  "subsample": "all",
+  "consensus": null,
+  "spatialGroups": [],
+  "genes": [],
+  "geneList": "",
+  "heatmapRowCentering": "",
+  "scatterColor": "",
+  "distributionPlot": "",
+  "distributionPoints": "",
+  "tab": "",
+  "heatmapFit": "",
+  "bamFileName": "",
+  "ideogramFileId": "",
+  "expressionFilter": [
+      0,
+      1
+  ],
+  "hiddenTraces": [],
+  "isSplitLabelArrays": null
+}
+
+export const exploreInfo = {
+  "cluster": {
+      "numPoints": 48478,
+      "isSubsampled": true
+  },
+  "taxonNames": [
+      "Homo sapiens"
+  ],
+  "inferCNVIdeogramFiles": null,
+  "bamBundleList": [],
+  "uniqueGenes": [
+      "A1BG",
+      "A1BG-AS1", // Truncated almost all of 10000+ gene list, for brevity here
+  ],
+  "geneLists": [],
+  "precomputedHeatmapLabel": null,
+  "annotationList": {
+      "default_cluster": "All Cells UMAP",
+      "default_annotation": {
+          "name": "biosample_id",
+          "type": "group",
+          "scope": "study",
+          "values": [
+              "BM02_6wkpp_r1",
+              "BM12_6wk",
+              "BM03_6wkpp_r1",
+              "BM05_6wkpp",
+              "BM08_6wk_r1",
+              "BM08_6wkpp_r2",
+              "BM13_6wk_r1",
+              "BM13_6wk_r3",
+              "BM07_7wkpp_r1",
+              "BM11_6wk_r1",
+              "BM01_7wkpp_r1",
+              "BM02_13wkpp_t1",
+              "BM08_13wk_r1",
+              "BM05_12wk_r2",
+              "BM03_13wk_r1",
+              "BM03_13wkpp_r2",
+              "BM01_13wkpp_r2",
+              "BM13_12wk",
+              "BM03_15dpp_r1",
+              "BM08_15dpp_r1",
+              "BM01_16dpp_r3",
+              "BM07_17dpp_r2",
+              "BM19_4dpp_r1",
+              "BM02_5dpp_r1",
+              "BM02_5dpp_r2",
+              "BM03_5dpp_r1",
+              "BM07_5dpp_r1",
+              "BM01_5dpp_r1",
+              "BM05_6dpp_r1",
+              "BM11_5dpp_r1",
+              "BM13_6dpp_r1",
+              "BM07_13wk_r1",
+              "BM01_23wk_r1",
+              "BM03_24wk_r1",
+              "BM03_24wk_r2",
+              "BM08_24wk",
+              "BM02_24wk_r2",
+              "BM02_10dpp_r1",
+              "BM03_10dpp_r1",
+              "BM03_10dpp_r2",
+              "BM01_12dpp_r1",
+              "BM07_10dpp_r1",
+              "BM13_13dpp_r1",
+              "BM02_14dpp_r1",
+              "BM04_t1_r2",
+              "BM10_t1_r1",
+              "BM06_t3",
+              "BM04_t3_r1",
+              "BT_t3_lot1",
+              "BT_t3_old",
+              "K1",
+              "K2",
+              "Kfresh",
+              "BM07_25wk_lot711",
+              "B2",
+              "BM5",
+              "BM06_t1_r1",
+              "BM05_26wk_r1",
+              "Bfresh"
+          ],
+          "identifier": "biosample_id--group--study"
+      },
+      "annotations": [
+          {
+              "name": "General_Celltype",
+              "type": "group",
+              "values": [
+                  "LC2",
+                  "GPMNB macrophages",
+                  "neutrophils",
+                  "B cells",
+                  "T cells",
+                  "removed",
+                  "CSN1S1 macrophages",
+                  "dendritic cells",
+                  "LC1",
+                  "eosinophils",
+                  "fibroblasts"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "biosample_id",
+              "type": "group",
+              "values": [
+                  "BM02_6wkpp_r1",
+                  "BM12_6wk",
+                  "BM03_6wkpp_r1",
+                  "BM05_6wkpp",
+                  "BM08_6wk_r1",
+                  "BM08_6wkpp_r2",
+                  "BM13_6wk_r1",
+                  "BM13_6wk_r3",
+                  "BM07_7wkpp_r1",
+                  "BM11_6wk_r1",
+                  "BM01_7wkpp_r1",
+                  "BM02_13wkpp_t1",
+                  "BM08_13wk_r1",
+                  "BM05_12wk_r2",
+                  "BM03_13wk_r1",
+                  "BM03_13wkpp_r2",
+                  "BM01_13wkpp_r2",
+                  "BM13_12wk",
+                  "BM03_15dpp_r1",
+                  "BM08_15dpp_r1",
+                  "BM01_16dpp_r3",
+                  "BM07_17dpp_r2",
+                  "BM19_4dpp_r1",
+                  "BM02_5dpp_r1",
+                  "BM02_5dpp_r2",
+                  "BM03_5dpp_r1",
+                  "BM07_5dpp_r1",
+                  "BM01_5dpp_r1",
+                  "BM05_6dpp_r1",
+                  "BM11_5dpp_r1",
+                  "BM13_6dpp_r1",
+                  "BM07_13wk_r1",
+                  "BM01_23wk_r1",
+                  "BM03_24wk_r1",
+                  "BM03_24wk_r2",
+                  "BM08_24wk",
+                  "BM02_24wk_r2",
+                  "BM02_10dpp_r1",
+                  "BM03_10dpp_r1",
+                  "BM03_10dpp_r2",
+                  "BM01_12dpp_r1",
+                  "BM07_10dpp_r1",
+                  "BM13_13dpp_r1",
+                  "BM02_14dpp_r1",
+                  "BM04_t1_r2",
+                  "BM10_t1_r1",
+                  "BM06_t3",
+                  "BM04_t3_r1",
+                  "BT_t3_lot1",
+                  "BT_t3_old",
+                  "K1",
+                  "K2",
+                  "Kfresh",
+                  "BM07_25wk_lot711",
+                  "B2",
+                  "BM5",
+                  "BM06_t1_r1",
+                  "BM05_26wk_r1",
+                  "Bfresh"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "donor_id",
+              "type": "group",
+              "values": [
+                  "BM02",
+                  "BM12",
+                  "BM03",
+                  "BM05",
+                  "BM08",
+                  "BM13",
+                  "BM07",
+                  "BM11",
+                  "BM01",
+                  "BM19",
+                  "BM04",
+                  "BM10",
+                  "BM06",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "time_post_partum_days",
+              "type": "numeric",
+              "values": [],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "time_post_partum_weeks",
+              "type": "numeric",
+              "values": [],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "milk_stage",
+              "type": "group",
+              "values": [
+                  "late_1",
+                  "mature",
+                  "early",
+                  "late_2",
+                  "transitional ",
+                  "transitional",
+                  "late_4",
+                  "NA",
+                  "late_3"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "infant_sick_YN",
+              "type": "group",
+              "values": [
+                  "no",
+                  "NA",
+                  "yes"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "weaning_YN",
+              "type": "group",
+              "values": [
+                  "NA",
+                  "no",
+                  "yes"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "mastisis_YN",
+              "type": "group",
+              "values": [
+                  "no",
+                  "yes",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "breast_soreness_YN",
+              "type": "group",
+              "values": [
+                  "no",
+                  "yes",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "directly_breastfeeding_YN",
+              "type": "group",
+              "values": [
+                  "yes",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "any_formula_YN",
+              "type": "group",
+              "values": [
+                  "no",
+                  "yes",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "mother_medications_YN",
+              "type": "group",
+              "values": [
+                  "no",
+                  "yes",
+                  "sunflower lecithin ",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "reported_menstruating_YN",
+              "type": "group",
+              "values": [
+                  "no",
+                  "N",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "maternal_medical_event_YN",
+              "type": "group",
+              "values": [
+                  "no",
+                  "yes",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "hormonal_birthcontrol_YN",
+              "type": "group",
+              "values": [
+                  "no",
+                  "yes",
+                  "yes ",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "daycare_YN",
+              "type": "group",
+              "values": [
+                  "no",
+                  "yes",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "vaccines_reported_YN",
+              "type": "group",
+              "values": [
+                  "no",
+                  "yes",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "vaccines_list",
+              "type": "group",
+              "values": [
+                  "NA",
+                  "9/3 and 9/10 – a hep B booster in the hospital",
+                  "no",
+                  "5/9/19 hepatitis B",
+                  "hepB ",
+                  "vaccines on 5/15",
+                  "(6/11) Dtap-hep, BIPV, rotavirus, pentavalent, big (PRP-T)",
+                  "HepB",
+                  "hepB (says 4/22 but probably 5/22?)",
+                  "4/3/19 Hepatitis B (at birth) ",
+                  "2 month vaccines",
+                  "Dtap, Gib, IPV, PCU13, Rotavirus (8/16/19)",
+                  "vaccines on 7/15",
+                  "influenza (day prior to sample)"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "solid_foods_YN",
+              "type": "group",
+              "values": [
+                  "no",
+                  "NA",
+                  "yes"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "reported_infant_medical_events_YN",
+              "type": "group",
+              "values": [
+                  "no",
+                  "yes",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "reported_infant_medical_events_description",
+              "type": "group",
+              "values": [
+                  "NA",
+                  "no",
+                  "maybe a stomache bug ",
+                  "hot and sleepy",
+                  "jaundice",
+                  "lounge tie removal mid july, vaccinations a few weeks prior ",
+                  "runny nose",
+                  "runny nose, diarrhea, vomitting, no fever",
+                  "maybe still jaundice",
+                  "stomach bug (August), runny nose (October/ currently)",
+                  "influenza vaccine received on 4/8/19"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "library_preparation_protocol",
+              "type": "group",
+              "values": [
+                  "EFO_0008919"
+              ],
+              "scope": "invalid",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "library_preparation_protocol__ontology_label",
+              "type": "group",
+              "values": [
+                  "Seq-Well"
+              ],
+              "scope": "invalid",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "species",
+              "type": "group",
+              "values": [
+                  "NCBITaxon_9606"
+              ],
+              "scope": "invalid",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "species__ontology_label",
+              "type": "group",
+              "values": [
+                  "Homo sapiens"
+              ],
+              "scope": "invalid",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "geographical_region",
+              "type": "group",
+              "values": [
+                  "GAZ_00003181"
+              ],
+              "scope": "invalid",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "geographical_region__ontology_label",
+              "type": "group",
+              "values": [
+                  "Boston"
+              ],
+              "scope": "invalid",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "sex",
+              "type": "group",
+              "values": [
+                  "female"
+              ],
+              "scope": "invalid",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "disease",
+              "type": "group",
+              "values": [
+                  "PATO_0000461"
+              ],
+              "scope": "invalid",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "disease__ontology_label",
+              "type": "group",
+              "values": [
+                  "normal"
+              ],
+              "scope": "invalid",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "organ",
+              "type": "group",
+              "values": [
+                  "UBERON_0001913"
+              ],
+              "scope": "invalid",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "organ__ontology_label",
+              "type": "group",
+              "values": [
+                  "milk"
+              ],
+              "scope": "invalid",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "Age",
+              "type": "group",
+              "values": [
+                  "31.0",
+                  "34.0",
+                  "33.0",
+                  "29.0",
+                  "35.0",
+                  "32.0",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "biosample_type",
+              "type": "group",
+              "values": [
+                  "PrimaryBioSample_BodyFluid"
+              ],
+              "scope": "invalid",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "week_delivered",
+              "type": "numeric",
+              "values": [],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "labor_induced_YN",
+              "type": "group",
+              "values": [
+                  "Y",
+                  "N",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "antibiotics_during_delivery",
+              "type": "group",
+              "values": [
+                  "N",
+                  "Y",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "delivery_mode",
+              "type": "group",
+              "values": [
+                  "vaginal",
+                  "C section",
+                  "vaginal ",
+                  "NA"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "ethnicity__ontology_label",
+              "type": "group",
+              "values": [
+                  "European",
+                  "Asian",
+                  "Hispanic or Latin American",
+                  "ancestry category"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "BMI_during_study",
+              "type": "numeric",
+              "values": [],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "BMI_pre_pregnancy",
+              "type": "numeric",
+              "values": [],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "ethnicity",
+              "type": "group",
+              "values": [
+                  "HANCESTRO_0005",
+                  "HANCESTRO_0008",
+                  "HANCESTRO_0014",
+                  "HANCESTRO_0004"
+              ],
+              "scope": "invalid",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "cell_type",
+              "type": "group",
+              "values": [
+                  "CL_0000066",
+                  "CL_0000235",
+                  "CL_0000775",
+                  "CL_0000236",
+                  "CL_0000084",
+                  "CL_0000548",
+                  "CL_0000451",
+                  "CL_0000771",
+                  "CL_0000057"
+              ],
+              "scope": "invalid",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "cell_type__ontology_label",
+              "type": "group",
+              "values": [
+                  "epithelial cell",
+                  "macrophage",
+                  "neutrophil",
+                  "B cell",
+                  "T cell",
+                  "animal cell",
+                  "dendritic cell",
+                  "eosinophil",
+                  "fibroblast"
+              ],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "organism_age",
+              "type": "numeric",
+              "values": [],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "height_inches",
+              "type": "numeric",
+              "values": [],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "height_meter",
+              "type": "numeric",
+              "values": [],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "ext_weight_during_study_lbs",
+              "type": "numeric",
+              "values": [],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "est_pre_pregnancy_weight_lbs",
+              "type": "numeric",
+              "values": [],
+              "scope": "study",
+              "is_differential_expression_enabled": false
+          },
+          {
+              "name": "Epithelial Cell Subclusters",
+              "type": "group",
+              "values": [
+                  "Secretory Lactocytes",
+                  "LC1",
+                  "KRT high lactocytes 1",
+                  "Cycling Lactocytes",
+                  "MT High Secretory Lactocytes",
+                  "KRT high lactocytes 2"
+              ],
+              "scope": "cluster",
+              "cluster_name": "Epithelial Cell Subclusters",
+              "is_differential_expression_enabled": null
+          }
+      ],
+      "clusters": [
+          "All Cells UMAP",
+          "Epithelial Cell Subclusters"
+      ],
+      "subsample_thresholds": {
+          "All Cells UMAP": [
+              20000,
+              10000,
+              1000
+          ],
+          "Epithelial Cell Subclusters": [
+              20000,
+              10000,
+              1000
+          ]
+      }
+  },
+  "clusterGroupNames": [
+      "All Cells UMAP",
+      "Epithelial Cell Subclusters"
+  ],
+  "spatialGroups": [],
+  "differentialExpression": [
+      {
+          "cluster_name": "All Cells UMAP",
+          "annotation_name": "General_Celltype",
+          "annotation_scope": "study",
+          "select_options": [
+              [
+                  "LC2",
+                  "cluster_umap_txt--General_Celltype--LC2--study--wilcoxon.tsv"
+              ],
+              [
+                  "GPMNB macrophages",
+                  "cluster_umap_txt--General_Celltype--GPMNB_macrophages--study--wilcoxon.tsv"
+              ],
+              [
+                  "LC1",
+                  "cluster_umap_txt--General_Celltype--LC1--study--wilcoxon.tsv"
+              ],
+              [
+                  "neutrophils",
+                  "cluster_umap_txt--General_Celltype--neutrophils--study--wilcoxon.tsv"
+              ],
+              [
+                  "B cells",
+                  "cluster_umap_txt--General_Celltype--B_cells--study--wilcoxon.tsv"
+              ],
+              [
+                  "T cells",
+                  "cluster_umap_txt--General_Celltype--T_cells--study--wilcoxon.tsv"
+              ],
+              [
+                  "dendritic cells",
+                  "cluster_umap_txt--General_Celltype--dendritic_cells--study--wilcoxon.tsv"
+              ],
+              [
+                  "CSN1S1 macrophages",
+                  "cluster_umap_txt--General_Celltype--CSN1S1_macrophages--study--wilcoxon.tsv"
+              ],
+              [
+                  "eosinophils",
+                  "cluster_umap_txt--General_Celltype--eosinophils--study--wilcoxon.tsv"
+              ],
+              [
+                  "fibroblasts",
+                  "cluster_umap_txt--General_Celltype--fibroblasts--study--wilcoxon.tsv"
+              ]
+          ]
+      },
+      {
+          "cluster_name": "All Cells UMAP",
+          "annotation_name": "cell_type__ontology_label",
+          "annotation_scope": "study",
+          "select_options": [
+              [
+                  "epithelial cell",
+                  "cluster_umap_txt--cell_type__ontology_label--epithelial_cell--study--wilcoxon.tsv"
+              ],
+              [
+                  "macrophage",
+                  "cluster_umap_txt--cell_type__ontology_label--macrophage--study--wilcoxon.tsv"
+              ],
+              [
+                  "neutrophil",
+                  "cluster_umap_txt--cell_type__ontology_label--neutrophil--study--wilcoxon.tsv"
+              ],
+              [
+                  "B cell",
+                  "cluster_umap_txt--cell_type__ontology_label--B_cell--study--wilcoxon.tsv"
+              ],
+              [
+                  "T cell",
+                  "cluster_umap_txt--cell_type__ontology_label--T_cell--study--wilcoxon.tsv"
+              ],
+              [
+                  "dendritic cell",
+                  "cluster_umap_txt--cell_type__ontology_label--dendritic_cell--study--wilcoxon.tsv"
+              ],
+              [
+                  "eosinophil",
+                  "cluster_umap_txt--cell_type__ontology_label--eosinophil--study--wilcoxon.tsv"
+              ],
+              [
+                  "fibroblast",
+                  "cluster_umap_txt--cell_type__ontology_label--fibroblast--study--wilcoxon.tsv"
+              ]
+          ]
+      }
+  ],
+  "hasImageCache": [],
+  "imageFiles": [],
+  "clusterPointAlpha": 1,
+  "colorProfile": null,
+  "bucketId": "fc-febd4c65-881d-497f-b101-01a7ec427e6a",
+  "canEdit": true
+}


### PR DESCRIPTION
This shows the "Differential expression" button in more cases, helping discoverability now that we have 90% less DE data.

### Background <span id="background"></span>
Previously, we [showed the DE button](https://github.com/broadinstitute/single_cell_portal_core/pull/1502) only when the current clustering and annotation had DE results.  Then we [restricted DE](https://github.com/broadinstitute/single_cell_portal_core/pull/1715) to only cell type-like annotations, because the false positive rate of the Wilcoxon method seems too high even for exploratory analysis.  Naively, this would mean showing the DE button 90% less frequently.  That in turn would likely greatly diminish the overall value of DE in SCP.

Now, to A) only surface higher-quality DE while also B) avoiding a precipitous drop in DE discoverability and engagement, the big blue "Differential expression" button is shown whenever _any_ annotation in the study has DE results, even if the current annotation lacks DE results.  This means the DE button will be shown in _more_ cases than before the 90% restriction.

In that 90% case, the UX flow is:
1. See the DE button
2. Select a different annotation (and sometimes also a different clustering) from a list of those that have DE results
3. Select a group 
4. See the DE table

The main UX cost here is the the "Differential expression" button is more for a general feature of the study, rather than something directly related to the current clustering and annotation like the other controls in the right panel.  The bet here is that any cost in user confusion will be substantially less than the benefit of exploring DE results.

### Impact <span id="impact"></span>
The updated DE UX will likely increase indicators of interest (i.e. clicks on the DE button among users who see it), and may well also increase deeper DE engagement, like interacting with the DE table.

### Video <span id="video"></span>
Here's how it looks:

https://user-images.githubusercontent.com/1334561/222259046-5473589b-71cb-41bc-b384-4a5ba17864ac.mov

### Test <span id="test"></span>
A new automated test confirms behavior.  Optionally, if you want to manually verify, follow the steps in the video, i.e.:

1.  **If local**, after pulling, since we're only testing frontend changes, try booting with the frontend service worker cache enabled for faster page loads: `bin/docker-compose-setup.sh -c`.  Then go to a study with DE results.  **If on staging**, go to ["Human milk - differential expression"](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP303/human-milk-differential-expression#study-visualize) (SCP303).
2. Change the default annotation to one that does not have "cell" and "type" in the name (e.g. `biosample_id`).  E.g. click "Settings" then "View options", then change "Default annotation" to e.g. "biosample_id", then click "Update settings", then go back to "Explore".
3. Confirm the blue "Differential expression" button appears, click it
4. Confirm the panel says "No DE results for:", and lists the current clustering and annotation, then gives a dropdown to select a clustering / annotation that has DE.  Select one of them.  If your current clustering lacks DE results, select one from the menu, then select an annotation.
6. Select a group
7. Confirm you see the DE table
8. Confirm the scatter plots show the name of your newly selected clustering and annotation

### Further details
[Slides](https://docs.google.com/presentation/d/1Zd_FO7HqUlxORJqTMEbp5SmZto-PvMKdtTg35nYecS4/edit) give more context.  Recordings for the [demo presentation](https://drive.google.com/file/d/1_6buLOdH4WLqUPMqFTC2QCQvH--DHCRp/view?t=51s) and [feedback](https://drive.google.com/file/d/1_6buLOdH4WLqUPMqFTC2QCQvH--DHCRp/view?t=15m02s) add richer commentary.

This satisfies SCP-4954.