### PR TITLE
Seed test workspace for orchestration smoke tests (SCP-5272)

### DIFF
--- a/test/integration/external/fire_cloud_client_test.rb
+++ b/test/integration/external/fire_cloud_client_test.rb
@@ -26,7 +26,9 @@ class FireCloudClientTest < ActiveSupport::TestCase
     @resource_error_msg = 'Resource representation is only available with these types' # for error handling
 
     # seed one workspace to prevent test_workspaces from failing due to order of operations corner case
-    @fire_cloud_client.create_workspace(@fire_cloud_client.project, "workspace-#{@random_test_seed}")
+    workspace_name = "workspace-#{@random_test_seed}"
+    Rails.logger.info "seeing #{workspace_name} for testing"
+    @fire_cloud_client.create_workspace(@fire_cloud_client.project, workspace_name)
   end
 
   # given ongoing issues with workspace deletion throwing spurious errors, do cleanup at end and ignore errors

--- a/test/integration/external/fire_cloud_client_test.rb
+++ b/test/integration/external/fire_cloud_client_test.rb
@@ -27,7 +27,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
 
     # seed one workspace to prevent test_workspaces from failing due to order of operations corner case
     workspace_name = "workspace-#{@random_test_seed}"
-    Rails.logger.info "seeing #{workspace_name} for testing"
+    Rails.logger.info "seeding #{workspace_name} for testing"
     @fire_cloud_client.create_workspace(@fire_cloud_client.project, workspace_name)
   end
 

--- a/test/integration/external/fire_cloud_client_test.rb
+++ b/test/integration/external/fire_cloud_client_test.rb
@@ -24,6 +24,9 @@ class FireCloudClientTest < ActiveSupport::TestCase
     @test_email = 'singlecelltest@gmail.com'
     @random_test_seed = SecureRandom.uuid # use same random seed to differentiate between entire runs
     @resource_error_msg = 'Resource representation is only available with these types' # for error handling
+
+    # seed one workspace to prevent test_workspaces from failing due to order of operations corner case
+    @fire_cloud_client.create_workspace(@fire_cloud_client.project, "workspace-#{@random_test_seed}")
   end
 
   # given ongoing issues with workspace deletion throwing spurious errors, do cleanup at end and ignore errors


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a corner case found mostly during the orchestration smoke test where `FireCloudClientTest#test_workspaces` fails due to the fact that no workspaces have been created yet.  This only happens when this test runs before any other tests that create workspaces.  Now, a single workspace is seeded during setup to prevent this from happening.

#### MANUAL TESTING
1. Pull this branch and initialize your environment with `./rails_local_setup.rb && source config/secrets/.source_env.bash`
2. Run the test that fails with `bin/rails test test/integration/external/fire_cloud_client_test.rb -n 'test_workspaces'`
3. In `test.log`, look for the statement that seeds a test workspace like:
```
seeding workspace-828239e3-1511-4443-bca3-b7a76ac4e52e for testing
```
4. Confirm the test does not fail, and that you see a cleanup message for the above workspace:
```
SUITE FireCloudClientTest starting
fire_cloud_client_test.rb:120 test_workspaces starting
fire_cloud_client_test.rb:120 test_workspaces completed (3.356 sec)
.running cleanup of 1 test workspaces
deleting single-cell-portal-development/workspace-828239e3-1511-4443-bca3-b7a76ac4e52e
FireCloudClientTest: Cleaning up 0 studies, 0 users
SUITE FireCloudClientTest completed (30.82 sec)
```