### PR TITLE
Using GitHub Actions to build portal Docker image (SCP-4944)

### DIFF
--- a/.github/workflows/build-and-publish-development-image.yml
+++ b/.github/workflows/build-and-publish-development-image.yml
@@ -36,7 +36,7 @@ jobs:
           # this will create a Docker volume called 'gcloud-config' that contains credentials for use with gcloud
           export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )
           vault read -format=json $VAULT_SECRET_PATH | jq .data > $SERVICE_ACCOUNT_PATH
-          docker run -v "$SERVICE_ACCOUNT_PATH:$SERVICE_ACCOUNT_PATH" -it --name gcloud-config $GCLOUD_DOCKER_IMAGE gcloud \
+          docker run -v "$SERVICE_ACCOUNT_PATH:$SERVICE_ACCOUNT_PATH" --name gcloud-config $GCLOUD_DOCKER_IMAGE gcloud \
                  auth activate-service-account --key-file=$SERVICE_ACCOUNT_PATH
       - name: Build development image
         env:

--- a/.github/workflows/build-and-publish-development-image.yml
+++ b/.github/workflows/build-and-publish-development-image.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   Build-And-Publish-Development-Image:
-    runs-on: ubuntu-20.04
+    runs-on: self-hosted
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-publish-development-image.yml
+++ b/.github/workflows/build-and-publish-development-image.yml
@@ -43,7 +43,7 @@ jobs:
           VERSION_TAG: github-action-test
         run: |
           # copy configs locally to enable auth to gcr via gcloud alias below
-          docker cp gcloud-config:/root/.config/gcloud /root/.config/gcloud --quiet
-          docker cp gcloud-config:/root/.docker ~/Desktop/docker --quiet
+          sudo docker cp gcloud-config:/root/.config/gcloud /root/.config/gcloud --quiet
+          sudo docker cp gcloud-config:/root/.docker ~/Desktop/docker --quiet
           # substitutes 'docker run ARGS gcloud' for regular gcloud command
           bin/build_image.sh -v $VERSION_TAG -g "docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"

--- a/.github/workflows/build-and-publish-development-image.yml
+++ b/.github/workflows/build-and-publish-development-image.yml
@@ -36,14 +36,14 @@ jobs:
           # this will create a Docker volume called 'gcloud-config' that contains credentials for use with gcloud
           export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )
           vault read -format=json $VAULT_SECRET_PATH | jq .data > $SERVICE_ACCOUNT_PATH
-          docker run -v "$SERVICE_ACCOUNT_PATH:$SERVICE_ACCOUNT_PATH" --name gcloud-config $GCLOUD_DOCKER_IMAGE sh -c \
-            "gcloud auth activate-service-account --key-file=$SERVICE_ACCOUNT_PATH && gcloud auth configure-docker gcr.io --quiet"
+          docker run -v "$SERVICE_ACCOUNT_PATH:$SERVICE_ACCOUNT_PATH" --name gcloud-config $GCLOUD_DOCKER_IMAGE gcloud \
+                         auth activate-service-account --key-file=$SERVICE_ACCOUNT_PATH
       - name: Build development image
         env:
           VERSION_TAG: github-action-test
         run: |
-          # copy configs locally to enable auth to gcr via gcloud alias below
-          docker cp gcloud-config:/root/.config/gcloud $HOME/.config/gcloud --quiet
-          docker cp gcloud-config:/root/.docker  $HOME/.docker --quiet
+          # auth into GCR via Docker with token
+          docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud \ 
+                 auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://gcr.io
           # substitutes 'docker run ARGS gcloud' for regular gcloud command
           bin/build_image.sh -v $VERSION_TAG -g "docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"

--- a/.github/workflows/build-and-publish-development-image.yml
+++ b/.github/workflows/build-and-publish-development-image.yml
@@ -43,7 +43,8 @@ jobs:
           VERSION_TAG: github-action-test
         run: |
           # copy configs locally to enable auth to gcr via gcloud alias below
-          sudo docker cp gcloud-config:/root/.config/gcloud /root/.config/gcloud --quiet
-          sudo docker cp gcloud-config:/root/.docker ~/Desktop/docker --quiet
+          echo $(whoami)
+          # sudo docker cp gcloud-config:/root/.config/gcloud /root/.config/gcloud --quiet
+          # sudo docker cp gcloud-config:/root/.docker  /root/.docker --quiet
           # substitutes 'docker run ARGS gcloud' for regular gcloud command
-          bin/build_image.sh -v $VERSION_TAG -g "docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"
+          # bin/build_image.sh -v $VERSION_TAG -g "docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"

--- a/.github/workflows/build-and-publish-development-image.yml
+++ b/.github/workflows/build-and-publish-development-image.yml
@@ -36,11 +36,14 @@ jobs:
           # this will create a Docker volume called 'gcloud-config' that contains credentials for use with gcloud
           export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )
           vault read -format=json $VAULT_SECRET_PATH | jq .data > $SERVICE_ACCOUNT_PATH
-          docker run -v "$SERVICE_ACCOUNT_PATH:$SERVICE_ACCOUNT_PATH" --name gcloud-config $GCLOUD_DOCKER_IMAGE gcloud \
-                 auth activate-service-account --key-file=$SERVICE_ACCOUNT_PATH
+          docker run -v "$SERVICE_ACCOUNT_PATH:$SERVICE_ACCOUNT_PATH" --name gcloud-config $GCLOUD_DOCKER_IMAGE sh -c \
+            "gcloud auth activate-service-account --key-file=$SERVICE_ACCOUNT_PATH && gcloud auth configure-docker gcr.io --quiet"
       - name: Build development image
         env:
           VERSION_TAG: github-action-test
         run: |
+          # copy configs locally to enable auth to gcr via gcloud alias below
+          docker cp gcloud-config:/root/.config/gcloud /root/.config/gcloud --quiet
+          docker cp gcloud-config:/root/.docker ~/Desktop/docker --quiet
           # substitutes 'docker run ARGS gcloud' for regular gcloud command
           bin/build_image.sh -v $VERSION_TAG -g "docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"

--- a/.github/workflows/build-and-publish-development-image.yml
+++ b/.github/workflows/build-and-publish-development-image.yml
@@ -43,8 +43,7 @@ jobs:
           VERSION_TAG: github-action-test
         run: |
           # copy configs locally to enable auth to gcr via gcloud alias below
-          echo $(whoami)
-          # sudo docker cp gcloud-config:/root/.config/gcloud /root/.config/gcloud --quiet
-          # sudo docker cp gcloud-config:/root/.docker  /root/.docker --quiet
+          docker cp gcloud-config:/root/.config/gcloud $HOME/.config/gcloud --quiet
+          docker cp gcloud-config:/root/.docker  $HOME/.docker --quiet
           # substitutes 'docker run ARGS gcloud' for regular gcloud command
-          # bin/build_image.sh -v $VERSION_TAG -g "docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"
+          bin/build_image.sh -v $VERSION_TAG -g "docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"

--- a/.github/workflows/build-and-publish-development-image.yml
+++ b/.github/workflows/build-and-publish-development-image.yml
@@ -1,0 +1,20 @@
+name: Build and publish development Docker image
+on:
+  push:
+    branches:
+      - jb-github-actions-cd
+env:
+  DOCKER_IMAGE_NAME: "gcr.io/broad-singlecellportal-staging/single-cell-portal"
+
+jobs:
+  Build-And-Publish-Development-Image:
+    runs-on: self-hosted
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Build development image
+        env:
+          VERSION_TAG: github-action-test
+        run: |
+          bin/build_image.sh -v $VERSION_TAG
+          

--- a/.github/workflows/build-and-publish-development-image.yml
+++ b/.github/workflows/build-and-publish-development-image.yml
@@ -5,6 +5,9 @@ on:
       - jb-github-actions-cd
 env:
   DOCKER_IMAGE_NAME: "gcr.io/broad-singlecellportal-staging/single-cell-portal"
+  GCLOUD_DOCKER_IMAGE: "gcr.io/google.com/cloudsdktool/google-cloud-cli:latest"
+  VAULT_SECRET_PATH: "secret/kdux/scp/staging/scp_service_account.json"
+  SERVICE_ACCOUNT_PATH: "/tmp/scp_service_account.json"
 
 jobs:
   Build-And-Publish-Development-Image:
@@ -12,9 +15,28 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
+      - name: Install vault
+        shell: bash
+        run: |
+          sudo apt-get update && sudo apt-get -y install curl unzip jq
+          sudo curl -O https://releases.hashicorp.com/vault/1.9.0/vault_1.9.0_linux_amd64.zip
+          sudo unzip vault_1.9.0_linux_amd64.zip
+          sudo mv vault /usr/local/bin
+      - name: Download gcloud Docker image
+        shell: bash
+        run: |
+          docker pull $GCLOUD_DOCKER_IMAGE
+      - name: Authenticate to gcloud
+        shell: bash
+        run: |
+          # this will create a Docker volume called 'gcloud-config' that contains credentials for use with gcloud
+          export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )
+          vault read -format=json $VAULT_SECRET_PATH | jq .data > $SERVICE_ACCOUNT_PATH
+          docker run -v "$SERVICE_ACCOUNT_PATH:$SERVICE_ACCOUNT_PATH" -it -t gcloud-config $GCLOUD_DOCKER_IMAGE gcloud \
+                 auth activate-service-account --key-file=$SERVICE_ACCOUNT_PATH
       - name: Build development image
         env:
           VERSION_TAG: github-action-test
         run: |
-          bin/build_image.sh -v $VERSION_TAG
-          
+          # substitutes 'docker run ARGS gcloud' for regular gcloud command
+          bin/build_image.sh -v $VERSION_TAG -g "docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"

--- a/.github/workflows/build-and-publish-development-image.yml
+++ b/.github/workflows/build-and-publish-development-image.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   Build-And-Publish-Development-Image:
-    runs-on: self-hosted
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -27,6 +27,10 @@ jobs:
         run: |
           docker pull $GCLOUD_DOCKER_IMAGE
       - name: Authenticate to gcloud
+        env:
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+          VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+          VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
         shell: bash
         run: |
           # this will create a Docker volume called 'gcloud-config' that contains credentials for use with gcloud

--- a/.github/workflows/build-and-publish-development-image.yml
+++ b/.github/workflows/build-and-publish-development-image.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   Build-And-Publish-Development-Image:
-    runs-on: self-hosted
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
           # this will create a Docker volume called 'gcloud-config' that contains credentials for use with gcloud
           export VAULT_TOKEN=$( vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_SECRET_ID )
           vault read -format=json $VAULT_SECRET_PATH | jq .data > $SERVICE_ACCOUNT_PATH
-          docker run -v "$SERVICE_ACCOUNT_PATH:$SERVICE_ACCOUNT_PATH" -it -t gcloud-config $GCLOUD_DOCKER_IMAGE gcloud \
+          docker run -v "$SERVICE_ACCOUNT_PATH:$SERVICE_ACCOUNT_PATH" -it --name gcloud-config $GCLOUD_DOCKER_IMAGE gcloud \
                  auth activate-service-account --key-file=$SERVICE_ACCOUNT_PATH
       - name: Build development image
         env:

--- a/.github/workflows/build-and-publish-development-image.yml
+++ b/.github/workflows/build-and-publish-development-image.yml
@@ -43,7 +43,7 @@ jobs:
           VERSION_TAG: github-action-test
         run: |
           # auth into GCR via Docker with token
-          docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud \ 
-                 auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://gcr.io
+          AUTH_TOKEN=$(docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud auth print-access-token)
+          docker login -u oauth2accesstoken --password $AUTH_TOKEN https://gcr.io
           # substitutes 'docker run ARGS gcloud' for regular gcloud command
           bin/build_image.sh -v $VERSION_TAG -g "docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -43,13 +43,11 @@ jobs:
           echo $AUTH_TOKEN | docker login -u oauth2accesstoken --password-stdin https://gcr.io
       - name: Build requested Docker image
         run: |
-          # substitutes 'docker run ARGS gcloud' for regular gcloud command
-          GCLOUD_ALIAS="docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"
-          # determine if VERSION_TAG should be set
+          # substitute 'docker run ARGS gcloud' for regular gcloud command and determine if VERSION_TAG should be set
           if [[ ${{ github.ref_name }} == 'master' ]]; then
-            bin/build_image.sh -g $GCLOUD_ALIAS
+            bin/build_image.sh -g "docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"
           else
-            bin/build_image.sh -v ${{ github.ref_name }} -g $GCLOUD_ALIAS
+            bin/build_image.sh -v ${{ github.ref_name }} -g "docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"
           fi
           
           

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - jb-github-actions-cd
+      - development
+      - master
+  workflow_dispatch:
 env:
   DOCKER_IMAGE_NAME: "gcr.io/broad-singlecellportal-staging/single-cell-portal"
   GCLOUD_DOCKER_IMAGE: "gcr.io/google.com/cloudsdktool/google-cloud-cli:latest"

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -1,4 +1,4 @@
-name: Build and publish development Docker image
+name: Build and publish single-cell-portal Docker image
 on:
   push:
     branches:
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         run: |
           docker pull $GCLOUD_DOCKER_IMAGE
-      - name: Authenticate to gcloud
+      - name: Authenticate to gcloud and docker
         env:
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
           VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
@@ -38,12 +38,18 @@ jobs:
           vault read -format=json $VAULT_SECRET_PATH | jq .data > $SERVICE_ACCOUNT_PATH
           docker run -v "$SERVICE_ACCOUNT_PATH:$SERVICE_ACCOUNT_PATH" --name gcloud-config $GCLOUD_DOCKER_IMAGE gcloud \
                          auth activate-service-account --key-file=$SERVICE_ACCOUNT_PATH
-      - name: Build requested Docker image
-        run: |
           # auth into GCR via Docker with token
           AUTH_TOKEN=$(docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud auth print-access-token)
-          docker login -u oauth2accesstoken --password $AUTH_TOKEN https://gcr.io
-          # determine version tag (currently testing)
-          BUILD_ARGS=${{ github.ref_name == 'jb-github-actions-cd' && '-v github-action-test' || '-v build-name-diff' }}
+          echo $AUTH_TOKEN | docker login -u oauth2accesstoken --password-stdin https://gcr.io
+      - name: Build requested Docker image
+        run: |
           # substitutes 'docker run ARGS gcloud' for regular gcloud command
-          bin/build_image.sh $BUILD_ARGS -g "docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"
+          GCLOUD_ALIAS="docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"
+          # determine if VERSION_TAG should be set
+          if [[ ${{ github.ref_name }} == 'master' ]]; then
+            bin/build_image.sh -g $GCLOUD_ALIAS
+          else
+            bin/build_image.sh -v ${{ github.ref_name }} -g $GCLOUD_ALIAS
+          fi
+          
+          

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -10,7 +10,7 @@ env:
   SERVICE_ACCOUNT_PATH: "/tmp/scp_service_account.json"
 
 jobs:
-  Build-And-Publish-Development-Image:
+  Build-And-Publish-Docker-Image:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
@@ -38,12 +38,12 @@ jobs:
           vault read -format=json $VAULT_SECRET_PATH | jq .data > $SERVICE_ACCOUNT_PATH
           docker run -v "$SERVICE_ACCOUNT_PATH:$SERVICE_ACCOUNT_PATH" --name gcloud-config $GCLOUD_DOCKER_IMAGE gcloud \
                          auth activate-service-account --key-file=$SERVICE_ACCOUNT_PATH
-      - name: Build development image
-        env:
-          VERSION_TAG: github-action-test
+      - name: Build requested Docker image
         run: |
           # auth into GCR via Docker with token
           AUTH_TOKEN=$(docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud auth print-access-token)
           docker login -u oauth2accesstoken --password $AUTH_TOKEN https://gcr.io
+          # determine version tag (currently testing)
+          BUILD_ARGS=${{ github.ref_name == 'jb-github-actions-cd' && '-v github-action-test' || '-v build-name-diff' }}
           # substitutes 'docker run ARGS gcloud' for regular gcloud command
-          bin/build_image.sh -v $VERSION_TAG -g "docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"
+          bin/build_image.sh $BUILD_ARGS -g "docker run --rm --volumes-from gcloud-config $GCLOUD_DOCKER_IMAGE gcloud"

--- a/bin/build_image.sh
+++ b/bin/build_image.sh
@@ -63,7 +63,7 @@ function main {
   echo "*** PUSH COMPLETE ***"
   # pushing an image with the same tag as an existing one (which will happen each time with 'development') can leave
   # behind an untagged image that needs to be deleted - these can be found with --filter='-tags:*'
-  UNTAGGED=$($GCLOUD_ALIAS container images list-tags $IMAGE_NAME --filter='-tags:*' --format='get(digest)')
+  UNTAGGED=$($GCLOUD_ALIAS container images list-tags $IMAGE_NAME --filter="-tags:*" --format="get(digest)")
   if [[ -n "$UNTAGGED" ]]; then
     echo "*** DELETING UNTAGGED IMAGE DIGEST $UNTAGGED ***"
     $GCLOUD_ALIAS container images delete $IMAGE_NAME@$UNTAGGED --quiet || exit_with_error_message "could not delete image $UNTAGGED"

--- a/bin/build_image.sh
+++ b/bin/build_image.sh
@@ -14,6 +14,7 @@ usage=$(
 cat <<EOF
 $0 [OPTION]
 -v VALUE  specify version tag for docker image
+-g VALUE  provide an alias for the gcloud command (if running via gcloud Docker image, for instance)
 -h        print this text
 EOF
 )
@@ -26,7 +27,8 @@ function main {
   # TODO: (SCP-4496): Move production-related GCR images out of staging project
   VERSION_TAG=$(extract_release_tag "0")
   IMAGE_NAME='gcr.io/broad-singlecellportal-staging/single-cell-portal'
-  while getopts "v:h" OPTION; do
+  GCLOUD_ALIAS='gcloud'
+  while getopts "v:g:h" OPTION; do
     case $OPTION in
       v)
         VERSION_TAG="$OPTARG"
@@ -34,6 +36,10 @@ function main {
       h)
         echo "$usage"
         exit 0
+        ;;
+      g)
+        echo "### SUBSTITUTING '$OPTARG' FOR $GCLOUD_ALIAS ###"
+        GCLOUD_ALIAS=("$OPTARG")
         ;;
       *)
         echo "unrecognized option"
@@ -44,7 +50,7 @@ function main {
   done
 
   # skip building a tagged release if it already exists, unless this is the development branch
-  EXISTING_DIGEST=$(gcloud container images list-tags $IMAGE_NAME --filter="tags:$VERSION_TAG" --format='get(digest)')
+  EXISTING_DIGEST=$($GCLOUD_ALIAS container images list-tags $IMAGE_NAME --filter="tags:$VERSION_TAG" --format='get(digest)')
   if [[ "$VERSION_TAG" != 'development' ]] && [[ -n "$EXISTING_DIGEST" ]]; then
     exit_with_error_message "unable to build $VERSION_TAG as it already exists with digest $EXISTING_DIGEST"
   fi
@@ -57,10 +63,10 @@ function main {
   echo "*** PUSH COMPLETE ***"
   # pushing an image with the same tag as an existing one (which will happen each time with 'development') can leave
   # behind an untagged image that needs to be deleted - these can be found with --filter='-tags:*'
-  UNTAGGED=$(gcloud container images list-tags $IMAGE_NAME --filter='-tags:*' --format='get(digest)')
+  UNTAGGED=$($GCLOUD_ALIAS container images list-tags $IMAGE_NAME --filter='-tags:*' --format='get(digest)')
   if [[ -n "$UNTAGGED" ]]; then
     echo "*** DELETING UNTAGGED IMAGE DIGEST $UNTAGGED ***"
-    gcloud container images delete $IMAGE_NAME@$UNTAGGED --quiet || exit_with_error_message "could not delete image $UNTAGGED"
+    $GCLOUD_ALIAS container images delete $IMAGE_NAME@$UNTAGGED --quiet || exit_with_error_message "could not delete image $UNTAGGED"
     echo "*** UNTAGGED IMAGE $UNTAGGED SUCCESSFULLY DELETED ***"
   fi
 }


### PR DESCRIPTION
UPDATE: This can't be merged until we either implement deployments through Github Actions, or we can figure out a trigger for Jenkins to watch for the completion of these builds.  Otherwise, Jenkins will deploy to staging before the requested tag has been built.

#### BACKGROUND
Starting next May, DevOps will no longer maintain any Jenkins servers in DSP.  Since we use Jenkins for our CD pipeline (building Docker images, running deployments), we will need to migrate these tasks over to Github Actions, or we will have to maintain our Jenkins server ourselves.

#### CHANGES
This update reimplements the tasks for building the portal Docker image as a single workflow, and can be run from any Github-hosted runner (not just self-hosted).  Since these runners do not have `gcloud` installed or configured, this is now done via the `google-cloud-cli:latest` Docker image.  This is how the `build_image.sh` script determines what tags are available, and runs checks/cleanups before and after building and publishing the image.  In addition, since the `runner` user does not have publish permissions in our GCR repository, we can use the `gcloud` container to generate an access token to authenticate into GCR via `docker login`.

It will be possible to trigger this build manually like we do in Jenkins, but this will not be enabled until this feature branch has been merged into the default `development` branch.  Afterwards, it can be triggered against any desired branch.  Running against `master` will set the tag to the most recent release.  Selecting any other branch will tag the image with the name of that branch.

Additionally, we will need to migrate to Artifact Registry by May 15, 2024.  This work will be compatible with that planned migration - the only updates needed will be in the `docker push` and any `gcloud container` calls.  The rest of this workflow should still function correctly after the migration.

NOTE: before merging this PR, we should disable the corresponding Jenkins jobs:
Development tag: https://scp-jenkins.dsp-techops.broadinstitute.org/job/scp-build-portal-docker-image-from-development/
Release tag: https://scp-jenkins.dsp-techops.broadinstitute.org/job/scp-build-portal-docker-image-from-master/

#### MANUAL TESTING
Since this relies on pushes to target branches, manual testing is not recommended as it may clobber changes in GCR.  Instead, please see an instance of a successful run [here](https://github.com/broadinstitute/single_cell_portal_core/actions/runs/6869970091), as well as evidence of a successful preemptive check when [an existing tag was found](https://github.com/broadinstitute/single_cell_portal_core/actions/runs/6879663548/job/18712093386#step:6:16).