### PR TITLE
Restore fast native local development environment (SCP-4997)

### DIFF
--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -4,7 +4,11 @@ Developing on SCP natively, i.e. outside a Docker container, is less robust but 
 
 ## SETUP
 Commands below assume your CPU is Apple Silicon / M1, not Intel.
-1. Append `CFLAGS="-Wno-error=implicit-function-declaration"` to your `~/.zshrc` (if using Z shell macOS default in Terminal, or `~/.bash_profile` if Bash), then run `source ~/.zschrc`
+1. Append the following to your `~/.zshrc` (if using Z shell macOS default in Terminal, or `~/.bash_profile` if Bash), then run `source ~/.zschrc`:
+```
+# Avoid compilation errors with occasional Ruby gems, e.g. bson_ext, puma
+CFLAGS="-Wno-error=implicit-function-declaration"
+```
 2. Run `rbenv -v`.  If it is not found, `brew install rbenv`, then `rbenv init` to set up rbenv in your shell, then close terminal and reopen it.
 3. Run `ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'`.  
   - If it outputs contains "OpenSSL 1.1.1", go to Step 4.  

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -78,6 +78,15 @@ new shell.
 NOTE: If you ever use the `bin/run_tests.sh` script locally, this will write out and delete any shell env files 
 after completion.  You will need to run `./ruby_local_setup.rb` again to repopulate them.
 
+Once you're all set up, you'll want to run each of the following commands in a separate terminal (or tab of your terminal):
+* `rails s # Run Rails app server`
+* `bin/vite dev # Run Vite -- enables HMR for reloading JS / CSS changes instantly`
+* `rails jobs:work # Run Delayed Job worker, to enable Ingest Pipeline jobs that parse uploaded files`
+
+Here's what starting up a regular development session in native local SCP looks like:
+
+https://user-images.githubusercontent.com/1334561/223493169-13702c5a-c91d-4389-9b52-5925a43822c9.mov
+
 ## KNOWN ISSUES
 1. Developing outside the docker container inherently runs more risk that your code will not work in the docker environment in staging/production.  Be careful!  If your changes are non-trivial, confirm your changes work in the containerized deploy before committing (especially changes involving package.json and/or the Gemfile)
 2. You may experience difficulty toggling back and forth between containerized and non-containerized deployment, as node-sass bindings are OS-specific.  If you see an error like 'No matching version of node-sass found'

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -7,7 +7,7 @@ live css/js reloading, faster build times, and byebug debugging in rails.
 Commands below assume your CPU is Apple Silicon / M1, not Intel.
 1. Run `rbenv -v`.  If it is not found, `brew install rbenv`, then `rbenv init` to set up rbenv in your shell, then close terminal and reopen it.
 2. Run `ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'`.  
-  - If it outputs contains "OpenSSL 1.1.1", go to Step 4.  
+  - If it outputs contains "OpenSSL 1.1.1", go to Step 3.  
   - Else, if output contains something like "OpenSSL 3.0.7", install the needed version of OpenSSL, and install Ruby so that it compiles with the needed version of OpenSSL:
      - Run `brew install openssl@1.1`
      - Run `rbenv uninstall 3.1.3`

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -6,14 +6,14 @@ live css/js reloading, faster build times, and byebug debugging in rails.
 ## SETUP
 Commands below assume your CPU is Apple Silicon / M1, not Intel.
 1. Run `rbenv -v`.  If it is not found, `brew install rbenv`, then `rbenv init` to set up rbenv in your shell, then close terminal and reopen it.
-2. Run `ruby -v` to ensure Ruby 3.1.3 is installed on your local machine.  If not, run `rbenv install 3.1.3` (current [as of 2023-01-26](https://github.com/broadinstitute/single_cell_portal_core/pull/1713)) then `rbenv global 3.1.3`.
-3. Run `ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'`.  
+2. Run `ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'`.  
   - If it outputs contains "OpenSSL 1.1.1", go to Step 4.  
   - Else, if output contains something like "OpenSSL 3.0.7", install the needed version of OpenSSL, and install Ruby so that it compiles with the needed version of OpenSSL:
      - Run `brew install openssl@1.1`
      - Run `rbenv uninstall 3.1.3`
      - Run `LDFLAGS="-L/opt/homebrew/opt/openssl@1.1/lib" CPPFLAGS="-I/opt/homebrew/opt/openssl@1.1/include" CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)" RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)" rbenv install 3.1.3`
      - Run `ruby -v` to ensure Ruby 3.1.3 is installed
+3. Run `ruby -v` to ensure Ruby 3.1.3 is installed on your local machine.  If not, run `rbenv install 3.1.3` (current [as of 2023-01-26](https://github.com/broadinstitute/single_cell_portal_core/pull/1713)) then `rbenv global 3.1.3`.
 4. Run `bundler -v` to ensure Bundler is installed.  If not, `gem install bundler`.
 5. Run `node -v` to ensure Node is installed. If not, install via https://nodejs.org/en/download/
 6. Run `yarn -v` to ensure Yarn is installed. If not, install via `brew install yarn`

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -20,7 +20,8 @@ Commands below assume your CPU is Apple Silicon / M1, not Intel.
 7. `cd` to where you have the `single_cell_portal_core` Git repo checked out.
 8. Run `bundle install`
   - That might fail with a message that contains "An error occurred while installing bson_ext"
-  - If so, follow steps from https://stackoverflow.com/a/64248633, i.e.:
+  - If so, run: ``gem install bson_ext -v '1.5.1' --source 'https://rubygems.org/' -- --with-cflags="-Wno-error=implicit-function-declaration"``
+  - If that fails, follow steps from https://stackoverflow.com/a/64248633, i.e.:
     - Run `cd /Users/$(whoami)/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bson_ext-1.5.1/ext/cbson`
     - Insert one line, near to the top of the file, `bson_buffer.h`:
 
@@ -67,7 +68,7 @@ to determine which `vault` paths to read from).
 
 ## REGULAR DEVELOPMENT
 Adding `source <<path-to-single-cell-portal-core>>/config/secrets/.source_env.bash` to your .bash_profile will source the 
-secrets read from vault to each new shell, saving you the trouble of rerunning the setup process every time you open a 
+secrets read from Vault to each new shell, saving you the trouble of rerunning the setup process every time you open a 
 new shell.  
 
 NOTE: If you ever use the `bin/run_tests.sh` script locally, this will write out and delete any shell env files 
@@ -79,8 +80,9 @@ after completion.  You will need to run `./ruby_local_setup.rb` again to repopul
    * if this error occurs when trying to deploy in the container, fix it by deleting the `node-modules/node-sass` folder, and then rerunning the load_env_secrets process
    * if the error is when you're trying to run locally, fix it by running `npm rebuild node-sass`
 
-## TROUBLE SHOOTING
+## TROUBLESHOOTING
+If the content below doesn't answer your question, try searching.  Beyond Google and Stack Overflow, searching this repo's issues, commits, and other files can help.  Searching in Broad Institute's Slack instance, especially #scp-implementation can also help -- e.g. enter "<your query> in:#scp-implementation" in the Slack search box.
 1. If the version you specified for Ruby is not the same as the version returned from running `ruby -v`, run `which ruby` to find out what path to Ruby is being used. The path should be something like: `<user>/.rbenv/shims/ruby`. If it is not, try adding `export PATH="$HOME/.rbenv/shims:$PATH"` to your `~/.bash_profile` to point it at the correct path. 
-2. If, after adding your certificate as a trusted certificate, `localhost:3000` still claims that the certificate is not trusted you might need to update your system default configuration to "Always Trust". On MacOS this can be done in the keychain access app by clicking on the localhost cert and then in the Trust dropdown choosing "Always Trust".
+2. If, after adding your certificate as a trusted certificate, `localhost:3000` still claims that the certificate is not trusted, then ensure you followed the SETUP steps that mention certificates.
 3. If you need to download Xcode for your rbenv install be aware that it can take a very long time (multiple hours) and if you are a Broad employee it is recommended you download through `selfservice` from BITS.
-4. If when trying to run `bundle install` you get an error like `An error occurred while installing bson_ext (1.5.1), and Bundler cannot continue...` you can try `gem install bson_ext -v '1.5.1' --source 'https://rubygems.org/' -- --with-cflags="-Wno-error=implicit-function-declaration"`
+4. If when trying to run `bundle install` you get an error like `An error occurred while installing bson_ext (1.5.1), and Bundler cannot continue...`, see steps above that mention bson_ext.

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -54,7 +54,7 @@ bson_ext (1.5.1)
 10. Run `./rails_local_setup.rb` to will write out required variables into an shell env file (using your Broad username 
 to determine which `vault` paths to read from).
 11. Run the source command the script outputs -- this will export those needed variables into the current shell
-12. Add `config/local_ssl/localhost.crt` to your system's trusted certificates. On macOS, you can drag this file into the 
+12. Add `config/certs/localhost.crt` to your system's trusted certificates. On macOS, you can drag this file into the 
 keychain access app, use the "System" keychain, and the "Certificates" category. Then you will likely need to open the 
 newly added certificate in the keychain access app and update the "Trust" setting to be "Always Trust" rather than "Use 
 System Defaults".

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -89,7 +89,7 @@ after completion.  You will need to run `./ruby_local_setup.rb` again to repopul
 If the content below doesn't answer your question, try searching.  Beyond Google and Stack Overflow, searching this repo's issues, commits, and other files can help.  Searching in Broad Institute's Slack instance, especially #scp-implementation can also help -- e.g. enter "<your query> in:#scp-implementation" in the Slack search box.  
 
 ### HELP FROM TEAM
-If the above docs and search techniques don't work, then ask for help in #scp-implementation.  Copy and paste relevant text from your error, and a screenshot image if it's relevant.  Please do include at least the error's text, as images can't be searched and are thus much less likely to be helpful in the future.
+If the above docs and search techniques don't work, then ask for help in [#scp-implementation](https://broadinstitute.slack.com/archives/CBEHTH601).  Copy and paste relevant text from your error, and a screenshot image if it's relevant.  Please do include at least the error's text, as images can't be searched and are thus much less likely to be helpful in the future.
 
 ### AD-HOC UPDATES
 Finally, if you think this doc should be updated, please edit it!  Don't feel hindered.  If you don't have a ticket that would otherwise relate, then note [SCP-5023](https://broadworkbench.atlassian.net/browse/SCP-5023) in the title of your PR to merge your ad-hoc changes.

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -75,14 +75,22 @@ NOTE: If you ever use the `bin/run_tests.sh` script locally, this will write out
 after completion.  You will need to run `./ruby_local_setup.rb` again to repopulate them.
 
 ## KNOWN ISSUES
-1. Developing outside the docker container inherently runs more risk that your code will not work in the docker environment in staging/production.  BE CAREFUL.  If your changes are non-trivial, confirm your changes work in the containerized deploy before committing (ESPECIALLY changes involving package.json and/or the Gemfile)
+1. Developing outside the docker container inherently runs more risk that your code will not work in the docker environment in staging/production.  Be careful!  If your changes are non-trivial, confirm your changes work in the containerized deploy before committing (especially changes involving package.json and/or the Gemfile)
 2. You may experience difficulty toggling back and forth between containerized and non-containerized deployment, as node-sass bindings are OS-specific.  If you see an error like 'No matching version of node-sass found'
    * if this error occurs when trying to deploy in the container, fix it by deleting the `node-modules/node-sass` folder, and then rerunning the load_env_secrets process
    * if the error is when you're trying to run locally, fix it by running `npm rebuild node-sass`
 
-## TROUBLESHOOTING
-If the content below doesn't answer your question, try searching.  Beyond Google and Stack Overflow, searching this repo's issues, commits, and other files can help.  Searching in Broad Institute's Slack instance, especially #scp-implementation can also help -- e.g. enter "<your query> in:#scp-implementation" in the Slack search box.
+## TROUBLESHOOTING  
 1. If the version you specified for Ruby is not the same as the version returned from running `ruby -v`, run `which ruby` to find out what path to Ruby is being used. The path should be something like: `<user>/.rbenv/shims/ruby`. If it is not, try adding `export PATH="$HOME/.rbenv/shims:$PATH"` to your `~/.bash_profile` to point it at the correct path. 
 2. If, after adding your certificate as a trusted certificate, `localhost:3000` still claims that the certificate is not trusted, then ensure you followed the SETUP steps that mention certificates.
 3. If you need to download Xcode for your rbenv install be aware that it can take a very long time (multiple hours) and if you are a Broad employee it is recommended you download through `selfservice` from BITS.
 4. If when trying to run `bundle install` you get an error like `An error occurred while installing bson_ext (1.5.1), and Bundler cannot continue...`, see steps above that mention bson_ext.
+
+### SEARCH
+If the content below doesn't answer your question, try searching.  Beyond Google and Stack Overflow, searching this repo's issues, commits, and other files can help.  Searching in Broad Institute's Slack instance, especially #scp-implementation can also help -- e.g. enter "<your query> in:#scp-implementation" in the Slack search box.  
+
+### HELP FROM TEAM
+If the above docs and search techniques don't work, then ask for help in #scp-implementation.  Copy and paste relevant text from your error, and a screenshot image if it's relevant.  Please do include at least the error's text, as images can't be searched and are thus much less likely to be helpful in the future.
+
+### AD-HOC UPDATES
+Finally, if you think this doc should be updated, please edit it!  Don't feel hindered.  If you don't have a ticket that would otherwise relate, then note [SCP-5023](https://broadworkbench.atlassian.net/browse/SCP-5023) in the title of your PR to merge your ad-hoc changes.

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -37,19 +37,19 @@ int bson_buffer_get_max_size(bson_buffer_t buffer);
  * Return NULL on allocation failure. */
 bson_buffer_t bson_buffer_new(void);
 ```
-
-  - Run `pwd`, confirm you are still in `/Users/$(whoami)/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bson_ext-1.5.1/ext/cbson`
-  - Run `make`, which will output warnings you can ignore
-  - Run `cd ../..`, i.e., go to the `bson_ext-1.5.1` directory
-  - Run `gem spec ../../cache/bson_ext-1.5.1.gem --ruby > ../../specifications/bson_ext-1.5.1.gemspec`
-  - Run `gem list bson_ext`, and confirm it outputs:
+  -
+    - Run `pwd`, confirm you are still in `/Users/$(whoami)/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bson_ext-1.5.1/ext/cbson`
+    - Run `make`, which will output warnings you can ignore
+    - Run `cd ../..`, i.e., go to the `bson_ext-1.5.1` directory
+    - Run `gem spec ../../cache/bson_ext-1.5.1.gem --ruby > ../../specifications/bson_ext-1.5.1.gemspec`
+    - Run `gem list bson_ext`, and confirm it outputs:
 
 ```
 *** LOCAL GEMS ***
 bson_ext (1.5.1)
 ```
-
-  - Change directories back to `single_cell_portal_core`
+  -
+    - Change directories back to `single_cell_portal_core`
 9. Run `yarn install`
 10. Run `./rails_local_setup.rb` to will write out required variables into an shell env file (using your Broad username 
 to determine which `vault` paths to read from).

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -4,20 +4,21 @@ Developing on SCP natively, i.e. outside a Docker container, is less robust but 
 
 ## SETUP
 Commands below assume your CPU is Apple Silicon / M1, not Intel.
-1. Run `rbenv -v`.  If it is not found, `brew install rbenv`, then `rbenv init` to set up rbenv in your shell, then close terminal and reopen it.
-2. Run `ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'`.  
-  - If it outputs contains "OpenSSL 1.1.1", go to Step 3.  
+1. Append `CFLAGS="-Wno-error=implicit-function-declaration"` to your `~/.zshrc` (if using Z shell macOS default in Terminal, or `~/.bash_profile` if Bash), then run `source ~/.zschrc`
+2. Run `rbenv -v`.  If it is not found, `brew install rbenv`, then `rbenv init` to set up rbenv in your shell, then close terminal and reopen it.
+3. Run `ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'`.  
+  - If it outputs contains "OpenSSL 1.1.1", go to Step 4.  
   - Else, if output contains something like "OpenSSL 3.0.7", install the needed version of OpenSSL, and install Ruby so that it compiles with the needed version of OpenSSL:
      - Run `brew install openssl@1.1`
      - Run `rbenv uninstall 3.1.3`
      - Run `LDFLAGS="-L/opt/homebrew/opt/openssl@1.1/lib" CPPFLAGS="-I/opt/homebrew/opt/openssl@1.1/include" CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)" RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)" rbenv install 3.1.3`
      - Run `ruby -v` to ensure Ruby 3.1.3 is installed
-3. Run `ruby -v` to ensure Ruby 3.1.3 is installed on your local machine.  If not, run `rbenv install 3.1.3` (current [as of 2023-01-26](https://github.com/broadinstitute/single_cell_portal_core/pull/1713)) then `rbenv global 3.1.3`.
-4. Run `bundler -v` to ensure Bundler is installed.  If not, `gem install bundler`.
-5. Run `node -v` to ensure Node is installed. If not, install via https://nodejs.org/en/download/
-6. Run `yarn -v` to ensure Yarn is installed. If not, install via `brew install yarn`
-7. `cd` to where you have the `single_cell_portal_core` Git repo checked out.
-8. Run `bundle install`
+4. Run `ruby -v` to ensure Ruby 3.1.3 is installed on your local machine.  If not, run `rbenv install 3.1.3` (current [as of 2023-01-26](https://github.com/broadinstitute/single_cell_portal_core/pull/1713)) then `rbenv global 3.1.3`.
+5. Run `bundler -v` to ensure Bundler is installed.  If not, `gem install bundler`.
+6. Run `node -v` to ensure Node is installed. If not, install via https://nodejs.org/en/download/
+7. Run `yarn -v` to ensure Yarn is installed. If not, install via `brew install yarn`
+8. `cd` to where you have the `single_cell_portal_core` Git repo checked out.
+9. Run `bundle install`
   - That might fail with a message that contains "An error occurred while installing bson_ext"
   - If so, run: ``gem install bson_ext -v '1.5.1' --source 'https://rubygems.org/' -- --with-cflags="-Wno-error=implicit-function-declaration"``
   - If that fails, follow steps from https://stackoverflow.com/a/64248633, i.e.:
@@ -50,23 +51,23 @@ bson_ext (1.5.1)
 ```
   -
     - Change directories back to `single_cell_portal_core`
-9. Run `yarn install`
-10. Run `./rails_local_setup.rb` to will write out required variables into an shell env file (using your Broad username 
+10. Run `yarn install`
+11. Run `./rails_local_setup.rb` to will write out required variables into an shell env file (using your Broad username 
 to determine which `vault` paths to read from).
-11. Run the source command the script outputs -- this will export those needed variables into the current shell
-12. Add `config/certs/localhost.crt` to your system's trusted certificates. 
+12. Run the source command the script outputs -- this will export those needed variables into the current shell
+13. Add `config/certs/localhost.crt` to your system's trusted certificates. 
   -  Automatic route (preferred), run `sudo security add-trusted-cert -d -r trustAsRoot -k /Library/Keychains/System.keychain config/certs/localhost.crt`
   - Manual route (alternative): On macOS, drag the certificate file into the Keychain Access app, use the "System" keychain, and the "Certificates" category. Then left click on the newly added certificate in the Keychain Access app, click "Get Info", then toggle open the "Trust" section, then set "When using this certificate" to "Always Trust" rather than "Use System Defaults"; and ensure "Always Trust" also gets set on all other drop-down menus in the "Trust" section.
-12. Run `rails s`
-13. If you're developing JS, for hot module replacement and live reload, in a separate terminal, run `bin/vite dev`
-14. If you are working on functionality that involves delayed jobs, like uploading data:
+14. Run `rails s`
+15. If you're developing JS, for hot module replacement and live reload, in a separate terminal, run `bin/vite dev`
+16. If you are working on functionality that involves delayed jobs, like uploading data:
     * In another terminal, run the source command output in step 7
     * run `rails jobs:work`
-15. You're all set!  You can now go to https://localhost:3000 and see the website.
-16. Confirm you can sign in and upload a file
+17. You're all set!  You can now go to https://localhost:3000 and see the website.
+18. Confirm you can sign in and upload a file
 
 ## REGULAR DEVELOPMENT
-Adding `source <<path-to-single-cell-portal-core>>/config/secrets/.source_env.bash` to your .bash_profile will source the 
+Adding `source <<path-to-single-cell-portal-core>>/config/secrets/.source_env.bash` to your .zschrc or .bash_profile will source the 
 secrets read from Vault to each new shell, saving you the trouble of rerunning the setup process every time you open a 
 new shell.  
 
@@ -80,7 +81,7 @@ after completion.  You will need to run `./ruby_local_setup.rb` again to repopul
    * if the error is when you're trying to run locally, fix it by running `npm rebuild node-sass`
 
 ## TROUBLESHOOTING  
-1. If the version you specified for Ruby is not the same as the version returned from running `ruby -v`, run `which ruby` to find out what path to Ruby is being used. The path should be something like: `<user>/.rbenv/shims/ruby`. If it is not, try adding `export PATH="$HOME/.rbenv/shims:$PATH"` to your `~/.bash_profile` to point it at the correct path. 
+1. If the version you specified for Ruby is not the same as the version returned from running `ruby -v`, run `which ruby` to find out what path to Ruby is being used. The path should be something like: `<user>/.rbenv/shims/ruby`. If it is not, try adding `export PATH="$HOME/.rbenv/shims:$PATH"` to your `~/.zschrc` or `~/.bash_profile` to point it at the correct path. 
 2. If, after adding your certificate as a trusted certificate, `localhost:3000` still claims that the certificate is not trusted, then ensure you followed the SETUP steps that mention certificates.
 3. If you need to download Xcode for your rbenv install be aware that it can take a very long time (multiple hours) and if you are a Broad employee it is recommended you download through `selfservice` from BITS.
 4. If when trying to run `bundle install` you get an error like `An error occurred while installing bson_ext (1.5.1), and Bundler cannot continue...`, see steps above that mention bson_ext.

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -20,8 +20,36 @@ Commands below assume your CPU is Apple Silicon / M1, not Intel.
 7. `cd` to where you have the `single_cell_portal_core` Git repo checked out.
 8. Run `bundle install`
   - That might fail with a message that contains "An error occurred while installing bson_ext"
-  - If so, follow steps from https://stackoverflow.com/a/64248633, noting that:
-  - The path in that answer won't work if you're using rbenv (as you should) for Ruby version management.  Instead of that path in that StackOverflow answer, use a path like cd /Users/$(whoami)/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bson_ext-1.5.1
+  - If so, follow steps from https://stackoverflow.com/a/64248633, i.e.:
+    - Run `cd /Users/$(whoami)/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bson_ext-1.5.1/ext/cbson`
+    - Insert one line, near to the top of the file:
+
+```
+/* A buffer */
+typedef struct bson_buffer* bson_buffer_t;
+/* A position in the buffer */
+typedef int bson_buffer_position;
+
+/***** THE FOLLOWING IS THE LINE YOU NEED TO INSERT ****/
+int bson_buffer_get_max_size(bson_buffer_t buffer); 
+
+ /* Allocate and return a new buffer.
+ * Return NULL on allocation failure. */
+bson_buffer_t bson_buffer_new(void);
+```
+
+  - Run `pwd`, confirm you are still in `/Users/$(whoami)/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bson_ext-1.5.1/ext/cbson`
+  - Run `make`, which will output warnings you can ignore
+  - Run `cd ../..`, i.e., go to the `bson_ext-1.5.1` directory
+  - Run `gem spec ../../cache/bson_ext-1.5.1.gem --ruby > ../../specifications/bson_ext-1.5.1.gemspec`
+  - Run `gem list bson_ext`, and confirm it outputs:
+
+```
+*** LOCAL GEMS ***
+bson_ext (1.5.1)
+```
+
+  - Change directories back to `single_cell_portal_core`
 9. Run `yarn install`
 10. Run `./rails_local_setup.rb` to will write out required variables into an shell env file (using your Broad username 
 to determine which `vault` paths to read from).

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -54,10 +54,9 @@ bson_ext (1.5.1)
 10. Run `./rails_local_setup.rb` to will write out required variables into an shell env file (using your Broad username 
 to determine which `vault` paths to read from).
 11. Run the source command the script outputs -- this will export those needed variables into the current shell
-12. Add `config/certs/localhost.crt` to your system's trusted certificates. On macOS, you can drag this file into the 
-keychain access app, use the "System" keychain, and the "Certificates" category. Then you will likely need to open the 
-newly added certificate in the keychain access app and update the "Trust" setting to be "Always Trust" rather than "Use 
-System Defaults".
+12. Add `config/certs/localhost.crt` to your system's trusted certificates. 
+  -  Automatic route (preferred), run `sudo security add-trusted-cert -d -r trustAsRoot -k /Library/Keychains/System.keychain config/certs/localhost.crt`
+  - Manual route (alternative): On macOS, drag the certificate file into the Keychain Access app, use the "System" keychain, and the "Certificates" category. Then left click on the newly added certificate in the Keychain Access app, click "Get Info", then toggle open the "Trust" section, then set "When using this certificate" to "Always Trust" rather than "Use System Defaults"; and ensure "Always Trust" also gets set on all other drop-down menus in the "Trust" section.
 12. Run `rails s`
 13. If you're developing JS, for hot module replacement and live reload, in a separate terminal, run `bin/vite dev`
 14. If you are working on functionality that involves delayed jobs, like uploading data:

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -22,7 +22,7 @@ Commands below assume your CPU is Apple Silicon / M1, not Intel.
   - That might fail with a message that contains "An error occurred while installing bson_ext"
   - If so, follow steps from https://stackoverflow.com/a/64248633, i.e.:
     - Run `cd /Users/$(whoami)/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bson_ext-1.5.1/ext/cbson`
-    - Insert one line, near to the top of the file:
+    - Insert one line, near to the top of the file, `bson_buffer.h`:
 
 ```
 /* A buffer */

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -4,29 +4,40 @@ Developing on SCP without a Docker container, while less robust, opens up some f
 live css/js reloading, faster build times, and byebug debugging in rails.
 
 ## SETUP
-
-1. Run `ruby -v` to ensure Ruby 3.1.2 is installed on your local machine.  If not, [install rbenv](https://github.com/rbenv/rbenv#installation) 
-(via `brew install rbenv` if on macOS) then `rbenv init` to set up rbenv in your shell. Then close out terminal and reopen 
-and run `rbenv install 3.1.2`. (version is current as of 08/09/2022)
-2. Run `bundler -v` to ensure Bundler is installed.  If not, `gem install bundler`.
-3. Run `node -v` to ensure Node is installed. If not, install via https://nodejs.org/en/download/
-4. Run `yarn -v` to ensure Yarn is installed. If not, install via `brew install yarn`
-5. `cd` to where you have the `single_cell_portal_core` Git repo checked out.
-6. Run `bundle install`
-7. Run `yarn install`
-8. Run `./rails_local_setup.rb` to will write out required variables into an shell env file (using your Broad username 
+Commands below assume your CPU is Apple Silicon / M1, not Intel.
+1. Run `rbenv -v`.  If it is not found, `brew install rbenv`, then `rbenv init` to set up rbenv in your shell, then close terminal and reopen it.
+2. Run `ruby -v` to ensure Ruby 3.1.3 is installed on your local machine.  Then close out terminal and reopen 
+and run `rbenv install 3.1.3`. (version is current [as of 2023-01-26](https://github.com/broadinstitute/single_cell_portal_core/pull/1713))
+3. Run `ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'`.  
+  - If it outputs contains "OpenSSL 1.1.1", go to Step 4.  
+  - Else, if output contains something like "OpenSSL 3.0.7", install the needed version of OpenSSL, and install Ruby so that it compiles with the needed version of OpenSSL:
+     - Run `brew install openssl@1.1`
+     - Run `rbenv uninstall 3.1.3`
+     - Run `LDFLAGS="-L/opt/homebrew/opt/openssl@1.1/lib" CPPFLAGS="-I/opt/homebrew/opt/openssl@1.1/include" CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)" RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)" rbenv install 3.1.3`
+     - Run `ruby -v` to ensure Ruby 3.1.3 is installed
+4. Run `bundler -v` to ensure Bundler is installed.  If not, `gem install bundler`.
+5. Run `node -v` to ensure Node is installed. If not, install via https://nodejs.org/en/download/
+6. Run `yarn -v` to ensure Yarn is installed. If not, install via `brew install yarn`
+7. `cd` to where you have the `single_cell_portal_core` Git repo checked out.
+8. Run `bundle install`
+  - That might fail with a message that contains "An error occurred while installing bson_ext"
+  - If so, follow steps from https://stackoverflow.com/a/64248633, noting that:
+  - The path in that answer won't work if you're using rbenv (as you should) for Ruby version management.  Instead of that path in that StackOverflow answer, use a path like cd /Users/$(whoami)/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bson_ext-1.5.1
+9. Run `yarn install`
+10. Run `./rails_local_setup.rb` to will write out required variables into an shell env file (using your Broad username 
 to determine which `vault` paths to read from).
-9. Run the source command the script outputs -- this will export those needed variables into the current shell
-10. Add `config/local_ssl/localhost.crt` to your system's trusted certificates. On macOS, you can drag this file into the 
+11. Run the source command the script outputs -- this will export those needed variables into the current shell
+12. Add `config/local_ssl/localhost.crt` to your system's trusted certificates. On macOS, you can drag this file into the 
 keychain access app, use the "System" keychain, and the "Certificates" category. Then you will likely need to open the 
 newly added certificate in the keychain access app and update the "Trust" setting to be "Always Trust" rather than "Use 
 System Defaults".
-11. Run `rails s`
-12. If you're developing JS, for hot module replacement and live reload, in a separate terminal, run `bin/vite dev`
-13. If you are working on functionality that involves delayed jobs, like uploading data:
+12. Run `rails s`
+13. If you're developing JS, for hot module replacement and live reload, in a separate terminal, run `bin/vite dev`
+14. If you are working on functionality that involves delayed jobs, like uploading data:
     * In another terminal, run the source command output in step 7
     * run `rails jobs:work`
-14. You're all set!  You can now go to https://localhost:3000 and see the website.
+15. You're all set!  You can now go to https://localhost:3000 and see the website.
+16. Confirm you can sign in and upload a file
 
 ## REGULAR DEVELOPMENT
 Adding `source <<path-to-single-cell-portal-core>>/config/secrets/.source_env.bash` to your .bash_profile will source the 

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -84,6 +84,7 @@ after completion.  You will need to run `./ruby_local_setup.rb` again to repopul
 2. If, after adding your certificate as a trusted certificate, `localhost:3000` still claims that the certificate is not trusted, then ensure you followed the SETUP steps that mention certificates.
 3. If you need to download Xcode for your rbenv install be aware that it can take a very long time (multiple hours) and if you are a Broad employee it is recommended you download through `selfservice` from BITS.
 4. If when trying to run `bundle install` you get an error like `An error occurred while installing bson_ext (1.5.1), and Bundler cannot continue...`, see steps above that mention bson_ext.
+5. If you can't sign in to your local SCP, then look for "SSL_CTX_load_verify_file" in `development.log`.  E.g., run `grep -B 3 -A 2 SSL_CTX_load_verify_file log/development.log`.  If you see that error in your logs, see steps above that mention OpenSSL.
 
 ### SEARCH
 If the content below doesn't answer your question, try searching.  Beyond Google and Stack Overflow, searching this repo's issues, commits, and other files can help.  Searching in Broad Institute's Slack instance, especially #scp-implementation can also help -- e.g. enter "<your query> in:#scp-implementation" in the Slack search box.  

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -6,8 +6,7 @@ live css/js reloading, faster build times, and byebug debugging in rails.
 ## SETUP
 Commands below assume your CPU is Apple Silicon / M1, not Intel.
 1. Run `rbenv -v`.  If it is not found, `brew install rbenv`, then `rbenv init` to set up rbenv in your shell, then close terminal and reopen it.
-2. Run `ruby -v` to ensure Ruby 3.1.3 is installed on your local machine.  Then close out terminal and reopen 
-and run `rbenv install 3.1.3`. (version is current [as of 2023-01-26](https://github.com/broadinstitute/single_cell_portal_core/pull/1713))
+2. Run `ruby -v` to ensure Ruby 3.1.3 is installed on your local machine.  If not, run `rbenv install 3.1.3` (current [as of 2023-01-26](https://github.com/broadinstitute/single_cell_portal_core/pull/1713)) then `rbenv global 3.1.3`.
 3. Run `ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'`.  
   - If it outputs contains "OpenSSL 1.1.1", go to Step 4.  
   - Else, if output contains something like "OpenSSL 3.0.7", install the needed version of OpenSSL, and install Ruby so that it compiles with the needed version of OpenSSL:

--- a/NON_CONTAINERIZED_DEV_README.md
+++ b/NON_CONTAINERIZED_DEV_README.md
@@ -1,7 +1,6 @@
-# Developing on SCP without a Docker container
+# Developing on SCP natively, without a Docker container
 
-Developing on SCP without a Docker container, while less robust, opens up some faster development paradigms, including 
-live css/js reloading, faster build times, and byebug debugging in rails.
+Developing on SCP natively, i.e. outside a Docker container, is less robust but faster.  In native mode, full pages load are 4-7x faster, tests run faster, and rich [byebug debugging](https://github.com/deivid-rodriguez/byebug/blob/master/GUIDE.md) in Rails is possible.
 
 ## SETUP
 Commands below assume your CPU is Apple Silicon / M1, not Intel.


### PR DESCRIPTION
This describes how to run SCP natively, i.e. without Docker, which makes local page load times drastically faster.

### Background
Previously, local SCP did not work natively.  It needed Docker, which abstracted away problems with essential dependencies that emerged while shifting from old Intel- to new M1-CPU Macs and from Ruby 2 to 3.  Docker was key to enabling work on new development machines.  

But Docker was quite slow.  As most of the team shifted to new machines by January 2023, early reports of slowness became reproducible more broadly and clear in [development analytics](https://docs.google.com/presentation/d/1UoA9uZZjv6tDobx2VPDVAv-_PxCq9QJUf9rm-I-RGVg/edit#slide=id.g20f5ae807d5_0_10).  Local page load times were 2-3x slower in early Q1 '23 than in Q4 '22, coinciding with the shift to M1 and Docker.

### Impact
Now, local SCP can run natively on M1.  It's snappy.  Analytics show [native](https://mixpanel.com/s/1kbL6R) local M1 SCP is 5-10x faster than in [Docker](https://mixpanel.com/s/1edR57).  

Even more than saving 5-20 seconds per page load, the ergonomic impact is in preserving mental context.  In other words, local speeds now much better preserve _human working memory_ across page loads.  That improves productivity.

In summary, this restores our development environment to how it was before [September 2022](https://docs.google.com/presentation/d/1UoA9uZZjv6tDobx2VPDVAv-_PxCq9QJUf9rm-I-RGVg/edit#slide=id.g20f5ae807d5_0_30).  Now we can also take advantage of fast new M1 machines.

### Video
Here's a video showing local native SCP.  Note the speed of booting the three main services -- `rails s`, `bin/vite dev`, and `rails jobs:work`.  Each is nearly instant.  The equivalent in Docker took me > 20 seconds (presumably because it does more, e.g. installs dependencies).

Initial full load of the home page takes 9 seconds.  Subsequent full page load takes 5 seconds.  The equivalent in Docker took me > 70 seconds and > 24 seconds, respectively.  So empirical spot measurements show full page load speedup of > 4-7x.

https://user-images.githubusercontent.com/1334561/223493169-13702c5a-c91d-4389-9b52-5925a43822c9.mov

### Test

Follow instructions in NON_CONTAINERIZED_DEV_README.md.

### Further details
The [demo presentation](https://drive.google.com/file/d/1Q6Ya2xLWA_mwlqbSrGxBn9SieQpiHFZR/view?t=34m25s) has more context.  [Slides](https://docs.google.com/presentation/d/1UoA9uZZjv6tDobx2VPDVAv-_PxCq9QJUf9rm-I-RGVg/edit) from a related topic two weeks ago give deeper background, including local performance [milestones](https://docs.google.com/presentation/d/1UoA9uZZjv6tDobx2VPDVAv-_PxCq9QJUf9rm-I-RGVg/edit#slide=id.g20f5ae807d5_0_5), and [graphs](https://docs.google.com/presentation/d/1UoA9uZZjv6tDobx2VPDVAv-_PxCq9QJUf9rm-I-RGVg/edit#slide=id.g20f5ae807d5_0_10) showing systematic local slowdown that motivates this work

Jon gave key technical insight.  Emily, Jean, and Michelle have all successfully installed native local SCP with these instructions.  Their review has helped correct and refine this work.

This satisfies SCP-4997.