### PR TITLE
Update to scp-ingest-pipeline:1.25.1 (SCP-4831)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.24.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.25.0'
 
     config.autoload_paths << Rails.root.join('lib')
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.25.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.25.1'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
This PR now updates to scp-ingest-pipeline:1.25.1, largely infrastructural changes. Upgrade to Ubuntu 20.04, Python 3.10 and a couple python library security updates - plus small fixes to the docker image so `test_create_default_testing_study` now passes.

A passing CI build for this PR will prove that this image is now correct.

If a manual test is preferred, one can validate by running the automated test manually:

1. run the integration test `study_creation_test.rb`:
bin/run_tests.sh -l -t test/integration/study_creation_test.rb
2. while the test is running, `tail -f log/test.log` and confirm that the candidate docker image is being used. The PAPI request object info should contain:
>   :image_uri: gcr.io/broad-singlecellportal-staging/scp-ingest-portal:1.25.1
3. the output for the integration test should pass with the following as part of the output:
> After XXX seconds, expression_matrix_example.txt is parsed, metadata.v2-0-0.txt is parsed, cluster_example_2.txt is parsed.
