### PR TITLE
Enable hierarchical cell filtering, and reset all filters (SCP-5386)

### DIFF
--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -407,7 +407,9 @@ export function CellFilteringPanel({
       <div
         className="filter-section-header"
         onClick={event => {
-          if (Array.from(event.target.classList).includes('fa-undo')) {
+          console.log('event.target.classList', event.target.classList)
+          const domClasses = Array.from(event.target.classList)
+          if (domClasses.includes('fa-undo') || domClasses.length === 0) {
             // Don't toggle facet collapse on "Reset filters" button click
             return
           }

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -301,6 +301,8 @@ function FacetHeader({
   const tooltipableFacetNameStyle = {
     width: 'content-fit'
   }
+
+  const loadingClass = !facet.isLoaded ? 'loading' : ''
   if (!facet.isLoaded) {
     facetNameStyle.color = '#777'
     facetNameStyle.cursor = 'default'
@@ -350,7 +352,7 @@ function FacetHeader({
         className={`cell-facet-header ${toggleClass}`}
         onClick={() => setIsFullyCollapsed(!isFullyCollapsed)}
       >
-        <span className="cell-facet-name">
+        <span className={`cell-facet-name ${loadingClass}`}>
           <span
             style={tooltipableFacetNameStyle}
             data-original-title={title}
@@ -402,34 +404,33 @@ export function CellFilteringPanel({
   /** Top header for the "Filter" section, including all-facet controls */
   function FilterSectionHeader({ facets, checkedMap, handleResetFilters, isAllListsCollapsed, setIsAllListsCollapsed }) {
     return (
-      <div className="filter-section-header">
+      <div
+        className="filter-section-header"
+        onClick={event => {
+          if (Array.from(event.target.classList).includes('fa-undo')) {
+            // Don't toggle facet collapse on "Reset filters" button click
+            return
+          }
+          setIsAllListsCollapsed(!isAllListsCollapsed)
+        }}
+      >
         <span
-          onClick={event => {
-            if (Array.from(event.target.classList).includes('fa-undo')) {
-              // Don't toggle facet collapse on "Reset filters" button click
-              return
-            }
-            setIsAllListsCollapsed(!isAllListsCollapsed)
-          }}
-        >
-          <span
-            className="filter-section-name"
-            style={{ 'fontWeight': 'bold' }}
-            {...tooltipAttrs}
-            data-original-title="Use checkboxes to show or hide cells in plots.  Deselected values are
+          className="filter-section-name"
+          style={{ 'fontWeight': 'bold' }}
+          {...tooltipAttrs}
+          data-original-title="Use checkboxes to show or hide cells in plots.  Deselected values are
         assigned to the '--Filtered--' group. Hover over this legend entry to highlight."
-          >Filter by</span>
-          <FacetTools
-            isCollapsed={isAllListsCollapsed}
-            setIsCollapsed={setIsAllListsCollapsed}
-            whatToToggle="all filter lists"
-            isLoaded={true}
-            isRoot={true}
-            facets={facets}
-            checkedMap={checkedMap}
-            handleResetFilters={handleResetFilters}
-          />
-        </span>
+        >Filter by</span>
+        <FacetTools
+          isCollapsed={isAllListsCollapsed}
+          setIsCollapsed={setIsAllListsCollapsed}
+          whatToToggle="all filter lists"
+          isLoaded={true}
+          isRoot={true}
+          facets={facets}
+          checkedMap={checkedMap}
+          handleResetFilters={handleResetFilters}
+        />
       </div>
     )
   }

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -118,10 +118,7 @@ function ResetFiltersButton({ facets, checkedMap, handleResetFilters }) {
   Object.entries(checkedMap).forEach(([facet, filters]) => {
     numCheckedFilters += filters.length
   })
-  console.log('numTotalFilters', numTotalFilters)
-  console.log('numCheckedFilters', numCheckedFilters)
   const isResetEligible = numTotalFilters !== numCheckedFilters
-  console.log('isResetEligible', isResetEligible)
   const resetDisplayClass = isResetEligible ? '' : 'hide-reset'
 
   return (
@@ -351,7 +348,7 @@ function FacetHeader({
       />
       <span
         className={`cell-facet-header ${toggleClass}`}
-        onClick={() => {setIsFullyCollapsed(!isFullyCollapsed)}}
+        onClick={() => setIsFullyCollapsed(!isFullyCollapsed)}
       >
         <span className="cell-facet-name">
           <span
@@ -404,25 +401,16 @@ export function CellFilteringPanel({
 
   /** Top header for the "Filter" section, including all-facet controls */
   function FilterSectionHeader({ facets, checkedMap, handleResetFilters, isAllListsCollapsed, setIsAllListsCollapsed }) {
-    // Assess if filter-section-level checkbox should be indeterminate, i.e. "-",
-    // which is a common state in hierarchical checkboxes to indicate that
-    // some lower checkboxes are checked, and some are not.
-    let numTotalFilters = 0
-    facets.forEach(facet => numTotalFilters += facet.groups.length)
-    let numCheckedFilters = 0
-    Object.entries(checkedMap).forEach(([facet, filters]) => {
-      numCheckedFilters += filters.length
-    })
-    console.log('numTotalFilters', numTotalFilters)
-    console.log('numCheckedFilters', numCheckedFilters)
-    const isResetEligible = numTotalFilters !== numCheckedFilters
-    console.log('isResetEligible', isResetEligible)
-    const resetDisplayClass = isResetEligible ? '' : 'hide-reset'
-
     return (
       <div className="filter-section-header">
         <span
-          onClick={() => {setIsAllListsCollapsed(!isAllListsCollapsed)}}
+          onClick={event => {
+            if (Array.from(event.target.classList).includes('fa-undo')) {
+              // Don't toggle facet collapse on "Reset filters" button click
+              return
+            }
+            setIsAllListsCollapsed(!isAllListsCollapsed)
+          }}
         >
           <span
             className="filter-section-name"

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -114,7 +114,6 @@ function isChecked(annotation, item, checkedMap) {
   return checkedMap[annotation]?.includes(item)
 }
 
-
 /** Cell filter component */
 function CellFilter({
   facet, filter, isChecked, checkedMap, handleCheck
@@ -127,7 +126,7 @@ function CellFilter({
   }
 
   return (
-    <label className="cell-filter-label">
+    <label className="cell-filter-label" style={{ marginLeft: '18px' }}>
       <div style={{ marginLeft: '2px', lineHeight: '14px', ...facetLabelStyle }}>
         <input
           type="checkbox"
@@ -153,7 +152,7 @@ function CellFilter({
 /** Facet name and collapsible list of filter checkboxes */
 function CellFacet({
   facet,
-  checkedMap, handleCheck, updateFilteredCells,
+  checkedMap, handleCheck, handleCheckAllFilters, updateFilteredCells,
   isAllListsCollapsed
 }) {
   if (Object.keys(facet).length === 0) {
@@ -211,6 +210,7 @@ function CellFacet({
     >
       <FacetHeader
         facet={facet}
+        handleCheckAllFilters={handleCheckAllFilters}
         isFullyCollapsed={isFullyCollapsed}
         setIsFullyCollapsed={setIsFullyCollapsed}
       />
@@ -231,7 +231,7 @@ function CellFacet({
       {!isFullyCollapsed && filters.length > numFiltersPartlyCollapsed &&
         <a
           className="facet-toggle"
-          style={{ 'fontSize': '13px' }}
+          style={{ 'fontSize': '13px', 'marginLeft': '18px' }}
           onClick={() => {setIsPartlyCollapsed(!isPartlyCollapsed)}}
         >
           {isPartlyCollapsed ? 'More...' : 'Less...'}
@@ -242,7 +242,7 @@ function CellFacet({
 }
 
 /** Get stylized name of facet, optional tooltip, collapse controls */
-function FacetHeader({ facet, isFullyCollapsed, setIsFullyCollapsed }) {
+function FacetHeader({ facet, handleCheckAllFilters, isFullyCollapsed, setIsFullyCollapsed }) {
   const [facetName, rawFacetName] = parseAnnotationName(facet.annotation)
   const isConventional = getIsConventionalAnnotation(rawFacetName)
 
@@ -250,7 +250,7 @@ function FacetHeader({ facet, isFullyCollapsed, setIsFullyCollapsed }) {
     fontWeight: 'bold',
     marginBottom: '1px',
     display: 'inline-block',
-    width: 'calc(100% - 30px)'
+    width: 'calc(100% - 40px)'
   }
   const tooltipableFacetNameStyle = {
     width: 'content-fit'
@@ -273,24 +273,30 @@ function FacetHeader({ facet, isFullyCollapsed, setIsFullyCollapsed }) {
   const toggleClass = `cell-filters-${isFullyCollapsed ? 'hidden' : 'shown'}`
 
   return (
-    <div
-      className={`cell-facet-header ${toggleClass}`}
-      onClick={() => {setIsFullyCollapsed(!isFullyCollapsed)}}
-    >
-      <span style={facetNameStyle}>
-        <span
-          style={tooltipableFacetNameStyle}
-          data-original-title={title}
-          {...tooltipAttrs}
-        >
-          {facetName}
-        </span>
-      </span>
-      <CollapseToggleChevron
-        isCollapsed={isFullyCollapsed}
-        whatToToggle="filter list"
-        isLoaded={facet.isLoaded}
+    <div>
+      <input
+        type="checkbox"
+        style={{ display: 'inline', marginRight: '5px' }}
       />
+      <span
+        className={`cell-facet-header ${toggleClass}`}
+        onClick={() => {setIsFullyCollapsed(!isFullyCollapsed)}}
+      >
+        <span style={facetNameStyle}>
+          <span
+            style={tooltipableFacetNameStyle}
+            data-original-title={title}
+            {...tooltipAttrs}
+          >
+            {facetName}
+          </span>
+        </span>
+        <CollapseToggleChevron
+          isCollapsed={isFullyCollapsed}
+          whatToToggle="filter list"
+          isLoaded={facet.isLoaded}
+        />
+      </span>
     </div>
   )
 }
@@ -346,6 +352,16 @@ export function CellFilteringPanel({
         />
       </div>
     )
+  }
+
+  /** Add or remove all checked item from list */
+  function handleCheckAllFilters(event) {
+    const facetName = event.target.name.split(':')[0]
+    const isCheck = event.target.checked
+    const updatedList = isCheck ? facets[facetName] : []
+    checkedMap[facetName] = updatedList
+    setCheckedMap(checkedMap)
+    updateFilteredCells(checkedMap)
   }
 
   /** Add or remove checked item from list */
@@ -410,7 +426,8 @@ export function CellFilteringPanel({
         </label>
         { Object.keys(checkedMap).length !== 0 &&
         <>
-          <div style={{ marginTop: '10px' }}>
+          <div style={{ marginTop: '10px', marginLeft: '-10px' }}>
+            {/* <div style={{ marginTop: '10px' }}> */}
             <FilterSectionHeader
               isAllListsCollapsed={isAllListsCollapsed}
               setIsAllListsCollapsed={setIsAllListsCollapsed}
@@ -422,6 +439,7 @@ export function CellFilteringPanel({
                     facet={facet}
                     checkedMap={checkedMap}
                     handleCheck={handleCheck}
+                    handleCheckAllFilters={handleCheckAllFilters}
                     updateFilteredCells={updateFilteredCells}
                     isAllListsCollapsed={isAllListsCollapsed}
                     key={i}

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -358,7 +358,12 @@ export function CellFilteringPanel({
         className="filter-section-header"
         onClick={() => {setIsAllListsCollapsed(!isAllListsCollapsed)}}
       >
+        <input
+          type="checkbox"
+          className="root-checkbox"
+        />
         <span
+          className="filter-section-name"
           style={{ 'fontWeight': 'bold' }}
           {...tooltipAttrs}
           data-original-title="Use checkboxes to show or hide cells in plots.  Deselected values are
@@ -447,7 +452,7 @@ export function CellFilteringPanel({
         </label>
         { Object.keys(checkedMap).length !== 0 &&
         <>
-          <div style={{ marginTop: '10px', marginLeft: '-10px' }}>
+          <div className="filter-section" style={{ marginTop: '10px', marginLeft: '-10px' }}>
             {/* <div style={{ marginTop: '10px' }}> */}
             <FilterSectionHeader
               isAllListsCollapsed={isAllListsCollapsed}

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -88,7 +88,7 @@ function CollapseToggleChevron({ isCollapsed, whatToToggle, isLoaded }) {
   }
 
   return (
-    <span style={{ float: 'right', marginRight: '5px' }}>
+    <span className="facet-tools">
       {!isLoaded &&
       <span
         {...tooltipAttrs}
@@ -249,12 +249,7 @@ function FacetHeader({
   const [facetName, rawFacetName] = parseAnnotationName(facet.annotation)
   const isConventional = getIsConventionalAnnotation(rawFacetName)
 
-  const facetNameStyle = {
-    fontWeight: 'bold',
-    marginBottom: '1px',
-    display: 'inline-block',
-    width: 'calc(100% - 40px)'
-  }
+  const facetNameStyle = {}
   const tooltipableFacetNameStyle = {
     width: 'content-fit'
   }
@@ -290,9 +285,9 @@ function FacetHeader({
     <div>
       <input
         type="checkbox"
+        className="cell-facet-header-checkbox"
         data-analytics-name={`facet-${facet.annotation}`}
         name={`facet-${facet.annotation}`}
-        style={{ display: 'inline', marginRight: '5px' }}
         onChange={event => {
           handleCheckAllFilters(event)
         }}
@@ -307,7 +302,7 @@ function FacetHeader({
         className={`cell-facet-header ${toggleClass}`}
         onClick={() => {setIsFullyCollapsed(!isFullyCollapsed)}}
       >
-        <span style={facetNameStyle}>
+        <span className="cell-facet-name">
           <span
             style={tooltipableFacetNameStyle}
             data-original-title={title}

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -407,7 +407,6 @@ export function CellFilteringPanel({
       <div
         className="filter-section-header"
         onClick={event => {
-          console.log('event.target.classList', event.target.classList)
           const domClasses = Array.from(event.target.classList)
           if (domClasses.includes('fa-undo') || domClasses.length === 0) {
             // Don't toggle facet collapse on "Reset filters" button click

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -345,8 +345,8 @@ export default function ExploreDisplayTabs({
         main = 'col-md-9'
         side = 'col-md-3'
       } else if (panelToShow === 'cell-filtering') {
-        main = 'col-md-10'
-        side = 'col-md-2'
+        main = 'col-md-10-5'
+        side = 'col-md-2-5'
       } else {
         // Default state, when side panel is "Options" and not collapsed
         main = 'col-md-10'

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -97,7 +97,7 @@ function logFilterCells(t0Counts, t0, filterableCells, results, selection) {
   const numFacetsSelected = Object.keys(selection).length
   const numFiltersSelected = Object.values(selection).reduce((numFilters, selectedFiltersForThisFacet) => {
     // return accumulator (an integer) + current value (an array, specifically its length)
-    return numFilters + selectedFiltersForThisFacet.length
+    return numFilters + selectedFiltersForThisFacet?.length
   }, 0)
   const filterLogProps = {
     'perfTime': filterPerfTime,

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -425,8 +425,8 @@ export async function initCellFaceting(
   perfTimes.fetch = Date.now() - timeFetchStart
 
   // Below line is worth keeping, but only uncomment to debug in development.
-  // This helps simulate waiting on server response, even when using local
-  // service worker caching.
+  // This helps simulate waiting on server response, to slow data load even
+  // when using local service worker caching.
   //
   // await new Promise(resolve => setTimeout(resolve, 3000))
 

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -50,7 +50,7 @@
 }
 
 input.cell-facet-header-checkbox,
-input.root-checkbox {
+input.reset-cell-filters {
   display: inline;
   margin-right: 5px;
   position: relative;
@@ -111,16 +111,18 @@ input.root-checkbox {
 
 .cell-facet .cell-filters-shown .facet-toggle-chevron,
 .cell-facet .cell-facet-header-checkbox,
-.filter-section .root-checkbox {
+.filter-section .reset-cell-filters,
+.filter-section:hover .reset-cell-filters.hide-reset {
   visibility: hidden;
 }
 
 .cell-facet:hover .cell-filters-shown .facet-toggle-chevron,
 .cell-facet:hover .cell-facet-header-checkbox,
 .cell-facet:has(.cell-filters-hidden) .cell-facet-header-checkbox,
-.filter-section:hover .root-checkbox {
+.filter-section:hover .reset-cell-filters {
   visibility: visible;
 }
+
 
 .facet-tools {
   float: right;

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -44,17 +44,44 @@
   cursor: pointer;
 }
 
-.cell-facet-header {
-  padding-bottom: 5px;
+.facet-toggle-chevron {
+  position: relative;
+  top: 2px;
 }
 
-.cell-facet-header.cell-filters-hidden {
-  padding-bottom: 0px;
+input.cell-facet-header-checkbox {
+  display: inline;
+  margin-right: 5px;
+  position: relative;
+  top: -1px;
+  cursor: pointer;
+}
+
+.cell-facet-name {
+  font-weight: bold;
+  margin-bottom: 5px;
+  vertical-align: top;
+  display: inline-block;
+  width: calc(100% - 40px);
+}
+
+.cell-facet:has(.cell-filters-hidden) {
+  .cell-facet-name {
+    margin-bottom: 0px;
+  }
+}
+
+.cell-facet-name {
+  font-weight: bold;
+  vertical-align: top;
+  display: inline-block;
+  width: calc(100% - 40px);
 }
 
 .filter-section-header {
   padding-bottom: 5px;
   border-bottom: 1px solid #DDD;
+  margin-bottom: 3px;
 }
 
 .cell-facet {
@@ -88,3 +115,8 @@
   visibility: visible;
 }
 
+.facet-tools {
+  float: right;
+  margin-right: 5px;
+  margin-top: -1px;
+}

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -47,6 +47,7 @@
 .facet-toggle-chevron {
   position: relative;
   top: 2px;
+  left: 4px;
 }
 
 input.cell-facet-header-checkbox {
@@ -74,7 +75,7 @@ input.cell-facet-header-checkbox {
 .filter-section-name {
   margin-bottom: 0px;
   margin-left: 18px;
-  width: calc(100% - 60px);
+  width: fit-content;
 }
 
 .cell-facet:has(.cell-filters-hidden) {
@@ -87,7 +88,10 @@ input.cell-facet-header-checkbox {
   font-weight: bold;
   vertical-align: top;
   display: inline-block;
-  width: calc(100% - 40px);
+}
+
+.cell-facet-name.loading {
+  width: calc(100% - 60px);
 }
 
 .filter-section-header {

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -49,13 +49,17 @@
   top: 2px;
 }
 
-input.cell-facet-header-checkbox,
-input.reset-cell-filters {
+input.cell-facet-header-checkbox {
   display: inline;
   margin-right: 5px;
   position: relative;
   top: -1px;
   cursor: pointer;
+}
+
+.reset-cell-filters {
+  margin-right: 8px;
+  top: 0px;
 }
 
 .cell-facet-name,
@@ -65,6 +69,12 @@ input.reset-cell-filters {
   vertical-align: top;
   display: inline-block;
   width: calc(100% - 40px);
+}
+
+.filter-section-name {
+  margin-bottom: 0px;
+  margin-left: 18px;
+  width: calc(100% - 60px);
 }
 
 .cell-facet:has(.cell-filters-hidden) {
@@ -123,6 +133,13 @@ input.reset-cell-filters {
   visibility: visible;
 }
 
+.reset-cell-filters {
+  color: #777;
+}
+
+.reset-cell-filters:hover {
+  color: #77D;
+}
 
 .facet-tools {
   float: right;

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -49,7 +49,8 @@
   top: 2px;
 }
 
-input.cell-facet-header-checkbox {
+input.cell-facet-header-checkbox,
+input.root-checkbox {
   display: inline;
   margin-right: 5px;
   position: relative;
@@ -57,7 +58,8 @@ input.cell-facet-header-checkbox {
   cursor: pointer;
 }
 
-.cell-facet-name {
+.cell-facet-name,
+.filter-section-name {
   font-weight: bold;
   margin-bottom: 5px;
   vertical-align: top;
@@ -108,13 +110,15 @@ input.cell-facet-header-checkbox {
 }
 
 .cell-facet .cell-filters-shown .facet-toggle-chevron,
-.cell-facet .cell-facet-header-checkbox {
+.cell-facet .cell-facet-header-checkbox,
+.filter-section .root-checkbox {
   visibility: hidden;
 }
 
 .cell-facet:hover .cell-filters-shown .facet-toggle-chevron,
 .cell-facet:hover .cell-facet-header-checkbox,
-.cell-facet:has(.cell-filters-hidden) .cell-facet-header-checkbox {
+.cell-facet:has(.cell-filters-hidden) .cell-facet-header-checkbox,
+.filter-section:hover .root-checkbox {
   visibility: visible;
 }
 

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -107,11 +107,14 @@ input.cell-facet-header-checkbox {
   color: #77D;
 }
 
-.cell-facet .cell-filters-shown .facet-toggle-chevron {
+.cell-facet .cell-filters-shown .facet-toggle-chevron,
+.cell-facet .cell-facet-header-checkbox {
   visibility: hidden;
 }
 
-.cell-facet:hover .cell-filters-shown .facet-toggle-chevron {
+.cell-facet:hover .cell-filters-shown .facet-toggle-chevron,
+.cell-facet:hover .cell-facet-header-checkbox,
+.cell-facet:has(.cell-filters-hidden) .cell-facet-header-checkbox {
   visibility: visible;
 }
 

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -15,7 +15,7 @@
 .cell-filter-label {
   font-weight: normal;
   cursor: pointer;
-  width: 100%;
+  width: calc(100% - 18px);
   vertical-align: top;
 
   &:hover {
@@ -30,7 +30,7 @@
 
 .cell-filter-label-text {
   display: inline-block;
-  width: calc(100% - 70px);
+  width: calc(100% - 90px);
 }
 
 .cell-filter-count {

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -528,7 +528,23 @@ h6,
 	padding: 3em;
 }
 
+.col-md-10-5 {
+  position: relative;
+  min-height: 1px;
+  padding-right: 15px;
+  padding-left: 15px;
+  float: left;
+  width: 80%;
+}
 
+.col-md-2-5 {
+  position: relative;
+  min-height: 1px;
+  padding-right: 15px;
+  padding-left: 15px;
+  float: left;
+  width: 20%;
+}
 
 @media (min-width: 768px) {
   #view-options .col-sm-4,

--- a/app/javascript/styles/_global.scss
+++ b/app/javascript/styles/_global.scss
@@ -534,7 +534,7 @@ h6,
   padding-right: 15px;
   padding-left: 15px;
   float: left;
-  width: 80%;
+  width: 82%;
 }
 
 .col-md-2-5 {
@@ -543,7 +543,7 @@ h6,
   padding-right: 15px;
   padding-left: 15px;
   float: left;
-  width: 20%;
+  width: 18%;
 }
 
 @media (min-width: 768px) {

--- a/test/js/explore/cell-filtering-panel.test.js
+++ b/test/js/explore/cell-filtering-panel.test.js
@@ -40,7 +40,7 @@ describe('"Cell filtering" panel', () => {
     expect(header).toHaveTextContent('Filter by')
   })
 
-  it('renders initially', async () => {
+  it('toggles facet collapse on chevron click', async () => {
     const cluster = 'All Cells UMAP'
     const shownAnnotation = {
       'name': 'General_Celltype',
@@ -77,5 +77,42 @@ describe('"Cell filtering" panel', () => {
       facetNode => Array.from(facetNode.classList).includes('cell-filters-hidden')
     )
     expect(isAllFacetsHidden).toEqual(true)
+  })
+
+  it('deselects all filters in facet on parent checkbox click', async () => {
+    const cluster = 'All Cells UMAP'
+    const shownAnnotation = {
+      'name': 'General_Celltype',
+      'type': 'group',
+      'scope': 'study',
+      'isDisabled': false
+    }
+
+    // Mock functions
+    const updateClusterParams = jest.fn()
+    const updateFilteredCells = jest.fn()
+
+    const { container } = render(
+      <CellFilteringPanel
+        annotationList={annotationList}
+        cluster={cluster}
+        shownAnnotation={shownAnnotation}
+        updateClusterParams={updateClusterParams}
+        cellFaceting={cellFaceting}
+        cellFilteringSelection={cellFilteringSelection}
+        cellFilterCounts={cellFilterCounts}
+        updateFilteredCells={updateFilteredCells}
+      />
+    )
+
+    // screen.debug(container, 300000) // Print cell filtering panel HTML
+    const facetCheckbox = container.querySelector('.cell-facet-header-checkbox')
+    fireEvent.click(facetCheckbox)
+
+    expect(updateFilteredCells).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'cell_type__ontology_label--group--study': []
+      })
+    )
   })
 })


### PR DESCRIPTION
This adds easy high-level filtering, and a way to reset filters.  Common tasks that were often 25+ clicks are now 2 clicks.

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/cb9ba195-6634-4a49-86c3-6fa15ab9941b

### Overview
Previously, if you wanted to deselect all filters in a facet, you needed to click every filter.  That can be a lot!  This kind of task is common if you want to filter _additively_.  For example, if the "Cell type" (or "Donor ID" or "Biosample ID") facet has 26 filters and you _only_ want to see 1 cell type, then you'd need to click 25 times to deselect all the other cell types.  

Now, that task is only 2 clicks.  Click the new facet-level checkbox beside any facet label to deselect _all_ filters in the facet, then click the 1 cell type you want to see.  This optimizes the interaction cost from O(n + 1) to O(2) -- substantial savings in human time and working memory.

You can now also click an intuitive icon atop the filter section to reset all filters to their default state.

### Test
A new automated test verifies some of the new behavior.  To manually test:

1.  Go to "Human milk - differential expression" study ([SCP303](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP303/human-milk-differential-expression) if on staging)
2. Click "Filter plotted cells"
3. Scroll down to "Donor ID" facet
4. Hover over facet, click checkbox to left of "Donor ID"
5. Confirm all "Donor ID" filters are deselected, and plot shows only filtered cells in grey
6. Click grey undo icon at right of "Filter by" section header
7. Confirm all "Donor ID" filters are selected, and plot shows no filtered cells in grey

This satisfies SCP-5386.