### PR TITLE
Create panel manager for explore page (SCP-5215)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -1,0 +1,473 @@
+import React, { useState, useEffect } from 'react'
+import _clone from 'lodash/clone'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faLink, faEye, faTimes, faUndo } from '@fortawesome/free-solid-svg-icons'
+
+import ClusterSelector from '~/components/visualization/controls/ClusterSelector'
+import AnnotationSelector from '~/components/visualization/controls/AnnotationSelector'
+import SubsampleSelector from '~/components/visualization/controls/SubsampleSelector'
+import { ExploreConsensusSelector } from '~/components/visualization/controls/ConsensusSelector'
+import SpatialSelector from '~/components/visualization/controls/SpatialSelector'
+import CreateAnnotation from '~/components/visualization/controls/CreateAnnotation'
+import PlotDisplayControls from '~/components/visualization/PlotDisplayControls'
+import GeneListSelector from '~/components/visualization/controls/GeneListSelector'
+import InferCNVIdeogramSelector from '~/components/visualization/controls/InferCNVIdeogramSelector'
+import { createCache } from './plot-data-cache'
+import { getShownAnnotation, getDefaultSpatialGroupsForCluster } from '~/lib/cluster-utils'
+import useResizeEffect from '~/hooks/useResizeEffect'
+import { getFeatureFlagsWithDefaults } from '~/providers/UserProvider'
+import DifferentialExpressionPanel, { DifferentialExpressionPanelHeader } from './DifferentialExpressionPanel'
+import DifferentialExpressionModal from '~/components/explore/DifferentialExpressionModal'
+
+/** Get the selected clustering and annotation, or their defaults */
+function getSelectedClusterAndAnnot(exploreInfo, exploreParams) {
+  const annotList = exploreInfo.annotationList
+  let selectedCluster
+  let selectedAnnot
+  if (exploreParams?.cluster) {
+    selectedCluster = exploreParams.cluster
+    selectedAnnot = exploreParams.annotation
+  } else {
+    selectedCluster = annotList.default_cluster
+    selectedAnnot = annotList.default_annotation
+  }
+
+  return [selectedCluster, selectedAnnot]
+}
+
+/** Determine if currently selected cluster has differential expression outputs available */
+function getClusterHasDe(exploreInfo, exploreParams) {
+  const flags = getFeatureFlagsWithDefaults()
+  if (!flags?.differential_expression_frontend || !exploreInfo) {return false}
+  let clusterHasDe = false
+  const selectedCluster = getSelectedClusterAndAnnot(exploreInfo, exploreParams)[0]
+
+  clusterHasDe = exploreInfo.differentialExpression.some(deItem => {
+    return (
+      deItem.cluster_name === selectedCluster
+    )
+  })
+
+  return clusterHasDe
+}
+
+/** Determine if current annotation has one-vs-rest or pairwise DE */
+function getHasComparisonDe(exploreInfo, exploreParams, comparison) {
+  const flags = getFeatureFlagsWithDefaults()
+  if (!flags?.differential_expression_frontend || !exploreInfo) {return false}
+
+  const [selectedCluster, selectedAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
+
+  const hasComparisonDe = exploreInfo.differentialExpression.some(deItem => {
+    return (
+      deItem.cluster_name === selectedCluster &&
+      deItem.annotation_name === selectedAnnot.name &&
+      deItem.annotation_scope === selectedAnnot.scope &&
+      deItem.select_options[comparison].length > 0
+    )
+  })
+
+  return hasComparisonDe
+}
+
+/** Return list of annotations that have differential expression enabled */
+function getAnnotationsWithDE(exploreInfo) {
+  if (!exploreInfo) {return false}
+
+  let annotsWithDe = []
+
+  annotsWithDe = exploreInfo.differentialExpression.filter(deItem => {
+    return deItem
+  }).map(annot => {
+    return {
+      cluster_name: annot.cluster_name,
+      name: annot.annotation_name,
+      scope: annot.annotation_scope,
+      type: 'group'
+    }
+  })
+
+  const clustersWithDe = Array.from(new Set(annotsWithDe.map(a => a.cluster_name)))
+
+  return {
+    clusters: clustersWithDe,
+    annotations: annotsWithDe,
+    subsample_thresholds: exploreInfo.annotationList.subsample_thresholds
+  }
+}
+
+
+
+/** Determine if current annotation has differential expression results available */
+function getAnnotHasDe(exploreInfo, exploreParams) {
+  const flags = getFeatureFlagsWithDefaults()
+  if (!flags?.differential_expression_frontend || !exploreInfo) {
+    // set isDifferentialExpressionEnabled to false as user cannot see DE results, even if present for annotation
+    if (window.SCP) {
+      window.SCP.isDifferentialExpressionEnabled = false
+    }
+    return false
+  }
+
+  let annotHasDe = false
+  const [selectedCluster, selectedAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
+
+  annotHasDe = exploreInfo.differentialExpression.some(deItem => {
+    return (
+      deItem.cluster_name === selectedCluster &&
+      deItem.annotation_name === selectedAnnot.name &&
+      deItem.annotation_scope === selectedAnnot.scope
+    )
+  })
+
+  return annotHasDe
+}
+
+/**
+ * Determine if current annotation has differential expression results that are user-generated.
+ *
+ * DE results have two dimensions:
+ * - Comparison type: either "one-vs-rest" or "pairwise"
+ * - Source: "author-computed" "or SCP-computed"
+ *
+ * Author-computed DE is also often called "precomputed" or "user-uploaded" or "study-owner-generated"
+ * or "custom".  Whereas SCP-generated DE is computed only for cell-type-like annotations and only as
+ * one-vs-rest comparisons, user-generated DE can be more comprehensive -- it can be available for
+ * any annotation, and as one-vs-rest and/or pairwise comparisons.
+ */
+function getIsAuthorDe(exploreInfo, exploreParams) {
+  const flags = getFeatureFlagsWithDefaults()
+  if (!flags?.differential_expression_frontend || !exploreInfo) {
+    return false
+  }
+
+  const [selectedCluster, selectedAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
+
+  const deItem = exploreInfo.differentialExpression.find(deItem => {
+    return (
+      deItem.cluster_name === selectedCluster &&
+      deItem.annotation_name === selectedAnnot.name &&
+      deItem.annotation_scope === selectedAnnot.scope
+    )
+  })
+
+  const isAuthorDe = deItem?.select_options.is_author_de
+
+  return isAuthorDe
+}
+
+/**
+ * Manages the right panel section of the explore view of a study. We have three options for the right side
+ * panel with different controls to adjust the plots: Options (or default), Differential Expression, and
+ * Facet Filtering (currently in progress)
+ *
+ * This manager will return the correct content and header for the appropriate panel to display.
+ *
+ *  */
+export default function ExploreDisplayPanelManager({
+  studyAccession, exploreInfo, setExploreInfo, exploreParams, updateExploreParams,
+  clearExploreParams, exploreParamsWithDefaults, routerLocation,
+  annotation, searchGenes, clusterName, shownTab, countsByLabel, showUpstreamDifferentialExpressionPanel,
+  setShowUpstreamDifferentialExpressionPanel, setShowDifferentialExpressionPanel, showDifferentialExpressionPanel,
+  setShowViewOptionsControls, setIsCellSelecting, currentPointsSelected, showViewOptionsControls, isCellSelecting,
+  deGenes, setDeGenes, deGroup, setDeGroup, deGroupB, setDeGroupB, setShowDeGroupPicker, getPanelWidths
+}) {
+  const [, setRenderForcer] = useState({})
+  const [dataCache] = useState(createCache())
+
+  // Differential expression settings
+  const flags = getFeatureFlagsWithDefaults()
+  // `differential_expression_frontend` enables exemptions if study owners don't want DE
+  const studyHasDe = flags?.differential_expression_frontend && exploreInfo?.differentialExpression.length > 0
+  const annotHasDe = getAnnotHasDe(exploreInfo, exploreParams)
+  const clusterHasDe = getClusterHasDe(exploreInfo, exploreParams)
+  const hasOneVsRestDe = getHasComparisonDe(exploreInfo, exploreParams, 'one_vs_rest')
+  const hasPairwiseDe = getHasComparisonDe(exploreInfo, exploreParams, 'pairwise')
+  const isAuthorDe = getIsAuthorDe(exploreInfo, exploreParams)
+
+  // exploreParams object without genes specified, to pass to cluster comparison plots
+  const referencePlotDataParams = _clone(exploreParams)
+
+  referencePlotDataParams.genes = []
+
+  /** Handle clicks on "View Options" toggler element */
+  function toggleViewOptions() {
+    setShowViewOptionsControls(!showViewOptionsControls)
+  }
+
+  const annotationList = exploreInfo ? exploreInfo.annotationList : null
+  // hide the cluster controls if we're on a genome tab, or if there aren't clusters to choose
+  const showClusterControls = !['genome', 'infercnv-genome', 'geneListHeatmap'].includes(shownTab) &&
+                                annotationList?.clusters?.length
+
+  let hasSpatialGroups = false
+  if (exploreInfo) {
+    hasSpatialGroups = exploreInfo.spatialGroups.length > 0
+  }
+
+  const shownAnnotation = getShownAnnotation(exploreParamsWithDefaults.annotation, annotationList)
+
+  /** in the event a component takes an action which updates the list of annotations available
+    * e.g. by creating a user annotation, this updates the list */
+  function setAnnotationList(newAnnotationList) {
+    const newExploreInfo = Object.assign({}, exploreInfo, { annotationList: newAnnotationList })
+    setExploreInfo(newExploreInfo)
+  }
+
+  /** copies the url to the clipboard */
+  function copyLink(routerLocation) {
+    navigator.clipboard.writeText(routerLocation.href)
+  }
+
+  /** handles cluster selection to also populate the default spatial groups */
+  function updateClusterParams(newParams) {
+    if (newParams.cluster && !newParams.spatialGroups) {
+      newParams.spatialGroups = getDefaultSpatialGroupsForCluster(newParams.cluster, exploreInfo.spatialGroups)
+      dataCache.clear()
+    }
+
+    // if the user updates any cluster params, store all of them in the URL so we don't end up with
+    // broken urls in the event of a default cluster/annotation changes
+    // also, unset any gene lists as we're about to re-render the explore tab and having gene list selected will show
+    // the wrong tabs
+    const updateParams = { geneList: '', ideogramFileId: '' }
+
+    const clusterParamNames = ['cluster', 'annotation', 'subsample', 'spatialGroups']
+    clusterParamNames.forEach(param => {
+      updateParams[param] = param in newParams ? newParams[param] : exploreParamsWithDefaults[param]
+    })
+    // if a user switches to a numeric annotation, change the tab to annotated scatter (SCP-3833)
+    if (newParams.annotation?.type === 'numeric' &&
+      exploreParamsWithDefaults.genes?.length &&
+      exploreParamsWithDefaults.annotation?.type !== 'numeric'
+    ) {
+      updateParams.tab = 'annotatedScatter'
+    }
+    // if the user changes annotation, unset hiddenTraces
+    if (newParams.annotation && newParams.annotation.name !== exploreParams.annotation.name) {
+      updateParams.hiddenTraces = []
+    }
+
+    updateExploreParams(updateParams)
+  }
+
+  /** handles gene list selection */
+  function updateGeneList(geneListName) {
+    const geneListInfo = exploreInfo.geneLists.find(gl => gl.name === geneListName)
+    if (!geneListInfo) {
+      updateExploreParams({ geneList: '', heatmapRowCentering: '', heatmapFit: '' })
+    } else {
+      updateExploreParams({
+        geneList: geneListName,
+        heatmapRowCentering: '',
+        heatmapFit: 'both',
+        genes: []
+      })
+    }
+  }
+
+  /** handles updating inferCNV/ideogram selection */
+  function updateInferCNVIdeogramFile(annotationFile) {
+    updateExploreParams({ ideogramFileId: annotationFile, tab: 'infercnv-genome' })
+  }
+
+  /** if the user hasn't selected anything, and there are genelists to view, but no clusters
+    * default to the first gene list */
+  useEffect(() => {
+    if ((exploreInfo && exploreInfo.annotationList.clusters.length === 0 &&
+      exploreInfo.geneLists.length && !exploreParams.tab && !exploreParams.geneList)) {
+      updateGeneList(exploreInfo.geneLists[0].name)
+    }
+  }, [exploreInfo?.geneLists])
+
+  /** on window resize call setRenderForcer, which is just trivial state to ensure a re-render
+   * ensuring that the plots get passed fresh dimensions */
+  useResizeEffect(() => {
+    setRenderForcer({})
+  }, 300)
+
+  return (
+    <>
+      {/* Render plots for the given Explore view state */}
+      <div>
+        {/* Render "Options" panel at right of page */}
+        <div>
+          <div className="view-options-toggle">
+            {!showDifferentialExpressionPanel && !showUpstreamDifferentialExpressionPanel &&
+              <>
+                <FontAwesomeIcon className="fa-lg" icon={faEye}/> <span className="options-label">OPTIONS</span>
+                <button className={`action ${showDifferentialExpressionPanel ? '' : 'action-with-bg'}`}
+                  onClick={toggleViewOptions}
+                  title="Hide options"
+                  data-analytics-name="view-options-hide">
+                  <FontAwesomeIcon className="fa-lg" icon={faTimes}/>
+                </button>
+              </>
+            }
+            {getPanelWidths().side === 'hidden' && <button>HI</button>}
+            {(showDifferentialExpressionPanel || showUpstreamDifferentialExpressionPanel) &&
+              <DifferentialExpressionPanelHeader
+                setDeGenes={setDeGenes}
+                setDeGroup={setDeGroup}
+                setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
+                setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
+                isUpstream={showUpstreamDifferentialExpressionPanel}
+                cluster={exploreParamsWithDefaults.cluster}
+                annotation={shownAnnotation}
+                setDeGroupB={setDeGroupB}
+                isAuthorDe={isAuthorDe}
+                deGenes={deGenes}
+              />
+            }
+          </div>
+          {!showDifferentialExpressionPanel && !showUpstreamDifferentialExpressionPanel &&
+          <>
+            <div>
+              <div className={showClusterControls ? '' : 'hidden'}>
+                <ClusterSelector
+                  annotationList={annotationList}
+                  cluster={exploreParamsWithDefaults.cluster}
+                  annotation={exploreParamsWithDefaults.annotation}
+                  updateClusterParams={updateClusterParams}
+                  spatialGroups={exploreInfo ? exploreInfo.spatialGroups : []}/>
+                {hasSpatialGroups &&
+                <SpatialSelector allSpatialGroups={exploreInfo.spatialGroups}
+                  spatialGroups={exploreParamsWithDefaults.spatialGroups}
+                  updateSpatialGroups={spatialGroups => updateClusterParams({ spatialGroups })}/>
+                }
+                <AnnotationSelector
+                  annotationList={annotationList}
+                  cluster={exploreParamsWithDefaults.cluster}
+                  shownAnnotation={shownAnnotation}
+                  updateClusterParams={updateClusterParams}/>
+                { shownTab === 'scatter' && <CreateAnnotation
+                  isSelecting={isCellSelecting}
+                  setIsSelecting={setIsCellSelecting}
+                  annotationList={exploreInfo ? exploreInfo.annotationList : null}
+                  currentPointsSelected={currentPointsSelected}
+                  cluster={exploreParamsWithDefaults.cluster}
+                  annotation={exploreParamsWithDefaults.annotation}
+                  subsample={exploreParamsWithDefaults.subsample}
+                  updateClusterParams={updateClusterParams}
+                  setAnnotationList={setAnnotationList}
+                  studyAccession={studyAccession}/>
+                }
+                {studyHasDe &&
+                <>
+                  <div className="row de-modal-row-wrapper">
+                    <div className="col-xs-12 de-modal-row">
+                      <button
+                        className=
+                          {`btn btn-primary differential-expression${annotHasDe ? '' : '-nondefault'}`}
+                        onClick={() => {
+                          if (annotHasDe) {
+                            setShowDifferentialExpressionPanel(true)
+                            setShowDeGroupPicker(true)
+                          } else if (studyHasDe) {
+                            setShowUpstreamDifferentialExpressionPanel(true)
+                          }
+                        }}
+                      >Differential expression</button>
+                      <DifferentialExpressionModal />
+                    </div>
+                  </div>
+                </>
+                }
+                <SubsampleSelector
+                  annotationList={annotationList}
+                  cluster={exploreParamsWithDefaults.cluster}
+                  subsample={exploreParamsWithDefaults.subsample}
+                  updateClusterParams={updateClusterParams}/>
+              </div>
+              { exploreInfo?.geneLists?.length > 0 &&
+              <GeneListSelector
+                geneList={exploreParamsWithDefaults.geneList}
+                studyGeneLists={exploreInfo.geneLists}
+                selectLabel={exploreInfo.precomputedHeatmapLabel ?? undefined}
+                updateGeneList={updateGeneList}/>
+              }
+              { exploreParams.genes?.length > 1 && !['genome', 'infercnv-genome'].includes(shownTab) &&
+              <ExploreConsensusSelector
+                consensus={exploreParamsWithDefaults.consensus}
+                updateConsensus={consensus => updateExploreParams({ consensus })}/>
+              }
+              { !!exploreInfo?.inferCNVIdeogramFiles &&
+                <InferCNVIdeogramSelector
+                  inferCNVIdeogramFile={exploreParamsWithDefaults.ideogramFileId}
+                  studyInferCNVIdeogramFiles={exploreInfo.inferCNVIdeogramFiles}
+                  updateInferCNVIdeogramFile={updateInferCNVIdeogramFile}
+                />
+              }
+            </div>
+            <PlotDisplayControls
+              shownTab={shownTab}
+              exploreParams={exploreParamsWithDefaults}
+              updateExploreParams={updateExploreParams}
+              allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}/>
+            <button className="action action-with-bg margin-extra-right"
+              onClick={clearExploreParams}
+              title="Reset all view options"
+              data-analytics-name="explore-view-options-reset">
+              <FontAwesomeIcon icon={faUndo}/> Reset view
+            </button>
+            <button onClick={() => copyLink(routerLocation)}
+              className="action action-with-bg"
+              data-toggle="tooltip"
+              title="Copy a link to this visualization to the clipboard">
+              <FontAwesomeIcon icon={faLink}/> Get link
+            </button>
+          </>
+          }
+          {showDifferentialExpressionPanel && countsByLabel && annotHasDe &&
+          <>
+            <DifferentialExpressionPanel
+              deGroup={deGroup}
+              deGenes={deGenes}
+              searchGenes={searchGenes}
+              exploreParamsWithDefaults={exploreParamsWithDefaults}
+              exploreInfo={exploreInfo}
+              clusterName={exploreParamsWithDefaults.cluster}
+              annotation={shownAnnotation}
+              setShowDeGroupPicker={setShowDeGroupPicker}
+              setDeGenes={setDeGenes}
+              setDeGroup={setDeGroup}
+              hasOneVsRestDe={hasOneVsRestDe}
+              hasPairwiseDe={hasPairwiseDe}
+              isAuthorDe={isAuthorDe}
+              deGroupB={deGroupB}
+              setDeGroupB={setDeGroupB}
+              countsByLabel={countsByLabel}
+            />
+          </>
+          }
+          {showUpstreamDifferentialExpressionPanel &&
+          <>
+            {!clusterHasDe &&
+            <>
+              <ClusterSelector
+                annotationList={getAnnotationsWithDE(exploreInfo)}
+                cluster={''}
+                annotation={''}
+                updateClusterParams={updateClusterParams}
+                hasSelection={false}
+                spatialGroups={exploreInfo ? exploreInfo.spatialGroups : []}/>
+            </>
+            }
+            {clusterHasDe &&
+              <AnnotationSelector
+                annotationList={getAnnotationsWithDE(exploreInfo)}
+                cluster={exploreParamsWithDefaults.cluster}
+                shownAnnotation={shownAnnotation}
+                updateClusterParams={updateClusterParams}
+                hasSelection={false}
+                setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
+                setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
+              />
+            }
+          </>
+          }
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -220,18 +220,6 @@ export default function ExploreDisplayTabs({
   // Below line is worth keeping, but only uncomment to debug in development
   // window.SCP.updateFilteredCells = updateFilteredCells
 
-  /** in the event a component takes an action which updates the list of annotations available
-    * e.g. by creating a user annotation, this updates the list */
-  function setAnnotationList(newAnnotationList) {
-    const newExploreInfo = Object.assign({}, exploreInfo, { annotationList: newAnnotationList })
-    setExploreInfo(newExploreInfo)
-  }
-
-  /** copies the url to the clipboard */
-  function copyLink(routerLocation) {
-    navigator.clipboard.writeText(routerLocation.href)
-  }
-
   /** handler for when the user selects points in a plotly scatter graph */
   function plotPointsSelected(points) {
     log('select:scatter:cells')

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -1,18 +1,9 @@
 import React, { useState, useEffect } from 'react'
 import _clone from 'lodash/clone'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faLink, faArrowLeft, faEye, faTimes, faUndo } from '@fortawesome/free-solid-svg-icons'
+import { faArrowLeft, faEye } from '@fortawesome/free-solid-svg-icons'
 
 import StudyGeneField from './StudyGeneField'
-import ClusterSelector from '~/components/visualization/controls/ClusterSelector'
-import AnnotationSelector from '~/components/visualization/controls/AnnotationSelector'
-import SubsampleSelector from '~/components/visualization/controls/SubsampleSelector'
-import { ExploreConsensusSelector } from '~/components/visualization/controls/ConsensusSelector'
-import SpatialSelector from '~/components/visualization/controls/SpatialSelector'
-import CreateAnnotation from '~/components/visualization/controls/CreateAnnotation'
-import PlotDisplayControls from '~/components/visualization/PlotDisplayControls'
-import GeneListSelector from '~/components/visualization/controls/GeneListSelector'
-import InferCNVIdeogramSelector from '~/components/visualization/controls/InferCNVIdeogramSelector'
 import { createCache } from './plot-data-cache'
 import ScatterTab from './ScatterTab'
 import PlotUtils from '~/lib/plot'
@@ -23,17 +14,16 @@ import DotPlot from '~/components/visualization/DotPlot'
 import Heatmap from '~/components/visualization/Heatmap'
 import GeneListHeatmap from '~/components/visualization/GeneListHeatmap'
 import GenomeView from './GenomeView'
-import { getAnnotationValues, getShownAnnotation, getDefaultSpatialGroupsForCluster } from '~/lib/cluster-utils'
+import { getAnnotationValues, getShownAnnotation } from '~/lib/cluster-utils'
 import RelatedGenesIdeogram from '~/components/visualization/RelatedGenesIdeogram'
 import InferCNVIdeogram from '~/components/visualization/InferCNVIdeogram'
 import useResizeEffect from '~/hooks/useResizeEffect'
 import LoadingSpinner from '~/lib/LoadingSpinner'
 import { log } from '~/lib/metrics-api'
 import { getFeatureFlagsWithDefaults } from '~/providers/UserProvider'
-import DifferentialExpressionPanel, { DifferentialExpressionPanelHeader } from './DifferentialExpressionPanel'
+import ExploreDisplayPanelManager from './ExploreDisplayPanelManager'
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger'
 import Tooltip from 'react-bootstrap/lib/Tooltip'
-import DifferentialExpressionModal from '~/components/explore/DifferentialExpressionModal'
 import PlotTabs from './PlotTabs'
 
 /** Get the selected clustering and annotation, or their defaults */
@@ -50,22 +40,6 @@ function getSelectedClusterAndAnnot(exploreInfo, exploreParams) {
   }
 
   return [selectedCluster, selectedAnnot]
-}
-
-/** Determine if currently selected cluster has differential expression outputs available */
-function getClusterHasDe(exploreInfo, exploreParams) {
-  const flags = getFeatureFlagsWithDefaults()
-  if (!flags?.differential_expression_frontend || !exploreInfo) {return false}
-  let clusterHasDe = false
-  const selectedCluster = getSelectedClusterAndAnnot(exploreInfo, exploreParams)[0]
-
-  clusterHasDe = exploreInfo.differentialExpression.some(deItem => {
-    return (
-      deItem.cluster_name === selectedCluster
-    )
-  })
-
-  return clusterHasDe
 }
 
 /** Determine if current annotation has one-vs-rest or pairwise DE */
@@ -87,56 +61,6 @@ function getHasComparisonDe(exploreInfo, exploreParams, comparison) {
   return hasComparisonDe
 }
 
-/** Return list of annotations that have differential expression enabled */
-function getAnnotationsWithDE(exploreInfo) {
-  if (!exploreInfo) {return false}
-
-  let annotsWithDe = []
-
-  annotsWithDe = exploreInfo.differentialExpression.filter(deItem => {
-    return deItem
-  }).map(annot => {
-    return {
-      cluster_name: annot.cluster_name,
-      name: annot.annotation_name,
-      scope: annot.annotation_scope,
-      type: 'group'
-    }
-  })
-
-  const clustersWithDe = Array.from(new Set(annotsWithDe.map(a => a.cluster_name)))
-
-  return {
-    clusters: clustersWithDe,
-    annotations: annotsWithDe,
-    subsample_thresholds: exploreInfo.annotationList.subsample_thresholds
-  }
-}
-
-/** Determine if current annotation has differential expression results available */
-function getAnnotHasDe(exploreInfo, exploreParams) {
-  const flags = getFeatureFlagsWithDefaults()
-  if (!flags?.differential_expression_frontend || !exploreInfo) {
-    // set isDifferentialExpressionEnabled to false as user cannot see DE results, even if present for annotation
-    if (window.SCP) {
-      window.SCP.isDifferentialExpressionEnabled = false
-    }
-    return false
-  }
-
-  let annotHasDe = false
-  const [selectedCluster, selectedAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
-
-  annotHasDe = exploreInfo.differentialExpression.some(deItem => {
-    return (
-      deItem.cluster_name === selectedCluster &&
-      deItem.annotation_name === selectedAnnot.name &&
-      deItem.annotation_scope === selectedAnnot.scope
-    )
-  })
-
-  return annotHasDe
-}
 
 /**
  * Determine if current annotation has differential expression results that are user-generated.
@@ -201,12 +125,7 @@ export default function ExploreDisplayTabs({
   // morpheus JSON data
   const [morpheusData, setMorpheusData] = useState(null)
   // Differential expression settings
-  const flags = getFeatureFlagsWithDefaults()
   // `differential_expression_frontend` enables exemptions if study owners don't want DE
-  const studyHasDe = flags?.differential_expression_frontend && exploreInfo?.differentialExpression.length > 0
-  const annotHasDe = getAnnotHasDe(exploreInfo, exploreParams)
-  const clusterHasDe = getClusterHasDe(exploreInfo, exploreParams)
-  const hasOneVsRestDe = getHasComparisonDe(exploreInfo, exploreParams, 'one_vs_rest')
   const hasPairwiseDe = getHasComparisonDe(exploreInfo, exploreParams, 'pairwise')
   const isAuthorDe = getIsAuthorDe(exploreInfo, exploreParams)
 
@@ -219,12 +138,7 @@ export default function ExploreDisplayTabs({
 
   // Hash of trace label names to the number of points in that trace
   const [countsByLabel, setCountsByLabel] = useState(null)
-
-  const showDifferentialExpressionTable = (
-    showViewOptionsControls &&
-    deGenes !== null
-  )
-
+  const showDifferentialExpressionTable = (showViewOptionsControls && deGenes !== null)
   const plotContainerClass = 'explore-plot-tab-content'
 
   const {
@@ -267,70 +181,17 @@ export default function ExploreDisplayTabs({
   const isCorrelatedScatter = enabledTabs.includes('correlatedScatter')
 
   const annotationList = exploreInfo ? exploreInfo.annotationList : null
-  // hide the cluster controls if we're on a genome tab, or if there aren't clusters to choose
-  const showClusterControls = !['genome', 'infercnv-genome', 'geneListHeatmap'].includes(shownTab) &&
-                                annotationList?.clusters?.length
-
-  let hasSpatialGroups = false
-  if (exploreInfo) {
-    hasSpatialGroups = exploreInfo.spatialGroups.length > 0
-  }
 
   const shownAnnotation = getShownAnnotation(exploreParamsWithDefaults.annotation, annotationList)
-
-  /** in the event a component takes an action which updates the list of annotations available
-    * e.g. by creating a user annotation, this updates the list */
-  function setAnnotationList(newAnnotationList) {
-    const newExploreInfo = Object.assign({}, exploreInfo, { annotationList: newAnnotationList })
-    setExploreInfo(newExploreInfo)
-  }
-
-  /** copies the url to the clipboard */
-  function copyLink(routerLocation) {
-    navigator.clipboard.writeText(routerLocation.href)
-  }
 
   /** handler for when the user selects points in a plotly scatter graph */
   function plotPointsSelected(points) {
     log('select:scatter:cells')
     setCurrentPointsSelected(points)
   }
-
   /** Handle clicks on "View Options" toggler element */
   function toggleViewOptions() {
     setShowViewOptionsControls(!showViewOptionsControls)
-  }
-
-  /** handles cluster selection to also populate the default spatial groups */
-  function updateClusterParams(newParams) {
-    if (newParams.cluster && !newParams.spatialGroups) {
-      newParams.spatialGroups = getDefaultSpatialGroupsForCluster(newParams.cluster, exploreInfo.spatialGroups)
-      dataCache.clear()
-    }
-
-    // if the user updates any cluster params, store all of them in the URL so we don't end up with
-    // broken urls in the event of a default cluster/annotation changes
-    // also, unset any gene lists as we're about to re-render the explore tab and having gene list selected will show
-    // the wrong tabs
-    const updateParams = { geneList: '', ideogramFileId: '' }
-
-    const clusterParamNames = ['cluster', 'annotation', 'subsample', 'spatialGroups']
-    clusterParamNames.forEach(param => {
-      updateParams[param] = param in newParams ? newParams[param] : exploreParamsWithDefaults[param]
-    })
-    // if a user switches to a numeric annotation, change the tab to annotated scatter (SCP-3833)
-    if (newParams.annotation?.type === 'numeric' &&
-      exploreParamsWithDefaults.genes.length &&
-      exploreParamsWithDefaults.annotation?.type !== 'numeric'
-    ) {
-      updateParams.tab = 'annotatedScatter'
-    }
-    // if the user changes annotation, unset hiddenTraces
-    if (newParams.annotation && newParams.annotation.name !== exploreParams.annotation.name) {
-      updateParams.hiddenTraces = []
-    }
-
-    updateExploreParams(updateParams)
   }
 
   /** handles gene list selection */
@@ -346,11 +207,6 @@ export default function ExploreDisplayTabs({
         genes: []
       })
     }
-  }
-
-  /** handles updating inferCNV/ideogram selection */
-  function updateInferCNVIdeogramFile(annotationFile) {
-    updateExploreParams({ ideogramFileId: annotationFile, tab: 'infercnv-genome' })
   }
 
   /** if the user hasn't selected anything, and there are genelists to view, but no clusters
@@ -370,12 +226,13 @@ export default function ExploreDisplayTabs({
 
   /** Get widths for main (plots) and side (options or DE) panels, for current Explore state */
   function getPanelWidths() {
+    console.log('showViewOptionsControls hi:', showViewOptionsControls)
     let main
     let side
     const isSelectingDE = showDifferentialExpressionPanel || showUpstreamDifferentialExpressionPanel
     if (showViewOptionsControls) {
       if (
-        showDifferentialExpressionTable ||
+        (deGenes !== null) ||
         (hasPairwiseDe && (showDifferentialExpressionPanel || showUpstreamDifferentialExpressionPanel))
       ) {
         // DE table is shown, or pairwise DE is available.  Least horizontal space for plots.
@@ -441,16 +298,6 @@ export default function ExploreDisplayTabs({
                 searchGenes={searchGenes}
                 speciesList={exploreInfo.taxonNames}
               />
-            }
-            { !showViewOptionsControls &&
-              <button className={showDifferentialExpressionPanel ?
-                'action view-options-toggle view-options-toggle-on' :
-                'action view-options-toggle view-options-toggle-on minified-options'
-              }
-              onClick={toggleViewOptions}
-              data-analytics-name="view-options-show">
-                <FontAwesomeIcon className="fa-lg" icon={faEye}/>
-              </button>
             }
             { enabledTabs.includes('annotatedScatter') &&
               <div className={shownTab === 'annotatedScatter' ? '' : 'hidden'}>
@@ -587,184 +434,50 @@ export default function ExploreDisplayTabs({
             }
           </div>
         </div>
-
-        {/* Render "Options" panel at right of page */}
+        { !showViewOptionsControls &&
+              <button className={showDifferentialExpressionPanel ?
+                'action view-options-toggle view-options-toggle-on' :
+                'action view-options-toggle view-options-toggle-on minified-options'
+              }
+              onClick={toggleViewOptions}
+              data-analytics-name="view-options-show">
+                <FontAwesomeIcon className="fa-lg" icon={faEye}/>
+              </button>
+            }
         <div className={getPanelWidths().side}>
-          <div className="view-options-toggle">
-            {!showDifferentialExpressionPanel && !showUpstreamDifferentialExpressionPanel &&
-              <>
-                <FontAwesomeIcon className="fa-lg" icon={faEye}/> <span className="options-label">OPTIONS</span>
-                <button className={`action ${showDifferentialExpressionPanel ? '' : 'action-with-bg'}`}
-                  onClick={toggleViewOptions}
-                  title="Hide options"
-                  data-analytics-name="view-options-hide">
-                  <FontAwesomeIcon className="fa-lg" icon={faTimes}/>
-                </button>
-              </>
-            }
-            {(showDifferentialExpressionPanel || showUpstreamDifferentialExpressionPanel) &&
-              <DifferentialExpressionPanelHeader
-                setDeGenes={setDeGenes}
-                setDeGroup={setDeGroup}
-                setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
-                setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
-                isUpstream={showUpstreamDifferentialExpressionPanel}
-                cluster={exploreParamsWithDefaults.cluster}
-                annotation={shownAnnotation}
-                setDeGroupB={setDeGroupB}
-                isAuthorDe={isAuthorDe}
-                deGenes={deGenes}
-              />
-            }
-          </div>
-
-          {!showDifferentialExpressionPanel && !showUpstreamDifferentialExpressionPanel &&
-          <>
-            <div>
-              <div className={showClusterControls ? '' : 'hidden'}>
-                <ClusterSelector
-                  annotationList={annotationList}
-                  cluster={exploreParamsWithDefaults.cluster}
-                  annotation={exploreParamsWithDefaults.annotation}
-                  updateClusterParams={updateClusterParams}
-                  spatialGroups={exploreInfo ? exploreInfo.spatialGroups : []}/>
-                {hasSpatialGroups &&
-                <SpatialSelector allSpatialGroups={exploreInfo.spatialGroups}
-                  spatialGroups={exploreParamsWithDefaults.spatialGroups}
-                  updateSpatialGroups={spatialGroups => updateClusterParams({ spatialGroups })}/>
-                }
-                <AnnotationSelector
-                  annotationList={annotationList}
-                  cluster={exploreParamsWithDefaults.cluster}
-                  shownAnnotation={shownAnnotation}
-                  updateClusterParams={updateClusterParams}/>
-                { shownTab === 'scatter' && <CreateAnnotation
-                  isSelecting={isCellSelecting}
-                  setIsSelecting={setIsCellSelecting}
-                  annotationList={exploreInfo ? exploreInfo.annotationList : null}
-                  currentPointsSelected={currentPointsSelected}
-                  cluster={exploreParamsWithDefaults.cluster}
-                  annotation={exploreParamsWithDefaults.annotation}
-                  subsample={exploreParamsWithDefaults.subsample}
-                  updateClusterParams={updateClusterParams}
-                  setAnnotationList={setAnnotationList}
-                  studyAccession={studyAccession}/>
-                }
-                {studyHasDe &&
-                <>
-                  <div className="row de-modal-row-wrapper">
-                    <div className="col-xs-12 de-modal-row">
-                      <button
-                        className=
-                          {`btn btn-primary differential-expression${annotHasDe ? '' : '-nondefault'}`}
-                        onClick={() => {
-                          if (annotHasDe) {
-                            setShowDifferentialExpressionPanel(true)
-                            setShowDeGroupPicker(true)
-                          } else if (studyHasDe) {
-                            setShowUpstreamDifferentialExpressionPanel(true)
-                          }
-                        }}
-                      >Differential expression</button>
-                      <DifferentialExpressionModal />
-                    </div>
-
-                  </div>
-                </>
-                }
-                <SubsampleSelector
-                  annotationList={annotationList}
-                  cluster={exploreParamsWithDefaults.cluster}
-                  subsample={exploreParamsWithDefaults.subsample}
-                  updateClusterParams={updateClusterParams}/>
-              </div>
-              { exploreInfo?.geneLists?.length > 0 &&
-              <GeneListSelector
-                geneList={exploreParamsWithDefaults.geneList}
-                studyGeneLists={exploreInfo.geneLists}
-                selectLabel={exploreInfo.precomputedHeatmapLabel ?? undefined}
-                updateGeneList={updateGeneList}/>
-              }
-              { exploreParams.genes.length > 1 && !['genome', 'infercnv-genome'].includes(shownTab) &&
-              <ExploreConsensusSelector
-                consensus={exploreParamsWithDefaults.consensus}
-                updateConsensus={consensus => updateExploreParams({ consensus })}/>
-              }
-              { !!exploreInfo?.inferCNVIdeogramFiles &&
-                <InferCNVIdeogramSelector
-                  inferCNVIdeogramFile={exploreParamsWithDefaults.ideogramFileId}
-                  studyInferCNVIdeogramFiles={exploreInfo.inferCNVIdeogramFiles}
-                  updateInferCNVIdeogramFile={updateInferCNVIdeogramFile}
-                />
-              }
-            </div>
-            <PlotDisplayControls
-              shownTab={shownTab}
-              exploreParams={exploreParamsWithDefaults}
-              updateExploreParams={updateExploreParams}
-              allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}/>
-            <button className="action action-with-bg margin-extra-right"
-              onClick={clearExploreParams}
-              title="Reset all view options"
-              data-analytics-name="explore-view-options-reset">
-              <FontAwesomeIcon icon={faUndo}/> Reset view
-            </button>
-            <button onClick={() => copyLink(routerLocation)}
-              className="action action-with-bg"
-              data-toggle="tooltip"
-              title="Copy a link to this visualization to the clipboard">
-              <FontAwesomeIcon icon={faLink}/> Get link
-            </button>
-          </>
-          }
-          {showDifferentialExpressionPanel && countsByLabel && annotHasDe &&
-          <>
-            <DifferentialExpressionPanel
-              deGroup={deGroup}
-              deGenes={deGenes}
-              searchGenes={searchGenes}
-              exploreParamsWithDefaults={exploreParamsWithDefaults}
-              exploreInfo={exploreInfo}
-              clusterName={exploreParamsWithDefaults.cluster}
-              annotation={shownAnnotation}
-              setShowDeGroupPicker={setShowDeGroupPicker}
-              setDeGenes={setDeGenes}
-              setDeGroup={setDeGroup}
-              hasOneVsRestDe={hasOneVsRestDe}
-              hasPairwiseDe={hasPairwiseDe}
-              isAuthorDe={isAuthorDe}
-              deGroupB={deGroupB}
-              setDeGroupB={setDeGroupB}
-              countsByLabel={countsByLabel}
-            />
-          </>
-          }
-          {showUpstreamDifferentialExpressionPanel &&
-          <>
-            {!clusterHasDe &&
-            <>
-              <ClusterSelector
-                annotationList={getAnnotationsWithDE(exploreInfo)}
-                cluster={''}
-                annotation={''}
-                updateClusterParams={updateClusterParams}
-                hasSelection={false}
-                spatialGroups={exploreInfo ? exploreInfo.spatialGroups : []}/>
-            </>
-            }
-            {clusterHasDe &&
-              <AnnotationSelector
-                annotationList={getAnnotationsWithDE(exploreInfo)}
-                cluster={exploreParamsWithDefaults.cluster}
-                shownAnnotation={shownAnnotation}
-                updateClusterParams={updateClusterParams}
-                hasSelection={false}
-                setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
-                setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
-              />
-            }
-          </>
-          }
+          <ExploreDisplayPanelManager
+            deGroup={deGroup}
+            deGenes={deGenes}
+            searchGenes={searchGenes}
+            exploreParamsWithDefaults={exploreParamsWithDefaults}
+            exploreInfo={exploreInfo}
+            clusterName={exploreParamsWithDefaults.cluster}
+            annotation={shownAnnotation}
+            setShowDeGroupPicker={setShowDeGroupPicker}
+            setDeGenes={setDeGenes}
+            setDeGroup={setDeGroup}
+            isAuthorDe={isAuthorDe}
+            deGroupB={deGroupB}
+            setDeGroupB={setDeGroupB}
+            countsByLabel={countsByLabel}
+            showUpstreamDifferentialExpressionPanel = {showUpstreamDifferentialExpressionPanel}
+            showDifferentialExpressionPanel = {showDifferentialExpressionPanel}
+            shownTab = {shownTab}
+            exploreParams= {exploreParams}
+            studyAccession = {studyAccession}
+            setExploreInfo = {setExploreInfo}
+            updateExploreParams = {updateExploreParams}
+            clearExploreParams = {clearExploreParams}
+            routerLocation = {routerLocation}
+            setShowUpstreamDifferentialExpressionPanel = {setShowUpstreamDifferentialExpressionPanel}
+            setShowDifferentialExpressionPanel = {setShowDifferentialExpressionPanel}
+            setShowViewOptionsControls = {setShowViewOptionsControls}
+            setIsCellSelecting = {setIsCellSelecting}
+            currentPointsSelected = {currentPointsSelected}
+            showViewOptionsControls = {showViewOptionsControls}
+            isCellSelecting = {isCellSelecting}
+            getPanelWidths = {getPanelWidths}
+          />
         </div>
       </div>
     </>

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -153,7 +153,6 @@
 
 .view-options-toggle-on {
   position: absolute;
-  top: 0px;
   right: 1px;
   padding: 0.5em;
   background: #fff;


### PR DESCRIPTION
Part one for the Facet Filter component - just a refactor of existing code no new functionality and very little new code. I wanted to get this out so any other work being done in these files can work within this refactor and also because this is already a large PR so wanted to split the actual new feature into its' own PR.


This PR restructures the code a little bit to make the addition of the Filter Facet component easier.

The Explore tab consists of (among other things) the Plot (left side) the Panel (right side) and tabs (Scatter, Dot Plot, etc.) The code in `ExploreDisplayTabs` had managed which tabs, plots and panels to show and was almost 900 lines long. Now that we want to add a third right-side Panel option (Facet Filter) it would make the logic more complicated and make this file even longer. So instead I have separated out a bunch of the logic for managing the right-side Panel into a file called `ExploreDisplayPanelManager`. This will then figure out which of the soon to be three panels (Options/Regular, DE, Facet Filter) to display. 


To test this PR:
- There is no new functionality and all the looks should be the same - so pull down this branch and start up a local server.
- Navigate to a study (one with DE will have more cases to test)
- Then compare to Staging or Prod, clicking around, clicking the DE button, changing sizes etc. 
- There should not be a difference between local and Staging or Prod.


Upcoming work - the new Facet Filter panel will be added and the `ExploreDisplayPanelManager` will sort out when to show this.

Notes - I haven't added new tests yet, will plan to incorporate in future PR.

Showing that staging and local are the same looking:
https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/e4e90e92-db8f-49c2-9106-9b13c492b618


![Screenshot 2023-08-28 at 12 26 42 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/7b9ea53b-b7d0-416e-891b-68ddc5374d94)
