### PR TITLE
Show "Explore" tab by default, to ease feature discovery (SCP-5020)

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -164,8 +164,7 @@ class SiteController < ApplicationController
     # decide what tab to show by default for this user
     # normally we would do this in React but the tab display is in the Rails HTML view
     # we need to check server-side since we have to account for @study.can_visualize? as well
-    @explore_tab_default = @study.can_visualize? &&
-                           AbTest.override_for_feature?('explore_tab_default', request.cookies['user_id'])
+    @explore_tab_default = @study.can_visualize?
   end
 
   def record_download_acceptance

--- a/db/migrate/20230510164721_retire_explore_tab_default_feature_flag.rb
+++ b/db/migrate/20230510164721_retire_explore_tab_default_feature_flag.rb
@@ -1,0 +1,11 @@
+  class RetireExploreTabDefaultFeatureFlag < Mongoid::Migration
+    def self.up
+      FeatureFlag.retire_feature_flag('explore_tab_default')
+    end
+
+    def self.down
+      FeatureFlag.create!(name: 'explore_tab_default',
+                          default_value: false,
+                          description: 'show the explore tab in study overview by default')
+    end
+  end


### PR DESCRIPTION
This shows the Explore tab by default, if applicable, making it easier to start using the page's main features.

Previously, the Summary tab was the default.  That gave users an abstract of the study, assuming the study owners provided it.  Results of our first A/B test, enabled by #1727, showed users engage more when they land on the Explore tab by default.  Based on that, this makes the Explore tab the default landing page for all studies and all users -- as long as the study has visualizations initialized.

Before:

<img width="1512" alt="Explore_tab_default_before__SCP_2023-05-18" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/07e953eb-8677-41fa-8671-e9aadc5c6448">

After:

<img width="1512" alt="Explore_tab_default_after__SCP_2023-05-18" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/295990e3-4cd5-44f2-aa59-cf0f0d56fafa">

To test:
* Go to a study that has visualizations initialized
* Confirm it shows visualizations by default

This satisfies SCP-5020.