### PR TITLE
Update to Ingest Pipeline 1.27.2, for author DE fix

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.27.1'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.27.2'
 
     # Docker image for image pipeline jobs
     config.image_pipeline_docker_image = 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_c2b090043'


### PR DESCRIPTION
This fixes sorting in pairwise output filenames for author DE, via [Ingest Pipeline 1.27.2](https://github.com/broadinstitute/scp-ingest-pipeline/pull/315), resolving a bug described in #1814.