### PR TITLE
Re-plot filtered cells from cell faceting as mostly transparent (SCP-5277)

### DIFF
--- a/app/javascript/components/explore/FacetFilterPanel.jsx
+++ b/app/javascript/components/explore/FacetFilterPanel.jsx
@@ -215,7 +215,7 @@ export function FacetFilterPanel({
           <h5>Filter plotted points by:
             <a className="action help-icon"
                data-toggle="tooltip"
-               data-original-title="Use the checkboxes to filter points from the plot.  Unselected values are
+               data-original-title="Use the checkboxes to filter points from the plot.  Deselected values are
                 assigned to the '--Filtered--' group. Hover over this legend entry to highlight."
 
           >

--- a/app/javascript/components/explore/FacetFilterPanel.jsx
+++ b/app/javascript/components/explore/FacetFilterPanel.jsx
@@ -212,9 +212,13 @@ export function FacetFilterPanel({
         </label>
         { Object.keys(checkedMap).length !== 0 &&
         <div style={{ 'marginTop': '5px' }}>
-          <h5>Filter plotted points by: <a className="action help-icon"
-            data-toggle="tooltip"
-            data-original-title="Use the checkboxes to add and remove points from the plot.">
+          <h5>Filter plotted points by:
+            <a className="action help-icon"
+               data-toggle="tooltip"
+               data-original-title="Use the checkboxes to filter points from the plot.  Unselected values are
+                assigned to the '--Filtered--' group. Hover over this legend entry to highlight."
+
+          >
             <FontAwesomeIcon icon={faInfoCircle}/>
           </a></h5>
           <div style={{ border: '1px solid black', margin: '2px', padding: '2px' }}>

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -961,9 +961,10 @@ ScatterPlot.intersect = intersect
  * @returns {Object} reorganized scatter data object with new --Filtered-- trace
  */
 export function reassignFilteredCells(plotted, originalData, filteredData) {
-  const allIndexes = [...Array(originalData['x'].length).keys()]
+  const reassignedIndices = []
   const plottedSet = new Set(plotted)
-  const reassignedIndices = allIndexes.filter(i => !plottedSet.has(i))
+  for (let i = 0;  i < 1e6; i++)
+    if (!plottedSet.has(i)) reassignedIndices.push(i)
   const newPlotData = {}
   const keys = Object.keys(originalData)
   keys.forEach(key =>  {

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -930,7 +930,9 @@ export function intersect(filteredCells, scatter) {
   const dataArrays = scatter.data
   const keys = Object.keys(dataArrays)
   keys.forEach(key => intersectedData[key] = [])
-  window.dataArrays = dataArrays
+  // Uncomment for debugging, but be sure to comment out before PR
+  // window.dataArrays = dataArrays
+
   // array of cell indexes that are being plotted
   const plotted = []
   for (let i = 0; i < filteredCells.length; i++) {
@@ -941,7 +943,7 @@ export function intersect(filteredCells, scatter) {
       const key = keys[j]
       const dataArray = dataArrays[key]
       const filteredElement = dataArray[allCellsIndex]
-      intersectedData[keys[j]].push(filteredElement)
+      intersectedData[key].push(filteredElement)
     }
   }
   return [intersectedData, plotted]
@@ -960,9 +962,8 @@ ScatterPlot.intersect = intersect
  */
 export function reassignFilteredCells(plotted, originalData, filteredData) {
   const allIndexes = [...Array(originalData['x'].length).keys()]
-  const originalSet = new Set(allIndexes)
   const plottedSet = new Set(plotted)
-  const reassignedIndices = [...originalSet].filter(i => !plottedSet.has(i))
+  const reassignedIndices = allIndexes.filter(i => !plottedSet.has(i))
   const newPlotData = {}
   const keys = Object.keys(originalData)
   keys.forEach(key =>  {
@@ -982,8 +983,8 @@ export function reassignFilteredCells(plotted, originalData, filteredData) {
       }
     }
   }
-  for (let j = 0; j < keys.length; j++) {
-    const key = keys[j]
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i]
     newPlotData[key].push(...filteredData[key])
   }
   return newPlotData

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -963,7 +963,7 @@ ScatterPlot.intersect = intersect
 export function reassignFilteredCells(plotted, originalData, filteredData) {
   const reassignedIndices = []
   const plottedSet = new Set(plotted)
-  for (let i = 0;  i < 1e6; i++)
+  for (let i = 0;  i < originalData['x'].length; i++)
     if (!plottedSet.has(i)) reassignedIndices.push(i)
   const newPlotData = {}
   const keys = Object.keys(originalData)

--- a/app/javascript/lib/cluster-utils.js
+++ b/app/javascript/lib/cluster-utils.js
@@ -19,6 +19,8 @@ export const emptyDataParams = {
 }
 
 export const UNSPECIFIED_ANNOTATION_NAME = '--Unspecified--'
+export const FILTERED_TRACE_NAME = '--Filtered--'
+export const FILTERED_TRACE_COLOR = 'rgba(225, 225, 225, 0.1)'
 
 /** takes the server response and returns subsample default subsample for the cluster */
 export function getDefaultSubsampleForCluster(annotationList, clusterName) {


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update changes the behavior of the cell faceting feature to re-plot filtered groups as mostly transparent, light grey points instead of completely removing them.  This retains the original shape of the plot while also clearly demonstrating which cells have been filtered.  In addition, these cells are added to a new trace called `--Filtered--`, which can also be hovered over in the legend to bring them to the front for closer inspection.

Also, this update refactors the `intersect` and `reassignFilteredCells` functions outside of the `ScatterPlot` component to allow them to be tested directly, while still preserving HMR in local development.

Demo of new plotting behavior:

https://github.com/broadinstitute/single_cell_portal_core/assets/729968/e13b2e13-e3a3-48ba-8e3d-57c4502c578c

Note: If you are performing cell faceting on anything other than the default annotation, selecting groups will cause a full reload of the scatter plot, including calling the API.  This has been tracked in SCP-5313.

#### MANUAL TESTING
1. Boot as normal and sign in, then ensure the `show_cell_facet_filtering` is enabled for your user account
3. Load the `Human milk - differential expression` study
4. If you haven't already done so, set the default annotation to `General_Celltype` (this makes testing a little easier)
5. Click the button to start cell faceting once it is enabled
6. Confirm you can add/remove groups and that they are moved to the `--Filtered--` trace which can then be hovered over
