### PR TITLE
Reuse expression data for dotplots and heatmaps (SCP-5263)

### DIFF
--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -44,7 +44,7 @@ module Api
               key :description, 'Type of plot data requested'
               key :required, true
               key :type, :string
-              key :enum, %w(violin heatmap json)
+              key :enum, %w(violin heatmap morpheus)
             end
             parameter do
               key :name, :cluster
@@ -108,9 +108,9 @@ module Api
           case data_type
           when 'violin'
             render_violin
-          when 'heatmap'
+          when 'heatmap' # Only used for pre-computed heatmaps
             render_heatmap
-          when 'json'
+          when 'morpheus'
             render_morpheus_json
           else
             render json: { error: "Unknown expression data type: #{data_type}" }, status: :bad_request

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -198,6 +198,8 @@ export default function ExploreDisplayTabs({
   // a plotly points_selected event
   const [currentPointsSelected, setCurrentPointsSelected] = useState(null)
 
+  // morpheus JSON data
+  const [morpheusData, setMorpheusData] = useState(null)
   // Differential expression settings
   const flags = getFeatureFlagsWithDefaults()
   // `differential_expression_frontend` enables exemptions if study owners don't want DE
@@ -532,7 +534,7 @@ export default function ExploreDisplayTabs({
                      exploreParamsWithDefaults?.annotation,
                      exploreParamsWithDefaults?.annotationList?.annotations
                   )}
-                  useJson={true}
+                  setMorpheusData={setMorpheusData}
                   dimensions={getPlotDimensions({ showViewOptionsControls, showDifferentialExpressionTable })}
                 />
               </div>
@@ -542,7 +544,7 @@ export default function ExploreDisplayTabs({
                 <Heatmap
                   studyAccession={studyAccession}
                   {... exploreParamsWithDefaults}
-                  useJson={true}
+                  morpheusData={morpheusData}
                   dimensions={getPlotDimensions({ showViewOptionsControls, showDifferentialExpressionTable })}
                 />
               </div>

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -532,6 +532,7 @@ export default function ExploreDisplayTabs({
                      exploreParamsWithDefaults?.annotation,
                      exploreParamsWithDefaults?.annotationList?.annotations
                   )}
+                  useJson={true}
                   dimensions={getPlotDimensions({ showViewOptionsControls, showDifferentialExpressionTable })}
                 />
               </div>
@@ -541,6 +542,7 @@ export default function ExploreDisplayTabs({
                 <Heatmap
                   studyAccession={studyAccession}
                   {... exploreParamsWithDefaults}
+                  useJson={true}
                   dimensions={getPlotDimensions({ showViewOptionsControls, showDifferentialExpressionTable })}
                 />
               </div>

--- a/app/javascript/components/visualization/DotPlot.jsx
+++ b/app/javascript/components/visualization/DotPlot.jsx
@@ -197,24 +197,26 @@ function RawDotPlot({
   const { ErrorComponent, showError, setShowError, setErrorContent } = useErrorMessage()
 
   useEffect(() => {
+    /** Fetch Morpheus data for dot plot */
+    async function getDataset() {
+      const [dataset, perfTimes] = await fetchMorpheusJson(
+        studyAccession,
+        genes,
+        cluster,
+        annotation.name,
+        annotation.type,
+        annotation.scope,
+        subsample
+      )
+      logFetchMorpheusDataset(perfTimes, cluster, annotation, genes)
+      return dataset
+    }
     if (annotation.name) {
       // put spinner up manually
       const target = `#${graphId}`
       $(target).empty()
-      $(target).html( morpheusLoadingSpinner())
-      async function getDataset() {
-        const [dataset, perfTimes] = await fetchMorpheusJson(
-          studyAccession,
-          genes,
-          cluster,
-          annotation.name,
-          annotation.type,
-          annotation.scope,
-          subsample
-        )
-        logFetchMorpheusDataset(perfTimes, cluster, annotation, genes)
-        return dataset
-      }
+      $(target).html(morpheusLoadingSpinner())
+
       getDataset().then(dataset => {
         performance.mark(`perfTimeStart-${graphId}`)
         log('dot-plot:initialize')

--- a/app/javascript/components/visualization/Heatmap.jsx
+++ b/app/javascript/components/visualization/Heatmap.jsx
@@ -2,13 +2,13 @@ import React, { useState, useEffect, useRef } from 'react'
 import _uniqueId from 'lodash/uniqueId'
 
 import { log } from '~/lib/metrics-api'
-import { getExpressionHeatmapURL, getAnnotationCellValuesURL } from '~/lib/scp-api'
+import { getExpressionHeatmapURL, getAnnotationCellValuesURL, fetchMorpheusJson } from '~/lib/scp-api'
 
 import { useUpdateEffect } from '~/hooks/useUpdate'
 import useErrorMessage from '~/lib/error-message'
 import { renderHeatmap, refitHeatmap } from '~/lib/morpheus-heatmap'
 import { withErrorBoundary } from '~/lib/ErrorBoundary'
-import LoadingSpinner from '~/lib/LoadingSpinner'
+import LoadingSpinner, { morpheusLoadingSpinner } from '~/lib/LoadingSpinner'
 
 
 /** renders a morpheus powered heatmap for the given params
@@ -16,42 +16,31 @@ import LoadingSpinner from '~/lib/LoadingSpinner'
   * @param cluster {string} the name of the cluster, or blank/null for the study's default
   * @param annotation {obj} an object with name, type, and scope attributes
   * @param subsample {string} a string for the subsampel to be retrieved.
+  * @param morpheusData {object} JSON Morpheus dataset
  */
 function RawHeatmap({
-  studyAccession, genes=[], cluster, annotation={}, subsample, heatmapFit, heatmapRowCentering
+  studyAccession, genes=[], cluster, annotation={}, subsample, heatmapFit, heatmapRowCentering,
+  morpheusData
 }) {
   const [graphId] = useState(_uniqueId('heatmap-'))
   const morpheusHeatmap = useRef(null)
-  const expressionValuesURL = getExpressionHeatmapURL({
-    studyAccession,
-    genes,
-    cluster,
-    heatmapRowCentering
-  })
   const { ErrorComponent, setShowError, setErrorContent } = useErrorMessage()
   // we can't render until we know what the cluster is, since morpheus requires the annotation name
   // so don't try until we've received this, unless we're showing a Gene List
-  const canRender = !!cluster
-
-  const annotationCellValuesURL = getAnnotationCellValuesURL({
-    studyAccession,
-    cluster,
-    annotationName: annotation.name,
-    annotationScope: annotation.scope,
-    annotationType: annotation.type,
-    subsample
-  })
+  const canRender = !!cluster && !!morpheusData
 
   useEffect(() => {
     if (canRender) {
+      const target = `#${graphId}`
+      $(target).empty()
+      $(target).html( morpheusLoadingSpinner())
       performance.mark(`perfTimeStart-${graphId}`)
-
       log('heatmap:initialize')
       setShowError(false)
       morpheusHeatmap.current = renderHeatmap({
-        target: `#${graphId}`,
-        expressionValuesURL,
-        annotationCellValuesURL,
+        target,
+        dataset: morpheusData,
+        annotationCellValuesURL: '',
         annotationName: annotation.name,
         fit: heatmapFit,
         rowCentering: heatmapRowCentering,
@@ -64,6 +53,7 @@ function RawHeatmap({
   }, [
     studyAccession,
     genes.join(','),
+    morpheusData,
     cluster,
     annotation.name,
     annotation.scope,

--- a/app/javascript/components/visualization/Heatmap.jsx
+++ b/app/javascript/components/visualization/Heatmap.jsx
@@ -33,7 +33,7 @@ function RawHeatmap({
     if (canRender) {
       const target = `#${graphId}`
       $(target).empty()
-      $(target).html( morpheusLoadingSpinner())
+      $(target).html(morpheusLoadingSpinner())
       performance.mark(`perfTimeStart-${graphId}`)
       log('heatmap:initialize')
       setShowError(false)

--- a/app/javascript/lib/LoadingSpinner.jsx
+++ b/app/javascript/lib/LoadingSpinner.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faDna } from '@fortawesome/free-solid-svg-icons'
+import { faDna, faSpinner } from '@fortawesome/free-solid-svg-icons'
 
 /** show dna spinning indicator.
  * If no arguments or children are passed in, the spinner is rendered
@@ -22,4 +22,17 @@ export default function LoadingSpinner({ children, testId, isLoading, className=
       children
     }
   </>
+}
+
+/**
+ * loading spinner specific to Morpheus - needed for JSON dataset
+ * includes outer wrapper to align to viewport properly
+ */
+export function morpheusLoadingSpinner() {
+  return `
+    <div style="overflow:hidden;text-align:center;">
+      <i class="fas fa-spinner fa-spin fa-3x"></i>
+      <span style="padding-left:4px;vertical-align:middle;font-weight:bold;">Loading...</span>
+    </div>
+  `
 }

--- a/app/javascript/lib/morpheus-heatmap.js
+++ b/app/javascript/lib/morpheus-heatmap.js
@@ -4,14 +4,14 @@ import { morpheusErrorHandler } from '~/lib/error-message'
 
 /** Render Morpheus heatmap */
 export function renderHeatmap({
-  target, expressionValuesURL, annotationCellValuesURL, annotationName,
-  fit, rowCentering, sortColumns=true, setShowError, setError, genes, colorMin, colorMax
+  target, dataset, annotationCellValuesURL, annotationName,
+  fit, rowCentering, sortColumns=true, setShowError, setError, genes, colorMin, colorMax,
 }) {
   const $target = $(target)
   $target.empty()
 
   const config = {
-    dataset: expressionValuesURL,
+    dataset,
     el: $target,
     menu: null,
     error: morpheusErrorHandler($target, setShowError, setError),
@@ -48,12 +48,15 @@ export function renderHeatmap({
 
   // Load annotations if specified
   if (annotationCellValuesURL !== '') {
-    config.columnAnnotations = [{
-      file: annotationCellValuesURL,
-      datasetField: 'id',
-      fileField: 'NAME',
-      include: [annotationName]
-    }]
+    if (typeof dataset !== 'object') {
+      config.columnAnnotations = [{
+        file: annotationCellValuesURL,
+        datasetField: 'id',
+        fileField: 'NAME',
+        include: [annotationName]
+      }]
+    }
+
     if (sortColumns) {
       config.columnSortBy = [
         { field: annotationName, order: 0 }

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -635,6 +635,51 @@ export async function fetchExpressionViolin(
   return [violin, perfTimes]
 }
 
+/**
+ * Returns an object with a Morpheus JSON dataset data to share among components
+ *
+ * See definition: app/controllers/api/v1/visualization/expression_controller.rb
+ *
+ * @param {String} studyAccession Study accession
+ * @param {(String|String[])} genes Gene name or array of gene names
+ * @param {String} clusterName Name of cluster
+ * @param {String} annotationName Name of annotation
+ * @param {String} annotationType Type of annotation ("group" or "numeric")
+ * @param {String} annotationName Scope of annotation ("study" or "cluster")
+ * @param {String} subsample Subsampling threshold
+ * @param {Boolean} mock If using mock data.  Helps development, tests.
+ *
+ */
+export async function fetchMorpheusJson(
+  studyAccession,
+  genes,
+  clusterName,
+  annotationName,
+  annotationType,
+  annotationScope,
+  subsample,
+  mock=false
+) {
+  let geneString = genes
+  if (Array.isArray(genes)) {
+    geneString = genes.join(',')
+  }
+  const paramObj = {
+    cluster: clusterName,
+    annotation_name: annotationName,
+    annotation_type: annotationType,
+    annotation_scope: annotationScope,
+    subsample,
+    genes: geneString
+  }
+  const apiUrl = `/studies/${studyAccession}/expression/json${stringifyQuery(paramObj)}`
+  // don't camelcase the keys since those can be cluster names,
+  // so send false for the 4th argument
+  const [violin, perfTimes] = await scpApi(apiUrl, defaultInit(), mock, false)
+
+  return [violin, perfTimes]
+}
+
 /** Get URL for a Morpheus-suitable annotation values file */
 export function getAnnotationCellValuesURL(
   {

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -672,7 +672,7 @@ export async function fetchMorpheusJson(
     subsample,
     genes: geneString
   }
-  const apiUrl = `/studies/${studyAccession}/expression/json${stringifyQuery(paramObj)}`
+  const apiUrl = `/studies/${studyAccession}/expression/morpheus${stringifyQuery(paramObj)}`
   // don't camelcase the keys since those can be cluster names,
   // so send false for the 4th argument
   const [violin, perfTimes] = await scpApi(apiUrl, defaultInit(), mock, false)

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -1,4 +1,6 @@
 class ExpressionVizService
+  extend Indexer
+
   def self.get_global_expression_render_data(study:,
                                              subsample:,
                                              genes:,
@@ -405,5 +407,70 @@ class ExpressionVizService
       row_data = [headers.join("\t"), rows.join("\n")]
     end
     row_data.join("\n")
+  end
+
+  # return expression data in JSON format to be shared across multiple Morpheus components
+  # data structure defined at https://software.broadinstitute.org/morpheus/configuration.html#datasetJSON
+  #
+  # * *params*
+  #   * +study+ (Study) => study to query expression data from
+  #   * +genes+ (Array<Hash>) => array of gene expression data
+  #   * +cluster+ (ClusterGroup) => clustering object to query cells from
+  #   * +annotation+ (Hash) => annotation object
+  #   * +subsample_threshold+ (Integer, nil) => subsampling threshold, used to determine which cells/annotations to load
+  #   * ++
+  def self.get_morpheus_json_data(study:, genes:, cluster:, annotation:, subsample_threshold:)
+    subsample_annotation = "#{annotation[:name]}--#{annotation[:type]}--#{annotation[:scope]}"
+    cells = cluster.concatenate_data_arrays('text', 'cells', subsample_threshold, subsample_annotation)
+    annotation_array = ClusterVizService.get_annotation_values_array(
+      study, cluster, annotation, cells, subsample_annotation, subsample_threshold
+    )
+    gene_names = genes.map { |g| g['name'] }
+    row_count = gene_names.count
+    col_count = cells.count
+    string_props = { 'morpheus.discrete' => true, 'morpheus.dataType' => 'string' }
+    data_type = 'Float32'
+    # data structure for Morpheus
+    {
+      seriesNames: [subsample_annotation],
+      seriesArrays: {
+        options: {
+          name: subsample_annotation, rows: row_count, columns: col_count, array: get_series_arrays(cells, genes),
+          defaultValue: 0, dataType: data_type
+        }
+      },
+      seriesDataTypes: [data_type],
+      rows: row_count,
+      columns: col_count,
+      rowMetadataModel: {
+        itemCount: 2,
+        vectors: [
+          { array: gene_names, name: 'id', n: row_count, properties: string_props },
+          { array: row_count.times.map { '' }, name: 'Description', n: row_count, properties: {} } # mimic GCT format
+        ]
+      },
+      columnMetadataModel: {
+        itemCount: col_count,
+        vectors: [
+          { array: cells, name: 'id', n: col_count, properties: {} },
+          { array: annotation_array, name: annotation[:name], n: col_count, properties: string_props }
+        ]
+      }
+    }
+  end
+
+  def self.get_series_arrays(cells, genes)
+    cell_index = array_to_hashmap(cells)
+    genes.map do |gene|
+      series = { values: [], indices: [] }
+      gene['scores'].each do |cell, exp_val|
+        cell_position = cell_index[cell]
+        next if cell_position.nil?
+
+        series[:values] << exp_val
+        series[:indices] << cell_position
+      end
+      series
+    end
   end
 end

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -419,7 +419,7 @@ class ExpressionVizService
   #   * +cluster+ (ClusterGroup) => clustering object to query cells from
   #   * +annotation+ (Hash) => annotation object
   #   * +subsample_threshold+ (Integer, nil) => subsampling threshold, used to determine which cells/annotations to load
-  def self.get_morpheus_json_data(study:, genes:, cluster:, annotation:, subsample_threshold:)
+  def self.get_morpheus_json_data(study:, genes:, cluster:, annotation:, subsample_threshold: nil)
     subsample_annotation = "#{annotation[:name]}--#{annotation[:type]}--#{annotation[:scope]}"
     cells = cluster.concatenate_data_arrays('text', 'cells', subsample_threshold, subsample_annotation)
     annotation_array = ClusterVizService.get_annotation_values_array(

--- a/app/lib/indexer.rb
+++ b/app/lib/indexer.rb
@@ -3,6 +3,7 @@ module Indexer
 
   # convert an array of values to hash of indexes
   # e.g. ['a', 'b', 'c'] => { a: 0, b: 1, c: 2 }
+  # can only be used with unique arrays like cell names
   def array_to_hashmap(array)
     array.index_with.with_index { |_, index| index }
   end

--- a/app/lib/indexer.rb
+++ b/app/lib/indexer.rb
@@ -1,0 +1,9 @@
+# common methods for creating indexes of data
+module Indexer
+
+  # convert an array of values to hash of indexes
+  # e.g. ['a', 'b', 'c'] => { a: 0, b: 1, c: 2 }
+  def array_to_hashmap(array)
+    array.index_with.with_index { |_, index| index }
+  end
+end

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -7,6 +7,7 @@ class ClusterGroup
   ###
 
   include Mongoid::Document
+  include Indexer
 
   field :name, type: String
   field :cluster_type, type: String
@@ -389,7 +390,7 @@ class ClusterGroup
     # if cluster cells & study cells are identical, return empty array so we can set #use_default_index
     return [] if cluster_cells == study_cells
 
-    all_cells_hash = study_cells.index_with.with_index { |_, index| index }
+    all_cells_hash = array_to_hashmap(study_cells)
     cluster_cells.map { |cell| all_cells_hash[cell] }
   end
 


### PR DESCRIPTION
#### BACKGROUND
Currently, when a user is visualizing multi-gene expression data as a dotplot or heatmap, we make separate API calls from each component to load the same data.  This means that one gene search spawn 4 calls for identical data (2 for expression as a tsv, 2 for annotations as a tsv).  Since the data is identical, we should be able to share it across components.  Futhermore, the current setup can lead to stability issues when users are requesting many genes in rapid succession, as each new gene requested spawns 4 more API calls.

#### CHANGES
This update changes both the UI and API layers to reuse expression data for both components.  This is done by switching from a GCT format (plain text matrix file) to a JSON representation of a [Morpheus dataset](https://software.broadinstitute.org/morpheus/configuration.html#datasetJSON) via the API which is then passed from the `DotPlot` component to the associated `HeatMap` component.  Additionally, this dataset contains both expression and annotation information, meaning that we only make 1 API call instead of 4.  This will reduce load on the server, and could open avenues down the road for increasing the limit of the number of genes requested in a single search, or client-side caching of individual gene expression scores.  Benchmarking has shown that this is at least as performant as the current implementation, and potentially 10-20% faster.  Additionally, this new implementation works with the refinements made in #1842 so that requests can be saved in the service worker cache for faster iteration times in local development.

#### MANUAL TESTING
1. Boot as normal and load the `Human milk - differential expression` study
2. Select the `All Cells UMAP` cluster and `General_Celltype` annotation
3. Open Chrome DevTools -> Network
4. Query for the genes `STAT5A` and `CD68`
5. In the network tab, confirm you see only one request for the expression JSON endpoint like: `https://localhost:3000/single_cell/api/v1/studies/SCP66/expression/json?annotation_name=General_Celltype&annotation_scope=study&annotation_type=group&cluster=All%20Cells%20UMAP&genes=STAT5A%2CCD68&subsample=all`
6. Open the dotplot tab and confirm you see the following plot:
![2_genes dotplot](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/de8f5c51-282d-41f6-b7e9-76f9a13ea14c)
7. Click the heatmap tab and confirm there is a heatmap for both genes
8. Go back to the dotplot tab, and request another gene: `KLF6`
9. Confirm that the dotplot starts to re-render, and only one more request is made to the expression JSON endpoint in the network tab
10. Confirm the following dotplot finishes rendering with the plot below, and that the heatmap tab now has 3 genes
![3_genes dotplot](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/5b060ea3-85ce-4ad0-8fe8-6e42a5f8427c)
