### PR TITLE
Restore dot plot filtering availability in Explore tab (SCP-5175)

### DIFF
--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -74,7 +74,6 @@
   background: #fff;
   display: flex;
   flex-wrap: wrap;
-  z-index: 0;
 
   button.action {
     background: #fff;


### PR DESCRIPTION
In our latest release the morpheus filtering modal got obstructed again.

https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/f6cc5a47-0ddf-47a1-acd7-08d24e716321

This PR fixes this issue (extended video to demonstrate that removing the z-index has no appreciable impact on the availability of the explore-tab-content)

https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/b0af25d5-1d5c-4c56-91a0-f68c863b9b1f

To test:

Pull this branch and start up a local server
Go to any study with visualizable graphs with at least 3 genes
Search genes in the explore tab and note that the auto-suggest select remains on top of the graph content
After searching click the filter button and observe that the modal for filtering is clickable and usable
