### PR TITLE
Ensure API user is registered for Terra before ToS check (SCP-5448)

### DIFF
--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -76,7 +76,7 @@ module Api
       end
 
       def check_terra_tos_acceptance
-        if api_user_signed_in?
+        if api_user_signed_in? && current_api_user.registered_for_firecloud
           user_status = current_api_user.check_terra_tos_status
           render json: { must_accept: user_status[:must_accept] }, status: user_status[:http_code]
         else
@@ -231,7 +231,7 @@ module Api
         end
       end
 
-      def renew_user_access_token      
+      def renew_user_access_token
         if current_api_user
           Rails.logger.info "Renewing user access token via SCP API for #{current_api_user.id}"
           render json: RequestUtils.get_user_access_token(current_api_user)

--- a/test/integration/external/import_service_config/hca_test.rb
+++ b/test/integration/external/import_service_config/hca_test.rb
@@ -137,7 +137,10 @@ module ImportServiceConfig
             assert study_file.persisted?
             assert_equal study.external_identifier, @attributes[:study_id]
             assert_equal study_file.external_identifier, @attributes[:file_id]
-            assert_equal study_file.external_link_url, access_url
+            # trim off query params to prevent test failures when catalog/version updates
+            trimmed_access_url = access_url.split('?').first
+            trimmed_external_url = study_file.external_link_url.split('?').first
+            assert_equal trimmed_external_url, trimmed_access_url
           end
         end
       end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a silent error that caused an [increase in `403` errors](https://broad-institute.sentry.io/issues/4704255686/?environment=production&project=1424198) in Sentry.  The bug is that for API users SCP was not properly honoring whether a user was registered for Terra before checking their terms of service status.  These requests then returned `403` from Sam as the user was not permitted to make this API call.  It should be noted that there does not appear to be any user-facing issues with this bug since we specifically look for a `401` in the case of a failed request.

Also, this update fixes a newly found test regression where updates to HCA catalogs can break an assertion in `test/integration/external/import_service_config/hca_test.rb`.

#### MANUAL TESTING
Note: if you have already accepted the Terra terms of service with your Broad account, you will need to load an account that has not yet accepted them.  You can then go to Terra and sign in with this account to have Terra set your `permitSystemUsage` flag to `false` as the rolling acceptance window has not yet expired.
1. Boot as normal and sign in with an account that has not accepted the Terra terms of service
2. Confirm you are redirected to https://localhost:3000/single_cell/terra_tos
3. In a separate terminal, open a Rails console session, load the above account and unset `registered_for_firecloud`
```
email = <email address of above account>
user = User.find_by(email:)
user.update(registered_for_firecloud: false)
```
4. Back in the portal, click the SCP logo in the top left to go to the home page
5. Confirm you are not redirected back to the Terra ToS page
6. Back in the console, reset `registered_for_firecloud`
```
user.update(registered_for_firecloud: true)
```
7. Back in the UI, refresh the page and confirm you are eventually redirected back to the ToS page