### PR TITLE
Mass assign studies to collections as curator (SCP-2624)

### DIFF
--- a/app/controllers/branding_groups_controller.rb
+++ b/app/controllers/branding_groups_controller.rb
@@ -94,7 +94,7 @@ class BrandingGroupsController < ApplicationController
       )
 
       if @branding_group.update(clean_params)
-        notice = "Collection '#{@branding_group.name}' was successfully updated."
+        notice = "Successfully updated collection \"#{@branding_group.name}\""
         if missing_studies.any?
           notice += " #{missing_studies.join(', ')} could not be added to this collection."
         end

--- a/app/controllers/branding_groups_controller.rb
+++ b/app/controllers/branding_groups_controller.rb
@@ -6,7 +6,6 @@ class BrandingGroupsController < ApplicationController
 
   before_action :authenticate_curator, only: [:show, :edit, :update]
   before_action :authenticate_admin, only: [:index, :create, :destroy]
-  before_action :set_viewable_studies, only: [:edit]
 
   # GET /branding_groups
   # GET /branding_groups.json
@@ -157,10 +156,6 @@ class BrandingGroupsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_branding_group
     @branding_group = BrandingGroup.find(params[:id])
-  end
-
-  def set_viewable_studies
-    @viewable_studies = Study.accessible(current_user)
   end
 
   # Never trust parameters from the scary internet, only allow the permit list through.

--- a/app/controllers/branding_groups_controller.rb
+++ b/app/controllers/branding_groups_controller.rb
@@ -47,7 +47,7 @@ class BrandingGroupsController < ApplicationController
 
     respond_to do |format|
       if @branding_group.save
-        notice = "Collection '#{@branding_group.name}' was successfully updated."
+        notice = "Successfully updated collection \"#{@branding_group.name}\""
         if missing_studies.any?
           notice += " #{missing_studies.join(', ')} could not be added to this collection."
         end
@@ -141,7 +141,7 @@ class BrandingGroupsController < ApplicationController
     Study.where(:accession.in => accessions).select { |study| study.can_view?(user, check_groups: false) }
   end
 
-  # covert a comma- or space-delimited string to an array of strings, removing empty values
+  # convert a comma- or space-delimited string to an array of strings, removing empty values
   def self.param_to_array(param)
     param.split(/[,\s]/).map(&:strip).reject(&:blank?)
   end

--- a/app/controllers/branding_groups_controller.rb
+++ b/app/controllers/branding_groups_controller.rb
@@ -6,6 +6,7 @@ class BrandingGroupsController < ApplicationController
 
   before_action :authenticate_curator, only: [:show, :edit, :update]
   before_action :authenticate_admin, only: [:index, :create, :destroy]
+  before_action :set_viewable_studies, only: [:edit]
 
   # GET /branding_groups
   # GET /branding_groups.json
@@ -156,6 +157,10 @@ class BrandingGroupsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_branding_group
     @branding_group = BrandingGroup.find(params[:id])
+  end
+
+  def set_viewable_studies
+    @viewable_studies = Study.accessible(current_user)
   end
 
   # Never trust parameters from the scary internet, only allow the permit list through.

--- a/app/models/branding_group.rb
+++ b/app/models/branding_group.rb
@@ -65,6 +65,10 @@ class BrandingGroup
     users.map(&:email)
   end
 
+  def study_list
+    studies.map(&:accession)
+  end
+
   # determine if user can edit branding group (all portal admins & collection curators)
   def can_edit?(user)
     !!(user && (user.admin? || users.include?(user)))

--- a/app/models/branding_group.rb
+++ b/app/models/branding_group.rb
@@ -65,6 +65,7 @@ class BrandingGroup
     users.map(&:email)
   end
 
+  # list of study accessions
   def study_list
     studies.map(&:accession)
   end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -789,14 +789,14 @@ class Study
   end
 
   # return all studies either owned by or shared with a given user as a Mongoid criterion
-  def self.accessible(user)
+  def self.accessible(user, check_groups: true)
     if user.admin?
       self.where(queued_for_deletion: false)
     else
       owned = self.where(user_id: user._id, queued_for_deletion: false).map(&:_id)
       shares = StudyShare.where(email: /#{user.email}/i).map(&:study).select {|s| !s.queued_for_deletion }.map(&:_id)
       group_shares = []
-      if user.registered_for_firecloud
+      if user.registered_for_firecloud && check_groups
         user_client = FireCloudClient.new(user:, project: FireCloudClient::PORTAL_NAMESPACE)
         user_groups = user_client.get_user_groups.map {|g| g['groupEmail']}
         group_shares = StudyShare.where(:email.in => user_groups).map(&:study).select {|s| !s.queued_for_deletion }.map(&:id)

--- a/app/views/branding_groups/_form.html.erb
+++ b/app/views/branding_groups/_form.html.erb
@@ -25,13 +25,16 @@
   </div>
   <div class="form-group">
     <%= f.label :user_ids, 'Curators' %><br />
-    <p class="help-block">Add/remove curator emails in a comma-delimited list (you may not remove yourself)</p>
+    <p class="help-block">Add/remove curator emails (you may not remove yourself).</p>
     <%= f.hidden_field :user_ids %>
     <%= text_field_tag :curator_emails, @branding_group.curator_list.join(', '), class: 'form-control' %>
   </div>
   <div class="form-group">
     <%= f.label :user_ids, 'Included studies' %><br />
-    <p class="help-block">Add/remove study accessions in a comma-delimited list</p>
+    <p class="help-block">
+      Add/remove study accessions to this collection.  Any studies that are not found or you do not have
+      permission to view will be removed from the list.
+    </p>
     <%= f.hidden_field :study_ids %>
     <%= text_field_tag :study_accessions, @branding_group.study_list.join(', '), class: 'form-control' %>
   </div>

--- a/app/views/branding_groups/_form.html.erb
+++ b/app/views/branding_groups/_form.html.erb
@@ -30,6 +30,12 @@
     <%= text_field_tag :curator_emails, @branding_group.curator_list.join(', '), class: 'form-control' %>
   </div>
   <div class="form-group">
+    <%= f.label :user_ids, 'Included studies' %><br />
+    <p class="help-block">Add/remove study accessions in a comma-delimited list</p>
+    <%= f.hidden_field :study_ids %>
+    <%= text_field_tag :study_accessions, @branding_group.study_list.join(', '), class: 'form-control' %>
+  </div>
+  <div class="form-group">
     <%= f.label :external_link_url, 'External Link URL <span class="fas fa-question-circle" data-toggle="tooltip" data-placement="top" title="This link will be available in the \"Help & Resources\" dropdown inside the collection, as well as in the Collections Directory."></span>'.html_safe %>
     <%= f.text_field :external_link_url, class: 'form-control' %>
   </div>

--- a/app/views/branding_groups/show.html.erb
+++ b/app/views/branding_groups/show.html.erb
@@ -8,6 +8,18 @@
       <span class="label label-primary"><%= email %></span>
     <% end %>
   </p>
+  <p class="lead">
+    Included studies:
+    <% @branding_group.studies.each do |study| %>
+      <span class="label label-primary"><%= link_to(
+                                              study.accession,
+                                              view_study_path(
+                                                accession: study.accession,
+                                                study_name: study.url_safe_name,
+                                                scpbr: @branding_group.name_as_id),
+                                              class: 'white') %></span>
+    <% end %>
+  </p>
   <div class="row">
     <div class="col-md-3">
       <p>Font Family: <span id="branding_group_font_family"><%= @branding_group.font_family %></span></p>

--- a/test/controllers/branding_group_controller_test.rb
+++ b/test/controllers/branding_group_controller_test.rb
@@ -85,9 +85,10 @@ class BrandingGroupControllerTest < ActionDispatch::IntegrationTest
     assert_equal 3, @collection.study_list.size
     assert_equal accessions.sort, @collection.study_list.sort
     accessions = [studies.first.accession]
+    # test sanitizer logic by using blank space and extra commas
     curator_params = {
-      curator_emails: @user.email,
-      study_accessions: accessions.join(','),
+      curator_emails: " #{@user.email}  , ,",
+      study_accessions: "      #{studies.first.accession},,, ",
       branding_group: {
         name: @collection.name
       }

--- a/test/controllers/branding_group_controller_test.rb
+++ b/test/controllers/branding_group_controller_test.rb
@@ -53,16 +53,26 @@ class BrandingGroupControllerTest < ActionDispatch::IntegrationTest
       branding_group: {
         tag_line: updated_tag
       },
-      curator_emails: ''
+      curator_emails: '',
+      study_accessions: ''
     }
     patch branding_group_path(@collection), params: collection_params
     assert_redirected_to branding_group_path(@collection)
     @collection.reload
     assert_equal updated_tag, @collection.tag_line
-    # test adding/removing curators to collections
+    # test mass assignment of studies/curators
     new_user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    studies = []
+    5.times do
+      studies << FactoryBot.create(:detached_study,
+                                   name_prefix: 'Collection Mass Assignment',
+                                   user: @user,
+                                   test_array: @@studies_to_clean)
+    end
+    accessions = studies.shuffle.take(3).map(&:accession)
     curator_params = {
       curator_emails: [@user.email, new_user.email].join(','),
+      study_accessions: accessions.join(','),
       branding_group: {
         name: @collection.name # need at least one parameter to avoid ActionController::ParameterMissing
       }
@@ -72,8 +82,12 @@ class BrandingGroupControllerTest < ActionDispatch::IntegrationTest
     @collection.reload
     assert @collection.can_edit?(@user)
     assert @collection.can_edit?(new_user)
+    assert_equal 3, @collection.study_list.size
+    assert_equal accessions.sort, @collection.study_list.sort
+    accessions = [studies.first.accession]
     curator_params = {
-      curator_emails: "#{@user.email}",
+      curator_emails: @user.email,
+      study_accessions: accessions.join(','),
       branding_group: {
         name: @collection.name
       }
@@ -83,6 +97,7 @@ class BrandingGroupControllerTest < ActionDispatch::IntegrationTest
     @collection.reload
     assert @collection.can_edit?(@user)
     assert_not @collection.can_edit?(new_user)
+    assert_equal accessions, @collection.study_list
   end
 
   test 'should enforce admin credentials for creating/deleting collections' do
@@ -96,7 +111,8 @@ class BrandingGroupControllerTest < ActionDispatch::IntegrationTest
         background_color: '#FFFFFF',
         public: true
       },
-      curator_emails: @user.email
+      curator_emails: @user.email,
+      study_accessions: ''
     }
     post branding_groups_path, params: collection_params
     assert_redirected_to site_path


### PR DESCRIPTION
#### BACKGROUND
As a collection curator, you can currently only add studies individually to collections by editing each study directly.  For large collections, this can be painful to manage, as well as very slow.

#### CHANGES
This update adds the ability to mass assign studies directly on the collection itself.   An new form field called `Included studies` will allow the curator to enter a comma/space delimited list of study accessions.  This list is sanitized and validated before all valid studies are assigned to the collection.  Any studies that do not pass validation (either don't exist or curator does not have permission to view them) will be removed, and the curator will be notified which studies were not added.

Updated form:
![Screenshot 2023-08-10 at 4 05 41 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/b69ff50a-d162-4e13-8e9f-1f735bb53eb4)


#### MANUAL TESTING
1. Boot as normal and sign in
2. Click `Browse collections` and click `Edit` next to any collection
3. In the `Included studies` field, enter a selection of valid study accessions, using a mix of commas/spaces, with extra space as well between accessions
4. Click `Update collection` at the bottom of the page
5. After the collection saves, you should see list of buttons to view each study from the edit page
![Screenshot 2023-08-10 at 4 45 15 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/ddccd636-c044-472e-a77c-0208e1123373)
6. Clicking any of the links should load that study in the corresponding collection view (with `?scpbr=` in the URL)
7. Go back to the edit page, and enter a bogus accession like `SCP00000`
8. Confirm the collection still save, but that you get a message saying `SCP00000 could not be added to this collection`.