### PR TITLE
Make Viridis default color profile for expression scatter plots (SCP-3545)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,7 @@
 module ApplicationHelper
 
+  DEFAULT_COLOR_PROFILE = 'Viridis'.freeze
+
   # overriding link_to to preserve branding_group params
   def scp_link_to(name, url, html_options={}, &block)
     if url.start_with?('https') || url.start_with?('/')
@@ -217,7 +219,7 @@ module ApplicationHelper
     elsif params[:cluster].blank? && !selected_study.default_color_profile.blank? # no cluster requested, so go to defaults
       selected_study.default_color_profile
     else
-      'Reds'
+      DEFAULT_COLOR_PROFILE
     end
   end
 

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -754,7 +754,7 @@ function getPlotlyTraces({
 
       Object.assign(workingTrace.marker, {
         showscale: true,
-        colorscale: scatterColor,
+        colorscale: scatterColor || defaultScatterColor,
         reversescale: shouldReverseScale(scatterColor),
         color: colors,
         colorbar: { title, titleside: 'right' }

--- a/app/javascript/components/visualization/plot-options.jsx
+++ b/app/javascript/components/visualization/plot-options.jsx
@@ -28,7 +28,7 @@ PlotOptions.SCATTER_COLOR_OPTIONS = [
   'Rainbow', 'Portland', 'Jet', 'Hot', 'Blackbody', 'Earth', 'Electric', 'Viridis', 'Cividis'
 ]
 
-PlotOptions.defaultScatterColor = 'Reds'
+PlotOptions.defaultScatterColor = 'Viridis'
 
 PlotOptions.dotPlotColorScheme = {
   // Blue, purple, red.  These red and blue hues are accessible, per WCAG.

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -487,7 +487,7 @@ class IngestJob
       study.default_options[:annotation] = cluster.annotation_select_value(annotation_object)
       is_numeric = annotation_object[:type] == 'numeric'
     end
-    study.default_options[:color_profile] = 'Reds' if is_numeric
+    study.default_options[:color_profile] = ApplicationHelper::DEFAULT_COLOR_PROFILE if is_numeric
   end
 
   # set the default cluster for the study, if not already set

--- a/test/js/visualization/scatter-plot.test.js
+++ b/test/js/visualization/scatter-plot.test.js
@@ -226,10 +226,8 @@ describe('getPlotlyTraces handles expression graphs', () => {
     plotData.genes = ['foo']
 
     let [traces] = ScatterPlot.getPlotlyTraces(plotData)
-    // check that it doesn't reverse Reds when Reds is applied as the default
-    // Note that if the defaultScatterColor is ever changed to a non-Reds colorscale,
-    // this test will need to be updated
-    expect(traces[0].marker.reversescale).toEqual(false)
+    // since Viridis is now the default color profile, this should return true
+    expect(traces[0].marker.reversescale).toEqual(true)
 
     // check that does not reverse Reds when that is the explicitly specified colorscale
     plotData.scatterColor = 'Reds'


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update changes the default expression color profile to `Viridis` from `Reds`.  We had previously done [research](https://docs.google.com/document/d/1U9ikJOxe4Fb9fieX3Rse-591xGD_KMZP5uxAml8YA3w/edit#heading=h.vgsws97lyzyo) to support this change, and had never followed through on switching it.  Since the release of the cell filtering feature, this has become more pertinent as "filtered" cells are now difficult to distinguish from cells that have low or no observed expression when using single-color profiles.

#### MANUAL TESTING
1. Boot as normal and load any study with expression data
2. Query for a gene, and confirm that the default profile is `Viridis`
3. Select `Reds` from the color profile, and confirm it is still flipped with red being the maximum value