### PR TITLE
Adding limited CI job to run against staging Terra orchestration API (SCP-5196)

### DIFF
--- a/.github/actions/docker-build-env-setup/action.yml
+++ b/.github/actions/docker-build-env-setup/action.yml
@@ -1,0 +1,40 @@
+name: 'Docker Build Env Setup'
+description: 'Installs vault and runs docker build during CI, incorporating changes as necessary'
+runs:
+  using: 'composite'
+  steps:
+    - name: Install vault
+      shell: bash
+      run: |
+        sudo apt-get update && sudo apt-get -y install curl unzip jq
+        sudo curl -O https://releases.hashicorp.com/vault/1.9.0/vault_1.9.0_linux_amd64.zip
+        sudo unzip vault_1.9.0_linux_amd64.zip
+        sudo mv vault /usr/local/bin
+    - name: Detect changes to Dockerfile
+      id: changed-dockerfile
+      uses: tj-actions/changed-files@v35.4.4
+      with:
+        files: Dockerfile
+    - name: Rebuild local image if Dockerfile changed
+      shell: bash
+      if: steps.changed-dockerfile.outputs.any_changed == 'true'
+      run: |
+        # the previous step uses the changed-files action to detect if the Dockerfile has any updates
+        # this will require rebuilding the image locally as the downstream "test" image will fail otherwise
+        # see https://github.com/marketplace/actions/changed-files for more info on this action
+        echo "#### CHANGES DETECTED TO DOCKERFILE, REBUILDING IMAGE LOCALLY ####"
+        docker build -t $DOCKER_IMAGE_NAME:development -f Dockerfile .
+    - name: Build test docker image
+      shell: bash
+      run: |
+        # The "broad-singlecellportal-staging" GCR repository is used in production.
+        # The "development" tag is used in non-production deployment.  For production deployment, tag is version number for
+        # upcoming release, e.g. 1.20.0.
+        # More context: https://github.com/broadinstitute/single_cell_portal_core/pull/1552#discussion_r910424433
+        # TODO: (SCP-4496): Move production-related GCR images out of staging project
+        # add ci- prefix to avoid post-merge build failing due to missing GITHUB_HEAD_REF
+        # and strip any slashes from GITHUB_HEAD_REF to avoid 'invalid reference format' error with tag
+        # this will happen on dependabot PRs
+        SAFE_HEAD_REF=$(echo $GITHUB_HEAD_REF | sed -e 's/\//_/g')
+        DOCKER_IMAGE_TAG="ci-$SAFE_HEAD_REF-$GITHUB_SHA"
+        docker build -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG -f test/Dockerfile-test .

--- a/.github/actions/docker-build-env-setup/action.yml
+++ b/.github/actions/docker-build-env-setup/action.yml
@@ -1,7 +1,7 @@
 name: 'Docker Build Env Setup'
 description: 'Installs vault and runs docker build during CI, incorporating changes as necessary'
 outputs:
-  build-test-image:
+  docker-tag:
     description: 'Tag for locally built Docker image'
     value: ${{ steps.build-test-image.outputs.docker-tag }}
 runs:

--- a/.github/actions/docker-build-env-setup/action.yml
+++ b/.github/actions/docker-build-env-setup/action.yml
@@ -1,5 +1,9 @@
 name: 'Docker Build Env Setup'
 description: 'Installs vault and runs docker build during CI, incorporating changes as necessary'
+outputs:
+  build-test-image:
+    description: 'Tag for locally built Docker image'
+    value: ${{ steps.build-test-image.outputs.docker-tag }}
 runs:
   using: 'composite'
   steps:
@@ -25,6 +29,7 @@ runs:
         echo "#### CHANGES DETECTED TO DOCKERFILE, REBUILDING IMAGE LOCALLY ####"
         docker build -t $DOCKER_IMAGE_NAME:development -f Dockerfile .
     - name: Build test docker image
+      id: build-test-image
       shell: bash
       run: |
         # The "broad-singlecellportal-staging" GCR repository is used in production.
@@ -37,4 +42,6 @@ runs:
         # this will happen on dependabot PRs
         SAFE_HEAD_REF=$(echo $GITHUB_HEAD_REF | sed -e 's/\//_/g')
         DOCKER_IMAGE_TAG="ci-$SAFE_HEAD_REF-$GITHUB_SHA"
+        # output Docker tag for use downstream
+        echo "docker-tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
         docker build -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG -f test/Dockerfile-test .

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -15,25 +15,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: Install vault
-        run: |
-          sudo apt-get update && sudo apt-get -y install curl unzip jq
-          sudo curl -O https://releases.hashicorp.com/vault/1.9.0/vault_1.9.0_linux_amd64.zip
-          sudo unzip vault_1.9.0_linux_amd64.zip
-          sudo mv vault /usr/local/bin
-      - name: Detect changes to Dockerfile
-        id: changed-dockerfile
-        uses: tj-actions/changed-files@v35.4.4
-        with:
-          files: Dockerfile
-      - name: Rebuild local image if Dockerfile changed
-        if: steps.changed-dockerfile.outputs.any_changed == 'true'
-        run: |
-          # the previous step uses the changed-files action to detect if the Dockerfile has any updates
-          # this will require rebuilding the image locally as the downstream "test" image will fail otherwise
-          # see https://github.com/marketplace/actions/changed-files for more info on this action
-          echo "#### CHANGES DETECTED TO DOCKERFILE, REBUILDING IMAGE LOCALLY ####"
-          docker build -t $DOCKER_IMAGE_NAME:development -f Dockerfile .
+      - name: Build image and setup env
+        uses: actions/docker-build-env-setup-composite-action@v1
       - name: Load secrets and run tests
         env:
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
@@ -44,17 +27,6 @@ jobs:
           CI: true
         run: |
           export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )
-          # The "broad-singlecellportal-staging" GCR repository is used in production.
-          # The "development" tag is used in non-production deployment.  For production deployment, tag is version number for
-          # upcoming release, e.g. 1.20.0.
-          # More context: https://github.com/broadinstitute/single_cell_portal_core/pull/1552#discussion_r910424433
-          # TODO: (SCP-4496): Move production-related GCR images out of staging project
-          # add ci- prefix to avoid post-merge build failing due to missing GITHUB_HEAD_REF
-          # and strip any slashes from GITHUB_HEAD_REF to avoid 'invalid reference format' error with tag
-          # this will happen on dependabot PRs
-          SAFE_HEAD_REF=$(echo $GITHUB_HEAD_REF | sed -e 's/\//_/g')
-          DOCKER_IMAGE_TAG="ci-$SAFE_HEAD_REF-$GITHUB_SHA"
-          docker build -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG -f test/Dockerfile-test .
           bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json \
                                   -s secret/kdux/scp/staging/scp_service_account.json \
                                   -r secret/kdux/scp/staging/read_only_service_account.json \

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: Build image and setup env
+        id: build-image-setup-env
         uses: ./.github/actions/docker-build-env-setup
       - name: Load secrets and run tests
         env:
@@ -24,6 +25,7 @@ jobs:
           RAILS_LOG_TO_STDOUT: true
           VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
           VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
+          DOCKER_IMAGE_TAG: ${{ steps.build-image-setup-env.outputs.docker-tag }}
           CI: true
         run: |
           export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: Build image and setup env
-        uses: actions/docker-build-env-setup-composite-action@v1
+        uses: ./.github/actions/docker-build-env-setup
       - name: Load secrets and run tests
         env:
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -1,0 +1,69 @@
+name: SCP Continuous Integration
+on:
+  push:
+    branches:
+      - jb-alpha-orch-ci
+      - development
+      - master
+env:
+  DOCKER_IMAGE_NAME: "gcr.io/broad-singlecellportal-staging/single-cell-portal"
+
+jobs:
+  Run-Orch-Smoketest:
+    runs-on: self-hosted
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install vault
+        run: |
+          sudo apt-get update && sudo apt-get -y install curl unzip jq
+          sudo curl -O https://releases.hashicorp.com/vault/1.9.0/vault_1.9.0_linux_amd64.zip
+          sudo unzip vault_1.9.0_linux_amd64.zip
+          sudo mv vault /usr/local/bin
+      - name: Detect changes to Dockerfile
+        id: changed-dockerfile
+        uses: tj-actions/changed-files@v35.4.4
+        with:
+          files: Dockerfile
+      - name: Rebuild local image if Dockerfile changed
+        if: steps.changed-dockerfile.outputs.any_changed == 'true'
+        run: |
+          # the previous step uses the changed-files action to detect if the Dockerfile has any updates
+          # this will require rebuilding the image locally as the downstream "test" image will fail otherwise
+          # see https://github.com/marketplace/actions/changed-files for more info on this action
+          echo "#### CHANGES DETECTED TO DOCKERFILE, REBUILDING IMAGE LOCALLY ####"
+          docker build -t $DOCKER_IMAGE_NAME:development -f Dockerfile .
+      - name: Load secrets and run tests
+        env:
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          RAILS_LOG_TO_STDOUT: true
+          VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+          VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
+          ORCH_SMOKE_TEST: true
+          CI: true
+        run: |
+          export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )
+          # The "broad-singlecellportal-staging" GCR repository is used in production.
+          # The "development" tag is used in non-production deployment.  For production deployment, tag is version number for
+          # upcoming release, e.g. 1.20.0.
+          # More context: https://github.com/broadinstitute/single_cell_portal_core/pull/1552#discussion_r910424433
+          # TODO: (SCP-4496): Move production-related GCR images out of staging project
+          # add ci- prefix to avoid post-merge build failing due to missing GITHUB_HEAD_REF
+          # and strip any slashes from GITHUB_HEAD_REF to avoid 'invalid reference format' error with tag
+          # this will happen on dependabot PRs
+          SAFE_HEAD_REF=$(echo $GITHUB_HEAD_REF | sed -e 's/\//_/g')
+          DOCKER_IMAGE_TAG="ci-$SAFE_HEAD_REF-$GITHUB_SHA"
+          docker build -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG -f test/Dockerfile-test .
+          bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json \
+                                  -s secret/kdux/scp/staging/scp_service_account.json \
+                                  -e test -v $DOCKER_IMAGE_TAG -n single-cell-portal-test \
+                                  -c bin/run_orch_smoke_test.sh
+      - name: Preserve all test logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-logs
+          path: |
+            log/test.log
+            log/delayed_job.test.log

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: Build image and setup env
+        id: build-image-setup-env
         uses: ./.github/actions/docker-build-env-setup
       - name: Load secrets and run tests
         env:
@@ -20,6 +21,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
           VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
+          DOCKER_IMAGE_TAG: ${{ steps.build-image-setup-env.outputs.docker-tag }}
           ORCH_SMOKE_TEST: true
           CI: true
         run: |

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: Build image and setup env
-        uses: actions/docker-build-env-setup-composite-action@v1
+        uses: ./.github/actions/docker-build-env-setup
       - name: Load secrets and run tests
         env:
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -12,25 +12,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: Install vault
-        run: |
-          sudo apt-get update && sudo apt-get -y install curl unzip jq
-          sudo curl -O https://releases.hashicorp.com/vault/1.9.0/vault_1.9.0_linux_amd64.zip
-          sudo unzip vault_1.9.0_linux_amd64.zip
-          sudo mv vault /usr/local/bin
-      - name: Detect changes to Dockerfile
-        id: changed-dockerfile
-        uses: tj-actions/changed-files@v35.4.4
-        with:
-          files: Dockerfile
-      - name: Rebuild local image if Dockerfile changed
-        if: steps.changed-dockerfile.outputs.any_changed == 'true'
-        run: |
-          # the previous step uses the changed-files action to detect if the Dockerfile has any updates
-          # this will require rebuilding the image locally as the downstream "test" image will fail otherwise
-          # see https://github.com/marketplace/actions/changed-files for more info on this action
-          echo "#### CHANGES DETECTED TO DOCKERFILE, REBUILDING IMAGE LOCALLY ####"
-          docker build -t $DOCKER_IMAGE_NAME:development -f Dockerfile .
+      - name: Build image and setup env
+        uses: actions/docker-build-env-setup-composite-action@v1
       - name: Load secrets and run tests
         env:
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
@@ -41,17 +24,6 @@ jobs:
           CI: true
         run: |
           export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )
-          # The "broad-singlecellportal-staging" GCR repository is used in production.
-          # The "development" tag is used in non-production deployment.  For production deployment, tag is version number for
-          # upcoming release, e.g. 1.20.0.
-          # More context: https://github.com/broadinstitute/single_cell_portal_core/pull/1552#discussion_r910424433
-          # TODO: (SCP-4496): Move production-related GCR images out of staging project
-          # add ci- prefix to avoid post-merge build failing due to missing GITHUB_HEAD_REF
-          # and strip any slashes from GITHUB_HEAD_REF to avoid 'invalid reference format' error with tag
-          # this will happen on dependabot PRs
-          SAFE_HEAD_REF=$(echo $GITHUB_HEAD_REF | sed -e 's/\//_/g')
-          DOCKER_IMAGE_TAG="ci-$SAFE_HEAD_REF-$GITHUB_SHA"
-          docker build -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG -f test/Dockerfile-test .
           bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json \
                                   -s secret/kdux/scp/staging/scp_service_account.json \
                                   -e test -v $DOCKER_IMAGE_TAG -n single-cell-portal-test \

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -38,7 +38,6 @@ jobs:
         env:
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          RAILS_LOG_TO_STDOUT: true
           VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
           VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
           ORCH_SMOKE_TEST: true
@@ -66,4 +65,3 @@ jobs:
           name: test-logs
           path: |
             log/test.log
-            log/delayed_job.test.log

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -1,10 +1,7 @@
 name: Terra Orchestration API Smoke Test
 on:
-  push:
-    branches:
-      - jb-alpha-orch-ci
-      - development
-      - master
+  schedule:
+    - cron: "0 8 * * 1,3,5"
 env:
   DOCKER_IMAGE_NAME: "gcr.io/broad-singlecellportal-staging/single-cell-portal"
 

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -1,4 +1,5 @@
-name: SCP Continuous Integration
+name: Terra Orchestration API Smoke Test
+description: 'Limited CI to run against staging instance of Terra orchestration API'
 on:
   push:
     branches:

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -1,5 +1,4 @@
 name: Terra Orchestration API Smoke Test
-description: 'Limited CI to run against staging instance of Terra orchestration API'
 on:
   push:
     branches:

--- a/app/controllers/admin_configurations_controller.rb
+++ b/app/controllers/admin_configurations_controller.rb
@@ -250,7 +250,7 @@ class AdminConfigurationsController < ApplicationController
         portal_users.each do |user|
           unless user_group['membersEmails'].include?(user.email)
             # check if user is FireCloud member first
-            user_client = FireCloudClient.new(user, FireCloudClient::PORTAL_NAMESPACE)
+            user_client = FireCloudClient.new(user:, project: FireCloudClient::PORTAL_NAMESPACE)
             if user_client.registered?
               logger.info "#{Time.zone.now}: adding #{user.email} to #{@group_name}"
               ApplicationController.firecloud_client.add_user_to_group(@group_name, 'member', user_email)

--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -653,7 +653,7 @@ module Api
 
           # submission must be done as user, so create a client with current_user and submit
           # TODO: figure out better way to assign access token based on API vs. MVC app, and figure out how to set submitter correctly
-          user_client = FireCloudClient.new(current_api_user, @study.firecloud_project)
+          user_client = FireCloudClient.new(user: current_api_user, project: @study.firecloud_project)
 
           logger.info "Creating submission for #{@analysis_configuration.configuration_identifier} using configuration: #{submission_config['name']} in #{@study.firecloud_project}/#{@study.firecloud_workspace}"
           @submission = user_client.create_workspace_submission(@study.firecloud_project, @study.firecloud_workspace,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,7 +42,10 @@ class ApplicationController < ActionController::Base
 
   def self.read_only_firecloud_client
     if ENV['READ_ONLY_SERVICE_ACCOUNT_KEY'].present?
-      @@read_only_client ||= FireCloudClient.new(nil, FireCloudClient::PORTAL_NAMESPACE, File.absolute_path(ENV['READ_ONLY_SERVICE_ACCOUNT_KEY']))
+      @@read_only_client ||= FireCloudClient.new(user: nil,
+                                                 project: FireCloudClient::PORTAL_NAMESPACE,
+                                                 service_account: File.absolute_path(ENV['READ_ONLY_SERVICE_ACCOUNT_KEY'])
+      )
     end
   end
 

--- a/app/controllers/billing_projects_controller.rb
+++ b/app/controllers/billing_projects_controller.rb
@@ -148,7 +148,7 @@ class BillingProjectsController < ApplicationController
     # parallelize retrieving workspace storage estimates
     Parallel.map(workspaces, in_threads: 100) do |workspace|
       begin
-        client = FireCloudClient.new(current_user, params[:project_name])
+        client = FireCloudClient.new(user: current_user, project: params[:project_name])
         workspace_name = workspace.dig('workspace', 'name')
         cost_estimate = client.get_workspace_storage_cost(params[:project_name], workspace_name)
         actual_cost = cost_estimate['estimate'].gsub(/\$/, '').to_f
@@ -184,7 +184,7 @@ class BillingProjectsController < ApplicationController
   # create client scoped to current user
   def create_firecloud_client
     project_name = params[:project_name].present? ? params[:project_name] : 'single-cell-portal'
-    @fire_cloud_client = FireCloudClient.new(current_user, project_name)
+    @fire_cloud_client = FireCloudClient.new(user: current_user, project: project_name)
   end
 
   # load portal service account email for use in view (we don't want to display this in the portal)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -24,7 +24,7 @@ class ProfilesController < ApplicationController
     @profiles_available = ApplicationController.firecloud_client.services_available?(FireCloudClient::THURLOE_SERVICE)
     if @profiles_available
       begin
-        user_client = FireCloudClient.new(current_user, FireCloudClient::PORTAL_NAMESPACE)
+        user_client = FireCloudClient.new(user: current_user, project: FireCloudClient::PORTAL_NAMESPACE)
         profile = user_client.get_profile
         profile['keyValuePairs'].each do |attribute|
           if @fire_cloud_profile.respond_to?("#{attribute['key']}=")
@@ -74,7 +74,7 @@ class ProfilesController < ApplicationController
     begin
       @fire_cloud_profile = FireCloudProfile.new(profile_params)
       if @fire_cloud_profile.valid?
-        user_client = FireCloudClient.new(current_user, FireCloudClient::PORTAL_NAMESPACE)
+        user_client = FireCloudClient.new(user: current_user, project: FireCloudClient::PORTAL_NAMESPACE)
         user_client.set_profile(profile_params)
         # log that user has registered so we can use this elsewhere
         if !current_user.registered_for_firecloud
@@ -159,7 +159,7 @@ class ProfilesController < ApplicationController
   def profile_params
     params.require(:fire_cloud_profile).permit(:contactEmail, :email, :firstName, :lastName, :institute, :institutionalProgram,
                                             :nonProfitStatus, :pi, :programLocationCity, :programLocationState,
-                                            :programLocationCountry, :title)
+                                            :programLocationCountry, :title, :termsOfService)
   end
 
   def tos_params

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -415,7 +415,7 @@ class SiteController < ApplicationController
       ApplicationController.firecloud_client.create_workspace_configuration(@study.firecloud_project, @study.firecloud_workspace, submission_config)
 
       # submission must be done as user, so create a client with current_user and submit
-      client = FireCloudClient.new(current_user, @study.firecloud_project)
+      client = FireCloudClient.new(user: current_user, project: @study.firecloud_project)
       logger.info "Creating submission for #{@analysis_configuration.configuration_identifier} using configuration: #{submission_config['name']} in #{@study.firecloud_project}/#{@study.firecloud_workspace}"
       @submission = client.create_workspace_submission(@study.firecloud_project, @study.firecloud_workspace,
                                                          submission_config['namespace'], submission_config['name'],

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1066,7 +1066,7 @@ class StudiesController < ApplicationController
   def set_user_projects
     @projects = [['Default Project', FireCloudClient::PORTAL_NAMESPACE]]
     begin
-      client = FireCloudClient.new(current_user, 'single-cell-portal')
+      client = FireCloudClient.new(user: current_user, project: 'single-cell-portal')
       if current_user.registered_for_firecloud && client.registered?
         available_projects = client.get_billing_projects
         available_projects.each do |project|

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -138,10 +138,15 @@ class FireCloudClient
   # * *return*
   #   - +Hash+ of values for all instance variables for this client
   def attributes
-    sanitized_values = self.to_h.dup
-    sanitized_values[:access_token] = 'REDACTED'
-    sanitized_values[:issuer] = self.issuer
-    sanitized_values
+    {
+      user:,
+      project:,
+      access_token: 'REDACTED',
+      issuer:,
+      api_root:,
+      storage:, expires_at:,
+      service_account_credentials:
+    }
   end
 
   #

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -81,8 +81,11 @@ class FireCloudClient
   # will set the access token, FireCloud api url root and GCP storage driver instance
   #
   # * *params*
+  #   - +service_account+ (String) => File path to JSON keyfile for service account
   #   - +user+: (User) => User object from which access tokens are generated
   #   - +project+: (String) => Default GCP Project to use (can be overridden by other parameters)
+  #   - +api_root+ (String) => URL for base Terra orchestration API instance (defaults to api.firecloud.org)
+  #
   # * *return*
   #   - +FireCloudClient+ object
   def initialize(user: nil, project: nil, service_account: self.class.get_primary_keyfile, api_root: BASE_URL)
@@ -1252,10 +1255,10 @@ class FireCloudClient
   #   - +FireCloudClient+ instance, or nil if user has not registered with Terra
   def self.new_with_pet_account(user, project)
     # create a temporary client in order to retrieve the user's pet service account keyfile
-    tmp_client = self.new(user, project)
+    tmp_client = new(user:, project:)
     if tmp_client.registered?
       pet_service_account_json = tmp_client.get_pet_service_account_key(project)
-      self.new(user, project, pet_service_account_json)
+      new(user:, project:, service_account: pet_service_account_json)
     else
       nil
     end

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -85,7 +85,7 @@ class FireCloudClient
   #   - +project+: (String) => Default GCP Project to use (can be overridden by other parameters)
   # * *return*
   #   - +FireCloudClient+ object
-  def initialize(user = nil, project = nil, service_account = self.class.get_primary_keyfile)
+  def initialize(user: nil, project: nil, service_account: self.class.get_primary_keyfile, api_root: BASE_URL)
     # when initializing without a user, default to base configuration
     if user.nil?
       # instantiate Google Cloud Storage driver to work with files in workspace buckets
@@ -130,8 +130,7 @@ class FireCloudClient
 
       self.storage = Google::Cloud::Storage.new(**storage_attr)
     end
-    # set FireCloud API base url
-    self.api_root = BASE_URL
+    self.api_root = api_root.chomp('/')
   end
 
   # return a hash of instance attributes for this client
@@ -1285,7 +1284,7 @@ class FireCloudClient
   end
 
   # get JSON keyfile contents for a user's pet service account in the requested project
-  # response from this API call can be passed to FireCloudClient.new(user, project_name, service_account_contents)
+  # response from this API call can be passed to FireCloudClient.new(**params)
   # to create an instance of FireCloudClient that is able to call GCS methods as the user in the request project
   #
   # * *params*

--- a/app/models/fire_cloud_profile.rb
+++ b/app/models/fire_cloud_profile.rb
@@ -1,9 +1,11 @@
 class FireCloudProfile
   include ActiveModel::Model
 
+  TERRA_TOS_URL = 'https://app.terra.bio/#terms-of-service'.freeze
+
   attr_accessor :contactEmail, :email, :firstName, :lastName, :institute, :institutionalProgram,
                 :nonProfitStatus, :pi, :programLocationCity, :programLocationState,
-                :programLocationCountry, :title
+                :programLocationCountry, :title, :termsOfService
 
   validates_format_of :firstName, :lastName, :pi, :programLocationCity,
                       :programLocationState, :programLocationCountry, with: ValidationTools::NAME_CHARS,
@@ -15,4 +17,11 @@ class FireCloudProfile
   validates_format_of :email, :contactEmail, with: Devise.email_regexp, message: 'is not a valid email address.'
 
   validates_inclusion_of :nonProfitStatus, in: ['true', 'false']
+
+  def attributes
+    {
+      contactEmail:, email:, firstName:, lastName:, institute:, institutionalProgram:, nonProfitStatus:, pi:,
+      programLocationCity:, programLocationState:, programLocationCountry:, title:, termsOfService: TERRA_TOS_URL
+    }
+  end
 end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -778,7 +778,7 @@ class Study
       shares = StudyShare.where(email: /#{user.email}/i).map(&:study).select {|s| !s.queued_for_deletion }.map(&:id)
       group_shares = []
       if user.registered_for_firecloud && (user.refresh_token.present? || user.api_access_token.present?)
-        user_client = FireCloudClient.new(user, FireCloudClient::PORTAL_NAMESPACE)
+        user_client = FireCloudClient.new(user:, project: FireCloudClient::PORTAL_NAMESPACE)
         user_groups = user_client.get_user_groups.map {|g| g['groupEmail']}
         group_shares = StudyShare.where(:email.in => user_groups).map(&:study).select {|s| !s.queued_for_deletion }.map(&:id)
       end
@@ -797,7 +797,7 @@ class Study
       shares = StudyShare.where(email: /#{user.email}/i).map(&:study).select {|s| !s.queued_for_deletion }.map(&:_id)
       group_shares = []
       if user.registered_for_firecloud
-        user_client = FireCloudClient.new(user, FireCloudClient::PORTAL_NAMESPACE)
+        user_client = FireCloudClient.new(user:, project: FireCloudClient::PORTAL_NAMESPACE)
         user_groups = user_client.get_user_groups.map {|g| g['groupEmail']}
         group_shares = StudyShare.where(:email.in => user_groups).map(&:study).select {|s| !s.queued_for_deletion }.map(&:id)
       end
@@ -900,7 +900,7 @@ class Study
       group_shares = self.study_shares.keep_if {|share| share.is_group_share?}.select {|share| permissions.include?(share.permission)}.map(&:email)
       # get user's FC groups
       if user.access_token.present?
-        client = FireCloudClient.new(user, FireCloudClient::PORTAL_NAMESPACE)
+        client = FireCloudClient.new(user:, project: FireCloudClient::PORTAL_NAMESPACE)
       elsif user.api_access_token.present?
         client = FireCloudClient.new
         client.access_token[:access_token] = user.api_access_token
@@ -1829,7 +1829,7 @@ class Study
 
     # check if project is valid to use
     if self.firecloud_project != FireCloudClient::PORTAL_NAMESPACE
-      client = FireCloudClient.new(self.user, self.firecloud_project)
+      client = FireCloudClient.new(user: self.user, project: self.firecloud_project)
       projects = client.get_billing_projects.map {|project| project['projectName']}
       unless projects.include?(self.firecloud_project)
         errors.add(:firecloud_project, ' is not a project you are a member of.  Please choose another project.')
@@ -1942,7 +1942,7 @@ class Study
 
     # check if project is valid to use
     if self.firecloud_project != FireCloudClient::PORTAL_NAMESPACE
-      client = FireCloudClient.new(self.user, self.firecloud_project)
+      client = FireCloudClient.new(user: self.user, project: self.firecloud_project)
       projects = client.get_billing_projects.map {|project| project['projectName']}
       unless projects.include?(self.firecloud_project)
         errors.add(:firecloud_project, ' is not a project you are a member of.  Please choose another project.')
@@ -2065,7 +2065,7 @@ class Study
       if self.firecloud_project == FireCloudClient::PORTAL_NAMESPACE
         client = ApplicationController.firecloud_client
       else
-        client = FireCloudClient.new(self.user, self.firecloud_project)
+        client = FireCloudClient.new(user: self.user, project: self.firecloud_project)
       end
       group_email = sa_owner_group['groupEmail']
       acl = client.create_workspace_acl(group_email, 'OWNER', true, false)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -228,7 +228,7 @@ class User
       begin
         workspace = ApplicationController.firecloud_client.get_workspace(study.firecloud_project, study.firecloud_workspace)
         project_name = workspace.dig('workspace', 'googleProject') || FireCloudClient::PORTAL_NAMESPACE
-        client = FireCloudClient.new(self, project_name)
+        client = FireCloudClient.new(user: self, project: project_name)
         client.get_pet_service_account_token(project_name)
       rescue RestClient::Exception
         # returning nil here will be caught at the UI level and show an error message
@@ -360,7 +360,7 @@ class User
     if self.registered_for_firecloud
       nil
     else
-      client = FireCloudClient.new(self, FireCloudClient::PORTAL_NAMESPACE)
+      client = FireCloudClient.new(user: self, project: FireCloudClient::PORTAL_NAMESPACE)
       if client.registered?
         Rails.logger.info "#{Time.zone.now} - setting user firecloud registrations status for #{self.email} to true"
         self.update(registered_for_firecloud: true)
@@ -384,7 +384,7 @@ class User
   #   - (Hash) => { must_accept: T/F, status: HTTP status code }
   def check_terra_tos_status
     begin
-      client = FireCloudClient.new(self, FireCloudClient::PORTAL_NAMESPACE)
+      client = FireCloudClient.new(user: self, project: FireCloudClient::PORTAL_NAMESPACE)
       user_registration = client.get_registration&.with_indifferent_access
       tos_accepted = user_registration.dig('enabled', 'tosAccepted')
       tos_accepted = true if tos_accepted.nil? # failover protection if status isn't found
@@ -411,7 +411,7 @@ class User
   def get_billing_projects
     projects = {User: [], Owner: []}
     if self.registered_for_firecloud
-      client = FireCloudClient.new(self, FireCloudClient::PORTAL_NAMESPACE)
+      client = FireCloudClient.new(user: self, project: FireCloudClient::PORTAL_NAMESPACE)
       user_projects = client.get_billing_projects
       user_projects.each do |project|
         if project['creationStatus'] == 'Ready'

--- a/app/views/profiles/_user_firecloud_profile.html.erb
+++ b/app/views/profiles/_user_firecloud_profile.html.erb
@@ -1,9 +1,7 @@
 <%= form_for(@fire_cloud_profile, url: update_user_firecloud_profile_path, html: {class: 'form', id: 'firecloud-profile', data: {remote: true}}) do |f| %>
   <%= f.hidden_field :email %>
   <div class="bs-callout bs-callout-primary">
-    <p class="text-primary">Use this form to register or update your Terra profile.
-      <span class="text-danger"> <i class="fas fa-fw fa-exclamation-triangle"></i> All fields are required.</span>
-    </p>
+    <p class="text-primary">Use this form to register or update your Terra profile. <span class="text-danger"><i class="fas fa-fw fa-exclamation-triangle"></i> All fields are required.</span></p>
   </div>
   <% if @fire_cloud_profile.errors.any? %>
     <div class="bs-callout bs-callout-danger" id="study-errors-block">
@@ -77,19 +75,7 @@
 
     <div class="form-group row">
       <div class="col-xs-12 text-center">
-        <div class="checkbox">
-          <h4>
-            <label for="fire_cloud_profile_termsOfService">
-              <%= f.check_box :termsOfService, { checked: false }, FireCloudProfile::TERRA_TOS_URL, '' %>
-              I have read and accept Terra's
-              <%= link_to 'terms of service', FireCloudProfile::TERRA_TOS_URL, target: :_blank %>
-            </label>
-          </h4>
-        </div>
-        <%= link_to 'Update profile', '#/',
-                    class: 'btn btn-lg btn-success',
-                    id: 'update-user-firecloud-profile',
-                    disabled: true %>
+        <%= link_to 'Update profile', '#/', class: 'btn btn-lg btn-success', id: 'update-user-firecloud-profile'%>
       </div>
     </div>
   </div>
@@ -97,13 +83,7 @@
 <% end %>
 
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-    const submitBtn = $('#update-user-firecloud-profile')
-    $('#fire_cloud_profile_termsOfService').click(function() {
-      let hasAccepted = $(this).prop('checked')
-      submitBtn.attr('disabled', !hasAccepted)
-    });
-
-    submitBtn.click(function(event) {
+    $('#firecloud-profile .form-control').click(function(event) {
         var formElements = $('#firecloud-profile .form-control');
         var valid = true;
         formElements.each(function(index, el) {

--- a/app/views/profiles/_user_firecloud_profile.html.erb
+++ b/app/views/profiles/_user_firecloud_profile.html.erb
@@ -75,7 +75,7 @@
 
     <div class="form-group row">
       <div class="col-xs-12 text-center">
-        <%= link_to 'Update profile', '#/', class: 'btn btn-lg btn-success', id: 'update-user-firecloud-profile'%>
+        <%= link_to 'Update profile', '#/', class: 'btn btn-lg btn-success', id: 'update-user-firecloud-profile' %>
       </div>
     </div>
   </div>
@@ -83,7 +83,7 @@
 <% end %>
 
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-    $('#firecloud-profile .form-control').click(function(event) {
+    $('#update-user-firecloud-profile').click(function(event) {
         var formElements = $('#firecloud-profile .form-control');
         var valid = true;
         formElements.each(function(index, el) {

--- a/app/views/profiles/_user_firecloud_profile.html.erb
+++ b/app/views/profiles/_user_firecloud_profile.html.erb
@@ -1,7 +1,9 @@
 <%= form_for(@fire_cloud_profile, url: update_user_firecloud_profile_path, html: {class: 'form', id: 'firecloud-profile', data: {remote: true}}) do |f| %>
   <%= f.hidden_field :email %>
   <div class="bs-callout bs-callout-primary">
-    <p class="text-primary">Use this form to register or update your Terra profile. <span class="text-danger"><i class="fas fa-fw fa-exclamation-triangle"></i> All fields are required.</span></p>
+    <p class="text-primary">Use this form to register or update your Terra profile.
+      <span class="text-danger"> <i class="fas fa-fw fa-exclamation-triangle"></i> All fields are required.</span>
+    </p>
   </div>
   <% if @fire_cloud_profile.errors.any? %>
     <div class="bs-callout bs-callout-danger" id="study-errors-block">
@@ -75,8 +77,19 @@
 
     <div class="form-group row">
       <div class="col-xs-12 text-center">
-        <br />
-        <%= link_to 'Update profile', '#/', class: 'btn btn-lg btn-success', id: 'update-user-firecloud-profile' %>
+        <div class="checkbox">
+          <h4>
+            <label for="fire_cloud_profile_termsOfService">
+              <%= f.check_box :termsOfService, { checked: false }, FireCloudProfile::TERRA_TOS_URL, '' %>
+              I have read and accept Terra's
+              <%= link_to 'terms of service', FireCloudProfile::TERRA_TOS_URL, target: :_blank %>
+            </label>
+          </h4>
+        </div>
+        <%= link_to 'Update profile', '#/',
+                    class: 'btn btn-lg btn-success',
+                    id: 'update-user-firecloud-profile',
+                    disabled: true %>
       </div>
     </div>
   </div>
@@ -84,7 +97,13 @@
 <% end %>
 
 <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-    $('#update-user-firecloud-profile').click(function(event) {
+    const submitBtn = $('#update-user-firecloud-profile')
+    $('#fire_cloud_profile_termsOfService').click(function() {
+      let hasAccepted = $(this).prop('checked')
+      submitBtn.attr('disabled', !hasAccepted)
+    });
+
+    submitBtn.click(function(event) {
         var formElements = $('#firecloud-profile .form-control');
         var valid = true;
         formElements.each(function(index, el) {

--- a/app/views/profiles/_user_firecloud_profile.html.erb
+++ b/app/views/profiles/_user_firecloud_profile.html.erb
@@ -76,6 +76,7 @@
     <div class="form-group row">
       <div class="col-xs-12 text-center">
         <%= link_to 'Update profile', '#/', class: 'btn btn-lg btn-success', id: 'update-user-firecloud-profile' %>
+        <br />
       </div>
     </div>
   </div>

--- a/bin/load_env_secrets.sh
+++ b/bin/load_env_secrets.sh
@@ -29,6 +29,7 @@ PASSENGER_APP_ENV="development"
 COMMAND="bin/boot_docker"
 THIS_DIR="$(cd "$(dirname "$0")"; pwd)"
 CONFIG_DIR="$THIS_DIR/../config"
+SPECIAL_CMD="false"
 while getopts "p:s:r:c:e:v:n:H" OPTION; do
 case $OPTION in
   p)
@@ -42,6 +43,7 @@ case $OPTION in
     ;;
   c)
     COMMAND="$OPTARG"
+    SPECIAL_CMD="true"
     ;;
   v)
     DOCKER_IMAGE_TAG="$OPTARG"
@@ -109,14 +111,14 @@ if [[ -n $READ_ONLY_SERVICE_ACCOUNT_PATH ]] ; then
   echo "setting value for: READ_ONLY_GOOGLE_CLOUD_KEYFILE_JSON"
   READ_ONLY_CREDS_VALS=$(vault read -format=json $READ_ONLY_SERVICE_ACCOUNT_PATH)
   READ_ONLY_JSON_CONTENTS=$(echo $READ_ONLY_CREDS_VALS | jq --raw-output .data)
-	echo "*** WRITING READ ONLY SERVICE ACCOUNT CREDENTIALS ***"
-	READONLY_FILEPATH="$CONFIG_DIR/.read_only_service_account.json"
-	echo $READ_ONLY_JSON_CONTENTS >| $READONLY_FILEPATH
+  echo "*** WRITING READ ONLY SERVICE ACCOUNT CREDENTIALS ***"
+  READONLY_FILEPATH="$CONFIG_DIR/.read_only_service_account.json"
+  echo $READ_ONLY_JSON_CONTENTS >| $READONLY_FILEPATH
   COMMAND=$COMMAND" -K /home/app/webapp/config/.read_only_service_account.json"
 fi
 
 # check for override of default bin/boot_docker command
-if [[ "$COMMAND" != "bin/boot_docker" ]] ; then
+if [[ "$SPECIAL_CMD" = "true" ]] ; then
   echo "RUNNING NON-STANDARD COMMAND: $COMMAND"
   $COMMAND -e $PASSENGER_APP_ENV -v $DOCKER_IMAGE_TAG
 else

--- a/bin/run_orch_smoke_test.sh
+++ b/bin/run_orch_smoke_test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+usage=$(
+cat <<EOF
+
+### shell script to load secrets from Vault and execute command ###
+$0
+
+[OPTIONS]
+-k VALUE	set the SERVICE_ACCOUNT_KEY variable, necessary for making authenticated calls to Terra Orchestration API
+-v VALUE  set the version of the Docker image to load (defaults to 'development')
+-e VALUE	set the environment to run tests in (defaults to "test")
+EOF
+)
+
+DOCKER_IMAGE_NAME="gcr.io/broad-singlecellportal-staging/single-cell-portal"
+DOCKER_IMAGE_VERSION="development"
+PASSENGER_APP_ENV="test"
+
+while getopts "k:e:v:" OPTION; do
+case $OPTION in
+	k)
+		SERVICE_ACCOUNT_KEY="$OPTARG"
+		;;
+	e)
+		PASSENGER_APP_ENV="$OPTARG"
+		;;
+  v)
+    DOCKER_IMAGE_VERSION="$OPTARG"
+    ;;
+  *)
+    echo "ignoring unused flags, variables still passed"
+    ;;
+  esac
+done
+
+docker run --rm -t --name single_cell_test -h localhost -v "$(pwd):/home/app/webapp:consistent" \
+	--mount type=volume,dst=/home/app/webapp/node_modules \
+	-e PASSENGER_APP_ENV="$PASSENGER_APP_ENV" -e MONGO_LOCALHOST="$MONGO_LOCALHOST" \
+	-e MONGO_INTERNAL_IP="$MONGO_INTERNAL_IP" -e PROD_DATABASE_PASSWORD="$PROD_DATABASE_PASSWORD" \
+	-e ORCH_SMOKE_TEST=true -e SERVICE_ACCOUNT_KEY="$SERVICE_ACCOUNT_KEY" \
+	-e PORTAL_NAMESPACE="$PORTAL_NAMESPACE" -e SECRET_KEY_BASE="$SECRET_KEY_BASE" \
+	-e GOOGLE_CLOUD_KEYFILE_JSON="$GOOGLE_CLOUD_KEYFILE_JSON" -e GOOGLE_PRIVATE_KEY="$GOOGLE_PRIVATE_KEY" \
+	-e GOOGLE_CLIENT_EMAIL="$GOOGLE_CLIENT_EMAIL" -e GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" \
+	-e GOOGLE_CLOUD_PROJECT="$GOOGLE_CLOUD_PROJECT" -e CODECOV_TOKEN="$CODECOV_TOKEN" \
+	-e RAILS_LOG_TO_STDOUT="$RAILS_LOG_TO_STDOUT" -e CI="$CI" \
+	-e GOOGLE_PROJECT_NUMBER="$GOOGLE_PROJECT_NUMBER" $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_VERSION \
+	bin/rails test test/integration/external/fire_cloud_client_test.rb

--- a/bin/run_orch_smoke_test.sh
+++ b/bin/run_orch_smoke_test.sh
@@ -10,14 +10,16 @@ $0
 -k VALUE	set the SERVICE_ACCOUNT_KEY variable, necessary for making authenticated calls to Terra Orchestration API
 -v VALUE  set the version of the Docker image to load (defaults to 'development')
 -e VALUE	set the environment to run tests in (defaults to "test")
+-d        set to run smoke test outside of Docker
 EOF
 )
 
 DOCKER_IMAGE_NAME="gcr.io/broad-singlecellportal-staging/single-cell-portal"
 DOCKER_IMAGE_VERSION="development"
 PASSENGER_APP_ENV="test"
+NON_DOCKERIZED="false"
 
-while getopts "k:e:v:" OPTION; do
+while getopts "k:e:v:d" OPTION; do
 case $OPTION in
 	k)
 		SERVICE_ACCOUNT_KEY="$OPTARG"
@@ -28,21 +30,29 @@ case $OPTION in
   v)
     DOCKER_IMAGE_VERSION="$OPTARG"
     ;;
+  d)
+    NON_DOCKERIZED=true
+    ;;
   *)
     echo "ignoring unused flags, variables still passed"
     ;;
   esac
 done
 
-docker run --rm -t --name single_cell_test -h localhost -v "$(pwd):/home/app/webapp:consistent" \
-	--mount type=volume,dst=/home/app/webapp/node_modules \
-	-e PASSENGER_APP_ENV="$PASSENGER_APP_ENV" -e MONGO_LOCALHOST="$MONGO_LOCALHOST" \
-	-e MONGO_INTERNAL_IP="$MONGO_INTERNAL_IP" -e PROD_DATABASE_PASSWORD="$PROD_DATABASE_PASSWORD" \
-	-e ORCH_SMOKE_TEST=true -e SERVICE_ACCOUNT_KEY="$SERVICE_ACCOUNT_KEY" \
-	-e PORTAL_NAMESPACE="$PORTAL_NAMESPACE" -e SECRET_KEY_BASE="$SECRET_KEY_BASE" \
-	-e GOOGLE_CLOUD_KEYFILE_JSON="$GOOGLE_CLOUD_KEYFILE_JSON" -e GOOGLE_PRIVATE_KEY="$GOOGLE_PRIVATE_KEY" \
-	-e GOOGLE_CLIENT_EMAIL="$GOOGLE_CLIENT_EMAIL" -e GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" \
-	-e GOOGLE_CLOUD_PROJECT="$GOOGLE_CLOUD_PROJECT" -e CODECOV_TOKEN="$CODECOV_TOKEN" \
-	-e RAILS_LOG_TO_STDOUT="$RAILS_LOG_TO_STDOUT" -e CI="$CI" \
-	-e GOOGLE_PROJECT_NUMBER="$GOOGLE_PROJECT_NUMBER" $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_VERSION \
-	bin/rails test test/integration/external/fire_cloud_client_test.rb
+if [[ "$NON_DOCKERIZED" = "true" ]]; then
+  ORCH_SMOKE_TEST=true bin/rails test test/integration/external/fire_cloud_client_test.rb
+else
+  docker run --rm -t --name single_cell_test -h localhost -v "$(pwd):/home/app/webapp:consistent" \
+  	--mount type=volume,dst=/home/app/webapp/node_modules \
+  	-e PASSENGER_APP_ENV="$PASSENGER_APP_ENV" -e MONGO_LOCALHOST="$MONGO_LOCALHOST" \
+  	-e MONGO_INTERNAL_IP="$MONGO_INTERNAL_IP" -e PROD_DATABASE_PASSWORD="$PROD_DATABASE_PASSWORD" \
+  	-e ORCH_SMOKE_TEST=true -e SERVICE_ACCOUNT_KEY="$SERVICE_ACCOUNT_KEY" \
+  	-e PORTAL_NAMESPACE="$PORTAL_NAMESPACE" -e SECRET_KEY_BASE="$SECRET_KEY_BASE" \
+  	-e GOOGLE_CLOUD_KEYFILE_JSON="$GOOGLE_CLOUD_KEYFILE_JSON" -e GOOGLE_PRIVATE_KEY="$GOOGLE_PRIVATE_KEY" \
+  	-e GOOGLE_CLIENT_EMAIL="$GOOGLE_CLIENT_EMAIL" -e GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" \
+  	-e GOOGLE_CLOUD_PROJECT="$GOOGLE_CLOUD_PROJECT" -e CODECOV_TOKEN="$CODECOV_TOKEN" \
+  	-e RAILS_LOG_TO_STDOUT="$RAILS_LOG_TO_STDOUT" -e CI="$CI" \
+  	-e GOOGLE_PROJECT_NUMBER="$GOOGLE_PROJECT_NUMBER" $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_VERSION \
+  	bin/rails test test/integration/external/fire_cloud_client_test.rb
+fi
+

--- a/bin/run_orch_smoke_test.sh
+++ b/bin/run_orch_smoke_test.sh
@@ -7,9 +7,9 @@ cat <<EOF
 $0
 
 [OPTIONS]
--k VALUE	set the SERVICE_ACCOUNT_KEY variable, necessary for making authenticated calls to Terra Orchestration API
+-k VALUE  set the SERVICE_ACCOUNT_KEY variable, necessary for making authenticated calls to Terra Orchestration API
 -v VALUE  set the version of the Docker image to load (defaults to 'development')
--e VALUE	set the environment to run tests in (defaults to "test")
+-e VALUE  set the environment to run tests in (defaults to "test")
 -d        set to run smoke test outside of Docker
 EOF
 )
@@ -21,12 +21,12 @@ NON_DOCKERIZED="false"
 
 while getopts "k:e:v:d" OPTION; do
 case $OPTION in
-	k)
-		SERVICE_ACCOUNT_KEY="$OPTARG"
-		;;
-	e)
-		PASSENGER_APP_ENV="$OPTARG"
-		;;
+  k)
+    SERVICE_ACCOUNT_KEY="$OPTARG"
+    ;;
+  e)
+    PASSENGER_APP_ENV="$OPTARG"
+    ;;
   v)
     DOCKER_IMAGE_VERSION="$OPTARG"
     ;;
@@ -43,16 +43,16 @@ if [[ "$NON_DOCKERIZED" = "true" ]]; then
   ORCH_SMOKE_TEST=true bin/rails test test/integration/external/fire_cloud_client_test.rb
 else
   docker run --rm -t --name single_cell_test -h localhost -v "$(pwd):/home/app/webapp:consistent" \
-  	--mount type=volume,dst=/home/app/webapp/node_modules \
-  	-e PASSENGER_APP_ENV="$PASSENGER_APP_ENV" -e MONGO_LOCALHOST="$MONGO_LOCALHOST" \
-  	-e MONGO_INTERNAL_IP="$MONGO_INTERNAL_IP" -e PROD_DATABASE_PASSWORD="$PROD_DATABASE_PASSWORD" \
-  	-e ORCH_SMOKE_TEST=true -e SERVICE_ACCOUNT_KEY="$SERVICE_ACCOUNT_KEY" \
-  	-e PORTAL_NAMESPACE="$PORTAL_NAMESPACE" -e SECRET_KEY_BASE="$SECRET_KEY_BASE" \
-  	-e GOOGLE_CLOUD_KEYFILE_JSON="$GOOGLE_CLOUD_KEYFILE_JSON" -e GOOGLE_PRIVATE_KEY="$GOOGLE_PRIVATE_KEY" \
-  	-e GOOGLE_CLIENT_EMAIL="$GOOGLE_CLIENT_EMAIL" -e GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" \
-  	-e GOOGLE_CLOUD_PROJECT="$GOOGLE_CLOUD_PROJECT" -e CODECOV_TOKEN="$CODECOV_TOKEN" \
-  	-e RAILS_LOG_TO_STDOUT="$RAILS_LOG_TO_STDOUT" -e CI="$CI" \
-  	-e GOOGLE_PROJECT_NUMBER="$GOOGLE_PROJECT_NUMBER" $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_VERSION \
-  	bin/rails test test/integration/external/fire_cloud_client_test.rb
+    --mount type=volume,dst=/home/app/webapp/node_modules \
+    -e PASSENGER_APP_ENV="$PASSENGER_APP_ENV" -e MONGO_LOCALHOST="$MONGO_LOCALHOST" \
+    -e MONGO_INTERNAL_IP="$MONGO_INTERNAL_IP" -e PROD_DATABASE_PASSWORD="$PROD_DATABASE_PASSWORD" \
+    -e ORCH_SMOKE_TEST=true -e SERVICE_ACCOUNT_KEY="$SERVICE_ACCOUNT_KEY" \
+    -e PORTAL_NAMESPACE="$PORTAL_NAMESPACE" -e SECRET_KEY_BASE="$SECRET_KEY_BASE" \
+    -e GOOGLE_CLOUD_KEYFILE_JSON="$GOOGLE_CLOUD_KEYFILE_JSON" -e GOOGLE_PRIVATE_KEY="$GOOGLE_PRIVATE_KEY" \
+    -e GOOGLE_CLIENT_EMAIL="$GOOGLE_CLIENT_EMAIL" -e GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" \
+    -e GOOGLE_CLOUD_PROJECT="$GOOGLE_CLOUD_PROJECT" -e CODECOV_TOKEN="$CODECOV_TOKEN" \
+    -e RAILS_LOG_TO_STDOUT="$RAILS_LOG_TO_STDOUT" -e CI="$CI" \
+    -e GOOGLE_PROJECT_NUMBER="$GOOGLE_PROJECT_NUMBER" $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_VERSION \
+    bin/rails test test/integration/external/fire_cloud_client_test.rb
 fi
 

--- a/bin/run_orch_smoke_test.sh
+++ b/bin/run_orch_smoke_test.sh
@@ -45,4 +45,4 @@ docker run --rm -t --name single_cell_test -h localhost -v "$(pwd):/home/app/web
 	-e GOOGLE_CLOUD_PROJECT="$GOOGLE_CLOUD_PROJECT" -e CODECOV_TOKEN="$CODECOV_TOKEN" \
 	-e RAILS_LOG_TO_STDOUT="$RAILS_LOG_TO_STDOUT" -e CI="$CI" \
 	-e GOOGLE_PROJECT_NUMBER="$GOOGLE_PROJECT_NUMBER" $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_VERSION \
-	bin/rails test test/integration/external/fire_cloud_client_test.rb
+	RAILS_ENV=$PASSENGER_APP_ENV bin/rails test test/integration/external/fire_cloud_client_test.rb

--- a/bin/run_orch_smoke_test.sh
+++ b/bin/run_orch_smoke_test.sh
@@ -45,4 +45,4 @@ docker run --rm -t --name single_cell_test -h localhost -v "$(pwd):/home/app/web
 	-e GOOGLE_CLOUD_PROJECT="$GOOGLE_CLOUD_PROJECT" -e CODECOV_TOKEN="$CODECOV_TOKEN" \
 	-e RAILS_LOG_TO_STDOUT="$RAILS_LOG_TO_STDOUT" -e CI="$CI" \
 	-e GOOGLE_PROJECT_NUMBER="$GOOGLE_PROJECT_NUMBER" $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_VERSION \
-	RAILS_ENV=$PASSENGER_APP_ENV bin/rails test test/integration/external/fire_cloud_client_test.rb
+	bin/rails test test/integration/external/fire_cloud_client_test.rb

--- a/nginx.conf
+++ b/nginx.conf
@@ -37,6 +37,7 @@ env MIXPANEL_SECRET;
 env CI;
 env RAILS_LOG_TO_STDOUT;
 env APP_INTERNAL_IP;
+env ORCH_SMOKE_TEST;
 env TZ=America/New_York;
 daemon off;
 

--- a/test/integration/external/fire_cloud_client_test.rb
+++ b/test/integration/external/fire_cloud_client_test.rb
@@ -12,7 +12,16 @@ require 'test_helper'
 class FireCloudClientTest < ActiveSupport::TestCase
 
   before(:all) do
-    @fire_cloud_client = ApplicationController.firecloud_client
+    if ENV['ORCH_SMOKE_TEST'] == 'true'
+      @fire_cloud_client = FireCloudClient.new(
+        api_root: 'https://firecloud-orchestration.dsde-staging.broadinstitute.org'
+      )
+      puts "SMOKE TEST: #{@fire_cloud_client.attributes}"
+      exit
+    else
+      @fire_cloud_client = ApplicationController.firecloud_client
+    end
+
     @test_email = 'singlecelltest@gmail.com'
     @random_test_seed = SecureRandom.uuid # use same random seed to differentiate between entire runs
     @resource_error_msg = 'Resource representation is only available with these types' # for error handling

--- a/test/integration/external/fire_cloud_client_test.rb
+++ b/test/integration/external/fire_cloud_client_test.rb
@@ -15,7 +15,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
     @smoke_test = ENV['ORCH_SMOKE_TEST'] == 'true'
     if @smoke_test
       api_root = 'https://firecloud-orchestration.dsde-staging.broadinstitute.org'
-      Rails.logger.info "Running smoke test against Terra orchestration API at #{api_root}"
+      puts "Running smoke test against Terra orchestration API at #{api_root}"
       @fire_cloud_client = FireCloudClient.new(api_root:)
     else
       @fire_cloud_client = ApplicationController.firecloud_client

--- a/test/integration/external/fire_cloud_client_test.rb
+++ b/test/integration/external/fire_cloud_client_test.rb
@@ -12,12 +12,11 @@ require 'test_helper'
 class FireCloudClientTest < ActiveSupport::TestCase
 
   before(:all) do
-    if ENV['ORCH_SMOKE_TEST'] == 'true'
-      @fire_cloud_client = FireCloudClient.new(
-        api_root: 'https://firecloud-orchestration.dsde-staging.broadinstitute.org'
-      )
-      puts "SMOKE TEST: #{@fire_cloud_client.attributes}"
-      exit
+    @smoke_test = ENV['ORCH_SMOKE_TEST'] == 'true'
+    if @smoke_test
+      api_root = 'https://firecloud-orchestration.dsde-staging.broadinstitute.org'
+      Rails.logger.info "Running smoke test against Terra orchestration API at #{api_root}"
+      @fire_cloud_client = FireCloudClient.new(api_root:)
     else
       @fire_cloud_client = ApplicationController.firecloud_client
     end
@@ -250,6 +249,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
 
   # get queue status
   def test_get_submission_queue_status
+    skip if @smoke_test # relies on assets that don't exist in staging Rawls
     status = @fire_cloud_client.get_submission_queue_status
     assert status.any?, 'Did not receive queue status object'
     assert status['workflowCountsByStatus'].any?, 'Did not receive queue count status'
@@ -274,6 +274,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
 
   # get method configurations
   def test_get_configurations
+    skip if @smoke_test # relies on assets that don't exist in staging Rawls
     # get all available configurations
     workflow_configurations = @fire_cloud_client.get_configurations
     assert workflow_configurations.any?, 'Did not find any method configurations'
@@ -297,6 +298,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
 
   # create a method configuration template from a method
   def test_create_configuration_template
+    skip if @smoke_test # relies on assets that don't exist in staging Rawls
     method = @fire_cloud_client.get_method('single-cell-portal', 'split-cluster', 1)
     assert method.present?, 'Did not retrieve a method to create a configuration template from'
 


### PR DESCRIPTION
#### BACKGROUND
Our current integration with Terra is such that SCP only ever points at their production instance.  This was done for a variety of reasons, mostly for the uptime commitments and QA/QC.  However, a few times this has led to a scenario where a breaking API change is released to production, which causes all SCP instances to encounter some level of degraded service, depending on the change/regression.

#### CHANGES
This update adds a "smoke test" that will run a limited CI job (only `fire_cloud_client_test.rb`) against the [staging](https://firecloud-orchestration.dsde-staging.broadinstitute.org) instance of orchestration.  By doing so, we aim to catch regressions _before_ they are released.  Staging is the appropriate instance as it is up consistently and receives updates weekly that are intended to be released to production.  This job will only run on commits to `development` or `master`, but also could be configured to run on a regular cadence (nightly, weekly, etc).  

In addition, this update contains other changes to support this work.  Most notably, `FireCloudClient` now uses keyword parameters instead of positional ones to make instantiating clients simpler.  Additionally, `FireCloudProfile` now can be used to make updates to your Terra profile from the console to aid in testing this work.  The necessary projects/permissions were created outside of this PR directly in the staging Terra instance.

#### MANUAL TESTING
In addition to the manual test instructions below, you can see in the "Checks" portion of this PR that the [CI job](https://github.com/broadinstitute/single_cell_portal_core/actions/runs/5591300236) has run successfully.

1. Pull this branch and enter a Rails console session
2. Register your service account in the staging SAM instance, adding in your email address for `contactEmail`:
```
client = FireCloudClient.new(
  api_root: 'https://firecloud-orchestration.dsde-staging.broadinstitute.org'
)
profile = FireCloudProfile.new(
  contactEmail: "< your email >",                                                                             
  email: client.issuer,
  firstName: "SCP Dev",
  lastName: "Service Account",
  institute: "Broad Institute",
  institutionalProgram: "DSP",
  nonProfitStatus: "true"",
  pi: "N/A",
  programLocationCity: "Cambridge",
  programLocationState: "MA",
  programLocationCountry: "USA",
  title: "N/A"
)
client.set_profile(profile.attributes)
```
3. In a separate terminal, run the smoke test shell script from the project root: 
```
# -d flag will run test outside of Docker
./rails_local_setup.rb && source config/secrets/.source_env.bash
bin/run_orch_smoke_test.sh -d
```

You should see similar output to this (note the logging statement that points to staging orchestration):
```
Run options: --seed 17362

# Running:

SUITE FireCloudClientTest starting
Running smoke test against Terra orchestration API at https://firecloud-orchestration.dsde-staging.broadinstitute.org
fire_cloud_client_test.rb:76 test_firecloud_api_available starting
...
```