### PR TITLE
Cell filtering: fix scalability in large datasets (SCP-5351)

### DIFF
--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -49,8 +49,6 @@ function RawScatterPlot({
   countsByLabel, setCountsByLabel, hiddenTraces=[], isSplitLabelArrays, updateExploreParams,
   filteredCells
 }) {
-  console.log('')
-  console.log('start RawScatterPlot')
   const [isLoading, setIsLoading] = useState(false)
   const [bulkCorrelation, setBulkCorrelation] = useState(null)
   const [labelCorrelations, setLabelCorrelations] = useState(null)
@@ -63,12 +61,8 @@ function RawScatterPlot({
   const [editedCustomColors, setEditedCustomColors] = useState({})
   const [customColors, setCustomColors] = useState({})
 
-  console.log('in RawScatterPlot, 1')
-
   const isRefGroup = getIsRefGroup(scatterData?.annotParams?.type, genes, isCorrelatedScatter)
   const [originalLabels, setOriginalLabels] = useState([])
-
-  console.log('in RawScatterPlot, 2')
 
   const flags = getFeatureFlagsWithDefaults()
 
@@ -125,8 +119,6 @@ function RawScatterPlot({
 
     return scatter
   }
-
-  console.log('in RawScatterPlot, 3')
 
   /** redraw the plot when editedCustomColors changes */
   useEffect(() => {
@@ -329,8 +321,6 @@ function RawScatterPlot({
     concludeRender()
   }
 
-  console.log('in RawScatterPlot, 4')
-
   /** Process scatter plot data fetched from server */
   function processScatterPlot(clusterResponse=null, filteredCells) {
     let [scatter, perfTimes] =
@@ -389,11 +379,8 @@ function RawScatterPlot({
     }
   }
 
-  console.log('in RawScatterPlot, 5')
-
   // Fetches plot data then draws it, upon load or change of any data parameter
   useEffect(() => {
-    console.log('start fetchData useEffect')
     /** retrieve and process data */
     async function fetchData() {
       setIsLoading(true)
@@ -490,7 +477,6 @@ function RawScatterPlot({
   ])
 
   useUpdateEffect(() => {
-    console.log('in first useUpdateEffect')
     // Don't update if graph hasn't loaded
     if (scatterData && !isLoading) {
       scatterData.customColors = customColors
@@ -503,7 +489,6 @@ function RawScatterPlot({
     Object.values(customColors).join(','), expressionFilter.join(','), isSplitLabelArrays])
 
   useUpdateEffect(() => {
-    console.log('in hiddenTraces useUpdateEffect')
     // Don't update if graph hasn't loaded
     if (scatterData && !isLoading) {
       const plotlyTraces = document.getElementById(graphElementId).data
@@ -528,7 +513,6 @@ function RawScatterPlot({
   }, [hiddenTraces.join(',')])
 
   useUpdateEffect(() => {
-    console.log('in activeTraceLabel useUpdateEffect')
     // Don't update if graph hasn't loaded
     if (scatterData && !isLoading) {
       setIsLoading(true)
@@ -579,8 +563,6 @@ function RawScatterPlot({
       Plotly.purge(graphElementId)
     }
   }, [])
-
-  console.log('in RawScatter plot, before return')
 
   return (
     <div className="plot">
@@ -977,6 +959,7 @@ export function intersect(filteredCells, scatter) {
       intersectedData[key].push(filteredElement)
     }
   }
+
   return [intersectedData, plotted]
 }
 
@@ -998,7 +981,9 @@ export function reassignFilteredCells(
 ) {
   const reassignedIndices = []
   const plottedSet = new Set(plotted)
-  for (let i = 0; i < originalData['x'].length; i++) {if (!plottedSet.has(i)) {reassignedIndices.push(i)}}
+  for (let i = 0; i < originalData['x'].length; i++) {
+    if (!plottedSet.has(i)) {reassignedIndices.push(i)}
+  }
   const newPlotData = {}
   const keys = Object.keys(originalData)
   keys.forEach(key => {
@@ -1024,8 +1009,9 @@ export function reassignFilteredCells(
   }
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i]
-    newPlotData[key].push(...filteredData[key])
+    newPlotData[key] = newPlotData[key].concat(filteredData[key])
   }
+
   return newPlotData
 }
 

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -49,6 +49,8 @@ function RawScatterPlot({
   countsByLabel, setCountsByLabel, hiddenTraces=[], isSplitLabelArrays, updateExploreParams,
   filteredCells
 }) {
+  console.log('')
+  console.log('start RawScatterPlot')
   const [isLoading, setIsLoading] = useState(false)
   const [bulkCorrelation, setBulkCorrelation] = useState(null)
   const [labelCorrelations, setLabelCorrelations] = useState(null)
@@ -61,8 +63,12 @@ function RawScatterPlot({
   const [editedCustomColors, setEditedCustomColors] = useState({})
   const [customColors, setCustomColors] = useState({})
 
+  console.log('in RawScatterPlot, 1')
+
   const isRefGroup = getIsRefGroup(scatterData?.annotParams?.type, genes, isCorrelatedScatter)
   const [originalLabels, setOriginalLabels] = useState([])
+
+  console.log('in RawScatterPlot, 2')
 
   const flags = getFeatureFlagsWithDefaults()
 
@@ -119,6 +125,8 @@ function RawScatterPlot({
 
     return scatter
   }
+
+  console.log('in RawScatterPlot, 3')
 
   /** redraw the plot when editedCustomColors changes */
   useEffect(() => {
@@ -321,6 +329,8 @@ function RawScatterPlot({
     concludeRender()
   }
 
+  console.log('in RawScatterPlot, 4')
+
   /** Process scatter plot data fetched from server */
   function processScatterPlot(clusterResponse=null, filteredCells) {
     let [scatter, perfTimes] =
@@ -379,8 +389,11 @@ function RawScatterPlot({
     }
   }
 
+  console.log('in RawScatterPlot, 5')
+
   // Fetches plot data then draws it, upon load or change of any data parameter
   useEffect(() => {
+    console.log('start fetchData useEffect')
     /** retrieve and process data */
     async function fetchData() {
       setIsLoading(true)
@@ -477,6 +490,7 @@ function RawScatterPlot({
   ])
 
   useUpdateEffect(() => {
+    console.log('in first useUpdateEffect')
     // Don't update if graph hasn't loaded
     if (scatterData && !isLoading) {
       scatterData.customColors = customColors
@@ -489,6 +503,7 @@ function RawScatterPlot({
     Object.values(customColors).join(','), expressionFilter.join(','), isSplitLabelArrays])
 
   useUpdateEffect(() => {
+    console.log('in hiddenTraces useUpdateEffect')
     // Don't update if graph hasn't loaded
     if (scatterData && !isLoading) {
       const plotlyTraces = document.getElementById(graphElementId).data
@@ -513,6 +528,7 @@ function RawScatterPlot({
   }, [hiddenTraces.join(',')])
 
   useUpdateEffect(() => {
+    console.log('in activeTraceLabel useUpdateEffect')
     // Don't update if graph hasn't loaded
     if (scatterData && !isLoading) {
       setIsLoading(true)
@@ -563,6 +579,8 @@ function RawScatterPlot({
       Plotly.purge(graphElementId)
     }
   }, [])
+
+  console.log('in RawScatter plot, before return')
 
   return (
     <div className="plot">
@@ -980,11 +998,10 @@ export function reassignFilteredCells(
 ) {
   const reassignedIndices = []
   const plottedSet = new Set(plotted)
-  for (let i = 0;  i < originalData['x'].length; i++)
-    if (!plottedSet.has(i)) reassignedIndices.push(i)
+  for (let i = 0; i < originalData['x'].length; i++) {if (!plottedSet.has(i)) {reassignedIndices.push(i)}}
   const newPlotData = {}
   const keys = Object.keys(originalData)
-  keys.forEach(key =>  {
+  keys.forEach(key => {
     newPlotData[key] = []
   })
   if (!annotIsNumeric) {

--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
@@ -242,11 +242,18 @@ export default function ScatterPlotLegend({
     log('hover:scatterlegend', { numLabels })
   }
 
-  // defermine what position from colorBrewerList maps to a given label
-  // takes into account whether items have been filtered out via cell filtering
+  let sortedOriginalLabels
+  if (originalLabels.length > 0) {
+    sortedOriginalLabels = [...originalLabels].sort(PlotUtils.labelSort)
+  }
+
+  /**
+   * Determine what position from colorBrewerList maps to a given label
+   * takes into account whether items have been filtered out via cell filtering
+   */
   function getColorIndex(label, index) {
     if (originalLabels.length > 0) {
-      return [...originalLabels].sort(PlotUtils.labelSort).indexOf(label)
+      return sortedOriginalLabels.indexOf(label)
     } else {
       return index
     }


### PR DESCRIPTION
This fixes a `RangeError: Maximum call stack size exceeded` error seen in ~ 150k+ cell clusterings, and slightly speeds up legend color when filtering.

To test:
* If on staging, go to [SCP367](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP367/neuronal-study-scp2247-on-staging) with filtering enabled.  If local, go to an especially large study that previously manifested the "RangeError: Maximum call stack size exceeded" error.
* Click "Cell filtering"
* Click any filter to deselect it
* Click it again to select it
* Confirm no "RangeError: Maximum call stack size exceeded" error message appears above the scatter plot

This satisfies SCP-5351.  Further context is available in today's [SCP demo recording](https://drive.google.com/file/d/1jZRJptJNqwiJyERKl3NCtBVXBwiDW4R8/view?t=4m8s).