### PR TITLE
Add ability to specify non-attribute methods for Parameterizable instances (SCP-5160)

### DIFF
--- a/app/models/concerns/parameterizable.rb
+++ b/app/models/concerns/parameterizable.rb
@@ -39,7 +39,8 @@ module Parameterizable
 
   # hash of instance variable names/values
   def attributes
-    self.class::PARAM_DEFAULTS.keys.index_with { |attr| send(attr) }.with_indifferent_access
+    restricted = defined?(self.class::NON_ATTRIBUTE_PARAMS) ? self.class::NON_ATTRIBUTE_PARAMS : []
+    (self.class::PARAM_DEFAULTS.keys - restricted).index_with { |attr| send(attr) }.with_indifferent_access
   end
 
   # return array of all initialized attributes as CLI arguments, e.g. annotation_name => --annotation-name

--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -30,6 +30,9 @@ class DifferentialExpressionParameters
     machine_type: 'n1-highmem-8'
   }.freeze
 
+  # values that are available as methods but not as attributes (and not passed to command line)
+  NON_ATTRIBUTE_PARAMS = %i[machine_type].freeze
+
   attr_accessor(*PARAM_DEFAULTS.keys)
 
   validates :annotation_name, :annotation_scope, :annotation_file, :cluster_file,

--- a/test/models/differential_expression_parameters_test.rb
+++ b/test/models/differential_expression_parameters_test.rb
@@ -76,4 +76,9 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
     params = DifferentialExpressionParameters.new
     assert_equal 'n1-highmem-8', params.machine_type
   end
+
+  test 'should remove non-attribute values from attribute hash' do
+    dense_params = DifferentialExpressionParameters.new(@dense_options)
+    assert_not_includes :machine_type, dense_params.attributes
+  end
 end

--- a/test/models/differential_expression_parameters_test.rb
+++ b/test/models/differential_expression_parameters_test.rb
@@ -79,6 +79,6 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
 
   test 'should remove non-attribute values from attribute hash' do
     dense_params = DifferentialExpressionParameters.new(@dense_options)
-    assert_not_includes :machine_type, dense_params.attributes
+    assert_not_includes dense_params.attributes, :machine_type
   end
 end


### PR DESCRIPTION
#### BACKGOUND & CHANGES
This fixes a regression with the `Parameterizable` module where some attributes that weren't previously passed as command line arguments were now being included.  Now, any class that implements this module can declare `NON_ATTRIBUTE_PARAMS` that will be available as instance methods w/ getters & setters, but are not passed as attributes to the command line.  This specifically addresses the issue with `--machine-type` being passed for automated differential expression ingest jobs.

#### MANUAL TESTING
1. Open a Rails console session
2. Create a `DifferentialExpressionParameters` object:
```
params = DifferentialExpressionParameters.new
```
3. Confirm that `machine_type` is not in the `attributes` hash, but can be called and set manually:
```
params.attributes
=> 
{"annotation_name"=>nil,                                
 "annotation_type"=>"group",                            
 "annotation_scope"=>nil,                               
 "annotation_file"=>nil,                                
 "cluster_file"=>nil,                                   
 "cluster_name"=>nil,                                   
 "matrix_file_path"=>nil,                               
 "matrix_file_type"=>nil,                               
 "gene_file"=>nil,                                      
 "barcode_file"=>nil} 

params.attributes.include? :machine_type
=> false

params.machine_type
=> "n1-highmem-8"

params.machine_type = 'n1-highmem-32'
=> "n1-highmem-32"

irb(main):007:0> params.machine_type
=> "n1-highmem-32"
```