### PR TITLE
Make explore tab content behind auto-suggest gene search (SCP-5109)

### DIFF
--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -70,6 +70,7 @@
 .explore-tab-content {
   background: #fff;
   flex-grow: 1;
+  z-index: 0;
 
   button.action {
     background: #fff;


### PR DESCRIPTION
Previously if you searched for 2 or 3 genes the Dot plot and Heatmap tabs content would be mixed with the auto suggest drop down from the gene search. 

This update simply sets the position for Explore tab content to be back so that the auto complete suggestions are fully in front.

Before:

https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/2d7b9523-ae12-4d98-b647-5c5af1aa3713



After:

https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/e32136fe-c737-4d3b-a1d5-a85eac3d4fbe

