### PR TITLE
Fix SearchFacetPopulator and associated tests re: OLS updates (SCP-5371)

### DIFF
--- a/app/lib/search_facet_populator.rb
+++ b/app/lib/search_facet_populator.rb
@@ -56,7 +56,7 @@ class SearchFacetPopulator
       urls.zip(browser_urls).each do |url, browser_url|
         ontology = fetch_json_from_url(url)
         # check if response has expected keys; if not, default to URL for name value
-        ontology_name = ontology.dig('config', 'title') ? ontology['config']['title'] : url
+        ontology_name = ontology.dig('config', 'title') || ontology.dig('config', 'localizedTitles', 'en') || url
         ontology_obj = {name: ontology_name, url: url, browser_url: browser_url}
         updated_facet.ontology_urls.push(ontology_obj)
       end

--- a/test/lib/search_facet_populator_test.rb
+++ b/test/lib/search_facet_populator_test.rb
@@ -17,7 +17,7 @@ class SearchFacetPopulatorTest < ActiveSupport::TestCase
     assert_equal true, disease_facet.is_array_based
     assert_equal 'https://www.ebi.ac.uk/ols/api/ontologies/mondo', disease_facet.ontology_urls.first['url']
     assert_equal 'https://www.ebi.ac.uk/ols/ontologies/mondo', disease_facet.ontology_urls.first['browser_url']
-    assert_equal 'Mondo Disease Ontology', disease_facet.ontology_urls.first['name']
+    assert_equal 'mondo', disease_facet.ontology_urls.first['name']
 
     sex_facet = SearchFacet.find_by(name: 'sex')
     assert_equal false, sex_facet.is_ontology_based
@@ -49,7 +49,7 @@ class SearchFacetPopulatorTest < ActiveSupport::TestCase
     assert_equal true, disease_facet.is_ontology_based
     assert_equal true, disease_facet.is_array_based
     assert_equal 'https://www.ebi.ac.uk/ols/api/ontologies/mondo', disease_facet.ontology_urls.first['url']
-    assert_equal 'Mondo Disease Ontology', disease_facet.ontology_urls.first['name']
+    assert_equal 'mondo', disease_facet.ontology_urls.first['name']
     assert_equal 'https://www.ebi.ac.uk/ols/ontologies/mondo', disease_facet.ontology_urls.first['browser_url']
     assert_not_equal disease_facet.convention_version, '1.1.3'
   end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a regression with `SearchFacetPopulator` and associated tests due to changes upstream to the Ontology Lookup Service API.  Specifically, the value for an ontology title no longer lives at `ontology.config.title` but has moved to `ontology.config.localizedTitles.en` to support translations.  We will now look first in the original place, and if no title is found, we will look in the localized section.  Fallback title remains the URL.

#### MANUAL TESTING
1. Pull branch and load secrets with `./rails_local_setup.rb && source config/secrets/.source_env.bash`
2. Run `bin/rails test test/lib/search_facet_populator_test.rb` and confirm all tests pass