### PR TITLE
Restoring column annotation bar in heatmaps (SCP-5255)

### DIFF
--- a/app/javascript/components/visualization/GeneListHeatmap.jsx
+++ b/app/javascript/components/visualization/GeneListHeatmap.jsx
@@ -48,7 +48,7 @@ function RawGeneListHeatmap({
     setShowError(false)
     morpheusHeatmap.current = renderHeatmap({
       target: `#${graphId}`,
-      expressionValuesURL,
+      dataset: expressionValuesURL,
       annotationCellValuesURL,
       annotationName: geneListName,
       fit: heatmapFit,

--- a/app/javascript/lib/morpheus-heatmap.js
+++ b/app/javascript/lib/morpheus-heatmap.js
@@ -48,28 +48,26 @@ export function renderHeatmap({
 
   // Load annotations if specified
   if (annotationCellValuesURL !== '') {
-    if (typeof dataset !== 'object') {
-      config.columnAnnotations = [{
-        file: annotationCellValuesURL,
-        datasetField: 'id',
-        fileField: 'NAME',
-        include: [annotationName]
-      }]
-    }
+    config.columnAnnotations = [{
+      file: annotationCellValuesURL,
+      datasetField: 'id',
+      fileField: 'NAME',
+      include: [annotationName]
+    }]
+  }
 
-    if (sortColumns) {
-      config.columnSortBy = [
-        { field: annotationName, order: 0 }
-      ]
-    }
-    config.columns = [
-      { field: 'id', display: 'text' },
-      { field: annotationName, display: 'color' }
-    ]
-    config.rows = [
-      { field: 'id', display: 'text' }
+  if (sortColumns) {
+    config.columnSortBy = [
+      { field: annotationName, order: 0 }
     ]
   }
+  config.columns = [
+    { field: 'id', display: 'text' },
+    { field: annotationName, display: 'color' }
+  ]
+  config.rows = [
+    { field: 'id', display: 'text' }
+  ]
   return new window.morpheus.HeatMap(config)
 }
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a new bug introduced in #1847 where heat map visualizations no longer had the annotation navbar below cell names.  This prevents users from sorting on labels, or seeing cell memberships for the various labels.  Additionally, it was discovered that gene list heatmaps were also broken and would not render.

#### MANUAL TESTING
1. Boot as normal and load the `Human milk - differential expression study`
2. Load `All Cells UMAP` and `General_Celltype`, then query for `STAT5A` and `CD68`
3. Wait for the dotplot/heatmap to render, then go to the heatmap and select `Fit options -> columns` from the `Heatmap` menu in the `Options` panel
4. Open the corresponding study on [production](https://singlecell.broadinstitute.org/single_cell/study/SCP1671/cellular-and-transcriptional-diversity-over-the-course-of-human-lactation?genes=STAT5A%2CCD68&tab=heatmap&heatmapFit=cols#study-visualize) and confirm the plots are identical
5. Back in your local instance, confirm you can click on the `General_Celltype` label on the far left of the heatmap and that it sorts correctly
6. Go back to the home page, and search for the `Cow liver cell analysis` synthetic study
7. Open this study and confirm the marker gene list `marker_1_gene_list.txt` renders correctly