### PR TITLE
Correct queries for annotation faceting data (SCP-5394)

### DIFF
--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -277,7 +277,8 @@ module Api
             study_file_id = scope == 'study' ? @study.metadata_file.id : cluster.study_file_id
             array_query = {
               name: annotation[:name], array_type: 'annotations', linear_data_type: data_obj.class.name,
-              linear_data_id: data_obj.id, study_id: @study.id, study_file_id:
+              linear_data_id: data_obj.id, study_id: @study.id, study_file_id:, subsample_annotation: nil,
+              subsample_threshold: nil
             }
             annotation_arrays[identifier] = DataArray.concatenate_arrays(array_query)
             facets << { annotation: identifier, groups: annotation[:values] }

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -984,7 +984,6 @@ export function reassignFilteredCells(
   for (let i = 0; i < originalData['x'].length; i++) {
     if (!plottedSet.has(i)) {reassignedIndices.push(i)}
   }
-  console.log(`reassignedIndices: ${JSON.stringify(reassignedIndices)} `)
   const newPlotData = {}
   const keys = Object.keys(originalData)
   keys.forEach(key => {

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -984,6 +984,7 @@ export function reassignFilteredCells(
   for (let i = 0; i < originalData['x'].length; i++) {
     if (!plottedSet.has(i)) {reassignedIndices.push(i)}
   }
+  console.log(`reassignedIndices: ${JSON.stringify(reassignedIndices)} `)
   const newPlotData = {}
   const keys = Object.keys(originalData)
   keys.forEach(key => {
@@ -1002,7 +1003,8 @@ export function reassignFilteredCells(
         newPlotData[key].push(FILTERED_TRACE_COLOR)
       } else {
         const dataArray = originalData[key]
-        const replottedElement = dataArray[idx]
+        const sourceIndex = reassignedIndices[idx]
+        const replottedElement = dataArray[sourceIndex]
         newPlotData[key].push(replottedElement)
       }
     }


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug with queries for cell filtering where subsampled cluster-based annotations return extra data, leading to incorrect counts in cell filtering results.  Now, subsampled arrays are ignored and filter counts are correct.  Additionally, this fixes a bug where the incorrect index was used for moving filtered cells to the `--Filtered--` trace when hiding a particular filter label.  This lead to the wrong cells being hidden in the plot.  Now, the correct index is used and thus maintains the correct association.

#### MANUAL TESTING
This requires a cluster with > 100K points.  I used the clustering/metadata files from [SCP2247](https://singlecell.broadinstitute.org/single_cell/study/SCP2247/neuronal-diversity-in-the-human-hypothalamus) for this.
1. Boot all services and sign in
2. Create a new study and use the clustering/metadata from above (or an existing study that has cluster-based annotations that are subsampled)
3. Wait for ingest & subsampling to complete if creating a new study
4. Go to the study and select the `celltype` annotation, noting the count for `NA` as `114256` (before, it would be around 60K)
5. Change to another annotation, and the click `Filter plotted cells`
6. In the entry for `celltype`, note that the count for `NA` is correct
7. Click `NA`, and note that the filtered population is the same size of `114256`
8. Reset the filters, and change the plotted annotation to `celltype`
9. Under `Seurat clusters`, click the entry for `12`
10. Confirm that the population in the bottom center (mostly `Ependymal` cells) has been reduced to `738` and that the grouping looks like the following:
![Screenshot 2023-10-31 at 2 38 41 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/ed525ec7-d7d3-490c-b3f0-6bc6d4070e9d)
and not like this:
![Screenshot 2023-10-31 at 2 44 22 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/be401b78-c35b-4e0f-8a6c-0b9bddef1302)

