### PR TITLE
Updating to scp-ingest-pipeline:1.28.2 (SCP-5419)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.28.1'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.28.2'
 
     # Docker image for image pipeline jobs
     config.image_pipeline_docker_image = 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_c2b090043'


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates to the latest version of `scp-ingest-pipeline` to address issues when attempting to validate convention metadata files that use terms imported from ontologies that have non-standard `fileLocation` URLs (like `GO`).  These URLs are used to form queries to validate terms, and cause lookups to fail when attempting to retrieve them.

#### MANUAL TESTING
1. Boot all services (including DelayedJob) and sign in
2. Go to the upload wizard for any study that does not yet have a metadata file
3. Upload the GO_terms.tsv testing file from our [test data bucket](https://console.cloud.google.com/storage/browser/_details/broad-singlecellportal-staging-testing-data/ols_testing/GO_terms.tsv;tab=live_object?project=broad-singlecellportal-staging)
4. Confirm that it successfully ingests and that you see the following entries for `disease` and `disease__ontology_label`

![Screenshot 2023-11-21 at 9 59 53 AM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/a0a54362-81a9-442a-b019-61a90b25d729)
