### PR TITLE
Adding NemoClient for retrieving data from NeMO Identifier API (SCP-5226)

### DIFF
--- a/app/models/nemo_client.rb
+++ b/app/models/nemo_client.rb
@@ -1,0 +1,99 @@
+# API client for interacting with Neurpscience Multi-Omic Data Portal (NeMO)
+class NemoClient
+  include ApiHelpers
+
+  attr_accessor :api_root
+
+  BASE_URL = 'https://api.nemoarchive.org'.freeze
+
+  DEFAULT_HEADERS = {
+    'Accept' => 'application/json',
+    'Content-Type' => 'application/json'
+  }.freeze
+
+  # base constructor
+  #
+  # * *return*
+  #   - +NemoClient+ object
+  def initialize
+    self.api_root = BASE_URL
+  end
+
+  # submit a request to NeMO API
+  #
+  # * *params*
+  #   - +http_method+ (String, Symbol) => HTTP method, e.g. :get, :post
+  #   - +path+ (String) => Relative URL path for API request being made
+  #   - +payload+ (Hash) => Hash representation of request body
+  #   - +retry_count+ (Integer) => Counter for tracking request retries
+  #
+  # * *returns*
+  #   - (Hash) => Parsed response body, if present
+  #
+  # * *raises*
+  #   - (RestClient::Exception) => if HTTP request fails for any reason
+  def process_api_request(http_method, path, payload: nil, retry_count: 0)
+    # Log API call for auditing/tracking purposes
+    Rails.logger.info "NeMO API request (#{http_method.to_s.upcase}) #{path}"
+    # process request
+    begin
+      execute_http_request(http_method, path, payload)
+    rescue RestClient::Exception => e
+      current_retry = retry_count + 1
+      context = " encountered when requesting '#{path}', attempt ##{current_retry}"
+      log_message = "#{e.message}: #{e.http_body}; #{context}"
+      Rails.logger.error log_message
+      # only retry if status code indicates a possible temporary error, and we are under the retry limit and
+      # not calling a method that is blocked from retries
+      if should_retry?(e.http_code) && retry_count < ApiHelpers::MAX_RETRY_COUNT
+        retry_time = retry_interval_for(current_retry)
+        sleep(retry_time)
+        process_api_request(http_method, path, payload:, retry_count: current_retry)
+      else
+        # we have reached our retry limit or the response code indicates we should not retry
+        ErrorTracker.report_exception(e, nil, {
+          method: http_method, url: path, payload:, retry_count:
+        })
+        error_message = parse_response_body(e.message)
+        Rails.logger.error "Retry count exceeded when requesting '#{path}' - #{error_message}"
+        raise e
+      end
+    end
+  end
+
+  # sub-handler for making external HTTP request
+  # does not have error handling, this is done by process_api_request
+  # allows for some methods to implement their own error handling (like health checks)
+  #
+  # * *params*
+  #   - +http_method+ (String, Symbol) => HTTP method, e.g. :get, :post
+  #   - +path+ (String) => Relative URL path for API request being made
+  #   - +payload+ (Hash) => Hash representation of request body
+  #
+  # * *returns*
+  #   - (Hash) => Parsed response body, if present
+  #
+  # * *raises*
+  #   - (RestClient::Exception) => if HTTP request fails for any reason
+  def execute_http_request(http_method, path, payload = nil)
+    response = RestClient::Request.execute(method: http_method, url: path, payload: payload, headers: DEFAULT_HEADERS)
+    # handle response using helper
+    handle_response(response)
+  end
+
+  # basic health check
+  #
+  # * *returns*
+  #   - (Boolean) => T/F if NeMO is responding to requests
+  def api_available?
+    path = "#{api_root}/status"
+    begin
+      # since this is a no-body response, ApiHelpers#handle_response will return true
+      execute_http_request(:get, path)
+    rescue RestClient::ExceptionWithResponse => e
+      Rails.logger.error "NeMO service unavailable: #{e.message}"
+      ErrorTracker.report_exception(e, nil, { method: :get, url: path, code: e.http_code })
+      false
+    end
+  end
+end

--- a/app/models/nemo_client.rb
+++ b/app/models/nemo_client.rb
@@ -21,7 +21,7 @@ class NemoClient
   #
   # * *return*
   #   - +NemoClient+ object
-  def initialize(api_root: BASE_URL, username: nil, password: nil)
+  def initialize(api_root: BASE_URL, username: ENV['NEMO_API_USERNAME'], password: ENV['NEMO_API_PASSWORD'])
     self.api_root = api_root.chomp('/')
     self.username = username
     self.password = password

--- a/app/models/nemo_client.rb
+++ b/app/models/nemo_client.rb
@@ -2,7 +2,7 @@
 class NemoClient
   include ApiHelpers
 
-  attr_accessor :api_root
+  attr_accessor :api_root, :username, :password
 
   BASE_URL = 'https://portal.nemoarchive.org/api'.freeze
 
@@ -15,8 +15,10 @@ class NemoClient
   #
   # * *return*
   #   - +NemoClient+ object
-  def initialize(api_root: BASE_URL)
+  def initialize(api_root: BASE_URL, username: nil, password: nil)
     self.api_root = api_root.chomp('/')
+    self.username = username
+    self.password = password
   end
 
   # submit a request to NeMO API
@@ -76,7 +78,11 @@ class NemoClient
   # * *raises*
   #   - (RestClient::Exception) => if HTTP request fails for any reason
   def execute_http_request(http_method, path, payload = nil)
-    response = RestClient::Request.execute(method: http_method, url: path, payload: payload, headers: DEFAULT_HEADERS)
+    headers = {
+      'user' => username,
+      'password' => password
+    }.merge(DEFAULT_HEADERS)
+    response = RestClient::Request.execute(method: http_method, url: path, payload:, headers:)
     # handle response using helper
     handle_response(response)
   end

--- a/app/models/nemo_client.rb
+++ b/app/models/nemo_client.rb
@@ -4,7 +4,7 @@ class NemoClient
 
   attr_accessor :api_root
 
-  BASE_URL = 'https://api.nemoarchive.org'.freeze
+  BASE_URL = 'https://portal.nemoarchive.org/api'.freeze
 
   DEFAULT_HEADERS = {
     'Accept' => 'application/json',
@@ -15,8 +15,8 @@ class NemoClient
   #
   # * *return*
   #   - +NemoClient+ object
-  def initialize
-    self.api_root = BASE_URL
+  def initialize(api_root: BASE_URL)
+    self.api_root = api_root.chomp('/')
   end
 
   # submit a request to NeMO API
@@ -81,6 +81,8 @@ class NemoClient
     handle_response(response)
   end
 
+  # API endpoints
+
   # basic health check
   #
   # * *returns*
@@ -95,5 +97,29 @@ class NemoClient
       ErrorTracker.report_exception(e, nil, { method: :get, url: path, code: e.http_code })
       false
     end
+  end
+
+  # get information about a file
+  #
+  # * *params*
+  #   - +identifier+ (String) => file identifier, usually a UUID or nemo:[a-z]{3}-[a-z0-9]{7}$
+  #
+  # * *returns*
+  #   - (Hash) => File metadata, including associations and access URLs
+  def file(identifier)
+    path = "#{api_root}/files/#{uri_encode(identifier)}"
+    process_api_request(:get, path)
+  end
+
+  # get information about a sample
+  #
+  # * *params*
+  #   - +identifier+ (String) => sample identifier, usually a UUID or nemo:[a-z]{3}-[a-z0-9]{7}$
+  #
+  # * *returns*
+  #   - (Hash) => Sample metadata, including associations and access URLs
+  def sample(identifier)
+    path = "#{api_root}/samples/#{uri_encode(identifier)}"
+    process_api_request(:get, path)
   end
 end

--- a/app/models/nemo_client.rb
+++ b/app/models/nemo_client.rb
@@ -1,4 +1,4 @@
-# API client for interacting with Neurpscience Multi-Omic Data Portal (NeMO)
+# API client for interacting with Neuroscience Multi-Omic Data Portal (NeMO)
 class NemoClient
   include ApiHelpers
 
@@ -113,7 +113,7 @@ class NemoClient
     end
   end
 
-  # generic handler to get an entity from the NeMO identifier API
+  # generic handler to get an entity from the NeMO Identifier API
   #
   # * *params*
   #   - +entity_type+ (String, Symbol) => type of entity, from ENTITY_TYPES

--- a/lib/api_helpers.rb
+++ b/lib/api_helpers.rb
@@ -152,6 +152,6 @@ module ApiHelpers
   # * *returns*
   #   - +String+ => URI-encoded parameter
   def uri_encode(parameter)
-    CGI.escape(parameter.to_s)
+    CGI.escapeURIComponent(parameter.to_s)
   end
 end

--- a/test/integration/external/data_repo_client_test.rb
+++ b/test/integration/external/data_repo_client_test.rb
@@ -87,7 +87,7 @@ class DataRepoClientTest < ActiveSupport::TestCase
     assert_equal expected_query, @data_repo_client.merge_query_options(opts)
     # ensure params are uri-encoded
     new_opts = { one: 'foo', two: 'bar bing' }
-    expected_encoded_query = '?one=foo&two=bar+bing'
+    expected_encoded_query = '?one=foo&two=bar%20bing'
     assert_equal expected_encoded_query, @data_repo_client.merge_query_options(new_opts)
   end
 

--- a/test/integration/external/nemo_client_test.rb
+++ b/test/integration/external/nemo_client_test.rb
@@ -5,6 +5,8 @@ class NemoClientTest < ActiveSupport::TestCase
     @nemo_client = NemoClient.new
     @nemo_is_ok = @nemo_client.api_available?
     @skip_message = '-- skipping due to NeMO API being unavailable --'
+    @file_id = 'c6c0fcfa-52d9-45ff-82b5-0864951878ce'
+    @study_full_name = "Lein;Vlmc;Transcriptome;10X Chromium 3' V3 Sequencing"
   end
 
   # skip a test if Azul is not up ; prevents unnecessary build failures due to releases/maintenance
@@ -22,5 +24,26 @@ class NemoClientTest < ActiveSupport::TestCase
   test 'should check if NeMO is up' do
     skip_if_api_down
     assert @nemo_client.api_available?
+  end
+
+  test 'should get a file' do
+    file = @nemo_client.file(@file_id)&.dig('data')
+    assert file.present?
+    expected_keys = %w[subject sample file]
+    assert_equal expected_keys.sort, file.keys.sort
+    assert_equal @file_id, file.dig('file', 'file_id')
+    assert_equal @study_full_name, file.dig('sample', 'study_full_name')
+    %w[identifier md5 access size].each do |expected_attribute|
+      assert_includes file['file'].keys, expected_attribute
+    end
+  end
+
+  test 'should get a sample' do
+    sample = @nemo_client.sample(@study_full_name)&.dig('data')
+    assert sample.present?
+    expected_keys = %w[case_id files sample subject]
+    assert_equal expected_keys.sort, sample.keys.sort
+    assert_equal @study_full_name, sample.dig('sample', 'study_full_name')
+    assert_equal @file_id, sample['files'].first['file_id']
   end
 end

--- a/test/integration/external/nemo_client_test.rb
+++ b/test/integration/external/nemo_client_test.rb
@@ -2,7 +2,9 @@ require 'test_helper'
 
 class NemoClientTest < ActiveSupport::TestCase
   before(:all) do
-    @nemo_client = NemoClient.new
+    @username = ENV['NEMO_API_USERNAME']
+    @password = ENV['NEMO_API_PASSWORD']
+    @nemo_client = NemoClient.new(username: @username, password: @password)
     @nemo_is_ok = @nemo_client.api_available?
     @skip_message = '-- skipping due to NeMO API being unavailable --'
     @file_id = 'c6c0fcfa-52d9-45ff-82b5-0864951878ce'
@@ -17,8 +19,10 @@ class NemoClientTest < ActiveSupport::TestCase
   end
 
   test 'should instantiate client' do
-    client = NemoClient.new
+    client = NemoClient.new(username: @username, password: @password)
     assert_equal NemoClient::BASE_URL, client.api_root
+    assert_equal @username, client.username
+    assert_equal @password, client.password
   end
 
   test 'should check if NeMO is up' do

--- a/test/integration/external/nemo_client_test.rb
+++ b/test/integration/external/nemo_client_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class NemoClientTest < ActiveSupport::TestCase
+  before(:all) do
+    @nemo_client = NemoClient.new
+    @nemo_is_ok = @nemo_client.api_available?
+    @skip_message = '-- skipping due to NeMO API being unavailable --'
+  end
+
+  # skip a test if Azul is not up ; prevents unnecessary build failures due to releases/maintenance
+  def skip_if_api_down
+    unless @nemo_is_ok
+      puts @skip_message; skip
+    end
+  end
+
+  test 'should instantiate client' do
+    client = NemoClient.new
+    assert_equal NemoClient::BASE_URL, client.api_root
+  end
+
+  test 'should check if NeMO is up' do
+    skip_if_api_down
+    assert @nemo_client.api_available?
+  end
+end

--- a/test/integration/external/nemo_client_test.rb
+++ b/test/integration/external/nemo_client_test.rb
@@ -7,8 +7,15 @@ class NemoClientTest < ActiveSupport::TestCase
     @nemo_client = NemoClient.new(username: @username, password: @password)
     @nemo_is_ok = @nemo_client.api_available?
     @skip_message = '-- skipping due to NeMO API being unavailable --'
-    @file_id = 'c6c0fcfa-52d9-45ff-82b5-0864951878ce'
-    @study_full_name = "Lein;Vlmc;Transcriptome;10X Chromium 3' V3 Sequencing"
+    @identifiers = {
+      collection: 'nemo:col-pxwhesp',
+      file: 'nemo:der-ah1o5qb',
+      grant: 'nemo:grn-qwzp05p',
+      project: 'nemo:std-hoxfi7n',
+      publication: 'nemo:dat-tfmg0va',
+      sample: 'nemo:smp-xmd8d0y',
+      subject: 'nemo:sbj-njhfvw6'
+    }
   end
 
   # skip a test if Azul is not up ; prevents unnecessary build failures due to releases/maintenance
@@ -30,24 +37,97 @@ class NemoClientTest < ActiveSupport::TestCase
     assert @nemo_client.api_available?
   end
 
-  test 'should get a file' do
-    file = @nemo_client.file(@file_id)&.dig('data')
-    assert file.present?
-    expected_keys = %w[subject sample file]
-    assert_equal expected_keys.sort, file.keys.sort
-    assert_equal @file_id, file.dig('file', 'file_id')
-    assert_equal @study_full_name, file.dig('sample', 'study_full_name')
-    %w[identifier md5 access size].each do |expected_attribute|
-      assert_includes file['file'].keys, expected_attribute
+  test 'should format authentication header' do
+    auth_header = @nemo_client.authorization_header
+    username_password = auth_header[:Authorization].split.last # trim off 'Basic '
+    assert_equal "#{@nemo_client.username}:#{@nemo_client.password}", Base64.decode64(username_password)
+  end
+
+  test 'should validate entity type' do
+    assert_raises ArgumentError do
+      @nemo_client.fetch_entity(:foo, 'bar')
     end
   end
 
-  test 'should get a sample' do
-    sample = @nemo_client.sample(@study_full_name)&.dig('data')
+  test 'should validate identifier format' do
+    assert_raises ArgumentError do
+      @nemo_client.file('foo')
+    end
+  end
+
+  test 'should get an entity' do
+    skip_if_api_down
+    entity_type = @identifiers.keys.sample
+    identifier = @identifiers[entity_type]
+    entity = @nemo_client.fetch_entity(entity_type, identifier)
+    assert entity.present?
+  end
+
+  test 'should get collection' do
+    skip_if_api_down
+    identifier = @identifiers[:collection]
+    collection = @nemo_client.collection(identifier)
+    assert collection.present?
+    assert_equal 'adey_sciATAC_human_cortex', collection['short_name']
+  end
+
+  test 'should get file' do
+    skip_if_api_down
+    identifier = @identifiers[:file]
+    file = @nemo_client.file(identifier)
+    assert file.present?
+    filename = 'human_var_scVI_VLMC.h5ad.tar'
+    assert_equal filename, file['file_name']
+    assert_equal 'h5ad', file['file_format']
+    access_url = file['urls'].first['url']
+    assert_equal filename, access_url.split('/').last
+  end
+
+  test 'should get grant' do
+    skip_if_api_down
+    identifier = @identifiers[:grant]
+    grant = @nemo_client.grant(identifier)
+    assert grant.present?
+    assert_equal '1U01MH114825-01', grant['grant_number']
+    assert_equal 'NIMH', grant['funding_agency']
+  end
+
+  test 'should get project' do
+    skip_if_api_down
+    identifier = @identifiers[:project]
+    project = @nemo_client.project(identifier)
+    assert project.present?
+    assert_equal 'study', project['project_type']
+    assert_equal 'biccn', project['program']
+    assert_equal 'dulac_poa_dev_sn_10x_proj', project['short_name']
+  end
+
+  test 'should get publication' do
+    skip_if_api_down
+    identifier = @identifiers[:publication]
+    publication = @nemo_client.publication(identifier)
+    assert publication.present?
+    assert_equal 'Bakken_2021_dLGN_CrossSpecies_Rseq', publication['short_name']
+    assert_equal 'https://doi.org/10.7554/eLife.64875', publication['doi']
+    assert_equal ["human", "macaques", "house mouse"].sort, publication['taxonomies'].sort
+  end
+
+  test 'should get sample' do
+    skip_if_api_down
+    identifier = @identifiers[:sample]
+    sample = @nemo_client.sample(identifier)
     assert sample.present?
-    expected_keys = %w[case_id files sample subject]
-    assert_equal expected_keys.sort, sample.keys.sort
-    assert_equal @study_full_name, sample.dig('sample', 'study_full_name')
-    assert_equal @file_id, sample['files'].first['file_id']
+    assert_equal 'marm028_M1', sample['source_sample_id']
+    assert sample['files'].any?
+  end
+
+  test 'should get subject' do
+    skip_if_api_down
+    identifier = @identifiers[:subject]
+    subject = @nemo_client.subject(identifier)
+    assert subject.present?
+    assert_equal 'CEMBA180911_4H', subject['source_subject_id']
+    assert_equal 'DNA methylation profiling of genomic DNA in individual mouse brain cell nuclei (RS1.1)',
+                 subject['grant_title']
   end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds the `NemoClient` for retrieving data from the forthcoming NeMO Identifier API.  This API is still in a beta release state, and is behind basic auth until it goes public later this year.  This client is not integrated anywhere yet, but has bindings for all the major entity types: files, projects, publications, etc.

NOTE:  This PR does not validate that we can retrieve all required information from the NeMO Identifier API.  Almost assuredly, there will be information missing that SCP requires, and this will need to be handled by the yet-to-be-implemented `ImportService`.  This update only deals with API connectivity.  But we will be able to retrieve file names/types/access urls, and basic project attributes like names, associated publications, etc.  Many file-level attributes will have to be set from default configurations as they may not be available (e.g. `library_preparation_protocol` for expression data or `obsm_key_name` for AnnData clustering embeds).

You can also interact with the [beta API](https://beta-assets.nemoarchive.org) in a browser, using the credentials from vault (look for `NEMO_API_USERNAME` and `NEMO_API_PASSWORD`).

#### MANUAL TESTING
1. Load a fresh copy of environment secrets and enter a Rails console session
2. Instantiate the client and validate it loads credentials and can see the API
```
client = NemoClient.new
=> 
#<NemoClient:0x0000000106e6e018

client.username
=> "single-cell-portal"

client.api_available?
=> true
```
3. Load an entity, and use the association links provided to traverse the data structures:
```
file_id = 'nemo:der-ah1o5qb'
=> "nemo:der-ah1o5qb"

file = client.file(file_id)
file
=> 
{"id"=>"nemo:der-ah1o5qb",                              
 "file_name"=>"human_var_scVI_VLMC.h5ad.tar",           
 "md5"=>"451a28b7f0f809335ba9d78a720ebc9b",             
 "sha256"=>nil,                                                                     
 ...

collection_id = file['collections'].first.split('/').last
=> "nemo:col-hwmwd2x"

collection = client.collection(collection_id)
collection
=> 
{"id"=>"nemo:col-hwmwd2x",           
 "col_type"=>"files",                
 "is_static"=>0,                     
 "short_name"=>"human_variation_10X",
 "name"=>"\"Human variation study (10x), GRU\"",
 ...
 
project_id = collection['projects'].first.split('/').last
=> "nemo:grn-gyy3k8j"

project = client.project(project_id)
project
=> 
{"id"=>"nemo:grn-gyy3k8j", 
 "project_type"=>"grant",
 "program"=>"other",
 "short_name"=>"AIBS Internal",
 "title"=>"Projects funded by internal Allen Institute for Brain Science funding",
 ...
```