### PR TITLE
Remove manual Appcue pin for visualization tour (SCP-5323)

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -165,7 +165,6 @@ class SiteController < ApplicationController
     # normally we would do this in React but the tab display is in the Rails HTML view
     # we need to check server-side since we have to account for @study.can_visualize? as well
     @explore_tab_default = @study.can_visualize?
-    @show_appcue_pin = FeatureFlaggable.feature_flags_for_instances(current_user).[](:show_appcue_viz_tour)
   end
 
   def record_download_acceptance

--- a/app/javascript/components/HomePageContent.jsx
+++ b/app/javascript/components/HomePageContent.jsx
@@ -10,7 +10,7 @@ import ResultsPanel from '~/components/search/results/ResultsPanel'
 import StudyDetails from '~/components/search/results/StudySearchResult'
 import StudySearchProvider, { StudySearchContext } from '~/providers/StudySearchProvider'
 import SearchFacetProvider from '~/providers/SearchFacetProvider'
-import UserProvider, { getFeatureFlagsWithDefaults } from '~/providers/UserProvider'
+import UserProvider from '~/providers/UserProvider'
 import ErrorBoundary from '~/lib/ErrorBoundary'
 
 /** include search controls and results */
@@ -30,8 +30,6 @@ const LinkableSearchTabs = function(props) {
   const location = useLocation()
   const basePath = location.pathname.includes('covid19') ? '/single_cell/covid19' : '/single_cell'
   const showGenesTab = location.pathname.includes('/app/genes')
-  const featureFlags = getFeatureFlagsWithDefaults()
-  const showVizAppcue = featureFlags && featureFlags?.show_appcue_viz_tour
 
   // the queryParams object does not support the more typical hasOwnProperty test
   return (

--- a/app/javascript/components/HomePageContent.jsx
+++ b/app/javascript/components/HomePageContent.jsx
@@ -45,13 +45,6 @@ const LinkableSearchTabs = function(props) {
           className={showGenesTab ? 'active' : ''}>
           <span className="fas fa-dna"></span> Search genes
         </Link>
-        { showVizAppcue &&
-          <a className='btn btn-primary appcue-pin'
-             href='https://singlecell.broadinstitute.org/single_cell/study/SCP2271'
-             data-analytics-name='appcue-viz-demo'>
-            Demo of SCP visualization tools
-          </a>
-        }
       </nav>
       <div className="tab-content top-pad">
         <Router basepath={basePath}>

--- a/app/views/site/_study_tabs_nav.html.erb
+++ b/app/views/site/_study_tabs_nav.html.erb
@@ -60,11 +60,5 @@
       <% end %>
     <% end %>
   <% end %>
-  <% if @show_appcue_pin %>
-    <%= link_to 'Demo of SCP visualization tools',
-                'https://singlecell.broadinstitute.org/single_cell/study/SCP2271',
-                class: 'btn btn-primary top-margin-5 appcue-pin',
-                data: { analytics_name: 'appcue-viz-demo' } %>
-  <% end %>
 </ul>
 

--- a/db/migrate/20230921192657_retire_appcue_pin_feature_flag.rb
+++ b/db/migrate/20230921192657_retire_appcue_pin_feature_flag.rb
@@ -1,0 +1,11 @@
+class RetireAppcuePinFeatureFlag < Mongoid::Migration
+  def self.up
+    FeatureFlag.retire_feature_flag('show_appcue_viz_tour')
+  end
+
+  def self.down
+    FeatureFlag.create!(name: 'show_appcue_viz_tour',
+                        default_value: false,
+                        description: "show the 'Take a tour of SCP's visualization tools' Appcue")
+  end
+end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update removes the manual Appcue pin for the SCP visualization tour.  Not using the client integration through Appcue resulting in the tour not behaving correctly.  As such, we are removing the manual pin.

#### MANUAL TESTING
1. Run the new migration to retire the feature flag with `./rails_local_setup.rb && source config/secrets/.source_env.bash && bin/rails db:migrate`
2. Boot as normal and sign in
3. Confirm you do not see the pin on the home page or any study overview
4. Go to the [Feature flags](https://localhost:3000/single_cell/feature_flags) admin console and confirm that `show_appcue_viz_tour` is no longer listed