### PR TITLE
Update gene search placeholder & label (SCP-5049)

### DIFF
--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -167,7 +167,7 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
             // the default blur behavior removes any entered free text,
             // we want to instead auto-convert entered free text to a gene tag
             onBlur={syncGeneArrayToInputText}
-            placeholder={searchDisabled ? 'No expression data to search' : 'Genes (e.g. "PTEN NF2")'}
+            placeholder={searchDisabled ? 'No expression data to search' : 'Search gene(s) and find plots'}
             isDisabled={searchDisabled}
             styles={{
               // if more genes are entered than fit, use a vertical scrollbar

--- a/app/javascript/components/search/genes/GeneSearchView.jsx
+++ b/app/javascript/components/search/genes/GeneSearchView.jsx
@@ -55,7 +55,10 @@ export default function GeneSearchView() {
     <div>
       <div className="row">
         <div className="col-md-12 col-sm-12 col-xs-12">
-          <GeneKeyword placeholder={geneSearchPlaceholder} helpTextContent={helpTextContent} />
+          <span className='text-search search-title'>
+          Search by genes
+            <GeneKeyword placeholder={geneSearchPlaceholder} helpTextContent={helpTextContent} />
+          </span>
         </div>
       </div>
       <div className="row">

--- a/test/js/explore/study-gene-keyword.test.js
+++ b/test/js/explore/study-gene-keyword.test.js
@@ -21,13 +21,13 @@ describe('Search query display text', () => {
 
   it('is disabled if there are no genes to search', async () => {
     const { container } = render(<StudyGeneField genes={[]} searchGenes={() => {}} allGenes={['PTEN']} speciesList={[]} />)
-    expect(container.querySelector('.gene-keyword-search-input').textContent.trim()).toEqual('Genes (e.g. "PTEN NF2")')
+    expect(container.querySelector('.gene-keyword-search-input').textContent.trim()).toEqual('Search gene(s) and find plots')
 
     const { container: emptyContainer } = render(<StudyGeneField genes={[]} searchGenes={() => {}} allGenes={[]} speciesList={[]} />)
     expect(emptyContainer.querySelector('.gene-keyword-search-input').textContent.trim()).toEqual('No expression data to search')
 
     const { container: loadingContainer } = render(<StudyGeneField genes={[]} searchGenes={() => {}} allGenes={[]} speciesList={[]} isLoading={true}/>)
-    expect(loadingContainer.querySelector('.gene-keyword-search-input').textContent.trim()).toEqual('Genes (e.g. "PTEN NF2")')
+    expect(loadingContainer.querySelector('.gene-keyword-search-input').textContent.trim()).toEqual('Search gene(s) and find plots')
   })
 })
 


### PR DESCRIPTION
Added a label of "Search by genes" to the home page gene search to match the filter and text search labels
![Screenshot 2023-07-20 at 10 58 56 AM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/36792028-a48f-4a05-ba68-f6609fb56a73)
![Screenshot 2023-07-20 at 10 59 29 AM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/9c0ef1c0-c304-4f18-be5e-358be6d033a4)

Updated the placeholder text to indicate action (Search and find)
![Screenshot 2023-07-20 at 10 43 20 AM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/5ede7128-c5b9-48a7-b83f-c10f5f0dee4c)

To test:
- Pull this branch
- Go to homepage and tab to gene search to see the new text above the search
- Go to a study and see the new placeholder text