### PR TITLE
Mark legacy AnnData files as reference, enforce metadata convention (SCP-4928, SCP-5042)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -301,6 +301,8 @@ module Api
           study_file.build_ann_data_file_info if study_file.ann_data_file_info.blank?
 
           safe_file_params = study_file.ann_data_file_info.merge_form_data(study_file_params.to_unsafe_hash)
+          # override to enforce metadata convention for all AnnData parsing
+          safe_file_params[:use_metadata_convention] = true
         else
           safe_file_params = study_file_params
         end

--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -101,7 +101,8 @@ class FileParseService
         end
 
         # enable / disable full ingest of AnnData files using the feature flag 'ingest_anndata_file'
-        # will ignore reference AnnData files (includes previously uploaded files)
+        # will ignore reference AnnData files (includes previously uploaded files) as the default for
+        # ann_data_file_info.reference_file is true legacy files were covered in data migration
         if do_anndata_file_ingest && !study_file.is_reference_anndata?
           params_object = AnnDataIngestParameters.new(
             anndata_file: study_file.gs_url, obsm_keys: study_file.ann_data_file_info.obsm_key_names

--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -51,7 +51,9 @@ class AnnDataFileInfo
     # merge in existing information about AnnData file, using form data first if present
     anndata_info_attributes = form_data[:ann_data_file_info_attributes] || attributes.with_indifferent_access
     # check value of :reference_anndata_file which is passed as a string
-    anndata_info_attributes[:reference_file] = merged_data[:reference_anndata_file] == 'true'
+    # it is not present in 'classic mode' so the absence of it means this is a reference upload
+    reference_file = merged_data[:reference_anndata_file].nil? ? true : merged_data[:reference_anndata_file] == 'true'
+    anndata_info_attributes[:reference_file] = reference_file
     merged_data.delete(:reference_anndata_file)
     fragments = []
     DATA_TYPE_FORM_KEYS.each do |key, form_segment_name|

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -618,6 +618,9 @@ class IngestJob
 
   # launch appropriate downstream jobs once an AnnData file successfully extracts "fragment" files
   def launch_anndata_subparse_jobs
+    # reference AnnData uploads don't have extract parameter so exit immediately
+    return nil if params_object.extract.blank?
+
     params_object.extract.each do |extract|
       case extract
       when 'cluster'

--- a/app/models/papi_client.rb
+++ b/app/models/papi_client.rb
@@ -323,7 +323,7 @@ class PapiClient
       # skip if parent file is AnnData as params_object will format command line
       command_line += " --cell-metadata-file #{study_file.gs_url} --study-accession #{study.accession} " \
                       "--ingest-cell-metadata" unless study_file.is_anndata?
-      if study_file.use_metadata_convention && !study_file.is_anndata?
+      if study_file.use_metadata_convention
         command_line += " --validate-convention --bq-dataset #{CellMetadatum::BIGQUERY_DATASET} " \
                         "--bq-table #{CellMetadatum::BIGQUERY_TABLE}"
       end

--- a/db/migrate/20230328175210_mark_ann_data_reference_files.rb
+++ b/db/migrate/20230328175210_mark_ann_data_reference_files.rb
@@ -1,0 +1,21 @@
+class MarkAnnDataReferenceFiles < Mongoid::Migration
+  def self.up
+    StudyFile.where(file_type: 'AnnData').each do |study_file|
+      # the IngestJob#set_anndata_file_info method handles initializing ann_data_file_info documents and checking for
+      # parsed data and as such makes a convenient proxy for determining whether an AnnData file is 'reference' or not
+      # Mongo queries don't honor 'default' values until they've been persisted to the document, hence this migration
+      study = study_file.study
+      job = IngestJob.new(study:, study_file:)
+      job.set_anndata_file_info
+      study_file.reload
+      info = study_file.ann_data_file_info
+      unless info.has_clusters? || info.has_metadata? || info.has_expression?
+        study_file.ann_data_file_info.reference_file = true
+        study_file.save
+      end
+    end
+  end
+
+  def self.down
+  end
+end

--- a/test/api/study_files_controller_test.rb
+++ b/test/api/study_files_controller_test.rb
@@ -213,7 +213,7 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
           y_axis_title: 'log(TPM) expression'
         },
         metadata_form_info_attributes: {
-          use_metadata_convention: true
+          use_metadata_convention: false # check that override is in place to enforce convention
         },
         cluster_form_info_attributes: {
           _id: cluster_frag_id,
@@ -230,6 +230,7 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     ann_data = StudyFile.find_by(study_id: @study.id, upload_file_name: 'data.h5ad')
     assert ann_data.present?
+    assert ann_data.use_metadata_convention
     assert ann_data.ann_data_file_info.present?
     assert_not ann_data.ann_data_file_info.reference_file?
     data_fragments = ann_data.ann_data_file_info.data_fragments


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update marks all previously uploaded AnnData files as "reference" files, meaning they will not be parsed, even if the user has their `ingest_anndata_file` feature flag set to `true`.  In addition, all AnnData files that are parsed will now have the metadata convention enforced.  Lastly, this fixes a new bug that caused all uploaded AnnData files in "classic" mode to be parsed, when they should not have.

#### MANUAL TESTING
1. Boot as normal, start Delayed::Job and sign in
2. Go to any study that is not in the "AnnData" mode and upload any `.h5ad` file as a reference file
3. Confirm it pushes to the bucket and does not attempt to parse.  Note: you will still see an ingest job, but the `--extract` parameter will not be present, and legacy behavior of simply opening the file and validating that it is readable is applied