### PR TITLE
Handle cell filtering when subsampled, denoise "Subsampling" menu (SCP-5311, SCP-5329)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -410,7 +410,7 @@ export default function ExploreDisplayPanelManager({
                         <button
                           disabled={!cellFaceting}
                           className={`btn btn-primary`}
-                          data-testid="cell facet filtering button"
+                          data-testid="cell-filtering-button"
                           {...cellFilteringTooltipAttrs}
                           onClick={() => toggleCellFilterPanel()}
                         >Cell filtering</button>

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -208,21 +208,19 @@ export default function ExploreDisplayPanelManager({
 
   const shownAnnotation = getShownAnnotation(exploreParamsWithDefaults.annotation, annotationList)
 
-
+  const isSubsampled = exploreParamsWithDefaults.subsample !== 'All Cells'
   let cellFilteringTooltipAttrs = {}
-  if (exploreParamsWithDefaults.subsample !== 'All Cells') {
+  if (isSubsampled) {
     cellFilteringTooltipAttrs = {
       'data-toggle': 'tooltip',
-      'data-original-title': 'Clicking will remove subsampling, which might be noticeably slower.'
+      'data-original-title': 'Clicking will remove subsampling; plots might be noticeably slower.'
     }
   }
 
   /** Toggle cell filtering panel, and remove subsampling if needed */
   function toggleCellFilterPanel() {
-    if (exploreParamsWithDefaults.subsample !== 'All Cells') {
-      updateClusterParams({
-        subsample: 'All Cells'
-      })
+    if (isSubsampled) {
+      updateClusterParams({ subsample: 'All Cells' })
       document.querySelector('.tooltip.fade.top.in').remove()
     }
     togglePanel('CFF')

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -179,7 +179,7 @@ export default function ExploreDisplayPanelManager({
   const [deGroupB, setDeGroupB] = useState(null)
   const [deGroup, setDeGroup] = useState(null)
 
-  const showFiltering = true // getFeatureFlagsWithDefaults()?.show_cell_facet_filtering
+  const showFiltering = getFeatureFlagsWithDefaults()?.show_cell_facet_filtering
 
   // Differential expression settings
   const flags = getFeatureFlagsWithDefaults()

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -208,7 +208,7 @@ export default function ExploreDisplayPanelManager({
 
   const shownAnnotation = getShownAnnotation(exploreParamsWithDefaults.annotation, annotationList)
 
-  const isSubsampled = exploreParamsWithDefaults.subsample !== 'All Cells'
+  const isSubsampled = exploreParamsWithDefaults.subsample !== 'all'
   let cellFilteringTooltipAttrs = {}
   if (isSubsampled) {
     cellFilteringTooltipAttrs = {

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -179,6 +179,8 @@ export default function ExploreDisplayPanelManager({
   const [deGroupB, setDeGroupB] = useState(null)
   const [deGroup, setDeGroup] = useState(null)
 
+  const showFiltering = getFeatureFlagsWithDefaults()?.show_cell_facet_filtering
+
   // Differential expression settings
   const flags = getFeatureFlagsWithDefaults()
   // `differential_expression_frontend` enables exemptions if study owners don't want DE
@@ -301,7 +303,7 @@ export default function ExploreDisplayPanelManager({
                 </button>
               </>
           }
-          {getFeatureFlagsWithDefaults()?.show_cell_facet_filtering && panelToShow === 'CFF' && <FacetFilterPanelHeader
+          {showFiltering && panelToShow === 'CFF' && <FacetFilterPanelHeader
             togglePanel = {togglePanel}
             setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
             setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
@@ -383,7 +385,7 @@ export default function ExploreDisplayPanelManager({
                   </div>
                 </>
                 }
-                { getFeatureFlagsWithDefaults()?.show_cell_facet_filtering &&
+                { showFiltering &&
                   <>
                     <div className="row">
                       <div className="col-xs-12 cff-button_style">
@@ -446,7 +448,7 @@ export default function ExploreDisplayPanelManager({
             </button>
           </>
         }
-        {getFeatureFlagsWithDefaults()?.show_cell_facet_filtering && panelToShow === 'CFF' && <FacetFilterPanel
+        {showFiltering && panelToShow === 'CFF' && <FacetFilterPanel
           annotationList={annotationList}
           cluster={exploreParamsWithDefaults.cluster}
           shownAnnotation={shownAnnotation}

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -179,7 +179,7 @@ export default function ExploreDisplayPanelManager({
   const [deGroupB, setDeGroupB] = useState(null)
   const [deGroup, setDeGroup] = useState(null)
 
-  const showFiltering = getFeatureFlagsWithDefaults()?.show_cell_facet_filtering
+  const showFiltering = true // getFeatureFlagsWithDefaults()?.show_cell_facet_filtering
 
   // Differential expression settings
   const flags = getFeatureFlagsWithDefaults()
@@ -207,6 +207,15 @@ export default function ExploreDisplayPanelManager({
   }
 
   const shownAnnotation = getShownAnnotation(exploreParamsWithDefaults.annotation, annotationList)
+
+
+  let cellFilteringTooltipAttrs = {}
+  if (exploreParamsWithDefaults.subsample !== 'All Cells') {
+    cellFilteringTooltipAttrs = {
+      'data-toggle': 'tooltip',
+      'title': 'Clicking will upsample plots, which might be noticeably slower.'
+    }
+  }
 
   /** in the event a component takes an action which updates the list of annotations available
     * e.g. by creating a user annotation, this updates the list */
@@ -304,7 +313,7 @@ export default function ExploreDisplayPanelManager({
               </>
           }
           {showFiltering && panelToShow === 'CFF' && <FacetFilterPanelHeader
-            togglePanel = {togglePanel}
+            togglePanel={togglePanel}
             setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
             setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
             isUpstream={showUpstreamDifferentialExpressionPanel}
@@ -326,7 +335,7 @@ export default function ExploreDisplayPanelManager({
                 setDeGroupB={setDeGroupB}
                 isAuthorDe={isAuthorDe}
                 deGenes={deGenes}
-                togglePanel = {togglePanel}
+                togglePanel={togglePanel}
               />
           }
         </div>
@@ -393,9 +402,8 @@ export default function ExploreDisplayPanelManager({
                           disabled={!cellFaceting}
                           className={`btn btn-primary`}
                           data-testid="cell facet filtering button"
-                          onClick={() => {
-                            togglePanel('CFF') // cell facet filtering
-                          }}
+                          {...cellFilteringTooltipAttrs}
+                          onClick={() => togglePanel('CFF')} // cell facet filtering
                         >Cell facet filtering</button>
                         {!cellFaceting && <LoadingSpinner className="fa-lg"/>}
                         {cellFaceting && <FacetFilteringModal />}

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -213,8 +213,19 @@ export default function ExploreDisplayPanelManager({
   if (exploreParamsWithDefaults.subsample !== 'All Cells') {
     cellFilteringTooltipAttrs = {
       'data-toggle': 'tooltip',
-      'title': 'Clicking will upsample plots, which might be noticeably slower.'
+      'data-original-title': 'Clicking will remove subsampling, which might be noticeably slower.'
     }
+  }
+
+  /** Toggle cell filtering panel, and remove subsampling if needed */
+  function toggleCellFilterPanel() {
+    if (exploreParamsWithDefaults.subsample !== 'All Cells') {
+      updateClusterParams({
+        subsample: 'All Cells'
+      })
+      document.querySelector('.tooltip.fade.top.in').remove()
+    }
+    togglePanel('CFF')
   }
 
   /** in the event a component takes an action which updates the list of annotations available
@@ -403,8 +414,8 @@ export default function ExploreDisplayPanelManager({
                           className={`btn btn-primary`}
                           data-testid="cell facet filtering button"
                           {...cellFilteringTooltipAttrs}
-                          onClick={() => togglePanel('CFF')} // cell facet filtering
-                        >Cell facet filtering</button>
+                          onClick={() => toggleCellFilterPanel()}
+                        >Cell filtering</button>
                         {!cellFaceting && <LoadingSpinner className="fa-lg"/>}
                         {cellFaceting && <FacetFilteringModal />}
                       </div>

--- a/app/javascript/components/explore/FacetFilterPanel.jsx
+++ b/app/javascript/components/explore/FacetFilterPanel.jsx
@@ -17,7 +17,7 @@ export function FacetFilterPanelHeader({
 }) {
   return (
     <>
-      <span> Cell facet filtering </span>
+      <span> Cell filtering </span>
       <button className="action fa-lg de-exit-panel"
         onClick={() => {
           updateFilteredCells({})
@@ -214,13 +214,13 @@ export function FacetFilterPanel({
         <div style={{ 'marginTop': '5px' }}>
           <h5>Filter plotted points by:
             <a className="action help-icon"
-               data-toggle="tooltip"
-               data-original-title="Use the checkboxes to filter points from the plot.  Deselected values are
+              data-toggle="tooltip"
+              data-original-title="Use the checkboxes to filter points from the plot.  Deselected values are
                 assigned to the '--Filtered--' group. Hover over this legend entry to highlight."
 
-          >
-            <FontAwesomeIcon icon={faInfoCircle}/>
-          </a></h5>
+            >
+              <FontAwesomeIcon icon={faInfoCircle}/>
+            </a></h5>
           <div style={{ border: '1px solid black', margin: '2px', padding: '2px' }}>
             { shownFacets.map(singleFacet => {
               return createFacetFilterCheckList(singleFacet)

--- a/app/javascript/components/explore/FacetFilteringModal.jsx
+++ b/app/javascript/components/explore/FacetFilteringModal.jsx
@@ -25,7 +25,7 @@ export default function FacetFilteringModal() {
       onClick={() => setShowCellFacetModall(true)}
       data-analytics-name="cell-facet-filter-info"
       data-toggle="tooltip"
-      data-original-title="Click to learn about cell facet filtering in SCP"
+      data-original-title="Click to learn about cell filtering in SCP"
       className="cff-icon-style"
     >
       <FontAwesomeIcon className="action help-icon" icon={faInfoCircle} />
@@ -41,7 +41,7 @@ export default function FacetFilteringModal() {
         onHide={() => closeModal(setShowCellFacetModall)}
         animation={false}>
         <Modal.Header>
-          <h4 className="text-center">Cell Facet Filtering</h4>
+          <h4 className="text-center">Cell filtering</h4>
         </Modal.Header>
         <Modal.Body>
           { cellFacetModalContent }

--- a/app/javascript/components/visualization/controls/SubsampleSelector.jsx
+++ b/app/javascript/components/visualization/controls/SubsampleSelector.jsx
@@ -18,10 +18,14 @@ function getSubsampleOptions(annotationList, clusterName) {
     if (!clusterSubsamples) {
       clusterSubsamples = []
     }
-    subsampleOptions = subsampleOptions.concat(clusterSubsamples.map(num => {
-      // convert everything to strings to make the comparisons easier
-      return { label: `${num}`, value: `${num}` }
-    }))
+    subsampleOptions = subsampleOptions.concat(
+      clusterSubsamples
+        .filter(num => num >= 100000)
+        .map(num => {
+        // convert everything to strings to make the comparisons easier
+          return { label: `${num}`, value: `${num}` }
+        })
+    )
   }
   subsampleOptions.push({ label: 'All Cells', value: 'all' })
   return subsampleOptions
@@ -46,6 +50,12 @@ export default function SubsampleSelector({
   }
 
   const subsampleOptions = getSubsampleOptions(annotationList, cluster)
+
+  const hasUsefulThreshold = subsampleOptions.find(option => option.value === '100000')
+
+  if (!hasUsefulThreshold) {
+    return <></>
+  }
 
   return (
     <div className="form-group">

--- a/app/javascript/lib/service-worker-cache.js
+++ b/app/javascript/lib/service-worker-cache.js
@@ -28,7 +28,7 @@ export async function fetchServiceWorkerCache(url, init) {
     isHit = false
   }
   const hitOrMiss = isHit ? 'hit' : 'miss'
-  console.log(`Service worker cache ${hitOrMiss} for SCP API fetch of URL: ${url}`)
+  console.debug(`Service worker cache ${hitOrMiss} for SCP API fetch of URL: ${url}`)
   return [response, isHit]
 }
 

--- a/test/js/explore/explore-display-tabs.test.js
+++ b/test/js/explore/explore-display-tabs.test.js
@@ -390,7 +390,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
   })
 
 
-  it('shows "Cell facet filtering" button when flag is enabled', async () => {
+  it('shows "Cell filtering" button when flag is enabled', async () => {
     jest
       .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
       .mockReturnValue({
@@ -406,6 +406,6 @@ describe('explore tabs are activated based on study info and parameters', () => 
       />
     ))
 
-    expect(screen.getByTestId('cell facet filtering button')).toHaveTextContent('Cell facet filtering')
+    expect(screen.getByTestId('cell-filtering-button')).toHaveTextContent('Cell filtering')
   })
 })


### PR DESCRIPTION
This smoothens UX for cell filtering in subsampled contexts.  It also only shows the "Subsampling" menu when it's useful.

### Handle cell filtering when subsampled
Previously in our prototype, clicking the "Cell filtering" (nee "Cell facet filtering") button broke when the clustering was subsampled.  This is because we only index cell cluster arrays for the `/facets` endpoint when "Subsampling: All Cells".  (See #1838 for more detail.)  These views are full resolution; they're not subsampled.  Such cases are relatively few but important, as they represent our largest clusterings.

Now, when you click "Cell filtering", the plots upgrade to full resolution, _which also enables cell filtering_.  This UX design keeps the button inviting -- i.e., active in blue, not disabled in grey -- and makes the technical upgrade effortless for the user -- rather than requiring them to manually change the "Subsampling" menu to "All Cells".  A tooltip informs the user of salient bits in tight copy.

### Denoise "Subsampling" menu
The "Subsampling" menu is also now hidden in cases where there is no clear use case.  We have subsampling thresholds of 1k, 10k, 20k, and 100k cells.  This means a "Subsampling" menu showed whenever a study had > 1000 cells.  Performance optimizations over the past few years make all except the top subsampling threshold (i.e. all except 100k) essentially useless, as there's no noticeable latency difference.  So now we only show the "Subsampling" menu when there's a "100000" option.  

This UI cleanup also offsets the visual load of the new "Cell filtering" button.

Here's how it looks!

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/04b81bdf-a3bc-413a-9f73-27d383edca93

(The empty cell filtering panel in the 1.3M study is caused by a pre-existing and out-of-scope issue.)

### Test
1.  Enable cell filtering, either via feature flag or by setting `showFiltering` to `true` in `ExplorePanelManager.jsx` 
2. Go to "Human milk - DE pilot" study
3. Confirm "Subsampling" menu is not shown
4. Confirm hovering "Cell filtering" button does not display a tooltip about subsampling
5. Go to a study that has a clustering of > 100K cells, like the 1.3M 10x mouse dataset
6. Confirm "Subsampling" menu is shown, but only displays options for "100000" and "All Cells"
7. Confirm hovering "Cell filtering" button displays a tooltip about subsampling

### Further details
[Today's SCP demo](https://drive.google.com/file/d/1ieHl9srebIF9fkbW5ED5kMThnc0ebfB8/view?t=26) has richer context.  This satisfies SCP-5311 and SCP-5329.