### PR TITLE
Fix cell filtering when data has "--Unspecified--" group (SCP-5398)

### DIFF
--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -296,6 +296,9 @@ module Api
               else
                 label = annotation_arrays[annotation][index] || '--Unspecified--'
               end
+              if label == ''
+                label = '--Unspecified--'
+              end
               facet[:groups].index(label)
             end
           end

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -253,7 +253,7 @@ function CellFacet({
 
   const [sortKey, setSortKey] = useState('count')
 
-  const unsortedFilters = facet.unsortedGroups
+  const unsortedFilters = facet.unsortedGroups ?? []
   let filters
 
   //  Naturally sort groups (see https://en.wikipedia.org/wiki/Natural_sort_order)
@@ -264,7 +264,7 @@ function CellFacet({
   } else {
     // Sort categorical filters (i.e., groups)
     const filterCounts = facet.originalFilterCounts
-    const sortedGroups = facet.unsortedGroups.sort((a, b) => {
+    const sortedGroups = unsortedFilters.sort((a, b) => {
       if (filterCounts[a] && filterCounts[b]) {
         return filterCounts[b] - filterCounts[a]
       }

--- a/test/api/visualization/annotations_controller_test.rb
+++ b/test/api/visualization/annotations_controller_test.rb
@@ -88,7 +88,7 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
                                     test_array: @@studies_to_clean)
     sign_in_and_update @user
     execute_http_request(:get, api_v1_study_annotations_path(@basic_study))
-    assert_equal 3, json.length
+    assert_equal 4, json.length
     assert_equal(%w[species disease cell_type foo], json.map { |annot| annot['name'] })
     expected_annotation = {
       name: 'species', type: 'group', values: %w[dog cat], scope: 'study', is_differential_expression_enabled: false
@@ -167,18 +167,19 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should load requested facet annotations' do
-    annotation_param = 'species--group--study,disease--group--study'
+    annotation_param = 'species--group--study,disease--group--study,cell_type--group--study'
     cluster = @basic_study.cluster_groups.by_name('clusterA.txt')
     annotations = Api::V1::Visualization::AnnotationsController.get_facet_annotations(
       @basic_study, cluster, annotation_param
     )
-    assert_equal 2, annotations.size
+    assert_equal 3, annotations.size
     expected_annotations = @basic_study.cell_metadata.map do |meta|
       {
         name: meta.name, type: meta.annotation_type, scope: 'study', values: meta.values,
         identifier: meta.annotation_select_value
       }
     end
+    expected_annotations[2][:values][1] = '--Unspecified--'
     assert_equal expected_annotations, annotations
     assert_empty Api::V1::Visualization::AnnotationsController.get_facet_annotations(
       @basic_study, cluster, 'does-not-exist--group--study'

--- a/test/api/visualization/annotations_controller_test.rb
+++ b/test/api/visualization/annotations_controller_test.rb
@@ -27,7 +27,8 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
                                                    cell_input: ['A', 'B', 'C'],
                                                    annotation_input: [
                                                      {name: 'species', type: 'group', values: ['dog', 'cat', 'dog']},
-                                                     {name: 'disease', type: 'group', values: ['none', 'none', 'measles']}
+                                                     {name: 'disease', type: 'group', values: ['none', 'none', 'measles']},
+                                                     {name: 'cell_type', type: 'group', values: ['big', '', 'big']}
                                                    ])
 
     marker_cluster_list = %w(Cluster1 Cluster2 Cluster3)
@@ -88,7 +89,7 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_and_update @user
     execute_http_request(:get, api_v1_study_annotations_path(@basic_study))
     assert_equal 3, json.length
-    assert_equal(%w[species disease foo], json.map { |annot| annot['name'] })
+    assert_equal(%w[species disease cell_type foo], json.map { |annot| annot['name'] })
     expected_annotation = {
       name: 'species', type: 'group', values: %w[dog cat], scope: 'study', is_differential_expression_enabled: false
     }.with_indifferent_access
@@ -139,14 +140,15 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should get annotation facets' do
     sign_in_and_update @user
-    annotations = 'species--group--study,disease--group--study'
+    annotations = 'species--group--study,disease--group--study,cell_type--group--study'
     facet_params = { cluster: 'clusterA.txt', annotations: }
     execute_http_request(:get, api_v1_study_annotations_facets_path(@basic_study, **facet_params))
     assert_response :success
     assert json['cells'].size == 3
     expected_facets = [
       { annotation: 'species--group--study', groups: %w[dog cat] }.with_indifferent_access,
-      { annotation: 'disease--group--study', groups: %w[none measles] }.with_indifferent_access
+      { annotation: 'disease--group--study', groups: %w[none measles] }.with_indifferent_access,
+      { annotation: 'cell_type--group--study', groups: %w[big --Unspecified--] }.with_indifferent_access
     ]
     # test validations
     assert_equal expected_facets, json['facets']


### PR DESCRIPTION
This fixes a rare case of overselection in cell filtering, and a problem in unreleased code merged last week.

### Overview
Previously, filtering would occasionally remove more cells than were in the deselected group.  It turns out this only occurs if a clustering had an annotation with cells that were _not_ assigned to any group by the author.  Such cells are typically marked with the special label "--Unspecified--" at request-time.

Now, filtering in a cluster that has an "--Unspecified--" group returns the expected number of cells.  Although the diagnosis was complex, the fix simply required refining how the ungrouped cells are detected and explicitly marked as unspecified.

These changes also fix a previously unreported bug in changes from last week (#1922).  While fixing the main issue, I found that filtering then searching a gene broke the Explore UI.  That now works as expected.

### Video
Here's how the bug and its fix look on copies of [SCP2407](https://singlecell.broadinstitute.org/single_cell/study/SCP2407/single-cell-atlas-of-the-liver-myeloid-compartment-before-and-after-cure-of-chronic-viral-hepatitis), a public study that motivated this work.

#### Bug
https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/bac360e1-4756-431f-ac69-a4b3df6b4689

#### Fix
https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/2463b851-f9fe-4cea-8326-574b1db5f7a4

### Test
An automated test was updated to prevent regression in "--Unspecified--" handling.  To manually test:

* If you're on staging and this PR is [deployed](https://scp-jenkins.dsp-techops.broadinstitute.org/job/scp-deploy-hotfix-to-staging/) there, go to [SCP374](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP374/hepatitis-and-unspecified-scp2407-on-staging) ("Hepatitis and --Unspecified--: SCP2407 on staging") with filtering enabled
* Click "Filter plotted cells" button
* Note the counts in the default filters for the "Celltype initial" facet, e.g. 3124 for "CD14+ Monocyte"
* Deselect the "CD14+ Monocyte" checkbox
* Confirm the "--Filtered--" scatter plot legend entry reports 3124 cells (not e.g. 5643)
* Select the "CD14+ Monocyte" checkbox
* Confirm the "--Filtered--" legend entry disappears

I've also added a new [manual smoke test for cell filtering](https://docs.google.com/document/d/1rKcOQPtkbhZCbTqxTnaT-4E29VLzkJrm0kAoWjLx3QA/edit#heading=h.o66s4o4su847) to the release engineering process.  That'll help ensure any breaks in the happy path for cell filtering don't reach production.

This satisfies SCP-5398.  It may well also fix SCP-5390, another bug related to "--Unspecified--".