### PR TITLE
Fix inaccessible dot plot options (SCP-5162)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -334,9 +334,8 @@ export default function ExploreDisplayTabs({
 
   return (
     <>
-
       {/* Render top content for Explore view, i.e. gene search box and plot tabs */}
-      <div className="row">
+      <div className="row bring-element-forward">
         <div className="col-md-5">
           <div className="flexbox">
             <StudyGeneField genes={exploreParams.genes}

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -335,7 +335,7 @@ export default function ExploreDisplayTabs({
   return (
     <>
       {/* Render top content for Explore view, i.e. gene search box and plot tabs */}
-      <div className="row bring-element-forward">
+      <div className="row position-forward">
         <div className="col-md-5">
           <div className="flexbox">
             <StudyGeneField genes={exploreParams.genes}

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -71,7 +71,6 @@
 .explore-tab-content {
   background: #fff;
   flex-grow: 1;
-  z-index: 0;
 
   button.action {
     background: #fff;
@@ -242,4 +241,8 @@
     color: #999999;
     border-bottom: 1px solid #ddd;
   }
+}
+
+.bring-element-forward {
+  z-index: 1;
 }

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -243,6 +243,7 @@
   }
 }
 
-.bring-element-forward {
-  z-index: 1;
+// to position content in the explore tab forward
+.position-forward {
+  z-index: 3;
 }


### PR DESCRIPTION
This [bug-fix ](https://github.com/broadinstitute/single_cell_portal_core/pull/1779) attempted to fix the issue of the explore-tab morpheus graph content and gene search select overlapping incorrectly by sending the graph content back, however testing for this only included making sure the graph content stayed behind the gene search. However, a user discovered that this approach breaks the filter modal for dotplots as the modal becomes in-accessible as it's now behind other elements that it should not be.

This PR now tries to fix both those issues by bringing the gene search row forward and leaving the graph content ordering alone. This way the gene search stays on top but the natural ordering for the content in the explore tab works as it always has.


https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/443ecb22-08db-4742-856b-15319757e2e8


To test:
- Pull this branch and start up a local server
- Go to any study with visualizable graphs with at least 3 genes
- Search genes in the explore tab and note that the auto-suggest select remains on top of the graph content
- After searching click the filter button and observe that the modal for filtering is clickable and usable
