### PR TITLE
Fix filter label associations when trimming null filters (SCP-5388)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -262,7 +262,7 @@ export default function ExploreDisplayTabs({
 
     // Filter cells by selection (i.e., selected facets and filters)
     const [newFilteredCells, newFilterCounts] = filterCells(
-      selection, cellsByFacet, initFacets, filtersByFacet, filterableCells
+      selection, cellsByFacet, initFacets, filtersByFacet, filterableCells, cellFaceting.rawFacets.facets
     )
 
     // Update UI

--- a/test/js/lib/cell-faceting.test.js
+++ b/test/js/lib/cell-faceting.test.js
@@ -57,7 +57,7 @@ describe('Cell faceting', () => {
       'General_Celltype--group--study': ['LC1', 'LC2']
     }
     const newFilteredCells = filterCells(
-      selections, cellsByFacet, facets, filtersByFacet, filterableCells
+      selections, cellsByFacet, facets, filtersByFacet, filterableCells, facets
     )[0]
     expect(newFilteredCells).toHaveLength(33)
   })


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a bug where the cell filtering UX can result in certain populations being stuck in a hidden state, and display a null count after being filtered.  This is a regression that was introduced in #1905 where calling `trimNullFilters` will remove populations that are not represented in the graph, causing array index positions to shift and associations being lost.  The fix is similar to #1893 where we pass around the original array of filters/labels to preserve their order and maintain the association.

Before the fix:

https://github.com/broadinstitute/single_cell_portal_core/assets/729968/68131e70-bd20-4b5b-a76a-595104ea636e

After:

https://github.com/broadinstitute/single_cell_portal_core/assets/729968/a6f74b9f-4441-4775-b639-3fba8d6064c4

#### MANUAL TESTING
1. Boot as normal and sign in, then load the `Human milk - differential expression` study
2. Select `Epithelial Cells UMAP` and `cell_type__ontology_label` for the cluster/annotation
3. Click `Filter plotted cells` then de-select/select any facet filter other than the `General Celltype` entries
4. Confirm the plot reverts back to normal and the `LC1` population is not stuck in a filtered state