### PR TITLE
AnnData file parsing/saving UX polishes and some tests (SCP-5076)

### DIFF
--- a/app/javascript/components/upload/CoordinateLabelFileForm.jsx
+++ b/app/javascript/components/upload/CoordinateLabelFileForm.jsx
@@ -18,7 +18,8 @@ export default function CoordinateLabelForm({
   associatedClusterFileOptions,
   updateCorrespondingClusters,
   bucketName,
-  isInitiallyExpanded
+  isInitiallyExpanded,
+  isAnnDataExperience
 }) {
   const associatedCluster = associatedClusterFileOptions.find(opt => opt.value === file.options.cluster_file_id)
   const validationMessages = validateFile({
@@ -28,7 +29,7 @@ export default function CoordinateLabelForm({
   })
   return <ExpandableFileForm {...{
     file, allFiles, updateFile, saveFile,
-    allowedFileExts, deleteFile, validationMessages, bucketName, isInitiallyExpanded
+    allowedFileExts, deleteFile, validationMessages, bucketName, isInitiallyExpanded, isAnnDataExperience
   }}>
     <div className="form-group">
       <label className="labeled-select">Corresponding cluster / spatial data *

--- a/app/javascript/components/upload/CoordinateLabelStep.jsx
+++ b/app/javascript/components/upload/CoordinateLabelStep.jsx
@@ -24,7 +24,8 @@ function CoordinateLabelForm({
   addNewFile,
   updateFile,
   saveFile,
-  deleteFile
+  deleteFile,
+  isAnnDataExperience
 }) {
   const coordinateFiles = formState.files.filter(coordinateLabelFileFilter)
   const associatedClusterFileOptions = formState.files.filter(f => f.file_type === 'Cluster')
@@ -84,6 +85,7 @@ function CoordinateLabelForm({
         updateCorrespondingClusters={updateCorrespondingClusters}
         bucketName={formState.study.bucket_id}
         isInitiallyExpanded={coordinateFiles.length === 1}
+        isAnnDataExperience={isAnnDataExperience}
       />
     })}
     <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_LABEL_FILE}/>

--- a/app/javascript/components/upload/ExpandableFileForm.jsx
+++ b/app/javascript/components/upload/ExpandableFileForm.jsx
@@ -5,6 +5,7 @@ import Modal from 'react-bootstrap/lib/Modal'
 import { Popover, OverlayTrigger } from 'react-bootstrap'
 import LoadingSpinner from '~/lib/LoadingSpinner'
 import FileUploadControl from './FileUploadControl'
+import Button from 'react-bootstrap/lib/Button'
 
 /** renders its children inside an expandable form with a header for file selection */
 export default function ExpandableFileForm({
@@ -53,7 +54,10 @@ export default function ExpandableFileForm({
               bucketName={bucketName}
               isAnnDataExperience={isAnnDataExperience} />
           </div>}
-          {getIsSaveEnabled(isAnnDataExperience, allFiles, file) && <SaveDeleteButtons {...{ file, updateFile, saveFile, deleteFile, validationMessages, isAnnDataExperience, allFiles, isLastClustering }} />}
+           <SaveDeleteButtons {...{ file, updateFile, saveFile, deleteFile, validationMessages, isAnnDataExperience, allFiles, isLastClustering }} />
+          {/* {getIsSaveEnabled(isAnnDataExperience, allFiles, file) && */}
+          {/* allow a user to 'x' out an added clustering before saving even if only one clustering */}
+
         </div>
         {expanded && children}
         <SavingOverlay file={file} updateFile={updateFile} />
@@ -115,11 +119,22 @@ export function SaveDeleteButtons({
       <button className="terra-secondary-btn" onClick={() => deleteFile(file)}>OK</button>
     </div>
   }
+
+  let deleteButtonToShow
+  if (!isExpressionMatrix && !isLastClustering) {
+    deleteButtonToShow = <DeleteButton file={file} deleteFile={deleteFile} setShowConfirmDeleteModal={setShowConfirmDeleteModal} isAnnDataExperience={isAnnDataExperience} allFiles={allFiles} />
+  } else if (isAnnDataExperience && file.status === 'new') {
+    deleteButtonToShow = <Button className="terra-secondary-btn"
+      type='button'
+      onClick={() => deleteFile(file)} aria-label='remove-additional-clustering' >
+      <FontAwesomeIcon icon={faTimes} />
+    </Button>
+  }
+
+
   return <div className="flexbox-align-center button-panel">
     <SaveButton file={file} saveFile={saveFile} allFiles={allFiles} validationMessages={validationMessages} isAnnDataExperience={isAnnDataExperience} />
-    {!isExpressionMatrix && !isLastClustering &&
-      <DeleteButton file={file} deleteFile={deleteFile} setShowConfirmDeleteModal={setShowConfirmDeleteModal} />
-    }
+    {deleteButtonToShow}
     <Modal
       show={showConfirmDeleteModal}
       onHide={() => setShowConfirmDeleteModal(false)}
@@ -148,9 +163,12 @@ function SaveButton({ file, saveFile, allFiles, validationMessages = {}, isAnnDa
 
   // show parsing in the save button for cluster and expression fragments if AnnData file is parsing
   let showParsingForFragment = false
+  let showSavingForFragment = false
   if (isAnnDataExperience) {
     const annDataFile = allFiles.find(f => f.file_type === 'AnnData')
     showParsingForFragment = annDataFile?.serverFile?.parse_status === 'parsing' &&
+      (file?.data_type === 'cluster' || file?.data_type === 'expression')
+    showSavingForFragment = annDataFile?.serverFile?.parse_status === 'saving' &&
       (file?.data_type === 'cluster' || file?.data_type === 'expression')
   }
 
@@ -166,11 +184,18 @@ function SaveButton({ file, saveFile, allFiles, validationMessages = {}, isAnnDa
     Save {file.uploadSelection && <span>&amp; Upload</span>}
   </button>
 
-  // the parsing status will show over the save button when file is saving
-  if (file.serverFile?.parse_status === 'parsing' || showParsingForFragment) {
+  // a parsing status to show over the save button for fragments when the AnnData file is parsing
+  if (showParsingForFragment) {
+    const name = allFiles.find(f => f.file_type === 'AnnData').name
     saveButton = <OverlayTrigger trigger={['hover', 'focus']} rootClose placement="top" overlay={parsingPopup}>
-      <span className="detail">Parsing <LoadingSpinner /></span>
+      <span className="detail">Parsing: {name} <LoadingSpinner /></span>
     </OverlayTrigger>
+  }
+
+  // a saving status to show over the save button for fragments when the AnnData file is saving
+  if (showSavingForFragment) {
+    const name = allFiles.find(f => f.file_type === 'AnnData').name
+    saveButton = <span className="detail"> Saving: {name} <LoadingSpinner /></span>
   }
 
   // if saving is disabled, wrap the disabled button in a popover that will show the errors
@@ -194,7 +219,7 @@ function SaveButton({ file, saveFile, allFiles, validationMessages = {}, isAnnDa
 /**
  * renders a delete button for a given file
  * will show a parsing indicator if the file is parsing (and therefore not deletable) */
-function DeleteButton({ file, deleteFile, setShowConfirmDeleteModal }) {
+function DeleteButton({ file, deleteFile, setShowConfirmDeleteModal, isAnnDataExperience, allFiles }) {
   /** delete file with/without confirmation dialog as appropriate */
   function handleDeletePress() {
     if (file.status === 'new') {
@@ -217,6 +242,19 @@ function DeleteButton({ file, deleteFile, setShowConfirmDeleteModal }) {
       <span className="detail">Parsing <LoadingSpinner /></span>
     </OverlayTrigger>
   }
+
+  console.log('de:', allFiles.find(f => f.file_type === 'AnnData')?.serverFile?.parse_status === 'parsing' &&
+  (file?.data_type === 'cluster' || file?.data_type === 'expression'))
+
+  // do not show delete button in fragments if AnnData file is updating, saving, or parsing
+  if (isAnnDataExperience) {
+    const annDataFile = allFiles.find(f => f.file_type === 'AnnData')
+    if ((annDataFile?.serverFile?.parse_status === 'parsing' || annDataFile?.serverFile?.parse_status === 'saving') &&
+     (file?.data_type === 'cluster' || file?.data_type === 'expression')) {
+      return null
+    }
+  }
+
   return deleteButton
 }
 

--- a/app/javascript/components/upload/ExpandableFileForm.jsx
+++ b/app/javascript/components/upload/ExpandableFileForm.jsx
@@ -173,10 +173,12 @@ function SaveButton({ file, saveFile, allFiles, validationMessages = {}, isAnnDa
   let showSavingForFragment = false
   if (isAnnDataExperience) {
     const annDataFile = allFiles.find(f => f.file_type === 'AnnData')
+
     showParsingForFragment = annDataFile?.serverFile?.parse_status === 'parsing' &&
-      (file?.data_type === 'cluster' || file?.data_type === 'expression')
+    ['cluster', 'expression'].includes(file?.data_type)
+
     showSavingForFragment = annDataFile?.serverFile?.parse_status === 'saving' &&
-      (file?.data_type === 'cluster' || file?.data_type === 'expression')
+    ['cluster', 'expression'].includes(file?.data_type)
   }
 
   //  primary save button shown by default as the save button
@@ -253,8 +255,10 @@ function DeleteButton({ file, deleteFile, setShowConfirmDeleteModal, isAnnDataEx
   // do not show delete button in fragments if AnnData file is updating, saving, or parsing
   if (isAnnDataExperience) {
     const annDataFile = allFiles.find(f => f.file_type === 'AnnData')
-    if ((annDataFile?.serverFile?.parse_status === 'parsing' || annDataFile?.serverFile?.parse_status === 'saving') &&
-     (file?.data_type === 'cluster' || file?.data_type === 'expression')) {
+    if (
+      ['parsing', 'saving'].includes(annDataFile?.serverFile?.parse_status) &&
+      ['cluster', 'expression'].includes(file?.data_type)
+    ) {
       return null
     }
   }

--- a/app/javascript/components/upload/GeneListFileForm.jsx
+++ b/app/javascript/components/upload/GeneListFileForm.jsx
@@ -15,7 +15,8 @@ export default function GeneListFileForm({
   deleteFile,
   miscFileTypes,
   bucketName,
-  isInitiallyExpanded
+  isInitiallyExpanded,
+  isAnnDataExperience
 }) {
   const allowedFileExts = FileTypeExtensions.plainText
 
@@ -26,7 +27,7 @@ export default function GeneListFileForm({
 
   return <ExpandableFileForm {...{
     file, allFiles, updateFile, saveFile,
-    allowedFileExts, deleteFile, validationMessages, bucketName, isInitiallyExpanded
+    allowedFileExts, deleteFile, validationMessages, bucketName, isInitiallyExpanded, isAnnDataExperience
   }}>
     <TextFormField label="Name" fieldName="name" file={file} updateFile={updateFile}/>
     <TextFormField label="Description (shown above heatmap)" fieldName="description" file={file} updateFile={updateFile}/>

--- a/app/javascript/components/upload/GeneListStep.jsx
+++ b/app/javascript/components/upload/GeneListStep.jsx
@@ -29,7 +29,8 @@ function GeneListForm({
   addNewFile,
   updateFile,
   saveFile,
-  deleteFile
+  deleteFile,
+  isAnnDataExperience
 }) {
   const geneListFiles = formState.files.filter(geneListFileFilter)
 
@@ -73,7 +74,9 @@ function GeneListForm({
         saveFile={saveFile}
         deleteFile={deleteFile}
         bucketName={formState.study.bucket_id}
-        isInitiallyExpanded={geneListFiles.length === 1}/>
+        isInitiallyExpanded={geneListFiles.length === 1}
+        isAnnDataExperience={isAnnDataExperience}
+        />
     })}
     <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_GENE_LIST_FILE}/>
   </div>

--- a/app/javascript/components/upload/MiscellaneousFileForm.jsx
+++ b/app/javascript/components/upload/MiscellaneousFileForm.jsx
@@ -17,12 +17,13 @@ export default function MiscellaneousFileForm({
   deleteFile,
   miscFileTypes,
   bucketName,
-  isInitiallyExpanded
+  isInitiallyExpanded,
+  isAnnDataExperience
 }) {
   const validationMessages = validateFile({ file, allFiles, allowedFileExts })
   return <ExpandableFileForm {...{
     file, allFiles, updateFile, saveFile,
-    allowedFileExts, deleteFile, validationMessages, bucketName, isInitiallyExpanded
+    allowedFileExts, deleteFile, validationMessages, bucketName, isInitiallyExpanded, isAnnDataExperience
   }}>
     <div className="form-group">
       <label className="labeled-select">File type:

--- a/app/javascript/components/upload/MiscellaneousFileForm.jsx
+++ b/app/javascript/components/upload/MiscellaneousFileForm.jsx
@@ -2,9 +2,8 @@ import React from 'react'
 
 import Select from '~/lib/InstrumentedSelect'
 import ExpandableFileForm from './ExpandableFileForm'
-import { FileTypeExtensions } from './upload-utils'
+import { FileTypeExtensions, validateFile } from './upload-utils'
 import { TextFormField } from './form-components'
-import { validateFile } from './upload-utils'
 
 const allowedFileExts = FileTypeExtensions.misc
 

--- a/app/javascript/components/upload/MiscellaneousStep.jsx
+++ b/app/javascript/components/upload/MiscellaneousStep.jsx
@@ -25,7 +25,8 @@ function MiscellaneousForm({
   addNewFile,
   updateFile,
   saveFile,
-  deleteFile
+  deleteFile,
+  isAnnDataExperience
 }) {
   const miscFiles = formState.files.filter(miscFileFilter)
 
@@ -53,7 +54,9 @@ function MiscellaneousForm({
         deleteFile={deleteFile}
         miscFileTypes={miscFileTypes}
         bucketName={formState.study.bucket_id}
-        isInitiallyExpanded={miscFiles.length === 1}/>
+        isInitiallyExpanded={miscFiles.length === 1}
+        isAnnDataExperience={isAnnDataExperience}
+      />
     })}
     <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_OTHER_FILE}/>
   </div>

--- a/app/javascript/components/upload/UploadWizard.jsx
+++ b/app/javascript/components/upload/UploadWizard.jsx
@@ -385,7 +385,6 @@ export function RawUploadWizard({ studyAccession, name }) {
     if (isAnnDataExperience && file.data_type === 'cluster') {
       annDataClusteringFragmentsDeletionHelper(file)
     } else if (isAnnDataExperience && file.status === 'new' && file.file_type === 'Cluster') {
-      console.log('in here')
       updateFile(fileId, { isDeleting: true })
 
       // allow a user to delete an added clustering that hasn't been saved
@@ -547,7 +546,6 @@ export function RawUploadWizard({ studyAccession, name }) {
         (response.files?.find(AnnDataFileFilter)?.ann_data_file_info?.data_fragments?.length > 0 ||
         response.files?.find(AnnDataFileFilter)?.ann_data_file_info?.reference_file === false) &&
         response.feature_flags?.ingest_anndata_file)
-        console.log(response.files)
       setServerState(response)
       setFormState(_cloneDeep(response))
       setTimeout(pollServerState, POLLING_INTERVAL)

--- a/app/javascript/components/upload/UploadWizard.jsx
+++ b/app/javascript/components/upload/UploadWizard.jsx
@@ -384,6 +384,12 @@ export function RawUploadWizard({ studyAccession, name }) {
     // if AnnDataExperience clusterings need to be handled differently
     if (isAnnDataExperience && file.data_type === 'cluster') {
       annDataClusteringFragmentsDeletionHelper(file)
+    } else if (isAnnDataExperience && file.status === 'new' && file.file_type === 'Cluster') {
+      console.log('in here')
+      updateFile(fileId, { isDeleting: true })
+
+      // allow a user to delete an added clustering that hasn't been saved
+      deleteFileFromForm(fileId)
     } else {
       if (file.status === 'new' || file?.serverFile?.parse_status === 'failed') {
         deleteFileFromForm(fileId)
@@ -415,10 +421,10 @@ export function RawUploadWizard({ studyAccession, name }) {
 
     // If the AnnData file contains more than one clustering proceed with deletion
     if (fragmentsInAnnDataFile.filter(f => f.data_type === 'cluster').length > 1) {
-
       // delete the clustering from the bucket and update the ClusterGroup
       let studyFileId = annDataFile._id
       updateFile(studyFileId, { isSaving: true })
+      updateFile(file._id, { isDeleting: true })
 
       await deleteAnnDataFragment(studyAccession, studyFileId, file._id)
 
@@ -541,6 +547,7 @@ export function RawUploadWizard({ studyAccession, name }) {
         (response.files?.find(AnnDataFileFilter)?.ann_data_file_info?.data_fragments?.length > 0 ||
         response.files?.find(AnnDataFileFilter)?.ann_data_file_info?.reference_file === false) &&
         response.feature_flags?.ingest_anndata_file)
+        console.log(response.files)
       setServerState(response)
       setFormState(_cloneDeep(response))
       setTimeout(pollServerState, POLLING_INTERVAL)

--- a/app/javascript/components/upload/form-components.jsx
+++ b/app/javascript/components/upload/form-components.jsx
@@ -8,7 +8,9 @@ import LoadingSpinner from '~/lib/LoadingSpinner'
 export function AddFileButton({ newFileTemplate, addNewFile, text='Add file' }) {
   return <div className="row top-margin">
     <div className="col-md-12">
-      <button className="btn btn-secondary terra-secondary-btn" onClick={() => addNewFile(newFileTemplate, true)}>
+      <button className="btn btn-secondary terra-secondary-btn"
+        data-testid="add-file-button" onClick={() => addNewFile(newFileTemplate, true)}
+      >
         <span className="fas fa-plus"></span> {text}
       </button>
     </div>

--- a/test/js/upload-wizard/file-info-responses.js
+++ b/test/js/upload-wizard/file-info-responses.js
@@ -461,7 +461,30 @@ export const IMAGE_FILE = {
 export const ANNDATA_FILE = {
   ann_data_file_info: {
     reference_file: false,
-    data_fragments: [ ]
+    data_fragments: [
+      {
+        '_id': '123445681',
+        'data_type': 'expression',
+        'taxon_id': '60b9175a6e5ec555cec81696',
+        'expression_file_info': {
+          'library_preparation_protocol': '10x 3\' v2',
+          'units': 'UMI-corrected raw counts',
+          'biosample_input_type': 'Whole cell',
+          'modality': 'Transcriptomic: unbiased',
+          'is_raw_counts': 'false'
+        }
+      },
+      {
+        '_id': '123445682',
+        'data_type': 'cluster',
+        'name': 'i am a clustering',
+        'description': '',
+        'obsm_key_name': 'X_umap',
+        'spatial_cluster_associations': [
+          ''
+        ]
+      }
+    ]
   },
   created_at: '2021-11-15T18:31:41.598Z',
   data_dir: '71e1a89e5c5d9300aabd0e757d1b569eb66644872b40bcbb720e2b39bc7e3822',
@@ -471,7 +494,7 @@ export const ANNDATA_FILE = {
   is_spatial: false,
   name: 'anndata.h5ad',
   options: {},
-  parse_status: 'unparsed',
+  parse_status: 'parsed',
   queued_for_deletion: false,
   remote_location: '',
   status: 'uploaded',

--- a/test/js/upload-wizard/update-anndata--clustering.test.js
+++ b/test/js/upload-wizard/update-anndata--clustering.test.js
@@ -1,0 +1,34 @@
+import { screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+
+import { renderWizardWithStudy, renderWizardWithStudyOnClusteringStep } from './upload-wizard-test-utils'
+import * as ScpApi from 'lib/scp-api'
+import { ANNDATA_FILE_STUDY } from './file-info-responses'
+
+describe('it allows navigating between steps', () => {
+  afterEach(() => {
+    // Restores all mocks back to their original value
+    jest.restoreAllMocks()
+  })
+
+  it('navigates to AnnData clustering step and expect an "add clustering" button to be available', async () => {
+    await renderWizardWithStudyOnClusteringStep({ featureFlags: { ingest_anndata_file: true }, studyInfo: ANNDATA_FILE_STUDY })
+
+    expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent('Expression matrices')
+    fireEvent.click(screen.getByText('Clustering'))
+    expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent('Clustering')
+    expect(screen.getByTestId('add-file-button')).toHaveTextContent('Add clustering')
+  })
+
+  it('navigates to AnnData clustering step and expect no delete button available', async () => {
+    await renderWizardWithStudyOnClusteringStep({ featureFlags: { ingest_anndata_file: true }, studyInfo: ANNDATA_FILE_STUDY })
+
+    expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent('Expression matrices')
+    fireEvent.click(screen.getByText('Clustering'))
+
+    expect(screen.queryByTestId('file-delete')).toBeNull()
+  })
+})
+
+// Add file button while on clustering
+// change a clustering name

--- a/test/js/upload-wizard/update-anndata-clustering.test.js
+++ b/test/js/upload-wizard/update-anndata-clustering.test.js
@@ -1,18 +1,19 @@
 import { screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 
-import { renderWizardWithStudy, renderWizardWithStudyOnClusteringStep } from './upload-wizard-test-utils'
-import * as ScpApi from 'lib/scp-api'
+import { renderWizardWithStudyOnClusteringStep } from './upload-wizard-test-utils'
 import { ANNDATA_FILE_STUDY } from './file-info-responses'
 
-describe('it allows navigating between steps', () => {
+describe('it allows clustering updates on AnnData file', () => {
   afterEach(() => {
     // Restores all mocks back to their original value
     jest.restoreAllMocks()
   })
 
   it('navigates to AnnData clustering step and expect an "add clustering" button to be available', async () => {
-    await renderWizardWithStudyOnClusteringStep({ featureFlags: { ingest_anndata_file: true }, studyInfo: ANNDATA_FILE_STUDY })
+    await renderWizardWithStudyOnClusteringStep({
+      featureFlags: { ingest_anndata_file: true }, studyInfo: ANNDATA_FILE_STUDY
+    })
 
     expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent('Expression matrices')
     fireEvent.click(screen.getByText('Clustering'))
@@ -21,14 +22,18 @@ describe('it allows navigating between steps', () => {
   })
 
   it('navigates to AnnData clustering step and expect no delete button available', async () => {
-    await renderWizardWithStudyOnClusteringStep({ featureFlags: { ingest_anndata_file: true }, studyInfo: ANNDATA_FILE_STUDY })
+    await renderWizardWithStudyOnClusteringStep({
+      featureFlags: { ingest_anndata_file: true }, studyInfo: ANNDATA_FILE_STUDY
+    })
 
     expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent('Expression matrices')
     fireEvent.click(screen.getByText('Clustering'))
 
+    // the test file has only one clustering so cannot delete it
     expect(screen.queryByTestId('file-delete')).toBeNull()
   })
 })
 
-// Add file button while on clustering
+// TODO (SCP-5126)
 // change a clustering name
+// delete a clustering


### PR DESCRIPTION
Worked a bit on the UX and tests for AnnData as other part of Dev Choice

1. Begin adding a few tests for the AnnData clustering fragments, including a TODO to complete adding more tests in the appropriate ticket. 

2. Polish the UX a bit more for deleting/updating clusterings in an AnnData file
- Most notably added a parsing status to cover the save/delete buttons of the fragments when the parent AnnData file is parsing
<img width="752" alt="Screenshot 2023-05-16 at 3 26 01 PM" src="https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/81c7c1af-bb5e-41b0-bea9-c9f106564632">
<img width="1494" alt="Screenshot 2023-05-16 at 3 26 08 PM" src="https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/4da1260a-e72f-414d-979b-f7f650f979ec">
- Added an "X" button for canceling adding a Clustering, this is a special scenario as cannot show the default Delete button for a single Clustering but need to allow a user to undo adding a Clustering essentially
<img width="964" alt="Screenshot 2023-05-16 at 4 25 07 PM" src="https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/892d3eda-17c2-404b-b21c-3855626daf8a">
- Deleting clusterings now say "Deleting" 

<img width="483" alt="Screenshot 2023-05-16 at 4 24 48 PM" src="https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/1a85cbc2-f73b-4c0a-afc7-02fe74f0b8f4">

