### PR TITLE
Prevent upload of author DE files without clustering & annotation associations (SCP-5234)

### DIFF
--- a/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
@@ -8,6 +8,10 @@ import { clusterFileFilter } from './ClusteringStep'
 import CreatableSelect from 'react-select/creatable'
 
 const allowedFileExts = FileTypeExtensions.plainText
+const requiredFields = [
+  { label: 'Associated annotation', propertyName: 'differential_expression_file_info.annotation_name'},
+  { label: 'Associated clustering file', propertyName: 'differential_expression_file_info.clustering_association'},
+]
 
 /** renders a form for editing/uploading a differential expression file */
 export default function DifferentialExpressionFileForm({
@@ -23,7 +27,7 @@ export default function DifferentialExpressionFileForm({
   menuOptions
 }) {
   // TODO (SCP-5154) Add DE specific clientside validation
-  const validationMessages = validateFile({ file, allFiles, allowedFileExts })
+  const validationMessages = validateFile({ file, allFiles, allowedFileExts, requiredFields })
 
   const fragmentType = isAnnDataExperience ? 'cluster' : null
 

--- a/app/javascript/components/upload/DifferentialExpressionStep.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionStep.jsx
@@ -49,7 +49,8 @@ export function DifferentialFileUploadForm({
     <div className="row">
       <div className="col-md-12">
         <p className="form-terra">
-          Upload a file with differential expression for a particular clustering and annotation.
+          Upload a file with differential expression for a particular clustering and annotation.  <strong>Parsed metadata
+          and clustering files are required before uploading</strong>.
         </p>
       </div>
     </div>

--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -201,7 +201,7 @@ function validateRequiredFields(file, requiredFields, validationMessages) {
     const existingValue = _get(file, field.propertyName)
     const isBlank = !existingValue || (typeof existingValue === 'object' && existingValue.length === 0)
     if (isBlank) {
-      validationMessages[field.propertyName] = `You must specify ${field.label}`
+      validationMessages[field.propertyName] = `You must specify: ${field.label}`
     }
   })
 }

--- a/test/js/upload-wizard/upload-expression-data.test.js
+++ b/test/js/upload-wizard/upload-expression-data.test.js
@@ -51,9 +51,9 @@ describe('it allows uploading of expression matrices', () => {
     expect(mainSaveButton()).toBeDisabled()
 
     fireEvent.mouseOver(mainSaveButton())
-    expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify units')
-    expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify species')
-    expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify Library preparation protocol')
+    expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify: units')
+    expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify: species')
+    expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify: Library preparation protocol')
 
     await selectEvent.select(getSelectByLabelText(screen, 'Species *'), 'chicken')
     await selectEvent.select(getSelectByLabelText(screen, 'Library preparation protocol *'), 'Drop-seq')

--- a/test/js/upload-wizard/upload-new-study.test.js
+++ b/test/js/upload-wizard/upload-new-study.test.js
@@ -83,13 +83,13 @@ async function testRawCountsUpload({ createFileSpy }) {
 
   fireEvent.mouseOver(saveButton())
   expect(screen.getByRole('tooltip')).not.toHaveTextContent('You must select a file')
-  expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify units')
-  expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify species')
-  expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify Library preparation protocol')
+  expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify: units')
+  expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify: species')
+  expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify: Library preparation protocol')
 
   await selectEvent.select(getSelectByLabelText(screen, 'Species *'), 'chicken')
   fireEvent.mouseOver(saveButton())
-  expect(screen.getByRole('tooltip')).not.toHaveTextContent('You must specify species')
+  expect(screen.getByRole('tooltip')).not.toHaveTextContent('You must specify: species')
 
   await selectEvent.select(getSelectByLabelText(screen, 'Library preparation protocol *'), 'Drop-seq')
   await selectEvent.select(getSelectByLabelText(screen, 'Units *'), 'raw counts')
@@ -131,7 +131,7 @@ async function testProcessedUpload({ createFileSpy }) {
   expect(saveButton()).toBeDisabled()
   fireEvent.mouseOver(saveButton())
   expect(screen.getByRole('tooltip')).toHaveTextContent('You must select a file')
-  expect(screen.getByRole('tooltip')).not.toHaveTextContent('You must specify units')
+  expect(screen.getByRole('tooltip')).not.toHaveTextContent('You must specify: units')
 
   fireFileSelectionEvent(screen.getByTestId('file-input'), {
     fileName: processedFileName,
@@ -141,13 +141,13 @@ async function testProcessedUpload({ createFileSpy }) {
   expect(screen.getByTestId('file-selection-name')).toHaveTextContent(processedFileName)
   fireEvent.mouseOver(saveButton())
   expect(screen.getByRole('tooltip')).not.toHaveTextContent('You must select a file')
-  expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify species')
-  expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify Library preparation protocol')
+  expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify: species')
+  expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify: Library preparation protocol')
 
   expect(saveButton()).toBeDisabled()
   await selectEvent.select(getSelectByLabelText(screen, 'Species *'), 'chicken')
   fireEvent.mouseOver(saveButton())
-  expect(screen.getByRole('tooltip')).not.toHaveTextContent('You must specify species')
+  expect(screen.getByRole('tooltip')).not.toHaveTextContent('You must specify: species')
 
   await selectEvent.select(getSelectByLabelText(screen, 'Library preparation protocol *'), 'Drop-seq')
   expect(saveButton()).toBeDisabled()
@@ -356,7 +356,7 @@ async function testCoordinateLabelUpload({ createFileSpy }) {
   expect(screen.getByTestId('file-selection-name')).toHaveTextContent(goodFileName)
   expect(saveButton()).toBeDisabled()
   fireEvent.mouseOver(saveButton())
-  expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify Corresponding cluster')
+  expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify: Corresponding cluster')
 
   await selectEvent.select(getSelectByLabelText(screen, 'Corresponding cluster / spatial data *'), 'cluster.txt')
 
@@ -408,7 +408,7 @@ async function testSequenceFileUpload({ createFileSpy }) {
   expect(screen.getByTestId('file-selection-name')).toHaveTextContent(goodFileName)
   expect(saveButton()).toBeDisabled()
   fireEvent.mouseOver(saveButton())
-  expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify species')
+  expect(screen.getByRole('tooltip')).toHaveTextContent('You must specify: species')
 
   await selectEvent.select(getSelectByLabelText(screen, 'Species *'), 'chicken')
 

--- a/test/js/upload-wizard/validations.test.js
+++ b/test/js/upload-wizard/validations.test.js
@@ -123,7 +123,7 @@ describe('it checks presence of required fields', () => {
       file, allFiles, allowedFileExts: ['.txt', '.txt.gz'],
       requiredFields: [{ label: 'species', propertyName: 'taxon_id' }]
     })
-    expect(msgs.taxon_id).toEqual('You must specify species')
+    expect(msgs.taxon_id).toEqual('You must specify: species')
   })
 
   it('messages both if multiple required fields are not present', async () => {
@@ -139,8 +139,8 @@ describe('it checks presence of required fields', () => {
       requiredFields: [{ label: 'species', propertyName: 'taxon_id' },
         { label: 'genome assembly', propertyName: 'genome_assembly_id' }]
     })
-    expect(msgs.taxon_id).toEqual('You must specify species')
-    expect(msgs.genome_assembly_id).toEqual('You must specify genome assembly')
+    expect(msgs.taxon_id).toEqual('You must specify: species')
+    expect(msgs.genome_assembly_id).toEqual('You must specify: genome assembly')
   })
 
   it('handles validating nested properties', async () => {
@@ -159,6 +159,6 @@ describe('it checks presence of required fields', () => {
         { label: 'biosample input type', propertyName: 'expression_file_info.biosample_input_type' }]
     })
     expect(msgs['expression_file_info.units']).toEqual(undefined)
-    expect(msgs['expression_file_info.biosample_input_type']).toEqual('You must specify biosample input type')
+    expect(msgs['expression_file_info.biosample_input_type']).toEqual('You must specify: biosample input type')
   })
 })


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes an issue where study owners were able to upload a differential expression file to be parsed before adding any metadata or clustering files.  This resulted in a file that was stuck and could not be ingested as is.  Now, the save button is disabled until those associations are set, which can only happen once both the metadata and cluster files have been ingested.

New validation messages:
![Screenshot 2023-07-31 at 2 44 36 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/9f4e1540-7dfc-41d0-a7cb-adf9afcc599a)

#### MANUAL TESTING
1. Boot as normal and sign in
2. Go to the `Feature flags` admin page and confirm that the `show_de_upload` feature flag is turned on (or is enabled for your user account if not)
3. Go to the upload wizard for any study that has both clustering and metadata
4. Click the nav entry for `Differential expression` and confirm that the save button is disabled with the above messages
5. Select a clustering file and annotation, then select any text file to upload (doesn't matter as we're not saving)
6. Confirm that the save button enables once all required fields are set