### PR TITLE
Change "Cell filtering" button to "Filter plotted cells" (SCP-5381)

### DIFF
--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -13,7 +13,7 @@ export function CellFilteringPanelHeader({
 }) {
   return (
     <>
-      <span> Cell filtering </span>
+      <span> Filter plotted cells </span>
       <button className="action fa-lg cell-filtering-exit-panel"
         onClick={() => {
           updateFilteredCells(null)

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -444,7 +444,7 @@ export default function ExploreDisplayPanelManager({
                           data-testid="cell-filtering-button"
                           {...cellFilteringTooltipAttrs}
                           onClick={() => toggleCellFilterPanel()}
-                        >Cell filtering</button>
+                        >Filter plotted cells</button>
                         <CellFilteringModal />
                       </div>
                     </div>

--- a/test/js/explore/explore-display-tabs.test.js
+++ b/test/js/explore/explore-display-tabs.test.js
@@ -407,7 +407,7 @@ describe('explore tabs are activated based on study info and parameters', () => 
       />
     ))
 
-    expect(screen.getByTestId('cell-filtering-button')).toHaveTextContent('Cell filtering')
+    expect(screen.getByTestId('cell-filtering-button')).toHaveTextContent('Filter plotted cells')
   })
 
   it('disables cell filtering button', async () => {


### PR DESCRIPTION
Early user feedback indicates the phrase "Cell filtering" (without more context) often connotes preprocessing QC.  

To clarify the new functionality refers to filtering cells in plots of generally post-quality-control cell data, this changes the button label and panel header to instead say "Filter plotted cells".

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/71d4a709-7e93-491c-b57f-6babb4432563

This satisfies SCP-5381.  More context is [in Slack](https://broadinstitute.slack.com/archives/CBEHTH601/p1697661183309579).