### PR TITLE
Update to ingest image 1.26.1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.26.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.26.1'
 
     config.autoload_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
Use [ingest image 1.26.1](https://github.com/broadinstitute/scp-ingest-pipeline/releases/tag/1.26.1), where processed_expression `extract` generates mtx fragment files.