### PR TITLE
Raise number of study gene search autocomplete results to 50 (SCP-4979)

### DIFF
--- a/app/javascript/lib/search-utils.js
+++ b/app/javascript/lib/search-utils.js
@@ -12,7 +12,7 @@ export const NUM_SUGGESTIONS = 50
  * @param {Array<String>} targets List of strings to match against
  * @param {Integer} numSuggestions Number of suggestions to show
  */
-export function getAutocompleteSuggestions(inputText, targets, numSuggestions= NUM_SUGGESTIONS) {
+export function getAutocompleteSuggestions(inputText, targets, numSuggestions=NUM_SUGGESTIONS) {
   // Autocomplete when user starts typing
   if (!targets?.length || !inputText) {
     return []

--- a/app/javascript/lib/search-utils.js
+++ b/app/javascript/lib/search-utils.js
@@ -1,5 +1,8 @@
 import stringSimilarity from 'string-similarity'
 
+// max number of autocomplete suggestions
+export const NUM_SUGGESTIONS = 50
+
 /**
  * Get list of autocomplete suggestions, based on input text
  *
@@ -9,7 +12,7 @@ import stringSimilarity from 'string-similarity'
  * @param {Array<String>} targets List of strings to match against
  * @param {Integer} numSuggestions Number of suggestions to show
  */
-export function getAutocompleteSuggestions(inputText, targets, numSuggestions=8) {
+export function getAutocompleteSuggestions(inputText, targets, numSuggestions= NUM_SUGGESTIONS) {
   // Autocomplete when user starts typing
   if (!targets?.length || !inputText) {
     return []

--- a/test/js/lib/search-utils.test.js
+++ b/test/js/lib/search-utils.test.js
@@ -1,4 +1,4 @@
-import { getAutocompleteSuggestions } from 'lib/search-utils'
+import { getAutocompleteSuggestions, NUM_SUGGESTIONS } from 'lib/search-utils'
 
 const targets = [
   'Tns1', 'Pik3ca', 'Pik3cd', 'Hvcn1', 'Tpte',
@@ -20,7 +20,7 @@ describe('Search utilties', () => {
     const suggestions = getAutocompleteSuggestions(inputGene, targets)
 
     expect(suggestions[0]).toEqual('PTEN')
-    expect(suggestions).toHaveLength(8)
+    expect(suggestions).toHaveLength(NUM_SUGGESTIONS)
   })
 
   it('suggests close inexact match first', async () => {


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update raises the number of autocomplete suggestions from 8 to 50 for study-based gene searches.  This is in response to a user request to address a case where the study had custom gene scores with composite names that contained similar prefixes, like `.m.C1_sick.[gene]`.  Only showing 8 suggestions made it harder to discover these scores, whereas 50 will allow for greater flexibility.  These results scroll automatically in the suggestions div, so no additional UI changes are necessary.

#### MANUAL TESTING
1. Boot as normal and load any synthetic study with many genes, such as `Human all genes`
2. In the gene search field, enter `pt` and confirm you see a scrolling div of suggestions like below:
![autocomplete](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/b88a74a5-cbff-4368-ba84-1f979e901b3d)

