### PR TITLE
Update UI to suggest gcloud storage instead of gsutil (SCP-5477)

### DIFF
--- a/app/javascript/components/upload/SequenceFileStep.jsx
+++ b/app/javascript/components/upload/SequenceFileStep.jsx
@@ -43,29 +43,29 @@ function SequenceForm({
     <div className="row">
       <div className="col-md-12">
         <div className="form-terra">
-          Primary sequence information, such as BAM, BAM Index, and FASTQ files<br/>
+          Primary sequence information, such as BAM, BAM Index, and FASTQ files<br />
           <p>
-            <b>Non-human Data</b><br/>
+            <b>Non-human Data</b><br />
             If you have a few, small (under 2 GB) non-human sequence files, they can be uploaded here.
             For uploading many or larger files, please refer to the instructions in
-            our <a href="https://singlecell.zendesk.com/hc/en-us/articles/360061006011-Uploading-Large-Files-Using-Gsutil-Tool" target="_blank" rel="noopener noreferrer">documentation</a>.
+            our <a href="https://singlecell.zendesk.com/hc/en-us/articles/360061006011" target="_blank" rel="noopener noreferrer">documentation</a>.
           </p>
           <p>
-            If you already have gsutil installed you can upload files directly using the following command:
+            If you already have the gcloud CLI installed (Sept 2022 or later) you can upload files directly using the following command:
           </p>
           <pre>
-            gsutil -m cp /path/to/files gs://{formState.study.bucket_id}
+            gcloud storage cp /path/to/files gs://{formState.study.bucket_id}
           </pre>
           <p>
-            <b>Primary Human Data</b><br/>
+            <b>Primary Human Data</b><br />
             Primary sequence data derived from humans should be stored in other biological databases and can be linked here
             by selecting &apos;Yes&apos; for &apos;Primary Human Data&apos; and then providing a link in the text field.
           </p>
         </div>
       </div>
     </div>
-    { sequenceFiles.length > 1 && <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_SEQUENCE_FILE}/> }
-    { sequenceFiles.map(file => {
+    {sequenceFiles.length > 1 && <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_SEQUENCE_FILE} />}
+    {sequenceFiles.map(file => {
       const associatedBaiFile = findBundleChildren(file, formState.files)[0]
       return <SequenceFileForm
         key={file.oldId ? file.oldId : file._id}
@@ -79,8 +79,8 @@ function SequenceForm({
         fileMenuOptions={serverState.menu_options}
         associatedBaiFile={associatedBaiFile}
         bucketName={formState.study.bucket_id}
-        isInitiallyExpanded={sequenceFiles.length === 1}/>
+        isInitiallyExpanded={sequenceFiles.length === 1} />
     })}
-    <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_SEQUENCE_FILE}/>
+    <AddFileButton addNewFile={addNewFile} newFileTemplate={DEFAULT_NEW_SEQUENCE_FILE} />
   </div>
 }

--- a/app/javascript/components/upload/SequenceFileStep.jsx
+++ b/app/javascript/components/upload/SequenceFileStep.jsx
@@ -51,7 +51,7 @@ function SequenceForm({
             our <a href="https://singlecell.zendesk.com/hc/en-us/articles/360061006011" target="_blank" rel="noopener noreferrer">documentation</a>.
           </p>
           <p>
-            If you already have the gcloud CLI installed (Sept 2022 or later) you can upload files directly using the following command:
+            If you already have the gcloud CLI installed (Sept 2022 release or later) you can upload files directly using the following command:
           </p>
           <pre>
             gcloud storage cp /path/to/files gs://{formState.study.bucket_id}

--- a/app/javascript/components/upload/SequenceFileStep.jsx
+++ b/app/javascript/components/upload/SequenceFileStep.jsx
@@ -45,7 +45,7 @@ function SequenceForm({
         <div className="form-terra">
           Primary sequence information, such as BAM, BAM Index, and FASTQ files<br />
           <p>
-            <b>Non-human Data</b><br />
+            <b>Non-human data</b><br />
             If you have a few, small (under 2 GB) non-human sequence files, they can be uploaded here.
             For uploading many or larger files, please refer to the instructions in
             our <a href="https://singlecell.zendesk.com/hc/en-us/articles/360061006011" target="_blank" rel="noopener noreferrer">documentation</a>.
@@ -57,7 +57,7 @@ function SequenceForm({
             gcloud storage cp /path/to/files gs://{formState.study.bucket_id}
           </pre>
           <p>
-            <b>Primary Human Data</b><br />
+            <b>Primary human data</b><br />
             Primary sequence data derived from humans should be stored in other biological databases and can be linked here
             by selecting &apos;Yes&apos; for &apos;Primary Human Data&apos; and then providing a link in the text field.
           </p>

--- a/app/lib/synthetic_study_populator.rb
+++ b/app/lib/synthetic_study_populator.rb
@@ -119,9 +119,9 @@ class SyntheticStudyPopulator
           study_file_params[:upload] = local_file
         end
 
-        study_file_params.merge!(process_genomic_file_params(study, finfo))
+        study_file_params.merge!(process_genomic_file_params(finfo))
         study_file_params.merge!(process_coordinate_file_params(study, finfo))
-        study_file_params.merge!(process_expression_file_params(study, finfo))
+        study_file_params.merge!(process_expression_file_params(finfo))
         study_file_params.merge!(process_label_file_params(study, finfo))
         study_file_params.merge!(process_mtx_file_params(study, finfo))
         study_file_params.merge!(process_sequence_file_params(study, finfo))
@@ -147,7 +147,7 @@ class SyntheticStudyPopulator
     end
   end
 
-  def self.process_expression_file_params(_study, file_info)
+  def self.process_expression_file_params(file_info)
     exp_params = {}
     if file_info['type'] == 'Expression Matrix' || file_info['type'] == 'MM Coordinate Matrix'
       exp_finfo_params = file_info['expression_file_info']
@@ -228,7 +228,7 @@ class SyntheticStudyPopulator
   end
 
   # process species/annotation arguments, return a hash of params suitable for passing to a StudyFile constructor
-  def self.process_genomic_file_params(_study, file_info)
+  def self.process_genomic_file_params(file_info)
     params = {}
     taxon_id = nil
     if file_info['species_scientific_name'].present?

--- a/app/lib/synthetic_study_populator.rb
+++ b/app/lib/synthetic_study_populator.rb
@@ -1,4 +1,3 @@
-
 # class to populate synthetic studies from files.
 # See db/seed/synthetic_studies for examples of the file formats
 #
@@ -12,9 +11,9 @@ class SyntheticStudyPopulator
   DEFAULT_EXAMPLE_STUDY_PATH = Rails.root.join('db', 'seed', 'example_studies')
   # populates all studies defined in db/seed/synthetic_studies
   def self.populate_all(user: User.first)
-    study_names = Dir.glob(DEFAULT_SYNTHETIC_STUDY_PATH.join('*')).select {|f| File.directory? f}
+    study_names = Dir.glob(DEFAULT_SYNTHETIC_STUDY_PATH.join('*')).select { |f| File.directory? f }
     study_names.each do |study_name|
-      populate(study_name, user: user)
+      populate(study_name, user:)
     end
   end
 
@@ -24,10 +23,10 @@ class SyntheticStudyPopulator
     study_path = study_folder
     if study_folder.exclude?('/')
       study_path = DEFAULT_SYNTHETIC_STUDY_PATH.join(study_folder).to_s
-      if !File.directory?(study_path)
+      unless File.directory?(study_path)
         study_path = DEFAULT_EXAMPLE_STUDY_PATH.join(study_folder).to_s
       end
-      if !File.directory?(study_path)
+      unless File.directory?(study_path)
         raise "No directory found for #{study_folder}"
       end
     end
@@ -49,7 +48,7 @@ class SyntheticStudyPopulator
   def self.collect_synthetic_studies
     study_names = []
     synthetic_base_path = DEFAULT_SYNTHETIC_STUDY_PATH
-    study_dirs = Dir.glob(synthetic_base_path.join('*')).select {|f| File.directory? f}
+    study_dirs = Dir.glob(synthetic_base_path.join('*')).select { |f| File.directory? f }
     study_dirs.each do |study_dir|
       synthetic_study_folder = synthetic_base_path.join(study_dir).to_s
       study_info_file = File.read(synthetic_study_folder + '/study_info.json')
@@ -59,14 +58,13 @@ class SyntheticStudyPopulator
     Study.where(:name.in => study_names)
   end
 
-  private
-
   def self.create_study(study_config, user, detached, update)
     existing_study = Study.find_by(name: study_config['study']['name'])
     if existing_study
-      if (update)
+      if update
         return existing_study
       end
+
       puts("Destroying Study #{existing_study.name}, id #{existing_study.id}")
       if !existing_study.detached
         existing_study.destroy_and_remove_workspace
@@ -79,7 +77,7 @@ class SyntheticStudyPopulator
     study.detached = detached
     study.study_detail = StudyDetail.new(full_description: study_config['study']['description'])
     study.user ||= user
-    if !study.detached
+    unless study.detached
       study.firecloud_project ||= ENV['PORTAL_NAMESPACE']
     end
     puts("Saving Study #{study.name}")
@@ -94,23 +92,24 @@ class SyntheticStudyPopulator
       begin
         study_file_params = {
           file_type: finfo['type'],
-          name: finfo['name'] ? finfo['name'] : finfo['filename'],
+          name: finfo['name'] || 'filename',
           use_metadata_convention: finfo['use_metadata_convention'] ? true : false,
           status: study.detached ? 'new' : 'uploading',
-          study: study
+          study:
         }
         if finfo['bucket_url'] && !study.detached
-          puts "moving file from remote bucket into workspace -- you must be signed into gsutil for this to work"
-          puts "getting file info from bucket"
-          bucket_file_info = `gsutil stat #{finfo['bucket_url']}`
-          bucket_file_size = bucket_file_info.match(/Content-Length:\s*([0-9]*)/)[1]
+          puts 'moving file from remote bucket into workspace -- you must be signed into gcloud CLI for this to work'
+          puts 'getting file info from bucket'
+          bucket_file_info = `gcloud storage objects describe #{finfo['bucket_url']}`
+          bucket_file_size = bucket_file_info.match(/size:\s*([0-9]*)/)[1]
           puts "File listed as #{bucket_file_size} bytes, beginning copy"
-          gsutil_command = "gsutil cp #{finfo['bucket_url']} #{study.gs_url}"
-          puts gsutil_command
-          exit_status = system(gsutil_command)
-          if !exit_status
+          gcloud_command = "gcloud storage cp #{finfo['bucket_url']} #{study.gs_url}"
+          puts gcloud_command
+          exit_status = system(gcloud_command)
+          unless exit_status
             raise 'Copy file failed -- stopping study population'
           end
+
           study_file_params[:status] = 'uploaded'
           study_file_params[:upload_file_size] = bucket_file_size
           study_file_params[:remote_location] = finfo['filename']
@@ -136,7 +135,7 @@ class SyntheticStudyPopulator
         else
           # make sure we still create needed bundled for unparsed files (e.g. bam/bai files)
           FileParseService.create_bundle_from_file_options(study_file, study)
-          if !study.detached
+          unless study.detached
             study.send_to_firecloud(study_file)
           end
         end
@@ -148,7 +147,7 @@ class SyntheticStudyPopulator
     end
   end
 
-  def self.process_expression_file_params(study, file_info)
+  def self.process_expression_file_params(_study, file_info)
     exp_params = {}
     if file_info['type'] == 'Expression Matrix' || file_info['type'] == 'MM Coordinate Matrix'
       exp_finfo_params = file_info['expression_file_info']
@@ -169,14 +168,14 @@ class SyntheticStudyPopulator
   def self.process_label_file_params(study, file_info)
     params = {}
     if file_info['type'] == 'Coordinate Labels'
-      if !file_info['cluster_file_name']
+      unless file_info['cluster_file_name']
         throw 'Coordinate label files must specify a cluster_file_name'
       end
-      matching_cluster_file = StudyFile.find_by(name: file_info['cluster_file_name'], study: study)
+      matching_cluster_file = StudyFile.find_by(name: file_info['cluster_file_name'], study:)
       if matching_cluster_file.nil?
         throw "No cluster file with name #{file_info['cluster_file_name']} to match coordinate labels"
       end
-      params[:options] = {'cluster_file_id' => matching_cluster_file.id.to_s}
+      params[:options] = { 'cluster_file_id' => matching_cluster_file.id.to_s }
     end
     params
   end
@@ -185,14 +184,14 @@ class SyntheticStudyPopulator
     params = {}
     if file_info['type'] == '10X Barcodes File' || file_info['type'] == '10X Genes File'
       matrix_name = file_info['matrix_file_name']
-      if !matrix_name
+      unless matrix_name
         throw 'Barcodes and Genes files must specify a matrix_file_name'
       end
-      matching_mtx_file = StudyFile.find_by(name: matrix_name, study: study)
+      matching_mtx_file = StudyFile.find_by(name: matrix_name, study:)
       if matching_mtx_file.nil?
         throw "No MTX file with name #{matrix_name} to match #{file_info['filename']}"
       end
-      params[:options] = {'matrix_id' => matching_mtx_file.id.to_s}
+      params[:options] = { 'matrix_id' => matching_mtx_file.id.to_s }
     end
     params
   end
@@ -200,37 +199,36 @@ class SyntheticStudyPopulator
   def self.process_sequence_file_params(study, file_info)
     params = {}
     if file_info['type'] == 'BAM Index'
-      if !file_info['bam_file_name']
+      unless file_info['bam_file_name']
         throw 'BAM index files must specify a bam_file_name'
       end
-      matching_bam_file = StudyFile.find_by(name: file_info['bam_file_name'], study: study)
+      matching_bam_file = StudyFile.find_by(name: file_info['bam_file_name'], study:)
       if matching_bam_file.nil?
         throw "No BAM file with name #{file_info['bam_file_name']} to match bai file"
       end
-      params[:options] = {'bam_id' => matching_bam_file.id.to_s}
+      params[:options] = { 'bam_id' => matching_bam_file.id.to_s }
     end
     params
   end
 
-
   # process coordinate/cluster arguments, return a hash of params suitable for passing to a StudyFile constructor
   def self.process_coordinate_file_params(study, file_info)
     params = {}
-    if !file_info['is_spatial'].nil?
+    unless file_info['is_spatial'].nil?
       params[:is_spatial] = file_info['is_spatial']
     end
     if file_info['spatial_cluster_associations'].present?
       # look up the ids for the associations
       # note that this requires the associated file to have already been added
       params[:spatial_cluster_associations] = file_info['spatial_cluster_associations'].map do |cluster_file_name|
-        StudyFile.find_by!(study: study, name: cluster_file_name).id.to_s
+        StudyFile.find_by!(study:, name: cluster_file_name).id.to_s
       end
     end
     params
   end
 
   # process species/annotation arguments, return a hash of params suitable for passing to a StudyFile constructor
-  def self.process_genomic_file_params(study, file_info)
+  def self.process_genomic_file_params(_study, file_info)
     params = {}
     taxon_id = nil
     if file_info['species_scientific_name'].present?
@@ -241,7 +239,7 @@ class SyntheticStudyPopulator
       params[:taxon_id] = taxon.id
     end
     if file_info['genome_assembly_name'].present?
-      if  params[:taxon_id].nil?
+      if params[:taxon_id].nil?
         throw "You must specify species_scientific_name to specify genome_assembly in #{file_info['filename']}. Stopping populate"
       end
       assembly = GenomeAssembly.find_by(name: file_info['genome_assembly_name'], taxon_id: params[:taxon_id])
@@ -254,7 +252,8 @@ class SyntheticStudyPopulator
       if params[:genome_assembly_id].nil?
         throw "You must specify genome_annotation_name to specify genome_annotation in #{file_info['filename']}. Stopping populate"
       end
-      annotation = GenomeAnnotation.find_by(name: file_info['genome_annotation_name'], genome_assembly_id: params[:genome_assembly_id])
+      annotation = GenomeAnnotation.find_by(name: file_info['genome_annotation_name'],
+                                            genome_assembly_id: params[:genome_assembly_id])
       if assembly.nil?
         throw "You must populate the GenomeAnnotation #{file_info['genome_annotation_name']} to ingest the file #{file_info['filename']}. Stopping populate"
       end
@@ -262,5 +261,4 @@ class SyntheticStudyPopulator
     end
     params
   end
-
 end

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -16,20 +16,20 @@
           </div>
           <div class="modal-body">
             <% if @study.has_bucket_access?(current_user) %>
-            <p class="lead">To download all files using <code>gsutil</code>, run the following command:</p>
-            <pre>gsutil -m cp -r gs://<%= @study.bucket_id %> [target path]</pre>
+            <p class="lead">To download all files using gcloud CLI tools, run the following command:</p>
+            <pre>gcloud storage cp -r gs://<%= @study.bucket_id %> [target path]</pre>
               <% if @directories.any? %>
                 <p class="lead">To download all data files in a specific folder, use the following commands:</p>
                 <table class="table table-condensed table-striped">
                   <thead>
                   <tr>
                     <th>Folder</th>
-                    <th>gsutil command</th>
+                    <th>gcloud CLI command</th>
                   </tr>
                   <% @directories.each do |directory| %>
                       <tr>
                         <td><%= directory.name %></td>
-                        <td><pre>gsutil -m cp gs://<%= @study.bucket_id %><%= directory.download_display_name %>*.<%= directory.file_type %>*<%= %> [target path]</pre></td>
+                        <td><pre>gcloud storage cp gs://<%= @study.bucket_id %><%= directory.download_display_name %>*.<%= directory.file_type %>*<%= %> [target path]</pre></td>
                       </tr>
                   <% end %>
                   </thead>

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -24,7 +24,7 @@
                   <thead>
                   <tr>
                     <th>Folder</th>
-                    <th>gcloud CLI command</th>
+                    <th>gcloud download command</th>
                   </tr>
                   <% @directories.each do |directory| %>
                       <tr>

--- a/app/views/studies/sync_study.html.erb
+++ b/app/views/studies/sync_study.html.erb
@@ -27,28 +27,17 @@
       What is sync?
     </a>
     <a
-      href="https://singlecell.zendesk.com/hc/en-us/articles/360061006011-Adding-large-files-with-gsutil"
+      href="https://singlecell.zendesk.com/hc/en-us/articles/360061006011"
       class="btn terra-secondary-btn"
       target="_blank"
       data-analytics-name="gsutil-link"
       data-toggle="tooltip"
-      data-original-title="Learn about adding large files with gsutil"
+      data-original-title="Learn about adding large files with gcloud CLI"
       data-placement="right"
     >
-      <%#= TODO (SCP-4148): Emphasize copy-from-bucket in gsutil for sync docs %>
-      Adding data with gsutil
+      Adding data with gcloud CLI
     </a>
-    <a
-      href="https://forms.gle/cRDSiDj5FgFyAELo6"
-      class="btn terra-secondary-btn"
-      target="_blank"
-      data-analytics-name="sync-survey-link"
-      data-toggle="tooltip"
-      data-original-title="Go to survey"
-      data-placement="right"
-    >
-      Take a 3-question survey to help improve sync
-    </a>
+
   </div>
 </div>
 

--- a/image-pipeline/expression-scatter-plots.js
+++ b/image-pipeline/expression-scatter-plots.js
@@ -21,20 +21,20 @@ import sharp from 'sharp'
 import { Storage } from '@google-cloud/storage'
 
 /** Print message with browser-tag preamble to local console and log file */
-function print(message, context={}) {
+function print(message, context = {}) {
   let preamble = ('preamble' in context === false) ? '' : context.preamble
   const timestamp = new Date().toISOString()
-  if (preamble !== '') {preamble = `${preamble} `}
+  if (preamble !== '') { preamble = `${preamble} ` }
   const fullMessage = preamble + message
 
   console.log(fullMessage)
 
-  logFileWriteStream.write(`[${timestamp}] -- : ${fullMessage }\n`)
+  logFileWriteStream.write(`[${timestamp}] -- : ${fullMessage}\n`)
   numLogEntries += 1
 
   // Stream logs to bucket in small chunks
   // For observability into ongoing jobs and crash-resilient logs
-  if (numLogEntries % 20 === 0 && context.bucket) {uploadLog(context.bucket)}
+  if (numLogEntries % 20 === 0 && context.bucket) { uploadLog(context.bucket) }
 }
 
 /** Is request a log post to Bard? */
@@ -168,7 +168,8 @@ async function makeExpressionScatterPlotImage(gene, page, context) {
 
   // TODO (SCP-4698): parallelize upload, and atomically trigger on success.
   //
-  // `gcloud storage cp` or (slower) `gsutil -m cp` would upload in parallel,
+  // `gcloud storage cp -Z` would compress locally, upload in parallel and
+  // store files compressed on cloud storage and decompressed during download
   // without needing to call GCS client library's bucket.upload on each file.
   // Ideally there would be a GCS client library equivalent of those commands,
   // but brief research found none.
@@ -251,8 +252,8 @@ async function prefetchExpressionData(gene, context) {
     const response = await fetch(url)
     const json = await response.json()
 
-    expressionArrayString = `[${ json.data.expression.toString() }]`
-    print(`Fetched expression data from URL: ${ url}`, context)
+    expressionArrayString = `[${json.data.expression.toString()}]`
+    print(`Fetched expression data from URL: ${url}`, context)
   }
 
   expressionByGene[gene] = expressionArrayString
@@ -444,7 +445,7 @@ async function parseCliArgs() {
   const { values } = parseArgs({ args, options })
 
   const bucket = values.bucket
-  print(`Command run via Node:\n\n${ commandToNode}\n`, { bucket })
+  print(`Command run via Node:\n\n${commandToNode}\n`, { bucket })
   await uploadLog(bucket)
 
   // Candidates for CLI argument
@@ -464,7 +465,7 @@ async function parseCliArgs() {
   // TODO (SCP-4564): Document how to adjust network rules to use staging locally
   const originsByEnvironment = {
     'development': 'https://localhost:3000',
-    'staging': `https://${ stagingDomainName}`,
+    'staging': `https://${stagingDomainName}`,
     'production': 'https://singlecell.broadinstitute.org'
   }
   const environment = values.environment || 'development'
@@ -472,7 +473,7 @@ async function parseCliArgs() {
 
   // Set origin for use in standalone fetch, which lacks Puppeteer host map
   const isStagingPAPI = environment === 'staging' && !process.env?.IS_LOCAL
-  const fetchOrigin = isStagingPAPI ? `https://${ stagingIP}` : origin
+  const fetchOrigin = isStagingPAPI ? `https://${stagingIP}` : origin
 
   return { values, numCPUs, origin, stagingHost, fetchOrigin }
 }
@@ -495,7 +496,7 @@ async function run() {
   } else {
     jsonDir = await makeLocalOutputDir('json')
   }
-  jsonFpStem = `${jsonDir + cluster }--`
+  jsonFpStem = `${jsonDir + cluster}--`
 
   // Cache for X, Y, and possibly Z coordinates
   coordinates = {}
@@ -579,7 +580,7 @@ async function fetchRankedGenes(context) {
 
   const lines = content.split('\n')
   lines.forEach(line => {
-    if (line[0] === '#') {return}
+    if (line[0] === '#') { return }
     const columns = line.split('\t')
     const gene = columns[0]
     rankedGenes.push(gene)
@@ -634,18 +635,18 @@ function msToTime(duration) {
   let minutes = Math.floor((duration / (1000 * 60)) % 60)
   let hours = Math.floor((duration / (1000 * 60 * 60)) % 24)
 
-  hours = (hours < 10) ? `0${ hours}` : hours
-  minutes = (minutes < 10) ? `0${ minutes}` : minutes
-  seconds = (seconds < 10) ? `0${ seconds}` : seconds
+  hours = (hours < 10) ? `0${hours}` : hours
+  minutes = (minutes < 10) ? `0${minutes}` : minutes
+  seconds = (seconds < 10) ? `0${seconds}` : seconds
 
-  return `${hours }:${ minutes }:${ seconds }.${ milliseconds}`
+  return `${hours}:${minutes}:${seconds}.${milliseconds}`
 }
 
 /** Wrap up job.  Log status, run time. */
-async function complete(error=null) {
+async function complete(error = null) {
   const bucket = values.bucket
   const context = { bucket }
-  if (error) {print(error.stack, context)}
+  if (error) { print(error.stack, context) }
 
   // Get timing data
   const endTime = Date.now()
@@ -682,7 +683,7 @@ const { values, numCPUs, origin, stagingHost, fetchOrigin } = await parseCliArgs
 
 let debugNonce = ''
 if (values['debug'] || values['debug-headless']) {
-  debugNonce = `_debug${ nonce}/`
+  debugNonce = `_debug${nonce}/`
 }
 
 let imagesDir


### PR DESCRIPTION
Moving away from `gsutil cp` and using `gcloud storage cp` has the [potential for faster data transfer](https://medium.com/tag-techblog/from-gsutil-to-gcloud-storage-introducing-simplicity-and-improved-performance-4946a1299786) for our study owners, making data upload less time-consuming. This shift from `gsutil` to `gcloud storage` has already been applied to [SCP documentation](https://singlecell.zendesk.com/hc/en-us/articles/360061006011) and this PR implements SCP UI updates to support the transition away from `gsutil cp`.

Most of the changes in this PR are linting whitespace updates ( eg. to change `<br/>` tags to `<br />` etc). 

The user-facing changes are:
* [Update of copy command for bulk download](https://github.com/broadinstitute/single_cell_portal_core/blob/42d24aa082b01c9f6bf1ff2e90273711fc3c6296/app/views/site/_study_download_data.html.erb#L19) in /app/views/site/_study_download_data.html.erb line 19
> To download all files using gcloud CLI tools, run the following command:
> gcloud storage cp -r gs://<%= @study.bucket_id %> [target path]

  
* [Update copy command for sequence file upload](https://github.com/broadinstitute/single_cell_portal_core/blob/42d24aa082b01c9f6bf1ff2e90273711fc3c6296/app/javascript/components/upload/SequenceFileStep.jsx#L54) in /app/javascript/components/upload/SequenceFileStep.jsx line 54
>  If you already have the gcloud CLI installed (Sept 2022 release or later) you can upload files directly using the following command:
> 
> `gcloud storage cp /path/to/files gs://{formState.study.bucket_id}`

  
* [Updated button text](https://github.com/broadinstitute/single_cell_portal_core/blob/42d24aa082b01c9f6bf1ff2e90273711fc3c6296/app/views/studies/sync_study.html.erb#L35) (`gsutil` -> `gcloud CLI`; line 35) for documentation, REMOVED button for survey (lines 39-51 deleted) in sync/app/views/studies/sync_study.html.erb  
[lines 101 - 106](https://github.com/broadinstitute/single_cell_portal_core/blob/42d24aa082b01c9f6bf1ff2e90273711fc3c6296/app/lib/synthetic_study_populator.rb#L101)


  
Non-user-facing changes: 

* Updated synthetic study populator to use gcloud storage functions] in app/lib/synthetic_study_populator.rb 

  
* Updated comment text containing "gsutil" to use "gcloud storage" instead:
/app/lib/study_sync_service.rb 
/image-pipeline/expression-scatter-plots.js
/test/services/study_sync_service_test.rb


This PR supports SCP-5477.