### PR TITLE
Upgrade to N2D instances for ingest, allow AnnData extraction to scale VM dynamically (SCP-5291)

### DIFF
--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -107,11 +107,13 @@ class FileParseService
           # obsm_key is only set for parsing a new singular clustering
           if obsm_key.present?
             params_object = AnnDataIngestParameters.new(
-              anndata_file: study_file.gs_url, extract: %w[cluster], obsm_keys: [obsm_key]
+              anndata_file: study_file.gs_url, extract: %w[cluster], obsm_keys: [obsm_key],
+              file_size: study_file.upload_file_size
             )
           else
             params_object = AnnDataIngestParameters.new(
-              anndata_file: study_file.gs_url, obsm_keys: study_file.ann_data_file_info.obsm_key_names
+              anndata_file: study_file.gs_url, obsm_keys: study_file.ann_data_file_info.obsm_key_names,
+              file_size: study_file.upload_file_size
             )
           end
           # TODO extract and parse Raw Exp Data (SCP-4710)
@@ -119,7 +121,7 @@ class FileParseService
           # setting attributes to false/nil will omit them from the command line later
           # values are interchangeable but are more readable depending on parameter type
           params_object = AnnDataIngestParameters.new(
-            anndata_file: study_file.gs_url, extract: nil, obsm_keys: nil
+            anndata_file: study_file.gs_url, extract: nil, obsm_keys: nil, file_size: study_file.upload_file_size
           )
         end
         job = IngestJob.new(

--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -40,12 +40,30 @@ class AnnDataIngestParameters
     matrix_file_type: nil,
     gene_file: nil,
     barcode_file: nil,
-    subsample: false
+    subsample: false,
+    file_size: 0
   }.freeze
+
+  # values that are available as methods but not as attributes (and not passed to command line)
+  NON_ATTRIBUTE_PARAMS = %i[file_size].freeze
+
+  # GCE machine types and file size ranges for handling fragment extraction
+  # produces a hash with entries like { 'n2-highmem-4' => 0..4.gigabytes }
+  EXTRACT_MACHINE_TYPES = [4, 8, 16, 32, 64, 96].map.with_index do |memory, index|
+    floor = index == 0 ? 0 : (memory / 2).gigabytes
+    # ranges that use '...' exclude the given end value.
+    { "n2d-highmem-#{memory}" => floor...memory.gigabytes }
+  end.reduce({}, :merge)
 
   attr_accessor(*PARAM_DEFAULTS.keys)
 
   validates :anndata_file, :cluster_file, :cell_metadata_file, :matrix_file, :gene_file, :barcode_file,
             format: { with: Parameterizable::GS_URL_REGEXP, message: 'is not a valid GS url' },
             allow_blank: true
+
+  # determine which GCE machine type to use for fragment extraction based on file size
+  # see https://ruby-doc.org/core-3.1.0/Range.html#method-i-3D-3D-3D for range detection doc
+  def machine_type
+    EXTRACT_MACHINE_TYPES.detect { |_, mem_range| mem_range === file_size }&.first || 'n2d-highmem-4'
+  end
 end

--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -49,10 +49,11 @@ class AnnDataIngestParameters
 
   # GCE machine types and file size ranges for handling fragment extraction
   # produces a hash with entries like { 'n2-highmem-4' => 0..4.gigabytes }
-  EXTRACT_MACHINE_TYPES = [4, 8, 16, 32].map.with_index do |memory, index|
-    floor = index == 0 ? 0 : (memory / 2).gigabytes
+  EXTRACT_MACHINE_TYPES = [4, 8, 16, 32].map.with_index do |cores, index|
+    floor = index == 0 ? 0 : (cores / 2).gigabytes
+    limit = (cores * 8).gigabytes
     # ranges that use '...' exclude the given end value.
-    { "n2d-highmem-#{memory}" => floor...memory.gigabytes }
+    { "n2d-highmem-#{cores}" => floor...limit }
   end.reduce({}, :merge)
 
   attr_accessor(*PARAM_DEFAULTS.keys)

--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -49,7 +49,7 @@ class AnnDataIngestParameters
 
   # GCE machine types and file size ranges for handling fragment extraction
   # produces a hash with entries like { 'n2-highmem-4' => 0..4.gigabytes }
-  EXTRACT_MACHINE_TYPES = [4, 8, 16, 32, 64, 96].map.with_index do |memory, index|
+  EXTRACT_MACHINE_TYPES = [4, 8, 16, 32].map.with_index do |memory, index|
     floor = index == 0 ? 0 : (memory / 2).gigabytes
     # ranges that use '...' exclude the given end value.
     { "n2d-highmem-#{memory}" => floor...memory.gigabytes }

--- a/app/models/concerns/parameterizable.rb
+++ b/app/models/concerns/parameterizable.rb
@@ -16,7 +16,7 @@ module Parameterizable
 
   # acceptable Google N-machine types
   # https://cloud.google.com/compute/docs/general-purpose-machines
-  GCE_MACHINE_TYPES = %w[n1 n2].map do |family|
+  GCE_MACHINE_TYPES = %w[n2 n2d].map do |family|
     %w[standard highmem highcpu].map do |series|
       [2, 4, 8, 16, 32, 64, 96].map do |cores|
         [family, series, cores].join('-')

--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -15,7 +15,7 @@ class DifferentialExpressionParameters
   # matrix_file_type: type of raw counts matrix (dense, sparse)
   # gene_file (optional): genes/features file for sparse matrix
   # barcode_file (optional): barcodes file for sparse matrix
-  # machine_type (optional): override for default ingest machine type (uses 'n1-highmem-8')
+  # machine_type (optional): override for default ingest machine type (uses 'n2d-highmem-8')
   PARAM_DEFAULTS = {
     annotation_name: nil,
     annotation_type: 'group',
@@ -27,7 +27,7 @@ class DifferentialExpressionParameters
     matrix_file_type: nil,
     gene_file: nil,
     barcode_file: nil,
-    machine_type: 'n1-highmem-8'
+    machine_type: 'n2d-highmem-8'
   }.freeze
 
   # values that are available as methods but not as attributes (and not passed to command line)

--- a/app/models/image_pipeline_parameters.rb
+++ b/app/models/image_pipeline_parameters.rb
@@ -17,7 +17,7 @@ class ImagePipelineParameters
     environment: Rails.env.to_s,
     cores: nil,
     docker_image: Rails.application.config.image_pipeline_docker_image,
-    machine_type: 'n1-standard-8',
+    machine_type: 'n2d-standard-8',
     data_cache_perftime: nil
   }.freeze
 

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -405,6 +405,7 @@ class IngestJob
       set_anndata_file_info if study_file.is_anndata?
       create_cell_name_indexes
     when :ingest_expression
+      set_anndata_file_info if study_file.is_anndata?
       study.delay.set_gene_count
       launch_differential_expression_jobs
     when :ingest_cluster

--- a/app/models/life_sciences_api_client.rb
+++ b/app/models/life_sciences_api_client.rb
@@ -31,10 +31,10 @@ class LifeSciencesApiClient
   }.freeze
 
   # jobs that require custom virtual machine types (e.g. more RAM, CPU)
-  CUSTOM_VM_ACTIONS = %i[differential_expression render_expression_arrays image_pipeline].freeze
+  CUSTOM_VM_ACTIONS = %i[differential_expression render_expression_arrays image_pipeline ingest_anndata].freeze
 
   # default GCE machine_type
-  DEFAULT_MACHINE_TYPE = 'n1-highmem-4'.freeze
+  DEFAULT_MACHINE_TYPE = 'n2d-highmem-4'.freeze
 
   # default compute region
   DEFAULT_COMPUTE_REGION = 'us-central1'
@@ -280,7 +280,7 @@ class LifeSciencesApiClient
   # assign the VM to the corresponding project network.  Otherwise, the VM uses the default network.
   #
   # * *params*
-  #   - +machine_type+ (String) => GCP VM machine type (defaults to 'n1-highmem-4': 4 CPU, 26GB RAM)
+  #   - +machine_type+ (String) => GCP VM machine type (defaults to 'n2d-highmem-4': 4 CPU, 32GB RAM)
   #   - +boot_disk_size_gb+ (Integer) => Size of boot disk for VM, in gigabytes (defaults to 100GB)
   #   - +preemptible+ (Boolean) => Indication of whether VM can be preempted (defaults to false)
   #   - +labels+ (Hash) => Key/value pairs of labels for VM

--- a/test/models/ann_data_ingest_parameters_test.rb
+++ b/test/models/ann_data_ingest_parameters_test.rb
@@ -58,7 +58,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
     cmd = '--ingest-anndata --anndata-file gs://bucket_id/test.h5ad --obsm-keys ["X_umap", "X_tsne"] --extract ' \
           '["cluster", "metadata", "processed_expression"]'
     assert_equal cmd, extraction.to_options_array.join(' ')
-    assert_equal 'n2-highmem-16', extraction.machine_type
+    assert_equal 'n2d-highmem-16', extraction.machine_type
   end
 
   test 'should validate cluster params' do

--- a/test/models/ann_data_ingest_parameters_test.rb
+++ b/test/models/ann_data_ingest_parameters_test.rb
@@ -5,7 +5,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
   before(:all) do
     @extract_params = {
       anndata_file: 'gs://bucket_id/test.h5ad',
-      file_size: 10.gigabytes
+      file_size: 100.gigabytes
     }
 
     @file_id = BSON::ObjectId.new

--- a/test/models/differential_expression_parameters_test.rb
+++ b/test/models/differential_expression_parameters_test.rb
@@ -74,7 +74,7 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
 
   test 'should set default machine type for DE jobs' do
     params = DifferentialExpressionParameters.new
-    assert_equal 'n1-highmem-8', params.machine_type
+    assert_equal 'n2d-highmem-8', params.machine_type
   end
 
   test 'should remove non-attribute values from attribute hash' do

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -100,7 +100,7 @@ class IngestJobTest < ActiveSupport::TestCase
       pipeline: {
         resources: {
           virtualMachine: {
-            machineType: 'n1-highmem-4',
+            machineType: 'n2d-highmem-4',
             bootDiskSizeGb: 300
           }
         }
@@ -128,7 +128,7 @@ class IngestJobTest < ActiveSupport::TestCase
         numGenes: @basic_study.genes.count,
         is_raw_counts: false,
         numCells: num_cells,
-        machineType: 'n1-highmem-4',
+        machineType: 'n2d-highmem-4',
         bootDiskSizeGb: 300,
         exitStatus: 0
       }.with_indifferent_access
@@ -150,7 +150,7 @@ class IngestJobTest < ActiveSupport::TestCase
       pipeline: {
         resources: {
           virtualMachine: {
-            machineType: 'n1-highmem-4',
+            machineType: 'n2d-highmem-4',
             bootDiskSizeGb: 300
           }
         }
@@ -176,7 +176,7 @@ class IngestJobTest < ActiveSupport::TestCase
         numCells: 0,
         is_raw_counts: false,
         numGenes: 0,
-        machineType: 'n1-highmem-4',
+        machineType: 'n2d-highmem-4',
         bootDiskSizeGb: 300,
         exitStatus: 1
       }.with_indifferent_access

--- a/test/models/life_sciences_api_client_test.rb
+++ b/test/models/life_sciences_api_client_test.rb
@@ -238,7 +238,7 @@ class LifeSciencesApiClientTest < ActiveSupport::TestCase
       cluster_name: 'cluster.txt',
       matrix_file_path: @expression_matrix.gs_url,
       matrix_file_type: 'dense',
-      machine_type: 'n1-highmem-16'
+      machine_type: 'n2d-highmem-16'
     }
     de_params = DifferentialExpressionParameters.new(de_opts)
     de_cmd = @client.get_command_line(study_file: @cluster_file, action: :differential_expression,


### PR DESCRIPTION
#### BACKGROUND
When a user uploads an AnnData file, regardless of whether or not this is a "reference" file, SCP will still launch an ingest process to validate that the file can be opened, and that data can be read.  Since all ingest VMs are `n1-highmem-4` instances (4 cores, 26 GB RAM), this process will fail with a `137` exit code (OOM exception) if the files is too large as AnnData files are not streamed line-by-line by our ingest code like plain text files.  Additionally, while these instances are cost-effective and reliable, there are newer generations of virtual machines available in GCE.

#### CHANGES
This update switches all ingest VMs to use the [`N2D`](https://cloud.google.com/compute/docs/general-purpose-machines#n2d_machines) family, which is the latest generation of general-purpose VMs in GCE.  These machines are based on a newer AMD platform and offer better performance and cost savings over previous N-generation machines.  Also, like the `n2` family, they offer 8 GB of RAM per CPU as opposed to 6.5 in `n1` instances.

Additionally, AnnData ingest processes now dynamically scale the machine type based off of the size of the file, up to 256 GB (`n2d-highmem-32`).  This is only true for the initial extraction phase - all downstream jobs will still use `n2d-highmem-4` instances.  The reason for the capping on extraction size is purely for cost reasons as we pay per CPU + GB RAM hourly for VMs.  For reference, this is the cost per hour for all `n2d` instances, not counting persistent disks:
```
n2d-highmem-2: $0.11                                                                                  
n2d-highmem-4: $0.23                                                                                                                                                         
n2d-highmem-8: $0.46                                                                           
n2d-highmem-16: $0.91                                                                            
n2d-highmem-32: $1.82                                                                           
n2d-highmem-48: $2.73                                                                           
n2d-highmem-64: $3.64                                                                         
n2d-highmem-80: $4.55                                                                 
n2d-highmem-96: $5.47
```

It is worth noting that this places an effective limit on the size of AnnData files at 256 GB, but given that the largest in the portal as of right now is only ~12.5 GB, this seems like a reasonable cap. The file that failed to ingest that prompted this work was 27 GB, which would open on the standard `n2d-highmem-4` instance.  Lastly, this fixes a bug in `IngestJob` where the `gene_count` was not set correctly following processed expression extraction.

#### MANUAL TESTING
1. Start all services and log in
2. Create a new study, or go to an existing study and upload a new parseable file
3. In `development.log`, note that `machine_type` is changed:
```
...
:resources:
  :regions:
  - us-central1
  :virtual_machine:
    :boot_disk_size_gb: 300
    :labels:
      :study_accession: scp101
      :user_id: 63e27b72f39faa00560c1e25
      :filename: cluster_example_txt
      :action: ingest_pipeline
      :docker_image: scp-ingest-pipeline
      :docker_tag: '1_27_3'
      :environment: development
      :file_type: cluster
      :machine_type: n2d-highmem-4
      :boot_disk_size_gb: '300'
    :machine_type: n2d-highmem-4
...
```
4. To test VM scaling, enter a Rails console session and confirm you see the same output from the following commands:
```
params = AnnDataIngestParameters.new
=>
#<AnnDataIngestParameters:0x0000000109658920
...

params.machine_type
=> "n2d-highmem-4"

params.file_size = 50.gigabytes
=> 53687091200

params.machine_type
=> "n2d-highmem-8"

params.file_size = 100.gigabytes
=> 107374182400

params.machine_type
=> "n2d-highmem-16"
```