### PR TITLE
Fix "Cell filtering" button when subsampled (SCP-5376)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -250,7 +250,6 @@ export default function ExploreDisplayPanelManager({
   function toggleCellFilterPanel() {
     if (isSubsampled) {
       updateClusterParams({ subsample: 'All Cells' })
-      document.querySelector('.tooltip.fade.top.in').remove()
     }
     togglePanel('cell-filtering')
   }

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -437,7 +437,7 @@ export default function ExploreDisplayPanelManager({
                 { showCellFiltering && clusterCanFilter &&
                   <>
                     <div className="row">
-                      <div className="col-xs-12 cell-filtering-button">
+                      <div className={`col-xs-12 cell-filtering-button ${shownTab === 'scatter' && !studyHasDe ? 'create-annotation-cell-filtering' : ''}`}>
                         <button
                           className={`btn btn-primary`}
                           data-testid="cell-filtering-button"
@@ -452,7 +452,7 @@ export default function ExploreDisplayPanelManager({
                 { showCellFiltering && !clusterCanFilter &&
                   <>
                     <div className="row">
-                      <div className="col-xs-12 cell-filtering-button">
+                      <div className={`col-xs-12 cell-filtering-button ${shownTab === 'scatter' && !studyHasDe ? 'create-annotation-cell-filtering' : ''}`}>
                         <button
                           disabled="disabled"
                           className={`btn btn-primary`}

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -258,7 +258,7 @@ export async function initCellFaceting(
 ) {
   // Prioritize and fetch annotation facets for all cells
   const selectedAnnotId = getIdentifierForAnnotation(selectedAnnot)
-  const applicableAnnots =
+  const eligibleAnnots =
     getGroupAnnotationsForClusterAndStudy(allAnnots, selectedCluster)
       .map(annot => { // Add identifiers to incoming annotations
         annot.identifier = getIdentifierForAnnotation(annot)
@@ -274,10 +274,15 @@ export async function initCellFaceting(
       })
 
   const allRelevanceSortedFacets =
-    sortAnnotationsByRelevance(applicableAnnots)
+    sortAnnotationsByRelevance(eligibleAnnots)
       .map(annot => {
         return { annotation: annot.identifier, groups: annot.values }
       })
+
+  if (allRelevanceSortedFacets.length === 0) {
+    throw Error('Only 1 eligible annotation is in this clustering; filtering needs > 1')
+  }
+
   const facetsToFetch = getFacetsToFetch(allRelevanceSortedFacets, prevCellFaceting)
 
   const newRawFacets = await fetchAnnotationFacets(studyAccession, facetsToFetch, selectedCluster)
@@ -301,7 +306,7 @@ export async function initCellFaceting(
     return facet
   })
 
-  // Have all applicable annotations been loaded with faceting data?
+  // Have all eligible annotations been loaded with faceting data?
   const isFullyLoaded = loadedFacets.length >= allRelevanceSortedFacets.length
 
   const cellFaceting = {

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -2,6 +2,12 @@
   margin-bottom: 17px;
 }
 
+.cell-filtering-button.create-annotation-cell-filtering {
+  position: relative;
+  top: -22px;
+  margin-bottom: 0px;
+}
+
 .cell-filtering-info-help-icon {
   margin-left: 10px;
 }


### PR DESCRIPTION
This fixes a bug that occasionally broke the "Cell filtering" button.  It also refines the button's layout and an error message.

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/567b17d5-6f47-49d3-b8af-3926c3c25a11

## Test
1.  Ensure cell filtering is enabled
2.  Go to a study that has a clustering with > 100k cells and > 1 annotations eligible for filtering (like [SCP323](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP323) on staging)
3.  Click "Cell filtering"
4. Confirm the cell filtering panel is shown

This satisfies SCP-5376.  More context is available [in Slack](https://broadinstitute.slack.com/archives/G01HY2DJTFY/p1697132980764819?thread_ts=1697132517.984959&cid=G01HY2DJTFY).