### PR TITLE
Fix upload on Chrome >= 111 on Mac (SCP-5036)

### DIFF
--- a/app/javascript/components/upload/FileUploadControl.jsx
+++ b/app/javascript/components/upload/FileUploadControl.jsx
@@ -66,14 +66,14 @@ export default function FileUploadControl({
     //
     // As of Chrome 111 on Mac, compound extensions with gz not only don't resolve, they
     // instantly crash the user's web browser.
-    const allowedExtsWithoutCompoundGz =
+    const allowedExtsWithoutCompounds =
       allowedFileExts.filter(ext => {
-        return (ext.match(/\./g) || []).length === 1 // Omits compound file extensions
+        return (ext.match(/\./g) || []).length === 1 // Files with 1 extension
       })
 
     // Allow any file that ends in .gz.  Still allows compounds extensions for upload, but
     // merely checks against a less precise list of allowed extensions.
-    inputAcceptExts = [...allowedExtsWithoutCompoundGz, '.gz']
+    inputAcceptExts = [...allowedExtsWithoutCompounds, '.gz']
   }
 
   if (file.serverFile?.parse_status === 'failed') {


### PR DESCRIPTION
This fixes upload on Chrome >= 111 on Mac by omitting compound file extensions from the "accept" attribute in the file input form.  Compound files are actually still accepted, and just as stringently as before these changes.  This simply removes some extraneous data applied at runtime, which had triggered the bug.

The bug [crashes the browser](https://broadinstitute.slack.com/archives/C9YSEMSFR/p1678821012052829) when it occurs, so it's severe.  It seems this [affects up to 14% of uploaders](https://mixpanel.com/s/25nfwz) as of right now, with potential incidence increasing 2-4% per day as auto-updates roll out across the Chrome user base.  A user also reported being blocked by this.  

Although they were able to use a workaround (use a different web browser), these factors mean this bug has a big negative impact on upload.  So this is intended for immediate release, albeit not through our hotfix mechanism due to infrastructure issues.

To test (assuming you're on Mac):
* Pull branch
* Upgrade Chrome to version 111
* Go to a local study upload page
* Click "Choose file"
* Confirm browser does not crash

This satisfies SCP-5036.