### PR TITLE
Sort pairwise comparison labels naturally (SCP-5004)

### DIFF
--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -78,7 +78,7 @@ class DifferentialExpressionResult
   # this is to handle cases where + or - are the only difference in labels, such as CD4+ and CD4-
   def filename_for(label, comparison: nil)
     if comparison.present?
-      first_label, second_label = [label, comparison].sort # comparisons must be sorted alphabetically
+      first_label, second_label = Naturally.sort([label, comparison]) # comparisons must be sorted alphabetically
       values = [cluster_name, annotation_name, first_label, second_label, annotation_scope, computational_method]
     else
       values = [cluster_name, annotation_name, label, annotation_scope, computational_method]

--- a/test/models/differential_expression_result_test.rb
+++ b/test/models/differential_expression_result_test.rb
@@ -15,7 +15,7 @@ class DifferentialExpressionResultTest < ActiveSupport::TestCase
     @library_preparation_protocol = Array.new(7, "10X 5' v3")
     @cell_types = ['B cell', 'T cell', 'B cell', 'T cell', 'T cell', 'B cell', 'B cell']
     @custom_cell_types = [
-      'Naive B cell', 'Naive Treg', 'Naive B cell', 'Naive Treg', 'Naive Treg', 'Naive B cell', 'Naive B cell'
+      'Custom 2', 'Custom 10', 'Custom 2', 'Custom 10', 'Custom 10', 'Custom 2', 'Custom 2'
     ]
     @raw_matrix = FactoryBot.create(:expression_file,
                                     name: 'raw.txt',
@@ -127,12 +127,13 @@ class DifferentialExpressionResultTest < ActiveSupport::TestCase
     result = DifferentialExpressionResult.new(
       study: @study, cluster_group: @cluster_group, cluster_name: @cluster_group.name, annotation_name: name,
       annotation_scope: 'study', matrix_file_id: @raw_matrix.id,
-      pairwise_comparisons: { 'Naive B cell' => ['Naive Treg'] }
+      pairwise_comparisons: { 'Custom 10' => ['Custom 2'] }
     )
     prefix = "_scp_internal/differential_expression"
     result.pairwise_comparisons.each_pair do |label, comparisons|
       comparisons.each do |comparison|
-        expected_filename = "#{prefix}/cluster_diffexp_txt--#{name}--Naive_B_cell--Naive_Treg--study--wilcoxon.tsv"
+        # should sort labels naturally and put 'Custom 2' in front of 'Custom 10'
+        expected_filename = "#{prefix}/cluster_diffexp_txt--#{name}--Custom_2--Custom_10--study--wilcoxon.tsv"
         assert_equal expected_filename, result.bucket_path_for(label, comparison:)
       end
     end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update addresses a PR comment that was not applied in #1753 to sort pairwise comparison labels naturally.  This will account for numerical values in string labels.

#### MANUAL TESTING
1. Enter a Rails console session and run the following block to create a `DifferentialExpressionResult`:
```
labels = ['1', '5', '10', '15', '50', '55']
# make a hash of each label to an array of all the other labels
pairwise_comparisons = Hash[labels.zip(labels.map {|lab| labels.select {|l| l != lab }})]
result = DifferentialExpressionResult.new(cluster_name: 'cluster', annotation_name: 'my-annotation', 
annotation_scope: 'study', pairwise_comparisons:)
```
2. Run a standard sort on the labels to note the order (placing `10` & `15` in front of `5`):
```
labels.sort
=> ["1", "10", "15", "5", "50", "55"]
```
3. Run the following block:
```
result.pairwise_comparisons.each_pair do |label, comparisons|
  comparisons.each do |comparison|
    puts "label: #{label}, comparison: #{comparison}"
    puts result.bucket_path_for(label, comparison:)
  end
end
```
Note in the output that labels are sorted naturally left to right in the filenames, putting the values in the correct numerical order:
```
label: 1, comparison: 5
_scp_internal/differential_expression/cluster--my_annotation--1--5--study--wilcoxon.tsv
label: 1, comparison: 10
_scp_internal/differential_expression/cluster--my_annotation--1--10--study--wilcoxon.tsv
label: 1, comparison: 15
_scp_internal/differential_expression/cluster--my_annotation--1--15--study--wilcoxon.tsv
label: 1, comparison: 50
_scp_internal/differential_expression/cluster--my_annotation--1--50--study--wilcoxon.tsv
label: 1, comparison: 55
_scp_internal/differential_expression/cluster--my_annotation--1--55--study--wilcoxon.tsv
label: 5, comparison: 1
_scp_internal/differential_expression/cluster--my_annotation--1--5--study--wilcoxon.tsv
label: 5, comparison: 10
_scp_internal/differential_expression/cluster--my_annotation--5--10--study--wilcoxon.tsv
label: 5, comparison: 15
_scp_internal/differential_expression/cluster--my_annotation--5--15--study--wilcoxon.tsv
...
```