### PR TITLE
Update Ingest Pipeline to 1.27.3

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.27.2'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.27.3'
 
     # Docker image for image pipeline jobs
     config.image_pipeline_docker_image = 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_c2b090043'


### PR DESCRIPTION
This incorporates an upstream security patch now available in Ingest Pipeline 1.27.3 (#316, #317).

Given staffing, per [compliance discussion](https://broadinstitute.slack.com/archives/CADU7L0SZ/p1687532450858819?thread_ts=1687464810.060679&cid=CADU7L0SZ), we can merge after 1 approval, then get a 2nd review when next reviewer returns.