### PR TITLE
Extending `ImportService` (SCP-5409)

### DIFF
--- a/app/lib/import_service.rb
+++ b/app/lib/import_service.rb
@@ -44,7 +44,6 @@ class ImportService
 
     begin
       study, study_file = configuration.import_from_service
-      # TODO: uncomment this block after file parsing is enabled for NeMO and SCP-5400 is complete
       # extra work will be required but is unknown until we have the dataset (e.g. populating AnnData data_fragments)
       identifier = "#{study.accession} (#{study.external_identifier})"
       log_message "Ingesting file: #{study_file.upload_file_name} (#{study_file.external_identifier}) from imported study #{identifier}"

--- a/app/lib/import_service.rb
+++ b/app/lib/import_service.rb
@@ -47,7 +47,7 @@ class ImportService
       # TODO: uncomment this block after file parsing is enabled for NeMO and SCP-5400 is complete
       # extra work will be required but is unknown until we have the dataset (e.g. populating AnnData data_fragments)
       identifier = "#{study.accession} (#{study.external_identifier})"
-      log_message "Ingesting file: #{study_file.upload_file_name} from imported study #{identifier}"
+      log_message "Ingesting file: #{study_file.upload_file_name} (#{study_file.external_identifier}) from imported study #{identifier}"
       FileParseService.run_parse_job(study_file, study, study.user)
       [study, study_file]
     rescue RuntimeError, RestClient::Exception, Google::Apis::ClientError => e

--- a/app/lib/import_service.rb
+++ b/app/lib/import_service.rb
@@ -7,7 +7,7 @@ class ImportService
   ALLOWED_CLIENTS = [NemoClient, HcaAzulClient].freeze
 
   # allowed configuration classes
-  ALLOWED_CONFIGS = [ImportServiceConfig::Nemo].freeze
+  ALLOWED_CONFIGS = [ImportServiceConfig::Nemo, ImportServiceConfig::Hca].freeze
 
   # generic handler to call an underlying client method and forward all positional/keyword params
   #
@@ -46,9 +46,9 @@ class ImportService
       study, study_file = configuration.import_from_service
       # TODO: uncomment this block after file parsing is enabled for NeMO and SCP-5400 is complete
       # extra work will be required but is unknown until we have the dataset (e.g. populating AnnData data_fragments)
-      # identifier = "#{study.accession} (#{study.external_identifier})"
-      # log_message "Ingesting file: #{study_file.upload_file_name} from imported study #{identifier}"
-      # FileParseService.run_parse_job(study_file, study, study.user)
+      identifier = "#{study.accession} (#{study.external_identifier})"
+      log_message "Ingesting file: #{study_file.upload_file_name} from imported study #{identifier}"
+      FileParseService.run_parse_job(study_file, study, study.user)
       [study, study_file]
     rescue RuntimeError, RestClient::NotFound, Google::Apis::ClientError => e
       log_message("Error importing from #{config_class}: #{e.class} - #{e.message}", level: :error)

--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -135,7 +135,7 @@ class AnnDataFileInfo
   # will apply transform method if specified, otherwise returns value in place (Object#presence)
   def hash_from_keys(source_hash, *keys, transform: :presence)
     values = keys.map do |key|
-      source_hash[key].send(transform) if source_hash[key].present? # skip transform on nil entries
+      source_hash&.[](key).send(transform) if source_hash&.[](key).present? # skip transform on nil entries
     end
     Hash[keys.zip(values)].reject { |_, v| v.blank? }
   end

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -84,8 +84,8 @@ class ExpressionFileInfo
 
   # remove invalid StudyFile ids, as well as nil/empty string values
   def sanitize_raw_counts_associations
-    invalid_ids = raw_counts_associations.select { |study_file_id| StudyFile.find(study_file_id).nil? }
-    raw_counts_associations.reject! { |study_file_id| study_file_id.blank? || invalid_ids.include?(study_file_id) }
+    invalid_ids = raw_counts_associations&.select { |study_file_id| StudyFile.find(study_file_id).nil? }
+    raw_counts_associations&.reject! { |study_file_id| study_file_id.blank? || invalid_ids.include?(study_file_id) }
   end
 
   # unset the value for :units unless :is_raw_counts is true

--- a/app/models/import_service_config.rb
+++ b/app/models/import_service_config.rb
@@ -132,6 +132,7 @@ module ImportServiceConfig
     ext = file_info[format_attribute].gsub(/^\./, '') # trim leading period, if present
     study_file.upload_content_type = get_file_content_type(ext)
     study_file.external_identifier = file_id
+    study_file.ann_data_file_info&.data_fragments = default_data_fragments
     study_file
   end
 
@@ -141,6 +142,19 @@ module ImportServiceConfig
     ExpressionFileInfo::LIBRARY_PREPARATION_VALUES.detect do |lib_prep|
       lib_prep.casecmp(sanitized_lib) == 0
     end
+  end
+
+  # default cluster embedding data fragments, assuming X_umap slot
+  def default_data_fragments
+    [
+      {
+        _id: BSON::ObjectId.new.to_s,
+        name: 'umap',
+        description: '',
+        obsm_key_name: 'X_umap',
+        spatial_cluster_associations: []
+      }.with_indifferent_access
+    ]
   end
 
   # empty methods to be overwritten in included classes

--- a/app/models/import_service_config.rb
+++ b/app/models/import_service_config.rb
@@ -131,11 +131,7 @@ module ImportServiceConfig
     study
   end
 
-  def to_study_file(study_id,
-                    taxon_common_name,
-                    taxon_attribute: :common_name,
-                    format_attribute: :file_format,
-                    obsm_key_names: nil)
+  def to_study_file(study_id, taxon_common_name, taxon_attribute: :common_name, format_attribute: :file_format)
     file_info = load_file.with_indifferent_access
     study_file = to_scp_model(StudyFile, study_file_default_settings, study_file_mappings, file_info)
     # assign study, taxon, and content_type

--- a/app/models/import_service_config.rb
+++ b/app/models/import_service_config.rb
@@ -169,6 +169,16 @@ module ImportServiceConfig
     end
   end
 
+  # populate the expression-based data_fragment (needed for form values in upload wizard)
+  def expression_data_fragment(scp_study_file)
+    {
+      _id: BSON::ObjectId.new.to_s,
+      data_type: :expression,
+      taxon_id: scp_study_file.taxon_id.to_s,
+      expression_file_info: scp_study_file.expression_file_info.attributes.reject { |k, _| %w[_id units].include? k }
+    }.with_indifferent_access
+  end
+
   # empty methods to be overwritten in included classes
   # these will contain service-specific logic for sourcing data and assigning attributes to save, as well as file IO
   # this will cover cases not dealt with in default mappings and :to_study or :to_study_file

--- a/app/models/import_service_config.rb
+++ b/app/models/import_service_config.rb
@@ -149,6 +149,7 @@ module ImportServiceConfig
     [
       {
         _id: BSON::ObjectId.new.to_s,
+        data_type: :cluster,
         name: 'umap',
         description: '',
         obsm_key_name: 'X_umap',

--- a/app/models/import_service_config.rb
+++ b/app/models/import_service_config.rb
@@ -144,7 +144,7 @@ module ImportServiceConfig
     ext = file_info[format_attribute].gsub(/^\./, '') # trim leading period, if present
     study_file.upload_content_type = get_file_content_type(ext)
     study_file.external_identifier = file_id
-    study_file.ann_data_file_info&.data_fragments = default_data_fragments(obsm_key_names)
+    study_file.ann_data_file_info&.data_fragments = default_data_fragments
     study_file
   end
 

--- a/app/models/import_service_config.rb
+++ b/app/models/import_service_config.rb
@@ -213,14 +213,13 @@ module ImportServiceConfig
         # clean up study to allow retries with different file
         ImportService.remove_study_workspace(study)
         file_in_bucket.delete
-        DeleteQueueJob.new(study).perform
+        DeleteQueueJob.new(study).delay.perform
         raise "could create study_file: #{errors.join('; ')}"
       end
     else
       error_msg = "could not create study: #{study.errors.full_messages.join('; ')}"
       log_message error_msg
       ImportService.remove_study_workspace(study)
-      DeleteQueueJob.new(study).delay.perform
       raise error_msg
     end
   end

--- a/app/models/import_service_config.rb
+++ b/app/models/import_service_config.rb
@@ -128,6 +128,7 @@ module ImportServiceConfig
     study.build_study_detail
     study.study_detail.full_description = sanitize_attribute(study.description)
     study.external_identifier = study_id
+    study.imported_from = service_name
     study
   end
 
@@ -140,6 +141,7 @@ module ImportServiceConfig
     ext = file_info[format_attribute].gsub(/^\./, '') # trim leading period, if present
     study_file.upload_content_type = get_file_content_type(ext)
     study_file.external_identifier = file_id
+    study_file.imported_from = service_name
     study_file.ann_data_file_info&.data_fragments = default_data_fragments
     study_file
   end

--- a/app/models/import_service_config.rb
+++ b/app/models/import_service_config.rb
@@ -2,6 +2,7 @@
 module ImportServiceConfig
   extend ActiveSupport::Concern
   include ActiveModel::Model
+  include ActiveModel::Validations
   include Loggable
 
   # allow word and space characters, plus the following: - . / ( ) , :
@@ -180,10 +181,11 @@ module ImportServiceConfig
         raise "could create study_file: #{errors.join('; ')}"
       end
     else
+      error_msg = "could not create study: #{study.errors.full_messages.join('; ')}"
+      log_message error_msg
       ImportService.remove_study_workspace(study)
-      errors = study.errors.full_messages.dup
-      DeleteQueueJob.new(study).perform
-      raise "could not create study: #{errors.join('; ')}"
+      DeleteQueueJob.new(study).delay.perform
+      raise error_msg
     end
   end
 

--- a/app/models/import_service_config/hca.rb
+++ b/app/models/import_service_config/hca.rb
@@ -96,6 +96,8 @@ module ImportServiceConfig
         found_libs = libraries.map { |lib| find_library_prep(lib) }.compact
         study_file.expression_file_info.library_preparation_protocol = found_libs.first
       end
+      exp_fragment = expression_data_fragment(study_file)
+      study_file.ann_data_file_info.data_fragments << exp_fragment
       study_file
     end
 

--- a/app/models/import_service_config/hca.rb
+++ b/app/models/import_service_config/hca.rb
@@ -5,6 +5,8 @@ module ImportServiceConfig
 
     PREFERRED_TAXONS = ['Homo sapiens', 'Mus musculus'].freeze
 
+    validates :file_id, :study_id, :user_id, :branding_group_id, presence: true
+
     # name for logging when calling ImportService.import_from
     SERVICE_NAME = 'HCA'.freeze
 
@@ -106,7 +108,7 @@ module ImportServiceConfig
     #   - (RuntimeError) => if either study or study_file fail to save correctly
     #   - (ArgumentError) => if no file_id & study_id are not provided
     def import_from_service
-      raise ArgumentError, 'must provide study_id and file_id' unless study_id && file_id
+      raise configuration.errors.full_messages.join(', ') unless valid?
 
       study = populate_study
       study_file = populate_study_file(study.id)

--- a/app/models/import_service_config/nemo.rb
+++ b/app/models/import_service_config/nemo.rb
@@ -105,7 +105,7 @@ module ImportServiceConfig
     def populate_study_file(scp_study_id)
       taxons = taxon_names
       preferred_name = taxons.detect { |name| PREFERRED_TAXONS.include?(name) } || taxons.first
-      study_file = to_study_file(scp_study_id, preferred_name, obsm_key_names:)
+      study_file = to_study_file(scp_study_id, preferred_name)
       library = study_file.expression_file_info.library_preparation_protocol
       if library.blank?
         library = load_study&.[]('technique')
@@ -130,7 +130,7 @@ module ImportServiceConfig
 
       traverse_associations! unless study_id
       study = populate_study
-      study_file = populate_study_file(study.id, obsm_key_names: default_obsm_key_names)
+      study_file = populate_study_file(study.id)
       nemo_gs_url = file_access_info(protocol: :gs)&.[]('url')
       # gotcha for some GS urls having an incorrect root folder, this likely is something that will be fixed with
       # the public release but for now leaving this hack in place

--- a/app/models/import_service_config/nemo.rb
+++ b/app/models/import_service_config/nemo.rb
@@ -111,6 +111,9 @@ module ImportServiceConfig
         library = load_study&.[]('technique')
       end
       study_file.expression_file_info.library_preparation_protocol = find_library_prep(library)
+      http_url = file_access_info(protocol: :http)&.[]('url')
+      study_file.external_link_url = http_url if http_url
+
       study_file
     end
 

--- a/app/models/import_service_config/nemo.rb
+++ b/app/models/import_service_config/nemo.rb
@@ -5,7 +5,7 @@ module ImportServiceConfig
 
     attr_accessor :project_id
 
-    validates :user_id, :branding_group_id, presence: true
+    validates :file_id, :user_id, :branding_group_id, presence: true
 
     PREFERRED_TAXONS = %w[human mouse].freeze
 
@@ -126,7 +126,7 @@ module ImportServiceConfig
     #   - (RuntimeError) => if either study or study_file fail to save correctly
     #   - (ArgumentError) => if no file_id is provided
     def import_from_service
-      raise ArgumentError, 'must provide file_id' if file_id.blank?
+      raise configuration.errors.full_messages.join(', ') unless valid?
 
       traverse_associations! unless study_id
       study = populate_study

--- a/app/models/import_service_config/nemo.rb
+++ b/app/models/import_service_config/nemo.rb
@@ -105,7 +105,7 @@ module ImportServiceConfig
     def populate_study_file(scp_study_id)
       taxons = taxon_names
       preferred_name = taxons.detect { |name| PREFERRED_TAXONS.include?(name) } || taxons.first
-      study_file = to_study_file(scp_study_id, preferred_name)
+      study_file = to_study_file(scp_study_id, preferred_name, obsm_key_names:)
       library = study_file.expression_file_info.library_preparation_protocol
       if library.blank?
         library = load_study&.[]('technique')
@@ -130,7 +130,7 @@ module ImportServiceConfig
 
       traverse_associations! unless study_id
       study = populate_study
-      study_file = populate_study_file(study.id)
+      study_file = populate_study_file(study.id, obsm_key_names: default_obsm_key_names)
       nemo_gs_url = file_access_info(protocol: :gs)&.[]('url')
       # gotcha for some GS urls having an incorrect root folder, this likely is something that will be fixed with
       # the public release but for now leaving this hack in place

--- a/app/models/import_service_config/nemo.rb
+++ b/app/models/import_service_config/nemo.rb
@@ -5,6 +5,8 @@ module ImportServiceConfig
 
     attr_accessor :project_id
 
+    validates :user_id, :branding_group_id, presence: true
+
     PREFERRED_TAXONS = %w[human mouse].freeze
 
     # name for logging when calling ImportService.import_from

--- a/app/models/import_service_config/nemo.rb
+++ b/app/models/import_service_config/nemo.rb
@@ -111,9 +111,10 @@ module ImportServiceConfig
         library = load_study&.[]('technique')
       end
       study_file.expression_file_info.library_preparation_protocol = find_library_prep(library)
+      exp_fragment = expression_data_fragment(study_file)
+      study_file.ann_data_file_info.data_fragments << exp_fragment
       http_url = file_access_info(protocol: :http)&.[]('url')
       study_file.external_link_url = http_url if http_url
-
       study_file
     end
 

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -274,6 +274,7 @@ class Study
   field :use_existing_workspace, type: Boolean, default: false
   field :default_options, type: Hash, default: {} # extensible hash where we can put arbitrary values as 'defaults'
   field :external_identifier, type: String # ID from external service, used for tracking via ImportService
+  field :imported_from, type: String # Human-readable tag for external service that study was imported from, e.g. HCA
   ##
   #
   # SWAGGER DEFINITIONS

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -736,6 +736,8 @@ class Study
   validates_uniqueness_of :url_safe_name, on: :update, message: ": The name you provided tried to create a public URL (%{value}) that is already assigned.  Please rename your study to a different value."
   validate :prevent_firecloud_attribute_changes, on: :update
   validates_presence_of :firecloud_project, :firecloud_workspace
+  validates_uniqueness_of :external_identifier, allow_blank: true
+
   # callbacks
   before_validation :set_url_safe_name
   before_validation :set_data_dir, :set_firecloud_workspace_name, on: :create

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -115,6 +115,7 @@ class StudyFile
   field :external_link_title, type: String # Link text
   field :external_link_description, type: String # Link tooltip
   field :external_identifier, type: String # for tracking external files from ImportService
+  field :imported_from, type: String # Human-readable tag for external service that study was imported from, e.g. HCA
 
   # for spatial files, the ids of cluster files that correspond to this file for default display
   field :spatial_cluster_associations, type: Array, default: []

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -660,6 +660,7 @@ class StudyFile
   validates_format_of :generation, with: /\A\d+\z/, if: proc { |f| f.generation.present? }
 
   validates_inclusion_of :file_type, in: STUDY_FILE_TYPES, unless: proc { |f| f.file_type == 'DELETE' }
+  validates_uniqueness_of :external_identifier, allow_blank: true
 
   validate :check_taxon, on: :create
   validate :check_assembly, on: :create

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -674,15 +674,18 @@ class StudyFile
 
   # return correct path to file based on visibility & type
   def download_path
-    if self.upload_file_name.nil?
-      self.human_fastq_url
+    if hosted_externally?
+      external_link_url || human_fastq_url
     else
-      if self.study.public?
-        download_file_path(accession: self.study.accession, study_name: self.study.url_safe_name, filename: self.bucket_location)
-      else
-        download_private_file_path(accession: self.study.accession, study_name: self.study.url_safe_name, filename: self.bucket_location)
-      end
+      download_method = study.public? ? :download_file_path : :download_private_file_path
+      download_args = { accession: study.accession, study_name: study.url_safe_name, filename: bucket_location }
+      send(download_method, **download_args)
     end
+  end
+
+  # determine if file is hosted on an external server for downloads
+  def hosted_externally?
+    (external_identifier.present? && external_link_url.present?) || (upload_file_name.nil? && human_fastq_url.present?)
   end
 
   # JSON response for jQuery uploader

--- a/app/views/layouts/_download_link.html.erb
+++ b/app/views/layouts/_download_link.html.erb
@@ -2,7 +2,7 @@
     <span class="label label-warning embargoed-file"><i class="fas fa-ban"></i> Data release date: <%= @study.embargo.to_s(:long) %></span>
 <% else %>
   <% if study_file.hosted_externally? %>
-      <%= link_to "<span class='fas fa-cloud-download'></span> External".html_safe, study_file.download_path, class: 'btn btn-primary',
+      <%= link_to "<span class='fas fa-cloud-download-alt'></span> External".html_safe, study_file.download_path, class: 'btn btn-primary',
                   target: :_blank, rel: 'noopener noreferrer', data: {"analytics-name": 'file-download:study-single:external'} %>
   <% else %>
       <% if study_file.generation && DownloadQuotaService.download_exceeds_quota?(current_user, study_file.upload_file_size) %>

--- a/app/views/layouts/_download_link.html.erb
+++ b/app/views/layouts/_download_link.html.erb
@@ -1,7 +1,7 @@
 <% if @user_embargoed %>
     <span class="label label-warning embargoed-file"><i class="fas fa-ban"></i> Data release date: <%= @study.embargo.to_s(:long) %></span>
 <% else %>
-  <% if study_file.upload_file_name.nil? && study_file.human_data %>
+  <% if study_file.hosted_externally? %>
       <%= link_to "<span class='fas fa-cloud-download'></span> External".html_safe, study_file.download_path, class: 'btn btn-primary',
                   target: :_blank, rel: 'noopener noreferrer', data: {"analytics-name": 'file-download:study-single:external'} %>
   <% else %>

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -35,7 +35,7 @@
                   </thead>
                 </table>
               <% end %>
-              Then <%= link_to "click here".html_safe, "#{generate_manifest_study_url(@study)}" %> for the file_supplemental_info.tsv containing file supplementary information (units, protocols, etc...)
+              Then <%= link_to "click here", "#{generate_manifest_study_url(@study)}", target: :_blank %> for the file_supplemental_info.tsv containing file supplementary information (units, protocols, etc...)
             <% elsif @study.public? && !@user_embargoed || current_user.admin? %>
               <p class="lead">To download all files using <code>curl</code>, click the button below to get the download command:</p>
               <p class="lead command-container text-center" id="command-container-all">

--- a/test/integration/external/import_service_config/hca_test.rb
+++ b/test/integration/external/import_service_config/hca_test.rb
@@ -111,11 +111,13 @@ module ImportServiceConfig
       assert scp_study.full_description.present?
       assert_equal @user_id, scp_study.user_id
       assert_equal @branding_group_id, scp_study.branding_group_ids.first
+      assert_equal @confiiguration.service_name, scp_study.imported_from
       # populate StudyFile, using above study
       scp_study_file = @configuration.populate_study_file(scp_study.id)
       assert_not scp_study_file.use_metadata_convention
       assert_equal 'aldinger20.processed.h5ad', scp_study_file.upload_file_name
       assert_equal 'SPLiT-seq', scp_study_file.expression_file_info.library_preparation_protocol
+      assert_equal @confiiguration.service_name, scp_study_file.imported_from
       assert_not scp_study_file.ann_data_file_info.reference_file
       @configuration.obsm_keys.each do |obsm_key_name|
         assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?

--- a/test/integration/external/import_service_config/hca_test.rb
+++ b/test/integration/external/import_service_config/hca_test.rb
@@ -122,6 +122,7 @@ module ImportServiceConfig
       @configuration.obsm_keys.each do |obsm_key_name|
         assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?
       end
+      assert scp_study_file.ann_data_file_info.find_fragment(data_type: :expression).present?
     end
 
     test 'should import from service' do

--- a/test/integration/external/import_service_config/hca_test.rb
+++ b/test/integration/external/import_service_config/hca_test.rb
@@ -111,13 +111,13 @@ module ImportServiceConfig
       assert scp_study.full_description.present?
       assert_equal @user_id, scp_study.user_id
       assert_equal @branding_group_id, scp_study.branding_group_ids.first
-      assert_equal @confiiguration.service_name, scp_study.imported_from
+      assert_equal @configuration.service_name, scp_study.imported_from
       # populate StudyFile, using above study
       scp_study_file = @configuration.populate_study_file(scp_study.id)
       assert_not scp_study_file.use_metadata_convention
       assert_equal 'aldinger20.processed.h5ad', scp_study_file.upload_file_name
       assert_equal 'SPLiT-seq', scp_study_file.expression_file_info.library_preparation_protocol
-      assert_equal @confiiguration.service_name, scp_study_file.imported_from
+      assert_equal @configuration.service_name, scp_study_file.imported_from
       assert_not scp_study_file.ann_data_file_info.reference_file
       @configuration.obsm_keys.each do |obsm_key_name|
         assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?

--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -12,6 +12,7 @@ module ImportServiceConfig
         file_id: 'nemo:der-ah1o5qb',
         project_id: 'nemo:grn-gyy3k8j',
         study_id: 'nemo:col-hwmwd2x',
+        obsm_key_names: %w[X_tsne X_umap],
         user_id: @user.id,
         branding_group_id: @branding_group.id
       }
@@ -29,6 +30,7 @@ module ImportServiceConfig
       @attributes.each do |name, value|
         assert_equal value, config.send(name)
       end
+      assert_equal @attributes[:obsm_key_names], config.obsm_keys
     end
 
     test 'should reference correct methods' do
@@ -138,6 +140,9 @@ module ImportServiceConfig
       assert_equal 'human_var_scVI_VLMC.h5ad.tar', scp_study_file.upload_file_name
       assert_equal "10x 3' v3", scp_study_file.expression_file_info.library_preparation_protocol
       assert_not scp_study_file.ann_data_file_info.reference_file
+      @configuration.obsm_keys.each do |obsm_key_name|
+        assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?
+      end
     end
 
     test 'should import from service' do

--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -145,6 +145,7 @@ module ImportServiceConfig
       @configuration.obsm_keys.each do |obsm_key_name|
         assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?
       end
+      assert scp_study_file.ann_data_file_info.find_fragment(data_type: :expression).present?
     end
 
     test 'should import from service' do

--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -134,11 +134,13 @@ module ImportServiceConfig
       assert scp_study.full_description.present?
       assert_equal @user_id, scp_study.user_id
       assert_equal @branding_group_id, scp_study.branding_group_ids.first
+      assert_equal @confiiguration.service_name, scp_study.imported_from
       # populate StudyFile, using above study
       scp_study_file = @configuration.populate_study_file(scp_study.id)
       assert scp_study_file.use_metadata_convention
       assert_equal 'human_var_scVI_VLMC.h5ad.tar', scp_study_file.upload_file_name
       assert_equal "10x 3' v3", scp_study_file.expression_file_info.library_preparation_protocol
+      assert_equal @confiiguration.service_name, scp_study_file.imported_from
       assert_not scp_study_file.ann_data_file_info.reference_file
       @configuration.obsm_keys.each do |obsm_key_name|
         assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?

--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -134,13 +134,13 @@ module ImportServiceConfig
       assert scp_study.full_description.present?
       assert_equal @user_id, scp_study.user_id
       assert_equal @branding_group_id, scp_study.branding_group_ids.first
-      assert_equal @confiiguration.service_name, scp_study.imported_from
+      assert_equal @configuration.service_name, scp_study.imported_from
       # populate StudyFile, using above study
       scp_study_file = @configuration.populate_study_file(scp_study.id)
       assert scp_study_file.use_metadata_convention
       assert_equal 'human_var_scVI_VLMC.h5ad.tar', scp_study_file.upload_file_name
       assert_equal "10x 3' v3", scp_study_file.expression_file_info.library_preparation_protocol
-      assert_equal @confiiguration.service_name, scp_study_file.imported_from
+      assert_equal @configuration.service_name, scp_study_file.imported_from
       assert_not scp_study_file.ann_data_file_info.reference_file
       @configuration.obsm_keys.each do |obsm_key_name|
         assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?

--- a/test/integration/external/import_service_test.rb
+++ b/test/integration/external/import_service_test.rb
@@ -21,6 +21,7 @@ class ImportServiceTest < ActiveSupport::TestCase
 
   test 'should call import from external service' do
     mock = Minitest::Mock.new
+    mock.expect :valid?, true
     mock.expect :import_from_service, [Study.new, StudyFile.new]
     ImportServiceConfig::Nemo.stub :new, mock do
       ImportService.import_from(ImportServiceConfig::Nemo, **@nemo_attributes)


### PR DESCRIPTION
#### BACKGROUND & CHANGEs
This extends work started in #1925 to include the following:
* Automatic file ingests via `FileParseService`
* Support for downloading files directly from external services
* Setting default or custom `obsm_key_names` for AnnData cluster extraction
* Prevent duplication of studies/files created via `ImportService`
* Human-readable `imported_from` tag for finding all studies/files imported from a given service

Note: Currently, `ImportService` will only work with HCA due to the lack of parseable files in NeMO.

#### MANUAL TESTING
1. Start DelayedJob and enter a Rails console session
2. Set up parameters for job (using `Spatial and single-cell transcriptional landscape of human cerebellar development` and the AnnData contributor matrix `aldinger20.processed.h5ad`) 
```
study_id = "85a9263b-0887-48ed-ab1a-ddfa773727b6"
file_id = 'b0517500-b39e-4c7a-b2f0-794ddc725433'
user_id = User.find_by(email: '<your email>').id
branding_group_id = BrandingGroup.first.id
params = { study_id:, file_id:, user_id:, branding_group_id: }
```
3. Call `ImportService` to create study/file and call ingest:
```
ImportService.import_from(ImportServiceConfig::Hca, **params)
...
Importing HCA study: Spatial and single-cell transcriptional landscape of human cerebellar development from 85a9263b-0887-48ed-ab1a-ddfa773727b6
Ingesting file: aldinger20.processed.h5ad (b0517500-b39e-4c7a-b2f0-794ddc725433) from imported study SCP130 (85a9263b-0887-48ed-ab1a-ddfa773727b6)
=> [#<Study _id: 65773cf094ec8f692d0a3f68, created_at: 2023-12-11 16:47:05.7065 UTC, updated_at: 2023-12-11 16:47:05.7065 UTC, user_id:  ...
```
4. Validate that the entities created correctly and that the file is parsing (should take ~15 minutes to ingest all data, though clustering/metadata is available quickly)
```
study = Study.find_by(external_identifier: params[:study_id])
=> #<Study _id: 65773cf094ec8f692d0a3f68, created_at: 2023-12-11 16:47:05.706 UTC, updated_at: 2023-12-11 16:47:06.846 UTC, user_id: BS...

study.imported_from
=> "HCA"

study_file = StudyFile.find_by(external_identifier: params[:file_id])
=> #<StudyFile _id: 65773d2994ec8f692d0a3f6d, created_at: 2023-12-11 16:47:38.22 UTC, updated_at: 2023-12-11 16:47:38.562 UTC, upload_f...

study_file.imported_from
=> "HCA"

study_file.download_path
=> "https://service.azul.data.humancellatlas.org/repository/files/b0517500-b39e-4c7a-b2f0-794ddc725433?catalog=dcp33&version=2021-11-15T11%3A23%3A19.351000Z"

study_file.parsing?
=> true
```