### PR TITLE
Making cell name indexing performant at scale (SCP-5261)

### DIFF
--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -260,7 +260,7 @@ module Api
           end
 
           # use new cell index arrays to load data much faster
-          indexed_cluster_cells = cluster.concatenate_data_arrays('index', 'cells')
+          indexed_cluster_cells = cluster.cell_index_array
           annotation_arrays = {}
           facets = []
           # build arrays of annotation values, and populate facets response array

--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -244,6 +244,11 @@ module Api
             render json: { error: "Cannot find cluster: #{params[:cluster]}" }, status: :not_found and return
           end
 
+          # need to check for presence as some clusters will not have them if cells were not found in all_cells_array
+          unless cluster.indexed
+            render json: { error: 'Cluster is not indexed' }, status: :bad_request and return
+          end
+
           if params[:annotations].include?('--numeric--')
             render json: { error: 'Cannot use numeric annotations for facets' }, status: :bad_request and return
           end

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -214,7 +214,7 @@ class ClusterVizService
     else
       # for study-wide annotations, load from study_metadata values instead of cluster-specific annotations
       metadata_obj = study.cell_metadata.by_name_and_type(annotation[:name], annotation[:type])
-      if subsample_annotation
+      if !cluster.indexed? || (subsample_annotation && subsample_threshold)
         annotation_hash = metadata_obj&.cell_annotations || {}
         annotation_array = cells&.map { |cell| annotation_hash[cell] } || []
       else

--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -220,7 +220,7 @@ class ClusterVizService
       else
         # full-resolution data can use the indexed cell names array for better performance (~3-5x)
         # benefit is most noticeable > 100k cells
-        index = cluster.concatenate_data_arrays('index', 'cells') || []
+        index = cluster.cell_index_array || []
         annotations = metadata_obj&.concatenate_data_arrays(metadata_obj.name, 'annotations') || []
         annotation_array = index.map { |idx| annotations[idx] }
       end

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -200,6 +200,7 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
       study_id: study.id, :study_file_ids.in => cluster_file_ids
     )
     cursor.delete_all if cursor.exists?
+    study.cluster_groups.update_all(indexed: false)
   end
 
   # delete convention data from BQ if a user deletes a convention metadata file, or a study that contains convention data

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1402,9 +1402,9 @@ class Study
     return nil if cluster_groups.empty?
 
     cluster_groups.each do |cluster_group|
-      Rails.logger.info "creating cell index in #{accession} for #{cluster_group.name}"
+      Rails.logger.info "creating cell index for #{accession}:#{cluster_group.name}"
       cluster_group.create_cell_name_index!
-      Rails.logger.info "finished cell index in #{accession} for #{cluster_group.name}"
+      Rails.logger.info "finished cell index for #{accession}:#{cluster_group.name}"
     end
   end
 

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1399,8 +1399,7 @@ class Study
   # for every cluster in this study, generate an indexed array of cluster cells using 'all cells' as the map
   # returns number of arrays created
   def create_all_cluster_cell_indices!
-    study_cells = all_cells_array
-    return nil if cluster_groups.empty? || study_cells.empty?
+    return nil if cluster_groups.empty?
 
     cluster_groups.each do |cluster_group|
       Rails.logger.info "creating cell index in #{accession} for #{cluster_group.name}"

--- a/db/migrate/20230724205457_create_cluster_index_arrays.rb
+++ b/db/migrate/20230724205457_create_cluster_index_arrays.rb
@@ -13,7 +13,8 @@ class CreateClusterIndexArrays < Mongoid::Migration
     study_ids = Study.pluck(:id)
     DataArray.where(
       name: 'index', array_type: 'cells', linear_data_type: 'ClusterGroup', :linear_data_id.in => cluster_ids,
-      :study_ids.in => study_ids, :study_file_ids.in => cluster_file_ids
+      :study_id.in => study_ids, :study_file_id.in => cluster_file_ids
     ).delete_all
+    ClusterGroup.update_all(indexed: false, is_indexing: false)
   end
 end


### PR DESCRIPTION
#### BACKGROUND
The visualization enhancements introduced in #1838 caused several problems when deployed to our staging host:
1. Data backfill nearly overloaded the app server, spiking to 99% and hovering between 80-95% CPU for several hours
2. Studies with very high cell counts (over 1M) take 6+ hours to complete
3. Some of the backfill created arrays of `nil` values due to integrity issues with source data
4. The optimized visualization code was unreachable due to faulty logic

#### CHANGES
This update addresses concerns regarding performance & data integrity with the following enhancements:

#### PERFORMANCE
The original implementation did not scale, as we were attempting to index an array of cells from a cluster against all of the cells from the metadata file.  As this operation is `O(n)`, very large arrays (> 1M) take incredibly long to index.  The new implementation instead creates a hash of cell names from the metadata file to their array position (e.g., `{ cell_1: 0, cell_2: 1, ... cell_N: all_cells.length }` and then performs a hash key lookup for each cell from the cluster file.  This operation is `O(1)` once the hash is created (which only takes seconds even for millions of cells).  Benchmarking has show that this can index clusters with over 1M cells against a similarly sized metadata file in seconds as opposed to hours.  Additionally, for cases where the lists of cells from the metadata and cluster files are identical (a common scenario), the indexing operation is completely skipped and the new field `use_default_index` is set on the cluster that will automatically return an enumerator from `0` to `cluster.points - 1`, since this is the value that would have been saved by `create_cell_name_index!`. 

#### INTEGRITY
New fields have been added to `ClusterGroup` - `indexed` and `is_indexing`, identical to the related subsampling fields.  These will govern whether a cluster has been (or is currently) being indexed, which will prevent concurrent jobs attempting to index the same cluster.  Additionally, checks have been added to prevent indexing a cluster if it contains cells not found in the metadata file, as this breaks downstream functionality.  Additional checks have been added to ensure that indexed arrays are only loaded when present.  Finally, the migration was updated to fix query logic bugs that prevented it from deleting the indexed arrays when rolled back.

The current plan is that once this branch is merged and deployed to staging, the migration will be rolled back manually and then re-run.  This will give an accurate estimate of expected performance when deployed to production.

#### MANUAL TESTING
This works best if you have a very large study in your local instance.  I recommend ingesting the clustering/metadata from the [1.46M COVID study](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP127/1-46m-covid) on staging.

1. Check out branch and start all services, including delayed_job
2. If desired, ingest the 1.46M cell study from staging
3. If you have already run the latest migration, roll it back in a separate terminal window with `bin/rails db:rollback`
4. Run the latest migration with `bin/rails db:migrate`
5. Open `development.log` and confirm you see messages like:
```
Migrating to CreateClusterIndexArrays (20230724205457)
creating cell index for SCP13:Major Cell Types
creating cell index for SCP17:cluster.tsv
finished cell index for SCP13:Major Cell Types
creating cell index for SCP13:CA1
using default cell index for SCP17:cluster.tsv
finished cell index for SCP17:cluster.tsv
creating cell index for SCP36:cluster_square
creating cell index for SCP17:cluster_example_with_periods.txt
creating cell index for SCP40:output/HCA-SCtranscriptomehumanpancreas-Pancreas-Cumulus.scp.X_diffmap_pca.coords.txt
creating cell index for SCP47:cluster.tsv
aborting cell index for SCP13:CA1 - 2 cells not found
finished cell index for SCP13:CA1
creating cell index for SCP13:CA3
aborting cell index for SCP17:cluster_example_with_periods.txt - 15 cells not found
using default cell index for SCP36:cluster_square
finished cell index for SCP17:cluster_example_with_periods.txt
finished cell index for SCP36:cluster_square
...
```
6. Confirm the migration completes without error quickly (should only take 15-20s depending on how many studies you have, and how large they are)