### PR TITLE
Enrich diagrams, onboarding in related genes ideogram (SCP-5186)

### DIFF
--- a/app/javascript/components/visualization/RelatedGenesIdeogram.jsx
+++ b/app/javascript/components/visualization/RelatedGenesIdeogram.jsx
@@ -148,8 +148,8 @@ export default function RelatedGenesIdeogram({
 
   const verticalPad = 40 // Total top and bottom padding
 
-  // For Ideogram functionality only available for human
-  const showAdvanced = taxon === 'Homo sapiens'
+  // For Ideogram functionality only available for human and mouse
+  const showAdvanced = ['Homo sapiens', 'Mus musculus'].includes(taxon)
 
   useEffect(() => {
     const ideoConfig = {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "core-js": "^3.6.4",
     "exifreader": "4.6.0",
     "fflate": "^0.7.3",
-    "ideogram": "1.43.0",
+    "ideogram": "1.44.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.13.2",
     "morpheus-app": "1.0.18",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "core-js": "^3.6.4",
     "exifreader": "4.6.0",
     "fflate": "^0.7.3",
-    "ideogram": "1.42.0",
+    "ideogram": "1.43.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.13.2",
     "morpheus-app": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5150,10 +5150,10 @@ iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ideogram@1.43.0:
-  version "1.43.0"
-  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.43.0.tgz#a1f695183616946bd76a4216feec2a63e7e8d997"
-  integrity sha512-0maLlGAYOo80IN9yO+YsgaBpGEZtI5AFRahJlopTgj5w7hWAnxOa1R/8Dwb+hsQ+6a6odYgkWJF43xLcvL5tWg==
+ideogram@1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.44.0.tgz#30af5fd22fe23c38260814d9a3836b4f70d6278c"
+  integrity sha512-OoNOR/LBtGNwrmLVDAafLMiQSRjZ2yd3JFqxavq9XtD4VeUrBHnN82XdXapTB8n6/JEL6m+7A4vFVHYEh79Uow==
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1835,6 +1835,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@popperjs/core@^2.9.0":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
 "@ranfdev/deepobj@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@ranfdev/deepobj/-/deepobj-1.0.2.tgz#9dba923578fa24aed3d3961975037b6423a03771"
@@ -5145,10 +5150,10 @@ iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ideogram@1.42.0:
-  version "1.42.0"
-  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.42.0.tgz#35203b567f330eb0c8a6af5fb5934eb48c734874"
-  integrity sha512-2iYz8Hre7lm5IzuFLYen4/NgI7bCyk25NFZT3CHm9ww/C8yu85h8UTlsgzmlnzHzUNnknZ8z305YXhRKLa+kLg==
+ideogram@1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.43.0.tgz#a1f695183616946bd76a4216feec2a63e7e8d997"
+  integrity sha512-0maLlGAYOo80IN9yO+YsgaBpGEZtI5AFRahJlopTgj5w7hWAnxOa1R/8Dwb+hsQ+6a6odYgkWJF43xLcvL5tWg==
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"
@@ -5158,6 +5163,7 @@ ideogram@1.42.0:
     d3-format "^2.0.0"
     d3-scale "^4.0.2"
     fflate "^0.7.3"
+    tippy.js "6.3.7"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -8945,6 +8951,13 @@ through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
+
+tippy.js@6.3.7:
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-6.3.7.tgz#8ccfb651d642010ed9a32ff29b0e9e19c5b8c61c"
+  integrity sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==
+  dependencies:
+    "@popperjs/core" "^2.9.0"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
This adds topology and signal peptides to protein diagrams, makes the legend interactive, and refines tooltips.

Here's how it looks!

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/2fc8c179-4b25-4574-ae8b-cc751c6c5e25

The goal is to help users discover genes, which the user then explores more fully in expression scatter plots and violin plots.  Specifically, these changes further help users learn about gene function and the degree of similarity between searched genes and related genes.  Having this conveniently in the app lets the user maintain flow.  Below are details on what's depicted in the video and how it relates to that goal.  

## Diagram improvements
Beyond deepening per below, RNA and protein diagram support is also wider.  Diagrams are shown for human _and_ mouse.

### Clearer basic features
Previously, protein diagrams showed "features" -- i.e. named 1D coordinate ranges -- from all member databases in InterPro. This made the diagrams maximally sequence-feature-rich, but also muddled them. The same features from Pfam, SMART, and other protein databases would often closely overlap. The end result was "fuzzy" protein diagrams.

Now, the diagrams show features from only the Pfam database.  (Pfam is the most comprehensive member database, and is hosted by InterPro and made available via Ensembl BioMart.)  The graphics now more clearly correspond to protein sequence diagrams in scientific illustrations.

### Topology and signal peptides
New topology and signal peptides enrich the granular functional insight provided by protein diagrams.  These protein sequence diagrams help form and refine hypotheses about the searched gene, and how other genes relate to it.  Such context augments exploration of study-specific gene expression.

For example, it's useful to see when a gene encodes a _membrane_ protein.  These are often targeted by pharmaceutical drugs, yet are underrepresented among protein structure databases.  In lieu of such 3D data -- or as an easier complement to it -- simpler 1D protein annotations for topological features and signal peptides can show glanceable fine details on a protein's typical subcellular location.

These new features reveal which proteins typically get trafficked to the outer cell membrane, or even an organelle membrane.  Topology features further show which _parts_ of the protein end up outside the cell (extracellular), inside the cell (cytosolic), or anchored in the membrane (transmembrane).  Signal peptides get cleaved off the protein en route to the protein's final destination; when these features exist, they appear at the start of the protein.  

## Onboarding refinements
Users sometimes wonder what "Interacting genes" means, or where related genes ideogram data is from.  Now, brief definitions and provenance can be found in tooltips shown upon hovering over entries in the legend at left.  The same gesture updates Ideogram to show only genes of that type.  This helps overview gene names for e.g. paralogs when there are many related genes.

Finally, per prior feedback, tooltips inside the diagrams now appear instantly on hover, rather than the default ~2 seconds.

## Test
To manually test this:
* In your terminal, stop Rails and Vite, then `yarn install --force`, then start Rails and Vite 
* Load a study with a representative set of real human genes 
* Search for a gene, like LDLR, GAD2, MTOR, PTEN, etc.
* Hover over the searched gene in related genes ideogram
* Confirm RNA and protein diagrams appear in popover
* Hover over diagrams, confirm scissors icon appears
* Hover over scissors icon, confirm tooltip shows quickly
* In "Related genes" legend, hover over legend entries for "Interacting genes" and "Paralogous genes"
* Confirm ideogram filters annotations to show only the hovered kind, while moused over the respective entry
* Confirm tooltips display for those two legend entries
* Load a study with a representative set of real mouse genes
* Search for a gene, like Ldlr, Gad2, Mtor, Pten, etc.
* Hover over the searched gene in related genes ideogram
* Confirm RNA and protein diagrams appear in popover

This upstream enhancement from Ideogram.js was integrated as part of Developer Choice Days.  It relates to SCP-5186.