### PR TITLE
Fix missing reference to download quota (SCP-5231)

### DIFF
--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -145,8 +145,8 @@ class BulkDownloadService
     file_bytes_requested = get_requested_bytes(files)
     dir_bytes_requested = get_requested_bytes(directories, size_method: :total_bytes)
     bytes_requested = file_bytes_requested + dir_bytes_requested
-    bytes_allowed = DownloadQuotaService.download_quota
     if DownloadQuotaService.download_exceeds_quota?(user, bytes_requested)
+      bytes_allowed = DownloadQuotaService.download_quota - user.daily_download_quota
       raise "Total file size exceeds user download quota: #{bytes_requested} bytes requested, #{bytes_allowed} bytes " \
             "allowed.  #{DownloadQuotaService::QUOTA_HELP_EMAIL}"
     else

--- a/app/lib/bulk_download_service.rb
+++ b/app/lib/bulk_download_service.rb
@@ -145,6 +145,7 @@ class BulkDownloadService
     file_bytes_requested = get_requested_bytes(files)
     dir_bytes_requested = get_requested_bytes(directories, size_method: :total_bytes)
     bytes_requested = file_bytes_requested + dir_bytes_requested
+    bytes_allowed = DownloadQuotaService.download_quota
     if DownloadQuotaService.download_exceeds_quota?(user, bytes_requested)
       raise "Total file size exceeds user download quota: #{bytes_requested} bytes requested, #{bytes_allowed} bytes " \
             "allowed.  #{DownloadQuotaService::QUOTA_HELP_EMAIL}"


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a broken reference to the total daily download quota when checking if a user has exceeded their quota after issuing a bulk download request.  There is no user-facing component to this bug - they already can't download the data as their quota is over the limit, and our current UX for bulk download already doesn't show error messages to users when something fails after they authorize the request.  This bug only occurs _after_ the request is approved, but then the total bytes requested exceeds the user quota.  This fix is only to correct an obvious bug that was found during triage, rather than improving the UX for the user, as that would entail more engineering work (instead of the single-line fix below).

#### MANUAL TESTING
1. Boot as normal, sign in, and run a text search on the home page for "Human milk - differential expression" (use quotes)
2. Click the Download button, and proceed all the way through authorizing the request, leaving the modal open to copy the command
3. In a separate tab, go to the Admin config panel, and create/update the Daily User Download Quota entry:
   - Configuration Type: `Daily User Download Quota`
   - Type of Value: `Numeric`
   - Value: `100`
   - Byte Operator: `megabyte`
4. Go back to the download command and copy/paste into a terminal and execute, noting the download does not complete
5. In `development.log`, note the request responded `403` and no error was thrown:
```
Started GET "/single_cell/api/v1/bulk_download/generate_curl_config?auth_code=ObkwzSp9&context=global&download_id=64b807ba94ec8fcd99becc44" for 127.0.0.1 at 2023-07-19 11:57:09 -0400
Processing by Api::V1::BulkDownloadController#generate_curl_config as JSON
  Parameters: {"auth_code"=>"ObkwzSp9", "context"=>"global", "download_id"=>"64b807ba94ec8fcd99becc44"}
Authenticating user via auth_token: ObkwzSp9
FireCloud API request (GET) https://api.firecloud.org/api/groups with tracking identifier: 60903e40e24139898f9729d0
Completed 403 Forbidden in 1290ms (Views: 0.5ms | MongoDB: 0.8ms | Allocations: 87348)
```