### PR TITLE
Only read 1 megabyte of log for email delivery (SCP-5454)

### DIFF
--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -1029,7 +1029,7 @@ class IngestJob
   def generate_error_email_body(email_type: :user)
     case email_type
     when :user
-      error_contents = read_parse_logfile(user_error_filepath)
+      error_contents = read_parse_logfile(user_error_filepath, range: 0..1.megabyte)
       message_body = "<p>'#{study_file.upload_file_name}' has failed during parsing.</p>"
     when :dev
       # only read first megabyte of error log to avoid email delivery failure
@@ -1038,7 +1038,7 @@ class IngestJob
       message_body += "<p>A copy of this file can be found at #{generate_bucket_browser_tag}</p>"
       message_body += "<p>Detailed logs and PAPI events as follows:"
     else
-      error_contents = read_parse_logfile(user_error_filepath)
+      error_contents = read_parse_logfile(user_error_filepath, range: 0..1.megabyte)
       message_body = "<p>'#{study_file.upload_file_name}' has failed during parsing.</p>"
     end
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug where the user-facing error email sometimes will not deliver in the case where the `user_error.log` file is very large, resulting in a `broken pipe` error in the logs.  This is due to the portal attempting to read the entire contents into memory and then adding it to the email body.  Now, this uses the [same logic as the admin error email](https://github.com/broadinstitute/single_cell_portal_core/blob/development/app/models/ingest_job.rb#L1036) where only 1 megabyte of the log is read.
