### PR TITLE
Handle keyword searching an accession that was entered lowercased (SCP-5076)

### DIFF
--- a/app/models/study_accession.rb
+++ b/app/models/study_accession.rb
@@ -8,7 +8,7 @@ class StudyAccession
   validates_uniqueness_of :accession
 
   # exclude everything that does not start with "SCP" and end with digits
-  ACCESSION_SANITIZER = /[^SCP\d+$]/
+  ACCESSION_SANITIZER = /[^SCP\d+$]/i
   # match on accepted accession format of "SCP" and ending with digits
   ACCESSION_FORMAT = /^SCP\d+$/
 


### PR DESCRIPTION
Currently if you try to search for an accession in the home page keyword search you must capitalize the letters "SCP" in order for it to work. This change allows you to type 'scp<#>' and it will update the term to 'SCP' before querying.

Current search:

https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/97c712e6-6d9d-4ff2-9a81-90d3aae97411

With this change:

https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/b338ee6f-c29b-4763-adaa-2d951d53962f

