### PR TITLE
Refine observability for "u.json is not a function" (SCP-5413)

### DIFF
--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -1018,7 +1018,19 @@ export default async function scpApi(
     }
   }
   if (toJson) {
+    const isJson = response.headers.get('content-type').includes('json')
+
+    if (!isJson) {
+      const text = await response.text()
+      const message =
+        `Error, response is not JSON as expected.  ` +
+        `Response text: ${text}.  ` +
+        `Requested URL: ${url}`
+      throw Error(message)
+    }
+
     const json = await response.json()
+
     // special handling for Terra terms of service checks
     // don't throw error so we can pass back JSON response
     if (typeof json.must_accept !== 'undefined') {
@@ -1045,6 +1057,7 @@ export default async function scpApi(
       throw new Error(json.error || json.errors)
     }
   }
+
   throw new Error(response)
 }
 

--- a/test/js/lib/scp-api.test.js
+++ b/test/js/lib/scp-api.test.js
@@ -84,7 +84,10 @@ describe('JavaScript client for SCP REST API', () => {
     expect.assertions(1)
     const mockErrorResponse = {
       json: () => Promise.resolve({
-        error: 'Internal Server Error'
+        error: 'Internal Server Error',
+      }),
+      headers: new Headers({
+        'content-type': 'application/json; charset=utf-8'
       })
     }
     jest
@@ -95,6 +98,29 @@ describe('JavaScript client for SCP REST API', () => {
       .then(() => {})
       .catch(error => {
         expect(error.message).toEqual('Internal Server Error')
+      })
+  })
+
+  it('catches non-JSON errors', async () => {
+    expect.assertions(1)
+    const mockErrorResponse = {
+      text: () => Promise.resolve(
+        'Response that is not JSON, i.e. crudely handled in server'
+      ),
+      headers: new Headers({
+        'content-type': 'text/html; charset=utf-8'
+      })
+    }
+    jest
+      .spyOn(global, 'fetch')
+      .mockReturnValue(Promise.resolve(mockErrorResponse))
+
+    return scpApi('/test/path', {}, false)
+      .then(() => {})
+      .catch(error => {
+        expect(error.message.includes(
+          'Response that is not JSON, i.e. crudely handled in server'
+        )).toEqual(true)
       })
   })
 


### PR DESCRIPTION
This fixes an observability bug, making a frequent error more actionable through clearer diagnostics.

Previously, when SCP API responded to the SCP API JS library with an error, and that response was _not_ JSON, we would get a cryptic error message in Sentry: [`u.json is not a function`](https://broad-institute.sentry.io/issues/4491686388/?environment=production&project=1424198&query=is%3Aunresolved+level%3Aerror+%21stack.abs_path%3A%2Aideogram%2A&referrer=issue-stream&sort=freq&statsPeriod=24h&stream_index=0).  

Now, we'll get a more detailed error message.  The message will include a high-level note explaining what happened ("Error, response is not JSON as expected.") as well as the response's text and the requested URL.  Logging these key details about the response will enable us to investigate the problem.

### Test
A new automated test verifies this behavior.  To manually test:
1.  In line 242 of `annotations_controller.rb`, add `render html: "<html>Previously unhandled HTML error</html>", status: 500 and return`
2.  In line 346 of `metrics-api.js`, change logToSentry(error) to logToSentry(error, false) to remove throttling
3.  In line 71 of `sentry-logging.js`, add a line `return false` to bypass Sentry log suppression in development
4.  Stop Vite, start it with `DISABLE_SENTRY=false bin/vite dev` dev to disable Sentry logging
5. Go to the "Human milk - differential expression" study
6. Open the Console panel in DevTools, wait for 15-30 seconds
7. Confirm you see an error message like:
```
Error, response is not JSON as expected.  Response text: &lt;html&gt;Previously unhandled HTML error&lt;/html&gt;.  Requested URL: https://localhost:3000/single_cell/api/v1/studies/SCP152/annotations/facets?annotations=cell_type__ontology_label--group--study%2Cinfant_sick_YN--group--study%2Cmastisis_YN--group--study%2Cmaternal_medical_event_YN--group--study%2Creported_infant_medical_events_YN--group--study&cluster=All Cells UMAP
```
8. Revert your local changes, e.g. via `git checkout .`

This satisfies SCP-5413.