### PR TITLE
Revert to using the previous class picker for CSS for Explore panel (SCP-5309)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -230,6 +230,37 @@ export default function ExploreDisplayTabs({
     setRenderForcer({})
   }, 300)
 
+
+  /** Get widths for main (plots) and side (options, DE, or FF) panels, for current Explore state */
+  function getPanelWidths() {
+    let main
+    let side
+    const isSelectingDE = showDifferentialExpressionPanel || showUpstreamDifferentialExpressionPanel
+    if (showViewOptionsControls) {
+      if (
+        (deGenes !== null) ||
+          (hasPairwiseDe && (showDifferentialExpressionPanel || showUpstreamDifferentialExpressionPanel))
+      ) {
+        // DE table is shown, or pairwise DE is available.  Least horizontal space for plots.
+        main = 'col-md-9'
+        side = 'col-md-3'
+      } else if (panelToShow === 'FF') {
+        main = 'col-md-10'
+        side = 'col-md-2'
+      } else {
+        // Default state, when side panel is "Options" and not collapsed
+        main = 'col-md-10'
+        // only set options-bg if we're outside the DE UX
+        side = isSelectingDE ? 'col-md-2' : 'col-md-2 options-bg'
+      }
+    } else {
+      // When options panel is collapsed.  Maximize horizontal space for plots.
+      main = 'col-md-12'
+      side = 'hidden'
+    }
+    return { main, side }
+  }
+
   return (
     <>
       {/* Render top content for Explore view, i.e. gene search box and plot tabs */}
@@ -265,7 +296,7 @@ export default function ExploreDisplayTabs({
 
       {/* Render plots for the given Explore view state */}
       <div className="row explore-tab-content">
-        <div className="flexible-plot-space">
+        <div className={getPanelWidths().main}>
           <div className="explore-plot-tab-content row">
             { showRelatedGenesIdeogram &&
               <RelatedGenesIdeogram
@@ -424,11 +455,7 @@ export default function ExploreDisplayTabs({
                 <FontAwesomeIcon className="fa-lg" icon={faEye}/>
               </button>
         }
-        {!enabledTabs.includes('loading') && <div
-          className={showViewOptionsControls ?
-            `flexible-plot-space panel-specifics ${panelToShow}-options-bg` : 'hidden'
-          }
-        >
+        <div className={getPanelWidths().side}>
           <ExploreDisplayPanelManager
             studyAccession = {studyAccession}
             exploreInfo={exploreInfo}
@@ -458,7 +485,7 @@ export default function ExploreDisplayTabs({
             panelToShow ={panelToShow}
             toggleViewOptions= {toggleViewOptions}
           />
-        </div>}
+        </div>
       </div>
     </>
   )

--- a/app/javascript/styles/_differentialExpression.scss
+++ b/app/javascript/styles/_differentialExpression.scss
@@ -162,7 +162,7 @@
   .vs-note {
     position: relative;
     top: 10px;
-    margin-left: 10px;
+    margin-left: 5px;
   }
 }
 

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -50,7 +50,7 @@
   }
 
   .plot-title {
-    margin-left: 1em;
+    margin-left: 1.5em;
     margin-top: 0.5em;
 
     .badge {
@@ -77,6 +77,7 @@
 .explore-tab-content {
   background: #fff;
   display: flex;
+  flex-wrap: wrap;
 
   button.action {
     background: #fff;
@@ -138,6 +139,7 @@
 }
 
 .explore-plot-tab-content {
+  border-right: 1px solid #ccc;
   min-height: 70vh;
 }
 
@@ -255,24 +257,6 @@
   margin-right: 10px;
 }
 
-.default-options-bg {
-  background: $options-color;
-  border-bottom: 1px solid #ccc;
-  max-width: 235px;
-  padding-left: 12px;
-  padding-right: 12px;
-}
-
-.DE-options-bg {
-  max-width: 345px;
-  padding-left: 17px;
-  padding-right: 14px;
-}
-
-.CFF-options-bg {
-  max-width: 235px;
-}
-
 .options-bg {
   background: $options-color;
   border-bottom: 1px solid #ccc;
@@ -291,11 +275,7 @@
   z-index: 3;
 }
 
-.flexible-plot-space{
-  flex-grow: 1;
-}
-
 .panel-specifics{
   border-left: 1px solid #ccc;
-  margin-left: 26px;
+  margin-left: 28px;
 }


### PR DESCRIPTION
I had tried to change the way the class/CSS was chosen for the different panels for the Explore tab but I think the original way was more effective. This returns to that convention. If you look at[ the old PR](https://github.com/broadinstitute/single_cell_portal_core/pull/1878/files#diff-d56fa6c127e17ffa714e80c992b809c04b0dda9a45a93425adca8a56f0d607c2L264) and search `getPanelWidths` you can find the original function. 

To test:
- Pull this branch and boot up a local server
- Go to a study that has Differential Expression
- Check that the explore tab looks good, the panel hides when appropriate, the loading state looks normal and the DE panel is sized okay

BEFORE:
Misaligned selects:
![Screenshot 2023-09-19 at 2 54 51 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/e6cfb0dd-9a9f-4500-a9b0-2dacbee3a45e)

Wrapping didn't work so once very very small panel was just inaccessible:
![Screenshot 2023-09-19 at 2 55 11 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/80611561-fcc1-40c9-b713-75334b414904)



NOW:

https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/0c53aa8c-3247-4561-8f7c-3c95567464cb

