### PR TITLE
Break out the renewal token loop if response is 204 (SCP-5164)

### DIFF
--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -263,7 +263,10 @@ export function setUpRenewalForUserAccessToken() {
     const userAccessTokenObj = response
     window.SCP.userAccessToken = userAccessTokenObj.accessToken
     window.SCP.userAccessTokenObject = userAccessTokenObj
-    setUpRenewalForUserAccessToken()
+    // response is 204 if user is not signed in anymore so stop trying to renew token
+    if (response.status !== 204) {
+      setUpRenewalForUserAccessToken()
+    }
   }, renewalTime)
 }
 


### PR DESCRIPTION
This addresses a bug brought about by https://github.com/broadinstitute/single_cell_portal_core/pull/1845 where the renewal loop would continue in rare cases involving multiple tabs, once the user had signed out in one of their tabs.

Now if the renewal loop encounters a 204 response it will stop trying to renew.

Here is the behavior when it was not being prevented from trying to renew (the expiration was set to 3000ms to make it more obvious)
https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/ed33e5f9-0794-462f-af02-3457baf4c354

Here it is fixed where once it encounters the first 204 response it stops trying to renew https://github.com/broadinstitute/single_cell_portal_core/pull/1845To test utilize [the steps Jon outlined in slack](https://broadinstitute.slack.com/archives/G01HY2DJTFY/p1691595288114059?thread_ts=1691526205.353539&cid=G01HY2DJTFY):

1. Pull this branch and boot up your local server
2. In `setUpRenewalForUserAccessToken`, set the renewal time to 3000 on line 257
3. Sign into SCP in one tab
4. Open a new tab and sign out in that tab
5. Wait 30 sec, then see that the renewal fails in the rails console with a 204, and then observe that the renewal tries stop after that first 204 response.
