### PR TITLE
Allow ignoring extra gmail periods (SCP-5219)

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -822,13 +822,9 @@ class Study
   # google allows arbitrary periods in email addresses so if the email is a gmail account remove any excess periods
   def remove_gmail_periods(email_address)
     email_address = email_address.downcase
-    if email_address.end_with?('gmail.com')
-      # sub out any periods with blanks, then replace the period for the '.com' at the end of the address
-      email_address = email_address.gsub('.', '').gsub(/com\z/, '.com')
-      return email_address
-    else 
-      return email_address
-    end
+    return email_address unless email_address.end_with?('gmail.com')
+    # sub out any periods with blanks, then replace the period for the '.com' at the end of the address
+    email_address = email_address.gsub('.', '').gsub(/com\z/, '.com')
   end
 
   # check if a given user can view study by share (does not take public into account - use Study.viewable(user) instead)
@@ -837,9 +833,9 @@ class Study
       false
     else
       # use if/elsif with explicit returns to ensure skipping downstream calls
-      if self.study_shares.can_view.map{
-        |email_address| remove_gmail_periods(email_address)
-      }.include?(remove_gmail_periods(user.email))
+      if self.study_shares.can_view.map do |email_address| 
+        remove_gmail_periods(email_address)
+      end.include?(remove_gmail_periods(user.email))
         return true
       elsif self.can_edit?(user)
         return true

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -819,13 +819,27 @@ class Study
     end
   end
 
+  # google allows arbitrary periods in email addresses so if the email is a gmail account remove any excess periods
+  def google_email_period_remover(email_address)
+    email_address = email_address.downcase
+    if email_address.end_with?('gmail.com')
+      # sub out any periods with blanks, then replace the period for the '.com' at the end of the address
+      email_address = email_address.gsub('.','').gsub(/com\z/,'.com')
+      return email_address
+    else 
+      return email_address
+    end
+  end
+
   # check if a given user can view study by share (does not take public into account - use Study.viewable(user) instead)
   def can_view?(user)
     if user.nil?
       false
     else
       # use if/elsif with explicit returns to ensure skipping downstream calls
-      if self.study_shares.can_view.map(&:downcase).include?(user.email.downcase)
+      if self.study_shares.can_view.map{
+        |email_address| google_email_period_remover(email_address)
+      }.include?(google_email_period_remover(user.email))
         return true
       elsif self.can_edit?(user)
         return true

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -820,11 +820,11 @@ class Study
   end
 
   # google allows arbitrary periods in email addresses so if the email is a gmail account remove any excess periods
-  def google_email_period_remover(email_address)
+  def remove_gmail_periods(email_address)
     email_address = email_address.downcase
     if email_address.end_with?('gmail.com')
       # sub out any periods with blanks, then replace the period for the '.com' at the end of the address
-      email_address = email_address.gsub('.','').gsub(/com\z/,'.com')
+      email_address = email_address.gsub('.', '').gsub(/com\z/, '.com')
       return email_address
     else 
       return email_address
@@ -838,8 +838,8 @@ class Study
     else
       # use if/elsif with explicit returns to ensure skipping downstream calls
       if self.study_shares.can_view.map{
-        |email_address| google_email_period_remover(email_address)
-      }.include?(google_email_period_remover(user.email))
+        |email_address| remove_gmail_periods(email_address)
+      }.include?(remove_gmail_periods(user.email))
         return true
       elsif self.can_edit?(user)
         return true


### PR DESCRIPTION
[Google does not care about extraneous periods in an email address](https://support.google.com/mail/answer/7436150?hl=en). However, the Portal does and we had a user write in from a gmail with a bunch of extra periods in it not being able to access a study that had been shared with them because the email added to the study did not match the extra periods. (e.g. in googles world e.mi.l.y@gmail.com is the same as emily@gmail.com)

This update will strip out extraneous periods from a gmail email address before checking if the user 'can_view' a study.

To test:
- Pull this branch and boot up a local server
- Go to a private study you own and share that study with another email address you own that is a gmail account, be sure to throw in lots of random periods before the '@gmail.com'.
- Copy the url to this study explore page
- Now log in to the Portal from that other gmail account 
- paste the url you copied above and you should have access to said study

To see the problem you can do this same exercise on prod but you will not be able to access the study as your 2nd gmail account.

Prod:

https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/e7ede89b-9f4a-43c2-9007-e1dd6e23bb6a


Resolved:

https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/430ae545-7dcc-40c6-ac4f-0c01d96a8277

