### PR TITLE
Add Slack notifications for orchestration smoke test (SCP-5232)

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -5,6 +5,8 @@ on:
       - development
       - master
   pull_request:
+    branches-ignore:
+      - jb-slack-notify-ci-job # temporarily disable to reduce CI backlog
 env:
   DOCKER_IMAGE_NAME: "gcr.io/broad-singlecellportal-staging/single-cell-portal"
 

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -5,8 +5,6 @@ on:
       - development
       - master
   pull_request:
-    branches-ignore:
-      - jb-slack-notify-ci-job # temporarily disable to reduce CI backlog
 env:
   DOCKER_IMAGE_NAME: "gcr.io/broad-singlecellportal-staging/single-cell-portal"
 

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -29,11 +29,12 @@ jobs:
           ORCH_SMOKE_TEST: true
           CI: true
         run: |
-          export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )
-          bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json \
-                                  -s secret/kdux/scp/staging/scp_service_account.json \
-                                  -e test -v $DOCKER_IMAGE_TAG -n single-cell-portal-test \
-                                  -c bin/run_orch_smoke_test.sh
+          exit 1 # manual testing for faster iteration
+#          export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )
+#          bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json \
+#                                  -s secret/kdux/scp/staging/scp_service_account.json \
+#                                  -e test -v $DOCKER_IMAGE_TAG -n single-cell-portal-test \
+#                                  -c bin/run_orch_smoke_test.sh
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
@@ -41,9 +42,9 @@ jobs:
         id: slack-message
         run: |
           if ${{ steps.run-smoke-test.outcome == 'failure' }}; then
-            echo "::set-output name=message::\"@channel :x Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}\""
+            echo "::set-output name=message::@channel :x Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}"
           else
-            echo "::set-output name=message::\":green_check_mark Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}\""
+            echo "::set-output name=message:::green_check_mark Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}"
           fi
       - name: Notify Slack
         id: slack-notify

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Build image and setup env
-        id: build-image-setup-env
-        uses: ./.github/actions/docker-build-env-setup
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Build image and setup env
+#        id: build-image-setup-env
+#        uses: ./.github/actions/docker-build-env-setup
       - name: Load secrets and run tests
         id: run-smoke-test
         env:
@@ -25,7 +25,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
           VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
-          DOCKER_IMAGE_TAG: ${{ steps.build-image-setup-env.outputs.docker-tag }}
+          # DOCKER_IMAGE_TAG: ${{ steps.build-image-setup-env.outputs.docker-tag }}
           ORCH_SMOKE_TEST: true
           CI: true
         run: |
@@ -38,18 +38,10 @@ jobs:
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-      - name: Set Slack message content
-        id: slack-message
-        run: |
-          if ${{ steps.run-smoke-test.outcome == 'failure' }}; then
-            echo "::set-output name=message::@channel :x Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}"
-          else
-            echo "::set-output name=message:::green_check_mark Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}"
-          fi
-      - name: Notify Slack
+      - name: Notify Slack failure
         id: slack-notify
         uses: slackapi/slack-github-action@v1.24.0
-        if: always()
+        if: failure()
         with:
           channel-id: "C05JHJ0UA1M" #scp-alerts
           payload: |
@@ -59,7 +51,27 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ steps.slack-message.outputs.message }} \nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": "@channel :x Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
+      - name: Notify Slack success
+        id: slack-notify
+        uses: slackapi/slack-github-action@v1.24.0
+        if: success()
+        with:
+          channel-id: "C05JHJ0UA1M" #scp-alerts
+          payload: |
+            {
+              "blocks": [
+                { 
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":green_check_mark Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -1,5 +1,8 @@
 name: Terra Orchestration API Smoke Test
 on:
+  push:
+    branches:
+      - jb-slack-notify-ci-job
   schedule:
     - cron: "0 8 * * 1,3,5"
 env:
@@ -16,6 +19,7 @@ jobs:
         id: build-image-setup-env
         uses: ./.github/actions/docker-build-env-setup
       - name: Load secrets and run tests
+        id: run-smoke-test
         env:
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -33,8 +37,16 @@ jobs:
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Set Slack message content
+        id: slack-message
+        run: |
+          if ${{ steps.run-smoke-test.outcome == 'failure' }}; then
+            echo "::set-output name=message::\"@channel :x Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}\""
+          else
+            echo "::set-output name=message::\":green_check_mark Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}\""
+          fi
       - name: Notify Slack
-        id: slack
+        id: slack-notify
         uses: slackapi/slack-github-action@v1.24.0
         if: always()
         with:
@@ -46,7 +58,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": "${{steps.slack-message.outputs.message}} \nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -49,8 +49,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}\n
-                             https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": "Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -41,7 +41,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.24.0
         if: always()
         with:
-          channel-id: 'CBEHTH601' #scp-implementation
+          channel-id: "C05JHJ0UA1M" #scp-alerts
           payload: |
             {
               "text": "Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}",
@@ -55,7 +55,6 @@ jobs:
                 }
               ]
             }
-
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
       - name: Preserve all test logs

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -1,6 +1,6 @@
 name: Terra Orchestration API Smoke Test
 on:
-  pull_request:
+  push:
     branches:
       - jb-slack-notify-ci-job
   schedule:

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -1,8 +1,5 @@
 name: Terra Orchestration API Smoke Test
 on:
-  push:
-    branches:
-      - jb-slack-notify-ci-job
   schedule:
     - cron: "0 8 * * 1,3,5"
 env:
@@ -67,7 +64,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":green_check_mark Orchestration smoke test: ${{ job.status }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": ":green_check: Orchestration smoke test: ${{ job.status }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -39,7 +39,6 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - name: Notify Slack failure
-        id: slack-notify
         uses: slackapi/slack-github-action@v1.24.0
         if: failure()
         with:
@@ -59,7 +58,6 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
       - name: Notify Slack success
-        id: slack-notify
         uses: slackapi/slack-github-action@v1.24.0
         if: success()
         with:
@@ -78,10 +76,10 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
-      - name: Preserve all test logs
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: test-logs
-          path: |
-            log/test.log
+#      - name: Preserve all test logs
+#        uses: actions/upload-artifact@v3
+#        if: always()
+#        with:
+#          name: test-logs
+#          path: |
+#            log/test.log

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -51,6 +51,7 @@ jobs:
                   "text": {
                     "type": "mrkdwn",
                     "text": "URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
                 }
               ]
             }

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: self-hosted
 
     steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Build image and setup env
-#        id: build-image-setup-env
-#        uses: ./.github/actions/docker-build-env-setup
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Build image and setup env
+        id: build-image-setup-env
+        uses: ./.github/actions/docker-build-env-setup
       - name: Load secrets and run tests
         id: run-smoke-test
         env:
@@ -25,20 +25,17 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
           VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
-          # DOCKER_IMAGE_TAG: ${{ steps.build-image-setup-env.outputs.docker-tag }}
+          DOCKER_IMAGE_TAG: ${{ steps.build-image-setup-env.outputs.docker-tag }}
           ORCH_SMOKE_TEST: true
           CI: true
         run: |
-          exit 1 # manual testing for faster iteration
-#          export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )
-#          bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json \
-#                                  -s secret/kdux/scp/staging/scp_service_account.json \
-#                                  -e test -v $DOCKER_IMAGE_TAG -n single-cell-portal-test \
-#                                  -c bin/run_orch_smoke_test.sh
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+          export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )
+          bin/load_env_secrets.sh -p secret/kdux/scp/staging/scp_config.json \
+                                  -s secret/kdux/scp/staging/scp_service_account.json \
+                                  -e test -v $DOCKER_IMAGE_TAG -n single-cell-portal-test \
+                                  -c bin/run_orch_smoke_test.sh
       - name: Notify Slack failure
+        id: notify-slack-on-fail
         uses: slackapi/slack-github-action@v1.24.0
         if: failure()
         with:
@@ -50,7 +47,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "@channel :x Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": "@channel :x: Orchestration smoke test: ${{ job.status }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]
@@ -58,6 +55,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
       - name: Notify Slack success
+        id: notify-slack-on-success
         uses: slackapi/slack-github-action@v1.24.0
         if: success()
         with:
@@ -69,17 +67,17 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":green_check_mark Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": ":green_check_mark Orchestration smoke test: ${{ job.status }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
-#      - name: Preserve all test logs
-#        uses: actions/upload-artifact@v3
-#        if: always()
-#        with:
-#          name: test-logs
-#          path: |
-#            log/test.log
+      - name: Preserve all test logs
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-logs
+          path: |
+            log/test.log

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -1,5 +1,8 @@
 name: Terra Orchestration API Smoke Test
 on:
+  pull_request:
+    branches:
+      - jb-slack-notify-ci-job
   schedule:
     - cron: "0 8 * * 1,3,5"
 env:
@@ -30,6 +33,30 @@ jobs:
                                   -s secret/kdux/scp/staging/scp_service_account.json \
                                   -e test -v $DOCKER_IMAGE_TAG -n single-cell-portal-test \
                                   -c bin/run_orch_smoke_test.sh
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Notify Slack
+        id: slack
+        uses: slackapi/slack-github-action@v1.24.0
+        if: always()
+        with:
+          channel-id: 'CBEHTH601' #scp-implementation
+          payload: |
+            {
+              "text": "Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}",
+              "blocks": [
+                { 
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }"
+                }
+              ]
+            }
+
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
       - name: Preserve all test logs
         uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -1,8 +1,5 @@
 name: Terra Orchestration API Smoke Test
 on:
-  push:
-    branches:
-      - jb-slack-notify-ci-job
   schedule:
     - cron: "0 8 * * 1,3,5"
 env:

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -50,7 +50,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }"
+                    "text": "URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                 }
               ]
             }

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -44,13 +44,13 @@ jobs:
           channel-id: "C05JHJ0UA1M" #scp-alerts
           payload: |
             {
-              "text": "Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}",
               "blocks": [
                 { 
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": "Orchestration smoke test ${{ steps.date.outputs.date }}: ${{ job.status }}\n
+                             https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -44,27 +44,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "@channel :x: Orchestration smoke test: ${{ job.status }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
-      - name: Notify Slack success
-        id: notify-slack-on-success
-        uses: slackapi/slack-github-action@v1.24.0
-        if: success()
-        with:
-          channel-id: "C05JHJ0UA1M" #scp-alerts
-          payload: |
-            {
-              "blocks": [
-                { 
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":green_check: Orchestration smoke test: ${{ job.status }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": ":x: Orchestration smoke test: ${{ job.status }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -58,7 +58,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{steps.slack-message.outputs.message}} \nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": "${{ steps.slack-message.outputs.message }} \nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]


### PR DESCRIPTION
#### BACKGROUND
Currently, our Terra orchestration API smoke test job runs on a fixed schedule: M/W/F at 8AM.  Scheduled Github actions only automatically notify the last user to edit the job.  If that person is away from work, potential failures will go unnoticed until their return.  Furthermore, Github only sends notifications on failures.  If the job stops running for whatever reason, then this also could go unnoticed until someone checks manually.

#### CHANGES
This update adds Slack notifications to the `#scp-alerts` channel at the conclusion of every run for the smoke test.  This way, all subscribed team members will be able to see the status of jobs without having to go to the actions overview page in this repository.  Additionally, if a job fails, it adds the `@channel` notifier to ping all members.  Successful jobs will still post, but no alert is sent.  This gives a quick and easy way to confirm that jobs are running.  All messages will contain a link to the corresponding run for further debugging (like downloading log files, for instance).

Note: some of the previous messages in this channel have incorrect formatting - there's no way to delete messages from app integrations, so please disregard these.

#### MANUAL TESTING
1. Visit the `#scp-alerts` channel to see previous test messages, including one from 2023-08-15 1:36PM that failed and set the `@channel` notification
2. Click any of the links to corresponding jobs and confirm you are take to the correct place