### PR TITLE
User-uploaded differential expression ingest, part 1 (SCP-5000)

### DIFF
--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -120,6 +120,10 @@ class FileParseService
           study:, study_file:, user:, action: :ingest_anndata, reparse:, persist_on_fail:, params_object:
         )
         job.delay.push_remote_and_launch_ingest
+      when 'Differential Expression'
+        action = :ingest_differential_expression
+        job = IngestJob.new(study:, study_file:, user:, action: , reparse:, persist_on_fail:)
+        job.delay.push_remote_and_launch_ingest
       end
 
       study_file.update(parse_status: 'parsing')

--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -104,6 +104,13 @@ class DifferentialExpressionResult
     result_files.to_a
   end
 
+  # number of different pairwise comparisons
+  # e.g. { a: [b,c] } => 2 comparisons (a:b, a:c)
+  #      { a: [b,c], b: [c] } => 3 comparisons (a:b, a:c, b:c)
+  def num_pairwise_comparisons
+    pairwise_comparisons.values.map(&:count).reduce(0, &:+)
+  end
+
   private
 
   # find the intersection of annotation values from the source, filtered for cells observed in cluster

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -603,7 +603,7 @@ class IngestJob
     annotation_identifier = "#{de_info.annotation_name}--group--#{de_info.annotation_scope}"
     Rails.logger.info "Creating differential expression result object for annotation: #{annotation_identifier} from " \
                       "user-uploaded file #{study_file.upload_file_name}"
-    # TODO: once SCP-4999 & SCP-5087 are completed
+    # TODO: SCP-5096, once SCP-4999 & SCP-5087 are completed
   end
 
   # launch an image pipeline job once :render_expression_arrays completes

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -14,8 +14,8 @@ class IngestJob
 
   # valid ingest actions to perform
   VALID_ACTIONS = %i[
-    ingest_expression ingest_cluster ingest_cell_metadata ingest_anndata subsample differential_expression
-    render_expression_arrays
+    ingest_expression ingest_cluster ingest_cell_metadata ingest_anndata ingest_differential_expression subsample
+    differential_expression render_expression_arrays
   ].freeze
 
   # Mappings between actions & models (for cleaning up data on re-parses)
@@ -23,6 +23,7 @@ class IngestJob
     ingest_expression: Gene,
     ingest_cluster: ClusterGroup,
     ingest_cell_metadata: CellMetadatum,
+    ingest_differential_expression: DifferentialExpressionResult,
     ingest_subsample: ClusterGroup
   }.freeze
 
@@ -901,6 +902,11 @@ class IngestJob
       cluster = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id)
       message << "Subsampling has completed for #{cluster.name}"
       message << "Subsamples generated: #{cluster.subsample_thresholds_required.join(', ')}"
+    when :ingest_differential_expression
+      result = DifferentialExpressionResult.find_by(study:, study_file:)
+      message << "Differential expression ingest completed for #{result.annotation_name}"
+      message << "One-vs-rest comparisons: #{result.observed_values.join(', ')}" if result.observed_values.any?
+      message << "Total pairwise comparisons: #{result.num_pairwise_comparisons}" if result.pairwise_comparisons.any?
     when :differential_expression
       message << "Differential expression calculations for #{params_object.cluster_name} have completed"
       message << "Selected annotation: #{params_object.annotation_name} (#{params_object.annotation_scope})"

--- a/test/models/papi_client_test.rb
+++ b/test/models/papi_client_test.rb
@@ -174,7 +174,7 @@ class PapiClientTest < ActiveSupport::TestCase
     annotation_name = 'Category'
     annotation_scope = 'cluster'
     de_file = @study.study_files.build(file_type: 'Differential Expression', upload_file_name: 'de.tsv')
-    de_file.build_differential_expression_file_info(annotation_name: , annotation_scope: , cluster_group:)
+    de_file.build_differential_expression_file_info(annotation_name:, annotation_scope:, cluster_group:)
     de_cmd = @client.get_command_line(study_file: de_file, action: :ingest_differential_expression, user_metrics_uuid:)
     assert de_cmd.any?
     assert de_cmd.include? de_file.id.to_s

--- a/test/models/papi_client_test.rb
+++ b/test/models/papi_client_test.rb
@@ -149,26 +149,46 @@ class PapiClientTest < ActiveSupport::TestCase
   end
 
   test 'should construct command line for pipeline jobs by file_type' do
-    exp_cmd = @client.get_command_line(study_file: @expression_matrix, action: :ingest_expression,
-                                       user_metrics_uuid: @user.metrics_uuid)
+    user_metrics_uuid = @user.metrics_uuid
+    exp_cmd = @client.get_command_line(study_file: @expression_matrix, action: :ingest_expression, user_metrics_uuid:)
     assert exp_cmd.any?
     assert exp_cmd.include? @study.id.to_s
     assert exp_cmd.include? @expression_matrix.id.to_s
-    assert exp_cmd.include? @user.metrics_uuid
+    assert exp_cmd.include? user_metrics_uuid
     assert exp_cmd.include? '--matrix-file'
     assert exp_cmd.include? @expression_matrix.gs_url
     assert exp_cmd.include? '--matrix-file-type'
     assert exp_cmd.include? 'dense'
 
-    cluster_cmd = @client.get_command_line(study_file: @cluster_file, action: :ingest_cluster,
-                                           user_metrics_uuid: @user.metrics_uuid)
+    cluster_cmd = @client.get_command_line(study_file: @cluster_file, action: :ingest_cluster, user_metrics_uuid:)
     assert cluster_cmd.any?
     assert cluster_cmd.include? @study.id.to_s
     assert cluster_cmd.include? @cluster_file.id.to_s
     assert cluster_cmd.include? '--cluster-file'
     assert cluster_cmd.include? @cluster_file.gs_url
-    assert cluster_cmd.include? @user.metrics_uuid
+    assert cluster_cmd.include? user_metrics_uuid
     assert cluster_cmd.include? '--ingest-cluster'
+
+    # user-uploaded DE file
+    cluster_group = @study.cluster_groups.first
+    annotation_name = 'Category'
+    annotation_scope = 'cluster'
+    de_file = @study.study_files.build(file_type: 'Differential Expression', upload_file_name: 'de.tsv')
+    de_file.build_differential_expression_file_info(annotation_name: , annotation_scope: , cluster_group:)
+    de_cmd = @client.get_command_line(study_file: de_file, action: :ingest_differential_expression, user_metrics_uuid:)
+    assert de_cmd.any?
+    assert de_cmd.include? de_file.id.to_s
+    assert de_cmd.include? '--differential-expression-file'
+    assert de_cmd.include? de_file.gs_url
+    assert de_cmd.include? '--annotation-name'
+    assert de_cmd.include? annotation_name
+    assert de_cmd.include? '--annotation-scope'
+    assert de_cmd.include? annotation_scope
+    assert de_cmd.include? '--cluster-name'
+    assert de_cmd.include? cluster_group.name
+    assert de_cmd.include? '--computational-method'
+    assert de_cmd.include? DifferentialExpressionResult::DEFAULT_COMP_METHOD
+    assert de_cmd.include? '--ingest-differential-expression'
   end
 
   test 'should get extra command line options' do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds necessary integration to be able to launch ingest jobs for user-uploaded differential expression files.  Full command lines for these processes can now be generated, and other various helper/reporting methods have been updated to accommodate this new study file type.  The new ingest process will be called `ingest_differential_expression` (with associated subparser of `--ingest-differential-expression`)

Existing Mixpanel reports for the `ingest` event that leverage `file_type` breakdowns will now show `Differential Expression` jobs for user-uploaded files.  Automatic "cell type" differential expression calculation show up on a separate Mixpanel event called `differential-expression-ingest`.

In addition, the `PapiClient#get_command_line` method has been refactored to always use arrays for assembling arguments for ingest processes.  Since this is how they are passed to Docker anyway, using arrays by default simplifies handling string-based parameters that contains spaces, and generally makes the code easier to read/understand.

#### MANUAL TESTING
Note: we cannot successfully parse these files until SCP-4999 and associated sub-tasks are completed.  This work is tracked in SCP-5096.  For now, we can validate that command lines are formatted correctly.
1. Pull branch and open a Rails console session
2. Load the Human milk - differential expression study:
```
study = Study.find_by(name: 'Human milk - differential expression')
```
3. Create a new temporary study file of type `Differential Expression`:
```
study_file = study.study_files.build(file_type: 'Differential Expression', upload_file_name: 'de.tsv')
cluster_group = study.default_cluster
annotation_name = 'cell_type__ontology_label'
annotation_scope = 'study'
diff_info = study_file.build_differential_expression_file_info(annotation_name:, annotation_scope:, cluster_group:)
```
4. Output the command line for the ingest process and validate they match (IDs may differ, but you should have the same number of parameters):
```
client = PapiClient.new
action = :ingest_differential_expression
user_metrics_uuid = study.user.metrics_uuid
client.get_command_line(study_file:,action:,user_metrics_uuid:)
=> 
["python",                                                                                                    
 "ingest_pipeline.py",                                                                                        
 "--study-id",                                                                                                
 "62718fbb94ec8f51542049d6",                                                                                  
 "--study-file-id",                                                                                           
 "64345c3894ec8f0ed6fa5136",                                                                                  
 "--user-metrics-uuid",                                                                                       
 "0fc4d8e5-6c4c-422e-94a3-c78801757202",                                                                      
 "ingest_differential_expression",                                                                            
 "--annotation-name",                                                                                         
 "cell_type__ontology_label",
 "--annotation-scope",
 "study",
 "--cluster-name",
 "All Cells UMAP",
 "--differential-expression-file",
 "gs://fc-32035468-639c-414f-8275-6d3998cfe355/de.tsv",
 "--computational-method",
 "wilcoxon",
 "--ingest-differential-expression"]
```