### PR TITLE
Prevent reading AnnData files in CSFV (SCP-5217)

### DIFF
--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -2,7 +2,10 @@ import _get from 'lodash/get'
 import React from 'react'
 
 export const PARSEABLE_TYPES = ['Cluster', 'Coordinate Labels', 'Expression Matrix', 'MM Coordinate Matrix',
-  '10X Genes File', '10X Barcodes File', 'Gene List', 'Metadata', 'Analysis Output']
+  '10X Genes File', '10X Barcodes File', 'Gene List', 'Metadata', 'Analysis Output', 'AnnData']
+// file types to ignore in CSFV context (still validated server-side)
+const UNVALIDATED_TYPES = ['AnnData']
+export const CSFV_VALIDATED_TYPES = PARSEABLE_TYPES.filter(ft => !UNVALIDATED_TYPES.includes(ft))
 
 const EXPRESSION_INFO_TYPES = ['Expression Matrix', 'MM Coordinate Matrix']
 

--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -4,7 +4,7 @@ import React from 'react'
 export const PARSEABLE_TYPES = ['Cluster', 'Coordinate Labels', 'Expression Matrix', 'MM Coordinate Matrix',
   '10X Genes File', '10X Barcodes File', 'Gene List', 'Metadata', 'Analysis Output', 'AnnData']
 // file types to ignore in CSFV context (still validated server-side)
-const UNVALIDATED_TYPES = ['AnnData']
+export const UNVALIDATED_TYPES = ['AnnData']
 export const CSFV_VALIDATED_TYPES = PARSEABLE_TYPES.filter(ft => !UNVALIDATED_TYPES.includes(ft))
 
 const EXPRESSION_INFO_TYPES = ['Expression Matrix', 'MM Coordinate Matrix']

--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -2,7 +2,7 @@ import _get from 'lodash/get'
 import React from 'react'
 
 export const PARSEABLE_TYPES = ['Cluster', 'Coordinate Labels', 'Expression Matrix', 'MM Coordinate Matrix',
-  '10X Genes File', '10X Barcodes File', 'Gene List', 'Metadata', 'Analysis Output', 'AnnData']
+  '10X Genes File', '10X Barcodes File', 'Gene List', 'Metadata', 'Analysis Output']
 
 const EXPRESSION_INFO_TYPES = ['Expression Matrix', 'MM Coordinate Matrix']
 

--- a/app/javascript/lib/validation/validate-file-content.js
+++ b/app/javascript/lib/validation/validate-file-content.js
@@ -10,7 +10,7 @@
 
 import { readFileBytes, oneMiB } from './io'
 import ChunkedLineReader, { GZIP_MAX_LINES } from './chunked-line-reader'
-import { PARSEABLE_TYPES } from '~/components/upload/upload-utils'
+import { CSFV_VALIDATED_TYPES, UNVALIDATED_TYPES } from '~/components/upload/upload-utils'
 import {
   parseDenseMatrixFile, parseFeaturesFile, parseBarcodesFile, parseSparseMatrixFile
 } from './expression-matrices-validation'
@@ -320,8 +320,8 @@ export async function parseClusterFile(chunker, mimeType) {
  * Throws an exception if the gzip is conflicted, since we don't want to parse further in that case
 */
 export async function validateGzipEncoding(file, fileType) {
-  // do not attempt to read AnnData files as this throws an error and prevents upload/sync
-  if (fileType === 'AnnData') {
+  // skip check on any file type not included in CSFV
+  if (UNVALIDATED_TYPES.includes(fileType)) {
     return false
   }
 
@@ -379,7 +379,7 @@ async function parseFile(file, fileType, fileOptions={}, sizeProps={}) {
     // if the file is compressed or we can't figure out the compression, don't try to parse further
     const isFileFragment = file.size > sizeProps?.fileSizeTotal // likely a partial download from a GCP bucket
     if (
-      !PARSEABLE_TYPES.includes(fileType) ||
+      !CSFV_VALIDATED_TYPES.includes(fileType) ||
       fileInfo.isGzipped && (isFileFragment || file.size >= MAX_GZIP_FILESIZE)
       // current gunzip implementation needs a whole file; see comment for MAX_GZIP_FILESIZE
     ) {

--- a/app/javascript/lib/validation/validate-file-content.js
+++ b/app/javascript/lib/validation/validate-file-content.js
@@ -10,7 +10,7 @@
 
 import { readFileBytes, oneMiB } from './io'
 import ChunkedLineReader, { GZIP_MAX_LINES } from './chunked-line-reader'
-import { PARSEABLE_TYPES, FileTypeExtensions } from '~/components/upload/upload-utils'
+import { PARSEABLE_TYPES } from '~/components/upload/upload-utils'
 import {
   parseDenseMatrixFile, parseFeaturesFile, parseBarcodesFile, parseSparseMatrixFile
 } from './expression-matrices-validation'


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug when attempting to sync an AnnData file as a "reference" file (non-parseable) that prevented the file from saving.  The issue was attempting to determine if the file is gzipped, but being unable to decode the raw file client-side.  Now, this step is skipped and the file is allowed to sync.

Note: we do not support ingesting AnnData files through the sync UI as there are none of the required components.  Users may only parse AnnData files through the "AnnData" upload wizard UX.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Go to the "My Studies" page and click "Details" for any study
3. Click the "View Google bucket" button and then upload the AnnData file at `test/test_data/anndata_test.h5ad`
4. Back in SCP, click "Sync workspace files" for that study
5. Once the sync UI load, find the form for `anndata_test.h5ad` and select `AnnData` as the file type
6. Confirm no error is shown and that you can sync the file
7. In `development.log`, confirm an ingest job is launched but no `--extract` parameter has been set (this will simply validate the file can be opened and will not ingest any data)
```
Request object sent to Google Life Sciences API, excluding 'environment' parameters:
---
:actions:
  :commands:
  - python
  - ingest_pipeline.py
  - "--study-id"
  - 63bdbf486cb53400554c7323
  - "--study-file-id"
  - 64ac2b7202c25b2bcce7f578
  - "--user-metrics-uuid"
  - 0fc4d8e5-6c4c-422e-94a3-c78801757202
  - ingest_anndata
  - "--ingest-anndata"
  - "--anndata-file"
  - gs://fc-f5fd5b66-3ea7-47c6-a0e5-fd257c6565e0/anndata_test.h5ad
  :image_uri: gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.27.2

```