### PR TITLE
Ease gene search: execute query in one step, not two (SCP-5053)

### DIFF
--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -36,7 +36,6 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
     * an array of already entered genes (geneArray),
     * and the current text the user is typing (inputText) */
   const [geneArray, setGeneArray] = useState(enteredGeneArray)
-  const [showEmptySearchModal, setShowEmptySearchModal] = useState(false)
   const [showTooManyGenesModal, setShowTooManyGenesModal] = useState(false)
 
   const [notPresentGenes, setNotPresentGenes] = useState(new Set([]))
@@ -73,13 +72,6 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
           logStudyGeneSearch(genesToSearch, trigger, speciesList)
         }
         searchGenes(genesToSearch)
-      }
-    } else {
-      if (event.type !== 'change:multiselect') {
-        // Don't show empty search modal if the user manually removed gene entry
-        setShowEmptySearchModal(true)
-      } else if (isNewExploreUX) {
-        setShowEmptySearchModal(true)
       }
     }
   }
@@ -205,15 +197,6 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
           <FontAwesomeIcon className="action fa-lg" icon={faFileUpload} />
         </label>}
       </div>
-      <Modal
-        show={showEmptySearchModal}
-        onHide={() => {setShowEmptySearchModal(false)}}
-        animation={false}
-        bsSize='small'>
-        <Modal.Body className="text-center">
-          Enter at least one gene to search
-        </Modal.Body>
-      </Modal>
       <Modal
         show={showNotPresentGeneChoice}
         onHide={() => {setShowNotPresentGeneChoice(false)}}

--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -87,7 +87,6 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
       return geneArray
     }
     const newGeneArray = geneArray.concat(getOptionsFromGenes(inputTextValues))
-    logGeneArrayChange(newGeneArray)
     setInputText(' ')
     setGeneArray(newGeneArray)
     return newGeneArray
@@ -116,37 +115,12 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
     fileReader.readAsText(file)
   }
 
-  /** Send analytics on how the gene search input changed */
-  function logGeneArrayChange(newArray) {
-    try {
-      let actionName = ''
-      let geneDiff = []
-      if (newArray.length > geneArray.length) {
-        actionName = 'add'
-        geneDiff = _differenceBy(newArray, geneArray, 'value')
-      } else {
-        actionName = 'remove'
-        geneDiff = _differenceBy(geneArray, newArray, 'value')
-      }
-      log('change:multiselect', {
-        text: geneDiff.map(item => item.value).join(','),
-        action: actionName,
-        type: 'gene',
-        numPreviousGenes: geneArray.length
-      })
-    } catch (err) {
-      // no-op, we just don't want logging fails to break the application
-    }
-  }
-
   /** Handles the change event corresponding a user adding or clearing one or more genes */
   function handleSelectChange(value) {
-    console.log('in handleSelectChange, value:', value)
     // react-select doesn't expose the actual click events, so we deduce the kind
     // of operation based on whether it lengthened or shortened the list
     const newValue = value ? value : []
     setNotPresentGenes(new Set([]))
-    logGeneArrayChange(newValue)
     setGeneArray(newValue)
   }
 

--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -43,7 +43,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
   const [showNotPresentGeneChoice, setShowNotPresentGeneChoice] = useState(false)
 
   // Determine if the flag show_explore_tab_ux_updates is toggled to show explore tab UX updates
-  const isNewExploreUX = true // getFeatureFlagsWithDefaults()?.show_explore_tab_ux_updates
+  const isNewExploreUX = getFeatureFlagsWithDefaults()?.show_explore_tab_ux_updates
 
   /** Handles a user submitting a gene search */
   function handleSearch(event) {

--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -11,15 +11,16 @@ import { log } from '~/lib/metrics-api'
 import { logStudyGeneSearch } from '~/lib/search-metrics'
 
 
-/** renders the gene text input
-  * This shares a lot of logic with search/genes/GeneKeyword, but is kept as a separate component for
-  * now, as the need for autocomplete raises additional complexity
-  *
-  * @param genes Array of genes currently inputted
-  * @param searchGenes Function to call to execute the API search
-  * @param allGenes String array of valid genes in the study
-  * @param speciesList String array of species scientific names
-  */
+/**
+* Renders the gene text input
+* This shares a lot of logic with search/genes/GeneKeyword, but is kept as a separate component for
+* now, as the need for autocomplete raises additional complexity
+*
+* @param genes Array of genes currently inputted
+* @param searchGenes Function to call to execute the API search
+* @param allGenes String array of valid genes in the study
+* @param speciesList String array of species scientific names
+*/
 export default function StudyGeneField({ genes, searchGenes, allGenes, speciesList, isLoading=false }) {
   const [inputText, setInputText] = useState('')
 
@@ -41,10 +42,11 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
   const [notPresentGenes, setNotPresentGenes] = useState(new Set([]))
   const [showNotPresentGeneChoice, setShowNotPresentGeneChoice] = useState(false)
 
-  /** handles a user submitting a gene search */
+  /** Handles a user submitting a gene search */
   function handleSearch(event) {
     event.preventDefault()
     const newGeneArray = syncGeneArrayToInputText()
+    console.log('newGeneArray', newGeneArray)
     const newNotPresentGenes = new Set([])
     if (newGeneArray) {
       newGeneArray.forEach(gene => {
@@ -88,7 +90,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
     return newGeneArray
   }
 
-  /** detects presses of the space bar to create a new gene chunk */
+  /** Detects presses of the space bar to create a new gene chunk */
   function handleKeyDown(event) {
     if (!inputText) {
       return
@@ -101,7 +103,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
     }
   }
 
-  /** handles a user selecting a gene list file to use */
+  /** Handles a user selecting a gene list file to use */
   function readGeneListFile(file) {
     const fileReader = new FileReader()
     fileReader.onloadend = () => {
@@ -111,7 +113,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
     fileReader.readAsText(file)
   }
 
-  /** send analytics on how the gene search input changed */
+  /** Send analytics on how the gene search input changed */
   function logGeneArrayChange(newArray) {
     try {
       let actionName = ''
@@ -134,8 +136,9 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
     }
   }
 
-  /** handles the change event corresponding a a user adding or clearing one or more genes */
+  /** Handles the change event corresponding a user adding or clearing one or more genes */
   function handleSelectChange(value) {
+    console.log('in handleSelectChange, value:', value)
     // react-select doesn't expose the actual click events, so we deduce the kind
     // of operation based on whether it lengthened or shortened the list
     const newValue = value ? value : []
@@ -152,6 +155,13 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
       setNotPresentGenes(new Set([]))
     }
   }, [genes.join(',')])
+
+  useEffect(() => {
+    if (genes.join(',') !== geneArray.map(opt => opt.label).join(',')) {
+      const selectEvent = new Event('change:multiselect')
+      handleSearch(selectEvent)
+    }
+  }, [geneArray])
 
   const searchDisabled = !isLoading && !allGenes?.length
 
@@ -227,7 +237,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
         animation={false}
         bsSize='small'>
         <Modal.Body className="text-center">
-        Invalid Search - Please remove &quot;{Array.from(notPresentGenes).join('", "')}&quot; from gene search.
+        Invalid search - Please remove &quot;{Array.from(notPresentGenes).join('", "')}&quot; from gene search.
         </Modal.Body>
       </Modal>
       <Modal

--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -73,7 +73,10 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
         searchGenes(genesToSearch)
       }
     } else {
-      setShowEmptySearchModal(true)
+      if (event.type !== 'change:multiselect') {
+        // Don't show empty search modal if the user manually removed gene entry
+        setShowEmptySearchModal(true)
+      }
     }
   }
 
@@ -237,7 +240,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
         animation={false}
         bsSize='small'>
         <Modal.Body className="text-center">
-        Invalid search - Please remove &quot;{Array.from(notPresentGenes).join('", "')}&quot; from gene search.
+        Invalid search.  Please remove &quot;{Array.from(notPresentGenes).join('", "')}&quot; from gene search.
         </Modal.Body>
       </Modal>
       <Modal

--- a/test/js/explore/explore-display-tabs.test.js
+++ b/test/js/explore/explore-display-tabs.test.js
@@ -55,7 +55,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
     }
     const expectedResults = {
       enabledTabs: ['loading'],
-      disabledTabs: ['scatter', 'distribution', 'correlatedScatter', 'dotplot', 'heatmap'],
+      disabledTabs: [],
       isGeneList: false,
       isGene: false,
       isMultiGene: false,


### PR DESCRIPTION
This decreases the [interaction cost](https://en.wikipedia.org/wiki/Interaction_cost) to execute a study gene search, mitigating occasional user confusion.

## Overview
Previously, users had to do two interactions to execute a search: 1) select the gene from autocomplete, then 2) submit the search by clicking the magnifying glass search icon or pressing "Enter" / "Return".  Users occasionally reported confusion with how to search a gene, and this two-step select-then-submit UX seemed to be a factor.  

Now, selecting a gene also searches it.  This combined interaction gesture is also seen in common search UIs like [Google web search](https://www.google.com/) and [Google Maps](https://www.google.com/maps).  Like #1782, this Explore UX update is only available behind a feature flag, so its effect can be assessed as part of that batch of changes.

## Video
### Before
https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/c57cf347-7f6d-4068-84c1-2885c65d6989

### After
https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/58973f1e-d77f-4f5c-82ed-08b33fab8cb0



## Observability
This sensitive trigger will likely increase apparent [study gene search activity reported in analytics](https://mixpanel.com/project/2120588/view/19059/app/boards#id=737684) by [2-3x](https://mixpanel.com/s/faOL5).  That seems unavoidable, and also reasonable.  When searching for 3 genes by serially and manually typing in their gene symbols, one after another, displaying "interstitial" plots -- e.g. the gene expression plot upon entering the 1st gene, then the correlation plot upon entering the 2nd gene -- seems valuable as a way to serendipitously discover features at essentially no cost to the user experience.  Pasting (from system clipboard) multiple gene symbols into the search box also executes search immediately, without another interaction, and only logs a single (multi-gene) search to Mixpanel.  

This change updates the `trigger` for study gene search from either `click` or `submit` to `change:multiselect`.  Previously, `change:multiselect` was a full event, rather than a property of the `search`.  The prior `change:multiselect` event is no longer logged; it was among our most frequent events, albeit less signal than this updated `search` event.

The cost in VM resources on the [app server](https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-a/instances/singlecell-01?project=broad-singlecellportal&tab=monitoring&pageState=(%22duration%22:(%22groupValue%22:%22P1M%22,%22customValue%22:null))) and [DB server](https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-a/instances/singlecell-mongo-01?project=broad-singlecellportal&tab=monitoring&pageState=(%22duration%22:(%22groupValue%22:%22P1M%22,%22customValue%22:null))) can be monitored after release.  It's very likely to be negligible.

## Test
To manually verify:
* Go to study with visualizations initialized
* In another browser tab, set "show_explore_tab_ux_updates" feature flag to true
* Refresh study page
* In the search box, type in a few letters
* Click on a suggestion from autocomplete
* Confirm that executes the search, and that you see a gene expression scatter plot
* In the search box, without clearing your existing query, type in a few letters
* Press "tab" on your keyboard to select a suggestion from autocomplete
* Confirm that executes the search, and that you see a correlation scatter plot
* In the search box, without clearing your existing query, type in a few letters
* Select a suggestion from autocomplete
* Confirm that executes the search, and that you see a dot plot

You might only see 2 genes in the dot plot, in which case you've encountered SCP-5148.  That seems like it might effectively only affect local development; it's worth keeping an eye on in staging.

This satisfies SCP-5053.