### PR TITLE
Show all Explore tabs by default (SCP-5050)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -81,13 +81,6 @@ function getClusterHasDe(exploreInfo, exploreParams) {
   return clusterHasDe
 }
 
-/** Determine if the flag show_explore_tab_ux_updates is toggled to show explore tab UX updates */
-function getShowExploreTabUpdates() {
-  return true
-  const flags = getFeatureFlagsWithDefaults()
-  return flags?.show_explore_tab_ux_updates
-}
-
 /** Return list of annotations that have differential expression enabled */
 function getAnnotationsWithDE(exploreInfo) {
   if (!exploreInfo) {return false}
@@ -360,6 +353,9 @@ export default function ExploreDisplayTabs({
     return { main, side }
   }
 
+  // Determine if the flag show_explore_tab_ux_updates is toggled to show explore tab UX updates
+  const isNewExploreUX = true // getFeatureFlagsWithDefaults()?.show_explore_tab_ux_updates
+
   return (
     <>
       <div className="row">
@@ -385,7 +381,7 @@ export default function ExploreDisplayTabs({
           </div>
         </div>
         <div>
-          <ul className={getShowExploreTabUpdates() ? 'nav nav-tabs study-plot-tabs' : 'nav nav-tabs'} role="tablist" data-analytics-name="explore-default">
+          <ul className={isNewExploreUX ? 'nav nav-tabs study-plot-tabs' : 'nav nav-tabs'} role="tablist" data-analytics-name="explore-tab">
             { enabledTabs.map(tabKey => {
               const label = tabList.find(({ key }) => key === tabKey).label
               return (
@@ -397,7 +393,8 @@ export default function ExploreDisplayTabs({
                 </li>
               )
             })}
-            { disabledTabs.map(tabKey => {
+            {isNewExploreUX &&
+            disabledTabs.map(tabKey => {
               const label = tabList.find(({ key }) => key === tabKey).label
               const tooltip = disabledTooltips[tabKey]
               const numGenes = tooltip.numToSearch
@@ -413,7 +410,8 @@ export default function ExploreDisplayTabs({
                 ><a>{label}</a>
                 </li>
               )
-            })}
+            })
+            }
           </ul>
         </div>
       </div>

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -381,7 +381,11 @@ export default function ExploreDisplayTabs({
           </div>
         </div>
         <div>
-          <ul className={isNewExploreUX ? 'nav nav-tabs study-plot-tabs' : 'nav nav-tabs'} role="tablist" data-analytics-name="explore-tab">
+          <ul
+            className={isNewExploreUX ? 'nav nav-tabs study-plot-tabs' : 'nav nav-tabs'}
+            role="tablist"
+            data-analytics-name="explore-tab"
+          >
             { enabledTabs.map(tabKey => {
               const label = tabList.find(({ key }) => key === tabKey).label
               return (
@@ -770,9 +774,9 @@ export function getEnabledTabs(exploreInfo, exploreParams) {
   const hasGenomeFiles = exploreInfo && exploreInfo?.bamBundleList?.length > 0
   const hasIdeogramOutputs = !!exploreInfo?.inferCNVIdeogramFiles
   const hasImages = exploreInfo?.imageFiles?.length > 0
-  const isNumeric = exploreParams.annotation.type === 'numeric'
+  const isNumeric = exploreParams?.annotation?.type === 'numeric'
 
-  const coreTabs = [
+  let coreTabs = [
     !isNumeric ? 'scatter' : 'annotatedScatter',
     'distribution', 'correlatedScatter',
     'dotplot', 'heatmap'
@@ -785,10 +789,12 @@ export function getEnabledTabs(exploreInfo, exploreParams) {
   } else if (isGene) {
     if (isMultiGene) {
       if (isConsensus) {
+        coreTabs = coreTabs.filter(tab => tab !== 'correlatedScatter') // omit for consensus
         if (isNumeric) {
           enabledTabs = ['annotatedScatter', 'dotplot', 'heatmap']
         } else {
           enabledTabs = ['scatter', 'distribution', 'dotplot']
+          coreTabs = coreTabs.filter(tab => tab !== 'heatmap') // omit for consensus
         }
       } else if (hasSpatialGroups) {
         enabledTabs = ['scatter', 'dotplot', 'heatmap']

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -822,11 +822,12 @@ export function getEnabledTabs(exploreInfo, exploreParams) {
     enabledTabs.push('images')
   }
 
+  let disabledTabs = coreTabs.filter(coreTab => !enabledTabs.includes(coreTab))
+
   if (!exploreInfo) {
     enabledTabs = ['loading']
+    disabledTabs = []
   }
-
-  const disabledTabs = coreTabs.filter(coreTab => !enabledTabs.includes(coreTab))
 
   return { enabledTabs, disabledTabs, isGeneList, isGene, isMultiGene, hasIdeogramOutputs }
 }

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -37,7 +37,7 @@ import Tooltip from 'react-bootstrap/lib/Tooltip'
 import DifferentialExpressionModal from '~/components/explore/DifferentialExpressionModal'
 
 const tabList = [
-  { key: 'loading', label: 'loading...' },
+  { key: 'loading', label: 'Loading...' },
   { key: 'scatter', label: 'Scatter' },
   { key: 'annotatedScatter', label: 'Annotated scatter' },
   { key: 'correlatedScatter', label: 'Correlation' },
@@ -50,6 +50,14 @@ const tabList = [
   { key: 'infercnv-genome', label: 'Genome (inferCNV)' },
   { key: 'images', label: 'Images' }
 ]
+
+const disabledTooltips = {
+  'scatter': { numToSearch: '1', isMulti: false },
+  'distribution': { numToSearch: '1', isMulti: false },
+  'correlatedScatter': { numToSearch: '2', isMulti: true },
+  'dotplot': { numToSearch: '2 or more', isMulti: true },
+  'heatmap': { numToSearch: '2 or more', isMulti: true }
+}
 
 /** Determine if currently selected cluster has differential expression outputs available */
 function getClusterHasDe(exploreInfo, exploreParams) {
@@ -383,6 +391,7 @@ export default function ExploreDisplayTabs({
               return (
                 <li key={tabKey}
                   role="presentation"
+                  aria-disabled="false"
                   className={`study-nav ${tabKey === shownTab ? 'active' : ''} ${tabKey}-tab-anchor`}>
                   <a onClick={() => updateExploreParams({ tab: tabKey })}>{label}</a>
                 </li>
@@ -390,12 +399,18 @@ export default function ExploreDisplayTabs({
             })}
             { disabledTabs.map(tabKey => {
               const label = tabList.find(({ key }) => key === tabKey).label
+              const tooltip = disabledTooltips[tabKey]
+              const numGenes = tooltip.numToSearch
+              const geneText = `gene${tooltip.isMulti ? 's' : ''}`
+              const text = `To show this plot, search ${numGenes} ${geneText} using the box at left`
               return (
                 <li key={tabKey}
                   role="presentation"
-                  aria-disabled={true}
-                  className={`study-nav disabled ${tabKey}-tab-anchor`}>
-                  <a onClick={() => updateExploreParams({ tab: tabKey })}>{label}</a>
+                  aria-disabled="true"
+                  className={`study-nav ${tabKey}-tab-anchor disabled`}
+                  data-toggle="tooltip"
+                  data-original-title={text}
+                ><a>{label}</a>
                 </li>
               )
             })}
@@ -808,8 +823,6 @@ export function getEnabledTabs(exploreInfo, exploreParams) {
   }
 
   const disabledTabs = coreTabs.filter(coreTab => !enabledTabs.includes(coreTab))
-
-  console.log('disabledTabs', disabledTabs)
 
   return { enabledTabs, disabledTabs, isGeneList, isGene, isMultiGene, hasIdeogramOutputs }
 }

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -380,7 +380,7 @@ export default function ExploreDisplayTabs({
             }
           </div>
         </div>
-        <div>
+        <div className={isNewExploreUX ? '' : 'col-md-4 col-md-offset-1'}>
           <ul
             className={isNewExploreUX ? 'nav nav-tabs study-plot-tabs' : 'nav nav-tabs'}
             role="tablist"

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -759,8 +759,13 @@ export function getEnabledTabs(exploreInfo, exploreParams) {
   const hasImages = exploreInfo?.imageFiles?.length > 0
   const isNumeric = exploreParams.annotation.type === 'numeric'
 
+  const coreTabs = [
+    !isNumeric ? 'scatter' : 'annotatedScatter',
+    'distribution', 'correlatedScatter',
+    'dotplot', 'heatmap'
+  ]
+
   let enabledTabs = []
-  let disabledTabs = []
 
   if (isGeneList) {
     enabledTabs = ['geneListHeatmap']
@@ -782,14 +787,11 @@ export function getEnabledTabs(exploreInfo, exploreParams) {
       }
     } else if (isNumeric) {
       enabledTabs = ['annotatedScatter', 'scatter']
-      disabledTabs = ['distribution', 'correlatedScatter', 'dotplot', 'heatmap']
     } else {
       enabledTabs = ['scatter', 'distribution']
-      disabledTabs = ['correlatedScatter', 'dotplot', 'heatmap']
     }
   } else if (hasClusters) {
     enabledTabs = ['scatter']
-    disabledTabs = ['distribution', 'correlatedScatter', 'dotplot', 'heatmap']
   }
   if (hasGenomeFiles) {
     enabledTabs.push('genome')
@@ -804,6 +806,8 @@ export function getEnabledTabs(exploreInfo, exploreParams) {
   if (!exploreInfo) {
     enabledTabs = ['loading']
   }
+
+  const disabledTabs = coreTabs.filter(coreTab => !enabledTabs.includes(coreTab))
 
   console.log('disabledTabs', disabledTabs)
 

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -363,8 +363,8 @@ export default function ExploreDisplayTabs({
               speciesList={exploreInfo ? exploreInfo.taxonNames : []}/>
             { // show if this is gene search || gene list
               (isGene || isGeneList || hasIdeogramOutputs) &&
-                <OverlayTrigger placement='top' overlay={
-                  <Tooltip id='back-to-cluster-view'>{'Return to cluster view'}</Tooltip>
+                <OverlayTrigger placement="top" overlay={
+                  <Tooltip id="back-to-cluster-view">{'Return to cluster view'}</Tooltip>
                 }>
                   <button className="action fa-lg"
                     aria-label="Back arrow"
@@ -376,7 +376,7 @@ export default function ExploreDisplayTabs({
           </div>
         </div>
         <div className="col-md-4 col-md-offset-1">
-          <ul className={getShowExploreTabUpdates() ? "nav nav-tabs study-plot-tabs" : "nav nav-tabs"} role="tablist" data-analytics-name="explore-default">
+          <ul className={getShowExploreTabUpdates() ? 'nav nav-tabs study-plot-tabs' : 'nav nav-tabs'} role="tablist" data-analytics-name="explore-default">
             { enabledTabs.map(tabKey => {
               const label = tabList.find(({ key }) => key === tabKey).label
               return (

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -354,7 +354,7 @@ export default function ExploreDisplayTabs({
   }
 
   // Determine if the flag show_explore_tab_ux_updates is toggled to show explore tab UX updates
-  const isNewExploreUX = true // getFeatureFlagsWithDefaults()?.show_explore_tab_ux_updates
+  const isNewExploreUX = getFeatureFlagsWithDefaults()?.show_explore_tab_ux_updates
 
   return (
     <>

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -222,8 +222,9 @@
       background: $action-color;
       align-self: baseline;
     }
-  } :hover {
-    color: #2a3f5f;
+    a:hover {
+      background: lighten($action-color, 10%);
+    }
   }
   li.active > a {
     border-left: 1px solid $action-color;

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -18,6 +18,7 @@
 
   button.action {
     border: none;
+    background: none;
   }
 
   button.action-plus {

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -239,11 +239,5 @@
     background: #fff;
     color: #999999;
     border-bottom: 1px solid #ddd;
-    aria-disabled: true;
   }
-
-  padding-left: 0;
-  margin-bottom: 0;
-  list-style: none;
-  margin-right: 3px;
 }

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -361,7 +361,7 @@ button[disabled] {
 }
 
 #cell-count {
-  background-color: #337ab7;
+  background-color: $action-color;
   color: #fff;
 }
 
@@ -886,6 +886,14 @@ figcaption.ck-editor__editable {
   border: none;
   background: transparent;
   color: $action-color;
+}
+
+.btn-primary {
+  background-color: $action-color;
+}
+
+.btn-primary:hover {
+  background-color: lighten($action-color, 10%);
 }
 
 .btn-warning-scp {

--- a/test/js/explore/explore-display-tabs.test.js
+++ b/test/js/explore/explore-display-tabs.test.js
@@ -55,6 +55,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
     }
     const expectedResults = {
       enabledTabs: ['loading'],
+      disabledTabs: ['scatter', 'distribution', 'correlatedScatter', 'dotplot', 'heatmap'],
       isGeneList: false,
       isGene: false,
       isMultiGene: false,
@@ -76,6 +77,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
     }
     const expectedResults = {
       enabledTabs: ['scatter'],
+      disabledTabs: ['distribution', 'correlatedScatter', 'dotplot', 'heatmap'],
       isGeneList: false,
       isGene: false,
       isMultiGene: false,
@@ -107,6 +109,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
     }
     const expectedResults = {
       enabledTabs: ['scatter', 'genome'],
+      disabledTabs: ['distribution', 'correlatedScatter', 'dotplot', 'heatmap'],
       isGeneList: false,
       isGene: false,
       isMultiGene: false,
@@ -131,6 +134,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
     }
     const expectedResults = {
       enabledTabs: ['geneListHeatmap'],
+      disabledTabs: ['scatter', 'distribution', 'correlatedScatter', 'dotplot', 'heatmap'],
       isGeneList: true,
       isGene: false,
       isMultiGene: false,
@@ -140,7 +144,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
     expect(expectedResults).toEqual(getEnabledTabs(exploreInfo, exploreParams))
   })
 
-  it('should enable scatter/distribution tabs when searching one gene', async () => {
+  it('should enable scatter and distribution tabs when searching one gene', async () => {
     const exploreInfo = defaultExploreInfo
 
     const exploreParams = {
@@ -156,6 +160,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
 
     const expectedResults = {
       enabledTabs: ['scatter', 'distribution'],
+      disabledTabs: ['correlatedScatter', 'dotplot', 'heatmap'],
       isGeneList: false,
       isGene: true,
       isMultiGene: false,
@@ -165,7 +170,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
     expect(expectedResults).toEqual(getEnabledTabs(exploreInfo, exploreParams))
   })
 
-  it('should enable dotplot/heatmap tabs when searching multiple genes', async () => {
+  it('should enable dotplot and heatmap tabs when searching multiple genes', async () => {
     const exploreInfo = {
       ...defaultExploreInfo
     }
@@ -183,6 +188,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
 
     const expectedResults = {
       enabledTabs: ['correlatedScatter', 'dotplot', 'heatmap'],
+      disabledTabs: ['scatter', 'distribution'],
       isGeneList: false,
       isGene: true,
       isMultiGene: true,
@@ -192,7 +198,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
     expect(expectedResults).toEqual(getEnabledTabs(exploreInfo, exploreParams))
   })
 
-  it('should enable scatter/dotplot/heatmap tabs when searching multiple genes', async () => {
+  it('should enable scatter, dotplot, and heatmap tabs when searching multiple genes', async () => {
     const exploreInfo = {
       ...defaultExploreInfo,
       spatialGroupNames: ['bing', 'baz'],
@@ -217,6 +223,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
 
     const expectedResults = {
       enabledTabs: ['scatter', 'dotplot', 'heatmap'],
+      disabledTabs: ['distribution', 'correlatedScatter'],
       isGeneList: false,
       isGene: true,
       isMultiGene: true,
@@ -226,7 +233,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
     expect(expectedResults).toEqual(getEnabledTabs(exploreInfo, exploreParams))
   })
 
-  it('should enable scatter/distribution/dotplot tabs when searching multiple genes w/ consensus', async () => {
+  it('should enable scatter, distribution, and dotplot tabs when searching multiple genes w/ consensus', async () => {
     const exploreInfo = defaultExploreInfo
 
     const exploreParams = {
@@ -244,6 +251,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
 
     const expectedResults = {
       enabledTabs: ['scatter', 'distribution', 'dotplot'],
+      disabledTabs: [],
       isGeneList: false,
       isGene: true,
       isMultiGene: true,
@@ -281,6 +289,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
 
     const expectedResults = {
       enabledTabs: ['infercnv-genome'],
+      disabledTabs: ['scatter', 'distribution', 'correlatedScatter', 'dotplot', 'heatmap'],
       isGeneList: false,
       isGene: false,
       isMultiGene: false,
@@ -297,9 +306,9 @@ describe('explore tabs are activated based on study info and parameters', () => 
         differential_expression_frontend: true
       })
 
-    const {container} = render((
+    const { container } = render((
       <ExploreDisplayTabs
-        studyAccession={"SCP123"}
+        studyAccession={'SCP123'}
         exploreParams={exploreParamsDe}
         exploreParamsWithDefaults={exploreParamsDe}
         exploreInfo={exploreInfoDe}

--- a/test/js/explore/explore-display-tabs.test.js
+++ b/test/js/explore/explore-display-tabs.test.js
@@ -55,7 +55,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
     }
     const expectedResults = {
       enabledTabs: ['loading'],
-      disabledTabs: ['scatter', 'distribution', 'correlatedScatter', 'dotplot', 'heatmap'],
+      disabledTabs: [],
       isGeneList: false,
       isGene: false,
       isMultiGene: false,


### PR DESCRIPTION
This shows more tabs by default in the Explore view, which aims to boost how well users can discover existing features.

Previously, only enabled tabs were shown in a given Explore view.  Now, essentially all tabs are shown, with some tabs in a new "disabled" state.  The overall visual styling for these was implemented in #1772.  This work enhances the tab display logic to show disabled tabs.  It also slightly refines visual styling for the tabs, and related visual elements, for greater consistency.  These updates are feature flagged, so the combined effect of previously-unmeasured Explore UX can be assessed as a batch when more changes are ready for production.

## Demo
Here's how it looks.

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/e0e3ced8-f6d6-4546-a032-7ad53a97a337

### No genes
Before:
<img width="1512" alt="Before_0_genes_more_tabs_Explore_UX__SCP_2023-05-22" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/398b29dd-ce0b-4414-b1c2-b7030e8bf8f3">

After:
<img width="1512" alt="After_0_genes_more_tabs_Explore_UX__SCP_2023-05-22" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/f84f9fe7-18b1-4dc7-b43e-20835f64f4d4">

### 1 gene
Before:
<img width="1512" alt="Before_1_gene_more_tabs_Explore_UX__SCP_2023-05-22" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/1342f6e3-47fc-48a6-b2fc-bb025dacfff8">

After:
<img width="1512" alt="After_1_gene_more_tabs_Explore_UX__SCP_2023-05-22" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/3f26e358-a801-4657-8b37-67781bbad209">

### 2 genes
Before:
<img width="1512" alt="Before_2_genes_more_tabs_Explore_UX__SCP_2023-05-22" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/aa0d19a0-244e-4d81-94cb-fcb518fc446f">

After:
<img width="1512" alt="After_2_genes_more_tabs_Explore_UX__SCP_2023-05-22" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/af3bda1e-4545-4d34-b5e2-dc4106fa191d">

### 3 genes
Before:
<img width="1512" alt="Before_3_genes_more_tabs_Explore_UX__SCP_2023-05-22" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/092dccc9-4673-4d77-b466-5f231a48e119">

After:
<img width="1512" alt="After_3_genes_more_tabs_Explore_UX__SCP_2023-05-22" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/686d1a14-a2a0-4f6c-9c9c-3024bceeb92f">

## Test
Automated tests verify the updated tab logic.  To manually verify:

* Go to study with visualizations initialized
* In another browser tab, set "show_explore_tab_ux_updates" feature flag to true
* Refresh study page
* Confirm you see disabled tabs in no-genes study UI: Distribution, Correlation, Dot plot, Heatmap

This satisfies SCP-5050.