### PR TITLE
Fix filter-then-search bug in sparkbar tooltips (SCP-5406)

### DIFF
--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -209,12 +209,13 @@ function BaselineSparkbar({ baselineCount, passedCount }) {
 
   const maxWidthPx = `${maxWidth}px`
   const passedWidthPx = `${selectedWidth}px`
+  const leftPx = -1 * `${passedWidthPx}px`
 
   const fullClass = baselineCount === passedCount ? ' full' : ''
   const baseTop = passedCount === 0 ? '0' : '-2px'
 
   const passedStyle = { width: passedWidthPx }
-  const filteredStyle = { width: maxWidthPx, left: -1 * passedWidthPx, top: baseTop }
+  const filteredStyle = { width: maxWidthPx, left: leftPx, top: baseTop }
 
   return (
     <>
@@ -284,7 +285,7 @@ function CellFilter({
   const filterDisplayName = filter.replace(/_/g, ' ')
 
   const baselineCount = facet.originalFilterCounts[filter]
-  const passedCount = facet.filterCounts[filter]
+  const passedCount = (facet.filterCounts && facet.filterCounts[filter]) ?? 0
   const quantitiesTooltip = getQuantitiesTooltip(baselineCount, passedCount, hasNondefaultSelection)
 
   return (


### PR DESCRIPTION
This fixes a bug in which filtering then searching a gene broke the Explore UI.  

This bug in #1931 was caught before release, while doing manual tests as part of release engineering.

### Test
1. Go to an initialized study
2. Apply a cell filter
3. Search a gene
4. Confirm page does not show a large error message

You might notice an issue in filter counts upon step 3.  It turns out that's pre-existing; see [context in Slack](https://broadinstitute.slack.com/archives/CBEHTH601/p1700585748862709?thread_ts=1700585742.808839&cid=CBEHTH601).

This relates to SCP-5406.