### PR TITLE
Error handling for cell filtering (SCP-5317)

### DIFF
--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -241,12 +241,12 @@ module Api
         def facets
           cluster = ClusterVizService.get_cluster_group(@study, params)
           if cluster.nil?
-            render json: { error: "Cannot find cluster: #{params[:cluster]}" }, status: :not_found and return
+            render json: { error: "Cannot find clustering: #{params[:cluster]}" }, status: :not_found and return
           end
 
           # need to check for presence as some clusters will not have them if cells were not found in all_cells_array
           unless cluster.indexed
-            render json: { error: 'Cluster is not indexed' }, status: :bad_request and return
+            render json: { error: 'Clustering is not indexed' }, status: :bad_request and return
           end
 
           # annotation validation

--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -249,11 +249,16 @@ module Api
             render json: { error: 'Cluster is not indexed' }, status: :bad_request and return
           end
 
+          # annotation validation
           if params[:annotations].include?('--numeric--')
             render json: { error: 'Cannot use numeric annotations for facets' }, status: :bad_request and return
           end
 
           annotations = self.class.get_facet_annotations(@study, cluster, params[:annotations])
+          if annotations.empty? && params[:annotations].blank?
+            render json: { error: 'Must provide at least one annotation' }, status: :bad_request and return
+          end
+
           missing = self.class.find_missing_annotations(annotations, params[:annotations])
           if missing.any?
             render json: { error: "Cannot find annotations: #{missing.join(', ')}" }, status: :not_found and return

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -202,8 +202,7 @@ module Api
                                                                      cluster: @cluster,
                                                                      annot_name: params[:annotation_name],
                                                                      annot_type: params[:annotation_type],
-                                                                     annot_scope: params[:annotation_scope],
-                                                                     fallback: false)
+                                                                     annot_scope: params[:annotation_scope])
         end
 
         def set_subsampling_threshold

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -472,7 +472,6 @@ export default function ExploreDisplayPanelManager({
             updateFilteredCells={updateFilteredCells}
             exploreParams={exploreParams}
             exploreInfo={exploreInfo}
-            setCellFaceting={setCellFaceting}
             studyAccession={studyAccession}>
         </FacetFilterPanel>}
         {panelToShow === 'DE' && countsByLabel && annotHasDe &&

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -171,7 +171,8 @@ export default function ExploreDisplayPanelManager({
   exploreParamsWithDefaults, routerLocation, searchGenes, countsByLabel, setShowUpstreamDifferentialExpressionPanel,
   setShowDifferentialExpressionPanel, showUpstreamDifferentialExpressionPanel, togglePanel, shownTab,
   showDifferentialExpressionPanel, setIsCellSelecting, currentPointsSelected, isCellSelecting, deGenes,
-  setDeGenes, setShowDeGroupPicker, cellFaceting, setCellFaceting, updateFilteredCells, panelToShow, toggleViewOptions
+  setDeGenes, setShowDeGroupPicker, cellFaceting, setCellFaceting, clusterCanFilter, filterErrorText,
+  updateFilteredCells, panelToShow, toggleViewOptions
 }) {
   const [, setRenderForcer] = useState({})
   const [dataCache] = useState(createCache())
@@ -383,7 +384,7 @@ export default function ExploreDisplayPanelManager({
                   </div>
                 </>
                 }
-                { getFeatureFlagsWithDefaults()?.show_cell_facet_filtering &&
+                { getFeatureFlagsWithDefaults()?.show_cell_facet_filtering && clusterCanFilter &&
                   <>
                     <div className="row">
                       <div className="col-xs-12 cff-button_style">
@@ -397,6 +398,21 @@ export default function ExploreDisplayPanelManager({
                         >Cell facet filtering</button>
                         {!cellFaceting && <LoadingSpinner className="fa-lg"/>}
                         {cellFaceting && <FacetFilteringModal />}
+                      </div>
+                    </div>
+                  </>
+                }
+                { getFeatureFlagsWithDefaults()?.show_cell_facet_filtering && !clusterCanFilter &&
+                  <>
+                    <div className="row">
+                      <div className="col-xs-12 cff-button_style">
+                        <button
+                          disabled="disabled"
+                          className={`btn btn-primary`}
+                          data-testid="cell facet filtering button"
+                          data-toggle="tooltip"
+                          data-original-title={`Cell filtering cannot be displayed for this selection: ${filterErrorText}.`}
+                        >Filtering unavailable</button>
                       </div>
                     </div>
                   </>
@@ -446,17 +462,18 @@ export default function ExploreDisplayPanelManager({
             </button>
           </>
         }
-        {getFeatureFlagsWithDefaults()?.show_cell_facet_filtering && panelToShow === 'CFF' && <FacetFilterPanel
-          annotationList={annotationList}
-          cluster={exploreParamsWithDefaults.cluster}
-          shownAnnotation={shownAnnotation}
-          updateClusterParams={updateClusterParams}
-          cellFaceting={cellFaceting}
-          updateFilteredCells={updateFilteredCells}
-          exploreParams={exploreParams}
-          exploreInfo={exploreInfo}
-          studyAccession={studyAccession}
-          setCellFaceting={setCellFaceting}>
+        {getFeatureFlagsWithDefaults()?.show_cell_facet_filtering && panelToShow === 'CFF' && clusterCanFilter &&
+          <FacetFilterPanel
+            annotationList={annotationList}
+            cluster={exploreParamsWithDefaults.cluster}
+            shownAnnotation={shownAnnotation}
+            updateClusterParams={updateClusterParams}
+            cellFaceting={cellFaceting}
+            updateFilteredCells={updateFilteredCells}
+            exploreParams={exploreParams}
+            exploreInfo={exploreInfo}
+            setCellFaceting={setCellFaceting}
+            studyAccession={studyAccession}>
         </FacetFilterPanel>}
         {panelToShow === 'DE' && countsByLabel && annotHasDe &&
           <>

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -172,7 +172,7 @@ export default function ExploreDisplayTabs({
         }).catch(error => {
           // NOTE: these 'errors' are in fact handled corner cases where faceting data isn't present for various reasons
           // as such, they don't need to be reported to Sentry/Mixpanel, only conveyed to the user
-          // example: 400 (Bad Request): Cluster is not indexed, Cannot use numeric annotations for facets, or
+          // example: 400 (Bad Request): Clustering is not indexed, Cannot use numeric annotations for facets, or
           // 404 (Not Found) Cluster not found
           // see app/controllers/api/v1/visualization/annotations_controller.rb#facets for more information
           setClusterCanFilter(false)
@@ -483,35 +483,35 @@ export default function ExploreDisplayTabs({
         }
         <div className={getPanelWidths().side}>
           <ExploreDisplayPanelManager
-            studyAccession = {studyAccession}
+            studyAccession={studyAccession}
             exploreInfo={exploreInfo}
-            setExploreInfo = {setExploreInfo}
-            exploreParams= {exploreParams}
-            updateExploreParams = {updateExploreParams}
-            clearExploreParams = {clearExploreParams}
+            setExploreInfo={setExploreInfo}
+            exploreParams={exploreParams}
+            updateExploreParams={updateExploreParams}
+            clearExploreParams={clearExploreParams}
             exploreParamsWithDefaults={exploreParamsWithDefaults}
-            routerLocation = {routerLocation}
+            routerLocation={routerLocation}
             searchGenes={searchGenes}
             countsByLabel={countsByLabel}
             setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
-            showDifferentialExpressionPanel = {showDifferentialExpressionPanel}
-            setShowDifferentialExpressionPanel = {setShowDifferentialExpressionPanel}
-            showUpstreamDifferentialExpressionPanel = {showUpstreamDifferentialExpressionPanel}
+            showDifferentialExpressionPanel={showDifferentialExpressionPanel}
+            setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
+            showUpstreamDifferentialExpressionPanel={showUpstreamDifferentialExpressionPanel}
             togglePanel={togglePanel}
-            shownTab = {shownTab}
-            setIsCellSelecting = {setIsCellSelecting}
-            currentPointsSelected = {currentPointsSelected}
-            isCellSelecting = {isCellSelecting}
+            shownTab={shownTab}
+            setIsCellSelecting={setIsCellSelecting}
+            currentPointsSelected={currentPointsSelected}
+            isCellSelecting={isCellSelecting}
             deGenes={deGenes}
             setDeGenes={setDeGenes}
             setShowDeGroupPicker={setShowDeGroupPicker}
-            cellFaceting = {cellFaceting}
-            setCellFaceting = {setCellFaceting}
-            clusterCanFilter = {clusterCanFilter}
-            filterErrorText = {filterErrorText}
-            updateFilteredCells = {updateFilteredCells}
-            panelToShow ={panelToShow}
-            toggleViewOptions= {toggleViewOptions}
+            cellFaceting={cellFaceting}
+            setCellFaceting={setCellFaceting}
+            clusterCanFilter={clusterCanFilter}
+            filterErrorText ={filterErrorText}
+            updateFilteredCells={updateFilteredCells}
+            panelToShow={panelToShow}
+            toggleViewOptions={toggleViewOptions}
           />
         </div>
       </div>

--- a/app/javascript/components/explore/FacetFilterPanel.jsx
+++ b/app/javascript/components/explore/FacetFilterPanel.jsx
@@ -38,11 +38,7 @@ export function FacetFilterPanel({
   shownAnnotation,
   updateClusterParams,
   cellFaceting,
-  updateFilteredCells,
-  exploreParams,
-  exploreInfo,
-  setCellFaceting,
-  studyAccession
+  updateFilteredCells
 }) {
   const [initialFivefacets, setInitialFiveFacets] = useState(cellFaceting?.facets)
   const [checkedMap, setCheckedMap] = useState({})
@@ -170,21 +166,6 @@ export function FacetFilterPanel({
       populateCheckedMap()
     }
   }, [cellFaceting])
-
-  // if the exploreParams update need to reset the initial cell facets
-  useEffect(() => {
-    const [selectedCluster, selectedAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
-    const allAnnots = exploreInfo?.annotationList.annotations
-    if (allAnnots && allAnnots.length > 0) {
-      initCellFaceting(
-        selectedCluster, selectedAnnot, studyAccession, allAnnots
-      )
-        .then(newCellFaceting => {
-          setCellFaceting(newCellFaceting)
-        })
-    }
-  }, [exploreParams])
-
 
   return (
     <>

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -12,12 +12,12 @@ class AnnotationVizService
   # - annot_name: string name of the annotation
   # - annot_type: string type (group or numeric)
   # - annot_scope: string scope (study, cluster, or user)
-  # - fallback: allow rescue to select first available annotation
+  # - fallback: allow rescue to select first available or default annotation
   # Returns:
   # - See populate_annotation_by_class for the object structure
   def self.get_selected_annotation(study, cluster: nil, annot_name: nil, annot_type: nil, annot_scope: nil, fallback: true)
     # construct object based on name, type & scope
-    if annot_name.blank?
+    if annot_name.blank? && fallback
       # get the default annotation
       default_annot = nil
       if annot_scope == 'study'

--- a/test/js/explore/explore-display-tabs.test.js
+++ b/test/js/explore/explore-display-tabs.test.js
@@ -27,9 +27,10 @@ jest.mock('lib/cell-faceting', () => {
 })
 
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import * as UserProvider from '~/providers/UserProvider'
 import ExploreDisplayTabs, { getEnabledTabs } from 'components/explore/ExploreDisplayTabs'
+import ExploreDisplayPanelManager from '~/components/explore/ExploreDisplayPanelManager'
 import PlotTabs from 'components/explore/PlotTabs'
 import {
   exploreInfo as exploreInfoDe,
@@ -407,5 +408,27 @@ describe('explore tabs are activated based on study info and parameters', () => 
     ))
 
     expect(screen.getByTestId('cell facet filtering button')).toHaveTextContent('Cell facet filtering')
+  })
+
+  it('disables cell filtering button', async () => {
+    jest
+      .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
+      .mockReturnValue({
+        show_cell_facet_filtering: true
+      })
+
+    render(
+      <ExploreDisplayPanelManager
+        studyAccession={'SCP123'}
+        exploreParams={exploreParamsDe}
+        exploreParamsWithDefaults={exploreParamsDe}
+        exploreInfo={exploreInfoDe}
+        clusterCanFilter={false}
+        filterErrorText={'Cluster is not indexed'}
+        panelToShow={'default'}
+      />
+    )
+
+    expect(screen.getByTestId('cell facet filtering button')).toHaveTextContent('Filtering unavailable')
   })
 })


### PR DESCRIPTION
#### BACKGROUND & CHANGES

This update adds basic error handling and some other small refinements to the cell filtering feature in the Explore tab.  Previously, if a cluster/annotation did not have data available for filtering (e.g. cluster is not found or indexed, annotation is numeric, etc.) the UI would not handle the `400` or `404` response and leave the button stuck in a loading state.  Now, exceptions are handled, and the cell filtering button will update to show the user when data is not available.

Other refinements:
- The `show_cell_facet_filtering` is now honored for requesting filtering data from the API (previously, data was always requested, regardless of flag state
- Changing the cluster/annotation will refresh filtering data
- Improved request validation in facets API endpoint

Note: there is still an outstanding issue with multiple competing requests for filtering data on page load.  This will be dealt with in a separate PR.

Example:
![Screenshot 2023-09-28 at 10 16 40 AM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/63a74dbc-0f76-4aef-878a-9821a457d46f)

Similar error messages will be displayed for the following edge cases (and associated error codes):
- `404`: 'Cannot find cluster'
- `400`: 'Cannot use numeric annotations for facets'
- `400`: 'Must provide at least one annotation'
- `404`: 'Cannot find annotations: (missing annotations)'

#### MANUAL TESTING
1. Boot as normal, and open Chrome > Dev Tools > Network tab
2. Load the `Human milk - differential expression` study, and confirm no request is made to the facet filtering endpoint 
3. Sign in and confirm you now see one (or more) requests for filtering data (you may need to enable the `show_cell_facet_filtering` if you haven't already done so)
4. Change the cluster/annotation and confirm you see an API update for filtering data
5. In a separate Rails console, update the `Epithelial Cells UMAP` cluster to be unindexed:
```
study = Study.find_by(name: 'Human milk - differential expression')
cluster = study.cluster_groups.last
cluster.update(indexed: false)
```
6. Back in the UI, select this cluster from the dropdown and confirm the filtering button disables accordingly with the error
7. Back in the Rails console, reset the cluster to its original state:
```
cluster.update(indexed: true)
```