### PR TITLE
Add missing updateExploreParams for correlation scatter plots (SCP-4453)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -408,6 +408,7 @@ export default function ExploreDisplayTabs({
                   plotPointsSelected={plotPointsSelected}
                   countsByLabel={countsByLabel}
                   setCountsByLabel={setCountsByLabel}
+                  updateExploreParams={updateExploreParams}
                 />
               </div>
             }
@@ -425,6 +426,7 @@ export default function ExploreDisplayTabs({
                   plotPointsSelected={plotPointsSelected}
                   countsByLabel={countsByLabel}
                   setCountsByLabel={setCountsByLabel}
+                  updateExploreParams={updateExploreParams}
                 />
               </div>
             }


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update restores the legend toggle feature for gene expression correlation plots.  This allows users to show/hide groups in scatter plots and to also persist this setting across visualizations via the `hiddenTraces` query string parameter.  This feature broke in correlation plots only as a side effect of #1518.

#### MANUAL TESTING
1. Boot as normal and load any study with clustering & expression data
2. Run a search for two genes
3. Confirm you can toggle any trace and that the URL updates accordingly when clicked
4. Confirm other non-correlation scatter plot legends (0-1 genes) work as normal