### PR TITLE
Adding migration to delete non-cell type differential expression results (SCP-4970)

### DIFF
--- a/app/models/ab_test_assignment.rb
+++ b/app/models/ab_test_assignment.rb
@@ -7,7 +7,7 @@ class AbTestAssignment
   belongs_to :ab_test
   belongs_to :user, optional: true, foreign_key: :metrics_uuid, primary_key: :metrics_uuid
 
-  field :metrics_uuid, type: String
+  field :metrics_uuid, type: String, overwrite: true
   field :group_name, type: String
 
   validates :metrics_uuid, uniqueness: { scope: :feature_flag_id }, presence: true

--- a/db/migrate/20230301214553_remove_non_cell_type_de_results.rb
+++ b/db/migrate/20230301214553_remove_non_cell_type_de_results.rb
@@ -1,0 +1,15 @@
+class RemoveNonCellTypeDeResults < Mongoid::Migration
+  def self.up
+    DifferentialExpressionResult.where(
+      :annotation_name.not => DifferentialExpressionService::CELL_TYPE_MATCHER
+    ).map do |result|
+      Rails.logger.info "deleting DE result for #{result.annotation_identifier} in #{result.study.accession}"
+      result.delay.destroy # run destroy in the background to prevent migration from delaying deployment
+    end
+  end
+
+  def self.down
+    # we can't regenerate the results without re-running the entire job, so nothing to do here
+    # results can be manually re-run if we decide later that we want them again
+  end
+end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update removes all non-"cell type" differential expression results from SCP.  This is a follow up to #1715 which defined those annotation as being the only type eligible for automated differential expression calculation.  This cleanup is run in the background on deployment to ensure that it does not interfere with a regular deployment

#### MANUAL TESTING
1. Boot as normal in Dockerized mode to ensure migrations are run
2. Open `development.log` and note similar log messages:
```
deleting DE result for biosample_id--group--study in SCP67
deleting DE result for donor_id--group--study in SCP67
deleting DE result for disease__ontology_label--group--study in SCP67
```
And then eventually:
```
Removing DE output  SCP67:biosample_id--group--study at _scp_internal/differential_expression/UMAP_crush--biosample_id--Inj1--study--wilcoxon.tsv
Removing DE output  SCP67:donor_id--group--study at _scp_internal/differential_expression/UMAP_crush--donor_id--Inj1--study--wilcoxon.tsv
Removing DE output  SCP67:disease__ontology_label--group--study at _scp_internal/differential_expression/UMAP_crush--disease__ontology_label--lesion_of_sciatic_nerve--study--wilcoxon.tsv
...
```
3. Once the migration completes and `Delayed::Job` has finished processing the `destroy` calls, open a Rails console session and confirm that all matching results have been removed:
```
DifferentialExpressionResult.where(:annotation_name.not => DifferentialExpressionService::CELL_TYPE_MATCHER).count
=> 0
```