### PR TITLE
Skip frequently failing tests in smoke test (SCP-5405)

### DIFF
--- a/test/integration/external/fire_cloud_client_test.rb
+++ b/test/integration/external/fire_cloud_client_test.rb
@@ -262,6 +262,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
 
   # get available workflows
   def test_get_methods
+    skip if @smoke_test
     # get all available methods
     workflow_methods = @fire_cloud_client.get_methods(entityType: 'workflow')
     assert workflow_methods.any?, 'Did not find any workflow methods'
@@ -325,7 +326,8 @@ class FireCloudClientTest < ActiveSupport::TestCase
   ##
 
   # main groups test - CRUD group & members
-  def test_create_and_mange_user_groups
+  def test_create_and_manage_user_groups
+    skip if @smoke_test
     # set group name
     group_name = "test-group-#{@random_test_seed}"
     puts 'creating group...'
@@ -380,6 +382,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
 
   # update a billing project's member list
   def test_update_billing_project_members
+    skip if @smoke_test
     # get all projects
     puts 'selecting project...'
     projects = @fire_cloud_client.get_billing_projects


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds 3 tests to the list of skipped tests for the Orchestration smoke test that runs 3x weekly in an effort to increase stability and improve signal on these builds while not reducing global coverage. The reasoning behind this change is that the referenced tests fail often for non-reproducible reasons in the staging instance of Sam, and don't cover "critical user journey" codepaths.  These tests will still run on normal CI builds.

#### MANUAL TESTING
Since this is not a smoke test build, you should be able to look at the output of the CI run below and see that the following tests ran: `FireCloudClientTest#test_create_and_mange_user_groups`, `FireCloudClientTest#test_update_billing_project_members`, and `FireCloudClientTest#test_get_methods`.