### PR TITLE
Fix rendering loop when no gene header is found (SCP-5425)

### DIFF
--- a/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
+++ b/app/javascript/components/upload/DifferentialExpressionFileForm.jsx
@@ -217,7 +217,7 @@ export default function DifferentialExpressionFileForm({
     )
   }
 
-  if (file && geneHeader && !file.differential_expression_file_info.gene_header) {
+  if (file && geneHeader && geneHeader?.label !== undefined && !file.differential_expression_file_info.gene_header) {
     updateDeFileInfo(file, {
       'gene_header': geneHeader,
       'group_header': groupHeader,

--- a/app/javascript/lib/validation/validate-differential-expression.js
+++ b/app/javascript/lib/validation/validate-differential-expression.js
@@ -129,7 +129,7 @@ function inferSizesAndSignificances(metrics) {
 /** Return a metric of differential expression size, if present in given metric */
 function getGeneHeader(header) {
   // Conventions -- Scanpy: names; Seurat: genes.  "gene" is SCP canonical.
-  const GENE_REGEX = new RegExp(/^(gene|genes|names)$/i)
+  const GENE_REGEX = new RegExp(/^(gene|genes|name|names)$/i)
   const gene = header.match(GENE_REGEX)
   return gene
 }


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a bug where the UI continually re-renders the `DifferentialExpressionFileForm` if a user selects a file and the UI cannot determine what the gene header column is.  Now, the UI correctly displays a warning stating that it cannot determine which column maps to gene names.

#### MANUAL TESTING
1. Download a copy of the test author DE file from https://raw.githubusercontent.com/broadinstitute/scp-ingest-pipeline/development/tests/data/author_de/lfc_qval_scanpy-like.csv and change the first column header to `foo`
2. Boot as normal and sign in
3. Go to the upload wizard for any study
4. Click the `Differential expression` header and upload `lfc_qval_scanpy-like.csv` 
5. Confirm you get an error message about the gene header