### PR TITLE
Consolidate checking Terra user groups for better error handling (SCP-5457)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -323,6 +323,21 @@ class User
   #
   ###
 
+  # get Terra user groups for a specified user, with error handling
+  # this prevents issues when user is not in compliance with Terra terms of service, or ToS status cannot be found
+  def user_groups
+    if registered_for_firecloud && (refresh_token.present? || api_access_token.present?)
+      user_client = FireCloudClient.new(user: self, project: FireCloudClient::PORTAL_NAMESPACE)
+      begin
+        user_client.get_user_groups.map { |group| group['groupEmail'] }
+      rescue RestClient::Exception
+        []
+      end
+    else
+      []
+    end
+  end
+
   # check if user currently has a download exemption (daily_download_quota: nil)
   def quota_exemption?
     daily_download_quota.nil?


### PR DESCRIPTION
#### BACKGROUND
Work on #1944 exposed a potential regression in users who had previously registered for Terra, but not accepted updated terms of service in a while.  The amount of time necessary is unclear (at least 1+ year), but instead of the new terms of service endpoint returning a status object it responds with `404`.  While this in and of itself is not a problem, it exposed a lack of proper error handling for some low-level Study accessor methods that relied on checking user groups in Terra for an authenticated user.  This resulted in an error cascade that left a blank page and no recourse for a user after signing in.  While they are technically signed in, they cannot navigate anywhere or sign out.  They can manually type in a URL for a study they can view, but unless they have one bookmarked, it would be almost impossible for them to get there.

#### CHANGES
This update moves checking user groups into a single handler (`User#user_groups`) that provides the necessary error handling.  Now, _any_ upstream exception will return an empty array, and the normal terms of service checking/handling can still apply.  This has the added benefit of simplifying many study permission-related methods and removing duplicated code.

#### MANUAL TESTING
This requires an account in the aforementioned state.  If you do not have access to one locally, you can use the `single.cell.user1@gmail.com` account referenced [here](https://docs.google.com/document/d/1QslqdIN0o7OCQ_bNY9YFvVgU6v_JtdQqnV4i33BwakQ/edit).
1. Boot as normal
2. If you do not have access to an account in the correct state, follow the steps outline in the document above to sign in with the `single.cell.user1@gmail.com` user account.  Otherwise, sign in with the account and skip to step 5
3. Accept the SCP terms if you are prompted to
4. In a separate Rails console session, set `registered_for_firecloud` to `true` for this account:
```
user = User.find_by(email: 'single.cell.user1@gmail.com')
user.update(registered_for_firecloud: true)
```
5. Refresh the homepage and confirm that the search interface renders and you can navigate around, and are not prompted to accept the Terra terms of service