### PR TITLE
Change FireCloud to Terra user facing text in study sharing settings (SCP-5326)

### DIFF
--- a/app/models/study_share.rb
+++ b/app/models/study_share.rb
@@ -28,9 +28,9 @@ class StudyShare
 	PERMISSION_TYPES = %w(Edit View Reviewer)
 	FIRECLOUD_ACLS = ['WRITER', 'READER', 'NO ACCESS']
 	PERMISSION_DESCRIPTIONS = [
-			'This user will have read/write access to both this study and FireCloud workspace',
-			'This user will have read access to both this study and FireCloud workspace (cannot edit)',
-			'This user will only have read access to this study (cannot download data or view FireCloud workspace)'
+			'This user will have read/write access to both this study and Terra workspace',
+			'This user will have read access to both this study and Terra workspace (cannot edit)',
+			'This user will only have read access to this study (cannot download data or view Terra workspace)'
 	]
 
 	# hashes that represent ACL mapping between the portal & firecloud and the inverse


### PR DESCRIPTION
Changed three instances of the text "FireCloud" in user facing text when it should say "Terra" in the Study Settings page. Found while doing documentation updates.



Before:
![Screenshot 2023-09-25 at 9 56 01 AM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/594bbfa5-f09d-44bc-9534-5f3e2bb5e569)

After (note I only changed the text below the drop down (arrow) but you can see the rest of the text on this page was already edited to say Terra (circled))
![Screenshot 2023-09-25 at 10 56 10 AM](https://github.com/broadinstitute/single_cell_portal_core/assets/54322292/eea689ed-0e64-4195-b015-652dccb2df0c)
