### PR TITLE
Make plot-specific tabs more salient (SCP-5051)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -343,7 +343,7 @@ export default function ExploreDisplayTabs({
           </div>
         </div>
         <div className="col-md-4 col-md-offset-1">
-          <ul className="nav nav-tabs" role="tablist" data-analytics-name="explore-default">
+          <ul className="nav nav-tabs study_plot_tabs" role="tablist" data-analytics-name="explore-default">
             { enabledTabs.map(tabKey => {
               const label = tabList.find(({ key }) => key === tabKey).label
               return (

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -212,3 +212,35 @@
     display: inline-block;
   }
 }
+
+.study_plot_tabs {
+  li  {
+    a {
+      font-size: larger;
+      color: #fff;
+      background: $action-color;
+      align-self: baseline;
+    }
+  } :hover {
+    color: #2a3f5f;
+  }
+  li.active > a {
+    border-left: 1px solid $action-color;
+    border-right: 1px solid $action-color;
+    border-top: 1px solid $action-color;
+    background: #fff;
+    color: #333;
+    margin-right: 8px;
+    margin-left: 8px;
+  }
+
+  li.disabled > a {
+    background: #fff;
+    color: #999999;
+  }
+
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none;
+  margin-right: 3px;
+}


### PR DESCRIPTION
Update the styling on the plot-specific tabs to make them more discoverable.

Changes include:
- All tab text increased size
- Active tab has a blue top, left, and right border
- Enabled but not active tabs are action blue in color and white text
- Hovering over active tabs makes the background grey and the text go to a slightly darker than action blue
- Disabled tabs text color is grey with background white

<img width="439" alt="Screenshot 2023-05-05 at 3 19 44 PM" src="https://user-images.githubusercontent.com/54322292/236558500-ab4ae791-4366-4f64-ad2b-953438cc8c7b.png">
<img width="419" alt="Screenshot 2023-05-05 at 3 20 00 PM" src="https://user-images.githubusercontent.com/54322292/236558524-73446339-9fbe-4262-8b8f-0dcae3dd54df.png">
<img width="454" alt="Screenshot 2023-05-05 at 3 19 50 PM" src="https://user-images.githubusercontent.com/54322292/236558625-bb4ab449-de03-486d-b25e-a076a0a8080e.png">
