### PR TITLE
Adding reference AnnData information to Mixpanel logging (SCP-5220)

### DIFF
--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -67,4 +67,9 @@ class AnnDataIngestParameters
   def machine_type
     EXTRACT_MACHINE_TYPES.detect { |_, mem_range| mem_range === file_size }&.first || 'n2d-highmem-4'
   end
+
+  # get the particular file (either source AnnData or fragment) being processed by this job
+  def associated_file
+    anndata_file || cluster_file || cell_metadata_file || matrix_file
+  end
 end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -907,7 +907,12 @@ class IngestJob
         }
       )
     when :ingest_anndata
-      # AnnData file analytics TODO
+      job_props.merge!(
+        {
+          referenceAnnDataFile: study_file.is_reference_anndata?,
+          extractedFileTypes: params_object.extract
+        }
+      )
     end
     job_props.with_indifferent_access
   end

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1050,6 +1050,11 @@ class StudyFile
     is_anndata? && ann_data_file_info&.reference_file
   end
 
+  # AnnData files that are used for visualization (e.g. extracted data)
+  def is_viz_anndata?
+    is_anndata? && !is_reference_anndata?
+  end
+
   # determine if a file is gzipped by reading the first two bytes and comparing to GZIP_MAGIC_NUMBER
   def gzipped?
     File.open(local_location.to_s).read(2) == GZIP_MAGIC_NUMBER # per IETF

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1055,6 +1055,21 @@ class StudyFile
     is_anndata? && !is_reference_anndata?
   end
 
+  # helper to reduce duplicates when reporting anndata ingest summaries to Mixpanel
+  def has_anndata_summary?
+    is_viz_anndata? && !!options[:anndata_summary]
+  end
+
+  def set_anndata_summary!
+    options.merge!(anndata_summary: true)
+    save
+  end
+
+  def unset_anndata_summary!
+    options.merge!(anndata_summary: false)
+    save
+  end
+
   # determine if a file is gzipped by reading the first two bytes and comparing to GZIP_MAGIC_NUMBER
   def gzipped?
     File.open(local_location.to_s).read(2) == GZIP_MAGIC_NUMBER # per IETF


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This adds additional information to Mixpanel events for AnnData extraction jobs reported from Rails.  Previously, we had no way of knowing if an AnnData ingest was a "reference" file or not (denoting that data was extracted from the archive when `false`).  Now, there are two additional parameters: `referenceAnnDataFile` and `extractedFileTypes`, which is an exact mirror of the `--extract` CLI parameter for ingest.

Example of new Mixpanel event attributes:
```
{
  "event"=>"ingest",
  "properties"=> {
    "perfTime"=>91743,
    "fileName"=>"compliant_pbmc3K.h5ad",
    "fileType"=>"AnnData",
    "fileSize"=>40178500,
    "action"=>"ingest_anndata",
    "studyAccession"=>"SCP135",
    "trigger"=>"bucket",
    "jobStatus"=>"success",
    "machineType"=>"n2d-highmem-4",
    "bootDiskSizeGb"=>300,
    "exitStatus"=>nil,
    "referenceAnnDataFile"=>false,
    "extractedFileTypes"=>["cluster", "metadata", "processed_expression"],
    "appId"=>"single-cell-portal",
    "env"=>"development",
    "logger"=>"app-backend",
    "authenticated"=>true,
    "registeredForTerra"=>true,
    "abTests"=>[]
  }
}
```

Additionally, a new Mixpanel event called `ingestSummary` has been added that will report after all downstream extraction parses have completed for a given AnnData file.  This new event will report overall `perfTime`, aggregrate `jobStatus` (`success` if everything parsed, or `failed` if any file failed to ingest), and `numFilesExtracted` to denote how many fragment files were processed.  This will only report once per user "action", e.g. the initial create, or if a user comes back and registers new clustering to extract.  Note: the `perfTime` in the latter case may include the latency between the first creation and the last parse, and as such will be artificially inflated.

Example Mixpanel event:

![ingestSummary](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/cc28a30c-707a-4489-9770-211538a11c2e)

**Important**: you will need to sign into the [development](https://bvdp-saturn-dev.appspot.com/#) version of Terra and register/accept the terms to allow your Mixpanel events to propagate to the Dev analytics site.

#### MANUAL TESTING
1. Boot all services and sign in
2. Create a new study and choose the `AnnData` UX
3. Upload any AnnData file, such as [this testing file](https://github.com/broadinstitute/scp-ingest-pipeline/raw/development/tests/data/anndata/trimmed_compliant_pbmc3K.h5ad) 
4. When the extraction phase completes, query theTerra Analytics Dev "[Events](https://mixpanel.com/project/2085496/view/19055/app/events#kZxxzdoh4JW8)" list using the following:
    * `Event Name: ingest`
    * `fileType: AnnData`
5. Confirm you see the new attributes as shown (note - it doesn't matter if the ingest succeeds or not, you should still see the event):
![Screenshot 2024-01-23 at 11 09 43 AM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/088cbb85-dcfe-40f3-a4cf-b4b945741f6d)
6. Once all downstream jobs have completed, confirm you see only one corresponding `ingestSummary` event for your file