### PR TITLE
Updating to v2.2.1 for scp-rails-baseimage (SCP-5171)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use SCP base Rails image, configure only project-specific items here
-FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:2.2.0
+FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:2.2.1
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-3.1.3'


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates to version `2.2.1` of `broad-singlecellportal-staging/rails-baseimage`, which applies normal security patches on the underlying `ubuntu:2004` image.

#### MANUAL TESTING
1. Start your Docker engine locally
2. Boot the portal with `bin/docker-compose-setup.sh`
3. After all services start, confirm the home page loads