### PR TITLE
Addressing CPU load in syncing large file counts (SCP-5295)

### DIFF
--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -518,6 +518,19 @@ module Api
                   end
                 end
               end
+              key :title, 'JSON object of StudyShares, StudyFiles, and DirectoryListings'
+              property :page_token do
+                key :type, :string
+                key :description, 'Token to next batch of files (if present)'
+              end
+              property :remaining_files do
+                key :type, :integer
+                key :description, 'Number of remaining files yet to process for sync'
+              end
+              property :next_page do
+                key :type, :string
+                key :description, 'URL for next page of results, with token (if present)'
+              end
             end
           end
           response 403 do
@@ -545,29 +558,114 @@ module Api
                       alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}.  #{SCP_SUPPORT_EMAIL}" and return
         end
 
-        # begin determining sync status with study_files and primary or other data
-        begin
-          @unsynced_files = StudySyncService.process_remotes(@study)
-        rescue => e
-          ErrorTracker.report_exception(e, current_user, @study, params)
-          MetricsService.report_error(e, request, current_user, @study)
-          logger.error "#{Time.zone.now}: error syncing files in workspace bucket #{@study.firecloud_workspace} due to error: #{e.message}"
-          redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
-                      alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}.  #{SCP_SUPPORT_EMAIL}" and return
+        sync_file_batch
+      end
+
+      swagger_path '/studies/{id}/sync_batch' do
+        operation :post do
+          key :tags, [
+            'Studies'
+          ]
+          key :summary, 'Sync a batch of files in a Study'
+          key :description, 'Synchronize a batch of remote files from GCS bucket for a study'
+          key :operationId, 'sync_batch_study_path'
+          parameter do
+            key :name, :id
+            key :in, :path
+            key :description, 'ID of Study to sync'
+            key :required, true
+            key :type, :string
+          end
+          parameter do
+            key :name, :page_token
+            key :in, :query
+            key :description, 'token for next batch of files'
+            key :required, true
+            key :type, :string
+          end
+          response 200 do
+            key :description, 'StudyShares, StudyFiles, and DirectoryListings'
+            schema do
+              key :title, 'JSON object of StudyShares, StudyFiles, and DirectoryListings'
+              property :study_shares do
+                key :type, :array
+                key :title, 'StudyShare array'
+                items do
+                  key :title, 'StudyShare'
+                  key :'$ref', :StudyShare
+                end
+              end
+              property :study_files do
+                key :type, :object
+                key :title, 'JSON object of synced, unsynced, and orphaned StudyFiles'
+                property :unsynced do
+                  key :title, 'Unsynced StudyFile array'
+                  key :type, :array
+                  items do
+                    key :title, 'StudyFile'
+                    key :'$ref', :StudyFile
+                  end
+                end
+                property :synced do
+                  key :title, 'Synced StudyFile array'
+                  key :type, :array
+                  items do
+                    key :title, 'StudyFile'
+                    key :'$ref', :StudyFile
+                  end
+                end
+                property :orphaned do
+                  key :title, 'Orphaned StudyFile array'
+                  key :type, :array
+                  items do
+                    key :title, 'StudyFile'
+                    key :'$ref', :StudyFile
+                  end
+                end
+              end
+              property :directory_listings do
+                key :type, :object
+                key :title, 'JSON object of synced and unsynced DirectoryListings'
+                property :unsynced do
+                  key :type, :array
+                  key :title, 'Unsynced DirectoryListing array'
+                  items do
+                    key :title, 'DirectoryListing'
+                    key :'$ref', :DirectoryListing
+                  end
+                end
+                property :synced do
+                  key :type, :array
+                  key :title, 'Synced DirectoryListing array'
+                  items do
+                    key :title, 'DirectoryListing'
+                    key :'$ref', :DirectoryListing
+                  end
+                end
+              end
+              property :page_token do
+                key :type, :string
+                key :description, 'Token to next batch of files (if present)'
+              end
+              property :remaining_files do
+                key :type, :integer
+                key :description, 'Number of remaining files yet to process for sync'
+              end
+            end
+          end
+          response 403 do
+            key :description, ApiBaseController.forbidden('edit Study')
+          end
+          extend SwaggerResponses::StudyControllerResponses
+          response 500 do
+            key :description, 'Server error when attempting to synchronize FireCloud workspace or access GCS objects'
+          end
         end
+      end
 
-        # refresh study state before continuing as new records may have been inserted
-        @study.reload
-        @synced_directories = @study.directory_listings.are_synced
-        @unsynced_directories = @study.directory_listings.unsynced
-
-        # split directories into primary data types and 'others'
-        @unsynced_primary_data_dirs, @unsynced_other_dirs = StudySyncService.load_unsynced_directories(@study)
-
-        # now determine if we have study_files that have been 'orphaned' (cannot find a corresponding bucket file)
-        @orphaned_study_files = StudySyncService.find_orphaned_files(@study)
-        @available_files = StudySyncService.set_available_files(@unsynced_files)
-        @synced_study_files = StudySyncService.set_synced_files(@study, @orphaned_study_files)
+      def sync_next_file_batch
+        sync_file_batch
+        render action: :sync_study
       end
 
       swagger_path '/studies/{id}/manifest' do
@@ -625,6 +723,36 @@ module Api
         manifest_obj = BulkDownloadService.generate_study_files_tsv(@study, include_dirs)
         response.headers['Content-Disposition'] = 'attachment; filename=file_supplemental_info.tsv'
         render plain: manifest_obj
+      end
+
+      # sync a batch of up to 1000 remote files
+      def sync_file_batch
+        # begin determining sync status with study_files and primary or other data
+        begin
+          remote_info = StudySyncService.process_remotes(@study, token: params[:page_token])
+          @unsynced_files = remote_info[:unsynced_study_files]
+          @next_page = remote_info[:page_token]
+          @remaining_files = remote_info[:remaining_files]
+        rescue => e
+          ErrorTracker.report_exception(e, current_user, @study, params)
+          MetricsService.report_error(e, request, current_user, @study)
+          logger.error "#{Time.zone.now}: error syncing files in workspace bucket #{@study.firecloud_workspace} due to error: #{e.message}"
+          redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
+                      alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}.  #{SCP_SUPPORT_EMAIL}" and return
+        end
+
+        # refresh study state before continuing as new records may have been inserted
+        @study.reload
+        @synced_directories = @study.directory_listings.are_synced
+        @unsynced_directories = @study.directory_listings.unsynced
+
+        # split directories into primary data types and 'others'
+        @unsynced_primary_data_dirs, @unsynced_other_dirs = StudySyncService.load_unsynced_directories(@study)
+
+        # now determine if we have study_files that have been 'orphaned' (cannot find a corresponding bucket file)
+        @orphaned_study_files = StudySyncService.find_orphaned_files(@study)
+        @available_files = StudySyncService.set_available_files(@unsynced_files)
+        @synced_study_files = StudySyncService.set_synced_files(@study, @orphaned_study_files)
       end
 
       private

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -547,7 +547,7 @@ module Api
 
         # begin determining sync status with study_files and primary or other data
         begin
-          @unsynced_files = StudySyncService.process_all_remotes(@study)
+          @unsynced_files = StudySyncService.process_remotes(@study)
         rescue => e
           ErrorTracker.report_exception(e, current_user, @study, params)
           MetricsService.report_error(e, request, current_user, @study)

--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -65,21 +65,4 @@ module StudiesHelper
       end
     end
   end
-
-  def sync_next_batch_link(study, remaining_files, page_token)
-    if remaining_files > 0
-      btn_class = 'btn-success'
-      disabled = false
-      original_title = 'Sync next batch of remote files'
-    else
-      btn_class = 'btn-default'
-      disabled = true
-      original_title = 'All remote files processed'
-    end
-    link_to "#{remaining_files} files remaining",
-            sync_next_file_batch_study_path(study, page_token:),
-            class: "btn #{btn_class} pull-right",
-            disabled:,
-            data: { toggle: 'tooltip', original_title:, placement: 'left' }
-  end
 end

--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -65,4 +65,21 @@ module StudiesHelper
       end
     end
   end
+
+  def sync_next_batch_link(study, remaining_files, page_token)
+    if remaining_files > 0
+      btn_class = 'btn-success'
+      disabled = false
+      original_title = 'Sync next batch of remote files'
+    else
+      btn_class = 'btn-default'
+      disabled = true
+      original_title = 'All remote files processed'
+    end
+    link_to "#{remaining_files} files remaining",
+            sync_next_file_batch_study_path(study, page_token:),
+            class: "btn #{btn_class} pull-right",
+            disabled:,
+            data: { toggle: 'tooltip', original_title:, placement: 'left' }
+  end
 end

--- a/app/lib/study_sync_service.rb
+++ b/app/lib/study_sync_service.rb
@@ -94,11 +94,11 @@ class StudySyncService
   # * *params*
   #   - +study+ (Study) => study to process remote files for
   #   - +token+ (String) => pointer to next page of files
-  #   - +batch_size+ (Integer) => amount of files to retrieve, defaulting to BATCH_SIZE + 1 (max param is non-inclusive)
+  #   - +batch_size+ (Integer) => amount of files to retrieve, defaulting to BATCH_SIZE
   #
   # * *returns*
   #   - (Google::Cloud::Storage::File::List)
-  def self.get_file_batch(study, token: nil, batch_size: BATCH_SIZE + 1)
+  def self.get_file_batch(study, token: nil, batch_size: BATCH_SIZE)
     ApplicationController.firecloud_client.execute_gcloud_method(
       :get_workspace_files, 0,
       study.bucket_id, delimiter: '_scp_internal', token:, max: batch_size

--- a/app/lib/study_sync_service.rb
+++ b/app/lib/study_sync_service.rb
@@ -1,7 +1,7 @@
 # collection of methods to be called during sync actions
 class StudySyncService
   # batch size for remote file processing
-  # value is mostly used for messaging & tests when overriden
+  # value is mostly used for messaging & tests when overridden
   BATCH_SIZE = 1000
 
   # mirror local permissions to that of the workspace

--- a/app/lib/study_sync_service.rb
+++ b/app/lib/study_sync_service.rb
@@ -94,13 +94,14 @@ class StudySyncService
   # * *params*
   #   - +study+ (Study) => study to process remote files for
   #   - +token+ (String) => pointer to next page of files
+  #   - +batch_size+ (Integer) => amount of files to retrieve, defaulting to BATCH_SIZE + 1 (max param is non-inclusive)
   #
   # * *returns*
   #   - (Google::Cloud::Storage::File::List)
-  def self.get_file_batch(study, token: nil)
+  def self.get_file_batch(study, token: nil, batch_size: BATCH_SIZE + 1)
     ApplicationController.firecloud_client.execute_gcloud_method(
       :get_workspace_files, 0,
-      study.bucket_id, delimiter: '_scp_internal', token:, max: BATCH_SIZE + 1 # max is non-inclusive
+      study.bucket_id, delimiter: '_scp_internal', token:, max: batch_size
     )
   end
 

--- a/app/views/api/v1/studies/sync_study.json.jbuilder
+++ b/app/views/api/v1/studies/sync_study.json.jbuilder
@@ -8,3 +8,10 @@ json.directory_listings do
   json.unsynced @unsynced_directories, partial: 'api/v1/directory_listings/directory_listing', as: :directory_listing
   json.synced @synced_directories, partial: 'api/v1/directory_listings/directory_listing', as: :directory_listing
 end
+json.set! :page_token, @next_page
+json.set! :remaining_files, @remaining_files
+if @next_page
+  json.set! :next_page, sync_batch_api_v1_study_url(
+    @study, page_token: @next_page, host: RequestUtils.get_hostname
+  )
+end

--- a/app/views/studies/sync_study.html.erb
+++ b/app/views/studies/sync_study.html.erb
@@ -60,6 +60,20 @@
   </div>
 <% end %>
 
+<% if @next_page.present? %>
+  <div class="bs-callout bs-callout-danger" id='files-remaining-notice'>
+    <h4>Unprocessed remote files: <%= @remaining_files %></h4>
+    <p>
+      For performance reasons, Single Cell Portal only reads remote files in batches of <%= StudySyncService::BATCH_SIZE %>.
+      We have detected that there are still <%= @remaining_files %> left to be processed in your study's bucket.  Please
+      use the link below to continue processing once you have completed syncing files in this batch.
+    </p>
+    <%= link_to "Process next batch <span class='fa fas fa-chevron-right'></span>".html_safe,
+                sync_next_file_batch_study_path(@study, page_token: @next_page),
+                class: "btn btn-default" %>
+  </div>
+<% end %>
+
 <div id="sync-files-target">
   <% if @orphaned_study_files.any? %>
     <div class="panel panel-danger">
@@ -144,20 +158,6 @@
       </div>
     </div>
 
-  <% end %>
-
-  <% if @next_page.present? %>
-    <div class="bs-callout bs-callout-danger" id='files-remaining-notice'>
-      <h4>Unprocessed remote files: <%= @remaining_files %></h4>
-      <p>
-        For performance reasons, Single Cell Portal only reads remote files in batches of <%= StudySyncService::BATCH_SIZE %>.
-        We have detected that there are still <%= @remaining_files %> left to be processed in your study's bucket.  Please
-        use the link below to continue processing once you have completed syncing files in this batch.
-      </p>
-      <%= link_to "Process next batch <span class='fa fas fa-chevron-right'></span>".html_safe,
-                  sync_next_file_batch_study_path(@study, page_token: @next_page),
-                  class: "btn btn-default" %>
-    </div>
   <% end %>
 
   <hr class="divider" />

--- a/app/views/studies/sync_study.html.erb
+++ b/app/views/studies/sync_study.html.erb
@@ -49,10 +49,8 @@
     >
       Take a 3-question survey to help improve sync
     </a>
-    <%= sync_next_batch_link(@study, @remaining_files, @next_page) %>
   </div>
 </div>
-
 
 <% if params[:configuration_name].present? && @special_sync %>
   <div class="bs-callout bs-callout-default">
@@ -146,6 +144,20 @@
       </div>
     </div>
 
+  <% end %>
+
+  <% if @next_page.present? %>
+    <div class="bs-callout bs-callout-danger" id='files-remaining-notice'>
+      <h4>Unprocessed remote files: <%= @remaining_files %></h4>
+      <p>
+        For performance reasons, Single Cell Portal only reads remote files in batches of <%= StudySyncService::BATCH_SIZE %>.
+        We have detected that there are still <%= @remaining_files %> left to be processed in your study's bucket.  Please
+        use the link below to continue processing once you have completed syncing files in this batch.
+      </p>
+      <%= link_to "Process next batch <span class='fa fas fa-chevron-right'></span>".html_safe,
+                  sync_next_file_batch_study_path(@study, page_token: @next_page),
+                  class: "btn btn-default" %>
+    </div>
   <% end %>
 
   <hr class="divider" />

--- a/app/views/studies/sync_study.html.erb
+++ b/app/views/studies/sync_study.html.erb
@@ -49,6 +49,7 @@
     >
       Take a 3-question survey to help improve sync
     </a>
+    <%= sync_next_batch_link(@study, @remaining_files, @next_page) %>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -198,6 +198,7 @@ Rails.application.routes.draw do
       member do
         get 'upload', to: 'studies#initialize_study', as: :initialize
         get 'sync', to: 'studies#sync_study', as: :sync
+        get 'sync_batch', to: 'studies#sync_next_file_batch', as: :sync_next_file_batch
         get 'sync/:submission_id', to: 'studies#sync_submission_outputs', as: :sync_submission_outputs
         patch 'upload', to: 'studies#do_upload'
         get 'resume_upload', to: 'studies#resume_upload'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
             resources :external_resources, only: [:index, :show, :create, :update, :destroy]
             member do
               post 'sync', to: 'studies#sync_study'
+              get 'sync_batch', to: 'studies#sync_next_file_batch'
               get 'manifest', to: 'studies#generate_manifest'
               get 'file_info', to: 'studies#file_info'
               get 'usage_stats', to: 'studies#usage_stats'

--- a/test/services/study_sync_service_test.rb
+++ b/test/services/study_sync_service_test.rb
@@ -26,7 +26,7 @@ class StudySyncServiceTest < ActiveSupport::TestCase
   end
 
   test 'should process all remotes' do
-    unsynced_files = StudySyncService.process_all_remotes(@full_study)
+    unsynced_files = StudySyncService.process_remotes(@full_study)
     unsynced_metadata = unsynced_files.detect { |f| f.name == 'metadata_example.txt' }
     assert unsynced_metadata.present?
   end


### PR DESCRIPTION
#### BACKGROUND
A recent production outage was found to have been caused by a user attempting to sync a study with 32K+ files in their workspace bucket.  Since sync will attempt to process all files at once - and will construct a map of folders/file types in memory - this caused the CPU to gradually increase over a span of tens of minutes.  Unfortunately, due to the long-running nature of the request, it eventually failed and caused the user to retry the operation repeatedly.  This eventually consumed all available CPU and caused the load balancer to block incoming requests after nginx responded `502`.

#### CHANGES
This update now limits all sync actions to 1000 files, and adds in a minimal pagination feature to notify the user how many remaining files there are, and gives them a link to process the next batch of 1000.  This batched sync will also only process workspace permissions on the first request, and all downstream calls only process files, not the workspace ACL.  This new functionality has been implemented in both the standard Rails MVC & API portions of the application.

Example notification of remaining files (with artificial batch size of 30)
<img width="1413" alt="Screenshot 2023-09-12 at 2 57 28 PM" src="https://github.com/broadinstitute/single_cell_portal_core/assets/729968/309996a5-07b1-4347-99e7-3d3809bb0fe8">


#### MANUAL TESTING
1. Boot as normal and sign in
2. Create a new study through the UI, then once you see the upload wizard, return to the 'My Studies' page
3. In a separate Rails console session, run the following block to seed the workspace bucket with files to process via sync:
```
study = Study.last
client = FireCloudClient.new
bucket = client.get_workspace_bucket(study.bucket_id)
file = File.open('test/test_data/metadata_example.txt')
puts "pushing #{File.basename(file)} to #{study.bucket_id}"
bucket.create_file file, File.basename(file)
Dir.chdir('tmp')
directory = 'file_type'
Dir.mkdir(directory)
50.times do
  filename = "#{directory}/#{SecureRandom.uuid}.csv"
  FileUtils.touch filename
  local = File.open(filename)
  puts "pushing #{filename} to #{study.bucket_id}"
  bucket.create_file local, filename
end
```
4. In `app/lib/study_sync_service.rb`, line 5, set `BATCH_SIZE` to `30` for testing
5. Back in the UI, find the entry for your new study, click the context menu on the right and select 'Sync workspace files'
6. Once the sync page loads, confirm you see the same message as above at the top of the page
7. Note the `DirectoryListing` for the `file_type` folder has `30` files
8. Click the link to `Process next batch`
9. Once the page loads, note you have a form for `metadata_example.txt`, and the file count for `file_type` has increased to `50`