### PR TITLE
Support numeric facets in cell filtering API requests (SCP-5410)

### DIFF
--- a/test/api/visualization/annotations_controller_test.rb
+++ b/test/api/visualization/annotations_controller_test.rb
@@ -26,9 +26,10 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
                                                    study: @basic_study,
                                                    cell_input: ['A', 'B', 'C'],
                                                    annotation_input: [
-                                                     {name: 'species', type: 'group', values: ['dog', 'cat', 'dog']},
-                                                     {name: 'disease', type: 'group', values: ['none', 'none', 'measles']},
-                                                     {name: 'cell_type', type: 'group', values: ['big', '', 'big']}
+                                                     { name: 'species', type: 'group', values: %w[dog cat dog] },
+                                                     { name: 'disease', type: 'group', values: %w[none none measles] },
+                                                     { name: 'cell_type', type: 'group', values: ['big', '', 'big'] },
+                                                     { name: 'nCount_RNA', type: 'numeric', values: [0.1, 0.5, 1.1] }
                                                    ])
 
     marker_cluster_list = %w(Cluster1 Cluster2 Cluster3)
@@ -88,8 +89,8 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
                                     test_array: @@studies_to_clean)
     sign_in_and_update @user
     execute_http_request(:get, api_v1_study_annotations_path(@basic_study))
-    assert_equal 4, json.length
-    assert_equal(%w[species disease cell_type foo], json.map { |annot| annot['name'] })
+    assert_equal 5, json.length
+    assert_equal(%w[species disease cell_type nCount_RNA foo], json.map { |annot| annot['name'] })
     expected_annotation = {
       name: 'species', type: 'group', values: %w[dog cat], scope: 'study', is_differential_expression_enabled: false
     }.with_indifferent_access
@@ -150,16 +151,18 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
       { annotation: 'disease--group--study', groups: %w[none measles] }.with_indifferent_access,
       { annotation: 'cell_type--group--study', groups: %w[big --Unspecified--] }.with_indifferent_access
     ]
-    # test validations
     assert_equal expected_facets, json['facets']
+    # test numeric facets
+    facet_params = { cluster: 'clusterA.txt', annotations: 'nCount_RNA--numeric--study' }
+    execute_http_request(:get, api_v1_study_annotations_facets_path(@basic_study, **facet_params))
+    expected_facets = [{ annotation: 'nCount_RNA--numeric--study', groups: [] }.with_indifferent_access]
+    assert_equal expected_facets, json['facets']
+    assert_equal [[0.1], [0.5], [1.1]], json['cells']
+    # test validations
     execute_http_request(:get, api_v1_study_annotations_facets_path(
       @basic_study, cluster: 'does-not-exist', annotations: ''
     ))
     assert_response :not_found
-    execute_http_request(:get, api_v1_study_annotations_facets_path(
-      @basic_study, cluster: 'clusterA.txt',  annotations: 'foo--numeric--study'
-    ))
-    assert_response :bad_request
     execute_http_request(:get, api_v1_study_annotations_facets_path(
       @basic_study, cluster: 'clusterA.txt', annotations: 'not-found--group--study'
     ))
@@ -167,12 +170,12 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should load requested facet annotations' do
-    annotation_param = 'species--group--study,disease--group--study,cell_type--group--study'
+    annotation_param = 'species--group--study,disease--group--study,cell_type--group--study,nCount_RNA--numeric--study'
     cluster = @basic_study.cluster_groups.by_name('clusterA.txt')
     annotations = Api::V1::Visualization::AnnotationsController.get_facet_annotations(
       @basic_study, cluster, annotation_param
     )
-    assert_equal 3, annotations.size
+    assert_equal 4, annotations.size
     expected_annotations = @basic_study.cell_metadata.map do |meta|
       {
         name: meta.name, type: meta.annotation_type, scope: 'study', values: meta.values,

--- a/test/factories/cell_metadatum.rb
+++ b/test/factories/cell_metadatum.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
       annotation_input { {} }
     end
     values {
-      annotation_input[:values].uniq
+      annotation_input[:type] == 'group' ? annotation_input[:values].uniq : []
     }
     name { annotation_input[:name] }
     annotation_type { annotation_input[:type] }


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds support for numeric facets to cell filtering API requests.  Now, instead of throwing a `400`, the API will add in the actual numeric value for each cell in a numeric annotation.  This will allow for filtering on the front end via a slider bar and a range check.

#### MANUALT TESTING
1. Boot as normal and open the [Swagger documentation](https://localhost:3000/single_cell/api/v1#/Visualization/study_annotation_facets_path) for the `/annotations/facets` endpoint
2. Find the study accession for the synthetic study `Male Mouse brain`
3. In the Swagger doc, enter the accession and the following:
    * `annotations` : `disease__ontology_label--group--study,Intensity--numeric--cluster` 
    * `cluster` : `cluster.tsv`
4. Click "Execute" and confirm that the request completes, and that the response looks like the following:
```
{ 
  "cells": [ [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 0, 2 ], [ 0, 2 ], [ 0, 2 ], [ 1, 2 ], [ 1, 2 ], [ 1, 2 ], [ 1, 2 ], [ 1, 2 ], [ 1, 2 ], [ 1, 2 ], [ 1, 2 ], [ 1, 2 ], [ 1, 2 ], [ 0, 2 ], [ 0, 2 ], [ 0, 2 ], [ 0, 2 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 3 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 4 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 5 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 6 ], [ 0, 7 ], [ 0, 7 ], [ 0, 7 ], [ 0, 7 ], [ 0, 7 ], [ 0, 7 ], [ 0, 7 ], [ 0, 7 ], [ 0, 7 ], [ 0, 7 ], [ 0, 7 ], [ 0, 7 ], [ 0, 7 ], [ 0, 8 ], [ 0, 8 ], [ 0, 8 ], [ 0, 8 ], [ 0, 8 ], [ 0, 8 ], [ 0, 8 ], [ 0, 8 ], [ 0, 8 ], [ 0, 8 ], [ 0, 8 ] ],
  "facets": [
    {
      "annotation": "disease__ontology_label--group--study",
      "groups": [
        "oral tuberculosis",
        "intestinal tuberculosis"
      ]
    },
    {
      "annotation": "Intensity--numeric--cluster",
      "groups": []
    }
  ]
}
```