### PR TITLE
Cell filtering: ensure correct facets on clustering change (SCP-5380)

### DIFF
--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -7,6 +7,11 @@ import Select from '~/lib/InstrumentedSelect'
 import LoadingSpinner from '~/lib/LoadingSpinner'
 import { annotationKeyProperties, clusterSelectStyle } from '~/lib/cluster-utils'
 
+const tooltipAttrs = {
+  'data-toggle': 'tooltip',
+  'data-delay': '{"show": 200}' // Avoid flurry of tooltips on passing hover
+}
+
 /** Top content for cell facet filtering panel shown at right in Explore tab */
 export function CellFilteringPanelHeader({
   togglePanel, updateFilteredCells
@@ -86,7 +91,7 @@ function CollapseToggleChevron({ isCollapsed, whatToToggle, isLoaded }) {
     <span style={{ float: 'right', marginRight: '5px' }}>
       {!isLoaded &&
       <span
-        data-toggle="tooltip"
+        {...tooltipAttrs}
         data-original-title="Loading data..."
         style={{ position: 'relative', top: '-5px', left: '-20px', cursor: 'default' }}
       >
@@ -95,8 +100,8 @@ function CollapseToggleChevron({ isCollapsed, whatToToggle, isLoaded }) {
       }
       <span
         className="facet-toggle-chevron"
-        data-toggle="tooltip"
         data-original-title={toggleIconTooltipText}
+        {...tooltipAttrs}
       >
         {toggleIcon}
       </span>
@@ -256,7 +261,6 @@ function FacetHeader({ facet, isFullyCollapsed, setIsFullyCollapsed }) {
   }
 
   let title = 'Author annotation'
-  const tooltipAttrs = { 'data-toggle': 'tooltip' }
   if (isConventional) {
     title = 'Conventional annotation'
     const note = conventionalMetadataGlossary[rawFacetName]
@@ -265,7 +269,6 @@ function FacetHeader({ facet, isFullyCollapsed, setIsFullyCollapsed }) {
     }
   }
   title += `.  Name in data: ${rawFacetName}`
-  tooltipAttrs['data-original-title'] = title
 
   const toggleClass = `cell-filters-${isFullyCollapsed ? 'hidden' : 'shown'}`
 
@@ -275,7 +278,11 @@ function FacetHeader({ facet, isFullyCollapsed, setIsFullyCollapsed }) {
       onClick={() => {setIsFullyCollapsed(!isFullyCollapsed)}}
     >
       <span style={facetNameStyle}>
-        <span style={tooltipableFacetNameStyle} {...tooltipAttrs}>
+        <span
+          style={tooltipableFacetNameStyle}
+          data-original-title={title}
+          {...tooltipAttrs}
+        >
           {facetName}
         </span>
       </span>
@@ -327,7 +334,7 @@ export function CellFilteringPanel({
       >
         <span
           style={{ 'fontWeight': 'bold' }}
-          data-toggle="tooltip"
+          {...tooltipAttrs}
           data-original-title="Use checkboxes to show or hide cells in plots.  Deselected values are
         assigned to the '--Filtered--' group. Hover over this legend entry to highlight."
         >Filter by</span>
@@ -373,13 +380,16 @@ export function CellFilteringPanel({
   const filterSectionHeight = window.innerHeight - verticalPad
   const filterSectionHeightProp = `${filterSectionHeight}px`
 
+  // Apply custom delay to tooltips added after initial pageload
+  window.$('[data-toggle="tooltip"]').tooltip()
+
   return (
     <>
       <div>
         <label className="labeled-select">
           <span
             className="cell-filtering-color-by"
-            data-toggle="tooltip"
+            {...tooltipAttrs}
             data-original-title="Color the plot by an annotation"
           >
           Color by

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -381,7 +381,7 @@ export function CellFilteringPanel({
   const filterSectionHeightProp = `${filterSectionHeight}px`
 
   // Apply custom delay to tooltips added after initial pageload
-  window.$('[data-toggle="tooltip"]').tooltip()
+  if (window.$) {window.$('[data-toggle="tooltip"]').tooltip()}
 
   return (
     <>

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -315,7 +315,7 @@ export function CellFilteringPanel({
   })
   const [checkedMap, setCheckedMap] = useState(cellFilteringSelection)
   const [colorByFacet, setColorByFacet] = useState(shownAnnotation)
-  const shownFacets = facets
+  const shownFacets = facets.filter(facet => facet.groups.length > 1)
   const [isAllListsCollapsed, setIsAllListsCollapsed] = useState(false)
 
   /** Top header for the "Filter" section, including all-facet controls */

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -9,7 +9,7 @@ import { annotationKeyProperties, clusterSelectStyle } from '~/lib/cluster-utils
 
 const tooltipAttrs = {
   'data-toggle': 'tooltip',
-  'data-delay': '{"show": 200}' // Avoid flurry of tooltips on passing hover
+  'data-delay': '{"show": 150}' // Avoid flurry of tooltips on passing hover
 }
 
 /** Top content for cell facet filtering panel shown at right in Explore tab */

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -13,7 +13,7 @@ export function CellFilteringPanelHeader({
 }) {
   return (
     <>
-      <span> Filter plotted cells </span>
+      <span>Filter plotted cells</span>
       <button className="action fa-lg cell-filtering-exit-panel"
         onClick={() => {
           updateFilteredCells(null)

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -65,9 +65,6 @@ function getHasComparisonDe(exploreInfo, exploreParams, comparison) {
 
 /** Handle switching to a new clustering that has annotations (i.e., facets) not in previous clustering */
 export function handleClusterSwitchForFiltering(cellFilteringSelection, newCellFaceting, setCellFilteringSelection) {
-  console.log('cellFilteringSelection', cellFilteringSelection)
-  console.log('newCellFaceting', newCellFaceting)
-  console.log('setCellFilteringSelection', setCellFilteringSelection)
   if (cellFilteringSelection) {
     const existingSelectionFacets = Object.keys(cellFilteringSelection)
     const updatedSelectionFacets = newCellFaceting.facets.filter(nf => !existingSelectionFacets.includes(nf.annotation))

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -176,12 +176,14 @@ export default function ExploreDisplayTabs({
             setCellFilteringSelection(initSelection)
           }
 
-          const existingSelectionFacets = Object.keys(cellFilteringSelection)
-          const updatedSelectionFacets = newCellFaceting.facets.filter(nf => !existingSelectionFacets.includes(nf.annotation))
+          // Handle switching to a new clustering that has annotations (i.e., facets) not in previous clustering
+          if (cellFilteringSelection) {
+            const existingSelectionFacets = Object.keys(cellFilteringSelection)
+            const updatedSelectionFacets = newCellFaceting.facets.filter(nf => !existingSelectionFacets.includes(nf.annotation))
+            if (updatedSelectionFacets.length > 0) {
+              updatedSelectionFacets.forEach(uf => cellFilteringSelection[uf.annotation] = uf.groups)
+            }
 
-          // Handles switching to a new clustering that has annotations (i.e., facets) not in previous clustering
-          if (updatedSelectionFacets.length > 0) {
-            updatedSelectionFacets.forEach(uf => cellFilteringSelection[uf.annotation] = uf.groups)
             setCellFilteringSelection(cellFilteringSelection)
           }
 

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -63,6 +63,22 @@ function getHasComparisonDe(exploreInfo, exploreParams, comparison) {
   return hasComparisonDe
 }
 
+/** Handle switching to a new clustering that has annotations (i.e., facets) not in previous clustering */
+export function handleClusterSwitchForFiltering(cellFilteringSelection, newCellFaceting, setCellFilteringSelection) {
+  console.log('cellFilteringSelection', cellFilteringSelection)
+  console.log('newCellFaceting', newCellFaceting)
+  console.log('setCellFilteringSelection', setCellFilteringSelection)
+  if (cellFilteringSelection) {
+    const existingSelectionFacets = Object.keys(cellFilteringSelection)
+    const updatedSelectionFacets = newCellFaceting.facets.filter(nf => !existingSelectionFacets.includes(nf.annotation))
+    if (updatedSelectionFacets.length > 0) {
+      updatedSelectionFacets.forEach(uf => cellFilteringSelection[uf.annotation] = uf.groups)
+    }
+
+    setCellFilteringSelection(cellFilteringSelection)
+  }
+}
+
 /** wrapper function with error handling/state setting for retrieving cell facet data */
 function getCellFacetingData(cluster, annotation, setterFunctions, context, prevCellFaceting) {
   const [
@@ -95,15 +111,7 @@ function getCellFacetingData(cluster, annotation, setterFunctions, context, prev
         }
 
         // Handle switching to a new clustering that has annotations (i.e., facets) not in previous clustering
-        if (cellFilteringSelection) {
-          const existingSelectionFacets = Object.keys(cellFilteringSelection)
-          const updatedSelectionFacets = newCellFaceting.facets.filter(nf => !existingSelectionFacets.includes(nf.annotation))
-          if (updatedSelectionFacets.length > 0) {
-            updatedSelectionFacets.forEach(uf => cellFilteringSelection[uf.annotation] = uf.groups)
-          }
-
-          setCellFilteringSelection(cellFilteringSelection)
-        }
+        handleClusterSwitchForFiltering(cellFilteringSelection, newCellFaceting, setCellFilteringSelection)
 
         setClusterCanFilter(true)
         setFilterErrorText('')

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -202,6 +202,7 @@ export default function ExploreDisplayTabs({
           // see app/controllers/api/v1/visualization/annotations_controller.rb#facets for more information
           setClusterCanFilter(false)
           setFilterErrorText(error.message)
+          console.error(error) // Show trace in console; retains debuggability if actual error
         })
       }
     }

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -175,15 +175,24 @@ export default function ExploreDisplayTabs({
             })
             setCellFilteringSelection(initSelection)
           }
+
+          const existingSelectionFacets = Object.keys(cellFilteringSelection)
+          const updatedSelectionFacets = newCellFaceting.facets.filter(nf => !existingSelectionFacets.includes(nf.annotation))
+
+          // Handles switching to a new clustering that has annotations (i.e., facets) not in previous clustering
+          if (updatedSelectionFacets.length > 0) {
+            updatedSelectionFacets.forEach(uf => cellFilteringSelection[uf.annotation] = uf.groups)
+            setCellFilteringSelection(cellFilteringSelection)
+          }
+
           setClusterCanFilter(true)
           setFilterErrorText('')
 
           setCellFilterCounts(newCellFaceting.filterCounts)
           setCellFaceting(newCellFaceting)
 
-          // Now that the cell faceting UI is initialized with the first
-          // facets (e.g. top 5), go ahead and initialize the remaining
-          // facets, in batches of 5
+          // The cell filtering UI is initialized in batches of 5 facets
+          // This recursively loads the next 5 facets until faceting is fully loaded.
           getCellFacetingData(cluster, annotation, newCellFaceting)
         }).catch(error => {
           // NOTE: these 'errors' are in fact handled corner cases where faceting data isn't present for various reasons

--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
@@ -262,7 +262,7 @@ export default function ScatterPlotLegend({
   /** retrieve the color for the label specified (used for filtered legends) */
   function getColorForLabelIcon(specifiedLabel) {
     const labelAndColor = fullLabelsMappedToColor.find(legendItem => legendItem.label === specifiedLabel)
-    return labelAndColor.iconColor
+    return labelAndColor?.iconColor
   }
 
   /** Update the labels to be shown in the legend based on the user filtering (used for filtered legends) */


### PR DESCRIPTION
This fixes a bug in cell filtering sometimes seen upon switching clusterings.

### Overview
Previously, if you changed the "Clustering" menu, and the new clustering was not study-wide and had annotations or groups different than the previous clustering, then a few problems would manifest:

1. If the new clustering had an annotation _not_ in the previous clustering, then the new facet would display, but all its filters would be unexpectedly not selected.  

2. If the new clustering had an annotation that _was_ in the previous clustering, but that annotation had only 1 group, then the facet would display, even though facets are only eligible for cell filtering if their annotations have > 1 group in the current clustering.

Now, cell filtering works as expected in those cases: filters in new facets are selected by default, and new facets that are ineligible are not shown.  Clusterings get changed [~660 times / day](https://mixpanel.com/s/37lHyd), so although it's unclear how often the other needed conditions are met, this is plausibly a high-incidence scenario, worth having fixed while the beta is closed.

This includes some related refinements.  It fixes the `iconColor` bug mentioned in #1907 -- it manifested reliably for me in some studies with Vite SW caching in development.  Also, tooltips in the cell filtering panel that display upon hovering over text are now slightly delayed.

### Video
Here's a video showing the problem on production, and its fix on development.

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/b967e5a4-2061-4baa-8361-11f09fe3e31c

### Test
A new automated test adds verification for this fix.  To manually test, if desired:

1.  Go to "Human milk - differential expression" DE pilot, with cell filtering enabled
2. Ensure your default clustering is "All Cells UMAP"
3. Switch clustering to "Epithelial Cell Subclusters"
4. Confirm that no "Cell type" facet is shown (i.e., case 1 described above is fixed)
5. Scroll down, confirm that "Epithelial Cell Subclusters" is shown, and that its filters are selected (case 2)

This satisfies SCP-5380.