### PR TITLE
Updating to new ToS endpoint, fixes to support testing (SCP-5298)

### DIFF
--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -1295,17 +1295,13 @@ class FireCloudClient
   # get a user's Terra terms of service status (only available directly from Sam)
   # contains information on acceptance version, date, and whether user is permitted system access based on state
   #
-  # + +params+
-  #   - +user+ (User) => user to check ToS status (can be nil, which will use service account)
-  #
   # * *returns*
   #   - (Hash) {
   #       acceptedOn: DateTime, isCurrentVersion: Boolean, latestAcceptedVersion: Integer, permitsSystemUsage: Boolean
   #     }
-  def get_terms_of_service(user: nil)
-    client = user.present? ? new(user:) : self
+  def get_terms_of_service
     path = "#{BASE_SAM_SERVICE_URL}/api/termsOfService/v1/user/self"
-    client.send(:process_firecloud_request, :get, path)
+    process_firecloud_request(:get, path)
   end
 
   #######

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -385,9 +385,8 @@ class User
   def check_terra_tos_status
     begin
       client = FireCloudClient.new(user: self, project: FireCloudClient::PORTAL_NAMESPACE)
-      user_registration = client.get_registration&.with_indifferent_access
-      tos_accepted = user_registration.dig('enabled', 'tosAccepted')
-      tos_accepted = true if tos_accepted.nil? # failover protection if status isn't found
+      user_registration = client.get_terms_of_service(user: self)&.with_indifferent_access
+      tos_accepted = user_registration['permitsSystemUsage']
 
       # return inverse as value of 'false' here means the user must accept the updated Terra ToS
       { must_accept: !tos_accepted, http_code: 200 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -385,7 +385,7 @@ class User
   def check_terra_tos_status
     begin
       client = FireCloudClient.new(user: self, project: FireCloudClient::PORTAL_NAMESPACE)
-      user_registration = client.get_terms_of_service(user: self)&.with_indifferent_access
+      user_registration = client.get_terms_of_service&.with_indifferent_access
       tos_accepted = user_registration['permitsSystemUsage']
 
       # return inverse as value of 'false' here means the user must accept the updated Terra ToS

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -104,40 +104,21 @@ class UserTest < ActiveSupport::TestCase
 
   test 'should determine if user needs to accept updated Terra Terms of Service' do
     mock = Minitest::Mock.new
-    user_registration = {
-      enabled: {
-        ldap: true,
-        allUsersGroup: true,
-        google: true,
-        tosAccepted: true,
-        adminEnabled: false
-      },
-      userInfo: {
-        userEmail: @user.email,
-        userSubjectId: @user.uid
-      }
+    user_terms = {
+      acceptedOn: DateTime.now - 1.day, isCurrentVersion: true, latestAcceptedVersion: '1', permitsSystemUsage: true
     }.with_indifferent_access
-    mock.expect :get_registration, user_registration
+    mock.expect :get_terms_of_service, user_terms
     FireCloudClient.stub :new, mock do
       assert_not @user.must_accept_terra_tos?
       mock.verify
     end
 
     # negative test
-    user_registration[:enabled][:tosAccepted] = false
+    user_terms[:permitsSystemUsage] = false
     mock = Minitest::Mock.new
-    mock.expect :get_registration, user_registration
+    mock.expect :get_terms_of_service, user_terms
     FireCloudClient.stub :new, mock do
       assert @user.must_accept_terra_tos?
-      mock.verify
-    end
-
-    # failover test
-    user_registration[:enabled].delete(:tosAccepted)
-    mock = Minitest::Mock.new
-    mock.expect :get_registration, user_registration
-    FireCloudClient.stub :new, mock do
-      assert_not @user.must_accept_terra_tos?
       mock.verify
     end
   end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update uses the new Sam endpoints for sourcing user Terra terms of service information.  The `/register` endpoint still contains the `tosAccepted` flag, but this information is apparently stale (at best) or completely incorrect.  The new endpoint contains information including acceptance date, version, and a boolean flag detailing whether or not the user is permitted system access (`permitsSystemUsage`).  This is the new flag that SCP will check for terms of service status.

Note: service accounts are exempt from this new ToS infrastructure, so attempting to check the ToS status for a service account will result in a `404`.

This also fixes a bug where overriding the default Terra billing project did not work from the constructor.  Now, calling `FireCloudClient.new(project: <value>)` will correctly set the value.

#### MANUAL TESTING
1. Pull this branch and enter a Rails console session
2. Load your user account:
```
user = User.find_by(email: <email address>)
```
3. Confirm you can get your terms of service status from the helper:
```
user.must_accept_terra_tos?
=> false
```
4. Use the API endpoint to get more detailed information:
```
client = FireCloudClient.new(user:)
=> 
#<FireCloudClient:0x0000000113df6650                                       
...

client.get_terms_of_service
=> {"acceptedOn"=>"1970-01-01T00:00:00Z", "isCurrentVersion"=>true, "latestAcceptedVersion"=>"1", "permitsSystemUsage"=>true}
```