### PR TITLE
Fixing AbTest dependencies/validations and associated tests (SCP-5025)

### DIFF
--- a/app/models/ab_test.rb
+++ b/app/models/ab_test.rb
@@ -16,6 +16,7 @@ class AbTest
   field :enabled, type: Boolean, default: false
 
   before_validation :sanitize_group_names
+  validates :feature_flag, uniqueness: true
   validate :two_groups?
   after_validation :migrate_assignments, on: :update
 

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -11,7 +11,7 @@ class FeatureFlag
   field :name, type: String
   field :default_value, type: Boolean, default: false
   field :description, type: String
-  has_one :ab_test, dependent: :delete_all
+  has_one :ab_test, dependent: :destroy
 
   # pointer to all per-model feature_flag_options, will delete all if this flag is removed
   has_many :feature_flag_options, dependent: :delete_all, primary_key: :name, foreign_key: :name

--- a/test/controllers/ab_tests_controller_test.rb
+++ b/test/controllers/ab_tests_controller_test.rb
@@ -16,9 +16,13 @@ class AbTestsControllerTest < ActionDispatch::IntegrationTest
   end
 
   teardown do
-    @feature_flag.ab_test&.destroy
-    @feature_flag.reload
+    AbTest.destroy_all
     AbTestAssignment.destroy_all
+    @feature_flag.reload
+  end
+
+  after(:all) do
+    @feature_flag.destroy
   end
 
   test 'should create A/B test' do

--- a/test/models/ab_test_test.rb
+++ b/test/models/ab_test_test.rb
@@ -21,6 +21,12 @@ class AbTestTest < ActiveSupport::TestCase
     @feature_flag.destroy
   end
 
+  test 'should prevent creating duplicate tests' do
+    assert_raise Mongoid::Errors::Validations do
+      AbTest.create!(feature_flag: @feature_flag, group_names: %w[foo bar])
+    end
+  end
+
   # we can't prove true random assignment, only that over a reasonable amount of iterations we would see a roughly
   # equal distribution (±2%); for reference, SCP had ~2.5K unique Study overview users/week in 2022
   test 'should distribute group assignments equally' do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update addresses an issue where duplicate `AbTest` entries could be created for the same feature flag, and would therefore cause some test assertions to fail when a delete was made but only one copy removed.  The root cause appeared to be that there was no uniqueness constraint placed for the `FeatureFlag` association.  Also, since the association is `has_one` from `FeatureFlag`, the dependent clause should have been `:destroy` and not `:delete_all` as there will only ever be one.  Both of these issues have been addressed, and a new test added to check for the uniqueness validation.

#### MANUAL TESTING
Since the whole point of this PR was to fix a test that only failed in CI (for the most part), and was not uniformly reproducible, manual testing will simply attempt to prove the absence of a negative as a positive condition.  However, you can run both updated test suites to confirm that they work locally for you:
1. Pull branch and load secrets into your environment with `./rails_local_setup.rb && source config/secrets/.source_env.bash`
2. Run both test suites and confirm there are no errors:
```
# run controller tests
$ bin/rails test test/controllers/ab_tests_controller_test.rb  

SUITE AbTestsControllerTest starting
... # test output
SUITE AbTestsControllerTest completed (12.595 sec)
Finished in 12.598215s, 0.3175 runs/s, 0.8731 assertions/s.

4 runs, 11 assertions, 0 failures, 0 errors, 0 skips

# run model tests 
$ bin/rails test test/models/ab_test_test.rb 

SUITE AbTestTest starting
... # test output
SUITE AbTestTest completed (4.83 sec)


Finished in 4.833363s, 1.2414 runs/s, 2.8965 assertions/s.

6 runs, 14 assertions, 0 failures, 0 errors, 0 skips


```