### PR TITLE
Adding configurable RAM limits for docker-compose in local development (SCP-5011)

### DIFF
--- a/bin/docker-compose-cleanup.sh
+++ b/bin/docker-compose-cleanup.sh
@@ -6,8 +6,8 @@
 
 # suppress 'variable is not set' warning, actual values are irrelevant
 export GCR_IMAGE="gcr.io/broad-singlecellportal-staging/single-cell-portal:development"
-export PORTAL_RAM_GB="6gb"
-export VITE_RAM_GB="2gb"
+export PORTAL_RAM_GB="6"
+export VITE_RAM_GB="2"
 echo "### REMOVING CONTAINERS/VOLUMES ###"
 # set VITE_FRONTEND_SERVICE_WORKER_CACHE to silence warnings from docker-compose
 VITE_FRONTEND_SERVICE_WORKER_CACHE="$VITE_FRONTEND_SERVICE_WORKER_CACHE" \

--- a/bin/docker-compose-cleanup.sh
+++ b/bin/docker-compose-cleanup.sh
@@ -4,8 +4,10 @@
 # stop/remove all containers/volumes created by docker-compose and revert environment config files
 # More context: https://github.com/broadinstitute/single_cell_portal_core#hybrid-docker-local-development
 
-# suppress '"GCR_IMAGE" variable is not set' warning, actual image/tag are irrelevant here
+# suppress variable is not set' warning, actual values are irrelevant
 export GCR_IMAGE="gcr.io/broad-singlecellportal-staging/single-cell-portal:development"
+export PORTAL_RAM_GB="6gb"
+export VITE_RAM_GB="2gb"
 echo "### REMOVING CONTAINERS/VOLUMES ###"
 # set VITE_FRONTEND_SERVICE_WORKER_CACHE to silence warnings from docker-compose
 VITE_FRONTEND_SERVICE_WORKER_CACHE="$VITE_FRONTEND_SERVICE_WORKER_CACHE" \

--- a/bin/docker-compose-cleanup.sh
+++ b/bin/docker-compose-cleanup.sh
@@ -4,7 +4,7 @@
 # stop/remove all containers/volumes created by docker-compose and revert environment config files
 # More context: https://github.com/broadinstitute/single_cell_portal_core#hybrid-docker-local-development
 
-# suppress variable is not set' warning, actual values are irrelevant
+# suppress 'variable is not set' warning, actual values are irrelevant
 export GCR_IMAGE="gcr.io/broad-singlecellportal-staging/single-cell-portal:development"
 export PORTAL_RAM_GB="6gb"
 export VITE_RAM_GB="2gb"

--- a/bin/docker-compose-setup.sh
+++ b/bin/docker-compose-setup.sh
@@ -10,6 +10,8 @@ $0 [OPTION]
 -d   run docker-compose in detached mode (default is attatched to terminal STDOUT)
 -c   enable VITE_FRONTEND_SERVICE_WORKER_CACHE (default is disabled)
 -i IMAGE_TAG   override default GCR image tag of development
+-p PORTAL_RAM_GB   set the amount of RAM in GB for the portal container
+-v VITE_RAM_GB   set the amount of RAM in GB for the vite container
 -h   print this text
 EOF
 )
@@ -17,7 +19,9 @@ EOF
 DETACHED=""
 VITE_FRONTEND_SERVICE_WORKER_CACHE="false"
 IMAGE_TAG="development"
-while getopts "dchi:" OPTION; do
+export PORTAL_RAM_GB="6"
+export VITE_RAM_GB="2"
+while getopts "dchi:p:v:" OPTION; do
 case $OPTION in
   d)
     echo "### SETTING DETACHED ###"
@@ -35,6 +39,14 @@ case $OPTION in
   i)
     echo "### SETTING GCR IMAGE TAG TO $OPTARG ###"
     IMAGE_TAG="$OPTARG"
+    ;;
+  p)
+    echo "### SETTING PORTAL_RAM_GB TO $OPTARG ###"
+    PORTAL_RAM_GB="$OPTARG"
+    ;;
+  v)
+    echo "### SETTING VITE_RAM_GB TO $OPTARG ###"
+    VITE_RAM_GB="$OPTARG"
     ;;
   *)
     echo "unrecognized option"

--- a/bin/docker-compose-setup.sh
+++ b/bin/docker-compose-setup.sh
@@ -7,12 +7,12 @@
 usage=$(
 cat <<EOF
 $0 [OPTION]
--d   run docker-compose in detached mode (default is attatched to terminal STDOUT)
--c   enable VITE_FRONTEND_SERVICE_WORKER_CACHE (default is disabled)
--i IMAGE_TAG   override default GCR image tag of development
--p PORTAL_RAM_GB   set the amount of RAM in GB for the portal container
--v VITE_RAM_GB   set the amount of RAM in GB for the vite container
--h   print this text
+-d  run docker-compose in detached mode (default is attatched to terminal STDOUT)
+-c  enable VITE_FRONTEND_SERVICE_WORKER_CACHE (default is disabled)
+-i  {IMAGE_TAG}  override default GCR image tag of development
+-p  {PORTAL_RAM_GB}  specify as integer the amount of RAM in GB for the single_cell container
+-v  {VITE_RAM_GB}  specify as integer the amount of RAM in GB for the single_cell_vite container
+-h  print this text
 EOF
 )
 

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -19,6 +19,10 @@ services:
       - .:/home/app/webapp
       - type: volume
         target: /home/app/webapp/node_modules
+    deploy:
+      resources:
+        limits:
+          memory: "${PORTAL_RAM_GB}gb"
   vite:
     container_name: single_cell_vite
     image: "${GCR_IMAGE}"
@@ -34,3 +38,7 @@ services:
       - .:/home/app/webapp
       - type: volume
         target: /home/app/webapp/node_modules
+    deploy:
+      resources:
+        limits:
+          memory: "${VITE_RAM_GB}gb"


### PR DESCRIPTION
#### BACKGROUND & CHANGES
Previously, local Docker instances would occasionally die with the error message `Killed: single_cell exited with code 137`.  This is due to Docker not being able to manage two instances that are consuming more RAM than is currently allocated to the Docker engine.  It can manage a single instance without setting limits, but multiple instances running concurrently will result in Docker killing one of the instances when the limit is exceeded.

This update adds configurable memory limits for both Docker containers when running locally via `docker-compose`.  They default to 2 & 6GB for the `single_cell_vite` and `single_cell` containers, respectively.  These limits can also be changed when calling `bin/docker-compose-setup.sh` via the `-p` and `-v` flags:
```
-p  {PORTAL_RAM_GB}  specify as integer the amount of RAM in GB for the single_cell container
-v  {VITE_RAM_GB}  specify as integer the amount of RAM in GB for the single_cell_vite container
```

Note: if you do not have at least 8GB of RAM allocated to your Docker engine, you should either increase this from the "Settings > Resources" menu in the Docker app, or set your own limits via the shell script.  1 & 4GB for the vite and portal instances is sufficient, though more is obviously better.

#### MANUAL TESTING
1. Boot via `bin/docker-compose-setup.sh`
2. Once both containers have started, in a separate terminal window run the following commands to confirm that memory limits have been enforced:
```
$ docker inspect single_cell | jq '.[0].HostConfig.Memory'
6442450944

$ docker inspect single_cell_vite | jq '.[0].HostConfig.Memory'
2147483648
```