### PR TITLE
Clearer actions and explanation in gene search error message (SCP-5276)

### DIFF
--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -199,7 +199,16 @@ export default function StudyGeneField({ genes, searchGenes, allGenes, speciesLi
         animation={false}
         bsSize='small'>
         <Modal.Body className="text-center">
-        Invalid search.  Please remove &quot;{Array.from(notPresentGenes).join('", "')}&quot; from gene search.
+          <p>
+            Invalid search. &quot;{Array.from(notPresentGenes).join('", "')}&quot;
+            is not a gene that was assayed in this study.
+          </p>
+          <p>
+            Please remove &quot;{Array.from(notPresentGenes).join('", "')}&quot; from gene search.
+          </p>
+          <p>
+            Hint: Start typing or hit space in the search bar to see suggestions of genes present in the study.
+          </p>
         </Modal.Body>
       </Modal>
       <Modal


### PR DESCRIPTION
A recent user request seemed to indicate confusion around the rather general error message when trying to search on a gene not present in a study. This PR updates that message to be more actionable and explain better the issue. 

Slack convo starting this improvement with more details via @eweitz: https://broadinstitute.slack.com/archives/CBEHTH601/p1692730969316049

![Screenshot 2023-08-22 at 4 20 48 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/cc966845-4e20-44d9-a628-11a28f530d51)
