### PR TITLE
Ensure proper cleanup of `DataArray` entries on file deletion (SCP-5158)

### DIFF
--- a/test/models/delete_queue_job_test.rb
+++ b/test/models/delete_queue_job_test.rb
@@ -218,6 +218,7 @@ class DeleteQueueJobTest < ActiveSupport::TestCase
       linear_data_id: @basic_study.id, linear_data_type: 'Study', values: %w[A B C D], cluster_name: 'metadata.txt'
     )
     assert DataArray.where(study_id: @basic_study.id, name: 'All Cells').exists?
+    study_file.delete
     metadata_file = FactoryBot.create(
       :metadata_file, study: @basic_study, use_metadata_convention: false, name: 'new_metadata.txt'
     )

--- a/test/models/delete_queue_job_test.rb
+++ b/test/models/delete_queue_job_test.rb
@@ -210,10 +210,10 @@ class DeleteQueueJobTest < ActiveSupport::TestCase
     end
   end
 
-  test 'ensure all metadata cell arrays are deleted on file deletion' do
+  test 'ensure all orphaned arrays are removed on file deletion' do
     # create orphaned data array, but needs actual study file to save
     study_file = FactoryBot.create(:study_file, study: @basic_study, file_type: 'Other', name: 'test.txt')
-    array = DataArray.create!(
+    DataArray.create!(
       study: @basic_study, study_file_id: study_file.id, name: 'All Cells', array_type: 'cells', array_index: 0,
       linear_data_id: @basic_study.id, linear_data_type: 'Study', values: %w[A B C D], cluster_name: 'metadata.txt'
     )


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds a secondary check on all file deletions to remove any `DataArray` documents that have been "orphaned" (defined as a document where the `study_file_id` no longer exists in the portal).  While the incidence of these are rare, and the direct cause is not completely understood, these documents can sometimes permanently block new ingests of the same file type, particularly in the case of metadata files.  The only indication that this is happening will be an ingest error with the message `batch ops error` and a code of `E11000` from MongoDB (unique index constraint violation).  The user is completely blocked in this case, unless they chose to create a completely new study.  Otherwise, it requires direct database intervention by an admin to fix.

Now, whenever a file is deleted in SCP, part of the `DeleteQueueJob` will be to check that study for any orphaned arrays and to delete them if found.  These queries will run in the background and complete very quickly, so load on the application is minimal.  In most cases, they will exit immediately.  A quick check on production found 110,663 orphaned arrays (out of almost 57M total documents, or less than 0.2% - details on the query are in the Jira ticket).  As of now, these documents are not causing any direct issues, and in the future if the study owner deletes any files (or has an ingest failure) they will automatically clean up.  This removes the need for a larger data migration, and will prevent the issue from getting larger moving forward.

#### MANUAL TESTING
1. Boot as normal (including DelayedJob workers) and sign in
2. Create a new study, and upload the metadata file at `test/test_data/alexandria_convention/metadata.v2-0-0.txt`
3. Once completed, open a Rails console session in a separate terminal window and manually delete the file and any `CellMetadatum` entries, but leave the `DataArray` documents in place (this simulates the error found by [this user](https://broadinstitute.zendesk.com/agent/tickets/310001)):
```
study = Study.last
study.metadata_file.delete
study.cell_metadata.delete_all
DataArray.where(study_id: study.id).exists?
=> true
```
4. Back in the upload wizard, refresh the page and re-upload the same file
5. Once the ingest fails with the `batch ops error`, wait ~30s for the `DeleteQueueJob` to run
6. In the Rails console, confirm that all `DataArray` documents from the prior upload have been removed:
```
DataArray.where(study_id: study.id).exists?
=> false
```