### PR TITLE
Making the options panel more salient (SCP-5055, SCP-5056, SCP-5057, SCP-5058)

### DIFF
--- a/app/javascript/components/explore/DifferentialExpressionModal.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionModal.jsx
@@ -24,7 +24,7 @@ export default function DifferentialExpressionModal() {
       onClick={() => setShowDeModal(true)}
       data-analytics-name="differential-expression-info"
       data-toggle="tooltip"
-      data-original-title="Learn about differential expression in SCP"
+      data-original-title="Click to learn about differential expression in SCP"
       className="de-info-help-icon"
     >
       <FontAwesomeIcon className="action help-icon" icon={faInfoCircle} />

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -333,6 +333,7 @@ export default function ExploreDisplayTabs({
   function getPanelWidths() {
     let main
     let side
+    const isSelectingDE = showDifferentialExpressionPanel || showUpstreamDifferentialExpressionPanel
     if (showViewOptionsControls) {
       if (showDifferentialExpressionTable) {
         // DE table is shown.  Least horizontal space for plots.
@@ -342,7 +343,7 @@ export default function ExploreDisplayTabs({
         // Default state, when side panel is "Options" and not collapsed
         main = 'col-md-10'
         // only set options-bg if we're outside the DE UX
-        side = showDifferentialExpressionPanel ? 'col-md-2' : 'col-md-2 options-bg'
+        side = isSelectingDE ? 'col-md-2' : 'col-md-2 options-bg'
       }
     } else {
       // When options panel is collapsed.  Maximize horizontal space for plots.

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import _clone from 'lodash/clone'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faLink, faArrowLeft, faCog, faTimes, faUndo } from '@fortawesome/free-solid-svg-icons'
+import { faLink, faArrowLeft, faEye, faTimes, faUndo } from '@fortawesome/free-solid-svg-icons'
 
 import StudyGeneField from './StudyGeneField'
 import ClusterSelector from '~/components/visualization/controls/ClusterSelector'
@@ -354,6 +354,8 @@ export default function ExploreDisplayTabs({
   // Determine if the flag show_explore_tab_ux_updates is toggled to show explore tab UX updates
   const isNewExploreUX = getFeatureFlagsWithDefaults()?.show_explore_tab_ux_updates
 
+  const optionsLabel = <span className="options-label">OPTIONS</span>
+
   return (
     <>
       <div className="row">
@@ -435,7 +437,7 @@ export default function ExploreDisplayTabs({
               <button className="action view-options-toggle view-options-toggle-on"
                 onClick={toggleViewOptions}
                 data-analytics-name="view-options-show">
-                OPTIONS <FontAwesomeIcon className="fa-lg" icon={faCog}/>
+                {optionsLabel} <FontAwesomeIcon className="fa-lg" icon={faEye}/>
               </button>
             }
             { enabledTabs.includes('annotatedScatter') &&
@@ -573,7 +575,7 @@ export default function ExploreDisplayTabs({
           <div className="view-options-toggle">
             {!showDifferentialExpressionPanel && !showUpstreamDifferentialExpressionPanel &&
               <>
-                <FontAwesomeIcon className="fa-lg" icon={faCog}/> OPTIONS
+                <FontAwesomeIcon className="fa-lg" icon={faEye}/> {optionsLabel}
                 <button className="action"
                   onClick={toggleViewOptions}
                   title="Hide options"
@@ -680,7 +682,7 @@ export default function ExploreDisplayTabs({
               exploreParams={exploreParamsWithDefaults}
               updateExploreParams={updateExploreParams}
               allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}/>
-            <button className="action"
+            <button className="action right-margin-10"
               onClick={clearExploreParams}
               title="Reset all view options"
               data-analytics-name="explore-view-options-reset">

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -341,7 +341,8 @@ export default function ExploreDisplayTabs({
       } else {
         // Default state, when side panel is "Options" and not collapsed
         main = 'col-md-10'
-        side = 'col-md-2'
+        // only set options-bg if we're outside the DE UX
+        side = showDifferentialExpressionPanel ? 'col-md-2' : 'col-md-2 options-bg'
       }
     } else {
       // When options panel is collapsed.  Maximize horizontal space for plots.
@@ -353,8 +354,6 @@ export default function ExploreDisplayTabs({
 
   // Determine if the flag show_explore_tab_ux_updates is toggled to show explore tab UX updates
   const isNewExploreUX = getFeatureFlagsWithDefaults()?.show_explore_tab_ux_updates
-
-  const optionsLabel = <span className="options-label">OPTIONS</span>
 
   return (
     <>
@@ -434,10 +433,13 @@ export default function ExploreDisplayTabs({
               />
             }
             { !showViewOptionsControls &&
-              <button className="action view-options-toggle view-options-toggle-on"
+              <button className={showDifferentialExpressionPanel ?
+                "action view-options-toggle view-options-toggle-on" :
+                "action minified-options view-options-toggle view-options-toggle-on"
+              }
                 onClick={toggleViewOptions}
                 data-analytics-name="view-options-show">
-                {optionsLabel} <FontAwesomeIcon className="fa-lg" icon={faEye}/>
+                <FontAwesomeIcon className="fa-lg" icon={faEye}/>
               </button>
             }
             { enabledTabs.includes('annotatedScatter') &&
@@ -575,8 +577,8 @@ export default function ExploreDisplayTabs({
           <div className="view-options-toggle">
             {!showDifferentialExpressionPanel && !showUpstreamDifferentialExpressionPanel &&
               <>
-                <FontAwesomeIcon className="fa-lg" icon={faEye}/> {optionsLabel}
-                <button className="action"
+                <FontAwesomeIcon className="fa-lg" icon={faEye}/> <span className="options-label">OPTIONS</span>
+                <button className={showDifferentialExpressionPanel ? "action" : "action action-with-bg"}
                   onClick={toggleViewOptions}
                   title="Hide options"
                   data-analytics-name="view-options-hide">
@@ -682,14 +684,14 @@ export default function ExploreDisplayTabs({
               exploreParams={exploreParamsWithDefaults}
               updateExploreParams={updateExploreParams}
               allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}/>
-            <button className="action right-margin-10"
+            <button className="action action-with-bg right-margin-10"
               onClick={clearExploreParams}
               title="Reset all view options"
               data-analytics-name="explore-view-options-reset">
               <FontAwesomeIcon icon={faUndo}/> Reset view
             </button>
             <button onClick={() => copyLink(routerLocation)}
-              className="action"
+              className="action action-with-bg"
               data-toggle="tooltip"
               title="Copy a link to this visualization to the clipboard">
               <FontAwesomeIcon icon={faLink}/> Get link

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -385,7 +385,7 @@ export default function ExploreDisplayTabs({
             { !showViewOptionsControls &&
               <button className={showDifferentialExpressionPanel ?
                 "action view-options-toggle view-options-toggle-on" :
-                "action minified-options view-options-toggle view-options-toggle-on"
+                "action view-options-toggle view-options-toggle-on minified-options"
               }
                 onClick={toggleViewOptions}
                 data-analytics-name="view-options-show">
@@ -530,8 +530,8 @@ export default function ExploreDisplayTabs({
             {!showDifferentialExpressionPanel && !showUpstreamDifferentialExpressionPanel &&
               <>
                 <FontAwesomeIcon className="fa-lg" icon={faEye}/> <span className="options-label">OPTIONS</span>
-                <button className={showDifferentialExpressionPanel ? "action" : "action action-with-bg"}
-                  onClick={toggleViewOptions}
+                <button className={`action ${showDifferentialExpressionPanel ? '' : 'action-with-bg'}`}
+                        onClick={toggleViewOptions}
                   title="Hide options"
                   data-analytics-name="view-options-hide">
                   <FontAwesomeIcon className="fa-lg" icon={faTimes}/>
@@ -636,7 +636,7 @@ export default function ExploreDisplayTabs({
               exploreParams={exploreParamsWithDefaults}
               updateExploreParams={updateExploreParams}
               allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}/>
-            <button className="action action-with-bg right-margin-10"
+            <button className="action action-with-bg margin-extra-right"
               onClick={clearExploreParams}
               title="Reset all view options"
               data-analytics-name="explore-view-options-reset">

--- a/app/javascript/components/visualization/controls/AnnotationSelector.jsx
+++ b/app/javascript/components/visualization/controls/AnnotationSelector.jsx
@@ -59,7 +59,7 @@ export default function AnnotationControl({
       <label className="labeled-select">Annotation&nbsp;
         <a className="action help-icon"
            data-toggle="tooltip"
-           data-original-title="Use this menu to specify how the data are grouped or colored">
+           data-original-title="Select how cells are colored">
           <FontAwesomeIcon icon={faInfoCircle}/>
         </a>
         {hasSelection &&

--- a/app/javascript/components/visualization/controls/AnnotationSelector.jsx
+++ b/app/javascript/components/visualization/controls/AnnotationSelector.jsx
@@ -2,6 +2,9 @@ import React from 'react'
 
 import Select from '~/lib/InstrumentedSelect'
 import { annotationKeyProperties, clusterSelectStyle } from '~/lib/cluster-utils'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faInfoCircle, faLink } from '@fortawesome/free-solid-svg-icons'
+import { OverlayTrigger, Popover } from 'react-bootstrap'
 
 /** takes the server response and returns annotation options suitable for react-select */
 function getAnnotationOptions(annotationList, clusterName) {
@@ -53,7 +56,12 @@ export default function AnnotationControl({
 
   return (
     <div className="form-group">
-      <label className="labeled-select">Annotation
+      <label className="labeled-select">Annotation&nbsp;
+        <a className="action help-icon"
+           data-toggle="tooltip"
+           data-original-title="Use this menu to specify how the data are grouped or colored">
+          <FontAwesomeIcon icon={faInfoCircle}/>
+        </a>
         {hasSelection &&
           <Select
             options={annotationOptions}

--- a/app/javascript/components/visualization/controls/SubsampleSelector.jsx
+++ b/app/javascript/components/visualization/controls/SubsampleSelector.jsx
@@ -50,7 +50,7 @@ export default function SubsampleSelector({
   return (
     <div className="form-group">
       <label className="labeled-select"> Subsampling&nbsp;
-        <OverlayTrigger trigger="click" rootClose placement="top" overlay={subsamplingPopover}>
+        <OverlayTrigger delayHide={1500} rootClose placement="top" overlay={subsamplingPopover}>
           <FontAwesomeIcon data-analytics-name="subsampling-help-icon"
             className="action log-click help-icon" icon={faInfoCircle}/>
         </OverlayTrigger>

--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -243,6 +243,6 @@
   z-index: 500;
 }
 
-.right-margin-10 {
+.margin-extra-right {
   margin-right: 10px;
 }

--- a/app/javascript/styles/_colors.scss
+++ b/app/javascript/styles/_colors.scss
@@ -9,3 +9,4 @@ $warning-icon-color: #C45500;
 
 $danger-color: rgb(219, 50, 20);
 $success-color: #75b041;
+$options-color: #E5EFF5

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -243,3 +243,15 @@
     border-bottom: 1px solid #ddd;
   }
 }
+
+.options-bg {
+  background-color: #dedede;
+}
+
+.options-label {
+  font-size: 1.2em;
+}
+
+.right-margin-10 {
+  margin-right: 10px;
+}

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -26,6 +26,7 @@
     float: right;
     background: #fff;
     color: #3D5A87;
+    background-color: $options-color;
     margin-top: -0.5rem;
   }
 
@@ -34,6 +35,7 @@
     float: right;
     background: #fff;
     color: #3D5A87;
+    background-color: $options-color;
     margin-top: -2.5rem;
   }
 
@@ -70,7 +72,8 @@
 
 .explore-tab-content {
   background: #fff;
-  flex-grow: 1;
+  display: flex;
+  flex-wrap: wrap;
   z-index: 0;
 
   button.action {
@@ -244,14 +247,23 @@
   }
 }
 
-.options-bg {
-  background-color: #dedede;
-}
-
 .options-label {
   font-size: 1.2em;
 }
 
 .right-margin-10 {
   margin-right: 10px;
+}
+
+.options-bg {
+  background: $options-color;
+  border-bottom: 1px solid #ccc;
+}
+
+.action-with-bg {
+  background: $options-color !important;
+}
+
+.minified-options {
+  background: #fff;
 }

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -251,7 +251,7 @@
   font-size: 1.2em;
 }
 
-.right-margin-10 {
+.margin-extra-right {
   margin-right: 10px;
 }
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update makes the view options panel in the Explore tab more noticeable.  These changes include:

- Making the background color slightly darker
- Making the work "OPTIONS" slightly larger
- Adding a tooltip explanation for the "Annotations" select
- Replacing the gear cog icon with an eye 

Demo of all changes:

https://github.com/broadinstitute/single_cell_portal_core/assets/729968/e49acdc1-ddd5-4ad0-8910-0bf7512afa1f

These only apply to the normal options panel view.  When a user is interacting with differential expression results, the UX is unchanged.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Load any study with visualizations and differential expression results (like `Human milk - differential expression`)
3. Confirm the options panel behaves as shown in the video
4. Click the Differential Expression button and confirm that the background goes back to white, and returns to light blue when closed