### PR TITLE
Fix reliability in pig related genes ideogram (SCP-5293)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "crossfilter2": "^1.5.4",
     "exifreader": "4.6.0",
     "fflate": "^0.7.3",
-    "ideogram": "1.44.0",
+    "ideogram": "1.44.1",
     "jquery": "3.5.1",
     "jquery-ui": "1.13.2",
     "morpheus-app": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5263,10 +5263,10 @@ iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ideogram@1.44.0:
-  version "1.44.0"
-  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.44.0.tgz#30af5fd22fe23c38260814d9a3836b4f70d6278c"
-  integrity sha512-OoNOR/LBtGNwrmLVDAafLMiQSRjZ2yd3JFqxavq9XtD4VeUrBHnN82XdXapTB8n6/JEL6m+7A4vFVHYEh79Uow==
+ideogram@1.44.1:
+  version "1.44.1"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.44.1.tgz#f5db448a6018841fae5b5db4bb251ccf816f2fbe"
+  integrity sha512-6ywrx4sCK50qXHPkBpABcq3wa14l0tTWs2NAqSQaZ6LfT6xPKUahN7P7GiGjc4mNc00TXeum7EawrejhTa1uOQ==
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"


### PR DESCRIPTION
This fixes slowness and reliability issues in related genes for pig (_Sus scrofa_), which affects some recently-initialized studies atop production, by pulling in a small upstream fix.

Here's how the fix looks:

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/df912490-cfab-4d17-8195-c6d31bf7a273

<span id="test"></span>
### Test
To manually test:
* If local: 
  * `yarn install --force`, then `bin/vite dev` (i.e., don't run with service worker caching)
  * Update a local study with all human genes to use "pig" as the species, by going to "Upload/Edit Data" and changing the "Species" drop-down from "human" to "pig"
* If on staging: go to https://singlecell-staging.broadinstitute.org/single_cell/study/SCP280/pig-all-genes
* Search a gene, e.g. RAD51
* Ensure it displays as shown in video

This satisfies SCP-5293.