### PR TITLE
Fix regression from userAccessToken renewal PR (SCP-5164)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -354,6 +354,8 @@ module ApplicationHelper
   def get_user_access_token_hash(user)
     if user.present?
       user.valid_access_token
+    else
+      {}
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,7 @@
       }
 
       window.SCP.userAccessTokenObject = <%= raw get_user_access_token_hash(current_user).to_json %>;
-      window.SCP.userAccessToken = window.SCP.userAccessTokenObject.access_token;
+      window.SCP.userAccessToken = window.SCP.userAccessTokenObject?.access_token ? window.SCP.userAccessTokenObject.access_token : "";
       window.SCP.userSignedIn = <%= user_signed_in? %>;
       window.SCP.environment = '<%= Rails.env %>';
       window.SCP.abTests = <%= raw @ab_test_assignments %>


### PR DESCRIPTION
This fixes the issue caused by the [PR #1845](https://github.com/broadinstitute/single_cell_portal_core/pull/1845)

Previously before that PR the userAccessToken itself was being returned via `get_user_access_token()` but that got refactored to `get_user_access_token_hash` to get the full object with the expirary info as well. There wasn't sufficient checks done then on the resulting object and so that broke the home page search when a user was signed out. This fixes that so the token is set appropriately either to a token or ""

Error:
![Screenshot 2023-08-07 at 4 16 34 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/2e629381-1244-4d99-ba57-c61d3833aff7)

Fixed - not signed in
![Screenshot 2023-08-07 at 4 45 28 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/8723abd4-5d38-4e19-83f1-fabb6ca64cb2)

Signed in
![Screenshot 2023-08-07 at 4 46 12 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/e3e116a2-f1a4-4fea-b3bc-7170af66cf9c)
