### PR TITLE
Stream, smoothen cell facet loading (SCP-5361)

### DIFF
--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -272,6 +272,7 @@ export function CellFilteringPanel({
   shownAnnotation,
   updateClusterParams,
   cellFaceting,
+  cellFilteringSelection,
   updateFilteredCells
 }) {
   if (!cellFaceting) {
@@ -285,47 +286,10 @@ export function CellFilteringPanel({
   }
 
   const facets = cellFaceting.facets
-  const [checkedMap, setCheckedMap] = useState({})
+  const [checkedMap, setCheckedMap] = useState(cellFilteringSelection)
   const [colorByFacet, setColorByFacet] = useState(shownAnnotation)
   const shownFacets = facets
   const [isAllListsCollapsed, setIsAllListsCollapsed] = useState(false)
-
-  /** used to populate the checkedMap for the initial facets shown */
-  function populateCheckedMap() {
-    const tmpCheckedMap = {}
-
-    const numFacets = facets.length
-    for (let i = 0; i < numFacets; i++) {
-      tmpCheckedMap[facets[i].annotation] = facets[i].groups
-    }
-
-    setCheckedMap(tmpCheckedMap)
-  }
-
-
-  /** Update the checkedMap state that is used for setting up the filtering checkboxes */
-  function updateCheckedMap(newSingleCellFaceting, event) {
-    const tmpCheckedMap = { ...checkedMap }
-    // add the new facet to the tmpCheckedMap
-    tmpCheckedMap[newSingleCellFaceting.value.annotation] = newSingleCellFaceting.value.groups
-
-    // set the checkedMap state with the updated list
-    setCheckedMap(tmpCheckedMap)
-
-    const tmpShownFacets = [...shownFacets]
-
-    // grab the index of the facet that is to be replaced
-    const indexToRep = tmpShownFacets.findIndex(facet => facet.annotation === event.name)
-
-    // replace the existing facet with the new facet at the index determined above
-    tmpShownFacets[indexToRep] = {
-      annotation: newSingleCellFaceting.value.annotation,
-      groups: newSingleCellFaceting.value.groups
-    }
-
-    // set the facets that are shown in the UI
-    // setShownFacets(tmpShownFacets)
-  }
 
   /** Top header for the "Filter" section, including all-facet controls */
   function FilterSectionHeader({ isAllListsCollapsed, setIsAllListsCollapsed }) {
@@ -384,13 +348,13 @@ export function CellFilteringPanel({
 
   const loadedFacets = cellFaceting.facets.filter(facet => facet.isLoaded).map(lf => parseAnnotationName(lf.annotation)[0])
 
-  /** populate the checkedMap state if it's empty
-   * (this is for initial setting upon page loading and the cellFaceting prop initializing) */
-  useEffect(() => {
-    // if (Object.keys(checkedMap).length === 0) {
-    populateCheckedMap()
-    // }
-  }, [loadedFacets.join(',')])
+  // /** populate the checkedMap state if it's empty
+  //  * (this is for initial setting upon page loading and the cellFaceting prop initializing) */
+  // useEffect(() => {
+  //   // if (Object.keys(checkedMap).length === 0) {
+  //   populateCheckedMap()
+  //   // }
+  // }, [loadedFacets.join(',')])
 
 
   return (

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -88,7 +88,7 @@ function CollapseToggleChevron({ isCollapsed, whatToToggle, isLoaded }) {
       <span
         data-toggle="tooltip"
         data-original-title="Loading data..."
-        style={{ position: 'relative', top: '-5px', left: '-20px', cursor: 'progress' }}
+        style={{ position: 'relative', top: '-5px', left: '-20px', cursor: 'default' }}
       >
         <LoadingSpinner height='14px'/>
       </span>
@@ -156,7 +156,7 @@ function CellFacet({
 
   let facetLabelStyle = {}
   if (!facet.isLoaded) {
-    facetLabelStyle = { color: '#777', cursor: 'wait' }
+    facetLabelStyle = { color: '#777', cursor: 'default' }
   }
 
   let facetStyle = {}
@@ -164,9 +164,9 @@ function CellFacet({
   if (!facet.isLoaded) {
     facetStyle = {
       color: '#777',
-      cursor: 'progress'
+      cursor: 'default'
     }
-    inputStyle.cursor = 'progress'
+    inputStyle.cursor = 'default'
   }
 
   return (
@@ -229,7 +229,7 @@ function FacetHeader({ facet, isFullyCollapsed, setIsFullyCollapsed }) {
   }
   if (!facet.isLoaded) {
     facetNameStyle.color = '#777'
-    facetNameStyle.cursor = 'progress'
+    facetNameStyle.cursor = 'default'
   }
 
   let title = 'Author annotation'

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -287,7 +287,7 @@ export function CellFilteringPanel({
   const facets = cellFaceting.facets
   const [checkedMap, setCheckedMap] = useState({})
   const [colorByFacet, setColorByFacet] = useState(shownAnnotation)
-  const [shownFacets, setShownFacets] = useState()
+  const shownFacets = facets
   const [isAllListsCollapsed, setIsAllListsCollapsed] = useState(false)
 
   /** used to populate the checkedMap for the initial facets shown */
@@ -300,9 +300,6 @@ export function CellFilteringPanel({
     }
 
     setCheckedMap(tmpCheckedMap)
-
-    // set the shownFacets with the same facets as the checkedMap starts with
-    setShownFacets(facets.slice(0, numFacets))
   }
 
 
@@ -327,7 +324,7 @@ export function CellFilteringPanel({
     }
 
     // set the facets that are shown in the UI
-    setShownFacets(tmpShownFacets)
+    // setShownFacets(tmpShownFacets)
   }
 
   /** Top header for the "Filter" section, including all-facet controls */
@@ -385,13 +382,16 @@ export function CellFilteringPanel({
   const filterSectionHeight = window.innerHeight - verticalPad
   const filterSectionHeightProp = `${filterSectionHeight}px`
 
+  const loadedFacets = cellFaceting.facets.filter(facet => facet.isLoaded).map(lf => parseAnnotationName(lf.annotation)[0])
+
   /** populate the checkedMap state if it's empty
    * (this is for initial setting upon page loading and the cellFaceting prop initializing) */
   useEffect(() => {
-    if (Object.keys(checkedMap).length === 0) {
-      populateCheckedMap()
-    }
-  }, [cellFaceting])
+    // if (Object.keys(checkedMap).length === 0) {
+    populateCheckedMap()
+    // }
+  }, [loadedFacets.join(',')])
+
 
   return (
     <>

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -346,17 +346,6 @@ export function CellFilteringPanel({
   const filterSectionHeight = window.innerHeight - verticalPad
   const filterSectionHeightProp = `${filterSectionHeight}px`
 
-  const loadedFacets = cellFaceting.facets.filter(facet => facet.isLoaded).map(lf => parseAnnotationName(lf.annotation)[0])
-
-  // /** populate the checkedMap state if it's empty
-  //  * (this is for initial setting upon page loading and the cellFaceting prop initializing) */
-  // useEffect(() => {
-  //   // if (Object.keys(checkedMap).length === 0) {
-  //   populateCheckedMap()
-  //   // }
-  // }, [loadedFacets.join(',')])
-
-
   return (
     <>
       <div>

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -197,7 +197,7 @@ export default function ExploreDisplayPanelManager({
   exploreParamsWithDefaults, routerLocation, searchGenes, countsByLabel, setShowUpstreamDifferentialExpressionPanel,
   setShowDifferentialExpressionPanel, showUpstreamDifferentialExpressionPanel, togglePanel, shownTab,
   showDifferentialExpressionPanel, setIsCellSelecting, currentPointsSelected, isCellSelecting, deGenes,
-  setDeGenes, setShowDeGroupPicker, cellFaceting, setCellFaceting, clusterCanFilter, filterErrorText,
+  setDeGenes, setShowDeGroupPicker, cellFaceting, cellFilteringSelection, clusterCanFilter, filterErrorText,
   updateFilteredCells, panelToShow, toggleViewOptions
 }) {
   const [, setRenderForcer] = useState({})
@@ -517,6 +517,7 @@ export default function ExploreDisplayPanelManager({
           shownAnnotation={shownAnnotation}
           updateClusterParams={updateClusterParams}
           cellFaceting={cellFaceting}
+          cellFilteringSelection={cellFilteringSelection}
           updateFilteredCells={updateFilteredCells}
           exploreParams={exploreParams}
           exploreInfo={exploreInfo}

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -199,6 +199,7 @@ export default function ExploreDisplayTabs({
 
   // if the exploreParams update need to reset the initial cell facets
   useEffect(() => {
+    if (!cellFaceting) {return}
     const [newCluster, newAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
     getCellFacetingData(newCluster, newAnnot)
   }, [exploreParams?.cluster, exploreParams?.annotation])

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -202,7 +202,7 @@ export default function ExploreDisplayTabs({
     if (!cellFaceting) {return}
     const [newCluster, newAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
     getCellFacetingData(newCluster, newAnnot)
-  }, [exploreParams?.cluster, exploreParams?.annotation])
+  }, [exploreInfo?.cluster, exploreInfo?.annotation])
 
   /** Update filtered cells to only those that match annotation group value filter selections */
   function updateFilteredCells(selection) {

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -108,6 +108,7 @@ export default function ExploreDisplayTabs({
 
   const [cellFaceting, setCellFaceting] = useState(null)
   const [filteredCells, setFilteredCells] = useState(null)
+  const [cellFilteringSelection, setCellFilteringSelection] = useState(null)
 
   // Hash of trace label names to the number of points in that trace
   const [countsByLabel, setCountsByLabel] = useState(null)
@@ -172,6 +173,13 @@ export default function ExploreDisplayTabs({
         initCellFaceting(
           cluster, annotation, studyAccession, allAnnots, prevCellFaceting
         ).then(newCellFaceting => {
+          if (!cellFilteringSelection) {
+            const initSelection = {}
+            newCellFaceting.facets.forEach(facet => {
+              initSelection[facet.annotation] = facet.groups
+            })
+            setCellFilteringSelection(initSelection)
+          }
           setClusterCanFilter(true)
           setCellFaceting(newCellFaceting)
           setFilterErrorText('')
@@ -221,6 +229,7 @@ export default function ExploreDisplayTabs({
 
     // Update UI
     setFilteredCells(newFilteredCells)
+    setCellFilteringSelection(selection)
   }
 
   // Below line is worth keeping, but only uncomment to debug in development
@@ -409,7 +418,8 @@ export default function ExploreDisplayTabs({
                     countsByLabel,
                     setCountsByLabel,
                     dataCache,
-                    filteredCells
+                    filteredCells,
+                    cellFilteringSelection
                   }}/>
               </div>
             }
@@ -522,7 +532,7 @@ export default function ExploreDisplayTabs({
             setDeGenes={setDeGenes}
             setShowDeGroupPicker={setShowDeGroupPicker}
             cellFaceting={cellFaceting}
-            setCellFaceting={setCellFaceting}
+            cellFilteringSelection={cellFilteringSelection}
             clusterCanFilter={clusterCanFilter}
             filterErrorText ={filterErrorText}
             updateFilteredCells={updateFilteredCells}

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -106,14 +106,14 @@ export default function ExploreDisplayTabs({
   }
   const [panelToShow, setPanelToShow] = useState(initialPanel)
 
-  const [cellFaceting, setCellFaceting] = useState(null)
-  const [filteredCells, setFilteredCells] = useState(null)
-  const [cellFilteringSelection, setCellFilteringSelection] = useState(null)
-
   // Hash of trace label names to the number of points in that trace
   const [countsByLabel, setCountsByLabel] = useState(null)
   const showDifferentialExpressionTable = (showViewOptionsControls && deGenes !== null)
   const plotContainerClass = 'explore-plot-tab-content'
+
+  const [cellFaceting, setCellFaceting] = useState(null)
+  const [filteredCells, setFilteredCells] = useState(null)
+  const [cellFilteringSelection, setCellFilteringSelection] = useState(null)
 
   // flow/error handling for cell filtering
   const [clusterCanFilter, setClusterCanFilter] = useState(true)
@@ -201,13 +201,8 @@ export default function ExploreDisplayTabs({
     }
   }
 
-  if (!cellFaceting) {
-    getCellFacetingData(selectedCluster, selectedAnnot)
-  }
-
   // if the exploreParams update need to reset the initial cell facets
   useEffect(() => {
-    if (!cellFaceting) {return}
     const [newCluster, newAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
     getCellFacetingData(newCluster, newAnnot)
   }, [exploreInfo?.cluster, exploreInfo?.annotation])

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -158,12 +158,6 @@ export default function ExploreDisplayTabs({
 
   const isCorrelatedScatter = enabledTabs.includes('correlatedScatter')
 
-  const annotationList = exploreInfo ? exploreInfo.annotationList : null
-
-  const shownAnnotation = getShownAnnotation(exploreParamsWithDefaults.annotation, annotationList)
-
-  const [selectedCluster, selectedAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
-
   /** wrapper function with error handling/state setting for retrieving cell facet data */
   function getCellFacetingData(cluster, annotation, prevCellFaceting) {
     const showCellFiltering = getFeatureFlagsWithDefaults()?.show_cell_facet_filtering
@@ -205,7 +199,7 @@ export default function ExploreDisplayTabs({
   useEffect(() => {
     const [newCluster, newAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
     getCellFacetingData(newCluster, newAnnot)
-  }, [exploreInfo?.cluster, exploreInfo?.annotation])
+  }, [exploreParams?.cluster, exploreParams?.annotation])
 
   /** Update filtered cells to only those that match annotation group value filter selections */
   function updateFilteredCells(selection) {

--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -14,7 +14,7 @@ const MAX_PLOTS = PLOTLY_CONTEXT_NAMES.length
 export default function ScatterTab({
   exploreInfo, exploreParamsWithDefaults, updateExploreParamsWithDefaults, studyAccession, isGene, isMultiGene,
   plotPointsSelected, isCellSelecting, showRelatedGenesIdeogram, showViewOptionsControls, showDifferentialExpressionTable,
-  scatterColor, countsByLabel, setCountsByLabel, dataCache, filteredCells
+  scatterColor, countsByLabel, setCountsByLabel, dataCache, filteredCells, cellFilteringSelection
 }) {
   // maintain the map of plotly contexts to the params that generated the corresponding visualization
   const plotlyContextMap = useRef({})

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -271,14 +271,13 @@ export async function initCellFaceting(
       })
   const facetsToFetch = getFacetsToFetch(allRelevanceSortedFacets, prevCellFaceting)
 
-  console.log('before fetchAnnotationFacets, facetsToFetch', facetsToFetch)
   const newRawFacets = await fetchAnnotationFacets(studyAccession, facetsToFetch, selectedCluster)
 
   // Below line is worth keeping, but only uncomment to debug in developmen.t
   // This helps simulate waiting on server response, even when using local
   // service worker caching.
   //
-  await new Promise(resolve => setTimeout(resolve, 5000))
+  // await new Promise(resolve => setTimeout(resolve, 5000))
 
   const rawFacets = mergeFacetsResponses(newRawFacets, prevCellFaceting)
 
@@ -299,7 +298,6 @@ export async function initCellFaceting(
   const cellFaceting = {
     filterableCells,
     cellsByFacet,
-    selections: [],
     facets,
     filtersByFacet,
     isFullyLoaded,

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -243,15 +243,6 @@ function getFacetsToFetch(allRelevanceSortedFacets, prevCellFaceting) {
     .slice(fetchOffset, fetchOffset + 5)
 }
 
-/**
- * Useful for local development, to simulate waiting on server.
- *
- * Below line is worth keeping, but only uncomment to debug in development.
- */
-// function timeout(ms) {
-//   return new Promise(resolve => setTimeout(resolve, ms))
-// }
-
 /** Get 5 default annotation facets: 1 for selected, and 4 others */
 export async function initCellFaceting(
   selectedCluster, selectedAnnot, studyAccession, allAnnots, prevCellFaceting
@@ -287,7 +278,7 @@ export async function initCellFaceting(
   // This helps simulate waiting on server response, even when using local
   // service worker caching.
   //
-  // await new Promise(resolve => setTimeout(resolve, 5000))
+  await new Promise(resolve => setTimeout(resolve, 5000))
 
   const rawFacets = mergeFacetsResponses(newRawFacets, prevCellFaceting)
 

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -280,6 +280,7 @@ export async function initCellFaceting(
       })
   const facetsToFetch = getFacetsToFetch(allRelevanceSortedFacets, prevCellFaceting)
 
+  console.log('before fetchAnnotationFacets, facetsToFetch', facetsToFetch)
   const newRawFacets = await fetchAnnotationFacets(studyAccession, facetsToFetch, selectedCluster)
 
   // Below line is worth keeping, but only uncomment to debug in developmen.t

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -277,7 +277,7 @@ export async function initCellFaceting(
   // This helps simulate waiting on server response, even when using local
   // service worker caching.
   //
-  // await new Promise(resolve => setTimeout(resolve, 5000))
+  // await new Promise(resolve => setTimeout(resolve, 3000))
 
   const rawFacets = mergeFacetsResponses(newRawFacets, prevCellFaceting)
 

--- a/test/js/explore/cell-filtering-panel.test-data.js
+++ b/test/js/explore/cell-filtering-panel.test-data.js
@@ -1122,3 +1122,236 @@ export const cellFaceting = {
     ]
   }
 }
+
+export const cellFilteringSelection = {
+  'cell_type__ontology_label--group--study': [
+    'epithelial cell',
+    'macrophage',
+    'neutrophil',
+    'B cell',
+    'T cell',
+    'animal cell',
+    'dendritic cell',
+    'eosinophil',
+    'fibroblast'
+  ],
+  'infant_sick_YN--group--study': [
+    'no',
+    'NA',
+    'yes'
+  ],
+  'mastisis_YN--group--study': [
+    'no',
+    'yes',
+    'NA'
+  ],
+  'maternal_medical_event_YN--group--study': [
+    'no',
+    'yes',
+    'NA'
+  ],
+  'reported_infant_medical_events_YN--group--study': [
+    'no',
+    'yes',
+    'NA'
+  ],
+  'reported_infant_medical_events_description--group--study': [
+    'NA',
+    'no',
+    'maybe a stomache bug ',
+    'hot and sleepy',
+    'jaundice',
+    'lounge tie removal mid july, vaccinations a few weeks prior ',
+    'runny nose',
+    'runny nose, diarrhea, vomitting, no fever',
+    'maybe still jaundice',
+    'stomach bug (August), runny nose (October/ currently)',
+    'influenza vaccine received on 4/8/19'
+  ],
+  'ethnicity__ontology_label--group--study': [
+    'European',
+    'Asian',
+    'Hispanic or Latin American',
+    'ancestry category'
+  ],
+  'biosample_id--group--study': [
+    'BM02_6wkpp_r1',
+    'BM12_6wk',
+    'BM03_6wkpp_r1',
+    'BM05_6wkpp',
+    'BM08_6wk_r1',
+    'BM08_6wkpp_r2',
+    'BM13_6wk_r1',
+    'BM13_6wk_r3',
+    'BM07_7wkpp_r1',
+    'BM11_6wk_r1',
+    'BM01_7wkpp_r1',
+    'BM02_13wkpp_t1',
+    'BM08_13wk_r1',
+    'BM05_12wk_r2',
+    'BM03_13wk_r1',
+    'BM03_13wkpp_r2',
+    'BM01_13wkpp_r2',
+    'BM13_12wk',
+    'BM03_15dpp_r1',
+    'BM08_15dpp_r1',
+    'BM01_16dpp_r3',
+    'BM07_17dpp_r2',
+    'BM19_4dpp_r1',
+    'BM02_5dpp_r1',
+    'BM02_5dpp_r2',
+    'BM03_5dpp_r1',
+    'BM07_5dpp_r1',
+    'BM01_5dpp_r1',
+    'BM05_6dpp_r1',
+    'BM11_5dpp_r1',
+    'BM13_6dpp_r1',
+    'BM07_13wk_r1',
+    'BM01_23wk_r1',
+    'BM03_24wk_r1',
+    'BM03_24wk_r2',
+    'BM08_24wk',
+    'BM02_24wk_r2',
+    'BM02_10dpp_r1',
+    'BM03_10dpp_r1',
+    'BM03_10dpp_r2',
+    'BM01_12dpp_r1',
+    'BM07_10dpp_r1',
+    'BM13_13dpp_r1',
+    'BM02_14dpp_r1',
+    'BM04_t1_r2',
+    'BM10_t1_r1',
+    'BM06_t3',
+    'BM04_t3_r1',
+    'BT_t3_lot1',
+    'BT_t3_old',
+    'K1',
+    'K2',
+    'Kfresh',
+    'BM07_25wk_lot711',
+    'B2',
+    'BM5',
+    'BM06_t1_r1',
+    'BM05_26wk_r1',
+    'Bfresh'
+  ],
+  'donor_id--group--study': [
+    'BM02',
+    'BM12',
+    'BM03',
+    'BM05',
+    'BM08',
+    'BM13',
+    'BM07',
+    'BM11',
+    'BM01',
+    'BM19',
+    'BM04',
+    'BM10',
+    'BM06',
+    'NA'
+  ],
+  'milk_stage--group--study': [
+    'late_1',
+    'mature',
+    'early',
+    'late_2',
+    'transitional ',
+    'transitional',
+    'late_4',
+    'NA',
+    'late_3'
+  ],
+  'weaning_YN--group--study': [
+    'NA',
+    'no',
+    'yes'
+  ],
+  'breast_soreness_YN--group--study': [
+    'no',
+    'yes',
+    'NA'
+  ],
+  'directly_breastfeeding_YN--group--study': [
+    'yes',
+    'NA'
+  ],
+  'any_formula_YN--group--study': [
+    'no',
+    'yes',
+    'NA'
+  ],
+  'mother_medications_YN--group--study': [
+    'no',
+    'yes',
+    'sunflower lecithin ',
+    'NA'
+  ],
+  'reported_menstruating_YN--group--study': [
+    'no',
+    'N',
+    'NA'
+  ],
+  'hormonal_birthcontrol_YN--group--study': [
+    'no',
+    'yes',
+    'yes ',
+    'NA'
+  ],
+  'daycare_YN--group--study': [
+    'no',
+    'yes',
+    'NA'
+  ],
+  'vaccines_reported_YN--group--study': [
+    'no',
+    'yes',
+    'NA'
+  ],
+  'vaccines_list--group--study': [
+    'NA',
+    '9/3 and 9/10 – a hep B booster in the hospital',
+    'no',
+    '5/9/19 hepatitis B',
+    'hepB ',
+    'vaccines on 5/15',
+    '(6/11) Dtap-hep, BIPV, rotavirus, pentavalent, big (PRP-T)',
+    'HepB',
+    'hepB (says 4/22 but probably 5/22?)',
+    '4/3/19 Hepatitis B (at birth) ',
+    '2 month vaccines',
+    'Dtap, Gib, IPV, PCU13, Rotavirus (8/16/19)',
+    'vaccines on 7/15',
+    'influenza (day prior to sample)'
+  ],
+  'solid_foods_YN--group--study': [
+    'no',
+    'NA',
+    'yes'
+  ],
+  'Age--group--study': [
+    '31.0',
+    '34.0',
+    '33.0',
+    '29.0',
+    '35.0',
+    '32.0',
+    'NA'
+  ],
+  'labor_induced_YN--group--study': [
+    'Y',
+    'N',
+    'NA'
+  ],
+  'antibiotics_during_delivery--group--study': [
+    'N',
+    'Y',
+    'NA'
+  ],
+  'delivery_mode--group--study': [
+    'vaginal',
+    'C section',
+    'vaginal ',
+    'NA'
+  ]
+}

--- a/test/js/explore/cell-filtering-panel.test.js
+++ b/test/js/explore/cell-filtering-panel.test.js
@@ -2,8 +2,7 @@ import React from 'react'
 import { render, fireEvent, screen, waitFor } from '@testing-library/react'
 import { CellFilteringPanel } from '~/components/explore/CellFilteringPanel'
 import {
-  annotationList,
-  cellFaceting
+  annotationList, cellFaceting, cellFilteringSelection
 } from './cell-filtering-panel.test-data'
 import '@testing-library/jest-dom/extend-expect'
 
@@ -28,6 +27,7 @@ describe('"Cell filtering" panel', () => {
         shownAnnotation={shownAnnotation}
         updateClusterParams={updateClusterParams}
         cellFaceting={cellFaceting}
+        cellFilteringSelection={cellFilteringSelection}
         updateFilteredCells={updateFilteredCells}
       />
     )
@@ -59,6 +59,7 @@ describe('"Cell filtering" panel', () => {
         shownAnnotation={shownAnnotation}
         updateClusterParams={updateClusterParams}
         cellFaceting={cellFaceting}
+        cellFilteringSelection={cellFilteringSelection}
         updateFilteredCells={updateFilteredCells}
       />
     )


### PR DESCRIPTION
This streams the facet loading UX for a smoother start to cell filtering.

## Overview
Previously (#1901), if you clicked "Cell filtering" before all facets had loaded, then facets beyond the top 5 would be stuck in a loading UI.  Those facets would remain disabled even after data was loaded.  Making non-top facets interactive required closing and re-opening the panel.

Now, facets become interactive as new batches of data are loaded, i.e. in a streaming fashion.  Here's how it looks.

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/16efe849-bd94-42fa-ab53-177fec28afeb

## Test
Automated tests were updated to account for these changes.  To manually test:
1.  Go to "Human milk - differential expression" with cell filtering enabled
2.  Soon after the page loads, click "Cell filtering"
3.  Confirm the first 5 facets appear and are interactive
4. Scroll fully down in panel, check if any facets are loaded
5.  Confirm any loading facets appear grey, with loading icon, and filters disabled
6. Wait for a while to let local `/facets` requests complete; don't exit "Cell filtering" panel
7. Confirm facets that were loading and disabled are now loaded and interactive, without any effort needed from you

This satisfies SCP-5361.