### PR TITLE
Fix name for staging deploy workflow_run trigger (SCP-5441)

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -22,7 +22,7 @@ env:
   ROLLBACK: ''
 
 jobs:
-  Deploy-To-Staging:
+  Deploy-To-Production:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,7 +1,7 @@
 name: Deploy to staging SCP instance
 on:
   workflow_run:
-    workflows: [Build-And-Publish-Docker-Image]
+    workflows: ["Build and publish single-cell-portal Docker image"]
     types:
       - completed
     branches: [development]


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug where the automatic deployment of the `development` branch to staging did not launch.  This is (hopefully) due to using the incorrect name reference for the workflow.

#### MANUAL TESTING
Since this is all about automation, we unfortunately can't test this until it merges.  Fingers crossed!