### PR TITLE
Fix mislogged error, improve logger resiliency (SCP-5315)

### DIFF
--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -335,8 +335,10 @@ export function logMenuChange(event) {
 /**
  * Log JS error (e.g. uncaught ReferenceError) to console, Sentry, and Mixpanel
  */
-export function logError(text, error = {}) {
-  console.error(error.message)
+export function logError(text, error) {
+  const message = error ? error.message : text
+
+  console.error(message)
 
   const props = { text, error }
   log('error', props) // Log to Mixpanel

--- a/app/javascript/lib/sentry-logging.js
+++ b/app/javascript/lib/sentry-logging.js
@@ -58,10 +58,10 @@ function printSuppression(errorObj, reason) {
   }
 
   const message = `Suppressing error report to Sentry: ${reasonMap[reason]}`
-  console.log(errorObj.url ? `${message }  Error:` : message)
+  console.log(errorObj?.url ? `${message }  Error:` : message)
 
   // Error objects are printed via console.error already, so only surface Sentry-suppressed responses
-  if (errorObj.url) {
+  if (errorObj?.url) {
     console.log(errorObj)
   }
 }

--- a/app/javascript/vite/application.js
+++ b/app/javascript/vite/application.js
@@ -67,7 +67,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (window.SCP.userSignedIn) {
     if (window.SCP.userAccessToken === '') {
-      logError('User access token is empty string')
+      const tokenErrorMessage = 'User access token is empty string'
+      const tokenError = new Error(tokenErrorMessage)
+      logError(tokenErrorMessage, tokenError)
     }
     ScpApi.setUpRenewalForUserAccessToken()
   }


### PR DESCRIPTION
This fixes a bug in logging an error with user access tokens.  It also makes the logging function a bit friendlier.

Previously, if `userAccessToken` were an empty string, the `logError` function would only log a text error message ("User access token is empty string").  Now, it logs a stack trace as well.  Also, to avoid erroring in future cases and also accommodate simpler calls with less diagnostic richness, `logError`  with only a text message now also works.

A user complained about getting logged out during upload.  This will help assess that issue's incidence.

Here's how this error now looks in Sentry.

<img width="1512" alt="Fix_mislogged_user_access_token_error__SCP_2023-10-30" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/22bf0593-cd66-4c08-9ffd-a6aaf6f9e4dc">

To test:
1.  In line 68 of `vite/application.js`, add a line `window.SCP.userAccessToken = ''` to simulate the error state
2. In line 346 of `metrics-api.js`, change `logToSentry(error)` to `logToSentry(error, false)` to remove throttling
3. In line 71 of `sentry-logging.js`, add a line `return false` to bypass Sentry log suppression in development
4. Stop Vite, start it with `VITE_FRONTEND_SERVICE_WORKER_CACHE=true bin/vite dev` to not disable Sentry logging
5. Refresh page
6. Confirm you see an error in DevTools console.  Click the toggle arrow to the left of the error to see a stack trace.
7. Wait 1-2 minutes
8. Go to [Sentry issues in development](https://broad-institute.sentry.io/issues/?environment=development&project=1424198&query=is%3Aunresolved+level%3Aerror+%21stack.abs_path%3A%2Aideogram%2A&referrer=issue-list&sort=freq&statsPeriod=24h)
9. Confirm you see an error "User access token is empty string"
10. Revert your local changes, e.g. via `git checkout .`

This satisfies SCP-5315.  