### PR TITLE
Retiring `show_explore_tab_ux_updates` feature flag (SCP-5144)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -331,9 +331,6 @@ export default function ExploreDisplayTabs({
     return { main, side }
   }
 
-  // Determine if the flag show_explore_tab_ux_updates is toggled to show explore tab UX updates
-  const isNewExploreUX = getFeatureFlagsWithDefaults()?.show_explore_tab_ux_updates
-
   return (
     <>
       {/* Render top content for Explore view, i.e. gene search box and plot tabs */}
@@ -364,7 +361,6 @@ export default function ExploreDisplayTabs({
           enabledTabs={enabledTabs}
           disabledTabs={disabledTabs}
           updateExploreParams={updateExploreParams}
-          isNewExploreUX={isNewExploreUX}
         />
       </div>
 

--- a/app/javascript/components/explore/PlotTabs.jsx
+++ b/app/javascript/components/explore/PlotTabs.jsx
@@ -29,13 +29,12 @@ const disabledTooltips = {
  * Responsible for shows tabs available for a given view of the study
 */
 export default function PlotTabs({
-  shownTab, enabledTabs, disabledTabs, updateExploreParams,
-  isNewExploreUX
+  shownTab, enabledTabs, disabledTabs, updateExploreParams
 }) {
   return (
-    <div className={isNewExploreUX ? '' : 'col-md-4 col-md-offset-1'}>
+    <div>
       <ul
-        className={isNewExploreUX ? 'nav nav-tabs study-plot-tabs' : 'nav nav-tabs'}
+        className='nav nav-tabs study-plot-tabs'
         role="tablist"
         data-analytics-name="explore-tab"
       >
@@ -50,8 +49,7 @@ export default function PlotTabs({
             </li>
           )
         })}
-        {isNewExploreUX &&
-          disabledTabs.map(tabKey => {
+        { disabledTabs.map(tabKey => {
             const label = tabList.find(({ key }) => key === tabKey).label
             const tooltip = disabledTooltips[tabKey]
             const numGenes = tooltip.numToSearch

--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -41,9 +41,6 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
   const [notPresentGenes, setNotPresentGenes] = useState(new Set([]))
   const [showNotPresentGeneChoice, setShowNotPresentGeneChoice] = useState(false)
 
-  // Determine if the flag show_explore_tab_ux_updates is toggled to show explore tab UX updates
-  const isNewExploreUX = getFeatureFlagsWithDefaults()?.show_explore_tab_ux_updates
-
   /** Handles a user submitting a gene search */
   function handleSearch(event) {
     event.preventDefault()
@@ -129,14 +126,13 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
     }
   }, [genes.join(',')])
 
-  if (isNewExploreUX) {
-    useEffect(() => {
-      if (genes.join(',') !== geneArray.map(opt => opt.label).join(',')) {
-        const selectEvent = new Event('change:multiselect')
-        handleSearch(selectEvent)
-      }
-    }, [geneArray])
-  }
+
+  useEffect(() => {
+    if (genes.join(',') !== geneArray.map(opt => opt.label).join(',')) {
+      const selectEvent = new Event('change:multiselect')
+      handleSearch(selectEvent)
+    }
+  }, [geneArray])
 
   const searchDisabled = !isLoading && !allGenes?.length
 

--- a/db/migrate/20230622173344_retire_show_explore_tab_ux_updates_feature_flag.rb
+++ b/db/migrate/20230622173344_retire_show_explore_tab_ux_updates_feature_flag.rb
@@ -1,0 +1,11 @@
+class RetireShowExploreTabUxUpdatesFeatureFlag < Mongoid::Migration
+  def self.up
+    FeatureFlag.retire_feature_flag('show_explore_tab_ux_updates')
+  end
+
+  def self.down
+    FeatureFlag.create!(name: 'show_explore_tab_ux_updates',
+                        default_value: false,
+                        description: 'show the "Update the Explore Tab" epic changes')
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2061,11 +2061,6 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
-"@rushstack/eslint-patch@^1.1.0":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz#0c8b74c50f29ee44f423f7416829c0bf8bb5eb27"
-  integrity sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==
-
 "@sentry-internal/tracing@7.55.2":
   version "7.55.2"
   resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.55.2.tgz#29687b8327cc9d980695603d451316706f2630ed"


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This udpate retires the `show_explore_tab_ux_updates` feature flag, removing all references in the code and deleting the flag entry from the database.

#### MANUAL TESTING
1. Pull branch and run migrations:
```
./rails_local_setup.rb && source config/secrets/.source_env.bash && bin/rails db:migrate
```
2. Boot as normal and load any study with visualizations
3. Confirm that the new UX is loaded with all visualization tabs displayed, and gene searches submit automatically once selected
4. Sign in and go to the "Feature Flags" admin page
5. Confirm `show_explore_tab_ux_updates` is no longer listed