### PR TITLE
Add 2 offending workspaces to the corrupted workspaces list (SCP-5278)

### DIFF
--- a/lib/study_cleanup_tools.rb
+++ b/lib/study_cleanup_tools.rb
@@ -66,7 +66,9 @@ module StudyCleanupTools
     'download-agreement-686b0d44c83659cd70616a3f0874fde5',
     'testing-study-6ec03b371c7cf59262df98424ff516e1',
     'new-study-99f2a94b-f8a6-4efb-aa3b-4ecef24e1dad',
-    'testing-study-jdwjl']
+    'testing-study-jdwjl', 
+    'test-study-06387e09-6661-45b5-bc1b-4fc507bd19ea',
+    'main-validation-study-szzob',]
     workspaces.each do |workspace|
       ws_attr = workspace.dig('workspace')
       ws_name = ws_attr['name']


### PR DESCRIPTION
Adding two more "corrupted" workspaces to the list of workspaces to skip in the cleanup script for test runs. 
More context:
 https://broadinstitute.slack.com/archives/C9YSEMSFR/p1692730832619399
https://broadinstitute.slack.com/archives/CBEHTH601/p1692803149757569
https://broadinstitute.slack.com/archives/CBEHTH601/p1692731943650589