### PR TITLE
Reliably load differential expression table, and other bucket data (SCP-4964)

### DIFF
--- a/app/controllers/api/v1/concerns/authenticator.rb
+++ b/app/controllers/api/v1/concerns/authenticator.rb
@@ -97,10 +97,12 @@ module Api
             response = RestClient.get OAUTH_V3_TOKEN_INFO + "?access_token=#{api_access_token}"
             credentials = JSON.parse response.body
             now = Time.zone.now
+            # expires_in = credentials['expires_in'].to_i - 3420 # 3 minutes
+            expires_in = credentials['expires_in'].to_i
             token_values = {
                 'access_token' => api_access_token,
-                'expires_in' => credentials['expires_in'],
-                'expires_at' => now + credentials['expires_in'].to_i,
+                'expires_in' => expires_in,
+                'expires_at' => now + expires_in,
                 'last_access_at' => now
             }
             email = credentials['email']

--- a/app/controllers/api/v1/concerns/authenticator.rb
+++ b/app/controllers/api/v1/concerns/authenticator.rb
@@ -97,7 +97,6 @@ module Api
             response = RestClient.get OAUTH_V3_TOKEN_INFO + "?access_token=#{api_access_token}"
             credentials = JSON.parse response.body
             now = Time.zone.now
-            # expires_in = credentials['expires_in'].to_i - 3420 # 3 minutes
             expires_in = credentials['expires_in'].to_i
             token_values = {
                 'access_token' => api_access_token,

--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -160,8 +160,12 @@ module Api
       end
 
       def renew_token
-        Rails.logger.info "Renewing token via SCP API for user #{user.id} in study #{@study.accession}"
-        render json: DifferentialExpressionService.get_read_access_token(@study, current_api_user, renew=true)
+        renewing_user = "an unauthenticated user (via read-only service account)"
+        if current_api_user
+          renewing_user = "user #{current_api_user.id}"
+        end
+        Rails.logger.info "Renewing token via SCP API for #{renewing_user} in study #{@study.accession}"
+        render json: RequestUtils.get_read_access_token(@study, current_api_user, renew: true)
       end
 
       swagger_path '/site/studies/{accession}/download' do

--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -161,7 +161,7 @@ module Api
 
       def renew_token
         Rails.logger.info "Renewing token via SCP API for study #{@study.accession}"
-        render json: DifferentialExpressionService.get_read_access_token(@study, current_api_user, renew=true)
+        render json: RequestUtils.get_read_access_token(@study, current_api_user, renew: true)
       end
 
       swagger_path '/site/studies/{accession}/download' do

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -345,7 +345,6 @@ module ApplicationHelper
   end
 
   # Return an access token for viewing GCS objects client side, depending on study privacy
-  # Context: https://github.com/broadinstitute/single_cell_portal_core/pull/239
   def get_read_access_token(study, user, renew=false)
     DifferentialExpressionService.get_read_access_token(study, user, renew=renew)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -347,7 +347,7 @@ module ApplicationHelper
   # Return an access token for viewing GCS objects client side, depending on study privacy
   # Context: https://github.com/broadinstitute/single_cell_portal_core/pull/239
   def get_read_access_token(study, user, renew=false)
-    DiffferentialExpressionService.get_read_access_token(study, user, renew=renew)
+    DifferentialExpressionService.get_read_access_token(study, user, renew=renew)
   end
 
   # Return the user's access token for bulk download of faceted search results

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -344,12 +344,23 @@ module ApplicationHelper
     email.gsub(/[@\.]/, '-')
   end
 
-	# Return an access token for viewing GCS objects client side, depending on study privacy
-	# Context: https://github.com/broadinstitute/single_cell_portal_core/pull/239
-  def get_read_access_token(study, user)
+  # Return an access token for viewing GCS objects client side, depending on study privacy
+  # Context: https://github.com/broadinstitute/single_cell_portal_core/pull/239
+  def get_read_access_token(study, user, renew=false)
     if study.present? && study.public? && ApplicationController.read_only_firecloud_client.present?
-      ApplicationController.read_only_firecloud_client.valid_access_token["access_token"]
+      read_only_client = ApplicationController.read_only_firecloud_client
+      if !renew
+        Rails.logger.info "Returning valid read-only access token for public study"
+        read_only_client.valid_access_token
+      else
+        # These read-only GCS tokens only last for 1 hour, so force refresh
+        # if `renew` is true, enabling e.g. frontend to not timeout GCS bucket
+        # fetches before 24-hour session expires.
+        Rails.logger.info "Force-refreshing read-only access token for public study"
+        read_only_client.refresh_access_token!
+      end
     elsif user.present? && user.registered_for_firecloud && study.present?
+      Rails.logger.info "Returning valid user GCS access token for private study"
       user.token_for_storage_object(study)
     else
       nil # there is no 'safe' token that will work as user has no Terra profile

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -347,24 +347,7 @@ module ApplicationHelper
   # Return an access token for viewing GCS objects client side, depending on study privacy
   # Context: https://github.com/broadinstitute/single_cell_portal_core/pull/239
   def get_read_access_token(study, user, renew=false)
-    if study.present? && study.public? && ApplicationController.read_only_firecloud_client.present?
-      read_only_client = ApplicationController.read_only_firecloud_client
-      if !renew
-        Rails.logger.info "Returning valid read-only access token for public study"
-        read_only_client.valid_access_token
-      else
-        # These read-only GCS tokens only last for 1 hour, so force refresh
-        # if `renew` is true, enabling e.g. frontend to not timeout GCS bucket
-        # fetches before 24-hour session expires.
-        Rails.logger.info "Force-refreshing read-only access token for public study"
-        read_only_client.refresh_access_token!
-      end
-    elsif user.present? && user.registered_for_firecloud && study.present?
-      Rails.logger.info "Returning valid user GCS access token for private study"
-      user.token_for_storage_object(study)
-    else
-      nil # there is no 'safe' token that will work as user has no Terra profile
-    end
+    DiffferentialExpressionService.get_read_access_token(study, user, renew=renew)
   end
 
   # Return the user's access token for bulk download of faceted search results

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -346,7 +346,7 @@ module ApplicationHelper
 
   # Return an access token for viewing GCS objects client side, depending on study privacy
   def get_read_access_token(study, user, renew=false)
-    DifferentialExpressionService.get_read_access_token(study, user, renew=renew)
+    RequestUtils.get_read_access_token(study, user, renew=renew)
   end
 
   # Return the user's access token for bulk download of faceted search results

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -345,8 +345,8 @@ module ApplicationHelper
   end
 
   # Return an access token for viewing GCS objects client side, depending on study privacy
-  def get_read_access_token(study, user, renew=false)
-    RequestUtils.get_read_access_token(study, user, renew=renew)
+  def get_read_access_token(study, user, renew: false)
+    RequestUtils.get_read_access_token(study, user, renew)
   end
 
   # Return the user's access token for bulk download of faceted search results

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -345,8 +345,8 @@ module ApplicationHelper
   end
 
   # Return an access token for viewing GCS objects client side, depending on study privacy
-  def get_read_access_token(study, user, renew: false)
-    RequestUtils.get_read_access_token(study, user, renew)
+  def get_read_access_token(study, user)
+    RequestUtils.get_read_access_token(study, user)
   end
 
   # Return the user's access token for bulk download of faceted search results

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -73,17 +73,11 @@ function getClusterHasDe(exploreInfo, exploreParams) {
   return clusterHasDe
 }
 
-function getAnnotationsWithDE(exploreInfo, exploreParams) {
+/** Return list of annotations that have differential expression enabled */
+function getAnnotationsWithDE(exploreInfo) {
   if (!exploreInfo) {return false}
 
   let annotsWithDe = []
-  const annotList = exploreInfo.annotationList
-  let selectedCluster
-  if (exploreParams?.cluster) {
-    selectedCluster = exploreParams.cluster
-  } else {
-    selectedCluster = annotList.default_cluster
-  }
 
   annotsWithDe = exploreInfo.differentialExpression.filter(deItem => {
     return deItem
@@ -674,7 +668,7 @@ export default function ExploreDisplayTabs({
             {!clusterHasDe &&
             <>
               <ClusterSelector
-                annotationList={getAnnotationsWithDE(exploreInfo, exploreParams)}
+                annotationList={getAnnotationsWithDE(exploreInfo)}
                 cluster={''}
                 annotation={''}
                 updateClusterParams={updateClusterParams}
@@ -684,7 +678,7 @@ export default function ExploreDisplayTabs({
             }
             {clusterHasDe &&
               <AnnotationSelector
-                annotationList={getAnnotationsWithDE(exploreInfo, exploreParams)}
+                annotationList={getAnnotationsWithDE(exploreInfo)}
                 cluster={exploreParamsWithDefaults.cluster}
                 shownAnnotation={shownAnnotation}
                 updateClusterParams={updateClusterParams}

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -227,16 +227,21 @@ export async function fetchStudyFileInfo(studyAccession, includeOptions=true, mo
  *    specify only when testing.
  */
 export function setupRenewalForReadOnlyToken(studyAccession, renewalTime=null) {
-  const readOnlyTokenObject = window.SCP.readOnlyTokenObject
+  // JSON processed by scpApi function gets camelcased, but JSON defined via
+  // Rails has snake-cased keys, so camelcase it here as is conventional for
+  // JSON that passes through scpApi.  E.g. expires_in -> expiresIn.
+  const readOnlyTokenObject = camelcaseKeys(window.SCP.readOnlyTokenObject)
+
   if (!renewalTime) {
     // ~55 minutes, in milliseconds
-    renewalTime = readOnlyTokenObject.expires_in * 1000 - FIVE_MINUTES
+    renewalTime = readOnlyTokenObject.expiresIn * 1000 - FIVE_MINUTES
   }
+
   setTimeout(async () => {
     const apiUrl = `/site/studies/${studyAccession}/renew_token`
     const [response] = await scpApi(apiUrl, defaultInit())
     const readOnlyTokenObject = response
-    window.SCP.readOnlyToken = readOnlyTokenObject.access_token
+    window.SCP.readOnlyToken = readOnlyTokenObject.accessToken
     window.SCP.readOnlyTokenObject = readOnlyTokenObject
     setupRenewalForReadOnlyToken(studyAccession)
   }, renewalTime)

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -223,19 +223,15 @@ export async function fetchStudyFileInfo(studyAccession, includeOptions=true, mo
  * 24 hours.
  *
  * @param {String} studyAccession Study accession, e.g. SCP123
- * @param {Number} renewalTime Milliseconds to wait until renewing token.  Null by default,
- *    specify only when testing.
  */
-export function setupRenewalForReadOnlyToken(studyAccession, renewalTime=null) {
+export function setupRenewalForReadOnlyToken(studyAccession) {
   // JSON processed by scpApi function gets camelcased, but JSON defined via
   // Rails has snake-cased keys, so camelcase it here as is conventional for
   // JSON that passes through scpApi.  E.g. expires_in -> expiresIn.
   const readOnlyTokenObject = camelcaseKeys(window.SCP.readOnlyTokenObject)
 
-  if (!renewalTime) {
-    // ~55 minutes, in milliseconds
-    renewalTime = readOnlyTokenObject.expiresIn * 1000 - FIVE_MINUTES
-  }
+  // ~55 minutes, in milliseconds
+  const renewalTime = readOnlyTokenObject.expiresIn * 1000 - FIVE_MINUTES
 
   setTimeout(async () => {
     const apiUrl = `/site/studies/${studyAccession}/renew_token`

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -217,19 +217,19 @@ export async function fetchStudyFileInfo(studyAccession, includeOptions=true, mo
 
 /**
  * Set up the renewal for read-only access tokens.  Read-only tokens expire in
- * 1 hour, which is much shorter than the default SCP authentication session
- * duration of 24 hours.
+ * 1 hour, much sooner than the default SCP authentication session duration of
+ * 24 hours.
  */
 export function setupRenewalForReadOnlyToken(studyAccession) {
-  const fullToken = window.SCP.fullReadOnlyToken
+  const readOnlyTokenObject = window.SCP.readOnlyTokenObject
   const fiveMinutes = 60 * 1000 * 5 // 5 minutes in milliseconds
-  const renewalTime = fullToken.expires_in * 1000 - fiveMinutes // ~55 minutes
+  const renewalTime = readOnlyTokenObject.expires_in * 1000 - fiveMinutes // ~55 minutes
   setTimeout(async () => {
     const apiUrl = `/studies/${studyAccession}/renew_token`
     const [response] = await scpApi(apiUrl, defaultInit())
-    const fullToken = response
-    window.SCP.readOnlyToken = fullToken.token
-    window.SCP.fullReadOnlyToken = fullToken
+    const readOnlyTokenObject = response
+    window.SCP.readOnlyToken = readOnlyTokenObject.access_token
+    window.SCP.readOnlyTokenObject = readOnlyTokenObject
     setupRenewalForReadOnlyToken(studyAccession)
   }, renewalTime)
 }

--- a/app/javascript/vite/application.js
+++ b/app/javascript/vite/application.js
@@ -48,6 +48,10 @@ document.addEventListener('DOMContentLoaded', () => {
   setupPageTransitionLog()
 
   checkMissingAuthToken()
+
+  if (window.SCP.readOnlyToken && window.SCP.studyAccession) {
+    ScpApi.setupRenewalForReadOnlyToken(window.SCP.studyAccession)
+  }
 })
 
 const componentsToExport = {

--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -309,23 +309,23 @@ class DifferentialExpressionService
     Rails.logger.info message
   end
 
-  # Return an access token for viewing GCS objects client side, depending on study privacy
-  # Context: https://github.com/broadinstitute/single_cell_portal_core/pull/239
+  # Get token for client-side access to GCS bucket, depending on study privacy
+  # Context: https://github.com/broadinstitute/single_cell_portal_core/pull/1747
   def self.get_read_access_token(study, user, renew=false)
     if study.present? && study.public? && ApplicationController.read_only_firecloud_client.present?
       read_only_client = ApplicationController.read_only_firecloud_client
       if !renew
-        Rails.logger.info "Returning valid read-only access token for public study"
+        Rails.logger.info "Returning read-only service account GCS access token for public study"
         read_only_client.valid_access_token
       else
         # These read-only GCS tokens only last for 1 hour, so force refresh
         # if `renew` is true, enabling e.g. frontend to not timeout GCS bucket
         # fetches before 24-hour session expires.
-        Rails.logger.info "Force-refreshing read-only access token for public study"
+        Rails.logger.info "Force-refreshing read-only service account GCS access token for public study"
         read_only_client.refresh_access_token!
       end
     elsif user.present? && user.registered_for_firecloud && study.present?
-      Rails.logger.info "Returning valid user GCS access token for private study"
+      Rails.logger.info "Returning read-only user GCS access token for private study"
       user.token_for_storage_object(study)
     else
       nil # there is no 'safe' token that will work as user has no Terra profile

--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -309,26 +309,4 @@ class DifferentialExpressionService
     Rails.logger.info message
   end
 
-  # Get token for client-side access to GCS bucket, depending on study privacy
-  # Context: https://github.com/broadinstitute/single_cell_portal_core/pull/1747
-  def self.get_read_access_token(study, user, renew=false)
-    if study.present? && study.public? && ApplicationController.read_only_firecloud_client.present?
-      read_only_client = ApplicationController.read_only_firecloud_client
-      if !renew
-        Rails.logger.info "Returning read-only service account GCS access token for public study"
-        read_only_client.valid_access_token
-      else
-        # These read-only GCS tokens only last for 1 hour, so force refresh
-        # if `renew` is true, enabling e.g. frontend to not timeout GCS bucket
-        # fetches before 24-hour session expires.
-        Rails.logger.info "Force-refreshing read-only service account GCS access token for public study"
-        read_only_client.refresh_access_token!
-      end
-    elsif user.present? && user.registered_for_firecloud && study.present?
-      Rails.logger.info "Returning read-only user GCS access token for private study"
-      user.token_for_storage_object(study)
-    else
-      nil # there is no 'safe' token that will work as user has no Terra profile
-    end
-  end
 end

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -192,7 +192,7 @@ class RequestUtils
 
   # Get token for client-side access to GCS bucket, depending on study privacy
   # Context: https://github.com/broadinstitute/single_cell_portal_core/pull/1747
-  def self.get_read_access_token(study, user, renew=false)
+  def self.get_read_access_token(study, user, renew: false)
     if study.present? && study.public? && ApplicationController.read_only_firecloud_client.present?
       read_only_client = ApplicationController.read_only_firecloud_client
       if !renew

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -189,4 +189,27 @@ class RequestUtils
   def self.static_asset_error?(exception)
     exception.is_a?(ActionController::RoutingError) || /(assets|static|packs|apple-touch)/.match?(exception.message)
   end
+
+  # Get token for client-side access to GCS bucket, depending on study privacy
+  # Context: https://github.com/broadinstitute/single_cell_portal_core/pull/1747
+  def self.get_read_access_token(study, user, renew=false)
+    if study.present? && study.public? && ApplicationController.read_only_firecloud_client.present?
+      read_only_client = ApplicationController.read_only_firecloud_client
+      if !renew
+        Rails.logger.info "Returning read-only service account GCS access token for public study"
+        read_only_client.valid_access_token
+      else
+        # These read-only GCS tokens only last for 1 hour, so force refresh
+        # if `renew` is true, enabling e.g. frontend to not timeout GCS bucket
+        # fetches before 24-hour session expires.
+        Rails.logger.info "Force-refreshing read-only service account GCS access token for public study"
+        read_only_client.refresh_access_token!
+      end
+    elsif user.present? && user.registered_for_firecloud && study.present?
+      Rails.logger.info "Returning read-only user GCS access token for private study"
+      user.token_for_storage_object(study)
+    else
+      nil # there is no 'safe' token that will work as user has no Terra profile
+    end
+  end
 end

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -93,7 +93,6 @@ class FireCloudClient
       storage_attr = {
         project_id: PORTAL_NAMESPACE,
         timeout: 3600
-        # timeout: 180
       }
 
       if !service_account.blank?
@@ -116,14 +115,12 @@ class FireCloudClient
       # set a default timeout if no token was retrieved; this prevents errors when attempting requests, although
       # the request will most likely fail with a 401, which is expected
       self.expires_at = self.access_token['expires_at'].present? ? self.access_token['expires_at'] : Time.now.in_time_zone + 1.hour
-      # self.expires_at = self.access_token['expires_at'].present? ? self.access_token['expires_at'] : Time.now.in_time_zone + 5.minutes
 
       # use user-defined project instead of portal default
       # if no keyfile is present, use environment variables
       storage_attr = {
           project_id: project,
           timeout: 3600
-          # timeout: 240
       }
 
       if !service_account.blank?
@@ -167,7 +164,6 @@ class FireCloudClient
     storage_attr = {
         project_id: project_name,
         timeout: 3600
-        # timeout: 600
     }
     if !ENV['SERVICE_ACCOUNT_KEY'].blank?
       storage_attr.merge!(credentials: self.class.get_primary_keyfile)

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -93,6 +93,7 @@ class FireCloudClient
       storage_attr = {
         project_id: PORTAL_NAMESPACE,
         timeout: 3600
+        # timeout: 180
       }
 
       if !service_account.blank?
@@ -115,12 +116,14 @@ class FireCloudClient
       # set a default timeout if no token was retrieved; this prevents errors when attempting requests, although
       # the request will most likely fail with a 401, which is expected
       self.expires_at = self.access_token['expires_at'].present? ? self.access_token['expires_at'] : Time.now.in_time_zone + 1.hour
+      # self.expires_at = self.access_token['expires_at'].present? ? self.access_token['expires_at'] : Time.now.in_time_zone + 5.minutes
 
       # use user-defined project instead of portal default
       # if no keyfile is present, use environment variables
       storage_attr = {
           project_id: project,
           timeout: 3600
+          # timeout: 240
       }
 
       if !service_account.blank?
@@ -164,6 +167,7 @@ class FireCloudClient
     storage_attr = {
         project_id: project_name,
         timeout: 3600
+        # timeout: 600
     }
     if !ENV['SERVICE_ACCOUNT_KEY'].blank?
       storage_attr.merge!(credentials: self.class.get_primary_keyfile)
@@ -1258,12 +1262,25 @@ class FireCloudClient
   #   - +project_name+ (String) => Name of a FireCloud billing project in which pet service account resides
   #
   # * *returns*
-  #   - +String+ pet service account OAuth2 access_token
+  #   - (Hash) => OAuth2 access token hash, with the following attributes
+  #     - +access_token+ (String) => OAuth2 access token
+  #     - +expires_in+ (Integer) => duration of token, in seconds
+  #     - +expires_at+ (String) => timestamp of when token expires
   def get_pet_service_account_token(project_name)
     path = BASE_SAM_SERVICE_URL + "/api/google/v1/user/petServiceAccount/#{project_name}/token"
-    # normal scopes, plus RO access for storage objects (removes unnecessary billing scope from GOOGLE_SCOPES)
+    # normal scopes, plus read-only access for storage objects,
+    # which omits unnecessary billing scope from GOOGLE_SCOPES
     token = process_firecloud_request(:post, path, GOOGLE_SCOPES.to_json)
     token.gsub(/\"/, '') # gotcha for removing escaped quotes in response body
+
+    expires_in = 3600 # 1 hour, in seconds
+    expires_at = Time.zone.now + expires_in
+
+    return {
+      'access_token' => token,
+      'expires_in' => expires_in,
+      'expires_at' => expires_at
+    }
   end
 
   # get JSON keyfile contents for a user's pet service account in the requested project

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,7 +148,6 @@ class User
             client_id: ENV['OAUTH_CLIENT_ID'],
             client_secret: ENV['OAUTH_CLIENT_SECRET'],
             expires_in: 3600
-            # expires_in: 120 # 2 minutes
         )
         token_vals = client.fetch_access_token
         expires_at = Time.zone.now + token_vals['expires_in'].to_i.seconds

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,10 +148,15 @@ class User
             client_id: ENV['OAUTH_CLIENT_ID'],
             client_secret: ENV['OAUTH_CLIENT_SECRET'],
             expires_in: 3600
+            # expires_in: 120 # 2 minutes
         )
         token_vals = client.fetch_access_token
         expires_at = Time.zone.now + token_vals['expires_in'].to_i.seconds
-        user_access_token = {'access_token' => token_vals['access_token'], 'expires_in' => token_vals['expires_in'], 'expires_at' => expires_at}
+        user_access_token = {
+          'access_token' => token_vals['access_token'],
+          'expires_in' => token_vals['expires_in'],
+          'expires_at' => expires_at
+        }
         self.update!(access_token: user_access_token)
         user_access_token
       rescue => e

--- a/app/views/site/_study_visualize.html.erb
+++ b/app/views/site/_study_visualize.html.erb
@@ -3,7 +3,8 @@
   window.SCP.renderComponent('study-visualize', 'ExploreView', {studyAccession: window.SCP.studyAccession})
   <% if @study.has_streamable_files(current_user) %>
     if (typeof window.SCP.readOnlyToken === 'undefined') {
-      window.SCP.readOnlyToken = '<%= get_read_access_token(@study, current_user) %>'
+      window.SCP.readOnlyTokenObject = <%= raw get_read_access_token(@study, current_user).to_json %>
+      window.SCP.readOnlyToken = window.SCP.readOnlyTokenObject.access_token
     }
   <% end %>
 </script>

--- a/app/views/studies/_shared_sync_functions.js.erb
+++ b/app/views/studies/_shared_sync_functions.js.erb
@@ -1,7 +1,8 @@
 // shared JS functions for sync forms
 
 // Used for sync CSFV
-window.SCP.readOnlyToken = '<%= get_read_access_token(@study, current_user) %>'
+window.SCP.readOnlyTokenObject = <%= raw get_read_access_token(@study, current_user).to_json %>
+window.SCP.readOnlyToken = window.SCP.readOnlyTokenObject.access_token
 
 $('#study-file-<%= study_file.id %>').on('change', '.file-type', async function() {
     var form = $(this).closest('form');

--- a/app/views/studies/initialize_study.html.erb
+++ b/app/views/studies/initialize_study.html.erb
@@ -3,7 +3,8 @@
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
     <% if FeatureFlaggable.feature_flags_for_instances(@selected_branding_group, current_user, @study)['reference_image_upload'] %>
       <%# if images are enabled, we need the read-only token so we can show already-uploaded images from the bucket for reference %>
-      window.SCP.readOnlyToken = '<%= get_read_access_token(@study, current_user) %>'
+      window.SCP.readOnlyTokenObject = <%= raw get_read_access_token(@study, current_user).to_json %>
+      window.SCP.readOnlyToken = window.SCP.readOnlyTokenObject.access_token
     <% end %>
     const wizardProps = {
       studyAccession: '<%= @study.accession %>',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,7 @@ Rails.application.routes.draw do
             get 'studies/:accession', to: 'site#view_study', as: :site_study_view
             get 'studies/:accession/download', to: 'site#download_data', as: :site_study_download_data
             get 'studies/:accession/stream', to: 'site#stream_data', as: :site_study_stream_data
+            get 'studies/:accession/renew_token', to: 'site#renew_token', as: :site_study_renew_token
 
           end
           scope :search do

--- a/lib/google_service_client.rb
+++ b/lib/google_service_client.rb
@@ -20,10 +20,11 @@ module GoogleServiceClient
     self.expires_at = Time.zone.now + new_token['expires_in']
 
     self.access_token = {
-      'access_token' => new_token,
+      'access_token' => new_token['access_token'],
       'expires_in' => new_token['expires_in'],
       'expires_at' => self.expires_at
     }
+
   end
 
   # check if an access_token is expired

--- a/lib/google_service_client.rb
+++ b/lib/google_service_client.rb
@@ -16,10 +16,14 @@ module GoogleServiceClient
     # determine if token source is a regular Google account (User) or a service account
     token_source = self.respond_to?(:user) && self.user.present? ? self.user : self.class
     new_token = token_source.generate_access_token(self.service_account_credentials)
-    new_expiry = Time.zone.now + new_token['expires_in']
-    self.access_token = new_token
-    self.expires_at = new_expiry
-    new_token
+    # Add `expires_at` to `new_token`
+    self.expires_at = Time.zone.now + new_token['expires_in']
+
+    self.access_token = {
+      'access_token' => new_token,
+      'expires_in' => new_token['expires_in'],
+      'expires_at' => self.expires_at
+    }
   end
 
   # check if an access_token is expired

--- a/lib/service_account_manager.rb
+++ b/lib/service_account_manager.rb
@@ -12,10 +12,14 @@ module ServiceAccountManager
   #   - (Hash) => OAuth2 access token hash, with the following attributes
   #     - +access_token+ (String) => OAuth2 access token
   #     - +expires_in+ (Integer) => duration of token, in seconds
+  #     - +expires_at+ (String) => timestamp of when token expires
   #     - +token_type+ (String) => type of access token (e.g. 'Bearer')
   def generate_access_token(service_account)
     creds = load_service_account_creds(service_account)
-    creds.fetch_access_token!
+    access_token = creds.fetch_access_token!
+    expires_at = Time.zone.now + access_token['expires_in']
+    access_token['expires_at'] = expires_at
+    access_token
   end
 
   # create a Google ServiceAccountCredentials instance for issuing access tokens, parsing service account attributes

--- a/test/integration/data_repo_client_test.rb
+++ b/test/integration/data_repo_client_test.rb
@@ -34,7 +34,7 @@ class DataRepoClientTest < ActiveSupport::TestCase
     current_expiry = @data_repo_client.expires_at
     sleep 1
     new_token = @data_repo_client.refresh_access_token!
-    assert_not_equal token, new_token
+    assert_not_equal token['access_token'], new_token['access_token']
     assert current_expiry < @data_repo_client.expires_at
   end
 
@@ -46,14 +46,14 @@ class DataRepoClientTest < ActiveSupport::TestCase
 
   test 'should get valid access token' do
     @data_repo_client.refresh_access_token!
-    access_token = @data_repo_client.access_token
+    token = @data_repo_client.access_token
     current_expiry = @data_repo_client.expires_at
     valid_token = @data_repo_client.valid_access_token
-    assert_equal access_token, valid_token
+    assert_equal token['access_token'], valid_token['access_token']
     @data_repo_client.expires_at = 1.day.ago
     sleep 1
     new_token = @data_repo_client.valid_access_token
-    assert_not_equal access_token, new_token
+    assert_not_equal token['access_token'], new_token['access_token']
     assert current_expiry < @data_repo_client.expires_at
   end
 

--- a/test/js/lib/scp-api.test.js
+++ b/test/js/lib/scp-api.test.js
@@ -3,7 +3,7 @@
 import CacheMock from 'browser-cache-mock';
 import 'isomorphic-fetch';
 
-import scpApi, { fetchSearch, fetchFacetFilters } from 'lib/scp-api'
+import scpApi, { fetchSearch, fetchFacetFilters, setupRenewalForReadOnlyToken } from 'lib/scp-api'
 import * as ServiceWorkerCache from 'lib/service-worker-cache'
 import * as SCPContextProvider from '~/providers/SCPContextProvider'
 
@@ -33,6 +33,8 @@ describe('JavaScript client for SCP REST API', () => {
       }
     })
 
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
   })
 
   // Note: tests that mock global.fetch must be cleared after every test
@@ -147,6 +149,26 @@ describe('JavaScript client for SCP REST API', () => {
     )
 
     done()
-})
+  })
+
+  it('sets timer for access token renewal', done => {
+    window.SCP = {
+      readOnlyTokenObject: {
+          'access_token': 'ya11.b.foo_bar-baz',
+          'expires_in': 3600, // 1 hour in seconds
+          'expires_at': '2023-03-28T11:12:02.044-04:00'
+      }
+    }
+
+    const expectedRenewalTime = 3300 * 1000 // 55 minutes in milliseconds
+
+    setupRenewalForReadOnlyToken('SCP123')
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), expectedRenewalTime);
+
+    process.nextTick(() => {
+      done()
+    })
+  })
 
 })


### PR DESCRIPTION
This fixes a bug where the differential expression table would often break.  It improves reliability for some other features, too.

## Bug
Previously, the DE table broke for almost [1 in 5 users who tried it](https://docs.google.com/presentation/d/1JIxltvjxyCLIo_zN1PaGs2KdF9RQEINMUUvPdT5ubmw/edit#slide=id.g1dfdc26ed34_0_64).  Although frequent in real usage, the bug is elusive.  The [problem](#problem) only occurs if the user loads a new DE table an hour or more after having loaded the page.  (This made the cause of the bug hard to diagnose with certainty, and the fix lengthy to fully test.)  The workaround is to refresh the page.  However, the bug was completely unhandled, so the user just saw a weirdly empty area where the DE table should be.  A message like "Refresh page to see this data" could convey the workaround, but would still be a rather poor user experience.

## Fix
Now, the DE table is much more reliable.  No page refresh needed!  The [solution](#solution) is to renew the access token that the frontend JavaScript client uses to fetch data from the study's GCS bucket.  The 1-hour token is renewed 5 minutes before it expires.  This access token renewal is secure because it happens not only while the access token is still valid, but also within the context of a valid, longer-lived refresh token and (for signed-in users) a 24-hour authentication session.

The fix [applies to 2 of 3 scenarios](https://github.com/broadinstitute/single_cell_portal_core/pull/1747#authentication-timeout-scenarios) for authentication timeout, which represent the vast majority of DE table usage.  The unresolved 3rd scenario is still fairly common, but different in cause and presentation.  This work has [clarified](https://broadworkbench.atlassian.net/browse/SCP-5064) that prevalent and elusive problem.

Diagrams below give more detail on the problem, the solution, and [how it integrates with existing authentication mechanics](#detail).

[AppSec approved](https://broadinstitute.slack.com/archives/CADU7L0SZ/p1679688996621989?thread_ts=1679685000.179099&cid=CADU7L0SZ) this as secure.

## Problem <span id="problem"></span>
![Unreliable_but_secure_client-side_bucket_access__SCP_2023-03-24](https://user-images.githubusercontent.com/1334561/227603969-1d61c5ae-aa1c-4f1d-b06b-cd8cf7287f57.png)

## Solution <span id="solution"></span>
![Reliable_and_secure_client-side_bucket_access__SCP_2023-03-24](https://user-images.githubusercontent.com/1334561/227604250-cc568215-32c9-4999-897d-f83a07bb9eaa.png)

## Detail <span id="detail"></span>
![Access_token_grants_for_reliable_and_secure_client-side_bucket_access__SCP_2023-03-24](https://user-images.githubusercontent.com/1334561/227632893-85348dac-6b8d-40b7-90a3-7aeaff09312d.png)

<span id="authentication-timeout-scenarios"></span>
## Authentication timeout scenarios
Below are details on the 3 broad cases that can manifest auth timeouts, where the user loads a DE table an hour or more after having loaded the page.

| Public? | Signed in? | DE table fixed? | Staging example | Production example |
| --- | --- | --- | --- | --- |
| Yes | No | Yes | [SCP344](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP344/#study-visualize) | [SCP1671](https://singlecell.broadinstitute.org/single_cell/study/SCP1671#study-visualize) |
| Yes | Yes | [No](https://broadworkbench.atlassian.net/browse/SCP-5064) | [SCP344](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP344#study-visualize) | [SCP1671](https://singlecell.broadinstitute.org/single_cell/study/SCP1671#study-visualize) |
| No | Yes | Yes | [SCP340](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP340#study-visualize) | [SCP2165](https://singlecell.broadinstitute.org/single_cell/study/SCP2165#study-visualize)|

Per above, the unfixed scenario is when the user is signed in, on a public study, and hasn't refreshed the page in over an hour.  The bug seems related but orthogonal to the GCS bucket auth bug that broke the DE table.  More details are in SCP-5064.

The private studies required special setup to be representative of those created by real users; they're created with a non-admin account so as to be unaffected by a related bug that only affects admins, SCP-5033.

## Test
A truly valid manual test requires > 1 hour and intricate setup.  I've done the test a few times now.  In my opinion, that effort is not worth the value of others reporting confirmation.  [Monitoring this error in Sentry](https://broad-institute.sentry.io/issues/3782541638/?project=1424198) after deployment would confirm the fix works in production.

Nonetheless, in case others consider it worthwhile, manual test instructions are documented below.  

* Create a public study using `mouse_brain` synthetic data.
* Upload raw counts, processed matrix, metadata, and cluster file
* Using a non-admin account like "[registeredinscpandterra](https://broadinstitute.slack.com/archives/CBEHTH601/p1600365349124700?thread_ts=1600365317.124600&cid=CBEHTH601)", create a private study using `mouse_brain` synthetic data.
* Upload raw counts, processed matrix, metadata, and cluster file
* Load 3 pages:
  * A) In your normal Chrome window, ensure you're signed in and go to the private study
  * B) In your normal Chrome window, ensure you're signed in and go to the public study
  * C) Open an incognito Chrome window and go to the public study
* Refresh each of the 3 pages in series, quickly, to ensure they finish loading at roughly the same wall-clock time
* In each of the 3 pages: 
  * Click "Differential expression", select an annotation with DE, select a group
  * Ensure DE table loads
  * Open Console panel in Chrome DevTools, paste in `window.SCP.readOnlyTokenObject`, hit enter
  * Ensure you see an object with properties `accessToken`, `expiresIn`, and `expiresAt`
  * Set your phone's alarm to 7 minutes before the time in `expiresAt`.  (Alarm should be < 55 minutes from now.)
  * Go to the Network panel in Chrome DevTools.
  * Do something else until your alarm sounds.  Don't refresh the page.
  * When your alarm sounds, look at the Network panel, confirm no `renew_token` request has been sent
  * Wait 1-3 minutes
  * Confirm `renew_token` request has been sent since your alarm sounded
  * Select a different group in the DE dropdown menu
  * Confirm DE table does not break

An automated test verifies an important part of handling the above.

Page (B) is the unfixed authentication scenario, i.e. "Public: Yes, Signed in: Yes", so it will fail, though it might take 2 hours instead of 1.  As noted above, SCP-5064 tracks that issue.

This satisfies SCP-4964.