### PR TITLE
Preserving all test logs (SCP-5028)

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -62,6 +62,7 @@ jobs:
                                   -n single-cell-portal-test
       - name: Preserve all test logs
         uses: actions/upload-artifact@v3
+        if: failure() # only save logs if CI run fails
         with:
           name: test-logs
           path: |

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -60,3 +60,10 @@ jobs:
                                   -r secret/kdux/scp/staging/read_only_service_account.json \
                                   -e test -v $DOCKER_IMAGE_TAG \
                                   -n single-cell-portal-test
+      - name: Preserve all test logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-logs
+          path: |
+            log/test.log
+            log/delayed_job.test.log

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -62,7 +62,6 @@ jobs:
                                   -n single-cell-portal-test
       - name: Preserve all test logs
         uses: actions/upload-artifact@v3
-        if: failure() # only save logs if CI run fails
         with:
           name: test-logs
           path: |

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -14,7 +14,7 @@ class IngestJob
 
   # valid ingest actions to perform
   VALID_ACTIONS = %i[
-    ingest_expression ingest_cluster ingest_cell_metadata ingest_anndata ingest_differential_expression subsample
+    ingest_expression ingest_cluster ingest_cell_metadata ingest_anndata ingest_differential_expression ingest_subsample
     differential_expression render_expression_arrays
   ].freeze
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,13 +76,6 @@ Rails.application.configure do
   Mongoid.logger.level = Logger::INFO
   Google::Apis.logger.level = Logger::INFO
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present? && ENV['CI']
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.log_level = :error
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
-
   config.bard_host_url = 'https://terra-bard-dev.appspot.com'
 
   # Terra Data Repo API base url


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update persists all test logfiles along with every CI run as workflow artifacts.  These logs are automatically persisted for up to 90 days, and are available at the bottom of the workflow summary page (under `Artifacts`).

Example:
![workflow_logs](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/c75d6be1-8286-41f2-b8a4-317f44bb79f9)

#### MANUAL TESTING
1. Go to the [workflow summary page](https://github.com/broadinstitute/single_cell_portal_core/actions/runs/5521868919) for the last run in this PR
2. Confirm you can download the log files at the bottom of the page and that both `test.log` and `delayed_job.test.log` are present
