### PR TITLE
Add user requested Library Preparation Protocol option (SCP-5048)

### DIFF
--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -64,9 +64,9 @@ class ExpressionFileInfo
                                 'Seq-Well v1', # scRNAseq
                                 'SeqFISH+', # spatial transcriptomic
                                 'SHARE-seq', # multiomic ATAC-seq
-                                'Slide-tags',
                                 'Slide-seq', # spatial transcriptomic
                                 'Slide-seqV2', # spatial transcriptomic
+                                'Slide-tags',
                                 'Smart-like', # scRNAseq
                                 'Smart-seq2/Fluidigm C1', # scRNAseq
                                 'Smart-seq2/plate-based', # scRNAseq

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -64,6 +64,7 @@ class ExpressionFileInfo
                                 'Seq-Well v1', # scRNAseq
                                 'SeqFISH+', # spatial transcriptomic
                                 'SHARE-seq', # multiomic ATAC-seq
+                                'Slide-tags',
                                 'Slide-seq', # spatial transcriptomic
                                 'Slide-seqV2', # spatial transcriptomic
                                 'Smart-like', # scRNAseq


### PR DESCRIPTION
We received a Zendesk request to add a new LPP to the drop down called "Slide-tags" this PR adds that option to the list.

To test:
- go to the upload wizard for a study you own
- go to the Raw Counts tab or processed matrix tab
- go to the library prep protocol dropdown and find "Slide-tags" and choose it
- saving/uploading should function as normal

![Screenshot 2023-03-23 at 4 13 43 PM](https://user-images.githubusercontent.com/54322292/227342156-88ecc5ab-44c0-4fcb-9941-c1a17e3e8422.png)
