### PR TITLE
Disable cell filtering if study has spatial clustering (SCP-5362)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -206,7 +206,12 @@ export default function ExploreDisplayPanelManager({
   const [deGroupB, setDeGroupB] = useState(null)
   const [deGroup, setDeGroup] = useState(null)
 
-  const showCellFiltering = getFeatureFlagsWithDefaults()?.show_cell_facet_filtering
+  let hasSpatialGroups = false
+  if (exploreInfo) {
+    hasSpatialGroups = exploreInfo.spatialGroups.length > 0
+  }
+
+  const showCellFiltering = getFeatureFlagsWithDefaults()?.show_cell_facet_filtering && !hasSpatialGroups
 
 
   // Differential expression settings
@@ -229,11 +234,6 @@ export default function ExploreDisplayPanelManager({
   // hide the cluster controls if we're on a genome tab, or if there aren't clusters to choose
   const showClusterControls = !['genome', 'infercnv-genome', 'geneListHeatmap'].includes(shownTab) &&
                                 annotationList?.clusters?.length
-
-  let hasSpatialGroups = false
-  if (exploreInfo) {
-    hasSpatialGroups = exploreInfo.spatialGroups.length > 0
-  }
 
   const shownAnnotation = getShownAnnotation(exploreParamsWithDefaults.annotation, annotationList)
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update disables cell filtering for studies that have spatial clustering.  The reasoning is that the cells in the spatial mappings may not be the same cells from the embeddings (e.g. UMAP), and so filtering by cell name will not work reliably across the two.  Having incomplete or non-existent filtering would be confusing, so as we evaluate potential workarounds or messaging cell filtering will be disabled for any studies with spatial clustering.

#### MANUAL TESTING
1. Boot as normal and load the `Chicken raw counts` study (or any other study with spatial clustering)
2. Confirm the `Cell filtering` button does not appear