### PR TITLE
Temporary patch to lower number of MAX_RESULTS in Azul queries (SCP-5161)

### DIFF
--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -15,7 +15,7 @@ class HcaAzulClient
   MANIFEST_FORMATS = %w[compact full terra.bdbag terra.pfb curl].freeze
 
   # maximum number of results to return
-  MAX_RESULTS = 200
+  MAX_RESULTS = 100
 
   # maximum length of query string (in characters) for requests
   MAX_QUERY_LENGTH = 8192


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes both the broken test `HcaAzulClientTest#test_should_get_all_projects_without_error` and normal faceted search queries for `species: Homo sapiens`.  The problem is asking Azul for more results than it can respond with before their load balancer responds `502`.  A more holistic solution has been proposed in SCP-5159, but before that can be prioritized, this will temporarily solve both problems.

#### MANUAL TESTING
1. Boot as normal and run a search for `species: Homo sapiens`
2. Confirm you see the HCA project `Human cerebral organoids recapitulate gene expression programs of fetal neocortex development` in the first page of results