### PR TITLE
Enable links to cell filtering; fix legend-filter interaction (SCP-5395, SCP-5417)

### DIFF
--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -209,13 +209,12 @@ function BaselineSparkbar({ baselineCount, passedCount }) {
 
   const maxWidthPx = `${maxWidth}px`
   const passedWidthPx = `${selectedWidth}px`
-  const leftPx = -1 * `${passedWidthPx}px`
 
   const fullClass = baselineCount === passedCount ? ' full' : ''
   const baseTop = passedCount === 0 ? '0' : '2px'
 
   const passedStyle = { width: passedWidthPx }
-  const filteredStyle = { width: maxWidthPx, left: leftPx, top: baseTop }
+  const filteredStyle = { width: maxWidthPx, top: baseTop }
 
   return (
     <>
@@ -474,9 +473,9 @@ function FacetHeader({
   // some lower checkboxes are checked, and some are not.
   const allFiltersInFacet = facet.groups
   const allCheckedFiltersInFacet = checkedMap[facet.annotation]
-  const isFacetCheckboxSelected = allFiltersInFacet.length === allCheckedFiltersInFacet.length
+  const isFacetCheckboxSelected = allFiltersInFacet?.length === allCheckedFiltersInFacet?.length
   const isIndeterminate = !(
-    allCheckedFiltersInFacet.length === 0 ||
+    allCheckedFiltersInFacet?.length === 0 ||
     isFacetCheckboxSelected
   )
 

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -133,6 +133,17 @@ function getCellFacetingData(cluster, annotation, setterFunctions, context, prev
   }
 }
 
+/** Get `facets` parameter value, for cell filtering */
+function getFacetsParam(selection) {
+  const innerParams = []
+  Object.entries(selection).forEach(([facet, filters]) => {
+    const innerParam = facet + filters.join('|')
+    innerParams.push(innerParam)
+  })
+  const facetParams = innerParams.join(';')
+  return facetParams
+}
+
 /**
  * Renders the gene search box and the tab selection
  * Responsible for determining which tabs are available for a given view of the study
@@ -259,6 +270,7 @@ export default function ExploreDisplayTabs({
     getCellFacetingData(newCluster, newAnnot, setterFunctions, context)
   }, [exploreParams?.cluster, exploreParams?.annotation])
 
+
   /** Update filtered cells to only those that match annotation group value filter selections */
   function updateFilteredCells(selection) {
     if (!cellFaceting) {return}
@@ -280,6 +292,11 @@ export default function ExploreDisplayTabs({
     setFilteredCells(newFilteredCells)
     setCellFilterCounts(newFilterCounts)
     setCellFilteringSelection(selection)
+
+    const facetsParam = getFacetsParam(selection)
+    console.log('facetsParam', facetsParam)
+
+    updateExploreParams({ facets: facetsParam })
   }
 
   // Below line is worth keeping, but only uncomment to debug in development

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -347,6 +347,25 @@ export default function ExploreDisplayTabs({
       return
     }
     const [newCluster, newAnnot] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
+
+    const paramCluster = exploreParams.cluster
+    const paramAnnot = exploreParams.annotation
+
+    if (
+      filteredCells &&
+      (
+        (paramCluster === '' && paramAnnot.name === '') ||
+        (paramCluster === newCluster && _isEqual(paramAnnot, newAnnot))
+      )
+    ) {
+      // We've fully loaded facets,
+      // and cluster and annotation are the default or not actually changed,
+      // but another parameter has changed.
+      // We only need to get cell faceting data when either clustering or
+      // annotation has changed, so skip unless we detect a change.
+      return
+    }
+
     const setterFunctions = [
       setCellFilteringSelection,
       setClusterCanFilter,

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -134,12 +134,32 @@ function getCellFacetingData(cluster, annotation, setterFunctions, context, prev
 }
 
 /** Get `facets` parameter value, for cell filtering */
-function getFacetsParam(selection) {
+function getFacetsParam(initFacets, selection) {
+  const minimalSelection = {}
+
+  const initSelection = {}
+  initFacets.forEach(facet => {
+    initSelection[facet.annotation] = facet.groups
+  })
+
   const innerParams = []
-  Object.entries(selection).forEach(([facet, filters]) => {
-    const innerParam = facet + filters.join('|')
+  Object.entries(initSelection).forEach(([facet, filters]) => {
+    filters.forEach(filter => {
+      if (!selection[facet].includes(filter)) {
+        if (facet in minimalSelection) {
+          minimalSelection[facet].push(filter)
+        } else {
+          minimalSelection[facet] = [filter]
+        }
+      }
+    })
+  })
+
+  Object.entries(minimalSelection).forEach(([facet, filters]) => {
+    const innerParam = `${facet}:${filters.join('|')}`
     innerParams.push(innerParam)
   })
+
   const facetParams = innerParams.join(';')
   return facetParams
 }
@@ -293,7 +313,7 @@ export default function ExploreDisplayTabs({
     setCellFilterCounts(newFilterCounts)
     setCellFilteringSelection(selection)
 
-    const facetsParam = getFacetsParam(selection)
+    const facetsParam = getFacetsParam(initFacets, selection)
     console.log('facetsParam', facetsParam)
 
     updateExploreParams({ facets: facetsParam })

--- a/app/javascript/components/explore/ExploreTabRouter.jsx
+++ b/app/javascript/components/explore/ExploreTabRouter.jsx
@@ -121,7 +121,7 @@ function buildExploreParamsFromQuery(query) {
   exploreParams.hiddenTraces = queryParams.hiddenTraces ? queryParams.hiddenTraces.split(',') : []
   exploreParams.isSplitLabelArrays = queryParams.isSplitLabelArrays === 'true' ? true : null
 
-  exploreParams.facets = queryParams.facets ? queryParams.facets.split(',') : []
+  exploreParams.facets = queryParams.facets ? queryParams.facets : ''
 
   return exploreParams
 }

--- a/app/javascript/components/explore/ExploreTabRouter.jsx
+++ b/app/javascript/components/explore/ExploreTabRouter.jsx
@@ -120,6 +120,9 @@ function buildExploreParamsFromQuery(query) {
 
   exploreParams.hiddenTraces = queryParams.hiddenTraces ? queryParams.hiddenTraces.split(',') : []
   exploreParams.isSplitLabelArrays = queryParams.isSplitLabelArrays === 'true' ? true : null
+
+  exploreParams.facets = queryParams.facets ? queryParams.facets.split(',') : []
+
   return exploreParams
 }
 
@@ -143,7 +146,8 @@ function buildQueryFromParams(exploreParams) {
     ideogramFileId: exploreParams.ideogramFileId,
     expressionFilter: exploreParams.expressionFilter ? exploreParams.expressionFilter.join(FILTER_RANGE_DELIMITER) : undefined,
     hiddenTraces: exploreParams.hiddenTraces.join(','),
-    isSplitLabelArrays: exploreParams.isSplitLabelArrays ? 'true' : undefined
+    isSplitLabelArrays: exploreParams.isSplitLabelArrays ? 'true' : undefined,
+    facets: exploreParams.facets
   }
 
   if (querySafeOptions.spatialGroups === '' && exploreParams.userSpecified['spatialGroups']) {
@@ -159,9 +163,12 @@ function buildQueryFromParams(exploreParams) {
 }
 
 /** controls list in which query string params are rendered into URL bar */
-const PARAM_LIST_ORDER = ['geneList', 'genes', 'cluster', 'spatialGroups', 'annotation', 'subsample', 'consensus',
+const PARAM_LIST_ORDER = [
+  'geneList', 'genes', 'cluster', 'spatialGroups', 'annotation', 'subsample', 'consensus',
   'tab', 'scatterColor', 'distributionPlot', 'distributionPoints',
-  'heatmapFit', 'heatmapRowCentering', 'bamFileName', 'ideogramFileId', 'expressionFilter', 'isSplitLabelArrays', 'hiddenTraces']
+  'heatmapFit', 'heatmapRowCentering', 'bamFileName', 'ideogramFileId', 'expressionFilter',
+  'isSplitLabelArrays', 'hiddenTraces', 'facets'
+]
 /** sort function for passing to stringify to ensure url params are specified in a user-friendly order */
 function paramSorter(a, b) {
   return PARAM_LIST_ORDER.indexOf(a) - PARAM_LIST_ORDER.indexOf(b)

--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
@@ -102,16 +102,21 @@ function LegendEntry({
   }, delayTimeForHover) // ms to delay the call to setActiveTraceLabel()
 
 
-  // clicking the label will either hide the trace, or pop up a color picker
-  const entryClickFunction = showColorControls ? () => setShowColorPicker(true) : toggleSelection
+  /** Clicking the label will either hide the trace, or pop up a color picker */
+  function handleEntryClick() {
+    if (showColorControls) {
+      setShowColorPicker(true)
+    } else {
+      toggleSelection()
+    }
+  }
 
   return (
     <>
       <div
         className={`scatter-legend-row ${shownClass}`}
         role="button"
-        onClick={entryClickFunction}
-
+        onClick={handleEntryClick}
         onMouseEnter={handleOnMouseEnter}
         onMouseLeave={handleOnMouseLeave}
       >

--- a/test/js/explore/explore-tab-router.test.js
+++ b/test/js/explore/explore-tab-router.test.js
@@ -96,6 +96,7 @@ describe('dataParams are appropriately managed on the url', () => {
       scatterColor: '',
       tab: '',
       expressionFilter: [0, 1],
+      facets: '',
       hiddenTraces: [],
       userSpecified: {
         annotation: true,


### PR DESCRIPTION
This URL-parameterizes cell filtering, to let users easily share and reproduce their findings.  It also fixes a legend-filter bug.

Here's how it looks!

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/c8be0fe1-ee58-498f-8560-750bff5c4927

And here's how it looked before.

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/08ef7c48-271c-453f-ad73-d6680e9b6e9e

Previously, users could not preserve their cell filtering state.  We have frontend infrastructure to register state in the URL, and route from URL parameters to application state, but it simply wasn't configured for cell filtering.  

Now, users can get easily back to where they were in filtering, or send their colleagues or other audience a URL that instantly reproduces their cell filtering results.  This initial implementation for sharing and bookmarking is crude but effective.  Later refinements could include e.g. A) opening the cell filtering panel on page load if `facets` is specified, B) indicating filters are being applied after the initial plot loads and before filters are applied, and C) using ontology IDs instead of labels when possible.

Incidentally, URL parameterization fixes a bug that caused filters (and their counts) to reset when a legend entry was clicked.

### Test
* Apply a filter, or multiple
* Refresh page
* Confirm filters get applied to plot automatically
* Click legend entry while filters are applied
* Confirm filters don't get cleared

This satisfies SCP-5395.