### PR TITLE
update to ingest 1.26.0

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.25.1'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.26.0'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
This updates to `scp-ingest-pipeline:1.26.0` in order to support extracting processed expression data from `AnnData` files.