### PR TITLE
Address some accessibility issues on SCP (SCP-5075)

### DIFF
--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -211,6 +211,7 @@ export default function DifferentialExpressionPanel({
             type="button"
             data-analytics-name="clear-de-search"
             className="clear-de-search-icon"
+            aria-label="Clear"
             onClick={handleClear} >
             <FontAwesomeIcon icon={faTimes} />
           </Button> }

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -334,6 +334,7 @@ export default function ExploreDisplayTabs({
                   <Tooltip id='back-to-cluster-view'>{'Return to cluster view'}</Tooltip>
                 }>
                   <button className="action fa-lg"
+                    aria-label="Back arrow"
                     onClick={() => searchGenes([])}>
                     <FontAwesomeIcon icon={faArrowLeft}/>
                   </button>

--- a/app/javascript/components/explore/ImageTab.jsx
+++ b/app/javascript/components/explore/ImageTab.jsx
@@ -47,7 +47,7 @@ export default function ImageTab({
         <div className="col-md-6">
           <h5 className="text-center">
             Associated Clusters
-            <button className="action" onClick={() => setShowClusters(!showClusters)}>
+            <button className="action" aria-label="Toggle show clusters" onClick={() => setShowClusters(!showClusters)}>
               [{showClusters ? 'hide' : 'show'}]
             </button>
           </h5>

--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -103,7 +103,7 @@ function ImageDisplay({ file, bucketName }) {
     <h5 className="plot-title">
       <FontAwesomeIcon icon={faImage} className="fa-lg fas"/> {file.name}
       &nbsp;
-      <button className="action" onClick={() => setShow(!show)}>[{show ? 'hide' : 'show'}]</button>
+      <button aria-label="Toggle show image" className="action" onClick={() => setShow(!show)}>[{show ? 'hide' : 'show'}]</button>
     </h5>
     { show &&
       <div>

--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -160,7 +160,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
       <div className="flexbox align-center">
         <div className="input-group">
           <div className="input-group-append">
-            <Button type="button" data-analytics-name="gene-search-submit" onClick={handleSearch} disabled={searchDisabled}>
+            <Button type="button" aria-label="Search genes" data-analytics-name="gene-search-submit" onClick={handleSearch} disabled={searchDisabled}>
               <FontAwesomeIcon icon={faSearch} />
             </Button>
           </div>

--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -61,7 +61,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
     } else if (newGeneArray && newGeneArray.length) {
       const genesToSearch = newGeneArray.map(g => g.value)
       if (genesToSearch.length > window.MAX_GENE_SEARCH) {
-        log('search-too-many-genes', {numGenes: genesToSearch.length})
+        log('search-too-many-genes', { numGenes: genesToSearch.length })
         setShowTooManyGenesModal(true)
       } else {
         if (event) { // this was not a 'clear'
@@ -160,7 +160,13 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
       <div className="flexbox align-center">
         <div className="input-group">
           <div className="input-group-append">
-            <Button type="button" aria-label="Search genes" data-analytics-name="gene-search-submit" onClick={handleSearch} disabled={searchDisabled}>
+            <Button
+              type="button"
+              aria-label="Search genes"
+              aria-disabled={searchDisabled}
+              data-analytics-name="gene-search-submit"
+              onClick={handleSearch}
+              disabled={searchDisabled}>
               <FontAwesomeIcon icon={faSearch} />
             </Button>
           </div>

--- a/app/javascript/components/search/controls/CombinedFacetControl.jsx
+++ b/app/javascript/components/search/controls/CombinedFacetControl.jsx
@@ -60,6 +60,7 @@ export default function CombinedFacetControl({ controlDisplayName, facetIds }) {
         <button
           ref={clearNode}
           className='facet-clear'
+          aria-label='Clear facet filters'
           onClick={() => clearFilters(true)}
         >
           <FontAwesomeIcon icon={faTimesCircle}/>

--- a/app/javascript/components/search/controls/FacetControl.jsx
+++ b/app/javascript/components/search/controls/FacetControl.jsx
@@ -59,6 +59,7 @@ function RawFacetControl({ facet }) {
           ref={clearNode}
           className='facet-clear'
           onClick={clearFacet}
+          aria-label='Clear facets'
         >
           <FontAwesomeIcon icon={faTimesCircle}/>
         </button>

--- a/app/javascript/components/search/controls/FiltersSearchBar.jsx
+++ b/app/javascript/components/search/controls/FiltersSearchBar.jsx
@@ -33,6 +33,7 @@ export default function FiltersSearchBar({ searchFilters, filtersBoxId }) {
           <Button
             className='search-button'
             onClick={handleFilterSearchSubmit}
+            aria-label='Search'
           >
             <FontAwesomeIcon icon={faSearch}/>
           </Button>

--- a/app/javascript/components/search/controls/KeywordSearch.jsx
+++ b/app/javascript/components/search/controls/KeywordSearch.jsx
@@ -82,14 +82,14 @@ export default function KeywordSearch({ keywordPrompt }) {
           placeholder={placeholder}
           name="keywordText"/>
         <div className="input-group-append">
-          <Button type='submit'>
+          <Button type='submit' aria-label='Search keywords'>
             <FontAwesomeIcon icon={faSearch} />
           </Button>
         </div>
         { showClear &&
           <Button className="keyword-clear"
             type='button'
-            onClick={handleClear} >
+            onClick={handleClear} aria-label='Clear' >
             <FontAwesomeIcon icon={faTimes} />
           </Button> }
       </InputGroup>

--- a/app/javascript/components/search/controls/download/DownloadButton.jsx
+++ b/app/javascript/components/search/controls/download/DownloadButton.jsx
@@ -34,6 +34,7 @@ export default function DownloadButton({ searchResults={} }) {
     id="download-button"
     className="btn btn-primary"
     disabled={downloadDisabled}
+    aria-label='Download'
     onClick={() => {setShowModal(!showModal)}}>
     <span>
       <FontAwesomeIcon className="icon-left" icon={faDownload}/> Download

--- a/app/javascript/components/search/controls/download/DownloadButton.jsx
+++ b/app/javascript/components/search/controls/download/DownloadButton.jsx
@@ -34,6 +34,7 @@ export default function DownloadButton({ searchResults={} }) {
     id="download-button"
     className="btn btn-primary"
     disabled={downloadDisabled}
+    aria-disabled={downloadDisabled}
     aria-label='Download'
     onClick={() => {setShowModal(!showModal)}}>
     <span>

--- a/app/javascript/components/search/genes/GeneKeyword.jsx
+++ b/app/javascript/components/search/genes/GeneKeyword.jsx
@@ -92,7 +92,7 @@ export default function GeneKeyword({ placeholder, helpTextContent }) {
           placeholder={placeholder}
         />
         <div className="input-group-append">
-          <Button type="submit">
+          <Button type="submit" aria-label="Search genes">
             <FontAwesomeIcon icon={faSearch} />
           </Button>
         </div>

--- a/app/javascript/components/search/results/PagingControl.jsx
+++ b/app/javascript/components/search/results/PagingControl.jsx
@@ -9,13 +9,17 @@ const PagingControl = ({ currentPage, totalPages, changePage, canPreviousPage, c
       <button
         className="text-button"
         onClick={() => {changePage(zeroIndexed ? 0 : 1)}}
-        disabled={!canPreviousPage}>
+        disabled={!canPreviousPage}
+        aria-disabled={!canPreviousPage}
+        aria-label='Page to start'>
         <FontAwesomeIcon icon={faAngleDoubleLeft}/>
       </button>
       <button
         className="text-button"
         onClick={() => {changePage(currentPage - 1)}}
-        disabled={!canPreviousPage}>
+        disabled={!canPreviousPage}
+        aria-disabled={!canPreviousPage}
+        aria-label='Page back'>
         <FontAwesomeIcon icon={faAngleLeft}/>
       </button>
       <span className="currentPage">
@@ -24,13 +28,17 @@ const PagingControl = ({ currentPage, totalPages, changePage, canPreviousPage, c
       <button
         className="text-button"
         onClick={() => {changePage(currentPage + 1)}}
-        disabled={!canNextPage}>
+        disabled={!canNextPage}
+        aria-disabled={!canNextPage}
+        aria-label='Page next'>
         <FontAwesomeIcon icon={faAngleRight}/>
       </button>
       <button
         className="text-button"
         onClick={() => {changePage(zeroIndexed ? totalPages - 1 : totalPages)}}
-        disabled={!canNextPage}>
+        disabled={!canNextPage}
+        aria-disabled={!canNextPage}
+        aria-label='Page to end'>
         <FontAwesomeIcon icon={faAngleDoubleRight}/>
       </button>
     </div>

--- a/app/javascript/components/search/results/ResultsPanel.jsx
+++ b/app/javascript/components/search/results/ResultsPanel.jsx
@@ -84,11 +84,11 @@ const FacetResultsFooter = ({ studySearchState }) => {
             per https://docs.google.com/spreadsheets/d/1FSpP2XTrG9FqAqD9X-BHxkCZae9vxZA3cQLow8mn-bk
           */}
           Learn more about our search capability on our{' '}
-          <a className= "link-with-blue-background"  href="https://singlecell.zendesk.com/hc/en-us/articles/360061006431-Search-Studies"
+          <a className= "link-darker-blue" href="https://singlecell.zendesk.com/hc/en-us/articles/360061006431-Search-Studies"
             target="_blank" rel="noreferrer">documentation
           </a>.  Study authors looking to make their studies more accessible can read our{' '}
           {/* eslint-disable-next-line max-len */}
-          <a className= "link-with-blue-background" href="https://singlecell.zendesk.com/hc/en-us/articles/4406379107355-Metadata-powered-Advanced-Search"
+          <a className= "link-darker-blue" href="https://singlecell.zendesk.com/hc/en-us/articles/4406379107355-Metadata-powered-Advanced-Search"
             target="_blank" rel="noreferrer"> metadata guide
           </a>.
         </div>

--- a/app/javascript/components/search/results/ResultsPanel.jsx
+++ b/app/javascript/components/search/results/ResultsPanel.jsx
@@ -84,11 +84,11 @@ const FacetResultsFooter = ({ studySearchState }) => {
             per https://docs.google.com/spreadsheets/d/1FSpP2XTrG9FqAqD9X-BHxkCZae9vxZA3cQLow8mn-bk
           */}
           Learn more about our search capability on our{' '}
-          <a href="https://singlecell.zendesk.com/hc/en-us/articles/360061006431-Search-Studies"
+          <a className= "link-with-blue-background"  href="https://singlecell.zendesk.com/hc/en-us/articles/360061006431-Search-Studies"
             target="_blank" rel="noreferrer">documentation
           </a>.  Study authors looking to make their studies more accessible can read our{' '}
           {/* eslint-disable-next-line max-len */}
-          <a href="https://singlecell.zendesk.com/hc/en-us/articles/4406379107355-Metadata-powered-Advanced-Search"
+          <a className= "link-with-blue-background" href="https://singlecell.zendesk.com/hc/en-us/articles/4406379107355-Metadata-powered-Advanced-Search"
             target="_blank" rel="noreferrer"> metadata guide
           </a>.
         </div>

--- a/app/javascript/components/upload/ExpandableFileForm.jsx
+++ b/app/javascript/components/upload/ExpandableFileForm.jsx
@@ -145,6 +145,7 @@ function SaveButton({ file, saveFile, validationMessages = {} }) {
     className={file.isDirty ? 'btn btn-primary margin-right' : 'btn terra-secondary-btn margin-right'}
     onClick={() => saveFile(file)}
     disabled={saveDisabled}
+    aria-disabled={saveDisabled}
     data-testid="file-save">
     Save {file.uploadSelection && <span>&amp; Upload</span>}
   </button>

--- a/app/javascript/components/upload/MetadataStep.jsx
+++ b/app/javascript/components/upload/MetadataStep.jsx
@@ -62,7 +62,7 @@ function MetadataForm({
           <div className="row">
             <div className="col-md-12" id="overflow-x-scroll">
               A <b>metadata file</b> lists all cells in the study
-              <img src={metadataExplainerImage}/>
+              <img src={metadataExplainerImage} alt={'Diagram of data required for metadata file'}/>
             </div>
           </div>
           <div className="row">
@@ -94,6 +94,7 @@ function MetadataForm({
               name={`metadataFormYes-${file._id}`}
               value="true"
               disabled={conventionRequired}
+              aria-disabled={conventionRequired}
               checked={file.use_metadata_convention}
               onChange={e => updateFile(file._id, { use_metadata_convention: true })} /> Yes
           </label>
@@ -102,6 +103,7 @@ function MetadataForm({
               name={`metadataFormNo-${file._id}`}
               value="false"
               disabled={conventionRequired}
+              aria-disabled={conventionRequired}
               checked={!file.use_metadata_convention}
               onChange={e => updateFile(file._id, { use_metadata_convention: false })} /> No
           </label> &nbsp; &nbsp;

--- a/app/javascript/components/upload/form-components.jsx
+++ b/app/javascript/components/upload/form-components.jsx
@@ -66,6 +66,7 @@ export function SaveDeleteButtons({ file, updateFile, saveFile, deleteFile, vali
     className={file.isDirty ? 'btn btn-primary margin-right' : 'btn terra-secondary-btn margin-right'}
     onClick={() => saveFile(file)}
     disabled={saveDisabled}
+    aria-disabled={saveDisabled}
     data-testid="file-save">
     Save { file.uploadSelection && <span>&amp; Upload</span> }
   </button>

--- a/app/javascript/components/visualization/controls/CreateAnnotation.jsx
+++ b/app/javascript/components/visualization/controls/CreateAnnotation.jsx
@@ -215,6 +215,7 @@ function CreateAnnotation({
                   <button
                     className="btn btn-primary"
                     disabled={!isCreateEnabled}
+                    aria-disabled={!isCreateEnabled}
                     data-analytics-name="create-annotation-create"
                     onClick={handleCreate}>Create</button>
                   &nbsp;
@@ -363,6 +364,7 @@ function CreateAnnotationButton({ expanded = false, ...props }) {
   return <button className = {buttonClass}
     data-analytics-name = {!isUserLoggedIn() ? 'toggle-create-annotation-signedout' :'toggle-create-annotation'}
     data-toggle="tooltip"
+    aria-label="Add annotation"
     data-original-title = {toolTipchoice()} // necessary to dynamically update the tooltip text
     {...props}>
     <FontAwesomeIcon icon={iconShape}/> &nbsp;

--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
@@ -362,6 +362,7 @@ export default function ScatterPlotLegend({
               data-analytics-name='legend-show-all'
               className={`stateful-link ${getActivity(showIsEnabled)}`}
               disabled={!showIsEnabled}
+              aria-disabled={!showIsEnabled}
               onClick={() => {showHideAll('show', labels, updateHiddenTraces)}}
             >Show all</a>
             <a
@@ -369,6 +370,7 @@ export default function ScatterPlotLegend({
               data-analytics-name='legend-hide-all'
               className={`stateful-link pull-right ${getActivity(hideIsEnabled)}`}
               disabled={!hideIsEnabled}
+              aria-disabled={!hideIsEnabled}
               onClick={() => {showHideAll('hide', labels, updateHiddenTraces)}}
             >Hide all</a>
           </>

--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -91,10 +91,12 @@
 
 .green-count {
   color: lighten(#80c065, 10%);
+  font-weight: 400;
 }
 
 .blue-count {
-  color: lighten(#4e72b8, 10%);
+  color: lighten(#4e72b8, 25%);
+  font-weight: 400;
 }
 
 #scp-footer {

--- a/app/javascript/styles/_colors.scss
+++ b/app/javascript/styles/_colors.scss
@@ -1,11 +1,13 @@
 /* defines global colors */
 
 /* color for primary buttons, links, and other indicators that something is a clickable action */
+// $action-color: #4d72aa;
 $action-color: #3D5A87;
 
 /* non-fatal errors -- color palette borrowed from Terra */
 $warning-background-color: #feeed8;
-$warning-icon-color: #f6901b;
+$warning-icon-color: #C45500;
+// C45500
 
 $danger-color: rgb(219, 50, 20);
 $success-color: #75b041;

--- a/app/javascript/styles/_colors.scss
+++ b/app/javascript/styles/_colors.scss
@@ -1,7 +1,7 @@
 /* defines global colors */
 
 /* color for primary buttons, links, and other indicators that something is a clickable action */
-$action-color: #4d72aa;
+$action-color: #3D5A87;
 
 /* non-fatal errors -- color palette borrowed from Terra */
 $warning-background-color: #feeed8;

--- a/app/javascript/styles/_colors.scss
+++ b/app/javascript/styles/_colors.scss
@@ -1,13 +1,11 @@
 /* defines global colors */
 
 /* color for primary buttons, links, and other indicators that something is a clickable action */
-// $action-color: #4d72aa;
 $action-color: #3D5A87;
 
 /* non-fatal errors -- color palette borrowed from Terra */
 $warning-background-color: #feeed8;
 $warning-icon-color: #C45500;
-// C45500
 
 $danger-color: rgb(219, 50, 20);
 $success-color: #75b041;

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -25,7 +25,7 @@
     float: right;
     background: #fff;
     color: #3D5A87;
-        margin-top: -0.5rem;
+    margin-top: -0.5rem;
   }
 
   button.action-minus {

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -24,15 +24,15 @@
     border: none;
     float: right;
     background: #fff;
-    color: #4d72aa;
-    margin-top: -0.5rem;
+    color: #3D5A87;
+        margin-top: -0.5rem;
   }
 
   button.action-minus {
     border: none;
     float: right;
     background: #fff;
-    color: #4d72aa;
+    color: #3D5A87;
     margin-top: -2.5rem;
   }
 

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -112,13 +112,13 @@ label {
 }
 
 .bs-callout-warning {
-  background-color: #fcf8f2;
-  border-left: 5px solid #f0ad4e;
-  color: #f0ad4e;
+  background-color: #C45500;
+  border-left: 5px solid #fff;
+  color: #fff;
 }
 
 .bs-callout-warning ul {
-  color: #f0ad4e;
+  color: #fff;
 }
 
 .bs-callout-info {
@@ -480,7 +480,7 @@ h6,
 
 .detail {
   font-style: italic;
-  color: #777;
+  color: #6c6c6c;
   font-weight: normal;
 }
 
@@ -874,4 +874,26 @@ figcaption.ck-editor__editable {
 
 .glossary {
   border-bottom: 1px #555 dashed;
+}
+
+.accessible-orange-button {
+    background-color: #C45500;
+    color: #fff;
+    border-color: #C45500;
+}
+
+.accessible-orange-button:hover, .accessible-orange-button:focus{
+  color: #fff;
+  background-color: #a54a05;
+  border-color: #a54a05;
+}
+
+.accessible-orange-button-icon {
+  background-color: #fff;
+  color: #C45500;
+}
+
+
+.link-with-blue-background {
+  color: #1b476d
 }

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -876,24 +876,23 @@ figcaption.ck-editor__editable {
   border-bottom: 1px #555 dashed;
 }
 
-.accessible-orange-button {
-    background-color: #C45500;
-    color: #fff;
-    border-color: #C45500;
+.btn-warning-scp {
+  background-color: #C45500;
+  color: #fff;
+  border-color: #C45500;
 }
 
-.accessible-orange-button:hover, .accessible-orange-button:focus{
+.btn-warning-scp:hover, .btn-warning-scp:focus{
   color: #fff;
   background-color: #a54a05;
   border-color: #a54a05;
 }
 
-.accessible-orange-button-icon {
+.btn-warning-scp-icon {
   background-color: #fff;
   color: #C45500;
 }
 
-
-.link-with-blue-background {
+.link-darker-blue {
   color: #1b476d
 }

--- a/app/javascript/styles/_resultsPanel.scss
+++ b/app/javascript/styles/_resultsPanel.scss
@@ -25,7 +25,7 @@
 }
 .highlight {
   color: green;
-  background: rgba($color: #74ae43, $alpha: 0.2);
+  background: #EAF3E2;
 }
 .results-panel > div > ul {
   background-color: #dce3e9;
@@ -83,15 +83,16 @@
     word-wrap: break-word;
   }
   .cell-count {
-    background-color: #74ae43;
+    color: #000000;
+    background-color: #deeed0;
     font-weight: normal;
-    margin-right: 0.5em
+    margin-right: 0.5em;
   }
   .facet-match, .gene-match {
     background-color: #fff;
     margin-right: 0.5em;
-    color: #74ae43;
-    border: 1px solid #74ae43;
+    color: #4C841F;
+    border: 1.25px solid #59a319;
     font-weight: normal;
   }
   &.inferred-match {
@@ -106,7 +107,7 @@
     font-style: italic;
     margin-bottom: 5px;
     border: 1px solid #ddd;
-    color: #888;
+    color: #6C6B6B;
   }
 }
 .pagination {
@@ -129,10 +130,10 @@
 }
 
 .study-type {
-  border: 1px solid #4d72aa;
+  border: 1.25px solid #4d72aa;
   background-color: white;
   font-weight: normal;
-  color: #777;
+  color: #545454;
   min-width: 44px;
   height: 20px;
   margin-right: 0.5em;

--- a/app/javascript/styles/_resultsPanel.scss
+++ b/app/javascript/styles/_resultsPanel.scss
@@ -83,7 +83,7 @@
     word-wrap: break-word;
   }
   .cell-count {
-    color: #000000;
+    color: #000;
     background-color: #deeed0;
     font-weight: normal;
     margin-right: 0.5em;

--- a/app/javascript/styles/_scatterPlot.scss
+++ b/app/javascript/styles/_scatterPlot.scss
@@ -25,6 +25,7 @@
 }
 
 .stateful-link {
+  // color: #4d72aa;
   color: #3D5A87;
   cursor: pointer;
 }

--- a/app/javascript/styles/_scatterPlot.scss
+++ b/app/javascript/styles/_scatterPlot.scss
@@ -25,7 +25,6 @@
 }
 
 .stateful-link {
-  // color: #4d72aa;
   color: #3D5A87;
   cursor: pointer;
 }

--- a/app/javascript/styles/_scatterPlot.scss
+++ b/app/javascript/styles/_scatterPlot.scss
@@ -25,7 +25,7 @@
 }
 
 .stateful-link {
-  color: #4d72aa;
+  color: #3D5A87;
   cursor: pointer;
 }
 

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -132,6 +132,7 @@ nav.search-links, #search-panel {
   }
 
   .clear-filters {
+    // color: #4d72aa;
     color: #3D5A87;
 
     margin-left: 10px;
@@ -263,8 +264,7 @@ nav.search-links, #search-panel {
   .accordion .card-header {
     padding: 5px;
     color: #3D5A87;
-
- font-weight: 500;
+    font-weight: 500;
     cursor: pointer;
   }
 

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -132,7 +132,8 @@ nav.search-links, #search-panel {
   }
 
   .clear-filters {
-    color: #4d72aa;
+    color: #3D5A87;
+
     margin-left: 10px;
     position: relative;
     top: 8px;
@@ -261,8 +262,9 @@ nav.search-links, #search-panel {
 
   .accordion .card-header {
     padding: 5px;
-    color: #4d72aa;
-    font-weight: 500;
+    color: #3D5A87;
+
+ font-weight: 500;
     cursor: pointer;
   }
 

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -132,7 +132,6 @@ nav.search-links, #search-panel {
   }
 
   .clear-filters {
-    // color: #4d72aa;
     color: #3D5A87;
 
     margin-left: 10px;

--- a/app/views/layouts/_generic_update_modal.html.erb
+++ b/app/views/layouts/_generic_update_modal.html.erb
@@ -7,7 +7,7 @@
             <div class="modal-body" id="generic-update-modal-body">
             </div>
             <div class="modal-footer">
-                <button class="close" aria-label='Close modal'data-dismiss="modal">×</button>
+                <button class="close" aria-label="Close modal" data-dismiss="modal">×</button>
             </div>
         </div>
     </div>

--- a/app/views/layouts/_generic_update_modal.html.erb
+++ b/app/views/layouts/_generic_update_modal.html.erb
@@ -7,7 +7,7 @@
             <div class="modal-body" id="generic-update-modal-body">
             </div>
             <div class="modal-footer">
-                <button class="close" data-dismiss="modal">×</button>
+                <button class="close" aria-label='Close modal'data-dismiss="modal">×</button>
             </div>
         </div>
     </div>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -1,6 +1,6 @@
 <nav class="navbar fluid navbar-inverse navbar-fixed-top sc-navbar rectangle" role="navigation" id="single-cell-navbar">
   <div class="navbar-header">
-    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#scp-navbar-dropdown-collapse">
+    <button type="button" class="navbar-toggle" aria-label='Toggle navbar' data-toggle="collapse" data-target="#scp-navbar-dropdown-collapse">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <title>
   <%= content_for?(:html_title) ? yield(:html_title) : "Single Cell Portal" %>
@@ -124,7 +124,7 @@
           <p class="text-danger text-center" id="alert-content"><strong></strong></p>
         </div>
         <div class="modal-footer">
-          <button class="close" data-dismiss="modal">×</button>
+          <button class="close" aria-label='Close' data-dismiss="modal">×</button>
         </div>
       </div>
     </div>
@@ -153,7 +153,7 @@
         <div id="spinner_target"></div>
       </div>
       <div class="modal-footer">
-        <button class="close" data-dismiss="modal">×</button>
+        <button class="close" aria-label='Close' data-dismiss="modal">×</button>
       </div>
     </div>
   </div>
@@ -168,7 +168,7 @@
 				<div class="spinner-target" id="delete-modal-spinner"></div>
 			</div>
 			<div class="modal-footer">
-				<button class="close" data-dismiss="modal">×</button>
+				<button class="close" aria-label='Close' data-dismiss="modal">×</button>
 			</div>
 		</div>
 	</div>
@@ -183,7 +183,7 @@
         <div class="spinner-target" id="generic-modal-spinner"></div>
       </div>
       <div class="modal-footer" id="generic-modal-footer">
-        <button class="close" data-dismiss="modal">×</button>
+        <button class="close" aria-label='Close' data-dismiss="modal">×</button>
       </div>
     </div>
   </div>
@@ -208,9 +208,9 @@
       <% end %>
     </div>
     <div class="footer-social-media-icons-block pull-right ">
-    <%= link_to "<i class='fab fa-youtube'></i>".html_safe, "https://www.youtube.com/channel/UCp_UGD74MW8up1YkWZrWkKw", target: :_blank, 'data-analytics-name' => 'youtube-link' %>
+    <%= link_to "<i class='fab fa-youtube'></i>".html_safe, "https://www.youtube.com/channel/UCp_UGD74MW8up1YkWZrWkKw", target: :_blank, 'data-analytics-name' => 'youtube-link',  'aria-label' => 'Youtube' %>
     &nbsp;
-    <%= link_to "<i class='fab fa-twitter-square', data-analytics-name='twitter-link' ></i>".html_safe, "https://twitter.com/SingleCellBroad", target: :_blank, 'data-analytics-name' => 'twitter-link'  %>
+    <%= link_to "<i class='fab fa-twitter-square', data-analytics-name='twitter-link' ></i>".html_safe, "https://twitter.com/SingleCellBroad", target: :_blank, 'data-analytics-name' => 'twitter-link', 'aria-label' => 'Twitter' %>
     &nbsp;
   </div>
     <div class="clearfix"></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -208,7 +208,7 @@
       <% end %>
     </div>
     <div class="footer-social-media-icons-block pull-right ">
-    <%= link_to "<i class='fab fa-youtube'></i>".html_safe, "https://www.youtube.com/channel/UCp_UGD74MW8up1YkWZrWkKw", target: :_blank, 'data-analytics-name' => 'youtube-link',  'aria-label' => 'Youtube' %>
+    <%= link_to "<i class='fab fa-youtube'></i>".html_safe, "https://www.youtube.com/channel/UCp_UGD74MW8up1YkWZrWkKw", target: :_blank, 'data-analytics-name' => 'youtube-link',  'aria-label' => 'YouTube' %>
     &nbsp;
     <%= link_to "<i class='fab fa-twitter-square', data-analytics-name='twitter-link' ></i>".html_safe, "https://twitter.com/SingleCellBroad", target: :_blank, 'data-analytics-name' => 'twitter-link', 'aria-label' => 'Twitter' %>
     &nbsp;

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <body>
     <%= yield %>
   </body>

--- a/app/views/layouts/nightly_admin_report.html.erb
+++ b/app/views/layouts/nightly_admin_report.html.erb
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
     <style type="text/css">

--- a/app/views/reports/_contact_modal.html.erb
+++ b/app/views/reports/_contact_modal.html.erb
@@ -21,7 +21,7 @@
         <% end %>
       </div>
       <div class="modal-footer">
-        <button class="close" data-dismiss="modal">×</button>
+        <button class="close" aria-label='Close' data-dismiss="modal">×</button>
       </div>
     </div>
   </div>

--- a/app/views/site/_main_banner_content.html.erb
+++ b/app/views/site/_main_banner_content.html.erb
@@ -1,8 +1,8 @@
 <div class="mask" id="main-banner">
   <% if FeatureAnnouncement.latest_features? %>
-    <%= scp_link_to "<span class='badge accessible-orange-button-icon'>#{FeatureAnnouncement.latest.count}</span> " \
+    <%= scp_link_to "<span class='badge btn-warning-scp-icon'>#{FeatureAnnouncement.latest.count}</span> " \
                     "#{pluralize_without_count(FeatureAnnouncement.latest.count, "New feature")}".html_safe,
-                    latest_feature_announcements_path, class: 'btn accessible-orange-button', id: 'latest-features-btn',
+                    latest_feature_announcements_path, class: 'btn btn-warning-scp', id: 'latest-features-btn',
                     data: { toggle: 'tooltip', placement: 'left' }, title: 'Learn about new Single Cell Portal features!' %>
   <% end %>
   <% if @selected_branding_group.present? %>

--- a/app/views/site/_main_banner_content.html.erb
+++ b/app/views/site/_main_banner_content.html.erb
@@ -23,7 +23,7 @@
     </div>
   <% else %>
     <div id="main-banner-logo">
-      <%= image_tag "SCP-logo.png", id: 'scp-logo' %>
+      <%= image_tag "SCP-logo.png", id: 'scp-logo', alt:'Single Cell Portal logo'%>
       <p id='main-banner-tag-line' class="scp-banner-position">Reducing barriers and accelerating single-cell research</p>
     </div>
   <% end %>

--- a/app/views/site/_main_banner_content.html.erb
+++ b/app/views/site/_main_banner_content.html.erb
@@ -1,8 +1,8 @@
 <div class="mask" id="main-banner">
   <% if FeatureAnnouncement.latest_features? %>
-    <%= scp_link_to "<span class='badge'>#{FeatureAnnouncement.latest.count}</span> " \
+    <%= scp_link_to "<span class='badge accessible-orange-button-icon'>#{FeatureAnnouncement.latest.count}</span> " \
                     "#{pluralize_without_count(FeatureAnnouncement.latest.count, "New feature")}".html_safe,
-                    latest_feature_announcements_path, class: 'btn btn-warning', id: 'latest-features-btn',
+                    latest_feature_announcements_path, class: 'btn accessible-orange-button', id: 'latest-features-btn',
                     data: { toggle: 'tooltip', placement: 'left' }, title: 'Learn about new Single Cell Portal features!' %>
   <% end %>
   <% if @selected_branding_group.present? %>
@@ -23,7 +23,7 @@
     </div>
   <% else %>
     <div id="main-banner-logo">
-      <%= image_tag "SCP-logo.png", id: 'scp-logo', alt:'Single Cell Portal logo'%>
+      <%= image_tag "SCP-logo.png", id: 'scp-logo', alt:'Single Cell P'%>
       <p id='main-banner-tag-line' class="scp-banner-position">Reducing barriers and accelerating single-cell research</p>
     </div>
   <% end %>

--- a/app/views/site/_main_banner_content.html.erb
+++ b/app/views/site/_main_banner_content.html.erb
@@ -23,7 +23,7 @@
     </div>
   <% else %>
     <div id="main-banner-logo">
-      <%= image_tag "SCP-logo.png", id: 'scp-logo', alt:'Single Cell P'%>
+      <%= image_tag "SCP-logo.png", id: 'scp-logo', alt:'Single Cell Portal logo'%>
       <p id='main-banner-tag-line' class="scp-banner-position">Reducing barriers and accelerating single-cell research</p>
     </div>
   <% end %>

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -77,7 +77,7 @@
             <% end %>
           </div>
           <div class="modal-footer">
-            <button class="close" data-dismiss="modal">×</button>
+            <button class="close" aria-label='Close' data-dismiss="modal">×</button>
           </div>
         </div>
       </div>

--- a/app/views/site/covid19.html.erb
+++ b/app/views/site/covid19.html.erb
@@ -11,7 +11,7 @@
     }
   </style>
   <div id="main-banner-logo">
-    <%= image_tag "SCP-logo.png", id: 'scp-logo' %>
+    <%= image_tag "SCP-logo.png", id: 'scp-logo', alt:'Single Cell Portal logo'%>
     <p id='main-banner-tag-line' class="scp-banner-position">Special section devoted to COVID-19 studies</p>
   </div>
 </div>


### PR DESCRIPTION
Accessibility standards are necessary to meet so that all users can utilize a web application regardless of things like visual impairment. This PR remediates some of the accessibility issues that exist in Single Cell Portal (concentration was done on the home page). This does not fix everything but the fixes that were focused on are described below:

Add `aria-labels` especially for icon based buttons (like buttons that are just 'x' for example)
- this enables a screenreader to read out the aria-label so  a user with visual-impairment utilizing a screenreader knows what a button does

Add `aria-disabled` for buttons that are disabled conditionally
- this enables a screenreader to detect that a button is disabled and gives a reason to help inform a user with visual-impairment utilizing a screenreader

Add  `lang="en"` to html elements
- WCAG Success Criterion 3.1.1 requires that a page language is specified in a way which may be 'programmatically determined' (i.e. via the lang attribute).

Add `alt-labels` for the images like logos
- allows a screenreader to describe an image for a user with visual-impairment utilizing a screenreader

Update color contrasts
- On certain buttons, links, text etc. the contrast between the color contrast between the text and background was not sufficient. This is likely the most noticeable change in this PR, lots of background colors got darkened, especially the color of the "New Feature" button. Sufficient contrast is important for users with visual-impairment (such as color-blindness) to more easily access the information on the page.


![compare cell count](https://user-images.githubusercontent.com/54322292/232838059-50870782-63b5-4529-9746-7b34631b539e.png)
![compare home page](https://user-images.githubusercontent.com/54322292/232838063-f4855ca2-31d9-49ba-b170-a1585f9e3158.png)
<img width="559" alt="Screenshot 2023-04-18 at 11 25 25 AM" src="https://user-images.githubusercontent.com/54322292/232838082-8c439563-0b2f-4b09-ba9f-810b54c4531c.png">
<img width="1131" alt="Screenshot 2023-04-18 at 10 40 35 AM" src="https://user-images.githubusercontent.com/54322292/232838107-a3c21b1c-862e-4b59-a99a-6e1be5dc8101.png">




To test:
- pull this branch and spin up your local server 
- inspect your page and find `lighthouse` and run an accessibility audit
- If you do the same ^ on prod you can compare the scores and see that the accessibility score has improved and many of the existing issues on prod are addressed. (this is not exhaustive, another iteration is needed to finish this clean up)

BEFORE/PROD
![Screenshot 2023-04-13 at 5 00 17 PM](https://user-images.githubusercontent.com/54322292/232839305-149b0d35-01fa-417c-aebd-fa94183e41fd.png)

AFTER
<img width="1501" alt="Screenshot 2023-04-18 at 1 42 05 PM" src="https://user-images.githubusercontent.com/54322292/232860004-bba3d493-d09b-43c0-ab22-28d8bc4cad86.png">
