### PR TITLE
Skip gzipping sequence/AnnData files before pushing to GCS (SCP-4960)

### DIFF
--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -219,7 +219,8 @@ class FileParseService
         true
       else
         # log that file is already compressed
-        Rails.logger.info "#{study_file.upload_file_name}:#{study_file.id} is already compressed, direct uploading"
+        log_message = "skipping gzip (file_type: #{study_file.file_type}, is_gzipped: #{study_file.gzipped?})"
+        Rails.logger.info "#{study_file.upload_file_name}:#{study_file.id} #{log_message}, direct uploading"
         false
       end
     rescue ArgumentError => e

--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -191,4 +191,41 @@ class FileParseService
       ErrorTracker.report_exception(e, nil, study)
     end
   end
+
+  # gzip a local file on server (if necessary) in preparation for pushing to GCS bucket
+  #
+  # * *params*
+  #   - +study_file+ (StudyFile) => recently uploaded file
+  #
+  # * *returns*
+  #   - (Boolean) => T/F on whether file was gzipped in-place
+  def self.compress_file_for_upload(study_file)
+    file_location = study_file.local_location.to_s
+    study = study_file.study
+
+    begin
+      if study_file.can_gzip?
+        Rails.logger.info "Performing gzip on #{study_file.upload_file_name}:#{study_file.id}"
+        # Compress all uncompressed files before upload.
+        # This saves time on upload and download, and money on egress and storage.
+        gzip_filepath = "#{file_location}.tmp.gz"
+        Zlib::GzipWriter.open(gzip_filepath) do |gz|
+          File.open(file_location, 'rb').each do |line|
+            gz.write line
+          end
+          gz.close
+        end
+        File.rename gzip_filepath, file_location
+        true
+      else
+        # log that file is already compressed
+        Rails.logger.info "#{study_file.upload_file_name}:#{study_file.id} is already compressed, direct uploading"
+        false
+      end
+    rescue ArgumentError => e
+      # handle 'negative string size (or size too big)' error
+      ErrorTracker.report_exception(e, nil, study, study_file)
+      false
+    end
+  end
 end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1638,9 +1638,7 @@ class Study
     begin
       Rails.logger.info "Uploading #{file.bucket_location}:#{file.id} to FireCloud workspace: #{firecloud_workspace}"
       was_gzipped = FileParseService.compress_file_for_upload(file)
-      if was_gzipped
-        opts.merge!(content_encoding: 'gzip')
-      end
+      opts = was_gzipped ? { content_encoding: 'gzip' } : {}
       remote_file = ApplicationController.firecloud_client.execute_gcloud_method(
         :create_workspace_file, 0, bucket_id, file.upload.path, file.bucket_location, opts
       )

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1636,7 +1636,7 @@ class Study
   # will compress plain text files before uploading to reduce storage/egress charges
   def send_to_firecloud(file)
     begin
-      Rails.logger.info "Uploading #{file.bucket_location}:#{file.id} to FireCloud workspace: #{firecloud_workspace}"
+      Rails.logger.info "Uploading #{file.bucket_location}:#{file.id} to Terra workspace: #{firecloud_workspace}"
       was_gzipped = FileParseService.compress_file_for_upload(file)
       opts = was_gzipped ? { content_encoding: 'gzip' } : {}
       remote_file = ApplicationController.firecloud_client.execute_gcloud_method(

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1636,45 +1636,26 @@ class Study
   # will compress plain text files before uploading to reduce storage/egress charges
   def send_to_firecloud(file)
     begin
-      Rails.logger.info "#{Time.zone.now}: Uploading #{file.bucket_location}:#{file.id} to FireCloud workspace: #{self.firecloud_workspace}"
-      file_location = file.local_location.to_s
-      # determine if file needs to be compressed
-      first_two_bytes = File.open(file_location).read(2)
-      gzip_signature = StudyFile::GZIP_MAGIC_NUMBER # per IETF
-      file_is_gzipped = (first_two_bytes == gzip_signature)
-
-      opts = {}
-      if file_is_gzipped or file.upload_file_name.last(4) == '.bam' or file.upload_file_name.last(5) == '.cram'
-        # log that file is already compressed
-        Rails.logger.info "#{Time.zone.now}: #{file.upload_file_name}:#{file.id} is already compressed, direct uploading"
-      else
-        Rails.logger.info "#{Time.zone.now}: Performing gzip on #{file.upload_file_name}:#{file.id}"
-        # Compress all uncompressed files before upload.
-        # This saves time on upload and download, and money on egress and storage.
-        gzip_filepath = file_location + '.tmp.gz'
-        Zlib::GzipWriter.open(gzip_filepath) do |gz|
-          File.open(file_location, 'rb').each do |line|
-            gz.write line
-          end
-          gz.close
-        end
-        File.rename gzip_filepath, file_location
+      Rails.logger.info "Uploading #{file.bucket_location}:#{file.id} to FireCloud workspace: #{firecloud_workspace}"
+      was_gzipped = FileParseService.compress_file_for_upload(file)
+      if was_gzipped
         opts.merge!(content_encoding: 'gzip')
       end
-      remote_file = ApplicationController.firecloud_client.execute_gcloud_method(:create_workspace_file, 0, self.bucket_id, file.upload.path,
-                                                                 file.bucket_location, opts)
+      remote_file = ApplicationController.firecloud_client.execute_gcloud_method(
+        :create_workspace_file, 0, bucket_id, file.upload.path, file.bucket_location, opts
+      )
       # store generation tag to know whether a file has been updated in GCP
-      Rails.logger.info "#{Time.zone.now}: Updating #{file.bucket_location}:#{file.id} with generation tag: #{remote_file.generation} after successful upload"
+      Rails.logger.info "Updating #{file.bucket_location}:#{file.id} with generation tag: #{remote_file.generation} after successful upload"
       file.update(generation: remote_file.generation)
-      Rails.logger.info "#{Time.zone.now}: Upload of #{file.bucket_location}:#{file.id} complete, scheduling cleanup job"
+      Rails.logger.info "Upload of #{file.bucket_location}:#{file.id} complete, scheduling cleanup job"
       # schedule the upload cleanup job to run in two minutes
       run_at = 2.minutes.from_now
-      Delayed::Job.enqueue(UploadCleanupJob.new(file.study, file, 0), run_at: run_at)
-      Rails.logger.info "#{Time.zone.now}: cleanup job for #{file.bucket_location}:#{file.id} scheduled for #{run_at}"
+      Delayed::Job.enqueue(UploadCleanupJob.new(file.study, file, 0), run_at:)
+      Rails.logger.info "cleanup job for #{file.bucket_location}:#{file.id} scheduled for #{run_at}"
     rescue => e
       ErrorTracker.report_exception(e, user, self, file)
-      Rails.logger.error "Unable to upload '#{file.bucket_location}:#{file.id} to study bucket #{self.bucket_id}; #{e.message}"
-      # notify admin of failure so they can push the file and relauch parse
+      Rails.logger.error "Unable to upload '#{file.bucket_location}:#{file.id} to study bucket #{bucket_id}; #{e.message}"
+      # notify admin of failure so they can push the file and relaunch parse
       SingleCellMailer.notify_admin_upload_fail(file, e).deliver_now
     end
   end

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1013,6 +1013,20 @@ class StudyFile
     file_type == 'AnnData'
   end
 
+  # determine if a file is gzipped by reading the first two bytes and comparing to GZIP_MAGIC_NUMBER
+  def gzipped?
+    File.open(local_location.to_s).read(2) == GZIP_MAGIC_NUMBER # per IETF
+  end
+
+  # quick check if file is of a type that is safe to gzip
+  # essentially any file that is not a BAM/CRAM or AnnData archive
+  def can_gzip?
+    return false if gzipped?
+
+    # Sequence data & AnnData files either already are or could be gzipped
+    !PRIMARY_DATA_TYPES.include?(file_type) && file_type != 'AnnData' && !upload_file_name.ends_with?('.cram')
+  end
+
   ###
   #
   # CACHING METHODS

--- a/test/integration/lib/file_parse_service_test.rb
+++ b/test/integration/lib/file_parse_service_test.rb
@@ -116,6 +116,18 @@ class FileParseServiceTest < ActiveSupport::TestCase
     assert_nil @coordinate_file.study_file_bundle
   end
 
+  test 'should gzip file before uploading' do
+    cluster_path = Rails.root.join('test/test_data/cluster_example.txt')
+    cluster_file = StudyFile.create!(
+      study: @basic_study,
+      upload: File.open(cluster_path),
+      file_type: 'Cluster',
+      name: 'cluster_example.txt'
+    )
+    assert FileParseService.compress_file_for_upload(cluster_file)
+    assert cluster_file.gzipped?
+  end
+
   # TODO: once SCP-2765 is completed, test that all genes/values are parsed from mtx bundle
   # this will replace the deprecated 'should parse valid mtx bundle' from study_validation_test.rb
   test 'should store all genes and expression values from mtx parse' do

--- a/test/models/study_file_test.rb
+++ b/test/models/study_file_test.rb
@@ -195,4 +195,25 @@ class StudyFileTest < ActiveSupport::TestCase
     assert ann_data_file.is_expression?
     assert ann_data_file.is_raw_counts_file?
   end
+
+  test 'should determine if file is/can be gzipped' do
+    bam_path = Rails.root.join("test/test_data/fixed_neurons_6days_2000_possorted_genome_bam_test_data.bam")
+    bam_file = StudyFile.create!(
+      study: @study,
+      upload: File.open(bam_path),
+      file_type: 'BAM',
+      name: 'fixed_neurons_6days_2000_possorted_genome_bam_test_data.bam'
+    )
+    assert bam_file.gzipped?
+    assert_not bam_file.can_gzip?
+    cluster_path = Rails.root.join('test/test_data/cluster_example.txt')
+    cluster_file = StudyFile.create!(
+      study: @study,
+      upload: File.open(cluster_path),
+      file_type: 'Cluster',
+      name: 'cluster_example.txt'
+    )
+    assert_not cluster_file.gzipped?
+    assert cluster_file.can_gzip?
+  end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds new logic that will prevent attempting to gzip AnnData files after they have been uploaded to SCP.  This is in response to [errors](https://broad-institute.sentry.io/issues/3903191037/events/2c6d2fd5c6b44501bfb6546a36baa6af/?project=1424198) when attempting to gzip and push very large AnnData files.  The end result is that the file is stuck in a a state prior to parsing but cannot be removed by the end user, and requires direct admin intervention to manually push the file.  Since the content of these files may or may not already be gzipped, directly pushing them to GCS avoids this potential issue.

The current behavior for other file types remains unchanged - all files will be compressed before upload unless they are already gzipped, or are sequence-based files (BAM, CRAM, etc.) that are compressed by default.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Chose any study that does not have an AnnData file already and upload one (available [here](https://console.cloud.google.com/storage/browser/_details/broad-singlecellportal-staging-testing-data/anndata/compliant_pbmc3K.h5ad;tab=live_object?project=broad-singlecellportal-staging) if you don't have one local)
3. Once the file has uploaded, note similar messages in `development.log`
```
Uploading compliant_pbmc3K.h5ad:63ffbe1f6f53abad2d6503c1 to FireCloud workspace: anndata-test
compliant_pbmc3K.h5ad:63ffbe1f6f53abad2d6503c1 skipping gzip (file_type: AnnData, is_gzipped: false), direct uploading
Updating compliant_pbmc3K.h5ad:63ffbe1f6f53abad2d6503c1 with generation tag: 1677704770683680 after successful upload
```