### PR TITLE
Add DE upload to Upload Wizard (SCP-4999)

### DIFF
--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -272,7 +272,8 @@ module Api
                 k[:id] = k[:id].to_s
                 k[:taxon_id] = k[:taxon_id].to_s;
                 k
-              end
+              end,
+            de_computational_method: DifferentialExpressionResult::SUPPORTED_COMP_METHODS
           }
         end
         render json: response_obj

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -750,7 +750,10 @@ module Api
           ann_data_file_info_attributes: [
             :_id, :reference_file, :has_clusters, :has_metadata, :has_expression, :has_raw_counts,
             data_fragments: AnnDataFileInfo::DATA_FRAGMENT_PARAMS
-          ]
+          ],
+          differential_expression_file_info_attributes: [
+            :_id, clustering_association: [], annotation_association: []
+          ],
         )
       end
     end

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -752,7 +752,7 @@ module Api
             data_fragments: AnnDataFileInfo::DATA_FRAGMENT_PARAMS
           ],
           differential_expression_file_info_attributes: [
-            :_id, :clustering_association, :annotation_association, :comp_method_association
+            :_id, :clustering_association, :annotation_association, :computational_method
           ],
         )
       end

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -752,7 +752,7 @@ module Api
             data_fragments: AnnDataFileInfo::DATA_FRAGMENT_PARAMS
           ],
           differential_expression_file_info_attributes: [
-            :_id, clustering_association: [], annotation_association: []
+            :_id, :clustering_association, :annotation_association, :comp_method_association
           ],
         )
       end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -984,7 +984,7 @@ class StudiesController < ApplicationController
                                        expression_file_info_attributes: [:id, :library_preparation_protocol, :units,
                                                                          :biosample_input_type, :modality, :is_raw_counts,
                                                                          raw_counts_associations: []],
-                                       differential_expression_file_info_attributes: [:_id, :clustering_association, :annotation_association, :comp_method_association]
+                                       differential_expression_file_info_attributes: [:_id, :clustering_association, :annotation_association, :computational_method]
                                        )
   end
 

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -983,7 +983,9 @@ class StudiesController < ApplicationController
                                                  :cluster_name, :annotation_name],
                                        expression_file_info_attributes: [:id, :library_preparation_protocol, :units,
                                                                          :biosample_input_type, :modality, :is_raw_counts,
-                                                                         raw_counts_associations: []])
+                                                                         raw_counts_associations: []],
+                                       differential_expression_file_info_attributes: [:_id, clustering_association: [], annotation_association: []]
+                                       )
   end
 
   def directory_listing_params

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -984,7 +984,7 @@ class StudiesController < ApplicationController
                                        expression_file_info_attributes: [:id, :library_preparation_protocol, :units,
                                                                          :biosample_input_type, :modality, :is_raw_counts,
                                                                          raw_counts_associations: []],
-                                       differential_expression_file_info_attributes: [:_id, clustering_association: [], annotation_association: []]
+                                       differential_expression_file_info_attributes: [:_id, :clustering_association, :annotation_association, :comp_method_association]
                                        )
   end
 

--- a/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
@@ -66,6 +66,7 @@ export default function DifferentialExpressionFileForm({
 
   const associatedCompMethod = compMethodOptions?.find(
     opt => opt.value === file.differential_expression_file_info.comp_method_association
+    opt => opt.value === file.differential_expression_file_info.computational_method
   )
 
   /** handle a change in the associated cluster select */
@@ -92,7 +93,7 @@ export default function DifferentialExpressionFileForm({
     if (option) {
       newVal = option.value
     }
-    updateFile(file._id, { differential_expression_file_info: { comp_method_association: newVal } })
+    updateFile(file._id, { differential_expression_file_info: { computational_method: newVal } })
   }
 
   return <ExpandableFileForm {...{

--- a/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
@@ -31,27 +31,27 @@ export default function DifferentialExpressionFileForm({
   const clusterFiles = matchingFormFiles(allFiles, clusterFileFilter, isAnnDataExperience, fragmentType)
   const clusterFileOptions = clusterFiles.map(cf => ({ label: cf.name, value: cf._id }))
   const associatedCluster = clusterFileOptions?.find(
-    opt => opt.value === file.differential_expression_file_info.clustering_association?.id
+    opt => opt.value === file.differential_expression_file_info.clustering_association
   )
 
   const annotsAlreadyInUse = []
   // retrieve the annotations that are already in use on a DE file
   allFiles.filter(differentialExpressionFileFilter).filter(
-    diffExpFile => diffExpFile.differential_expression_file_info.annotation_association?.length > 0
+    diffExpFile => diffExpFile.differential_expression_file_info.annotation_association
   ).forEach(file => {
-    annotsAlreadyInUse.push(file.differential_expression_file_info.annotation_association[0])
+    annotsAlreadyInUse.push(file.differential_expression_file_info.annotation_association)
   })
 
   // filter down the annotations to only allow choosing an annotation that hasn't been chosen already
   // each annotation is allowed to be associated with only one DE file
   const annotationOptions = annotationsAvailOnStudy?.map(
-    cf => ({ label: cf.name, value: cf.name })
+    cf => ({ label: cf.name, value: `${cf.name}--${cf.type}--${cf.scope}` })
   ).filter(
     annotObj => !annotsAlreadyInUse.includes(annotObj.value)
   )
 
   const associatedAnnotation = annotationOptions?.find(
-    opt => opt.value === file.differential_expression_file_info.annotation_association?.name
+    opt => opt.value === file.differential_expression_file_info.annotation_association
   )
 
   /* while mapping the computational methods constant to label/value pairs for the select
@@ -65,7 +65,7 @@ export default function DifferentialExpressionFileForm({
   )
 
   const associatedCompMethod = compMethodOptions?.find(
-    opt => opt.value === file.differential_expression_file_info.comp_method_association?.name
+    opt => opt.value === file.differential_expression_file_info.comp_method_association
   )
 
   /** handle a change in the associated cluster select */

--- a/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
@@ -128,7 +128,7 @@ export default function DifferentialExpressionFileForm({
           className="labeled-select"
           isClearable
           onChange={val => updateAssociatedCompMethod(file, val)}
-          placeholder="Start typing to select or add your method"
+          placeholder="Start typing to select or add your method or statistical test"
         />
       </label>
     </div>

--- a/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
@@ -23,6 +23,7 @@ export default function DifferentialExpressionFileForm({
   annotationsAvailOnStudy,
   menuOptions
 }) {
+  // TODO (SCP-5154) Add DE specific clientside validation
   const validationMessages = validateFile({ file, allFiles, allowedFileExts })
 
   const fragmentType = isAnnDataExperience ? 'cluster' : null
@@ -36,7 +37,7 @@ export default function DifferentialExpressionFileForm({
   const annotsAlreadyInUse = []
   // retrieve the annotations that are already in use on a DE file
   allFiles.filter(differentialExpressionFileFilter).filter(
-    diffExpFile => {return diffExpFile.differential_expression_file_info.annotation_association?.length > 0}
+    diffExpFile => diffExpFile.differential_expression_file_info.annotation_association?.length > 0
   ).forEach(file => {
     annotsAlreadyInUse.push(file.differential_expression_file_info.annotation_association[0])
   })
@@ -46,7 +47,7 @@ export default function DifferentialExpressionFileForm({
   const annotationOptions = annotationsAvailOnStudy?.map(
     cf => ({ label: cf.name, value: cf.name })
   ).filter(
-    annotObj => {return !annotsAlreadyInUse.includes(annotObj.value)}
+    annotObj => !annotsAlreadyInUse.includes(annotObj.value)
   )
 
   const associatedAnnotation = annotationOptions?.find(
@@ -58,7 +59,7 @@ export default function DifferentialExpressionFileForm({
    the ambiguous 'custom' option
    */
   const compMethodOptions = menuOptions.de_computational_method.filter(
-    compMethod => {return compMethod !== 'custom'}
+    compMethod => compMethod !== 'custom'
   ).map(
     opt => ({ label: opt.replace(/_/g, ' '), value: opt })
   )
@@ -118,10 +119,10 @@ export default function DifferentialExpressionFileForm({
       </label>
     </div>
     <div className="form-group">
-      <label className="labeled-select">Statistical test (computational-method)
+      <label className="labeled-select">Computational method
         {/* using CreateableSelect here so that users can add an option if their method isn't listed */}
         <CreatableSelect
-          data-analytics-name="differential-expression-statistical-test-select"
+          data-analytics-name="differential-expression-computational-method-select"
           options={compMethodOptions}
           value={associatedCompMethod}
           className="labeled-select"

--- a/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { FileTypeExtensions, matchingFormFiles } from './upload-utils'
+import { FileTypeExtensions, matchingFormFiles, validateFile } from './upload-utils'
 import { TextFormField } from './form-components'
 import ExpandableFileForm from './ExpandableFileForm'
 import Select from '~/lib/InstrumentedSelect'
@@ -22,6 +22,8 @@ export default function DifferentialExpressionFileForm({
   annotationsAvailOnStudy,
   menuOptions
 }) {
+  const validationMessages = validateFile({ file, allFiles, allowedFileExts })
+
   const fragmentType = isAnnDataExperience ? 'cluster' : null
 
   const clusterFiles = matchingFormFiles(allFiles, clusterFileFilter, isAnnDataExperience, fragmentType)
@@ -33,7 +35,7 @@ export default function DifferentialExpressionFileForm({
   const annotsAlreadyInUse = []
   // retrieve the annotations that are already in use on a DE file
   allFiles.filter(differentialExpressionFileFilter).filter(
-    diffExpFile => {return diffExpFile.differential_expression_file_info.annotation_association.length > 0}
+    diffExpFile => {return diffExpFile.differential_expression_file_info.annotation_association?.length > 0}
   ).forEach(file => {
     annotsAlreadyInUse.push(file.differential_expression_file_info.annotation_association[0])
   })
@@ -88,7 +90,7 @@ export default function DifferentialExpressionFileForm({
 
   return <ExpandableFileForm {...{
     file, allFiles, updateFile, saveFile,
-    allowedFileExts, deleteFile, bucketName, isInitiallyExpanded, isAnnDataExperience
+    allowedFileExts, deleteFile, validationMessages, bucketName, isInitiallyExpanded, isAnnDataExperience
   }}>
     <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
     <div className="form-group">

--- a/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
@@ -6,6 +6,7 @@ import ExpandableFileForm from './ExpandableFileForm'
 import Select from '~/lib/InstrumentedSelect'
 import { clusterFileFilter } from './ClusteringStep'
 import { differentialExpressionFileFilter } from './DifferentialExpressionStep'
+import CreatableSelect from 'react-select/creatable'
 
 const allowedFileExts = FileTypeExtensions.plainText
 
@@ -52,11 +53,16 @@ export default function DifferentialExpressionFileForm({
     opt => opt.value === file.differential_expression_file_info.annotation_association?.name
   )
 
-  // while mapping the computational methods constant to label/value pairs for the select
-  // update the labels to be more nicely human readable (e.g. remove snake casing)
-  const compMethodOptions = menuOptions.de_computational_method.map(
+  /* while mapping the computational methods constant to label/value pairs for the select
+   update the labels to be more nicely human readable (e.g. remove snake casing) and remove
+   the ambiguous 'custom' option
+   */
+  const compMethodOptions = menuOptions.de_computational_method.filter(
+    compMethod => {return compMethod !== 'custom'}
+  ).map(
     opt => ({ label: opt.replace(/_/g, ' '), value: opt })
   )
+
   const associatedCompMethod = compMethodOptions?.find(
     opt => opt.value === file.differential_expression_file_info.comp_method_association?.name
   )
@@ -113,12 +119,16 @@ export default function DifferentialExpressionFileForm({
     </div>
     <div className="form-group">
       <label className="labeled-select">Statistical test (computational-method)
-        <Select options={compMethodOptions}
+        {/* using CreateableSelect here so that users can add an option if their method isn't listed */}
+        <CreatableSelect
           data-analytics-name="differential-expression-statistical-test-select"
+          options={compMethodOptions}
           value={associatedCompMethod}
-          placeholder="Select one..."
-          onChange={val => updateAssociatedCompMethod
-          }/>
+          className="labeled-select"
+          isClearable
+          onChange={val => updateAssociatedCompMethod(file, val)}
+          placeholder="Start typing to select or add your method"
+        />
       </label>
     </div>
   </ExpandableFileForm>

--- a/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
@@ -65,7 +65,6 @@ export default function DifferentialExpressionFileForm({
   )
 
   const associatedCompMethod = compMethodOptions?.find(
-    opt => opt.value === file.differential_expression_file_info.comp_method_association
     opt => opt.value === file.differential_expression_file_info.computational_method
   )
 

--- a/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
@@ -1,0 +1,123 @@
+import React from 'react'
+
+import { FileTypeExtensions, matchingFormFiles } from './upload-utils'
+import { TextFormField } from './form-components'
+import ExpandableFileForm from './ExpandableFileForm'
+import Select from '~/lib/InstrumentedSelect'
+import { clusterFileFilter } from './ClusteringStep'
+import { differentialExpressionFileFilter } from './DifferentialExpressionStep'
+
+const allowedFileExts = FileTypeExtensions.plainText
+
+/** renders a form for editing/uploading a differential expression file */
+export default function DifferentialExpressionFileForm({
+  file,
+  allFiles,
+  updateFile,
+  saveFile,
+  deleteFile,
+  bucketName,
+  isInitiallyExpanded,
+  isAnnDataExperience,
+  annotationsAvailOnStudy,
+  menuOptions
+}) {
+  const fragmentType = isAnnDataExperience ? 'cluster' : null
+
+  const clusterFiles = matchingFormFiles(allFiles, clusterFileFilter, isAnnDataExperience, fragmentType)
+  const clusterFileOptions = clusterFiles.map(cf => ({ label: cf.name, value: cf._id }))
+  const associatedCluster = clusterFileOptions?.find(
+    opt => opt.value === file.differential_expression_file_info.clustering_association?.id
+  )
+
+  const annotsAlreadyInUse = []
+  // retrieve the annotations that are already in use on a DE file
+  allFiles.filter(differentialExpressionFileFilter).filter(
+    diffExpFile => {return diffExpFile.differential_expression_file_info.annotation_association.length > 0}
+  ).forEach(file => {
+    annotsAlreadyInUse.push(file.differential_expression_file_info.annotation_association[0])
+  })
+
+  // filter down the annotations to only allow choosing an annotation that hasn't been chosen already
+  // each annotation is allowed to be associated with only one DE file
+  const annotationOptions = annotationsAvailOnStudy?.map(
+    cf => ({ label: cf.name, value: cf.name })
+  ).filter(
+    annotObj => {return !annotsAlreadyInUse.includes(annotObj.value)}
+  )
+
+  const associatedAnnotation = annotationOptions?.find(
+    opt => opt.value === file.differential_expression_file_info.annotation_association?.name
+  )
+
+  // while mapping the computational methods constant to label/value pairs for the select
+  // update the labels to be more nicely human readable (e.g. remove snake casing)
+  const compMethodOptions = menuOptions.de_computational_method.map(
+    opt => ({ label: opt.replace(/_/g, ' '), value: opt })
+  )
+  const associatedCompMethod = compMethodOptions?.find(
+    opt => opt.value === file.differential_expression_file_info.comp_method_association?.name
+  )
+
+  /** handle a change in the associated cluster select */
+  function updateAssociatedCluster(file, option) {
+    let newVal = null
+    if (option) {
+      newVal = option.value
+    }
+    updateFile(file._id, { differential_expression_file_info: { clustering_association: newVal } })
+  }
+
+  /** handle a change in the associated annotation select */
+  function updateAssociatedAnnotation(file, option) {
+    let newVal = null
+    if (option) {
+      newVal = option.value
+    }
+    updateFile(file._id, { differential_expression_file_info: { annotation_association: newVal } })
+  }
+
+  /** handle a change in the associated computational method select */
+  function updateAssociatedCompMethod(file, option) {
+    let newVal = null
+    if (option) {
+      newVal = option.value
+    }
+    updateFile(file._id, { differential_expression_file_info: { comp_method_association: newVal } })
+  }
+
+  return <ExpandableFileForm {...{
+    file, allFiles, updateFile, saveFile,
+    allowedFileExts, deleteFile, bucketName, isInitiallyExpanded, isAnnDataExperience
+  }}>
+    <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
+    <div className="form-group">
+      <label className="labeled-select">Associated clustering file
+        <Select options={clusterFileOptions}
+          data-analytics-name="differential-expression-associated-cluster-select"
+          value={associatedCluster}
+          placeholder="Select one..."
+          onChange={val => updateAssociatedCluster(file, val)}/>
+      </label>
+    </div>
+    <div className="form-group">
+      <label className="labeled-select">Associated annotation
+        <Select options={annotationOptions}
+          data-analytics-name="differential-expression-associated-annotation-select"
+          value={associatedAnnotation}
+          placeholder="Select one..."
+          onChange={val => updateAssociatedAnnotation(file, val)}/>
+      </label>
+    </div>
+    <div className="form-group">
+      <label className="labeled-select">Statistical test (computational-method)
+        <Select options={compMethodOptions}
+          data-analytics-name="differential-expression-statistical-test-select"
+          value={associatedCompMethod}
+          placeholder="Select one..."
+          onChange={val => updateAssociatedCompMethod
+          }/>
+      </label>
+    </div>
+  </ExpandableFileForm>
+}

--- a/app/javascript/components/upload/DifferentialExpressionStep.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionStep.jsx
@@ -16,9 +16,9 @@ const DEFAULT_NEW_DE_FILE = {
 export const differentialExpressionFileFilter = file => file.file_type === 'Differential Expression'
 
 export default {
-  title: 'Differential Expression',
+  title: 'Differential expression',
   name: 'differential expression',
-  header: 'Differential Expression',
+  header: 'Differential expression',
   component: DifferentialFileUploadForm,
   fileFilter: differentialExpressionFileFilter
 }
@@ -48,7 +48,7 @@ export function DifferentialFileUploadForm({
     <div className="row">
       <div className="col-md-12">
         <p className="form-terra">
-          Upload a file with differential expression for a particular clustering and annotation
+          Upload a file with differential expression for a particular clustering and annotation.
         </p>
       </div>
     </div>

--- a/app/javascript/components/upload/DifferentialExpressionStep.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionStep.jsx
@@ -7,9 +7,9 @@ import DifferentialExpressionFileForm from './DifferentialExpressionFileForm'
 const DEFAULT_NEW_DE_FILE = {
   file_type: 'Differential Expression',
   differential_expression_file_info: {
-    clustering_association: [],
-    annotation_association: [],
-    comp_method_association: []
+    clustering_association: undefined,
+    annotation_association: undefined,
+    comp_method_association: undefined
   }
 }
 

--- a/app/javascript/components/upload/DifferentialExpressionStep.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionStep.jsx
@@ -9,7 +9,7 @@ const DEFAULT_NEW_DE_FILE = {
   differential_expression_file_info: {
     clustering_association: undefined,
     annotation_association: undefined,
-    comp_method_association: undefined
+    computational_method: undefined
   }
 }
 

--- a/app/javascript/components/upload/DifferentialExpressionStep.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionStep.jsx
@@ -1,0 +1,74 @@
+import React, { useEffect } from 'react'
+
+import { AddFileButton } from './form-components'
+import DifferentialExpressionFileForm from './DifferentialExpressionFileForm'
+
+
+const DEFAULT_NEW_DE_FILE = {
+  file_type: 'Differential Expression',
+  differential_expression_file_info: {
+    clustering_association: [],
+    annotation_association: [],
+    comp_method_association: []
+  }
+}
+
+export const differentialExpressionFileFilter = file => file.file_type === 'Differential Expression'
+
+export default {
+  title: 'Differential Expression',
+  name: 'differential expression',
+  header: 'Differential Expression',
+  component: DifferentialFileUploadForm,
+  fileFilter: differentialExpressionFileFilter
+}
+
+/** Renders a form for uploading differential expression files */
+export function DifferentialFileUploadForm({
+  formState,
+  serverState,
+  addNewFile,
+  updateFile,
+  saveFile,
+  deleteFile,
+  isAnnDataExperience,
+  annotationsAvailOnStudy
+}) {
+  const menuOptions = serverState.menu_options
+
+  const deFiles = formState.files.filter(differentialExpressionFileFilter)
+
+  useEffect(() => {
+    if (deFiles.length === 0) {
+      addNewFile(DEFAULT_NEW_DE_FILE)
+    }
+  }, [deFiles.length])
+
+  return <div>
+    <div className="row">
+      <div className="col-md-12">
+        <p className="form-terra">
+          Upload a file with differential expression for a particular clustering and annotation
+        </p>
+      </div>
+    </div>
+    { deFiles.map(file => {
+      return <DifferentialExpressionFileForm
+        key={file.oldId ? file.oldId : file._id}
+        file={file}
+        allFiles={formState.files}
+        updateFile={updateFile}
+        saveFile={saveFile}
+        deleteFile={deleteFile}
+        annDataFileTypes={['AnnData']}
+        bucketName={formState.study.bucket_id}
+        annotationsAvailOnStudy={annotationsAvailOnStudy}
+        isInitiallyExpanded={deFiles.length === 1}
+        menuOptions={menuOptions}/>
+    })}
+
+    <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_DE_FILE}/>
+  </div>
+}
+
+

--- a/app/javascript/components/upload/SeuratFileForm.jsx
+++ b/app/javascript/components/upload/SeuratFileForm.jsx
@@ -1,9 +1,8 @@
 import React from 'react'
 
 import ExpandableFileForm from './ExpandableFileForm'
-import { FileTypeExtensions } from './upload-utils'
+import { FileTypeExtensions, validateFile } from './upload-utils'
 import { TextFormField } from './form-components'
-import { validateFile } from './upload-utils'
 
 const allowedFileExts = FileTypeExtensions.seurat
 

--- a/app/javascript/components/upload/UploadWizard.jsx
+++ b/app/javascript/components/upload/UploadWizard.jsx
@@ -18,7 +18,7 @@ import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons
 import { formatFileFromServer, formatFileForApi, newStudyFileObj, StudyContext } from './upload-utils'
 import {
   createStudyFile, updateStudyFile, deleteStudyFile,
-  fetchStudyFileInfo, sendStudyFileChunk, RequestCanceller, deleteAnnDataFragment
+  fetchStudyFileInfo, sendStudyFileChunk, RequestCanceller, deleteAnnDataFragment, fetchExplore
 } from '~/lib/scp-api'
 import MessageModal, { successNotification, failureNotification } from '~/lib/MessageModal'
 import UserProvider from '~/providers/UserProvider'
@@ -33,6 +33,7 @@ import RawCountsStep from './RawCountsStep'
 import ProcessedExpressionStep from './ProcessedExpressionStep'
 import MetadataStep from './MetadataStep'
 import MiscellaneousStep from './MiscellaneousStep'
+import DifferentialExpressionStep from './DifferentialExpressionStep'
 import SequenceFileStep from './SequenceFileStep'
 import GeneListStep from './GeneListStep'
 import LoadingSpinner from '~/lib/LoadingSpinner'
@@ -56,6 +57,7 @@ const ALL_POSSIBLE_STEPS = [
   CoordinateLabelStep,
   SequenceFileStep,
   GeneListStep,
+  DifferentialExpressionStep,
   MiscellaneousStep,
   SeuratStep,
   AnnDataStep,
@@ -81,12 +83,18 @@ const MAIN_STEPS_ANNDATA = [
 export function RawUploadWizard({ studyAccession, name }) {
   const [serverState, setServerState] = useState(null)
   const [formState, setFormState] = useState(null)
+  const [annotationsAvailOnStudy, setAnnotationsAvailOnStudy] = useState(null)
 
   // study attributes to pass to the StudyContext later for use throughout the RawUploadWizard component, if needed
   // use complete study object, rather than defaultStudyState so that any updates to study.rb will be reflected in
   // this context
   const studyObj = serverState?.study
 
+  /** load the basic study info to get the study annotations */
+  async function loadStudyData() {
+    const exploreResponse = await fetchExplore(studyAccession)
+    setAnnotationsAvailOnStudy(exploreResponse?.annotationList?.annotations)
+  }
 
   // used for toggling between the split view for the upload experiences
   const [overrideExperienceMode, setOverrideExperienceMode] = useState(false)
@@ -102,11 +110,13 @@ export function RawUploadWizard({ studyAccession, name }) {
   if (isAnnDataExperience) {
     MAIN_STEPS = MAIN_STEPS_ANNDATA
     SUPPLEMENTAL_STEPS = ALL_POSSIBLE_STEPS.slice(6, 7)
-    NON_VISUALIZABLE_STEPS = ALL_POSSIBLE_STEPS.slice(8, 10)
+    // SUPPLEMENTAL_STEPS.splice(1, 0, DifferentialExpressionStep)
+    // TODO enable after raw counts are sorted for AnnData (SCP-5110)
+    NON_VISUALIZABLE_STEPS = ALL_POSSIBLE_STEPS.slice(10, 12)
   } else {
     MAIN_STEPS = MAIN_STEPS_CLASSIC
-    SUPPLEMENTAL_STEPS = ALL_POSSIBLE_STEPS.slice(5, 9)
-    NON_VISUALIZABLE_STEPS = ALL_POSSIBLE_STEPS.slice(9, 12)
+    SUPPLEMENTAL_STEPS = ALL_POSSIBLE_STEPS.slice(5, 10)
+    NON_VISUALIZABLE_STEPS = ALL_POSSIBLE_STEPS.slice(10, 13)
     if (allowReferenceImageUpload) {
       SUPPLEMENTAL_STEPS.splice(1, 0, ImageStep)
     }
@@ -549,7 +559,10 @@ export function RawUploadWizard({ studyAccession, name }) {
       setServerState(response)
       setFormState(_cloneDeep(response))
       setTimeout(pollServerState, POLLING_INTERVAL)
-    })
+    },
+    // get the annotations list
+    loadStudyData()
+    )
 
     window.document.title = `Upload - Single Cell Portal`
   }, [studyAccession])
@@ -610,13 +623,13 @@ export function RawUploadWizard({ studyAccession, name }) {
               addNewFile={addNewFile}
               isAnnDataExperience={isAnnDataExperience}
               deleteFileFromForm={deleteFileFromForm}
+              annotationsAvailOnStudy={annotationsAvailOnStudy}
             />
           </div>
         </div>
       </div></>
     }
   }
-
   return (
     <StudyContext.Provider value={studyObj}>
       {/* If the formState hasn't loaded show a spinner */}

--- a/app/javascript/components/upload/UploadWizard.jsx
+++ b/app/javascript/components/upload/UploadWizard.jsx
@@ -90,12 +90,6 @@ export function RawUploadWizard({ studyAccession, name }) {
   // this context
   const studyObj = serverState?.study
 
-  /** load the basic study info to get the study annotations */
-  async function loadStudyData() {
-    const exploreResponse = await fetchExplore(studyAccession)
-    setAnnotationsAvailOnStudy(exploreResponse?.annotationList?.annotations)
-  }
-
   // used for toggling between the split view for the upload experiences
   const [overrideExperienceMode, setOverrideExperienceMode] = useState(false)
   const allowReferenceImageUpload = serverState?.feature_flags?.reference_image_upload
@@ -559,13 +553,15 @@ export function RawUploadWizard({ studyAccession, name }) {
       setServerState(response)
       setFormState(_cloneDeep(response))
       setTimeout(pollServerState, POLLING_INTERVAL)
-    },
+    })
     // get the annotations list
-    loadStudyData()
-    )
+    fetchExplore(studyAccession).then(response => {
+      setAnnotationsAvailOnStudy(response?.annotationList?.annotations)
+    })
 
     window.document.title = `Upload - Single Cell Portal`
   }, [studyAccession])
+
 
   const nextStep = STEPS[currentStepIndex + 1]
   const prevStep = STEPS[currentStepIndex - 1]

--- a/app/javascript/components/upload/UploadWizard.jsx
+++ b/app/javascript/components/upload/UploadWizard.jsx
@@ -109,7 +109,8 @@ export function RawUploadWizard({ studyAccession, name }) {
     NON_VISUALIZABLE_STEPS = ALL_POSSIBLE_STEPS.slice(10, 12)
   } else {
     MAIN_STEPS = MAIN_STEPS_CLASSIC
-    SUPPLEMENTAL_STEPS = ALL_POSSIBLE_STEPS.slice(5, 10)
+    SUPPLEMENTAL_STEPS = serverState?.feature_flags?.show_de_upload ?
+      ALL_POSSIBLE_STEPS.slice(5, 10) : ALL_POSSIBLE_STEPS.slice(5, 9)
     NON_VISUALIZABLE_STEPS = ALL_POSSIBLE_STEPS.slice(10, 13)
     if (allowReferenceImageUpload) {
       SUPPLEMENTAL_STEPS.splice(1, 0, ImageStep)

--- a/app/javascript/components/upload/WizardNavPanel.jsx
+++ b/app/javascript/components/upload/WizardNavPanel.jsx
@@ -8,6 +8,8 @@ import { OverlayTrigger, Popover } from 'react-bootstrap'
 import { clusterFileFilter } from './ClusteringStep'
 import { metadataFileFilter } from './MetadataStep'
 import { processedFileFilter } from './ProcessedExpressionStep'
+import { differentialExpressionFileFilter } from './DifferentialExpressionStep'
+
 import LoadingSpinner from '~/lib/LoadingSpinner'
 
 

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -896,6 +896,12 @@ figcaption.ck-editor__editable {
   background-color: lighten($action-color, 10%);
 }
 
+.btn-primary:disabled,
+.btn-primary[disabled]{
+  background-color: #fff;
+  border-color: #666666;
+}
+
 .btn-warning-scp {
   background-color: #C45500;
   color: #fff;

--- a/app/models/differential_expression_file_info.rb
+++ b/app/models/differential_expression_file_info.rb
@@ -11,9 +11,7 @@ class DifferentialExpressionFileInfo
   field :computational_method, type: String, default: DifferentialExpressionResult::DEFAULT_COMP_METHOD
   field :clustering_association, type: String
   field :annotation_association, type: String
-  field :comp_method_association, type: String
 
-  validates :computational_method, inclusion: { in: DifferentialExpressionResult::SUPPORTED_COMP_METHODS }
   validates :annotation_name, presence: true, uniqueness: { scope: %i[annotation_scope cluster_group] }
   validates :annotation_scope, presence: true
   validate :annotation_exists?

--- a/app/models/differential_expression_file_info.rb
+++ b/app/models/differential_expression_file_info.rb
@@ -9,6 +9,9 @@ class DifferentialExpressionFileInfo
   field :annotation_name, type: String
   field :annotation_scope, type: String
   field :computational_method, type: String, default: DifferentialExpressionResult::DEFAULT_COMP_METHOD
+  field :clustering_association, type: String
+  field :annotation_association, type: String
+  field :comp_method_association, type: String
 
   validates :computational_method, inclusion: { in: DifferentialExpressionResult::SUPPORTED_COMP_METHODS }
   validates :annotation_name, presence: true, uniqueness: { scope: %i[annotation_scope cluster_group] }

--- a/db/migrate/20230530105311_add_flag_for_user_de_upload.rb
+++ b/db/migrate/20230530105311_add_flag_for_user_de_upload.rb
@@ -1,0 +1,11 @@
+class AddFlagForUserDeUpload < Mongoid::Migration
+  def self.up
+    FeatureFlag.create!(name: 'show_de_upload',
+                        default_value: false,
+                        description: 'show the differential expression upload tab in the upload wizard')
+  end
+
+  def self.down
+    FeatureFlag.find_by(name: 'show_de_upload')&.destroy
+  end
+end

--- a/test/js/upload-wizard/file-info-responses.js
+++ b/test/js/upload-wizard/file-info-responses.js
@@ -634,3 +634,43 @@ export const EMPTY_STUDY = {
   feature_flags: {},
   menu_options: BASIC_MENU_OPTIONS
 }
+
+export const GENERIC_EXPLORE_INFO = {
+  'inferCNVIdeogramFiles': null,
+  'bamBundleList': [],
+  'uniqueGenes': [
+    'ADCY5',
+    'AGPAT2'
+  ],
+  'geneLists': [
+    {
+      'name': 'time_varying_genes',
+      'heatmap_file_info': {
+        '_id': {
+          '$oid': '626892f3cc7ba073111aae92'
+        },
+        'custom_scaling': true,
+        'color_min': -1,
+        'color_max': 0.6,
+        'legend_label': 'diffExp4'
+      },
+      'description': 'genes varying over time (SCP4 staging)'
+    }
+  ],
+  'precomputedHeatmapLabel': 'custom diff. expression',
+  'annotationList': {
+    'default_cluster': null,
+    'default_annotation': null,
+    'annotations': [],
+    'clusters': [],
+    'subsample_thresholds': {}
+  },
+  'clusterGroupNames': [],
+  'spatialGroups': [],
+  'imageFiles': [],
+  'taxonNames': [],
+  'genes': [],
+  'clusterPointAlpha': 1,
+  'colorProfile': null,
+  'bucketId': 'fc-6e8a0a4d-6493-401c-b47c-1025a583f237'
+}

--- a/test/js/upload-wizard/file-upload-cancel.test.js
+++ b/test/js/upload-wizard/file-upload-cancel.test.js
@@ -8,7 +8,7 @@ import { RawUploadWizard } from 'components/upload/UploadWizard'
 import MockRouter from '../lib/MockRouter'
 import { fireFileSelectionEvent } from '../lib/file-mock-utils'
 import * as ScpApi from 'lib/scp-api'
-import { EMPTY_STUDY } from './file-info-responses'
+import { EMPTY_STUDY, GENERIC_EXPLORE_INFO} from './file-info-responses'
 
 describe('cancels a study file upload', () => {
   afterEach(() => {
@@ -21,6 +21,11 @@ describe('cancels a study file upload', () => {
     // pass in a clone of the response since it may get modified by the cache operations
     studyInfoSpy.mockImplementation(params => {
       const response = _cloneDeep(EMPTY_STUDY)
+      return Promise.resolve(response)
+    })
+    const exploreSpy = jest.spyOn(ScpApi, 'fetchExplore')
+    exploreSpy.mockImplementation(params => {
+      const response = _cloneDeep(GENERIC_EXPLORE_INFO)
       return Promise.resolve(response)
     })
 

--- a/test/js/upload-wizard/upload-wizard-test-utils.js
+++ b/test/js/upload-wizard/upload-wizard-test-utils.js
@@ -7,7 +7,7 @@ import MockRouter from '../lib/MockRouter'
 import { UserContext } from 'providers/UserProvider'
 import { RawUploadWizard } from 'components/upload/UploadWizard'
 import * as ScpApi from 'lib/scp-api'
-import { EMPTY_STUDY } from './file-info-responses'
+import { EMPTY_STUDY, GENERIC_EXPLORE_INFO } from './file-info-responses'
 import ClusteringStep from '~/components/upload/ClusteringStep'
 
 /** gets a pointer to the react-select node based on label text
@@ -23,7 +23,8 @@ export function getSelectByLabelText(screen, text) {
  * spinner to clear
 */
 export async function renderWizardWithStudy({
-  studyInfo=EMPTY_STUDY, featureFlags={}, studyAccession='SCP1', studyName='Chickens', initialSearch={}
+  studyInfo=EMPTY_STUDY, featureFlags={}, studyAccession='SCP1', studyName='Chickens',
+  initialSearch={}, exploreInfo=GENERIC_EXPLORE_INFO
 }) {
   // merge featureFlags data into studyInfo.feature_flags since this is where the upload wizard looks now
   studyInfo.feature_flags = featureFlags
@@ -34,6 +35,13 @@ export async function renderWizardWithStudy({
     const response = _cloneDeep(studyInfo)
     return Promise.resolve(response)
   })
+
+  const exploreSpy = jest.spyOn(ScpApi, 'fetchExplore')
+  exploreSpy.mockImplementation(params => {
+    const response = _cloneDeep(exploreInfo)
+    return Promise.resolve(response)
+  })
+
   const renderResult = render(
     <UserContext.Provider value={{ featureFlagsWithDefaults: featureFlags }}>
       <ReactNotifications/>
@@ -50,7 +58,8 @@ export async function renderWizardWithStudy({
  * spinner to clear
 */
 export async function renderWizardWithStudyOnClusteringStep({
-  studyInfo=EMPTY_STUDY, featureFlags={}, studyAccession='SCP1', studyName='Chickens', initialSearch={}
+  studyInfo=EMPTY_STUDY, featureFlags={}, studyAccession='SCP1', studyName='Chickens',
+  initialSearch={}, exploreInfo=GENERIC_EXPLORE_INFO
 }) {
   // merge featureFlags data into studyInfo.feature_flags since this is where the upload wizard looks now
   studyInfo.feature_flags = featureFlags
@@ -61,6 +70,13 @@ export async function renderWizardWithStudyOnClusteringStep({
     const response = _cloneDeep(studyInfo)
     return Promise.resolve(response)
   })
+
+  const exploreSpy = jest.spyOn(ScpApi, 'fetchExplore')
+  exploreSpy.mockImplementation(params => {
+    const response = _cloneDeep(exploreInfo)
+    return Promise.resolve(response)
+  })
+
   const renderResult = render(
     <UserContext.Provider value={{ featureFlagsWithDefaults: featureFlags }}>
       <ReactNotifications/>


### PR DESCRIPTION
This adds the UI to the Upload Wizard to allow users to upload their own DE files. 

Each DE file can be given an associated clustering, associated annotation, and associated computational method.

If an annotation has already been associated to a DE file (and this has been saved) that annotation option is not presented in the drop down anymore. 

The computational method dropdown uses `CreatableSelect` and a different placeholder to allow the user to type in their own method if it's not listed already. 

Actual uploading does not yet work, as the pieces are not all wired together with the Rails side (SCP-5096)

To test:
- Pull this branch and start up your local environment
- Head to a study that has clustering files already uploaded
- Go to the Upload Wizard and you will see the new Differential Expression tab
- In the Differential Expression tab you will see the form to add DE files and you can see the annotations and clusterings in the selects.


If you want to see that the used annotations are removed from the list you can go to the `DifferentialExpressionStep.jsx` file and alter the default DE file annotation_association to be some annotation that exists on your study. For example I tested on a study with `biosample_id` and so updated the default DE like so:
```
const DEFAULT_NEW_DE_FILE = {
  file_type: 'Differential Expression',
  differential_expression_file_info: {
    clustering_association: [],
    annotation_association: ['biosample_id'],
    comp_method_association: []
  }
}
```
Then when I re-loaded the page (or waited for HMR to do it for me) I checked in the annotation drop down and could see that `biosample_id` was no longer an option.

I am adding some unit tests to this PR shortly, just wanted to get the code up for review in the meantime

![Screenshot 2023-05-25 at 1 28 51 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/b0fa6396-0658-4c5c-8299-5a539769c492)
![Screenshot 2023-05-25 at 1 29 03 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/209e50de-63f8-4311-94cc-28a2c8bfd63c)
![Screenshot 2023-05-25 at 1 29 24 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/a8ddd03d-5518-46b3-98bf-0e8476cd4ffd)
