### PR TITLE
Instantly filter cells across annotations: client library (SCP-5213)

### DIFF
--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -161,7 +161,7 @@ module Api
               'Visualization'
             ]
             key :summary, 'Get facet assignments for a cluster'
-            key :description, 'Get annotation assignments (i.e facets) for specified cells from a cluster. ' \
+            key :description, 'Get annotation assignments (i.e. facets) for specified cells from a cluster. ' \
                               'Only applicable to full resolution data (i.e. all cells)'
             key :operationId, 'study_annotation_facets_path'
             parameter do

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -309,7 +309,7 @@ export default function ExploreDisplayTabs({
   }
 
   // Below line is worth keeping, but only uncomment to debug in development
-  window.SCP.updateFilteredCells = updateFilteredCells
+  // window.SCP.updateFilteredCells = updateFilteredCells
 
   /** in the event a component takes an action which updates the list of annotations available
     * e.g. by creating a user annotation, this updates the list */

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -304,7 +304,6 @@ export default function ExploreDisplayTabs({
     const filtersByFacet = cellFaceting.filtersByFacet
     const filterableCells = cellFaceting.filterableCells
     const newFilteredCells = filterCells(selections, cellsByFacet, facets, filtersByFacet, filterableCells)[0]
-    console.log('newFilteredCells', newFilteredCells)
     setFilteredCells(newFilteredCells)
   }
 

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -35,9 +35,11 @@ import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger'
 import Tooltip from 'react-bootstrap/lib/Tooltip'
 import DifferentialExpressionModal from '~/components/explore/DifferentialExpressionModal'
 import PlotTabs from './PlotTabs'
+import { fetchAnnotationFacets } from '~/lib/cell-faceting'
 
 /** Get the selected clustering and annotation, or their defaults */
 function getSelectedClusterAndAnnot(exploreInfo, exploreParams) {
+  if (!exploreInfo) {return [null, null]}
   const annotList = exploreInfo.annotationList
   let selectedCluster
   let selectedAnnot
@@ -277,6 +279,9 @@ export default function ExploreDisplayTabs({
   }
 
   const shownAnnotation = getShownAnnotation(exploreParamsWithDefaults.annotation, annotationList)
+
+  const [selectedCluster, selectedAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
+  const annotationFacets = fetchAnnotationFacets(selectedCluster, selectedAnnot, exploreInfo)
 
   /** in the event a component takes an action which updates the list of annotations available
     * e.g. by creating a user annotation, this updates the list */

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -548,6 +548,7 @@ export default function ExploreDisplayTabs({
                   dimensions={getPlotDimensions({
                     showRelatedGenesIdeogram, showViewOptionsControls, showDifferentialExpressionTable
                   })}
+                  filteredCells={filteredCells}
                   {...exploreParams}/>
               </div>
             }

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -295,8 +295,9 @@ export default function ExploreDisplayTabs({
   function updateFilteredCells(selections) {
     const cellsByFacet = cellFaceting.cellsByFacet
     const facets = cellFaceting.facets
+    const filtersByFacet = cellFaceting.filtersByFacet
     const filterableCells = cellFaceting.filterableCells
-    const newFilteredCells = filterCells(selections, cellsByFacet, facets, filterableCells)[0]
+    const newFilteredCells = filterCells(selections, cellsByFacet, facets, filtersByFacet, filterableCells)[0]
     console.log('newFilteredCells', newFilteredCells)
     setFilteredCells(newFilteredCells)
   }

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -286,9 +286,15 @@ export default function ExploreDisplayTabs({
   const [selectedCluster, selectedAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
 
   if (!cellFaceting) {
-    initCellFaceting(
-      selectedCluster, selectedAnnot, studyAccession, exploreInfo, setCellFaceting
-    )
+    const allAnnots = exploreInfo?.annotationList.annotations
+    if (allAnnots && allAnnots.length > 0) {
+      initCellFaceting(
+        selectedCluster, selectedAnnot, studyAccession, allAnnots
+      )
+        .then(newCellFaceting => {
+          setCellFaceting(newCellFaceting)
+        })
+    }
   }
 
   /** Update filtered cells to only those that match annotation group value filter selections */
@@ -303,7 +309,7 @@ export default function ExploreDisplayTabs({
   }
 
   // Below line is worth keeping, but only uncomment to debug in development
-  // window.SCP.updateFilteredCells = updateFilteredCells
+  window.SCP.updateFilteredCells = updateFilteredCells
 
   /** in the event a component takes an action which updates the list of annotations available
     * e.g. by creating a user annotation, this updates the list */

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -281,7 +281,9 @@ export default function ExploreDisplayTabs({
   const shownAnnotation = getShownAnnotation(exploreParamsWithDefaults.annotation, annotationList)
 
   const [selectedCluster, selectedAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
-  const annotationFacets = fetchAnnotationFacets(selectedCluster, selectedAnnot, exploreInfo)
+  const annotationFacets = fetchAnnotationFacets(
+    selectedCluster, selectedAnnot, studyAccession, exploreInfo
+  )
 
   /** in the event a component takes an action which updates the list of annotations available
     * e.g. by creating a user annotation, this updates the list */

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -296,7 +296,7 @@ export default function ExploreDisplayTabs({
     const cellsByFacet = cellFaceting.cellsByFacet
     const facets = cellFaceting.facets
     const filterableCells = cellFaceting.filterableCells
-    const newFilteredCells = filterCells(selections, cellsByFacet, facets, filterableCells)
+    const newFilteredCells = filterCells(selections, cellsByFacet, facets, filterableCells)[0]
     console.log('newFilteredCells', newFilteredCells)
     setFilteredCells(newFilteredCells)
   }
@@ -535,7 +535,8 @@ export default function ExploreDisplayTabs({
                     scatterColor: exploreParamsWithDefaults.scatterColor,
                     countsByLabel,
                     setCountsByLabel,
-                    dataCache
+                    dataCache,
+                    filteredCells
                   }}/>
               </div>
             }

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -301,8 +301,9 @@ export default function ExploreDisplayTabs({
     console.log('newFilteredCells', newFilteredCells)
     setFilteredCells(newFilteredCells)
   }
-  window.SCP.updateFilteredCells = updateFilteredCells
-  // Pass getFilteredResults
+
+  // Below line is worth keeping, but only uncomment to debug in development
+  // window.SCP.updateFilteredCells = updateFilteredCells
 
   /** in the event a component takes an action which updates the list of annotations available
     * e.g. by creating a user annotation, this updates the list */

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -35,7 +35,7 @@ import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger'
 import Tooltip from 'react-bootstrap/lib/Tooltip'
 import DifferentialExpressionModal from '~/components/explore/DifferentialExpressionModal'
 import PlotTabs from './PlotTabs'
-import { initAnnotationFacets } from '~/lib/cell-faceting'
+import { initCellFaceting, filterCells } from '~/lib/cell-faceting'
 
 /** Get the selected clustering and annotation, or their defaults */
 function getSelectedClusterAndAnnot(exploreInfo, exploreParams) {
@@ -219,6 +219,9 @@ export default function ExploreDisplayTabs({
   const [showDifferentialExpressionPanel, setShowDifferentialExpressionPanel] = useState(deGenes !== null)
   const [showUpstreamDifferentialExpressionPanel, setShowUpstreamDifferentialExpressionPanel] = useState(deGenes !== null)
 
+  const [cellFaceting, setCellFaceting] = useState(null)
+  const [filteredCells, setFilteredCells] = useState(null)
+
   // Hash of trace label names to the number of points in that trace
   const [countsByLabel, setCountsByLabel] = useState(null)
 
@@ -281,9 +284,24 @@ export default function ExploreDisplayTabs({
   const shownAnnotation = getShownAnnotation(exploreParamsWithDefaults.annotation, annotationList)
 
   const [selectedCluster, selectedAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
-  const annotationFacets = initAnnotationFacets(
-    selectedCluster, selectedAnnot, studyAccession, exploreInfo
-  )
+
+  if (!cellFaceting) {
+    initCellFaceting(
+      selectedCluster, selectedAnnot, studyAccession, exploreInfo, setCellFaceting
+    )
+  }
+
+  /** Update filtered cells to only those that match annotation group value filter selections */
+  function updateFilteredCells(selections) {
+    const cellsByFacet = cellFaceting.cellsByFacet
+    const facets = cellFaceting.facets
+    const filterableCells = cellFaceting.filterableCells
+    const newFilteredCells = filterCells(selections, cellsByFacet, facets, filterableCells)
+    console.log('newFilteredCells', newFilteredCells)
+    setFilteredCells(newFilteredCells)
+  }
+  window.SCP.updateFilteredCells = updateFilteredCells
+  // Pass getFilteredResults
 
   /** in the event a component takes an action which updates the list of annotations available
     * e.g. by creating a user annotation, this updates the list */

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -35,7 +35,7 @@ import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger'
 import Tooltip from 'react-bootstrap/lib/Tooltip'
 import DifferentialExpressionModal from '~/components/explore/DifferentialExpressionModal'
 import PlotTabs from './PlotTabs'
-import { fetchAnnotationFacets } from '~/lib/cell-faceting'
+import { initAnnotationFacets } from '~/lib/cell-faceting'
 
 /** Get the selected clustering and annotation, or their defaults */
 function getSelectedClusterAndAnnot(exploreInfo, exploreParams) {
@@ -281,7 +281,7 @@ export default function ExploreDisplayTabs({
   const shownAnnotation = getShownAnnotation(exploreParamsWithDefaults.annotation, annotationList)
 
   const [selectedCluster, selectedAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
-  const annotationFacets = fetchAnnotationFacets(
+  const annotationFacets = initAnnotationFacets(
     selectedCluster, selectedAnnot, studyAccession, exploreInfo
   )
 

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -298,12 +298,16 @@ export default function ExploreDisplayTabs({
   }
 
   /** Update filtered cells to only those that match annotation group value filter selections */
-  function updateFilteredCells(selections) {
+  function updateFilteredCells(selection) {
     const cellsByFacet = cellFaceting.cellsByFacet
     const facets = cellFaceting.facets
     const filtersByFacet = cellFaceting.filtersByFacet
     const filterableCells = cellFaceting.filterableCells
-    const newFilteredCells = filterCells(selections, cellsByFacet, facets, filtersByFacet, filterableCells)[0]
+
+    // Filter cells by selection (i.e., selected facets and filters)
+    const newFilteredCells = filterCells(selection, cellsByFacet, facets, filtersByFacet, filterableCells)[0]
+
+    // Update UI
     setFilteredCells(newFilteredCells)
   }
 

--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -14,7 +14,7 @@ const MAX_PLOTS = PLOTLY_CONTEXT_NAMES.length
 export default function ScatterTab({
   exploreInfo, exploreParamsWithDefaults, updateExploreParamsWithDefaults, studyAccession, isGene, isMultiGene,
   plotPointsSelected, isCellSelecting, showRelatedGenesIdeogram, showViewOptionsControls, showDifferentialExpressionTable,
-  scatterColor, countsByLabel, setCountsByLabel, dataCache
+  scatterColor, countsByLabel, setCountsByLabel, dataCache, filteredCells
 }) {
   // maintain the map of plotly contexts to the params that generated the corresponding visualization
   const plotlyContextMap = useRef({})
@@ -55,6 +55,7 @@ export default function ScatterTab({
               scatterColor={scatterColor}
               canEdit={exploreInfo.canEdit}
               bucketId={exploreInfo.bucketId}
+              filteredCells={filteredCells}
               dimensionProps={{
                 isMultiRow,
                 isTwoColumn: isTwoColRow,

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -346,9 +346,7 @@ function RawScatterPlot({
     scatter = updateScatterLayout(scatter)
     const layout = scatter.layout
 
-    console.log('in processScatterPlot, filteredCells', filteredCells)
     if (filteredCells) {
-      console.log('in processScatterPlot, scatter', scatter)
       scatter = intersect(filteredCells, scatter)
     }
 

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -45,7 +45,8 @@ function RawScatterPlot({
   studyAccession, cluster, annotation, subsample, consensus, genes, scatterColor, dimensionProps,
   isAnnotatedScatter=false, isCorrelatedScatter=false, isCellSelecting=false, plotPointsSelected, dataCache,
   canEdit, bucketId, expressionFilter=[0, 1],
-  countsByLabel, setCountsByLabel, hiddenTraces=[], isSplitLabelArrays, updateExploreParams
+  countsByLabel, setCountsByLabel, hiddenTraces=[], isSplitLabelArrays, updateExploreParams,
+  filteredCells
 }) {
   const [isLoading, setIsLoading] = useState(false)
   const [bulkCorrelation, setBulkCorrelation] = useState(null)
@@ -317,12 +318,39 @@ function RawScatterPlot({
     concludeRender()
   }
 
+  /** Intersect filtered cells with dataArrays results */
+  function intersect(filteredCells, scatter) {
+    const intersectedData = {}
+    const dataArrays = scatter.data
+    const keys = Object.keys(dataArrays)
+    keys.forEach(key => intersectedData[key] = [])
+    window.dataArrays = dataArrays
+    for (let i = 0; i < filteredCells.length; i++) {
+      const filteredCell = filteredCells[i]
+      const allCellsIndex = filteredCell.allCellsIndex
+      for (let j = 0; j < keys.length; j++) {
+        const key = keys[j]
+        const dataArray = dataArrays[key]
+        const filteredElement = dataArray[allCellsIndex]
+        intersectedData[keys[j]].push(filteredElement)
+      }
+    }
+    scatter.data = intersectedData
+    return scatter
+  }
+
   /** Process scatter plot data fetched from server */
-  function processScatterPlot(clusterResponse=null) {
+  function processScatterPlot(clusterResponse=null, filteredCells) {
     let [scatter, perfTimes] =
       (clusterResponse ? clusterResponse : [scatterData, null])
     scatter = updateScatterLayout(scatter)
     const layout = scatter.layout
+
+    console.log('in processScatterPlot, filteredCells', filteredCells)
+    if (filteredCells) {
+      console.log('in processScatterPlot, scatter', scatter)
+      scatter = intersect(filteredCells, scatter)
+    }
 
     const plotlyTraces = updateCountsAndGetTraces(scatter)
 
@@ -434,7 +462,7 @@ function RawScatterPlot({
           })
           // check that the data contains annotations needed for processing scatterplot
           if (respData1[0]?.data?.annotations?.length) {
-            processScatterPlot(respData1)
+            processScatterPlot(respData1, filteredCells)
           } else {
             // if the data was missing the necessary info, make an api call
             const respData = await fetchCluster({
@@ -448,7 +476,7 @@ function RawScatterPlot({
               isCorrelatedScatter,
               expressionArray
             })
-            processScatterPlot(respData)
+            processScatterPlot(respData, filteredCells)
           }
         } catch (error) {
           setIsLoading(false)
@@ -458,7 +486,10 @@ function RawScatterPlot({
       }
     }
     fetchData()
-  }, [cluster, annotation.name, subsample, genes.join(','), isAnnotatedScatter, consensus])
+  }, [
+    cluster, annotation.name, subsample, genes.join(','), isAnnotatedScatter, consensus,
+    filteredCells?.join(',')
+  ])
 
   useUpdateEffect(() => {
     // Don't update if graph hasn't loaded

--- a/app/javascript/components/visualization/StudyViolinPlot.jsx
+++ b/app/javascript/components/visualization/StudyViolinPlot.jsx
@@ -31,7 +31,7 @@ import LoadingSpinner from '~/lib/LoadingSpinner'
 */
 function RawStudyViolinPlot({
   studyAccession, genes, cluster, annotation, subsample, consensus, distributionPlot, distributionPoints,
-  updateDistributionPlot, setAnnotationList, dimensions={}
+  updateDistributionPlot, setAnnotationList, dimensions={}, filteredCells
 }) {
   const [isLoading, setIsLoading] = useState(false)
   // array of gene names as they are listed in the study itself
@@ -93,6 +93,7 @@ function RawStudyViolinPlot({
     annotation.scope,
     subsample,
     consensus
+    // filteredCells.join(',') // TODO (SCP-5275): Cell faceting for violin plots
   ])
 
   // useEffect for handling render param re-renders

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -1,8 +1,9 @@
+import crossfilter from 'crossfilter2'
+
 import {
-  getGroupAnnotationsForClusterAndStudy, getIdentifierForAnnotation, getAnnotationForIdentifier
+  getGroupAnnotationsForClusterAndStudy, getIdentifierForAnnotation
 } from '~/lib/cluster-utils'
 import { fetchAnnotationFacets } from '~/lib/scp-api'
-import crossfilter from 'crossfilter2'
 
 
 const CELL_TYPE_RE = new RegExp(/cell.*type/i)
@@ -169,11 +170,6 @@ function initCrossfilter(facetData) {
 export async function initCellFaceting(
   selectedCluster, selectedAnnot, studyAccession, allAnnots
 ) {
-  console.log('selectedCluster', selectedCluster),
-  console.log('selectedAnnot', selectedAnnot)
-  console.log('studyAccession', studyAccession)
-  console.log('allAnnots', allAnnots)
-
   // Prioritize and fetch annotation facets for all cells
   const selectedAnnotId = getIdentifierForAnnotation(selectedAnnot)
   const applicableAnnots =
@@ -189,10 +185,8 @@ export async function initCellFaceting(
           annot.identifier !== selectedAnnotId
         )
       })
-  console.log('applicableAnnots', applicableAnnots)
   const annotsToFacet = prioritizeAnnotations(applicableAnnots)
   const facetData = await fetchAnnotationFacets(studyAccession, annotsToFacet, selectedCluster)
-  console.log('facetData', facetData)
 
   const {
     filterableCells, cellsByFacet,
@@ -209,7 +203,6 @@ export async function initCellFaceting(
 
   // Below line is worth keeping, but only uncomment to debug in development
   // window.SCP.cellFaceting = cellFaceting
-  console.log('cellFaceting', cellFaceting)
   return cellFaceting
 }
 

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -1,0 +1,9 @@
+import { getAnnotationValues, getShownAnnotation } from '~/lib/cluster-utils'
+
+/** Get 5 default annotation facets: 1 for selected, and 4 others */
+export function fetchAnnotationFacets(selectedCluster, selectedAnnot, exploreInfo) {
+  const annotList = exploreInfo.annotationList
+  console.log('selectedCluster, selectedAnnot, exploreInfo', selectedCluster, selectedAnnot, exploreInfo)
+}
+
+window.SCP.fetchAnnotationFacets = fetchAnnotationFacets

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -13,11 +13,11 @@ import { fetchAnnotationFacets } from '~/lib/scp-api'
 import { log } from '~/lib/metrics-api'
 
 
-const CELL_TYPE_RE = new RegExp(/cell.*type/i)
+const CELL_TYPE_REGEX = new RegExp(/cell.*type/i)
 
 // Detect if a string mentions disease, sickness, malignant or malignancy,
 // indication, a frequent suffix of disease names, or a common suffix of cancer names
-const DISEASE_RE = new RegExp(/(disease|sick|malignan|indicat|itis|osis|oma)/i)
+const DISEASE_REGEX = new RegExp(/(disease|sick|malignan|indicat|itis|osis|oma)/i)
 
 /**
  * Prioritize unselected annotations to those worth showing by default as facets
@@ -56,7 +56,7 @@ function prioritizeAnnotations(annotList) {
   annotsToFacet = annotsToFacet.concat(cellTypeAndDiseaseConventionalAnnots)
 
   const cellTypeOrClinicalAnnots = annotList.filter(
-    annot => (CELL_TYPE_RE.test(annot.name) || DISEASE_RE.test(annot.name)) && isUnique(annot)
+    annot => (CELL_TYPE_REGEX.test(annot.name) || DISEASE_REGEX.test(annot.name)) && isUnique(annot)
   )
   annotsToFacet = annotsToFacet.concat(cellTypeOrClinicalAnnots)
 

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -168,7 +168,7 @@ function initCrossfilter(facetData) {
     // for the annotation facet at that index.
     //
     //  So, for the first element, `6`, we look up the element at index 0 in annotationFacets,
-    //  and get its `groups`.  Then the group value assignment would be the 6th string in the
+    //  and get its `groups`.  Then the group value assignment would be the 7th string in the
     //  `groups` array for the 0th annotation.
     const cellGroupIndexes = cells[i]
     for (let j = 0; j < cellGroupIndexes.length; j++) {

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -1,6 +1,7 @@
 import {
   getGroupAnnotationsForClusterAndStudy, getIdentifierForAnnotation
 } from '~/lib/cluster-utils'
+import { fetchAnnotationFacetData } from '~/lib/scp-api'
 
 
 /**
@@ -57,13 +58,18 @@ function prioritizeAnnotations(annotList) {
   studyAnnots.forEach(annot => seenAnnots.add(annot.identifiers))
   annotsToFacet = annotsToFacet.concat(studyAnnots)
 
-  annotsToFacet = annotsToFacet.slice(0, 5)
+  annotsToFacet =
+    annotsToFacet
+      .map(annot => annot.identifier)
+      .slice(0, 5)
 
   return annotsToFacet
 }
 
 /** Get 5 default annotation facets: 1 for selected, and 4 others */
-export function fetchAnnotationFacets(selectedCluster, selectedAnnot, exploreInfo) {
+export async function fetchAnnotationFacets(
+  selectedCluster, selectedAnnot, studyAccession, exploreInfo
+) {
   const allAnnots = exploreInfo?.annotationList
   if (!allAnnots) {return}
   console.log('allAnnots', allAnnots)
@@ -74,6 +80,8 @@ export function fetchAnnotationFacets(selectedCluster, selectedAnnot, exploreInf
   const annotsToFacet = prioritizeAnnotations(applicableAnnots)
   console.log('selectedCluster, selectedAnnot', selectedCluster, selectedAnnot)
   console.log('annotsToFacet', annotsToFacet)
+  const facets = await fetchAnnotationFacetData(studyAccession, annotsToFacet, selectedCluster)
+  console.log('facets', facets)
 }
 
 window.SCP.fetchAnnotationFacets = fetchAnnotationFacets

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -6,7 +6,10 @@ import crossfilter from 'crossfilter2'
 
 
 const CELL_TYPE_RE = new RegExp(/cell.*type/i)
-const CLINICAL_RE = new RegExp(/(disease|sick|malignan|indicat|itis|osis|oma)/i)
+
+// Detect if a string mentions disease, sickness, malignant or malignancy,
+// indication, a frequent suffix of disease names, or a common suffix of cancer names
+const DISEASE_RE = new RegExp(/(disease|sick|malignan|indicat|itis|osis|oma)/i)
 
 /**
  * Prioritize unselected annotations to those worth showing by default as facets
@@ -24,9 +27,9 @@ const CLINICAL_RE = new RegExp(/(disease|sick|malignan|indicat|itis|osis|oma)/i)
  *
  *   0. Not currently selected annotation -- this is set upstream, not here
  *   1. <= 2 annotations from metadata convention, for `cell type` and `disease`
- *   2.
+ *   2. 0-5 annotations that are cell-type-like or disease-like
  *   2. 0-2 cluster-based annotations
- *   3. 0-4 study-wide annotations
+ *   3. 0-5 study-wide annotations
  *
  * Annotations in above categories often don't exist, in which case we fall to the
  * the next prioritization rule.
@@ -47,7 +50,7 @@ function prioritizeAnnotations(annotList) {
   console.log('1 annotsToFacet', annotsToFacet)
 
   const cellTypeOrClinicalAnnots = annotList.filter(
-    annot => (CELL_TYPE_RE.test(annot.name) || CLINICAL_RE.test(annot.name)) && isUnique(annot)
+    annot => (CELL_TYPE_RE.test(annot.name) || DISEASE_RE.test(annot.name)) && isUnique(annot)
   )
   annotsToFacet = annotsToFacet.concat(cellTypeOrClinicalAnnots)
   console.log('2 annotsToFacet', annotsToFacet)
@@ -216,8 +219,8 @@ export async function initCellFaceting(
     filtersByFacet
   }
 
-  // DEBUG, remove before PR
-  window.cellFaceting = cellFaceting
+  // Below line is worth keeping, but only uncomment to debug in development
+  window.SCP.cellFaceting = cellFaceting
 
   setCellFaceting(cellFaceting)
 }

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -42,39 +42,32 @@ function prioritizeAnnotations(annotList) {
     return !annotsToFacet.includes(annot)
   }
 
-  console.log('0 annotsToFacet', annotsToFacet)
   const cellTypeAndDiseaseConventionalAnnots = annotList.filter(
     annot => ['cell_type__ontology_label', 'disease__ontology_label'].includes(annot.name)
   )
   annotsToFacet = annotsToFacet.concat(cellTypeAndDiseaseConventionalAnnots)
-  console.log('1 annotsToFacet', annotsToFacet)
 
   const cellTypeOrClinicalAnnots = annotList.filter(
     annot => (CELL_TYPE_RE.test(annot.name) || DISEASE_RE.test(annot.name)) && isUnique(annot)
   )
   annotsToFacet = annotsToFacet.concat(cellTypeOrClinicalAnnots)
-  console.log('2 annotsToFacet', annotsToFacet)
 
   const otherConventionalAnnots = annotList.filter(
     annot => annot.name.endsWith('__ontology_label') && isUnique(annot)
   ).slice(0, 2)
   annotsToFacet = annotsToFacet.concat(otherConventionalAnnots)
-  console.log('3 annotsToFacet', annotsToFacet)
 
   const clusterAnnots = annotList.filter(
     annot => ('cluster_name' in annot) && isUnique(annot)
   )
   annotsToFacet = annotsToFacet.concat(clusterAnnots)
-  console.log('4 annotsToFacet', annotsToFacet)
 
   const studyAnnots = annotList.filter(
     annot => !('cluster_name' in annot) && isUnique(annot)
   )
   annotsToFacet = annotsToFacet.concat(studyAnnots)
-  console.log('5 annotsToFacet', annotsToFacet)
 
   annotsToFacet = annotsToFacet.map(annot => annot.identifier).slice(0, 5)
-  console.log('6 annotsToFacet')
 
   return annotsToFacet
 }
@@ -94,10 +87,7 @@ export function filterCells(
     for (i = 0; i < facets.length; i++) {
       facet = facets[i]
       if (facet in selections) { // e.g. 'infant_sick_YN'
-        const friendlyFilters = selections[facet] // e.g. ['no', 'NA']
-        console.log('friendlyFilters', friendlyFilters)
-        console.log('filtersByFacet[facet]', filtersByFacet[facet])
-        // const filterValue = Object.keys(friendlyFilter)[0] // e.g.
+        const friendlyFilters = selections[facet] // e.g. ['yes', 'NA']
 
         const filter = {}
         friendlyFilters.forEach(friendlyFilter => {
@@ -105,8 +95,6 @@ export function filterCells(
           filter[filterIndex] = 1
         })
 
-        console.log('facet', facet)
-        console.log('filter', filter)
         if (Array.isArray(filter)) {
           fn = function(d) {
             // Filter is numeric range
@@ -186,7 +174,6 @@ export async function initCellFaceting(
   const allAnnots = exploreInfo?.annotationList
   if (!allAnnots || allAnnots.annotations.length === 0) {return}
 
-
   const selectedAnnotId = getIdentifierForAnnotation(selectedAnnot)
   const applicableAnnots =
     getGroupAnnotationsForClusterAndStudy(allAnnots, selectedCluster)
@@ -202,7 +189,6 @@ export async function initCellFaceting(
         )
       })
 
-  console.log('applicableAnnots', applicableAnnots)
   const annotsToFacet = prioritizeAnnotations(applicableAnnots)
   const facetData = await fetchAnnotationFacets(studyAccession, annotsToFacet, selectedCluster)
 
@@ -220,7 +206,7 @@ export async function initCellFaceting(
   }
 
   // Below line is worth keeping, but only uncomment to debug in development
-  window.SCP.cellFaceting = cellFaceting
+  // window.SCP.cellFaceting = cellFaceting
 
   setCellFaceting(cellFaceting)
 }

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -69,7 +69,7 @@ function prioritizeAnnotations(selectedAnnot, annotList) {
   annotsToFacet =
     annotsToFacet
       .map(annot => annot.identifier)
-      .slice(0, 4)
+      .slice(0, 10)
 
   return annotsToFacet
 }

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -75,7 +75,8 @@ function prioritizeAnnotations(selectedAnnot, annotList) {
 }
 
 /** Get filtered cell results */
-function getFilteredResults(selections, cellsByFacet, facets, filterableCells) {
+export function filterCells(selections, cellsByFacet, facets, filterableCells) {
+  facets = facets.map(facet => facet.annotation)
   let fn; let i; let facet; let results; let filter
   const counts = {}
 
@@ -124,7 +125,7 @@ function initCrossfilter(facetData) {
   const annotationFacets = facets.map(facet => facet.annotation)
   const filterableCells = []
   for (let i = 0; i < cells.length; i++) {
-    const filterableCell = {}
+    const filterableCell = { 'allCellsIndex': i }
 
     // An array of integers, e.g. [6, 0, 7, 0, 0]
     // Each element in the array is the index-offset of the cell's group value assignment
@@ -153,12 +154,14 @@ function initCrossfilter(facetData) {
 }
 
 /** Get 5 default annotation facets: 1 for selected, and 4 others */
-export async function initAnnotationFacets(
-  selectedCluster, selectedAnnot, studyAccession, exploreInfo
+export async function initCellFaceting(
+  selectedCluster, selectedAnnot, studyAccession, exploreInfo,
+  setCellFaceting
 ) {
   // Prioritize and fetch annotation facets for all cells
   const allAnnots = exploreInfo?.annotationList
-  if (!allAnnots) {return}
+  if (!allAnnots || allAnnots.annotations.length === 0) {return}
+  console.log('allAnnots', allAnnots)
   const applicableAnnots = [selectedAnnot].concat(
     getGroupAnnotationsForClusterAndStudy(allAnnots, selectedCluster)
       .filter(annotation => annotation.values.length > 1)
@@ -168,13 +171,11 @@ export async function initAnnotationFacets(
 
   const { filterableCells, cellsByFacet } = initCrossfilter(facetData)
 
-  window.SCP.cellFaceting = {
+  setCellFaceting({
     cellsByFacet,
     annotFacetSelections: [],
-    facets: facetData.facets.map(facet => facet.annotation),
-    filterableCells,
-    getFilteredResults
-  }
-  // const getAnnotationForIdentifier(identifier)
+    facets: facetData.facets,
+    filterableCells
+  })
 }
 

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -1,9 +1,79 @@
-import { getAnnotationValues, getShownAnnotation } from '~/lib/cluster-utils'
+import {
+  getGroupAnnotationsForClusterAndStudy, getIdentifierForAnnotation
+} from '~/lib/cluster-utils'
+
+
+/**
+ * Prioritize unselected annotations to those worth showing by default as facets
+ *
+ * To start, show <= 4 annotations (beyond the one current selected) facets by default.
+ *
+ * Preconditions -- annotations must be:
+ *   - Group-based and have > 1 group
+ *   - Cluster-based _and for this cluster_ or study-wide
+ *
+ * Prioritization logic applied here, after above preconditions are met:
+ *
+ *   0. Currently selected annotation -- this is set upstream, not here
+ *   1. <= 2 annotations from metadata convention, for `cell type` and `disease`
+ *   2. 2-4 other cluster-based annotations
+ *   3. 2-4 other study-wide annotations
+ *
+ * Annotations in above categories often don't exist, in which case we fall to the
+ * the next prioritization rule.
+ */
+function prioritizeAnnotations(annotList) {
+  let annotsToFacet = []
+  const seenAnnots = new Set()
+
+  // Add identifiers to incoming annotations
+  annotList = annotList.map(annot => {
+    annot.identifier = getIdentifierForAnnotation(annot)
+    return annot
+  })
+  console.log('0 annotList', annotList)
+
+  const cellTypeAndDiseaseAnnots = annotList.filter(
+    annot => ['cell_type__ontology_label', 'disease__ontology_label'].includes(annot.name)
+  )
+  cellTypeAndDiseaseAnnots.forEach(annot => seenAnnots.add(annot.identifier))
+  annotsToFacet = annotsToFacet.concat(cellTypeAndDiseaseAnnots)
+
+  const otherConventionalAnnots = annotList.filter(
+    annot => annot.name.endsWith('__ontology_label') && !seenAnnots.has(annot.identifier)
+  ).slice(0, 2)
+  otherConventionalAnnots.forEach(annot => seenAnnots.add(annot.identifiers))
+  annotsToFacet = annotsToFacet.concat(otherConventionalAnnots)
+
+  const clusterAnnots = annotList.filter(
+    annot => ('cluster_name' in annot) && !seenAnnots.has(annot.identifier)
+  )
+  clusterAnnots.forEach(annot => seenAnnots.add(annot.identifiers))
+  annotsToFacet = annotsToFacet.concat(clusterAnnots)
+
+  const studyAnnots = annotList.filter(
+    annot => !('cluster_name' in annot) && !seenAnnots.has(annot.identifier)
+  )
+  studyAnnots.forEach(annot => seenAnnots.add(annot.identifiers))
+  annotsToFacet = annotsToFacet.concat(studyAnnots)
+
+  annotsToFacet = annotsToFacet.slice(0, 5)
+
+  return annotsToFacet
+}
 
 /** Get 5 default annotation facets: 1 for selected, and 4 others */
 export function fetchAnnotationFacets(selectedCluster, selectedAnnot, exploreInfo) {
-  const annotList = exploreInfo.annotationList
-  console.log('selectedCluster, selectedAnnot, exploreInfo', selectedCluster, selectedAnnot, exploreInfo)
+  const allAnnots = exploreInfo?.annotationList
+  if (!allAnnots) {return}
+  console.log('allAnnots', allAnnots)
+  const applicableAnnots =
+    getGroupAnnotationsForClusterAndStudy(allAnnots, selectedCluster)
+      .filter(annotation => annotation.values.length > 1)
+  console.log('applicableAnnots', applicableAnnots)
+  const annotsToFacet = prioritizeAnnotations(applicableAnnots)
+  console.log('selectedCluster, selectedAnnot', selectedCluster, selectedAnnot)
+  console.log('annotsToFacet', annotsToFacet)
 }
 
 window.SCP.fetchAnnotationFacets = fetchAnnotationFacets

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -167,13 +167,14 @@ function initCrossfilter(facetData) {
 
 /** Get 5 default annotation facets: 1 for selected, and 4 others */
 export async function initCellFaceting(
-  selectedCluster, selectedAnnot, studyAccession, exploreInfo,
-  setCellFaceting
+  selectedCluster, selectedAnnot, studyAccession, allAnnots
 ) {
-  // Prioritize and fetch annotation facets for all cells
-  const allAnnots = exploreInfo?.annotationList
-  if (!allAnnots || allAnnots.annotations.length === 0) {return}
+  console.log('selectedCluster', selectedCluster),
+  console.log('selectedAnnot', selectedAnnot)
+  console.log('studyAccession', studyAccession)
+  console.log('allAnnots', allAnnots)
 
+  // Prioritize and fetch annotation facets for all cells
   const selectedAnnotId = getIdentifierForAnnotation(selectedAnnot)
   const applicableAnnots =
     getGroupAnnotationsForClusterAndStudy(allAnnots, selectedCluster)
@@ -188,9 +189,10 @@ export async function initCellFaceting(
           annot.identifier !== selectedAnnotId
         )
       })
-
+  console.log('applicableAnnots', applicableAnnots)
   const annotsToFacet = prioritizeAnnotations(applicableAnnots)
   const facetData = await fetchAnnotationFacets(studyAccession, annotsToFacet, selectedCluster)
+  console.log('facetData', facetData)
 
   const {
     filterableCells, cellsByFacet,
@@ -207,7 +209,7 @@ export async function initCellFaceting(
 
   // Below line is worth keeping, but only uncomment to debug in development
   // window.SCP.cellFaceting = cellFaceting
-
-  setCellFaceting(cellFaceting)
+  console.log('cellFaceting', cellFaceting)
+  return cellFaceting
 }
 

--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -122,6 +122,21 @@ export function getDefaultAnnotationForCluster(annotationList, clusterName, curr
   }
 }
 
+/** Get all group annotations for given cluster and this study */
+export function getGroupAnnotationsForClusterAndStudy(annotationList, clusterName) {
+  const annots = annotationList.annotations.filter(annot => {
+    console.log('annot', annot)
+    return (
+      annot.type === 'group' && // is group-based, i.e. not numeric
+      (
+        !('cluster_name' in annot) || // is study-wide
+        annot.cluster_name === clusterName // is cluster-based, and in this cluster
+      )
+    )
+  })
+  return annots
+}
+
 /** return an array of names of the spatial files associated with a given cluster */
 export function getDefaultSpatialGroupsForCluster(clusterName, spatialGroups) {
   const defaultGroups = []

--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -123,8 +123,8 @@ export function getDefaultAnnotationForCluster(annotationList, clusterName, curr
 }
 
 /** Get all group annotations for given cluster and this study */
-export function getGroupAnnotationsForClusterAndStudy(annotationList, clusterName) {
-  const annots = annotationList.annotations.filter(annot => {
+export function getGroupAnnotationsForClusterAndStudy(annotations, clusterName) {
+  const annots = annotations.filter(annot => {
     return (
       annot.type === 'group' && // is group-based, i.e. not numeric
       (

--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -125,7 +125,6 @@ export function getDefaultAnnotationForCluster(annotationList, clusterName, curr
 /** Get all group annotations for given cluster and this study */
 export function getGroupAnnotationsForClusterAndStudy(annotationList, clusterName) {
   const annots = annotationList.annotations.filter(annot => {
-    console.log('annot', annot)
     return (
       annot.type === 'group' && // is group-based, i.e. not numeric
       (

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -152,7 +152,7 @@ export async function createUserAnnotation(
  *
  * Docs: https://singlecell.broadinstitute.org/single_cell/api/v1#/Visualization/study_annotation_facets_path
  */
-export async function fetchAnnotationFacetData(studyAccession, annotations, cluster) {
+export async function fetchAnnotationFacets(studyAccession, annotations, cluster) {
   annotations = annotations.join(',')
   const params = `annotations=${annotations}&cluster=${cluster}`
   const apiUrl = `/studies/${studyAccession}/annotations/facets?${params}`

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -147,10 +147,15 @@ export async function createUserAnnotation(
 }
 
 /**
- * Get annotation assignments (i.e facets) for specified cells from a cluster.
+ * Get annotation assignments (i.e. facets) for specified cells from a cluster.
  * Only applicable to full resolution data (i.e. all cells).
  *
  * Docs: https://singlecell.broadinstitute.org/single_cell/api/v1#/Visualization/study_annotation_facets_path
+ *
+ * @param {String} studyAccession Study accession, e.g. SCP1234
+ * @param {Array<String>} annotations Array of annotation identifiers,
+ *  e.g. ['cell_type__ontology_label--group--study', 'disease__ontology_label']
+ * @param {String} cluster Name of requested cluster
  */
 export async function fetchAnnotationFacets(studyAccession, annotations, cluster) {
   annotations = annotations.join(',')

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -147,9 +147,23 @@ export async function createUserAnnotation(
 }
 
 /**
- * Returns list of all available search facets, including default filter values
+ * Get annotation assignments (i.e facets) for specified cells from a cluster.
+ * Only applicable to full resolution data (i.e. all cells).
  *
- * Docs: https:///singlecell.broadinstitute.org/single_cell/api/swagger_docs/v1#!/Search/search_facets_path
+ * Docs: https://singlecell.broadinstitute.org/single_cell/api/v1#/Visualization/study_annotation_facets_path
+ */
+export async function fetchAnnotationFacetData(studyAccession, annotations, cluster) {
+  annotations = annotations.join(',')
+  const params = `annotations=${annotations}&cluster=${cluster}`
+  const apiUrl = `/studies/${studyAccession}/annotations/facets?${params}`
+  const [annotationFacets] = await scpApi(apiUrl, defaultInit())
+  return annotationFacets
+}
+
+/**
+ * Returns list of all available global study search facets, including default filter values
+ *
+ * Docs: https:///singlecell.broadinstitute.org/single_cell/api/v1#/Search/search_facets_path
  *
  * @param {Boolean} mock If using mock data.  Helps development, tests.
  * @returns {Promise} Promise object containing camel-cased data from API

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
+    "crossfilter2": "^1.5.4",
     "exifreader": "4.6.0",
     "fflate": "^0.7.3",
     "ideogram": "1.42.0",

--- a/test/js/explore/explore-display-tabs.test.js
+++ b/test/js/explore/explore-display-tabs.test.js
@@ -17,6 +17,13 @@ jest.mock('components/visualization/InferCNVIdeogram', () => {
   }
 })
 
+// Mock cell faceting functionality, as it's tested in /test/js/lib/cell-faceting.test.js
+jest.mock('lib/cell-faceting', () => {
+  return {
+    initCellFaceting: jest.fn(() => {})
+  }
+})
+
 import React from 'react'
 import { render } from '@testing-library/react'
 import * as UserProvider from '~/providers/UserProvider'

--- a/test/js/explore/explore-display-tabs.test.js
+++ b/test/js/explore/explore-display-tabs.test.js
@@ -1,3 +1,5 @@
+
+
 // mock various modules from genome tab as these aren't being used, and throw compilation errors from jest
 jest.mock('components/explore/GenomeView', () => {
   return {
@@ -20,7 +22,7 @@ jest.mock('components/visualization/InferCNVIdeogram', () => {
 // Mock cell faceting functionality, as it's tested in /test/js/lib/cell-faceting.test.js
 jest.mock('lib/cell-faceting', () => {
   return {
-    initCellFaceting: jest.fn(() => {})
+    initCellFaceting: jest.fn(() => new Promise(() => {}))
   }
 })
 

--- a/test/js/lib/cell-faceting.test-data.js
+++ b/test/js/lib/cell-faceting.test-data.js
@@ -1,0 +1,1554 @@
+export const allAnnots = [
+  {
+    'name': 'General_Celltype',
+    'type': 'group',
+    'values': [
+      'LC2',
+      'GPMNB macrophages',
+      'neutrophils',
+      'B cells',
+      'T cells',
+      'removed',
+      'CSN1S1 macrophages',
+      'dendritic cells',
+      'LC1',
+      'eosinophils',
+      'fibroblasts'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'biosample_id',
+    'type': 'group',
+    'values': [
+      'BM02_6wkpp_r1',
+      'BM12_6wk',
+      'BM03_6wkpp_r1',
+      'BM05_6wkpp',
+      'BM08_6wk_r1',
+      'BM08_6wkpp_r2',
+      'BM13_6wk_r1',
+      'BM13_6wk_r3',
+      'BM07_7wkpp_r1',
+      'BM11_6wk_r1',
+      'BM01_7wkpp_r1',
+      'BM02_13wkpp_t1',
+      'BM08_13wk_r1',
+      'BM05_12wk_r2',
+      'BM03_13wk_r1',
+      'BM03_13wkpp_r2',
+      'BM01_13wkpp_r2',
+      'BM13_12wk',
+      'BM03_15dpp_r1',
+      'BM08_15dpp_r1',
+      'BM01_16dpp_r3',
+      'BM07_17dpp_r2',
+      'BM19_4dpp_r1',
+      'BM02_5dpp_r1',
+      'BM02_5dpp_r2',
+      'BM03_5dpp_r1',
+      'BM07_5dpp_r1',
+      'BM01_5dpp_r1',
+      'BM05_6dpp_r1',
+      'BM11_5dpp_r1',
+      'BM13_6dpp_r1',
+      'BM07_13wk_r1',
+      'BM01_23wk_r1',
+      'BM03_24wk_r1',
+      'BM03_24wk_r2',
+      'BM08_24wk',
+      'BM02_24wk_r2',
+      'BM02_10dpp_r1',
+      'BM03_10dpp_r1',
+      'BM03_10dpp_r2',
+      'BM01_12dpp_r1',
+      'BM07_10dpp_r1',
+      'BM13_13dpp_r1',
+      'BM02_14dpp_r1',
+      'BM04_t1_r2',
+      'BM10_t1_r1',
+      'BM06_t3',
+      'BM04_t3_r1',
+      'BT_t3_lot1',
+      'BT_t3_old',
+      'K1',
+      'K2',
+      'Kfresh',
+      'BM07_25wk_lot711',
+      'B2',
+      'BM5',
+      'BM06_t1_r1',
+      'BM05_26wk_r1',
+      'Bfresh'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'donor_id',
+    'type': 'group',
+    'values': [
+      'BM02',
+      'BM12',
+      'BM03',
+      'BM05',
+      'BM08',
+      'BM13',
+      'BM07',
+      'BM11',
+      'BM01',
+      'BM19',
+      'BM04',
+      'BM10',
+      'BM06',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'time_post_partum_days',
+    'type': 'numeric',
+    'values': [],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'time_post_partum_weeks',
+    'type': 'numeric',
+    'values': [],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'milk_stage',
+    'type': 'group',
+    'values': [
+      'late_1',
+      'mature',
+      'early',
+      'late_2',
+      'transitional ',
+      'transitional',
+      'late_4',
+      'NA',
+      'late_3'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'infant_sick_YN',
+    'type': 'group',
+    'values': [
+      'no',
+      'NA',
+      'yes'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'weaning_YN',
+    'type': 'group',
+    'values': [
+      'NA',
+      'no',
+      'yes'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'mastisis_YN',
+    'type': 'group',
+    'values': [
+      'no',
+      'yes',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'breast_soreness_YN',
+    'type': 'group',
+    'values': [
+      'no',
+      'yes',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'directly_breastfeeding_YN',
+    'type': 'group',
+    'values': [
+      'yes',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'any_formula_YN',
+    'type': 'group',
+    'values': [
+      'no',
+      'yes',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'mother_medications_YN',
+    'type': 'group',
+    'values': [
+      'no',
+      'yes',
+      'sunflower lecithin ',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'reported_menstruating_YN',
+    'type': 'group',
+    'values': [
+      'no',
+      'N',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'maternal_medical_event_YN',
+    'type': 'group',
+    'values': [
+      'no',
+      'yes',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'hormonal_birthcontrol_YN',
+    'type': 'group',
+    'values': [
+      'no',
+      'yes',
+      'yes ',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'daycare_YN',
+    'type': 'group',
+    'values': [
+      'no',
+      'yes',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'vaccines_reported_YN',
+    'type': 'group',
+    'values': [
+      'no',
+      'yes',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'vaccines_list',
+    'type': 'group',
+    'values': [
+      'NA',
+      '9/3 and 9/10 – a hep B booster in the hospital',
+      'no',
+      '5/9/19 hepatitis B',
+      'hepB ',
+      'vaccines on 5/15',
+      '(6/11) Dtap-hep, BIPV, rotavirus, pentavalent, big (PRP-T)',
+      'HepB',
+      'hepB (says 4/22 but probably 5/22?)',
+      '4/3/19 Hepatitis B (at birth) ',
+      '2 month vaccines',
+      'Dtap, Gib, IPV, PCU13, Rotavirus (8/16/19)',
+      'vaccines on 7/15',
+      'influenza (day prior to sample)'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'solid_foods_YN',
+    'type': 'group',
+    'values': [
+      'no',
+      'NA',
+      'yes'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'reported_infant_medical_events_YN',
+    'type': 'group',
+    'values': [
+      'no',
+      'yes',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'reported_infant_medical_events_description',
+    'type': 'group',
+    'values': [
+      'NA',
+      'no',
+      'maybe a stomache bug ',
+      'hot and sleepy',
+      'jaundice',
+      'lounge tie removal mid july, vaccinations a few weeks prior ',
+      'runny nose',
+      'runny nose, diarrhea, vomitting, no fever',
+      'maybe still jaundice',
+      'stomach bug (August), runny nose (October/ currently)',
+      'influenza vaccine received on 4/8/19'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'library_preparation_protocol',
+    'type': 'group',
+    'values': [
+      'EFO_0008919'
+    ],
+    'scope': 'invalid',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'library_preparation_protocol__ontology_label',
+    'type': 'group',
+    'values': [
+      'Seq-Well'
+    ],
+    'scope': 'invalid',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'species',
+    'type': 'group',
+    'values': [
+      'NCBITaxon_9606'
+    ],
+    'scope': 'invalid',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'species__ontology_label',
+    'type': 'group',
+    'values': [
+      'Homo sapiens'
+    ],
+    'scope': 'invalid',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'geographical_region',
+    'type': 'group',
+    'values': [
+      'GAZ_00003181'
+    ],
+    'scope': 'invalid',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'geographical_region__ontology_label',
+    'type': 'group',
+    'values': [
+      'Boston'
+    ],
+    'scope': 'invalid',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'sex',
+    'type': 'group',
+    'values': [
+      'female'
+    ],
+    'scope': 'invalid',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'disease',
+    'type': 'group',
+    'values': [
+      'PATO_0000461'
+    ],
+    'scope': 'invalid',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'disease__ontology_label',
+    'type': 'group',
+    'values': [
+      'normal'
+    ],
+    'scope': 'invalid',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'organ',
+    'type': 'group',
+    'values': [
+      'UBERON_0001913'
+    ],
+    'scope': 'invalid',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'organ__ontology_label',
+    'type': 'group',
+    'values': [
+      'milk'
+    ],
+    'scope': 'invalid',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'Age',
+    'type': 'group',
+    'values': [
+      '31.0',
+      '34.0',
+      '33.0',
+      '29.0',
+      '35.0',
+      '32.0',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'biosample_type',
+    'type': 'group',
+    'values': [
+      'PrimaryBioSample_BodyFluid'
+    ],
+    'scope': 'invalid',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'week_delivered',
+    'type': 'numeric',
+    'values': [],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'labor_induced_YN',
+    'type': 'group',
+    'values': [
+      'Y',
+      'N',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'antibiotics_during_delivery',
+    'type': 'group',
+    'values': [
+      'N',
+      'Y',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'delivery_mode',
+    'type': 'group',
+    'values': [
+      'vaginal',
+      'C section',
+      'vaginal ',
+      'NA'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'ethnicity__ontology_label',
+    'type': 'group',
+    'values': [
+      'European',
+      'Asian',
+      'Hispanic or Latin American',
+      'ancestry category'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'BMI_during_study',
+    'type': 'numeric',
+    'values': [],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'BMI_pre_pregnancy',
+    'type': 'numeric',
+    'values': [],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'ethnicity',
+    'type': 'group',
+    'values': [
+      'HANCESTRO_0005',
+      'HANCESTRO_0008',
+      'HANCESTRO_0014',
+      'HANCESTRO_0004'
+    ],
+    'scope': 'invalid',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'cell_type',
+    'type': 'group',
+    'values': [
+      'CL_0000066',
+      'CL_0000235',
+      'CL_0000775',
+      'CL_0000236',
+      'CL_0000084',
+      'CL_0000548',
+      'CL_0000451',
+      'CL_0000771',
+      'CL_0000057'
+    ],
+    'scope': 'invalid',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'cell_type__ontology_label',
+    'type': 'group',
+    'values': [
+      'epithelial cell',
+      'macrophage',
+      'neutrophil',
+      'B cell',
+      'T cell',
+      'animal cell',
+      'dendritic cell',
+      'eosinophil',
+      'fibroblast'
+    ],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'organism_age',
+    'type': 'numeric',
+    'values': [],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'height_inches',
+    'type': 'numeric',
+    'values': [],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'height_meter',
+    'type': 'numeric',
+    'values': [],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'ext_weight_during_study_lbs',
+    'type': 'numeric',
+    'values': [],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'est_pre_pregnancy_weight_lbs',
+    'type': 'numeric',
+    'values': [],
+    'scope': 'study',
+    'is_differential_expression_enabled': false
+  },
+  {
+    'name': 'Epithelial Cell Subclusters',
+    'type': 'group',
+    'values': [
+      'Secretory Lactocytes',
+      'LC1',
+      'KRT high lactocytes 1',
+      'Cycling Lactocytes',
+      'MT High Secretory Lactocytes',
+      'KRT high lactocytes 2'
+    ],
+    'scope': 'cluster',
+    'cluster_name': 'Epithelial Cell Subclusters',
+    'is_differential_expression_enabled': null
+  }
+]
+
+
+export const facetData = {
+  'cells': [
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      8,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      3,
+      3,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      4,
+      4,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      8,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      6,
+      7,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      6,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      8,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      4,
+      4,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      4,
+      4,
+      0,
+      0,
+      0
+    ],
+    [
+      7,
+      9,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      6,
+      7,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      4,
+      4,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      8,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      8,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      7,
+      9,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      6,
+      7,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      8,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      6,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      4,
+      4,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      2,
+      2,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    [
+      4,
+      4,
+      0,
+      0,
+      0
+    ],
+    [
+      4,
+      4,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      8,
+      0,
+      0,
+      0
+    ],
+    [
+      1,
+      1,
+      0,
+      0,
+      0
+    ]
+  ],
+  'facets': [
+    {
+      'annotation': 'cell_type__ontology_label--group--study',
+      'groups': [
+        'epithelial cell',
+        'macrophage',
+        'neutrophil',
+        'B cell',
+        'T cell',
+        'animal cell',
+        'dendritic cell',
+        'eosinophil',
+        'fibroblast'
+      ]
+    },
+    {
+      'annotation': 'General_Celltype--group--study',
+      'groups': [
+        'LC2',
+        'GPMNB macrophages',
+        'neutrophils',
+        'B cells',
+        'T cells',
+        'removed',
+        'CSN1S1 macrophages',
+        'dendritic cells',
+        'LC1',
+        'eosinophils',
+        'fibroblasts'
+      ]
+    },
+    {
+      'annotation': 'infant_sick_YN--group--study',
+      'groups': [
+        'no',
+        'NA',
+        'yes'
+      ]
+    },
+    {
+      'annotation': 'ethnicity__ontology_label--group--study',
+      'groups': [
+        'European',
+        'Asian',
+        'Hispanic or Latin American',
+        'ancestry category'
+      ]
+    },
+    {
+      'annotation': 'biosample_id--group--study',
+      'groups': [
+        'BM02_6wkpp_r1',
+        'BM12_6wk',
+        'BM03_6wkpp_r1',
+        'BM05_6wkpp',
+        'BM08_6wk_r1',
+        'BM08_6wkpp_r2',
+        'BM13_6wk_r1',
+        'BM13_6wk_r3',
+        'BM07_7wkpp_r1',
+        'BM11_6wk_r1',
+        'BM01_7wkpp_r1',
+        'BM02_13wkpp_t1',
+        'BM08_13wk_r1',
+        'BM05_12wk_r2',
+        'BM03_13wk_r1',
+        'BM03_13wkpp_r2',
+        'BM01_13wkpp_r2',
+        'BM13_12wk',
+        'BM03_15dpp_r1',
+        'BM08_15dpp_r1',
+        'BM01_16dpp_r3',
+        'BM07_17dpp_r2',
+        'BM19_4dpp_r1',
+        'BM02_5dpp_r1',
+        'BM02_5dpp_r2',
+        'BM03_5dpp_r1',
+        'BM07_5dpp_r1',
+        'BM01_5dpp_r1',
+        'BM05_6dpp_r1',
+        'BM11_5dpp_r1',
+        'BM13_6dpp_r1',
+        'BM07_13wk_r1',
+        'BM01_23wk_r1',
+        'BM03_24wk_r1',
+        'BM03_24wk_r2',
+        'BM08_24wk',
+        'BM02_24wk_r2',
+        'BM02_10dpp_r1',
+        'BM03_10dpp_r1',
+        'BM03_10dpp_r2',
+        'BM01_12dpp_r1',
+        'BM07_10dpp_r1',
+        'BM13_13dpp_r1',
+        'BM02_14dpp_r1',
+        'BM04_t1_r2',
+        'BM10_t1_r1',
+        'BM06_t3',
+        'BM04_t3_r1',
+        'BT_t3_lot1',
+        'BT_t3_old',
+        'K1',
+        'K2',
+        'Kfresh',
+        'BM07_25wk_lot711',
+        'B2',
+        'BM5',
+        'BM06_t1_r1',
+        'BM05_26wk_r1',
+        'Bfresh'
+      ]
+    }
+  ]
+}

--- a/test/js/lib/cell-faceting.test.js
+++ b/test/js/lib/cell-faceting.test.js
@@ -7,8 +7,15 @@ import { initCellFaceting, filterCells } from 'lib/cell-faceting'
 describe('Cell faceting', () => {
   it('filters cells by group filters in annotation facets', async () => {
     // To manually test:
-    // 1. Go to DE pilot study ("Human milk" / "Cellular and transcriptional diversity over the course of human lactation")
-    // 2. (TODO) In "Annotation" menu, select "Category"
+    // 1. In ExploreDisplayTabs.jsx, uncomment the line `// window.SCP.updateFilteredCells = updateFilteredCells`
+    // 2. Go to DE pilot study ("Human milk - differential expression")
+    // 3. In the Console panel in DevTools, run `window.SCP.updateFilteredCells({'cell_type__ontology_label--group--study': ['epithelial cell']}) // Apply 1 facet, 1 filter`
+    // 4.  Confirm the cluster scatter plot updates to show only cells in the "LC1" and "LC2" groups, with cell counts 4427 and 35398 respectively.
+    // 5. In Console, run `window.SCP.updateFilteredCells({'cell_type__ontology_label--group--study': ['epithelial cell'], 'infant_sick_YN--group--study': ['yes', 'NA']}) // Apply 2 facets, 3 filters`
+    // 6. Confirm LC1 cell count updates to 1090, LC2 to 10725.
+    // 7. In Console, run `window.SCP.updateFilteredCells({}) // Clear filters`
+    // 8. Confirm cluster scatter plots returns to its original state
+    // 9. In ExploreDisplayTabs.jsx, comment out the line `// window.SCP.updateFilteredCells = updateFilteredCells`
 
     const fetchAnnotationFacets = jest.spyOn(ScpApi, 'fetchAnnotationFacets')
     // pass in a clone of the response since it may get modified by the cache operations

--- a/test/js/lib/cell-faceting.test.js
+++ b/test/js/lib/cell-faceting.test.js
@@ -15,7 +15,7 @@ describe('Cell faceting', () => {
     // 6. Confirm LC1 cell count updates to 1090, LC2 to 10725.
     // 7. In Console, run `window.SCP.updateFilteredCells({}) // Clear filters`
     // 8. Confirm cluster scatter plots returns to its original state
-    // 9. In ExploreDisplayTabs.jsx, comment out the line `// window.SCP.updateFilteredCells = updateFilteredCells`
+    // 9. In ExploreDisplayTabs.jsx, comment out the line `window.SCP.updateFilteredCells = updateFilteredCells`
 
     const fetchAnnotationFacets = jest.spyOn(ScpApi, 'fetchAnnotationFacets')
     // pass in a clone of the response since it may get modified by the cache operations

--- a/test/js/lib/cell-faceting.test.js
+++ b/test/js/lib/cell-faceting.test.js
@@ -1,7 +1,7 @@
 import { allAnnots, facetData } from './cell-faceting.test-data'
 import * as ScpApi from 'lib/scp-api'
 
-import { initCellFaceting } from 'lib/cell-faceting'
+import { initCellFaceting, filterCells } from 'lib/cell-faceting'
 
 // Test functionality to filter cells shown in plots across annotation facets
 describe('Cell faceting', () => {
@@ -16,6 +16,7 @@ describe('Cell faceting', () => {
       facetData
     ))
 
+    // Test client-side cell faceting setup functionality
     const selectedCluster = 'All Cells UMAP'
     const selectedAnnot = { name: 'donor_id', type: 'group', scope: 'study' }
     const studyAccession = 'SCP152'
@@ -24,12 +25,10 @@ describe('Cell faceting', () => {
       selectedCluster, selectedAnnot, studyAccession, allAnnots
     )
 
+    const cellsByFacet = cellFaceting.cellsByFacet
+    const facets = cellFaceting.facets
     const filtersByFacet = cellFaceting.filtersByFacet
     const filterableCells = cellFaceting.filterableCells
-
-    // console.log('facets', facets)
-    console.log('filtersByFacet', filtersByFacet)
-    // console.log('filterableCells', filterableCells)
 
     const expectedFilterableCells99 = {
       'allCellsIndex': 99,
@@ -44,5 +43,15 @@ describe('Cell faceting', () => {
 
     expect(filterableCells[99]).toMatchObject(expectedFilterableCells99)
     expect(filtersByFacet['infant_sick_YN--group--study']).toEqual(expectedInfantSickYN)
+
+    // Test actual cell faceting
+    const selections = {
+      'cell_type__ontology_label--group--study': ['epithelial cell'],
+      'General_Celltype--group--study': ['LC1', 'LC2']
+    }
+    const newFilteredCells = filterCells(
+      selections, cellsByFacet, facets, filtersByFacet, filterableCells
+    )[0]
+    expect(newFilteredCells).toHaveLength(40)
   })
 })

--- a/test/js/lib/cell-faceting.test.js
+++ b/test/js/lib/cell-faceting.test.js
@@ -1,0 +1,48 @@
+import { allAnnots, facetData } from './cell-faceting.test-data'
+import * as ScpApi from 'lib/scp-api'
+
+import { initCellFaceting } from 'lib/cell-faceting'
+
+// Test functionality to filter cells shown in plots across annotation facets
+describe('Cell faceting', () => {
+  it('filters cells by group filters in annotation facets', async () => {
+    // To manually test:
+    // 1. Go to DE pilot study ("Human milk" / "Cellular and transcriptional diversity over the course of human lactation")
+    // 2. (TODO) In "Annotation" menu, select "Category"
+
+    const fetchAnnotationFacets = jest.spyOn(ScpApi, 'fetchAnnotationFacets')
+    // pass in a clone of the response since it may get modified by the cache operations
+    fetchAnnotationFacets.mockImplementation(() => Promise.resolve(
+      facetData
+    ))
+
+    const selectedCluster = 'All Cells UMAP'
+    const selectedAnnot = { name: 'donor_id', type: 'group', scope: 'study' }
+    const studyAccession = 'SCP152'
+
+    const cellFaceting = await initCellFaceting(
+      selectedCluster, selectedAnnot, studyAccession, allAnnots
+    )
+
+    const filtersByFacet = cellFaceting.filtersByFacet
+    const filterableCells = cellFaceting.filterableCells
+
+    // console.log('facets', facets)
+    console.log('filtersByFacet', filtersByFacet)
+    // console.log('filterableCells', filterableCells)
+
+    const expectedFilterableCells99 = {
+      'allCellsIndex': 99,
+      'cell_type__ontology_label--group--study': 1,
+      'General_Celltype--group--study': 1,
+      'infant_sick_YN--group--study': 0,
+      'ethnicity__ontology_label--group--study': 0,
+      'biosample_id--group--study': 0
+    }
+
+    const expectedInfantSickYN = ['no', 'NA', 'yes']
+
+    expect(filterableCells[99]).toMatchObject(expectedFilterableCells99)
+    expect(filtersByFacet['infant_sick_YN--group--study']).toEqual(expectedInfantSickYN)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3352,6 +3352,13 @@ crossfilter2@1.5.2:
   dependencies:
     "@ranfdev/deepobj" "1.0.2"
 
+crossfilter2@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/crossfilter2/-/crossfilter2-1.5.4.tgz#855a11245d9dc18631cd49d88101dc31a2bcffce"
+  integrity sha512-oOGqOM0RocwQFOXJnEaUKqYV6Mc1TNCRv3LrNUa0QlofQTutGAXyQaLW1aGKLls2sfnbwBEtsa6tPD3jY+ycqQ==
+  dependencies:
+    "@ranfdev/deepobj" "1.0.2"
+
 css-blank-pseudo@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/css-blank-pseudo/-/css-blank-pseudo-5.0.2.tgz#3df5cd950f64de960974da05e76954fd3d7442f9"


### PR DESCRIPTION
This implements a library to let users instantly filter plotted cells across annotations like "cell type", "disease", and more.

### Overview
Previously, users could filter cells only by groups in the annotation that is currently selected.  For example, if viewing the annotation "Infant sick", users could filter the cluster scatter plot to only show cells in (say) the groups "Yes" or "Not applicable" that are part of that single annotation.  

Now, this new client-side cell faceting library enables a UI to let users filter cells across _several_ annotations.  So users can refine the plotted cells to only those that have e.g. "Infant sick: Yes or Not applicable" **and** "Cell type: Epithelial cell" **and** "Daycare: Yes".  As is conventional in faceted search, selections _within_ a facet are Boolean ORs, and selections _across_ facets are Boolean ANDs.

Filtering is now also separable from coloring: you could e.g. color the resulting cluster scatter plot by, say "Donor ID".  This means that cell faceting is only relevant when there are multiple applicable annotations.

### Video

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/e2e6bc13-4723-4501-b33d-e0442c17ce3f

### Performance
It's extremely fast.

Whether for 50K cells or 1.3M cells, this client-side cell filtering takes 30-80 ms on my machine.  My laptop is a 14" 2021 MacBook Pro, with an Apple M1 Pro CPU and 16 GB RAM.  This is faster than most, but likely not abnormally higher-specced than the typical SCP user.  I was also running a screen recording, web server, IDE, and other programs during these local spot measurements.  This fast filtering is powered by [Crossfilter](https://github.com/crossfilter/crossfilter).

### Logging
The cell faceting library has analytics instrumentation which logs performance timing (`perfTime`) and related properties to Mixpanel for a new `filter-cells` log event.

### Test
Automated tests verify behavior in this new code.  If desired, to manually test it:

1. In ExploreDisplayTabs.jsx, uncomment the line `// window.SCP.updateFilteredCells = updateFilteredCells`
2. Go to DE pilot study ("Human milk - differential expression")
3. In the Console panel in DevTools, run `window.SCP.updateFilteredCells({'cell_type__ontology_label--group--study': ['epithelial cell']}) // Apply 1 facet, 1 filter`
4.  Confirm the cluster scatter plot updates to show only cells in the "LC1" and "LC2" groups, with cell counts 4427 and 35398 respectively.
5. In Console, run `window.SCP.updateFilteredCells({'cell_type__ontology_label--group--study': ['epithelial cell'], 'infant_sick_YN--group--study': ['yes', 'NA']}) // Apply 2 facets, 3 filters`.  In human-friendly Boolean terms, this translates to "Cell type: epithelial cell" AND ("Infant sick: yes OR NA").
6. Confirm LC1 cell count updates to 1090, LC2 to 10725.
7. In Console, run `window.SCP.updateFilteredCells({}) // Clear filters`
8. Confirm cluster scatter plots returns to its original state
9. In ExploreDisplayTabs.jsx, comment out the line `window.SCP.updateFilteredCells = updateFilteredCells`

*Be sure you do that last step!*  If you don't, tests will fail.

### Further details
This client-side library uses data from the new `/facets` endpoint described in #1838.  More context is available in this week's [SCP demo recording](https://drive.google.com/file/d/1whqhirP8ciQx4tkKnQ5No8CB9RzyBGbY/view?t=19m20s).  Sometimes, filtering is called "subsetting".  Per stakeholder feedback, one next step here is to use pale grey color / send-to-back for cells omitted by filtering (SCP-5277), rather than simply removing them from the plot.  

This satisfies SCP-5213.