### PR TITLE
Add migration script for new feature flag to gate explore tab UX updates (SCP-5128)

### DIFF
--- a/db/migrate/20230510115847_add_flag_for_explore_tab_ux_updates.rb
+++ b/db/migrate/20230510115847_add_flag_for_explore_tab_ux_updates.rb
@@ -1,0 +1,11 @@
+class AddFlagForExploreTabUxUpdates < Mongoid::Migration
+  def self.up
+    FeatureFlag.create!(name: 'show_explore_tab_ux_updates',
+                        default_value: false,
+                        description: 'show the "Update the Explore Tab" epic changes')
+  end
+
+  def self.down
+    FeatureFlag.find_by(name: 'show_explore_tab_ux_updates')&.destroy
+  end
+end


### PR DESCRIPTION
Add a feature flag defaulted to false that we can use for gating the UX updates that we are doing for the explore tab this quarter

Testing: There is not real functionality added with this PR but you can run the migration script to see the new flag.
* Pull this branch
* Open up terminal and run bin/rails db:migrate
* Start a server and open up localhost
* Navigate to the Feature Flags list page: https://localhost:3000/single_cell/feature_flags and see the new feature flag
![Screenshot 2023-05-10 at 12 11 53 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/ec4d3306-ef17-4951-96c0-764a4677d8c2)
