### PR TITLE
Updating to Terra orchestration V2 billing endpoints (SCP-5284)

### DIFF
--- a/app/controllers/billing_projects_controller.rb
+++ b/app/controllers/billing_projects_controller.rb
@@ -38,9 +38,9 @@ class BillingProjectsController < ApplicationController
     billing_projects.each do |project|
       project_name = project['projectName']
       @projects[project_name] = {
-          status: project['creationStatus'],
-          role: project['role'],
-          members: project['role'] == 'Owner' ? @fire_cloud_client.get_billing_project_members(project_name) : nil
+        status: project['status'],
+        roles: project['roles'],
+        members: project['roles'].include?('Owner') ? @fire_cloud_client.get_billing_project_members(project_name) : nil
       }
     end
   end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1070,7 +1070,7 @@ class StudiesController < ApplicationController
       if current_user.registered_for_firecloud && client.registered?
         available_projects = client.get_billing_projects
         available_projects.each do |project|
-          if project['status'] == 'Ready'
+          if project['status'] == 'Ready' && project['roles'].any?
             @projects << [project['projectName'], project['projectName']]
           end
         end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1070,7 +1070,7 @@ class StudiesController < ApplicationController
       if current_user.registered_for_firecloud && client.registered?
         available_projects = client.get_billing_projects
         available_projects.each do |project|
-          if project['creationStatus'] == 'Ready'
+          if project['status'] == 'Ready'
             @projects << [project['projectName'], project['projectName']]
           end
         end

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -382,6 +382,23 @@ class FireCloudClient
     process_firecloud_request(:get, path)
   end
 
+  # passthru to determine if a workspace exists
+  #
+  # * *params*
+  #   - +workspace_namespace+ (String) => namespace of workspace
+  #   - +workspace_name+ (String) => name of workspace
+  #
+  # * *return*
+  #   - +Boolean+
+  def workspace_exists?(workspace_namespace, workspace_name)
+    begin
+      get_workspace(workspace_namespace, workspace_name)
+      true
+    rescue RestClient::NotFound
+      false
+    end
+  end
+
   # delete a workspace
   #
   # * *params*

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -1159,15 +1159,6 @@ class FireCloudClient
     process_firecloud_request(:get, path)
   end
 
-  # list billing accounts for a given user
-  #
-  # * *return*
-  #   - +Array+ of Hashes of billing accounts
-  def get_billing_accounts
-    path = self.api_root + '/api/profile/billingAccounts'
-    process_firecloud_request(:get, path)
-  end
-
   # list all members of a FireCloud billing project
   #
   # * *params*

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -1197,7 +1197,7 @@ class FireCloudClient
   # * *return*
   #   - +Array+ of FireCloud user accounts
   def get_billing_project_members(project_id)
-    path = self.api_root + "/api/billing/#{project_id}/members"
+    path = self.api_root + "/api/billing/v2/#{project_id}/members"
     process_firecloud_request(:get, path)
   end
 
@@ -1212,7 +1212,7 @@ class FireCloudClient
   #   - +Array+ of FireCloud user accounts
   def add_user_to_billing_project(project_id, role, email)
     if BILLING_PROJECT_ROLES.include?(role)
-      path = self.api_root + "/api/billing/#{project_id}/#{role}/#{email}"
+      path = self.api_root + "/api/billing/v2/#{project_id}/#{role}/#{email}"
       process_firecloud_request(:put, path)
     else
       raise RuntimeError.new("Invalid billing account role \"#{role}\"; must be a member of \"#{BILLING_PROJECT_ROLES.join(', ')}\"")
@@ -1230,7 +1230,7 @@ class FireCloudClient
   #   - +Array+ of FireCloud user accounts
   def delete_user_from_billing_project(project_id, role, email)
     if BILLING_PROJECT_ROLES.include?(role)
-      path = self.api_root + "/api/billing/#{project_id}/#{role}/#{email}"
+      path = self.api_root + "/api/billing/v2/#{project_id}/#{role}/#{email}"
       process_firecloud_request(:delete, path)
     else
       raise RuntimeError.new("Invalid billing account role \"#{role}\"; must be a member of \"#{BILLING_PROJECT_ROLES.join(', ')}\"")

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -1155,7 +1155,7 @@ class FireCloudClient
   # * *return*
   #   - +Array+ of Hashes of billing projects
   def get_billing_projects
-    path = self.api_root + '/api/profile/billing'
+    path = self.api_root + '/api/billing/v2'
     process_firecloud_request(:get, path)
   end
 
@@ -1166,27 +1166,6 @@ class FireCloudClient
   def get_billing_accounts
     path = self.api_root + '/api/profile/billingAccounts'
     process_firecloud_request(:get, path)
-  end
-
-  # create a FireCloud billing project
-  #
-  # * *params*
-  #   - +project_name+ (String) => name of new billing project
-  #   - +billing_account+ (String) => ID of billing project (must start with billingAccounts/)
-  #
-  # * *return*
-  #   - +Array+ of FireCloud user accounts
-  def create_billing_project(project_name, billing_account)
-    if billing_account.start_with?('billingAccounts/')
-      path = self.api_root + '/api/billing'
-      project_payload = {
-          projectName: project_name,
-          billingAccount: billing_account
-      }.to_json
-      process_firecloud_request(:post, path, project_payload)
-    else
-      raise RuntimeError.new("Invalid billing account \"#{billing_account}\"; must begin with \"billingAccounts/\"")
-    end
   end
 
   # list all members of a FireCloud billing project

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -1191,7 +1191,7 @@ class FireCloudClient
   #   - +Array+ of FireCloud user accounts
   def add_user_to_billing_project(project_id, role, email)
     if BILLING_PROJECT_ROLES.include?(role)
-      path = self.api_root + "/api/billing/v2/#{project_id}/#{role}/#{email}"
+      path = self.api_root + "/api/billing/v2/#{project_id}/members/#{role}/#{email}"
       process_firecloud_request(:put, path)
     else
       raise RuntimeError.new("Invalid billing account role \"#{role}\"; must be a member of \"#{BILLING_PROJECT_ROLES.join(', ')}\"")
@@ -1209,7 +1209,7 @@ class FireCloudClient
   #   - +Array+ of FireCloud user accounts
   def delete_user_from_billing_project(project_id, role, email)
     if BILLING_PROJECT_ROLES.include?(role)
-      path = self.api_root + "/api/billing/v2/#{project_id}/#{role}/#{email}"
+      path = self.api_root + "/api/billing/v2/#{project_id}/members/#{role}/#{email}"
       process_firecloud_request(:delete, path)
     else
       raise RuntimeError.new("Invalid billing account role \"#{role}\"; must be a member of \"#{BILLING_PROJECT_ROLES.join(', ')}\"")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -416,7 +416,8 @@ class User
       user_projects.each do |project|
         safe_project = project.with_indifferent_access
         if safe_project[:status] == 'Ready'
-          projects[safe_project[:role].to_sym] << safe_project[:projectName]
+          role = safe_project[:roles].include?('Owner') ? :Owner : :User
+          projects[role] << safe_project[:projectName]
         end
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -409,13 +409,14 @@ class User
 
   # retrieve billing projects for a given user (if registered for firecloud)
   def get_billing_projects
-    projects = {User: [], Owner: []}
+    projects = { User: [], Owner: [] }
     if self.registered_for_firecloud
       client = FireCloudClient.new(user: self, project: FireCloudClient::PORTAL_NAMESPACE)
       user_projects = client.get_billing_projects
       user_projects.each do |project|
-        if project['creationStatus'] == 'Ready'
-          projects[project['role'].to_sym] << project['projectName']
+        safe_project = project.with_indifferent_access
+        if safe_project[:status] == 'Ready'
+          projects[safe_project[:role].to_sym] << safe_project[:projectName]
         end
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -415,7 +415,7 @@ class User
       user_projects = client.get_billing_projects
       user_projects.each do |project|
         safe_project = project.with_indifferent_access
-        if safe_project[:status] == 'Ready'
+        if safe_project[:status] == 'Ready' && safe_project[:roles].any?
           role = safe_project[:roles].include?('Owner') ? :Owner : :User
           projects[role] << safe_project[:projectName]
         end

--- a/app/views/billing_projects/index.html.erb
+++ b/app/views/billing_projects/index.html.erb
@@ -40,7 +40,7 @@
           </td>
           <td class="actions">
             <% unless project_attributes[:status] == 'Error' %>
-              <% if project_attributes[:role] == 'Owner' %>
+              <% if project_attributes[:roles].include?('Owner') %>
                 <%= scp_link_to "<i class='fas fa-fw fa-plus'></i> Add user".html_safe, new_billing_project_user_path(project_name), class: 'btn btn-xs btn-success add-billing-project-user' %>
               <% end %>
               <%= scp_link_to "<i class='fas fa-fw fa-briefcase'></i> Workspaces".html_safe, billing_project_workspaces_path(project_name), class: 'btn btn-xs btn-primary view-workspaces' %>

--- a/app/views/billing_projects/index.html.erb
+++ b/app/views/billing_projects/index.html.erb
@@ -23,10 +23,10 @@
       <% @projects.each do |project_name, project_attributes| %>
         <tr id="<%= project_name %>" class="billing-project">
           <td class="project-name"><%= project_name %></td>
-          <td class="user-role"><%= project_attributes[:role] %></td>
+          <td class="user-role"><%= project_attributes[:roles].join(', ') %></td>
           <td><%= get_project_status_label(project_attributes[:status]) %></td>
           <td>
-            <% if project_attributes[:role] == 'Owner' %>
+            <% if project_attributes[:roles].include?('Owner') %>
               <% project_attributes[:members].each do |member| %>
                 <% email = member['email'] == @portal_service_account ? 'SCP Service Account' : member['email'] %>
                 <p><big><label class="label label-<%= get_billing_member_class(member['role']) %>" id="<%= project_name %>-<%= email_as_id(email) %>"><%= email %></label></big>

--- a/test/integration/external/fire_cloud_client_test.rb
+++ b/test/integration/external/fire_cloud_client_test.rb
@@ -384,7 +384,6 @@ class FireCloudClientTest < ActiveSupport::TestCase
     puts 'selecting project...'
     projects = @fire_cloud_client.get_billing_projects
     assert projects.any?, 'Did not find any billing projects'
-    puts projects
 
     # select a project (only valid projects, not in the compute denylist)
     project_name = projects.select do |p|

--- a/test/integration/external/fire_cloud_client_test.rb
+++ b/test/integration/external/fire_cloud_client_test.rb
@@ -384,11 +384,14 @@ class FireCloudClientTest < ActiveSupport::TestCase
     puts 'selecting project...'
     projects = @fire_cloud_client.get_billing_projects
     assert projects.any?, 'Did not find any billing projects'
+    puts projects
 
     # select a project (only valid projects, not in the compute denylist)
-    project_name = projects.select {|p| p['creationStatus'] == 'Ready' &&
+    project_name = projects.select do |p|
+      p['status'] == 'Ready' &&
         !FireCloudClient::COMPUTE_DENYLIST.include?(p['projectName']) &&
-        p['role'] == 'Owner'}.sample['projectName']
+        p['roles'].include?('Owner')
+    end.sample['projectName']
     assert project_name.present?, 'Did not select a billing project'
 
     # get users

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -9,9 +9,9 @@ class UserTest < ActiveSupport::TestCase
     @existing_api_token = @user.api_access_token
     @user.update_last_access_at!
     @billing_projects = [
-        {'creationStatus'=>'Ready', 'projectName'=>'lab-billing-project', 'role'=>'User'},
-        {'creationStatus'=>'Ready', 'projectName'=>'my-billing-project', 'role'=>'Owner'},
-        {'creationStatus'=>'Ready', 'projectName'=>'my-other-billing-project', 'role'=>'Owner'}
+      { status: 'Ready', projectName: 'lab-billing-project', role: 'User' },
+      { status: 'Ready', projectName: 'my-billing-project', role: 'Owner' },
+      { status: 'Ready', projectName: 'my-other-billing-project', role: 'Owner' }
     ]
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -9,9 +9,9 @@ class UserTest < ActiveSupport::TestCase
     @existing_api_token = @user.api_access_token
     @user.update_last_access_at!
     @billing_projects = [
-      { status: 'Ready', projectName: 'lab-billing-project', role: 'User' },
-      { status: 'Ready', projectName: 'my-billing-project', role: 'Owner' },
-      { status: 'Ready', projectName: 'my-other-billing-project', role: 'Owner' }
+      { status: 'Ready', projectName: 'lab-billing-project', roles: %w[User] },
+      { status: 'Ready', projectName: 'my-billing-project', roles: %w[Owner] },
+      { status: 'Ready', projectName: 'my-other-billing-project', roles: %w[Owner] }
     ]
   end
 


### PR DESCRIPTION
#### BACKGROUND && CHANGES
This update changes the `FireCloudClient` class to point at the updated [V2 billing API endpoints](https://api.firecloud.org/#/BillingV2) in the Terra orchestration API.  This is in response to the planned retirement of said endpoints.  No user-facing functionality will change, only the internal implementation of using the new endpoints.  This update also filters out any billing projects for which the user has no defined role (meaning they cannot be used for study creation), and fixes an issue on error handling when workspace creation fails that prevented the page from redirecting and showing the error message.  Lastly, this update removes the unused `create_billing_project` and `get_billing_accounts` methods from `FireCloudClient`, as we no longer allow either action since we removed the billing OAuth scope.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Select "My billing projects" from the profile nav menu
3. Confirm the page loads and that you see billing projects, and that those you own also list the members
4. Click the "Create a study" link at the top of the page
5. Confirm you see the same billing projects listed in the select menu for `Terra billing project`. 