### PR TITLE
Adding visualization facets API endpoint, indexed cluster cell arrays (SCP-5214)

### DIFF
--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -188,7 +188,7 @@ module Api
               key :required, true
             end
             response 200 do
-              key :description, 'Hash of integer-based annotation assignments for all cells in requested cluster'
+              key :description, 'Array of integer-based annotation assignments for all cells in requested cluster'
               schema do
                 key :title, 'Annotations'
                 property :cells do
@@ -248,15 +248,16 @@ module Api
             render json: { error: 'Cannot use numeric annotations for facets' }, status: :bad_request and return
           end
 
-          # use new cell index arrays to load data much faster
-          indexed_cluster_cells = cluster.concatenate_data_arrays('index', 'cells')
-          annotation_arrays = {}
-          facets = []
           annotations = self.class.get_facet_annotations(@study, cluster, params[:annotations])
           missing = self.class.find_missing_annotations(annotations, params[:annotations])
           if missing.any?
             render json: { error: "Cannot find annotations: #{missing.join(', ')}" }, status: :not_found and return
           end
+
+          # use new cell index arrays to load data much faster
+          indexed_cluster_cells = cluster.concatenate_data_arrays('index', 'cells')
+          annotation_arrays = {}
+          facets = []
           # build arrays of annotation values, and populate facets response array
           annotations.each do |annotation|
             scope = annotation[:scope]

--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -280,9 +280,9 @@ module Api
               annotation = facet[:annotation]
               scope = annotation.split('--').last
               if scope == 'study'
-                label = annotation_arrays[annotation][value]
+                label = annotation_arrays[annotation][value] || '--Unspecified--'
               else
-                label = annotation_arrays[annotation][index]
+                label = annotation_arrays[annotation][index] || '--Unspecified--'
               end
               facet[:groups].index(label)
             end

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -97,15 +97,21 @@ class ExpressionVizService
         values[annotations[index]][:cells] << cell
       end
     else
-      # since annotations are in a hash format, subsampling isn't necessary as we're going to retrieve values by key lookup
-      annotations = study.cell_metadata.by_name_and_type(annotation[:name], annotation[:type])&.cell_annotations || {}
-      cells.each do |cell|
-        val = annotations[cell]
+      if subsample_threshold
+        annotations = study.cell_metadata.by_name_and_type(annotation[:name], annotation[:type])&.cell_annotations || {}
+      else
+        annotation_array = ClusterVizService.get_annotation_values_array(
+          study, cluster, annotation, cells, nil, nil
+        )
+      end
+      cells.each_with_index do |cell, index|
+        val_params = { subsample_threshold:, annotations:, annotation_array: }
+        val = set_expression_value(cell, index, **val_params)
         # must check if key exists
-        if values.has_key?(val)
-          values[annotations[cell]][:y] << gene['scores'][cell].to_f.round(4)
-          values[annotations[cell]][:cells] << cell
-        end
+        next unless values.key?(val)
+
+        values[val][:y] << gene['scores'][cell].to_f.round(4)
+        values[val][:cells] << cell
       end
     end
     # remove any empty values as annotations may have created keys that don't exist in cluster
@@ -227,21 +233,27 @@ class ExpressionVizService
         end
       end
     else
-      # no need to subsample annotation since they are in hash format (lookup done by key)
-      annotations = study.cell_metadata.by_name_and_type(annotation[:name], annotation[:type])&.cell_annotations || {}
-      cells.each do |cell|
-        val = annotations[cell]
+      if subsample_threshold
+        annotations = study.cell_metadata.by_name_and_type(annotation[:name], annotation[:type])&.cell_annotations || {}
+      else
+        annotation_array = ClusterVizService.get_annotation_values_array(
+          study, cluster, annotation, cells, nil, nil
+        )
+      end
+      cells.each_with_index do |cell, index|
+        val_params = { subsample_threshold:, annotations:, annotation_array: }
+        val = set_expression_value(cell, index, **val_params)
         # must check if key exists
-        if values.has_key?(val)
-          values[annotations[cell]][:cells] << cell
-          case consensus
-          when 'mean'
-            values[annotations[cell]][:y] << calculate_mean(genes, cell)
-          when 'median'
-            values[annotations[cell]][:y] << calculate_median(genes, cell)
-          else
-            values[annotations[cell]][:y] << calculate_mean(genes, cell)
-          end
+        next unless values.key?(val)
+
+        values[val][:cells] << cell
+        case consensus
+        when 'mean'
+          values[val][:y] << calculate_mean(genes, cell)
+        when 'median'
+          values[val][:y] << calculate_median(genes, cell)
+        else
+          values[val][:y] << calculate_mean(genes, cell)
         end
       end
     end
@@ -271,20 +283,20 @@ class ExpressionVizService
 
     cells.each_with_index do |cell, index|
       annotation_value = annotation_array[index]
-      if !annotation_value.nil?
-        case consensus
-        when 'mean'
-          expression_value = calculate_mean(genes, cell)
-        when 'median'
-          expression_value = calculate_median(genes, cell)
-        else
-          expression_value = calculate_mean(genes, cell)
-        end
-        viz_data[:annotations] << annotation_value
-        viz_data[:x] << annotation_value
-        viz_data[:y] << expression_value
-        viz_data[:cells] << cell
+      next if annotation_value.nil?
+
+      case consensus
+      when 'mean'
+        expression_value = calculate_mean(genes, cell)
+      when 'median'
+        expression_value = calculate_median(genes, cell)
+      else
+        expression_value = calculate_mean(genes, cell)
       end
+      viz_data[:annotations] << annotation_value
+      viz_data[:x] << annotation_value
+      viz_data[:y] << expression_value
+      viz_data[:cells] << cell
     end
     viz_data
   end
@@ -322,6 +334,18 @@ class ExpressionVizService
   def self.calculate_median(genes, cell)
     values = genes.map {|gene| gene['scores'][cell].to_f}
     Gene.array_median(values)
+  end
+
+  # extract expression value from appropriate object, depending on scenario
+  #
+  # * *params*
+  #   * +cell_name+ (String) => cluster cell name
+  #   * +index+ (Integer) => array index from cluster cells
+  #   * +subsample_threshold+ (Integer, nil) => subsampling threshold, used to determine which object to query
+  #   * +annotation_array+ (Array) => array of annotation values, reordered to match cluster cells
+  #   * +annotations+ (Hash) => cell metadata annotations hash
+  def self.set_expression_value(cell_name, index, subsample_threshold: nil, annotation_array: [], annotations: {})
+    subsample_threshold ? annotations[cell_name] : annotation_array[index]
   end
 
   # return a text file for morpheus to use when rendering dotplots/heatmaps

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -38,7 +38,7 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
       # now remove all child objects first to free them up to be re-used.
       case file_type
       when 'Cluster'
-        delete_differential_expression_results(study: study, study_file: object)
+        delete_differential_expression_results(study:, study_file: object)
         delete_parsed_data(object.id, study.id, ClusterGroup, DataArray)
         delete_user_annotations(study:, study_file: object)
         reset_default_cluster(study:)
@@ -48,10 +48,10 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
         remove_file_from_bundle
       when 'Expression Matrix'
         delete_parsed_data(object.id, study.id, Gene, DataArray)
-        delete_differential_expression_results(study: study, study_file: object)
+        delete_differential_expression_results(study:, study_file: object)
         study.set_gene_count
       when 'MM Coordinate Matrix'
-        delete_differential_expression_results(study: study, study_file: object)
+        delete_differential_expression_results(study:, study_file: object)
         delete_parsed_data(object.id, study.id, Gene, DataArray)
         study.set_gene_count
       when /10X/
@@ -69,20 +69,21 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
         end
         remove_file_from_bundle
       when 'Metadata'
-        delete_convention_data(study: study, metadata_file: object)
+        delete_convention_data(study:, metadata_file: object)
 
         # clean up all subsampled data, as it is now invalid and will be regenerated
         # once a user adds another metadata file
         ClusterGroup.where(study_id: study.id).each do |cluster_group|
           delete_subsampled_data(cluster_group)
         end
-        delete_differential_expression_results(study: study, study_file: object)
+        delete_differential_expression_results(study:, study_file: object)
         delete_parsed_data(object.id, study.id, CellMetadatum, DataArray)
+        delete_cell_index_arrays(study)
         study.update(cell_count: 0)
         reset_default_annotation(study:)
       when 'AnnData'
         unless object.is_reference_anndata?
-          delete_convention_data(study: study, metadata_file: object)
+          delete_convention_data(study:, metadata_file: object)
           # delete user annotations first as we lose associations later
           delete_user_annotations(study:, study_file: object)
           delete_parsed_data(object.id, study.id, ClusterGroup, CellMetadatum, Gene, DataArray)
@@ -188,6 +189,17 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
   def delete_subsampled_data(cluster)
     cluster.find_subsampled_data_arrays.delete_all
     cluster.update(subsampled: false)
+  end
+
+  # remove all indexed arrays of cluster-based cell names when deleting a metadata file
+  def delete_cell_index_arrays(study)
+    cluster_file_ids = study.study_files.where(file_type: 'Cluster').pluck(:id)
+    cluster_ids = study.cluster_groups.pluck(:id)
+    cursor = DataArray.where(
+      name: 'index', array_type: 'cells', linear_data_type: 'ClusterGroup', :linear_data_id.in => cluster_ids,
+      study_id: study.id, :study_file_ids.in => cluster_file_ids
+    )
+    cursor.delete_all if cursor.exists?
   end
 
   # delete convention data from BQ if a user deletes a convention metadata file, or a study that contains convention data

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -403,6 +403,7 @@ class IngestJob
       end
       launch_differential_expression_jobs unless study_file.is_anndata?
       set_anndata_file_info if study_file.is_anndata?
+      create_cell_name_indexes
     when :ingest_expression
       study.delay.set_gene_count
       launch_differential_expression_jobs
@@ -412,6 +413,7 @@ class IngestJob
       launch_subsample_jobs
       launch_differential_expression_jobs unless study_file.is_anndata?
       set_anndata_file_info if study_file.is_anndata?
+      create_cell_name_indexes
     when :ingest_subsample
       set_subsampling_flags
     when :differential_expression
@@ -514,6 +516,17 @@ class IngestJob
   def set_study_initialized
     if study.cluster_groups.any? && study.genes.any? && study.cell_metadata.any? && !study.initialized?
       study.update(initialized: true)
+    end
+  end
+
+  # create 'all cells' => cluster cells index arrays for visualization requests
+  def create_cell_name_indexes
+    case action
+    when :ingest_cell_metadata
+      study.create_all_cluster_cell_indices!
+    when :ingest_cluster
+      cluster = ClusterGroup.find_by(study:, study_file:, name: cluster_name_by_file_type)
+      cluster.create_cell_name_index!
     end
   end
 

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -833,7 +833,7 @@ class Study
       false
     else
       # use if/elsif with explicit returns to ensure skipping downstream calls
-      if self.study_shares.can_view.map do |email_address| 
+      if self.study_shares.can_view.map do |email_address|
         remove_gmail_periods(email_address)
       end.include?(remove_gmail_periods(user.email))
         return true
@@ -1394,6 +1394,19 @@ class Study
       all_cells += expression_matrix_cells(file)
     end
     all_cells.uniq # account for raw counts & processed matrix files repeating cell names
+  end
+
+  # for every cluster in this study, generate an indexed array of cluster cells using 'all cells' as the map
+  # returns number of arrays created
+  def create_all_cluster_cell_indices!
+    study_cells = all_cells_array
+    return nil if cluster_groups.empty? || study_cells.empty?
+
+    cluster_groups.each do |cluster_group|
+      Rails.logger.info "creating cell index in #{accession} for #{cluster_group.name}"
+      cluster_group.create_cell_name_index!
+      Rails.logger.info "finished cell index in #{accession} for #{cluster_group.name}"
+    end
   end
 
   # return the cells found in a single expression matrix

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
                       only: [:show, :index],
                       param: :cluster_name,
                       constraints: { cluster_name: /[^\/]+/ } # needed to allow '.' in cluster names
+            get 'annotations/facets', to: 'visualization/annotations#facets'
             resources :annotations, controller: 'visualization/annotations',
                       only: [:show, :index],
                       param: :annotation_name,

--- a/db/migrate/20230724205457_create_cluster_index_arrays.rb
+++ b/db/migrate/20230724205457_create_cluster_index_arrays.rb
@@ -1,0 +1,19 @@
+class CreateClusterIndexArrays < Mongoid::Migration
+  def self.up
+    accessions = Study.pluck(:accession)
+    accessions.each do |accession|
+      study = Study.find_by(accession:)
+      study.delay.create_all_cluster_cell_indices!
+    end
+  end
+
+  def self.down
+    cluster_file_ids = StudyFile.where(file_type: 'Cluster').pluck(:id)
+    cluster_ids = ClusterGroup.pluck(:id)
+    study_ids = Study.pluck(:id)
+    DataArray.where(
+      name: 'index', array_type: 'cells', linear_data_type: 'ClusterGroup', :linear_data_id.in => cluster_ids,
+      :study_ids.in => study_ids, :study_file_ids.in => cluster_file_ids
+    ).delete_all
+  end
+end

--- a/test/factories/cluster_group.rb
+++ b/test/factories/cluster_group.rb
@@ -69,6 +69,7 @@ FactoryBot.define do
                             study_file: evaluator.study_file)
         end
         cluster.set_point_count!
+        cluster.create_cell_name_index!
       end
     end
   end

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
                             values: evaluator.cell_input,
                             study_file: file)
         end
+        file.study.create_all_cluster_cell_indices!
       end
     end
     factory :cluster_file do


### PR DESCRIPTION
#### BACKGROUND
In order to support some of the planned features to allow users to visualize intersections & subsets of data (SCP-5178), we need to have data available to quickly find annotation memberships for populations of cells in a scatter plot.  This will allow us to build a "faceted search" feature within a plot that will let users progressively filter data based off of facet (i.e. annotation names) and filter (i.e. group-based annotation values) values.  Adding an API endpoint that will serve this data on demand in a performant manner is one of the first requirements.

#### CHANGES
This update adds that endpoint at `/api/v1/studies/:accession/annotations/facets` (in `Api::V1::Visualization::AnnotationsController#facets`).  This endpoint will compute integer-based assignments for the requested cluster/annotations.  A functional spec is available [here](https://docs.google.com/document/d/1OHJBF_6DnKCGgf4jwuZjq2iZJF5kDEl5eG23PLGVOR4/edit#heading=h.gcdzl0yfknth) with more detail on request parameters/responses.  In the response, the `cells` array shows where each cell from the cluster (outer array) maps to annotation values (inner arrays) as defined in the `facets` array, pulling those values from the `groups` key.

One of the major requirements for this was performance - it has to be able to return this data quickly (1-2s, ideally).  The initial implementation was woefully inadequate (25-30s for 50K cells, 2 annotations).  To address this problem, all clusters will now index their cell name arrays against the "all cells" array from the study metadata file.  By doing this, we pre-calculate the order in which a given cluster's cells appear in any study-based annotation (cluster-based annotations are not affected by this problem).  This now allows us to skip loading the entire hash of study based annotations, and instead _only_ retrieve the array of annotation labels.  Then, using the indexed cluster cell array, we can pull out the correct values for each cell only using the array index values.

Toy example:
```
metadata_cells = ['A', 'B', 'C', 'D', 'E']
metadata_labels = ['foo', 'bar', 'bing', 'baz', 'blah'] 
annotation_hash = { A: 'foo', B: 'bar', C: 'bing', D: 'baz', E: 'blah' }
cluster_cells = ['C', 'E', 'A', 'D', 'B']
indexed_cluster_cells = [2, 4, 0, 3, 1]

$ cluster_cells.first
=> 'C'
$ annotation_hash['C'] 
=> 'bing'
$ indexed_cluster_cells.first 
=> 2
$ metadata_labels[2] 
=> 'bing'
```

Benchmarking with production data has shown this approach to be 3-7x faster than using the entire hash to load the data (render/plotting times would be unaffected).  This performance boost holds at all resolutions, but is not appreciable at under 100K cells, and therefore is only applied to full resolution data (also since subsampling does not always sample the same cells across annotations, making backfill infeasible).  This update applies this technique to all visualizations that use full resolution study-based data.  Additionally, a migration has been added to backfill the necessary data, and hooks have been added to `IngestJob` to generate the arrays whenever cluster/metadata files are ingested (along with data cleanup calls in `DeleteQueueJob`).

The hope is that this performance enhancement will eventually remove the need to subsample data, which would be a major complexity/cost savings for the product, and a gain in performance/usability for all users.

#### MANUAL TESTING
If you plan to use the Swagger doc to test, you will need to make the following edit to `app/views/api/v1/api_docs/swagger_ui.html.erb` at the bottom of the page where Swagger is initialized:

```
 const ui = SwaggerUIBundle({
  syntaxHighlight: false,
  ...
```
This will prevent Swagger from crashing on the large array response.  Additionally, disable caching by running this in the terminal from project root:
```
bin/rails dev:cache
=> Development mode is no longer being cached.
```
Alternatively, you can use a client like [Postman](https://www.postman.com/).
1. Start all services, including `Delayed::Job` and then run the migration with `bin/rails db:migrate`
2. Load the `Human milk - differential expression` study and copy the study accession
3. Using Swagger, load `https://localhost:3000/single_cell/api/v1#/Visualization/study_annotation_facets_path`, or point Postman at `https://localhost:3000/single_cell/api/v1/studies/[:accession]/annotations/facets`, adding in the correct `:accession` value
4. Use the following request parameters:
    * accession: from above
    * annotations: `General_Celltype--group--study,disease__ontology_label--group--study`
    * cluster: 'All Cells UMAP'
5. Execute the request, and confirm the response comes back quickly (~3s, depending on your internet connection)
6. There should be a long array of nested two-element arrays for `cells`, and `facets` at the bottom should list both annotations and their values.
7. In a separate tab, load the same [study on production](https://singlecell.broadinstitute.org/single_cell/study/SCP1671/cellular-and-transcriptional-diversity-over-the-course-of-human-lactation)
8. Run the same visualization requests (normal & expression-based) in both tabs, confirming that you see the same plots (colors will be different in the scatter plots on production)