### PR TITLE
Encode annotation names for faceting API (SCP-5377)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -372,7 +372,7 @@ function RawScatterPlot({
     }
 
     scatter.hasArrayLabels =
-      scatter.annotParams.type === 'group' && scatter.data.annotations.some(annot => annot.includes('|'))
+      scatter.annotParams.type === 'group' && scatter.data.annotations.some(annot => annot?.includes('|'))
 
     if (clusterResponse) {
       concludeRender(scatter)

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -158,7 +158,7 @@ export async function createUserAnnotation(
  * @param {String} cluster Name of requested cluster
  */
 export async function fetchAnnotationFacets(studyAccession, annotations, cluster) {
-  annotations = annotations.join(',')
+  annotations = encodeURIComponent(annotations.join(','))
   const params = `annotations=${annotations}&cluster=${cluster}`
   const apiUrl = `/studies/${studyAccession}/annotations/facets?${params}`
   const [annotationFacets] = await scpApi(apiUrl, defaultInit())


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug with the cell filtering UX where annotations with non-word characters in their names (like `Viral+`) get improperly transformed to spaces leading to lookup errors.  Now, all annotation names in the cell faceting UX are encoded correctly before being transmitted. 

#### MANUAL TESTING
This will require editing the name of an existing annotation to replicate the behavior as we do not have any that currently fit this scenario in our synthetic/example data.  In addition, you will want to ensure that caching is turned off as this will impact the content of the `/explore` response.
1. Enter a Rails console session, and load the `Human milk - differential expression` study:
```
study = Study.find_by(name: 'Human milk - differential expression')
```
2. Update the `infant_sick_YN` annotation to include a `+` character (along with the underlying `DataArray` entries):
```
metadata = study.cell_metadata.by_name_and_type('infant_sick_YN', 'group')
data_arrays = DataArray.where(study_id: study.id, study_file_id: metadata.study_file_id, linear_data_type: 'CellMetadatum',
 linear_data_id: metadata.id)
new_name = metadata.name + '+'
metadata.update(name: new_name)
data_arrays.update_all(name: new_name)
```
3. In a separate terminal, ensure caching is turned off by running `bin/rails dev:cache` until you see `Development mode is no longer being cached.`
4. Boot as normal and sign in, then load the example study
5. Once the clustering loads, click the `Filter plotted cells` button and ensure that the `Infant sick YN+` annotation has loaded and is useable.
6. Back in the Rails console, undo the renaming of the annotation:
```
metadata.update(name: 'infant_sick_YN')
data_arrays.update_all(name: 'infant_sick_YN')
```