### PR TITLE
Add link to whitepaper (SCP-5207)

### DIFF
--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -236,9 +236,16 @@
   }
 }
 
-#latest-features-btn {
+#whitepaper-btn {
   position: absolute;
   top: 245px;
+  right: 15px;
+  z-index: 500;
+}
+
+#latest-features-btn {
+  top: 200px;
+  position: absolute;
   right: 15px;
   z-index: 500;
 }

--- a/app/views/site/_main_banner_content.html.erb
+++ b/app/views/site/_main_banner_content.html.erb
@@ -5,6 +5,10 @@
                     latest_feature_announcements_path, class: 'btn btn-warning-scp', id: 'latest-features-btn',
                     data: { toggle: 'tooltip', placement: 'left' }, title: 'Learn about new Single Cell Portal features!' %>
   <% end %>
+  <%= link_to "<span class='badge btn-warning-scp-icon'></span> " \
+  "Portal whitepaper".html_safe, 
+  "https://www.biorxiv.org/content/10.1101/2023.07.13.548886v1", class: 'btn btn-warning-scp', id: 'whitepaper-btn',
+  data: { toggle: 'tooltip', placement: 'left' }, title: 'Read the Single Cell Portal whitepaper!', target: :_blank %>
   <% if @selected_branding_group.present? %>
   <% content_for(:html_title) { "#{@selected_branding_group.name} - Collections - Single Cell Portal" } %>
     <% if @selected_branding_group.banner_image.file %>


### PR DESCRIPTION
Adds a button for the white paper link on the homepage per the design discussion in slack
![Screenshot 2023-07-20 at 12 25 05 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/543eebcc-b696-4d6c-b715-39b3d5c02ef6)
![Screenshot 2023-07-20 at 12 25 13 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/5e683590-186b-47ad-8807-2d22d9986b3f)

To test:
- pull this branch and boot up local and view the homepage, hover and click the button to see the full feature