### PR TITLE
Disable sentry plugin during local development (SCP-5327)

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -29,6 +29,7 @@ services:
     entrypoint: ./vite-dev-entrypoint.sh
     environment:
       RAILS_ENV: development
+      DISABLE_SENTRY: true
       VITE_RUBY_HOST: 0.0.0.0
       VITE_FRONTEND_SERVICE_WORKER_CACHE: "${VITE_FRONTEND_SERVICE_WORKER_CACHE}"
       VITE_DEV_MODE: "\"docker-compose\"" # extra quotes are to encode as JSON string value

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,14 @@ import { readFileSync } from 'fs'
 
 // Match latest non-draft at https://github.com/broadinstitute/single_cell_portal_core/releases
 const version = readFileSync('version.txt', { encoding: 'utf8' })
-const disableSentry = !!process.env.DISABLE_SENTRY
+
+// sentryVitePlugin should be disabled in local development as it prevents using breakpoints
+// to turn off locally, run:
+//
+// DISABLE_SENTRY=true bin/vite dev
+//
+// otherwise, this evaluates to false and leaves plugin enabled in all other scenarios
+const disableSentry = typeof process.env.DISABLE_SENTRY !== 'undefined' && process.env.DISABLE_SENTRY === 'true'
 
 export default defineConfig({
   'define': {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { readFileSync } from 'fs'
 
 // Match latest non-draft at https://github.com/broadinstitute/single_cell_portal_core/releases
 const version = readFileSync('version.txt', { encoding: 'utf8' })
+const disableSentry = !!process.env.DISABLE_SENTRY
 
 export default defineConfig({
   'define': {
@@ -23,7 +24,8 @@ export default defineConfig({
       'org': 'broad-institute',
       'project': 'single-cell-portal',
       'authToken': process.env.SENTRY_AUTH_TOKEN,
-      'telemetry': false
+      'telemetry': false,
+      'disable': disableSentry
     })
   ],
   'build': {


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug with the `sentryVitePlugin` where breakpoints do not work locally.  The cause is unclear, and disabling the plugin appears to fix the problem.  Since we do not report to Sentry in non-production environments, this seems preferable to digging in further.  It will default to _not_ disabling the plugin so as not to interfere with deployed instances.

This can be done in a local environment when starting the Vite dev server with:
```
DISABLE_SENTRY=true bin/vite dev
```

#### MANUAL TESTING
1. Boot vite with `DISABLE_SENTRY=true`, and start the Rails server as normal
2. Open Chrome DevTools, and go to the `Sources` tab
3. Press Cmd+P and open `metrics-api.js`
4. Add a breakpoint at line 406:
```
export function log(name, props = {}) {
==>  let isDifferentialExpressionEnabled // track differential expression visibility globally
```
5. On the homepage, click any link and confirm that the breakpoint halts execution when attempting to log to Mixpanel
6. (Optional) Boot in Dockerized mode with `bin/docker-compose-setup.sh`
7. Run the same test and confirm the breakpoint works