### PR TITLE
Speed up, improve scalability of cell filtering initialization (SCP-5389)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -230,8 +230,19 @@ export default function ExploreDisplayTabs({
   const isCorrelatedScatter = enabledTabs.includes('correlatedScatter')
 
 
-  // if the exploreParams update need to reset the initial cell facets
+  // If clustering or annotation changes, then update facets shown for cell filtering
   useEffect(() => {
+    if (!exploreInfo) {return}
+    if (exploreInfo.skipFetchFacets) {
+      // The loadStudyData in ExploreView updates exploreParams _twice_ upon
+      // loading the page.  To avoid doubling requests to the `/facets` API
+      // endpoint, this special `skipFetchFacets` prop is set to true in the
+      // 2nd upstream update.  This block _skips_ that 2nd volley of /facets
+      // requests triggered by that pageload-time double state update
+      // in loadStudyData.
+      exploreInfo.skipFetchFacets = false
+      return
+    }
     const [newCluster, newAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
     const setterFunctions = [
       setCellFilteringSelection,

--- a/app/javascript/components/explore/ExploreView.jsx
+++ b/app/javascript/components/explore/ExploreView.jsx
@@ -40,6 +40,10 @@ function RoutableExploreTab({ studyAccession }) {
         const newInfo = _cloneDeep(oldExploreInfo)
         newInfo.annotationList.annotations = userSpecificInfo.annotations
         newInfo.canEdit = userSpecificInfo.canEdit
+
+        // Avoid double requests when initializing cell faceting
+        newInfo.skipFetchFacets = true
+
         return newInfo
       })
     }, 500)

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -292,7 +292,7 @@ function initCrossfilter(facetData) {
     // An array of integers, e.g. [6, 0, 7, 0, 0]
     // Each element in the array is the index-offset of the cell's group value assignment
     // for the annotation facet at that index.
-    const facetIndex = new Uint8Array(cells[i])
+    const facetIndex = cells[i]
     filterableCell.facetIndex = facetIndex
     filterableCells.push(filterableCell)
   }

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -135,15 +135,17 @@ export function filterCells(
   const numCellsBefore = filterableCells.length
   const numCellsAfter = results.length
   const numFacetsSelected = Object.keys(selection).length
-  const numFiltersSelected = Object.values(selection).length
+  const numFiltersSelected = Object.values(selection).reduce((numFilters, selectedFiltersForThisFacet) => {
+    // return accumulator (an integer) + current value (an array, specifically its length)
+    return numFilters + selectedFiltersForThisFacet.length
+  }, 0)
   const filterLogProps = {
     'perfTime': filterPerfTime,
     'perfTime:counts': perfTimeCounts,
     numCellsBefore,
     numCellsAfter,
     numFacetsSelected,
-    numFiltersSelected,
-    selection
+    numFiltersSelected
   }
 
   // Log to Mixpanel

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -111,11 +111,14 @@ export function filterCells(
         })
 
         fn = function(d) {
+          // console.log('d', d)
           return filter.has(d)
         }
       } else {
         fn = null
       }
+
+      // Apply the actual crossfilter method
       cellsByFacet[facet].filter(fn)
     }
     results = cellsByFacet[facet].top(Infinity)
@@ -170,6 +173,8 @@ function mergeFacetsResponses(newRawFacets, prevCellFaceting) {
 
 /** Omit any filters that match 0 cells in the current clustering */
 function trimNullFilters(cellFaceting) {
+  return cellFaceting
+
   const filterCountsByFacet = cellFaceting.filterCounts
   const annotationFacets = cellFaceting.facets.map(facet => facet.annotation)
   const nonzeroFiltersByFacet = {} // filters to remove, as they match no cells
@@ -228,7 +233,8 @@ function getFilterCounts(annotationFacets, cellsByFacet, facets, selection) {
   for (let i = 0; i < annotationFacets.length; i++) {
     const facet = annotationFacets[i]
     const facetCrossfilter = cellsByFacet[facet]
-
+    // const facetCrossfilter = cellsByFacet[i]
+    console.log('facetCrossfilter', facetCrossfilter)
     // Set counts for each filter in facet
     const rawFilterCounts = facetCrossfilter.group().top(Infinity)
     const countsByFilter = {}
@@ -266,7 +272,7 @@ function getCellsByFacet(filterableCells, annotationFacets) {
   const cellsByFacet = {}
   for (let i = 0; i < annotationFacets.length; i++) {
     const facet = annotationFacets[i]
-    const facetCrossfilter = cellCrossfilter.dimension(d => d[facet])
+    const facetCrossfilter = cellCrossfilter.dimension(d => d.facetIndex[i])
     cellsByFacet[facet] = facetCrossfilter
   }
   return cellsByFacet
@@ -284,15 +290,8 @@ function initCrossfilter(facetData) {
     // An array of integers, e.g. [6, 0, 7, 0, 0]
     // Each element in the array is the index-offset of the cell's group value assignment
     // for the annotation facet at that index.
-    //
-    //  So, for the first element, `6`, we look up the element at index 0 in annotationFacets,
-    //  and get its `groups`.  Then the group value assignment would be the 7th string in the
-    //  `groups` array for the 0th annotation.
-    const cellGroupIndexes = cells[i]
-    for (let j = 0; j < cellGroupIndexes.length; j++) {
-      const annotationIdentifier = annotationFacets[j]
-      filterableCell[annotationIdentifier] = cellGroupIndexes[j]
-    }
+    const facetIndex = cells[i]
+    filterableCell.facetIndex = facetIndex
     filterableCells.push(filterableCell)
   }
 
@@ -403,7 +402,7 @@ export async function initCellFaceting(
   const cellFaceting = trimNullFilters(rawCellFaceting)
 
   // Below line is worth keeping, but only uncomment to debug in development
-  // window.SCP.cellFaceting = cellFaceting
+  window.SCP.cellFaceting = cellFaceting
   return cellFaceting
 }
 

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -118,7 +118,7 @@ export function filterCells(
       }
 
       // Apply the actual crossfilter method
-      cellsByFacet[facet].filter(fn)
+      cellsByFacet[facet].filterFunction(fn)
     }
     results = cellsByFacet[facet].top(Infinity)
   }

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -141,12 +141,14 @@ export function filterCells(
         fn = function(d) {
           return filter.has(d)
         }
+
+        // Apply the actual crossfilter method
+        cellsByFacet[facet].filterFunction(fn)
       } else {
         fn = null
+        // Apply the actual crossfilter method
+        cellsByFacet[facet].filter(fn)
       }
-
-      // Apply the actual crossfilter method
-      cellsByFacet[facet].filterFunction(fn)
     }
     results = cellsByFacet[facet].top(Infinity)
   }

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -162,9 +162,10 @@ function mergeFacetsResponses(newRawFacets, prevCellFaceting) {
 
   const facets = prevRawFacets.facets.concat(newRawFacets.facets)
 
-  const cells = prevRawFacets.cells.map((cell, i) => {
-    return cell.concat(newRawFacets.cells[i])
-  })
+  const cells = []
+  for (let i = 0; i < prevRawFacets.cells.length; i++) {
+    cells.push(prevRawFacets.cells[i].concat(newRawFacets.cells[i]))
+  }
 
   const mergedRawFacets = { cells, facets }
   return mergedRawFacets
@@ -176,6 +177,8 @@ function trimNullFilters(cellFaceting) {
   const annotationFacets = cellFaceting.facets.map(facet => facet.annotation)
   const nonzeroFiltersByFacet = {} // filters to remove, as they match no cells
   const nonzeroFilterCountsByFacet = {}
+
+  let hasAnyNullFilters = false
 
   const filterableCells = cellFaceting.filterableCells
 
@@ -197,6 +200,8 @@ function trimNullFilters(cellFaceting) {
         nonzeroFilterCounts[filter] = countsByFilter[filter]
       } else {
         facetHasNullFilter = true
+
+        hasAnyNullFilters = true
         nullFilterIndex = filterIndex
       }
     })
@@ -214,6 +219,8 @@ function trimNullFilters(cellFaceting) {
     nonzeroFiltersByFacet[facet] = nonzeroFilters
     cellFaceting.facets[i].groups = nonzeroFilters
   }
+
+  if (!hasAnyNullFilters) {return cellFaceting}
 
   cellFaceting.cellsByFacet = getCellsByFacet(filterableCells, annotationFacets)
   cellFaceting.filterableCells = filterableCells

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -173,8 +173,6 @@ function mergeFacetsResponses(newRawFacets, prevCellFaceting) {
 
 /** Omit any filters that match 0 cells in the current clustering */
 function trimNullFilters(cellFaceting) {
-  return cellFaceting
-
   const filterCountsByFacet = cellFaceting.filterCounts
   const annotationFacets = cellFaceting.facets.map(facet => facet.annotation)
   const nonzeroFiltersByFacet = {} // filters to remove, as they match no cells
@@ -207,8 +205,8 @@ function trimNullFilters(cellFaceting) {
     if (facetHasNullFilter) {
       for (let j = 0; j < cellFaceting.filterableCells.length; j++) {
         const cell = cellFaceting.filterableCells[j]
-        if (cell[facet] > nullFilterIndex) {
-          filterableCells[j][facet] -= 1 // Shift facet filter index to account for removal
+        if (cell[i] > nullFilterIndex) {
+          filterableCells[j][i] -= 1 // Shift facet filter index to account for removal
         }
       }
     }

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -111,7 +111,6 @@ export function filterCells(
         })
 
         fn = function(d) {
-          // console.log('d', d)
           return filter.has(d)
         }
       } else {
@@ -231,8 +230,6 @@ function getFilterCounts(annotationFacets, cellsByFacet, facets, selection) {
   for (let i = 0; i < annotationFacets.length; i++) {
     const facet = annotationFacets[i]
     const facetCrossfilter = cellsByFacet[facet]
-    // const facetCrossfilter = cellsByFacet[i]
-    console.log('facetCrossfilter', facetCrossfilter)
     // Set counts for each filter in facet
     const rawFilterCounts = facetCrossfilter.group().top(Infinity)
     const countsByFilter = {}
@@ -288,7 +285,7 @@ function initCrossfilter(facetData) {
     // An array of integers, e.g. [6, 0, 7, 0, 0]
     // Each element in the array is the index-offset of the cell's group value assignment
     // for the annotation facet at that index.
-    const facetIndex = cells[i]
+    const facetIndex = new Uint8Array(cells[i])
     filterableCell.facetIndex = facetIndex
     filterableCells.push(filterableCell)
   }
@@ -400,7 +397,7 @@ export async function initCellFaceting(
   const cellFaceting = trimNullFilters(rawCellFaceting)
 
   // Below line is worth keeping, but only uncomment to debug in development
-  window.SCP.cellFaceting = cellFaceting
+  // window.SCP.cellFaceting = cellFaceting
   return cellFaceting
 }
 

--- a/test/js/lib/cell-faceting.test.js
+++ b/test/js/lib/cell-faceting.test.js
@@ -39,11 +39,7 @@ describe('Cell faceting', () => {
 
     const expectedFilterableCells99 = {
       'allCellsIndex': 99,
-      'cell_type__ontology_label--group--study': 1,
-      'General_Celltype--group--study': 1,
-      'infant_sick_YN--group--study': 0,
-      'ethnicity__ontology_label--group--study': 0,
-      'biosample_id--group--study': 0
+      'facetIndex': [1, 1, 0, 0, 0]
     }
 
     const expectedInfantSickYN = ['no']


### PR DESCRIPTION
This improves time-to-interactive for cell filtering, makes the Explore UI snappier, and enables filtering bigger datasets.

### Overview
This often decreases memory usage by > 25% and speeds up processing time by 130-150% when initializing filters.  These scale and speed improvements are achieved through a few micro-optimizations, and one larger optimization.

**Decrease memory usage by > 25%.**  `initCrossfilter` now passes around an array of indexes, rather than structuring those indexes into an object.  This is basically how they're received from the `/facets` API.

**Speed up processing by 30-50%**.  Previously, `trimNullFilters` would always call `getCellsByFacet`.  That's a relatively expensive operation in setup, and not needed for all studies.  Now, calls to `getCellsByFacet` only happen when needed, i.e. we detect a "null filter" -- a filter that has a 0-count by default in a clustering.

**Speed up processing by 100%**.  The initial volley of requests to `/facets` was sent twice upon page load.  That's because an upstream component explicitly set state twice, as part of a long-standing unrelated optimization.  Now, that double-state-set doesn't cause a duplicate `/facets` fetch volley.  This cuts in half the time to fully initialize facets, which otherwise contributes to noticeable UI latency in very large datasets.

This also improves observability by newly logging metrics about the initialization of cell faceting, and refining filter-cell logs.

### Test
Automated tests were updated to account for these changes.  To manually test:
1.  Open Network panel in DevTools
2.  Go to "Human milk - differential expression" study.  If on staging, that's [SCP303](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP303).
3.  In DevTools Network panel, filter requests to "facets".  Confirm only 5 requests were sent to `/facets`, not 10.  (If local with service worker cache, go to DevTools Console, change "Default levels" menu to also show "Verbose" output, and enter "facets" into Console "Filter" box", and confirm 5 not 10 such messages are logged.)
4. Change "Clustering" from "All Cells UMAP" to "Epithelial Cells Subclusters"
5. Click "Filter plotted cells"
6. Confirm no "Cell type" facet is shown
7. Scroll down, confirm "Epithelial Cells Subclusters" facet is shown, with all filters selected
8. Deselect a filter, confirm plot updates as expected
9. Select the filter, confirm plot updates as expected

This satisfies SCP-5389.