### PR TITLE
Processed expression parsing from uploaded AnnData files (SCP-4912)

### DIFF
--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -107,7 +107,6 @@ class FileParseService
           params_object = AnnDataIngestParameters.new(
             anndata_file: study_file.gs_url, obsm_keys: study_file.ann_data_file_info.obsm_key_names
           )
-          # TODO extract and parse Processed Exp Data (SCP-4709)
           # TODO extract and parse Raw Exp Data (SCP-4710)
         else
           # setting attributes to false/nil will omit them from the command line later

--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -34,7 +34,8 @@ class AnnDataIngestParameters
             allow_blank: true
 
   # default values for parameters
-  # attributes marked as true are passed to the command line as a standalone flag with no value, e.g. --extract "['cluster', 'metadata']"
+  # attributes marked as true are passed to the command line as a standalone flag with no value
+  # e.g. --extract "['cluster', 'metadata']"
   # any parameters that are set to nil/false will not be passed to the command line
   PARAM_DEFAULTS = {
     ingest_anndata: true,
@@ -43,7 +44,7 @@ class AnnDataIngestParameters
     cluster_file: nil,
     name: nil,
     domain_ranges: nil,
-    extract: %w[cluster metadata],
+    extract: %w[cluster metadata processed_expression],
     cell_metadata_file: nil,
     ingest_cell_metadata: false,
     study_accession: nil

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -931,7 +931,7 @@ class IngestJob
         genes = Gene.where(study_id: study.id, study_file_id: study_file.id).count
         message << "Gene-level entries created: #{genes}"
       end
-      message << 'Other data types are being extracted as specified in your AnnData file.'
+      message << 'Clustering and metadata entries are being extracted as specified in your AnnData file.'
     end
     message
   end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -424,6 +424,7 @@ class IngestJob
       set_has_image_cache
     when :ingest_anndata
       launch_anndata_subparse_jobs
+      set_anndata_file_info
     end
     set_study_initialized
   end
@@ -660,6 +661,10 @@ class IngestJob
         )
         job = IngestJob.new(study:, study_file:, user:, action: :ingest_cell_metadata, params_object: metadata_params)
         job.delay.push_remote_and_launch_ingest
+      else
+        # processed_expression data is parsed during the initial extract phase, so nothing is required here
+        # logging is for debugging purposes only
+        Rails.logger.info "skipping extraction of #{extract} for #{study_file.upload_file_name}"
       end
     end
   end
@@ -922,6 +927,11 @@ class IngestJob
       message << "Complete runtime (data cache & image rendering): #{complete_pipeline_runtime}"
     when :ingest_anndata
       message << "AnnData file ingest has completed"
+      if study_file.ann_data_file_info.has_expression
+        genes = Gene.where(study_id: study.id, study_file_id: study_file.id).count
+        message << "Gene-level entries created: #{genes}"
+      end
+      message << 'Other data types are being extracted as specified in your AnnData file.'
     end
     message
   end

--- a/test/models/ann_data_file_info_test.rb
+++ b/test/models/ann_data_file_info_test.rb
@@ -114,7 +114,6 @@ class AnnDataFileInfoTest < ActiveSupport::TestCase
     ]
     assert_not ann_data_info.valid?
     error_messages = ann_data_info.errors.messages_for(:data_fragments)
-    puts error_messages
     assert_equal 2, error_messages.count
     error_messages.each do |message|
       assert message.include?('are not unique')

--- a/test/models/ann_data_ingest_parameters_test.rb
+++ b/test/models/ann_data_ingest_parameters_test.rb
@@ -36,8 +36,8 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
       assert extraction.send(attr).blank?
     end
 
-    cmd = '--ingest-anndata --anndata-file gs://test_bucket/test.h5ad --extract ["cluster", "metadata"] ' \
-          '--obsm-keys ["X_umap", "X_tsne"]'
+    cmd = '--ingest-anndata --anndata-file gs://test_bucket/test.h5ad --extract ["cluster", "metadata", ' \
+          '"processed_expression"] --obsm-keys ["X_umap", "X_tsne"]'
     assert_equal cmd, extraction.to_options_array.join(' ')
 
     cluster_ingest = AnnDataIngestParameters.new(@ingest_cluster_params)

--- a/test/models/ann_data_ingest_parameters_test.rb
+++ b/test/models/ann_data_ingest_parameters_test.rb
@@ -7,12 +7,13 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
       anndata_file: 'gs://test_bucket/test.h5ad',
     }
 
+    @file_id = BSON::ObjectId.new
     @ingest_cluster_params = {
       ingest_anndata: false,
       extract: nil,
       obsm_keys: nil,
       ingest_cluster: true,
-      cluster_file: 'gs://test_bucket/_scp_internal/anndata_ingest/h5ad_file_id/h5ad_frag.cluster.X_umap.tsv',
+      cluster_file: "gs://test_bucket/_scp_internal/anndata_ingest/#{@file_id}/h5ad_frag.cluster.X_umap.tsv",
       name: 'X_umap',
       domain_ranges: '{}'
     }
@@ -21,7 +22,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
       ingest_anndata: false,
       extract: nil,
       obsm_keys: nil,
-      cell_metadata_file: 'gs://test_bucket/_scp_internal/anndata_ingest/h5ad_file_id/h5ad_frag.metadata.tsv',
+      cell_metadata_file: "gs://test_bucket/_scp_internal/anndata_ingest/#{@file_id}/h5ad_frag.metadata.tsv",
       ingest_cell_metadata: true
     }
   end
@@ -47,9 +48,8 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
       assert cluster_ingest.send(attr).blank?
     end
     cluster_cmd = '--ingest-cluster --cluster-file gs://test_bucket/_scp_internal/anndata_ingest/' \
-                  'h5ad_file_id/h5ad_frag.cluster.X_umap.tsv --name X_umap --domain-ranges {}'
+                  "#{@file_id}/h5ad_frag.cluster.X_umap.tsv --name X_umap --domain-ranges {}"
     assert_equal cluster_cmd, cluster_ingest.to_options_array.join(' ')
-
 
     metadata_ingest = AnnDataIngestParameters.new(@ingest_metadata_params)
     assert metadata_ingest.valid?
@@ -57,16 +57,17 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
     %i[ingest_anndata extract anndata_file].each do |attr|
       assert metadata_ingest.send(attr).blank?
     end
-    metadata_cmd = '--cell-metadata-file gs://test_bucket/_scp_internal/anndata_ingest/h5ad_file_id/h5ad_frag.metadata.tsv --ingest-cell-metadata'
-    assert_equal metadata_cmd, metadata_ingest.to_options_array.join(' ')
+    md_cmd = "--cell-metadata-file gs://test_bucket/_scp_internal/anndata_ingest/#{@file_id}/h5ad_frag.metadata.tsv " \
+             "--ingest-cell-metadata"
+    assert_equal md_cmd, metadata_ingest.to_options_array.join(' ')
 
   end
 
   test 'should set fragment filename for extracted files' do
     extraction = AnnDataIngestParameters.new(@extract_params)
     %w[X_umap X_tsne].each do |fragment|
-      assert_equal "gs://test_bucket/_scp_internal/anndata_ingest/h5ad_file_id/h5ad_frag.cluster.#{fragment}.tsv",
-                   extraction.fragment_file_gs_url('test_bucket', 'cluster', 'h5ad_file_id', fragment)
+      assert_equal "gs://test_bucket/_scp_internal/anndata_ingest/#{@file_id}/h5ad_frag.cluster.#{fragment}.tsv",
+                   extraction.fragment_file_gs_url('test_bucket', 'cluster', @file_id, fragment)
     end
   end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds processed expression extraction to AnnData file uploads.  Since the parsing actually happens during the initial "extract" job, adding `processed_expression` to the command line will tell ingest to parse expression data along with extracting clustering/metadata fragment files for downstream processing.

This update also addresses an bug with `AnnDataFileInfo` objects extracting information from `data_fragments` when the `data_type` value is stored as a string instead of a symbol.

#### MANUAL TESTING
1. Pull branch and boot as normal, including `Delayed::Job` worker
2. Download https://github.com/broadinstitute/scp-ingest-pipeline/blob/development/tests/data/anndata/anndata_test.h5ad and upload to a new study using the "AnnData" UX
    * There is clustering information in the `X_tsne` and `spatial` slots
3. In `development.log`, note that `processed_expression` has been added to the command line for the initial extraction job:
```
:actions:
  :commands:
  - python
  - ingest_pipeline.py
  - "--study-id"
  - 6451311b94ec8f59c754a6d7
  - "--study-file-id"
  - 645135cff6429a66f6d29323
  - "--user-metrics-uuid"
  - 0fc4d8e5-6c4c-422e-94a3-c78801757202
  - ingest_anndata
  - "--ingest-anndata"
  - "--anndata-file"
  - gs://fc-38dbd25a-eea7-4273-849b-732b1e664249/anndata_test.h5ad
  - "--extract"
  - '["cluster", "metadata", "processed_expression"]'
  - "--obsm-keys"
  - '["X_tsne"]'
  :flags: []
  :image_uri: gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.26.0
...
```
4. When the job completes, note that the success email includes information about gene expression data that has been parsed:
```
Total parse time: 1 Minute and 7 Seconds
AnnData file ingest has completed
Gene-level entries created: 4
Clustering and metadata entries are being extracted as specified in your AnnData file.
```
5. Observe that the clustering & metadata jobs launch immediately after
6. (Optional) Once the metadata/clustering jobs complete, confirm you can load the study and search for the gene `Foo`:
![Screenshot 2023-05-02 at 12 46 29 PM](https://user-images.githubusercontent.com/729968/235731444-c600f171-e73b-4412-a6e8-6a8042ab3df6.png)
