### PR TITLE
Better error handling for checking user Terra terms of service compliance (SCP-5113)

### DIFF
--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -67,11 +67,12 @@ module Api
       end
 
       def check_terra_tos_acceptance
-        must_accept = false
         if api_user_signed_in?
-          must_accept = current_api_user.must_accept_terra_tos?
+          user_status = current_api_user.check_terra_tos_status
+          render json: { must_accept: user_status[:must_accept] }, status: user_status[:status]
+        else
+          render json: { must_accept: false }, status: :ok
         end
-        render json: {must_accept: must_accept}
       end
 
 

--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -63,6 +63,9 @@ module Api
           response 401 do
             key :description, 'Terra API rejected request due to user non-compliance with ToS'
           end
+          response 404 do
+            key :description, 'User account not found in Terra, does not need to accept ToS'
+          end
           response 406 do
             key :description, ApiBaseController.not_acceptable
           end

--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -60,8 +60,14 @@ module Api
           response 200 do
             key :description, 'Boolean for whether user has accepted current Terra ToS'
           end
+          response 401 do
+            key :description, 'Terra API rejected request due to user non-compliance with ToS'
+          end
           response 406 do
             key :description, ApiBaseController.not_acceptable
+          end
+          response 500 do
+            key :description, 'Server error'
           end
         end
       end
@@ -69,7 +75,7 @@ module Api
       def check_terra_tos_acceptance
         if api_user_signed_in?
           user_status = current_api_user.check_terra_tos_status
-          render json: { must_accept: user_status[:must_accept] }, status: user_status[:status]
+          render json: { must_accept: user_status[:must_accept] }, status: user_status[:http_code]
         else
           render json: { must_accept: false }, status: :ok
         end

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -250,8 +250,11 @@ export function setupRenewalForReadOnlyToken(studyAccession) {
  */
 export async function checkTerraTosAcceptance() {
   const apiUrl = '/site/check_terra_tos_acceptance'
-  const [response] = await scpApi(apiUrl, defaultInit())
-  return response.mustAccept
+  await scpApi(apiUrl, defaultInit()).then(response => {
+    return { mustAccept: response.mustAccept, status: response.status }
+  }).catch(error => {
+    return { mustAccept: error.mustAccept, status: error.status }
+  })
 }
 
 /**

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -250,11 +250,8 @@ export function setupRenewalForReadOnlyToken(studyAccession) {
  */
 export async function checkTerraTosAcceptance() {
   const apiUrl = '/site/check_terra_tos_acceptance'
-  await scpApi(apiUrl, defaultInit()).then(response => {
-    return { mustAccept: response.mustAccept, status: response.status }
-  }).catch(error => {
-    return { mustAccept: error.mustAccept, status: error.status }
-  })
+  const [response] = await scpApi(apiUrl, defaultInit())
+  return response.mustAccept
 }
 
 /**
@@ -927,26 +924,30 @@ export default async function scpApi(
     } else {
       return [response, perfTimes, true]
     }
-  } else if (response.status === 401 || response.status === 403) {
-    showMessage(
-      <div>
-        Authentication failed<br/>
-        Your session may have timed out. Please sign in again.<br/><br/>
-      </div>,
-      'api-auth-failure',
-      {
-        source: 'api',
-        url,
-        isError: true,
-        messageType: 'error-client',
-        statusCode: response.status
-      }
-    )
-    throw new Error(`Authentication error: ${response.status}`)
   }
   if (toJson) {
     const json = await response.json()
-    if (Array.isArray(json.errors)) {
+    // special handling for Terra terms of service checks
+    // don't throw error so we can pass back JSON response
+    if (typeof json.must_accept !== 'undefined') {
+      return [camelcaseKeys(json)]
+    } else if (response.status === 401 || response.status === 403) {
+      showMessage(
+        <div>
+          Authentication failed<br/>
+          Your session may have timed out. Please sign in again.<br/><br/>
+        </div>,
+        'api-auth-failure',
+        {
+          source: 'api',
+          url,
+          isError: true,
+          messageType: 'error-client',
+          statusCode: response.status
+        }
+      )
+      throw new Error(`Authentication error: ${response.status}`)
+    } else if (Array.isArray(json.errors)) {
       throw new ApiError(json, response.status, path)
     } else {
       throw new Error(json.error || json.errors)

--- a/app/javascript/vite/application.js
+++ b/app/javascript/vite/application.js
@@ -54,11 +54,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const path = window.location.pathname
   const onTosPage = path.includes('terra_tos') || path.includes('accept_tos')
   if (!onTosPage && window.SCP.userSignedIn) {
-    ScpApi.checkTerraTosAcceptance().then(mustAcceptTerraTos => {
-      if (mustAcceptTerraTos) {
-        window.location = '/single_cell/terra_tos'
-      }
-    })
+    let userStatus = ScpApi.checkTerraTosAcceptance()
+    if (userStatus.mustAccept && userStatus.status === 401) {
+      window.location = '/single_cell/terra_tos'
+    }
   }
 
   setTimeout(checkMissingAuthToken, 1000);

--- a/app/javascript/vite/application.js
+++ b/app/javascript/vite/application.js
@@ -54,10 +54,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const path = window.location.pathname
   const onTosPage = path.includes('terra_tos') || path.includes('accept_tos')
   if (!onTosPage && window.SCP.userSignedIn) {
-    let userStatus = ScpApi.checkTerraTosAcceptance()
-    if (userStatus.mustAccept && userStatus.status === 401) {
-      window.location = '/single_cell/terra_tos'
-    }
+    ScpApi.checkTerraTosAcceptance().then(mustAcceptTerraTos => {
+      if (mustAcceptTerraTos) {
+        window.location = '/single_cell/terra_tos'
+      }
+    })
   }
 
   setTimeout(checkMissingAuthToken, 1000);

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1733,7 +1733,7 @@ class Study
       # check if workspace is still available, otherwise mark detached
       begin
         ApplicationController.firecloud_client.get_workspace(self.firecloud_project, self.firecloud_workspace)
-      rescue RuntimeError => e
+      rescue RestClient::Exception => e
         Rails.logger.error "Marking #{self.name} as 'detached' due to missing workspace: #{self.firecloud_project}/#{self.firecloud_workspace}"
         self.update(detached: true)
       end
@@ -1901,7 +1901,7 @@ class Study
               acl = ApplicationController.firecloud_client.create_workspace_acl(share.email, StudyShare::FIRECLOUD_ACL_MAP[share.permission], true, false)
               ApplicationController.firecloud_client.update_workspace_acl(self.firecloud_project, self.firecloud_workspace, acl)
               Rails.logger.info "#{Time.zone.now}: Study: #{self.name} FireCloud workspace acl assignment for shares #{share.email} successful"
-            rescue RuntimeError => e
+            rescue RestClient::Exception => e
               ErrorTracker.report_exception(e, user, self, acl)
               errors.add(:study_shares, "Could not create a share for #{share.email} to workspace #{self.firecloud_workspace} due to: #{e.message}")
               return false
@@ -2010,7 +2010,7 @@ class Study
               acl = ApplicationController.firecloud_client.create_workspace_acl(share.email, StudyShare::FIRECLOUD_ACL_MAP[share.permission], true, false)
               ApplicationController.firecloud_client.update_workspace_acl(self.firecloud_project, self.firecloud_workspace, acl)
               Rails.logger.info "#{Time.zone.now}: Study: #{self.name} FireCloud workspace acl assignment for shares #{share.email} successful"
-            rescue RuntimeError => e
+            rescue RestClient::Exception => e
               ErrorTracker.report_exception(e, user, self, acl)
               errors.add(:study_shares, "Could not create a share for #{share.email} to workspace #{self.firecloud_workspace} due to: #{e.message}")
               return false
@@ -2069,7 +2069,7 @@ class Study
       client.update_workspace_acl(self.firecloud_project, self.firecloud_workspace, acl)
       updated = client.get_workspace_acl(self.firecloud_project, self.firecloud_workspace)
       return updated['acl'][group_email]['accessLevel'] == 'OWNER'
-    rescue RuntimeError => e
+    rescue RestClient::Exception => e
       ErrorTracker.report_exception(e, self.user, { firecloud_project: self.firecloud_workspace})
       Rails.logger.error "Unable to add portal service account to #{self.firecloud_workspace}: #{e.message}"
       false

--- a/app/models/study_share.rb
+++ b/app/models/study_share.rb
@@ -211,7 +211,7 @@ class StudyShare
 					begin
 						acl = ApplicationController.firecloud_client.create_workspace_acl(self.email, FIRECLOUD_ACL_MAP[self.permission])
 						ApplicationController.firecloud_client.update_workspace_acl(self.firecloud_project, self.study.firecloud_workspace, acl)
-					rescue RuntimeError => e
+					rescue RestClient::Exception => e
 						ErrorTracker.report_exception(e, nil, self.study, self)
 						errors.add(:base, "Could not create a share for #{self.email} to workspace #{self.firecloud_workspace} due to: #{e.message}")
 					end
@@ -229,7 +229,7 @@ class StudyShare
 				acl = ApplicationController.firecloud_client.create_workspace_acl(self.email, 'NO ACCESS')
 				ApplicationController.firecloud_client.update_workspace_acl(self.firecloud_project, self.firecloud_workspace, acl)
 			end
-		rescue RuntimeError => e
+		rescue RestClient::Exception => e
 			ErrorTracker.report_exception(e, nil, self.study, self)
 			Rails.logger.error "Could not remove share for #{self.email} to workspace #{self.firecloud_workspace} due to: #{e.message}"
 			SingleCellMailer.share_delete_fail(self.study, self.email).deliver_now

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -373,14 +373,12 @@ class User
   def must_accept_terra_tos?
     return false unless registered_for_firecloud
 
-    tos_status = check_terra_tos_status
-    # only return true if must_accept & a non-500 error code was returned
-    tos_status[:must_accept] && [200, 401].include?(tos_status[:http_code])
+    check_terra_tos_status[:must_accept]
   end
 
   # returns a Hash with a boolean for "must_accept" as well as the HTTP status code from the request
   # if a user is out of compliance with the Terra terms of service, then the value for tosAccepted will
-  # be false, or the request will fail with a 401 status
+  # be false.
   #
   # * *returns*
   #   - (Hash) => { must_accept: T/F, status: HTTP status code }
@@ -394,7 +392,8 @@ class User
       # return inverse as value of 'false' here means the user must accept the updated Terra ToS
       { must_accept: !tos_accepted, http_code: 200 }
     rescue RestClient::Exception => e
-      # 401: user is not in compliance with Terra ToS
+      # HTTP STATUS CODE EXPLANATIONS
+      # 401: user is not in compliance with Terra ToS (/register endpoint shouldn't give this but check anyway)
       # 404: user is not registered, does not need to accept Terra ToS
       # 5xx: upstream error, do not rely on this response
       must_accept = e.http_code == 401

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -147,7 +147,11 @@ class UserTest < ActiveSupport::TestCase
       exception = proc { raise RestClient::Exception.new(nil, http_code) }
       RestClient::Request.stub :execute, exception do
         user_status = @user.check_terra_tos_status
-        assert user_status[:must_accept]
+        if http_code == 401
+          assert user_status[:must_accept]
+        else
+          assert_not user_status[:must_accept]
+        end
         assert_equal http_code, user_status[:http_code]
       end
     end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds better error handling to checking an authenticated user's terms of service status in Terra.  Previously, any non-200 response from the `/register` [endpoint on orchestration](https://api.firecloud.org/#/Profile/getUserStatus) would cause SCP to thing the user needs to accept updated terms.  However, we have seen numerous instances of `503` responses, which do not contain any relevant information at all.  This causes SCP to redirect to a page containing erroneous information for the user, and is highly disruptive.

The new method `User#check_terra_tos_status` now handles the logic of checking this, and will now also emit the original HTTP status code as well.  This allows us better control over corner cases, as only a `200` response with `tosAccepted: false` or a `401` actually mean the user needs to accept updated terms (though in the latter case, the `/register` endpoint should not respond `401` according to the Swagger documentation, but as other API endpoints will, this is a reasonable guard clause).  `User#must_accept_terra_tos?` is preserved as a passthru calling the aforementioned method and only checking the `must_accept` value.

In addition, `FireCloudClient#process_firecloud_request` has been updated to emit the original `RestClient::Exception` error instead of reclassifying it as a `RuntimeError`.  This was necessary to preserve HTTP status codes.

#### MANUAL TESTING
To test normal usage:
1. Boot as normal and sign in with your account
2. Log in and confirm you are not redirected to the Terra ToS page, navigating around to various pages to confirm no redirect happens later
3. In a terminal window, get the password for the `single.cell.user1@gmail.com` account:
```
vault read secret/kdux/scp/development/$(whoami)/scp_config.json | grep TEST_USER_PASSWORD | awk '{ print $2 }'
```
4. Log out and log in with this account (note: you will have to accept the SCP terms of service if you've never used this account locally)
5. Once complete, load the home page and confirm you are redirected to the Terra ToS page
6. Navigate to the "My Profile" page (from the top right menu) and confirm you eventually get redirected back to the Terra ToS page

To test other states:
1. Log out and sign back in with your normal account
2. In `app/models/user.rb`, insert the following at line 387
```
raise RestClient::Exception.new(nil, 401)
```
3. Load the home page and confirm you are eventually redirected to the Terra ToS page
4. Back in `user.rb`, change the `401` to `404`
5. Load the home page again and confirm you do not get redirected
7. Try the same with `503` and any other valid HTTP status code to confirm you do not get redirected