### PR TITLE
Faster local frontend development for dot plots and heatmaps (SCP-5256)

### DIFF
--- a/app/javascript/components/visualization/DotPlot.jsx
+++ b/app/javascript/components/visualization/DotPlot.jsx
@@ -31,7 +31,7 @@ function patchServiceWorkerCache() {
 
   /**
    * Monkeypatched from
-   * https://github.com/cmap/morpheus.js/blob/8331b8db8696d1bf3255da2261ac729bfc7ea66a/sw.js#L24
+   * https://github.com/cmap/morpheus.js/blob/8331b8db8696d1bf3255da2261ac729bfc7ea66a/src/io/buffered_reader.js#L36
    * to enable service worker cache (SWC) in frontend-only SCP development.
    */
   window.morpheus.BufferedReader.parse = async function(url, options) {
@@ -68,6 +68,9 @@ function patchServiceWorkerCache() {
 
   /**
  * Adds rudimentary service worker cache optimization to Morpheus
+ *
+ * Monkeypatched from:
+ * https://github.com/cmap/morpheus.js/blob/8331b8db8696d1bf3255da2261ac729bfc7ea66a/src/util/util.js#L1444
  *
  * @param file
  *            a File or url

--- a/app/javascript/components/visualization/DotPlot.jsx
+++ b/app/javascript/components/visualization/DotPlot.jsx
@@ -51,7 +51,7 @@ function patchServiceWorkerCache() {
       const fetchSWCacheResult = await fetchServiceWorkerCache(url, fetchOptions)
       response = fetchSWCacheResult[0]
     } else {
-      response = fetch(url, fetchOptions)
+      response = await fetch(url, fetchOptions)
     }
 
     if (response.ok) {
@@ -128,7 +128,7 @@ function patchServiceWorkerCache() {
             const fetchSWCacheResult = await fetchServiceWorkerCache(fileOrUrl, fetchOptions)
             response = fetchSWCacheResult[0]
           } else {
-            response = fetch(fileOrUrl, fetchOptions)
+            response = await fetch(fileOrUrl, fetchOptions)
           }
           let text
           if (response.ok) {

--- a/app/javascript/components/visualization/DotPlot.jsx
+++ b/app/javascript/components/visualization/DotPlot.jsx
@@ -47,11 +47,9 @@ function patchServiceWorkerCache() {
     }
 
     let response
-    let isServiceWorkerCacheHit = false
     if (isServiceWorkerCacheEnabled) {
       const fetchSWCacheResult = await fetchServiceWorkerCache(url, fetchOptions)
       response = fetchSWCacheResult[0]
-      isServiceWorkerCacheHit = fetchSWCacheResult[1]
     } else {
       response = fetch(url, fetchOptions)
     }
@@ -92,11 +90,9 @@ function patchServiceWorkerCache() {
             }
           }
           let response
-          let isServiceWorkerCacheHit = false
           if (isServiceWorkerCacheEnabled) {
             const fetchSWCacheResult = await fetchServiceWorkerCache(fileOrUrl, fetchOptions)
             response = fetchSWCacheResult[0]
-            isServiceWorkerCacheHit = fetchSWCacheResult[1]
           } else {
             response = fetch(fileOrUrl, fetchOptions)
           }
@@ -125,11 +121,9 @@ function patchServiceWorkerCache() {
           }
         } else {
           let response
-          let isServiceWorkerCacheHit = false
           if (isServiceWorkerCacheEnabled) {
             const fetchSWCacheResult = await fetchServiceWorkerCache(fileOrUrl, fetchOptions)
             response = fetchSWCacheResult[0]
-            isServiceWorkerCacheHit = fetchSWCacheResult[1]
           } else {
             response = fetch(fileOrUrl, fetchOptions)
           }

--- a/app/javascript/components/visualization/DotPlot.jsx
+++ b/app/javascript/components/visualization/DotPlot.jsx
@@ -35,7 +35,6 @@ function patchServiceWorkerCache() {
    * to enable service worker cache (SWC) in frontend-only SCP development.
    */
   window.morpheus.BufferedReader.parse = async function(url, options) {
-    console.log('from eweitz, in window.morpheus.BufferedReader.parse')
     const delim = options.delimiter
     const regex = new RegExp(delim)
     const handleTokens = options.handleTokens

--- a/app/javascript/lib/service-worker-cache.js
+++ b/app/javascript/lib/service-worker-cache.js
@@ -28,7 +28,7 @@ export async function fetchServiceWorkerCache(url, init) {
     isHit = false
   }
   const hitOrMiss = isHit ? 'hit' : 'miss'
-  console.debug(`Service worker cache ${hitOrMiss} for SCP API fetch of URL: ${url}`)
+  console.log(`Service worker cache ${hitOrMiss} for SCP API fetch of URL: ${url}`)
   return [response, isHit]
 }
 


### PR DESCRIPTION
This speeds up frontend-only development involving [Morpheus](https://github.com/cmap/morpheus.js/), by leveraging [service worker caches](https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage).

### Background
About a year ago, #1565 enabled fast local frontend development for UI components that fetched data via the SCP API JS library.  Locally rendering Plotly.js charts for realistic data went from from 3-10 seconds to < 1 second.  If you're doing frontend-only visualization engineering in SCP, this service worker cache optimization is key for productivity.

### Impact
Previously, if you were doing clientside development that involves dot plots or heatmaps, and wanted to query a bunch of genes for a large, realistic number of cells, it would take a _long_ time to load the dot plot -- usually > 60 seconds.  Such extreme slowness makes it hard to do local work with dot plots.

It was slow because dot plots and heatmaps were not covered by a service worker cache.  That's due to Morpheus fetching API data via its internal JS library, not via the standard SCP API JS library.

Now, for all loads after the first, it's drastically faster, i.e. < 2 seconds.  The optimization from the SCP API JS library is now tailored and patched into Morpheus.  This greatly accelerates frontend matrix visualization development, which is lined up immediately after this.  It also enables seamless demonstrations involving dot plots, which are increasingly important to explore e.g. differential expression.

### Videos
Old, slow, uncached dot plots for 50 genes and 49k cells: ~1.2 minutes

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/2041ecef-4f1e-4e25-b170-88594923a1ad

New, fast, cached dot plots for 50 genes and 49k cells: < 2 seconds

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/be2a286c-9dc6-4aa0-9ec0-0b8430b26f96

### Test
To manually test:
* Stop Vite, then run in terminal: `VITE_FRONTEND_SERVICE_WORKER_CACHE="true" bin/vite dev`
* Go to a study that has a realistic number of genes, and also has differential expression enabled
* Open DevTools, go to Application -> Cache
* Confirm a cache scp-development-1.20.0 appears and is populated with some SCP API requests
* Click "Differential expression", select a group, load DE table
* Click "Dot plot"
* _Notice dot plot is very slow to load_
* Go to Network panel, filter to "cell/api", confirm some SCP API requests were sent
* Go to next page of DE table
* Click "Dot plot"
* _Go back to page 1 of DE table_
* Click "Dot plot"
* _Notice dot plot is very fast to load_
* Go to Network panel, filter to "cell/api", confirm some SCP API requests were not sent
* Confirm messages in Console begin "Service worker cache hit" for URLs including `/cell_values` and `/expression/heatmap`

This satisfies SCP-5256.