### PR TITLE
Make the placeholder text for AnnData clustering obsm key name less confusing (SCP-5281)

### DIFF
--- a/app/javascript/components/upload/ClusteringFileForm.jsx
+++ b/app/javascript/components/upload/ClusteringFileForm.jsx
@@ -71,7 +71,7 @@ export default function ClusteringFileForm({
         </div>
         <div className="col-md-6">
           <TextFormField label= {obsmKeyNameMessage()} fieldName="obsm_key_name" file={file}
-            updateFile={updateFile} placeholderText='x_tsne' isDisabled={file.parse_status !== 'unparsed'} />
+            updateFile={updateFile} placeholderText='For example, x_tsne' isDisabled={file.parse_status !== 'unparsed'} />
         </div>
       </div>
     } else {

--- a/app/javascript/components/upload/ClusteringFileForm.jsx
+++ b/app/javascript/components/upload/ClusteringFileForm.jsx
@@ -71,7 +71,7 @@ export default function ClusteringFileForm({
         </div>
         <div className="col-md-6">
           <TextFormField label= {obsmKeyNameMessage()} fieldName="obsm_key_name" file={file}
-            updateFile={updateFile} placeholderText='E.g. "x_tsne"' isDisabled={file.parse_status !== 'unparsed'} />
+            updateFile={updateFile} placeholderText='x_tsne' isDisabled={file.parse_status !== 'unparsed'} />
         </div>
       </div>
     } else {


### PR DESCRIPTION
Today we had a user attempt to upload an AnnData file in the AnnData Beta mode. However it failed with the error:

> KeyError: '"X_pca"'

The placeholder helper text in the Upload Wizard seems likely to blame as it says:

> E.g. "tsne"

This update removes the extra quotes and "E.g." and just keeps the example text
<img width="158" alt="Screenshot 2023-08-24 at 10 50 56 AM" src="https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/b5b04ff7-09c0-4344-9b87-11d10597d97f">
![Screenshot 2023-08-24 at 11 02 45 AM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/66f8a584-8339-41d6-b299-01bae2187b43)
