### PR TITLE
Handle TypeError when plot is completely filtered (SCP-5385)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -91,7 +91,7 @@ function RawScatterPlot({
       const label = labels
       newHiddenTraces = [...hiddenTraces]
 
-      if (value && !newHiddenTraces.includes(label)) {
+      if (value && !newHiddenTraces?.includes(label)) {
         newHiddenTraces.push(label)
       }
       if (!value) {


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This addresses an existing issue with cell filtering where a `TypeError: Cannot read properties of undefined (reading 'includes')` could be reliably triggered when filtering on non-default clusters/annotations.

Note: the other error referenced in the ticket (`TypeError: Cannot read properties of undefined (reading 'iconColor')` could not be reproduced despite repeated attempts.  It is plausible that a prior update fixed this unintentionally - it was first reported 2 weeks ago.  It's worth noting that Sentry has not seen either issue reported in the last 30 days, though cell filtering is feature-flagged and therefore only seeing limited use.  There is a suspicion that the multiple competing requests to load cell faceting data somehow clobber state in the UI and trigger the error.  This is difficult to reproduce locally, and almost impossible in production as the requests are cached and execute very quickly.  That particular problem has been addressed directly in #1904, so the lingering `includes` error may be the only residual bug.

#### MANUAL TESTING
1. Boot as normal, sign in, and load the `Human milk - differential expression` study
2. Select the Epithelial clustering and `biosample_id` as the annotation
3. Click `Cell filtering` and under `cell_type__ontology_label`, then deselect `epithelial cell`
4. Confirm that the entire plot filters without error
5. Re-select `epithelial cell` and confirm the plot returns to normal without issue 