### PR TITLE
Synonym retrieval, robust diagrams, denoised Sentry in related genes ideogram (SCP-5071)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "core-js": "^3.6.4",
     "exifreader": "4.6.0",
     "fflate": "^0.7.3",
-    "ideogram": "1.41.0",
+    "ideogram": "1.42.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.13.2",
     "morpheus-app": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6885,10 +6885,10 @@ identity-obj-proxy@^3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ideogram@1.41.0:
-  version "1.41.0"
-  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.41.0.tgz#6bac8155c62dddee6df00a4dccb75329fd498522"
-  integrity sha512-+4ZTleo7aIsBBA/x5KRFJst3v5OX8arsaB1/1n2U/63mvyfEIdgdUC5jL5RycBx+DAlx+Io8cC2oVNKebFIIYA==
+ideogram@1.42.0:
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.42.0.tgz#35203b567f330eb0c8a6af5fb5934eb48c734874"
+  integrity sha512-2iYz8Hre7lm5IzuFLYen4/NgI7bCyk25NFZT3CHm9ww/C8yu85h8UTlsgzmlnzHzUNnknZ8z305YXhRKLa+kLg==
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"


### PR DESCRIPTION
This polishes some rough edges in related genes ideogram, making it more robust.

<span id="synonym-retrieval"></span>
### Synonym retrieval
Genes are usually searched by name, e.g. CYBC1.  Occasionally they're searched by something else, in which case related genes ideogram previously always showed bare chromosomes.  Now, when genes are searched by an official Ensembl synonym that's in the study's expression matrix (e.g. "C17orf62"), the searched gene and any related genes are shown as expected, and the searched synonym is shown in the gene tooltip below the official name.

This find-by-synonym refinement should address many errors like `"C17orf62" is not a known gene in Homo sapiens`.  Those errors occur in roughly 2% of single-gene study gene searches.  I estimate [40-80%](https://broad-institute.sentry.io/issues/3776302320/events/9c85a59efcd64bdea4be99394003a792/events/?environment=production&project=1424198&referrer=previous-event&sort=freq&statsPeriod=24h&stream_index=2) of that 2% represent official Ensembl synonyms (which are now supported), with the rest being an eclectic mix of gene name variants.

<span id="more-robust-diagrams"></span>
### More robust diagrams
RNA and protein diagrams help learn more about gene function, gauge known transcriptional complexity, and assess paralog similarity.  However, it's not totally obvious that there is detail and functionality available upon mousing over near the diagram.  A new bit of text below the diagrams, "Hover for details", succinctly communicates that.  The RNA diagram also occasionally misrendered upon toggling between a transcript's mRNA and pre-mRNA states.  This likely occurred in 1-3% of canonical transcripts.  The diagrams now robustly transition between spliced and unspliced exons, even for certain multi-part 5'-UTRs as in the canonical transcript for the CTCF gene.

<span id="less-sentry-noise-etc"></span>
### Less Sentry noise, etc.
Data to refine pathway interaction summaries is unavailable in rare cases.  This has negligible user impact, e.g. 1 tooltip out of ~200 might say "Interacts with FOO" instead of "Inhibits FOO".  The bigger impact was simply central log noise, i.e. useless events in Sentry.  These 404s for missing cached WikiPathways GPML data are now better handled, and don't trigger an "[unexpected EOF](https://broad-institute.sentry.io/issues/3799089652/?environment=production&project=1424198&query=is%3Aunresolved+level%3Aerror+stack.abs_path%3A%2Aideogram%2A&referrer=issue-stream&statsPeriod=24h&stream_index=5)" error, so that's less log noise for Sentry.  The 404's are still logged locally, and a local DevTools console log explains it's handled.

Also, old and unused Ideogram service worker caches are now deleted, freeing up client disk space.  And the `ideogram` NPM package has been trimmed to reduce [local code search noise](https://broadinstitute.slack.com/archives/CBEHTH601/p1679678052827949?thread_ts=1679674434.440419&cid=CBEHTH601).  

### Video
Here's how it looks:

https://user-images.githubusercontent.com/1334561/233181063-105e3572-e476-4fdc-bb09-b932c1a8cb23.mov


### Test
To manually test:
* Pull branch
* `yarn install`
* Confirm output of `yarn list | grep ideogram` includes `ideogram@1.42.0`
* Restart Vite if you have it running
* Go to "Human milk - differential expression" study.  On staging, that's [SCP303](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP303).
* Confirm robust splice toggle
  * Search CTCF
  * Hover over gene in related genes ideogram
  * Hover near diagrams
  * Click scissors icon, wait 1-2 seconds, click it again
  * Confirm green and yellow transcript parts are in their original order
* Confirm no "unexpected EOF" error
  * Open DevTools, go to Console panel
  * Search TP53
  * Confirm no "unexpected EOF" error appears in DevTools Console panel
* Confirm synonym retrieval
  * Search C17orf62
  * Confirm the corresponding gene, CYBC1, appears in related genes ideogram
  * Hover over the gene
  * Confirm "Synonym: C17orf62" appears below the full gene name
  * _N.B.: A `TypeError` appears in the Console, but has no user impact_

Integrating this upstream Ideogram.js enhancement is a Developer's Choice Days project, tracked in [SCP-5071](https://broadworkbench.atlassian.net/browse/SCP-4887).

[SCP-5071]: https://broadworkbench.atlassian.net/browse/SCP-5071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ