### PR TITLE
Truncate list of genes for consensus scatter plots (SCP-5252)

### DIFF
--- a/app/javascript/components/visualization/PlotTitle.jsx
+++ b/app/javascript/components/visualization/PlotTitle.jsx
@@ -18,7 +18,7 @@ export function formatGeneList(genes) {
     return formattedGenes
   }
   const hiddenGenes = <Popover id="genes-tooltip" className="tooltip-wide">{makeGeneBadges(hidden)}</Popover>
-  const hiddenOverlay = <OverlayTrigger trigger={['hover', 'focus']} key='hidden-genes' rootClose placement="right"
+  const hiddenOverlay = <OverlayTrigger trigger={['hover','focus']} key='hidden-genes' rootClose placement="right"
                                         overlay={hiddenGenes}>
     <span className='badge'>and {hidden.length} more</span>
   </OverlayTrigger>

--- a/app/javascript/components/visualization/PlotTitle.jsx
+++ b/app/javascript/components/visualization/PlotTitle.jsx
@@ -3,20 +3,22 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 import { Popover, OverlayTrigger } from 'react-bootstrap'
 
+function makeGeneBadges(genes) {
+  return genes.map(gene => {
+    return <span className="badge popover-badge" key={gene}>{gene}</span>
+  })
+}
+
 // divide gene list into two parts, only showing first 3
-function formatGeneList(genes) {
+export function formatGeneList(genes) {
   const shown = genes.slice(0, 3)
   const hidden = genes.slice(3, genes.length + 1)
-  let formattedGenes = []
-  shown.map(gene => {
-    let badge = <span className="badge" key={gene}>{gene}</span>
-    formattedGenes.push(badge)
-  })
+  let formattedGenes = makeGeneBadges(shown)
   if (hidden.length === 0) {
     return formattedGenes
   }
-  const hiddenGenes = <Popover id="genes-tooltip" className="tooltip-wide">{hidden.join(', ')}</Popover>
-  const hiddenOverlay = <OverlayTrigger trigger={['hover','focus']} key='hidden-genes' rootClose placement="right"
+  const hiddenGenes = <Popover id="genes-tooltip" className="tooltip-wide">{makeGeneBadges(hidden)}</Popover>
+  const hiddenOverlay = <OverlayTrigger trigger={['hover', 'focus']} key='hidden-genes' rootClose placement="right"
                                         overlay={hiddenGenes}>
     <span className='badge'>and {hidden.length} more</span>
   </OverlayTrigger>

--- a/app/javascript/components/visualization/PlotTitle.jsx
+++ b/app/javascript/components/visualization/PlotTitle.jsx
@@ -1,6 +1,28 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
+import { Popover, OverlayTrigger } from 'react-bootstrap'
+
+// divide gene list into two parts, only showing first 3
+function formatGeneList(genes) {
+  const shown = genes.slice(0, 3)
+  const hidden = genes.slice(3, genes.length + 1)
+  let formattedGenes = []
+  shown.map(gene => {
+    let badge = <span className="badge" key={gene}>{gene}</span>
+    formattedGenes.push(badge)
+  })
+  if (hidden.length === 0) {
+    return formattedGenes
+  }
+  const hiddenGenes = <Popover id="genes-tooltip" className="tooltip-wide">{hidden.join(', ')}</Popover>
+  const hiddenOverlay = <OverlayTrigger trigger={['hover','focus']} key='hidden-genes' rootClose placement="right"
+                                        overlay={hiddenGenes}>
+    <span className='badge'>and {hidden.length} more</span>
+  </OverlayTrigger>
+  formattedGenes.push(hiddenOverlay)
+  return formattedGenes
+}
 
 /** Renders a plot title for scatter plots */
 export default function PlotTitle({
@@ -14,9 +36,7 @@ export default function PlotTitle({
     the data may not be suited for correlation analysis and you should trust the plot`
 
   if (genes.length) {
-    const geneList = genes.map(gene => {
-      return <span className="badge" key={gene}>{gene}</span>
-    })
+    const geneList = formatGeneList(genes)
     if (isCorrelatedScatter) {
       geneList.splice(1, 0, <span key="vs"> vs. </span>)
     }

--- a/app/javascript/components/visualization/PlotTitle.jsx
+++ b/app/javascript/components/visualization/PlotTitle.jsx
@@ -9,7 +9,7 @@ function makeGeneBadges(genes) {
   })
 }
 
-// divide gene list into two parts, only showing first 3
+/** Divide gene list into two parts, only showing first 3 */
 export function formatGeneList(genes) {
   const shown = genes.slice(0, 3)
   const hidden = genes.slice(3, genes.length + 1)

--- a/app/javascript/components/visualization/StudyViolinPlot.jsx
+++ b/app/javascript/components/visualization/StudyViolinPlot.jsx
@@ -14,6 +14,7 @@ import { withErrorBoundary } from '~/lib/ErrorBoundary'
 import useErrorMessage from '~/lib/error-message'
 import { logViolinPlot } from '~/lib/scp-api-metrics'
 import LoadingSpinner from '~/lib/LoadingSpinner'
+import { formatGeneList} from '~/components/visualization/PlotTitle'
 
 
 /** displays a violin plot of expression data for the given gene and study
@@ -134,7 +135,7 @@ function RawStudyViolinPlot({
        sometimes render a zero to the page*/}
       { isCollapsedView && studyGeneNames.length > 0 &&
         <div className="text-center">
-          <span>{_capitalize(consensus)} expression of {studyGeneNames.join(', ')}</span>
+          <span>{_capitalize(consensus)} expression of {formatGeneList(studyGeneNames)}</span>
         </div>
       }
     </div>

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -69,6 +69,10 @@
   }
 }
 
+.popover-badge {
+  font-weight: normal;
+  margin-right: 0.2em;
+}
 
 .explore-tab-content {
   background: #fff;


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a UI bug where long lists of queried genes in consensus scatter plots (i.e. collapsing gene expression by mean/median) will push the scatter plots down significantly on the page.  Now, only the first 3 genes queried will display in the plot header, and a final badge will show `and {n} more` with a popover containing the remaining gene names.  Additionally, this new styling has been applied to violin plot titles as well, which currently display the entire gene list underneath the plot.  While this doesn't have quite the same usability issue, it is harder to read, and this way the styling is unified.

An example of a 50-gene query on production:
<img width="592" alt="Screenshot 2023-08-16 at 11 03 02 AM" src="https://github.com/broadinstitute/single_cell_portal_core/assets/729968/b3980ad7-535b-4749-856c-b083ab6d81fe">

Updated UI with truncated list:
![Screenshot 2023-08-17 at 4 45 12 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/3f40f6d8-07ca-4f6c-b415-fe5bb023a361)

Existing violin plots titles:
![Screenshot 2023-08-17 at 4 55 55 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/49f58e06-5454-42ed-a872-ce6b8949a0b4)

Updated violin plot titles:
![Screenshot 2023-08-17 at 4 55 02 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/8e7f9a41-5713-453c-bddf-0a07924aece3)

#### MANUAL TESTING
1. Boot as normal and load any study with gene expression, such as the `Human milk - differential expression`
2. Query for 4 or more genes, then select "Mean" from the "Collapse by" menu
3. Confirm you get the popover badge containing the gene names not displayed
4. Click to the Distribution tab and confirm the same plot title
5. Go back to the default view, query for less than 4 genes and confirm that the popover is not shown