### PR TITLE
Always save logs in CI runs (SCP-5028)

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -36,6 +36,7 @@ jobs:
                                   -n single-cell-portal-test
       - name: Preserve all test logs
         uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: test-logs
           path: |

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -32,6 +32,7 @@ jobs:
                                   -c bin/run_orch_smoke_test.sh
       - name: Preserve all test logs
         uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: test-logs
           path: |


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug where failed CI runs do not save logfiles.  Now, logs are always retained, regardless of status.