### PR TITLE
Fix DE table columns (SCP-5402)

### DIFF
--- a/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
+++ b/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
@@ -35,8 +35,6 @@ export function parseDeFile(tsvText, isAuthorDe=false) {
 
     if (tsvLine === '') {continue}
     const row = tsvLine.split('\t')
-    console.log('row')
-    console.log(row)
 
     let deGene
 
@@ -253,7 +251,7 @@ export function PairwiseDifferentialExpressionGroupPicker({
 /** Pick groups of cells for one-vs-rest-only differential expression (DE) */
 export function OneVsRestDifferentialExpressionGroupPicker({
   bucketId, clusterName, annotation, deGenes, deGroup, setDeGroup, setDeGenes,
-  countsByLabel, deObjects, setDeFilePath, isAuthorDe, sizeMetric, significanceMetric
+  countsByLabel, deObjects, setDeFilePath, isAuthorDe
 }) {
   let groups = getLegendSortedLabels(countsByLabel)
   groups = groups.filter(group => {
@@ -272,7 +270,7 @@ export function OneVsRestDifferentialExpressionGroupPicker({
 
     setDeFilePath(deFilePath)
 
-    const deGenes = await fetchDeGenes(bucketId, deFilePath)
+    const deGenes = await fetchDeGenes(bucketId, deFilePath, isAuthorDe)
 
     setDeGroup(newGroup)
     setDeGenes(deGenes)

--- a/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
+++ b/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
@@ -68,7 +68,7 @@ export function parseDeFile(tsvText, isAuthorDe=false) {
       // names  scores  logfoldchanges  pvals pvals_adj pct_nz_group  pct_nz_reference
       const [
         index, // eslint-disable-line
-        name, score, size, altSignificance,	significance
+        name, score, size, altSignificance, significance
       ] = row
 
       deGene = {

--- a/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
+++ b/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
@@ -36,37 +36,55 @@ function parseDeFile(tsvText, isAuthorDe=false) {
     if (tsvLine === '') {continue}
     const row = tsvLine.split('\t')
 
-    // Each element in this array is DE data for the gene in this row
-    //
-    // TODO: There are usually more columns than size (e.g. logfoldchanges)
-    // and significance (e.g. pvals_adj) that may well be of interest.
-    // However, we don't parse those here before there is no UI for them.
-    // If we opt to build a UI for further metrics (e.g. pctNzGroup in Scanpy
-    // / pct.1 in Seurat, etc.), we would need to order them canonically
-    // across SCP-computed DE results and (Ingest Pipeline-processed) author
-    // DE results.
-    let [
-      index, // eslint-disable-line
-      name, size, significance
-    ] = row
-
+    let deGene
 
     if (isAuthorDe) {
-      size = round(size, 3),
-      significance = round(significance, 3)
-    }
+      // Each element in this array is DE data for the gene in this row
+      //
+      // TODO: There are usually more columns than size (e.g. logfoldchanges)
+      // and significance (e.g. pvals_adj) that may well be of interest.
+      // However, we don't parse those here before there is no UI for them.
+      // If we opt to build a UI for further metrics (e.g. pctNzGroup in Scanpy
+      // / pct.1 in Seurat, etc.), we would need to order them canonically
+      // across SCP-computed DE results and (Ingest Pipeline-processed) author
+      // DE results.
+      let [
+        index, // eslint-disable-line
+        name, size, significance
+      ] = row
 
-    const deGene = {
-      // TODO (SCP-5201): Show significant zeros, e.g. 0's to right of 9 in 0.900
-      size,
-      significance
+      if (isAuthorDe) {
+        size = round(size, 3),
+        significance = round(significance, 3)
+      }
+
+      deGene = {
+        // TODO (SCP-5201): Show significant zeros, e.g. 0's to right of 9 in 0.900
+        name,
+        size,
+        significance
+      }
+    } else {
+      // names  scores  logfoldchanges  pvals pvals_adj pct_nz_group  pct_nz_reference
+      const [
+        index, // eslint-disable-line
+        name, score, size, altSignificance,	significance
+      ] = row
+
+      deGene = {
+        // TODO (SCP-5201): Show significant zeros, e.g. 0's to right of 9 in 0.900
+        name,
+        size,
+        significance
+      }
     }
 
     Object.entries(deGene).forEach(([k, v]) => {
       // Cast numeric string values as floats
-      deGene[k] = parseFloat(v)
+      if (k !== 'name') {
+        deGene[k] = parseFloat(v)
+      }
     })
-    deGene.name = name
     deGenes.push(deGene)
   }
 

--- a/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
+++ b/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
@@ -27,7 +27,7 @@ function round(num, places) {
 /**
  * Transform raw TSV text into array of differential expression gene objects
  */
-function parseDeFile(tsvText, isAuthorDe=false) {
+export function parseDeFile(tsvText, isAuthorDe=false) {
   const deGenes = []
   const tsvLines = tsvText.split(newlineRegex)
   for (let i = 1; i < tsvLines.length; i++) {
@@ -35,6 +35,8 @@ function parseDeFile(tsvText, isAuthorDe=false) {
 
     if (tsvLine === '') {continue}
     const row = tsvLine.split('\t')
+    console.log('row')
+    console.log(row)
 
     let deGene
 

--- a/test/js/explore/differential-expression-panel.test.js
+++ b/test/js/explore/differential-expression-panel.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-tabs */
 /**
  * @fileoverview Tests for differential expression (DE) functionality
  */
@@ -8,7 +9,7 @@ import '@testing-library/jest-dom/extend-expect'
 
 import DifferentialExpressionPanel from 'components/explore/DifferentialExpressionPanel'
 import {
-  PairwiseDifferentialExpressionGroupPicker
+  PairwiseDifferentialExpressionGroupPicker, parseDeFile
 } from 'components/visualization/controls/DifferentialExpressionGroupPicker'
 import { exploreInfo, deObjects } from './differential-expression-panel.test-data'
 
@@ -211,5 +212,19 @@ describe('Differential expression panel', () => {
     // Ensure options in menu A display by default
     const pairwiseSelectA = container.querySelector('.pairwise-select')
     expect(pairwiseSelectA).toHaveTextContent('CSN1S1 macrophages')
+  })
+})
+
+describe('DE gene parsing', () => {
+  it('correctly transforms SCP-computed DE file', () => {
+    const tsvText =
+      `names	scores	logfoldchanges	pvals	pvals_adj	pct_nz_group	pct_nz_reference
+      0	CD74	11.55	4.138	7.695e-31	1.547e-26	1	0.7262
+      1	HLA-DPA1	11.05	3.753	2.291e-28	2.778e-24	1	0.5595
+      2	TCF4	10.92	7.512	9.554e-28	6.952e-24	0.8846	0.04085
+      3	HLA-DPB1	10.79	3.461	3.818e-27	2.221e-23	1	0.6034`
+    const deGenes = parseDeFile(tsvText)
+    expect(deGenes[0].size).toEqual(4.138)
+    expect(deGenes[0].significance).toEqual(1.547e-26)
   })
 })

--- a/test/js/explore/differential-expression-panel.test.js
+++ b/test/js/explore/differential-expression-panel.test.js
@@ -227,4 +227,17 @@ describe('DE gene parsing', () => {
     expect(deGenes[0].size).toEqual(4.138)
     expect(deGenes[0].significance).toEqual(1.547e-26)
   })
+
+  it('correctly transforms ingest-processed author DE file', () => {
+    const tsvText =
+    `gene	avg_log2FC	p_val_adj	pct.2	pct.1	p_val
+    0	ACE2	1.47710477	0.0	0.63504	0.8154	0.0
+    1	CD274	1.171502945	0.0	0.5616	0.76314	0.0
+    2	TP53	1.513586574	0.0	0.37492	0.68441	0.0`
+
+    const isAuthorDe = true
+    const deGenes = parseDeFile(tsvText, isAuthorDe)
+    expect(deGenes[0].size).toEqual(1.477)
+    expect(deGenes[0].significance).toEqual(0)
+  })
 })

--- a/test/js/explore/differential-expression-panel.test.js
+++ b/test/js/explore/differential-expression-panel.test.js
@@ -230,10 +230,10 @@ describe('DE gene parsing', () => {
 
   it('correctly transforms ingest-processed author DE file', () => {
     const tsvText =
-    `gene	avg_log2FC	p_val_adj	pct.2	pct.1	p_val
-    0	ACE2	1.47710477	0.0	0.63504	0.8154	0.0
-    1	CD274	1.171502945	0.0	0.5616	0.76314	0.0
-    2	TP53	1.513586574	0.0	0.37492	0.68441	0.0`
+      `gene	avg_log2FC	p_val_adj	pct.2	pct.1	p_val
+      0	ACE2	1.47710477	0.0	0.63504	0.8154	0.0
+      1	CD274	1.171502945	0.0	0.5616	0.76314	0.0
+      2	TP53	1.513586574	0.0	0.37492	0.68441	0.0`
 
     const isAuthorDe = true
     const deGenes = parseDeFile(tsvText, isAuthorDe)


### PR DESCRIPTION
This fixes a bug in which the table for SCP-computed DE and one-vs-rest author DE reported values for the wrong metric.  

The values are usually clearly awry upon basic scientific inspection, but it doesn't break the UI, so users would likely suspect something is broken with SCP computation even though the problem is confined to front-end parsing.

### Test
Two new automated tests protect against regressions.  To manually test:

1.  Go to any study with SCP-computed DE
2. Open Network panel in Chrome DevTools
3. Click "Differential expression"
4. Select a group
5. Note the first few genes in DE table, and their data for log2(FC) and adj. p-value.
6. In Network panel, filter to "googleapis", and find the file from the bucket
7. Confirm the same genes appear atop the values, and that their data logfoldchanges and pvals_adj match the DE table

This satisfies SCP-5402.