### PR TITLE
Restore manual Appcue pin for visualization tour of SCP viz demo study (SCP-5254)

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -165,6 +165,7 @@ class SiteController < ApplicationController
     # normally we would do this in React but the tab display is in the Rails HTML view
     # we need to check server-side since we have to account for @study.can_visualize? as well
     @explore_tab_default = @study.can_visualize?
+    @show_appcue_pin = FeatureFlaggable.feature_flags_for_instances(current_user).[](:show_appcue_viz_tour)
   end
 
   def record_download_acceptance

--- a/app/javascript/components/HomePageContent.jsx
+++ b/app/javascript/components/HomePageContent.jsx
@@ -10,7 +10,7 @@ import ResultsPanel from '~/components/search/results/ResultsPanel'
 import StudyDetails from '~/components/search/results/StudySearchResult'
 import StudySearchProvider, { StudySearchContext } from '~/providers/StudySearchProvider'
 import SearchFacetProvider from '~/providers/SearchFacetProvider'
-import UserProvider from '~/providers/UserProvider'
+import UserProvider, { getFeatureFlagsWithDefaults } from '~/providers/UserProvider'
 import ErrorBoundary from '~/lib/ErrorBoundary'
 
 /** include search controls and results */
@@ -22,12 +22,17 @@ export function StudySearchView() {
   </>
 }
 
+
+
 const LinkableSearchTabs = function(props) {
   // we can't use the regular ReachRouter methods for link highlighting
   // since the Reach router doesn't own the home path
   const location = useLocation()
   const basePath = location.pathname.includes('covid19') ? '/single_cell/covid19' : '/single_cell'
   const showGenesTab = location.pathname.includes('/app/genes')
+  const featureFlags = getFeatureFlagsWithDefaults()
+  const showVizAppcue = featureFlags && featureFlags?.show_appcue_viz_tour
+
   // the queryParams object does not support the more typical hasOwnProperty test
   return (
     <div>
@@ -40,6 +45,9 @@ const LinkableSearchTabs = function(props) {
           className={showGenesTab ? 'active' : ''}>
           <span className="fas fa-dna"></span> Search genes
         </Link>
+        { showVizAppcue &&
+          <a className='appcue-pin' href='single_cell/study/SCP2221'>Take a tour of SCP's visualization tools</a>
+        }
       </nav>
       <div className="tab-content top-pad">
         <Router basepath={basePath}>

--- a/app/javascript/components/HomePageContent.jsx
+++ b/app/javascript/components/HomePageContent.jsx
@@ -46,7 +46,11 @@ const LinkableSearchTabs = function(props) {
           <span className="fas fa-dna"></span> Search genes
         </Link>
         { showVizAppcue &&
-          <a className='appcue-pin' href='single_cell/study/SCP2221'>Take a tour of SCP's visualization tools</a>
+          <a className='btn btn-primary appcue-pin'
+             href='https://singlecell.broadinstitute.org/single_cell/study/SCP2271'
+             data-analytics-name='appcue-viz-demo'>
+            Demo of SCP visualization tools
+          </a>
         }
       </nav>
       <div className="tab-content top-pad">

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -36,6 +36,23 @@ label {
   color: palegoldenrod;
 }
 
+.appcue-pin {
+  background-color: rgb(51, 122, 183);
+  border-radius: 6px;
+  color: rgb(255, 255, 255);
+  cursor: pointer;
+  display: inline-block;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  height: 16px;
+  line-height: normal;
+  padding-bottom: 8px;
+  padding-left: 18px;
+  padding-right: 18px;
+  padding-top: 8px;
+  text-align: center;
+}
+
 .red {
   color: #d9534f;
 }

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -37,20 +37,9 @@ label {
 }
 
 .appcue-pin {
-  background-color: rgb(51, 122, 183);
-  border-radius: 6px;
-  color: rgb(255, 255, 255);
-  cursor: pointer;
-  display: inline-block;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 14px;
-  height: 16px;
-  line-height: normal;
-  padding-bottom: 8px;
-  padding-left: 18px;
-  padding-right: 18px;
-  padding-top: 8px;
-  text-align: center;
+  color: rgb(255, 255, 255) !important;
+  padding: 5px 10px !important;
+  font-size: 14px !important;
 }
 
 .red {

--- a/app/views/site/_study_tabs_nav.html.erb
+++ b/app/views/site/_study_tabs_nav.html.erb
@@ -56,7 +56,15 @@
             Settings <i class="fas fa-fw fa-cogs"></i>
           </a>
         </li>
+
       <% end %>
     <% end %>
   <% end %>
+  <% if @show_appcue_pin %>
+    <%= link_to 'Demo of SCP visualization tools',
+                'https://singlecell.broadinstitute.org/single_cell/study/SCP2271',
+                class: 'btn btn-primary top-margin-5 appcue-pin',
+                data: { analytics_name: 'appcue-viz-demo' } %>
+  <% end %>
 </ul>
+

--- a/db/migrate/20230913140856_create_show_appcue_viz_tour_feature_flag.rb
+++ b/db/migrate/20230913140856_create_show_appcue_viz_tour_feature_flag.rb
@@ -1,0 +1,11 @@
+class CreateShowAppcueVizTourFeatureFlag < Mongoid::Migration
+  def self.up
+    FeatureFlag.create!(name: 'show_appcue_viz_tour',
+                        default_value: false,
+                        description: "show the 'Take a tour of SCP's visualization tools' Appcue")
+  end
+
+  def self.down
+    FeatureFlag.retire_feature_flag('show_appcue_viz_tour')
+  end
+end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds in a manual button to link to the [Demo visualization study](https://singlecell.broadinstitute.org/single_cell/study/SCP2271/scp-visualizations-demo) on production.  Visibility of this flag is governed by the feature flag `show_appcue_viz_tour`.  

Examples of button on home page:
<img width="563" alt="appcue_button_home" src="https://github.com/broadinstitute/single_cell_portal_core/assets/729968/72a60598-36f3-4614-9346-b1e8e0ca7028">

And study overview page:
<img width="741" alt="appcue_button_study" src="https://github.com/broadinstitute/single_cell_portal_core/assets/729968/4c84fd12-be42-4b81-a5e7-b535687da078">

#### MANUAL TESTING
1. Run the new migration to create the feature flag
2. Boot as normal and note there is no button on the home page or on any study overview page
3. Sign in, and go to the "[Feature flags](https://localhost:3000/single_cell/feature_flags)" admin page, then set the flag override on your user account for `show_appcue_viz_tour` to `true`
4. Go back to the home page and confirm the button is shown
5. Load any study and confirm the button is present there as well
6. Open Chrome Dev Tools > Network
7. Click the link, confirm you are redirected to SCP2271 on production
8. Back in the Network tab, confirm you see a Mixpanel event for `click:tab` with the `text` value of `appcue-viz-demo` (the `tab` event is because these links are inside tabs on both pages)