### PR TITLE
Log viewport size, per-view counts, and indirect discovery (SCP-5183)

### DIFF
--- a/app/javascript/components/explore/DifferentialExpressionFilters.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionFilters.jsx
@@ -34,6 +34,7 @@ function SliderContainer({ metric, toggleDeFacet, isActive }) {
         </label>
       </div>
       <div className={`de-slider de-slider-${metric}`} data-metric={metric}></div>
+      <br/>
     </div>
   )
 }
@@ -185,14 +186,12 @@ export default function DifferentialExpressionFilters({
     <div>
       {!isAuthorDe && <br/>}
       {metrics.map(metric =>
-        <>
-          <SliderContainer
-            metric={metric}
-            toggleDeFacet={toggleDeFacet}
-            isActive={activeFacets[metric]}
-          />
-          <br/>
-        </>
+        <SliderContainer
+          metric={metric}
+          key={metric}
+          toggleDeFacet={toggleDeFacet}
+          isActive={activeFacets[metric]}
+        />
       )}
     </div>
   )

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -158,7 +158,6 @@ const columnHelper = createColumnHelper()
 function searchGenesFromTable(selectedGenes, searchGenes, logProps) {
   searchGenes(selectedGenes)
 
-  console.log('selectedGenes', selectedGenes)
   // Log this search to Mixpanel
   logSearchFromDifferentialExpression(
     logProps.event, selectedGenes, logProps.species, logProps.rank,

--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -158,6 +158,7 @@ const columnHelper = createColumnHelper()
 function searchGenesFromTable(selectedGenes, searchGenes, logProps) {
   searchGenes(selectedGenes)
 
+  console.log('selectedGenes', selectedGenes)
   // Log this search to Mixpanel
   logSearchFromDifferentialExpression(
     logProps.event, selectedGenes, logProps.species, logProps.rank,

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -17,6 +17,10 @@ import { setupWebVitalsLog, addPerfMetrics } from './metrics-perf'
 
 let metricsApiMock = false
 
+const numSincePageLoadByEventName = {}
+let numClicksSincePageLoad = 0
+const numSincePageLoadByEventText = {}
+
 const defaultInit = {
   method: 'POST',
   headers: {
@@ -429,6 +433,33 @@ export function log(name, props = {}) {
   props['viewportHeight'] = window.innerHeight
 
   props['timeSincePageLoad'] = Math.round(performance.now())
+
+  // Enables answering e.g.:
+  //  - How many times has the plot legend been clicked on this page load?
+  //  - How many times has the Annotation been changed on this page load?
+  //  - How many clientside file validations have been done on this page load?
+  //  - How many clicks have been done since page load?
+  //  - How many events with this `text` have been done since page load?
+  if (name in numSincePageLoadByEventName) {
+    numSincePageLoadByEventName[name] += 1
+  } else {
+    numSincePageLoadByEventName[name] = 1
+  }
+  props['numThisPageLoad:thisName'] = numSincePageLoadByEventName[name]
+  if (name.includes('click')) {
+    numClicksSincePageLoad += 1
+  }
+  props['numSincePageLoad:clicks'] = numClicksSincePageLoad
+  if ('text' in props || 'label' in props) {
+    const text = 'text' in props ? props['text'] : props['label']
+    if (text in numSincePageLoadByEventText) {
+      numSincePageLoadByEventText[text] += 1
+    } else {
+      numSincePageLoadByEventText[text] = 1
+    }
+    props['numSincePageLoad:thisText'] = numSincePageLoadByEventName[name]
+  }
+
 
   if (window.SCP && window.SCP.currentStudyAccession) {
     props['studyAccession'] = window.SCP.currentStudyAccession

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -445,11 +445,11 @@ export function log(name, props = {}) {
   } else {
     numSincePageLoadByEventName[name] = 1
   }
-  props['numThisPageLoad:thisName'] = numSincePageLoadByEventName[name]
+  props['numEventsThisPageLoad:thisName'] = numSincePageLoadByEventName[name]
   if (name.includes('click')) {
     numClicksSincePageLoad += 1
   }
-  props['numSincePageLoad:clicks'] = numClicksSincePageLoad
+  props['numEventsSincePageLoad:clicks'] = numClicksSincePageLoad
   if ('text' in props || 'label' in props) {
     const text = 'text' in props ? props['text'] : props['label']
     if (text in numSincePageLoadByEventText) {
@@ -457,7 +457,7 @@ export function log(name, props = {}) {
     } else {
       numSincePageLoadByEventText[text] = 1
     }
-    props['numSincePageLoad:thisText'] = numSincePageLoadByEventName[name]
+    props['numEventsSincePageLoad:thisText'] = numSincePageLoadByEventName[name]
   }
 
 

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -425,6 +425,9 @@ export function log(name, props = {}) {
     props['tab'] = tab
   }
 
+  props['viewportWidth'] = window.innerWidth
+  props['viewportHeight'] = window.innerHeight
+
   props['timeSincePageLoad'] = Math.round(performance.now())
 
   if (window.SCP && window.SCP.currentStudyAccession) {

--- a/app/javascript/lib/search-metrics.js
+++ b/app/javascript/lib/search-metrics.js
@@ -369,18 +369,6 @@ export function logSearchFromDifferentialExpression(
 
   numDifferentialGeneSelections += 1
 
-  // Put DE properties together by prepending them with `de:`.
-  // This makes them more coherent in Network panel and Mixpanel "Events" view
-  const deProps = {}
-  Object.entries(deGene).forEach(([key, value]) => {
-    if (key === 'name') {
-      // Redundant with pre-existing `genes` Mixpanel prop
-      return
-    }
-    deProps[`de:${key}`] = value
-  })
-  deProps['de:rank'] = rank
-
   const otherProps = Object.assign({
     // Consider logging cluster and annotation for all Explore events
     cluster,
@@ -388,7 +376,7 @@ export function logSearchFromDifferentialExpression(
 
     // Helps assess level of engagement
     numEventsSincePageView: numDifferentialGeneSelections
-  }, deProps)
+  })
 
   // Log time since last search via DE gene selection.  This can help answer
   // questions like "How much would instant gene expression plots help?" and
@@ -399,7 +387,7 @@ export function logSearchFromDifferentialExpression(
     otherProps.timeSinceLastSelection = Math.round(timeLast)
   }
 
-  logStudyGeneSearch([deGene.name], trigger, speciesList, otherProps)
+  logStudyGeneSearch(deGene, trigger, speciesList, otherProps)
 
   timeLastDifferentialExpressionSelection = performance.now()
 }


### PR DESCRIPTION
This enables staff to answer relevant questions about product usage and user experience, e.g.:

### How big is the user's window?
New `viewportWidth` and `viewportHeight` properties report the size of the user's app window.  This complements `screen_width` and `screen_height`, which report the size of the user's screen / device / monitor.  (The casing of these properties differs because the latter pair is "built in" as part of the mirrored Mixpanel suite, whereas the former is not.)

Knowing this can help inform how much effort we invest tailoring layouts for various viewport dimensions.

### How many clicks have there been in this page view?  
### How many times has this thing been clicked in this page view?
We sometimes make changes aimed at boosting general engagement.  While we can assess event-level total counts or statistics per user, we haven't been able to assess how engagement _within a given page view_ changes.  

The new properties `numEventsThisPageLoad:thisName` and `numEventsSincePageLoad:thisText` enable that at a reasonably granular level, by reporting the number of times an event with "this" name (i.e., the name of the event logged to Mixpanel), and "this" displayed text are done in the current page view.  The `numEventsSincePageLoad:clicks` does similarly, but for a higher-level metric -- the number of logged clicks in the given page view.

Knowing this can help assess the per-view impact of UX changes on engagement, both overall and for specific elements.

### Did the user see the gene they searched in a gene discovery UI component?
Sometimes, users learn about a gene through the DE table or ideogram, but don't search directly through those widgets as we'd typically expect.  The `search` event has new properties -- `numSearchedGenesInDifferentialExpressionTable` and `numSearchedGenesInIdeogram` -- which will help us systematically measure how often that happens.

Knowing this can help more accurately assess how much of our search activity is attributable to DE table and ideogram, and whether users understand they can interact through those widgets.

### Test
To manually test:
* Go to a page
* Resize browser
* Open Network panel in DevTools, filter to `bard method:POST`
* Click a button
* In Network panel, find post request to Bard and:
  * Confirm `viewportWidth` and `viewportHeight` appear, and differ from `screen_width` and `screen_height`
  * Confirm `numEventsThisPageLoad:thisName` and `numEventsSincePageLoad:clicks` report 1, and (assuming the element has text or a label) `numEventsSincePageLoad:thisText` reports 1
* Click a _different_ button, and confirm `numEventsThisPageLoad:thisName` and `numEventsSincePageLoad:clicks` report 2, and (assuming the element has text or a label) `numEventsSincePageLoad:thisText` reports 1 _and not 2_
* Go to a study with DE results
* Click "Differential expression" button
* In the main gene search box at upper left in page, type in a gene shown in the DE table, and execute a search for it
* In Bard post, confirm `numSearchedGenesInDifferentialExpressionTable` reports 1
* Click arrow to right of search box to "Return to cluster view"
* In main gene search box, search "PTEN"
* Confirm "PIK3CA" is shown in related genes ideogram
* In main gene search box, search "PIK3CA"
* In Bard post, confirm `numSearchedGenesInIdeogram` reports 1


For richer context, see [SCP demo discussion](https://drive.google.com/file/d/1rdtpUoNjmm-bAsAs3BlAo0Me7XYnJi7Q/view?t=10).  This was a Developer's Choice Day project, tracked in SCP-5183.