### PR TITLE
Avoid sparkbars in menus, and fix narrow edge case (SCP-5424)

### DIFF
--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -212,7 +212,7 @@ function BaselineSparkbar({ baselineCount, passedCount }) {
   const leftPx = -1 * `${passedWidthPx}px`
 
   const fullClass = baselineCount === passedCount ? ' full' : ''
-  const baseTop = passedCount === 0 ? '0' : '-2px'
+  const baseTop = passedCount === 0 ? '0' : '2px'
 
   const passedStyle = { width: passedWidthPx }
   const filteredStyle = { width: maxWidthPx, left: leftPx, top: baseTop }
@@ -220,8 +220,8 @@ function BaselineSparkbar({ baselineCount, passedCount }) {
   return (
     <>
       <span className="sparkbar">
-        <span className={`sparkbar-passed ${fullClass}`} style={passedStyle}> </span>
         <span className="sparkbar-filtered" style={filteredStyle}></span>
+        <span className={`sparkbar-passed ${fullClass}`} style={passedStyle}> </span>
       </span>
     </>
   )

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -167,6 +167,13 @@ input.cell-facet-header-checkbox {
   float: right;
 }
 
+
+@media (max-width: 1250px) {
+  .sparkbar {
+    display: none;
+  }
+}
+
 .sparkbar-passed,
 .sparkbar-filtered {
   float: right;

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -176,12 +176,10 @@ input.cell-facet-header-checkbox {
 
 .sparkbar .sparkbar-passed {
   background-color: #3AF;
-  z-index: 100;
 }
 
 .sparkbar .sparkbar-passed.full {
   background-color: #4ED;
-  z-index: 100;
 }
 
 .sparkbar-tooltip-passed {


### PR DESCRIPTION
This avoids showing sparkbars in the "Color by" menu, and odd sparkbar display for certain labels in narrow viewports.

### Video
#### Problem
https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/704c5bb6-e758-4451-a531-0a7209867edd

#### Fix
https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/9d36e26e-c2bb-4f0b-9ba5-bf09fd531177

### Test
1.  Click "Filter plotted cells"
2.  Deselect a checkbox to apply a filter
3.  Open the "Color by" dropdown menu
4.  Confirm sparkbars don't appear overlaid in menu options
5.  Close menu, keep filter applied
6.  Narrow your viewport significantly
7.  Confirm sparkbars disappear in narrow viewports, while filter counts are still shown

This satisfies SCP-5424.