### PR TITLE
File validation/update fixes for AnnData UX (SCP-5473)

### DIFF
--- a/app/javascript/components/upload/AnnDataFileForm.jsx
+++ b/app/javascript/components/upload/AnnDataFileForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import ExpandableFileForm from './ExpandableFileForm'
-import { FileTypeExtensions } from './upload-utils'
+import { FileTypeExtensions, validateFile } from './upload-utils'
 import { TextFormField } from './form-components'
 
 const allowedFileExts = FileTypeExtensions.annData
@@ -17,9 +17,14 @@ export default function AnnDataFileForm({
   isInitiallyExpanded,
   isAnnDataExperience
 }) {
+
+  const validationMessages = validateFile({
+    file, allFiles, allowedFileExts, requiredFields: []
+  })
+
   return <ExpandableFileForm {...{
     file, allFiles, updateFile, saveFile,
-    allowedFileExts, deleteFile, bucketName, isInitiallyExpanded, isAnnDataExperience
+    allowedFileExts, deleteFile, validationMessages, bucketName, isInitiallyExpanded, isAnnDataExperience
   }}>
     <TextFormField label="Description" fieldName="description" file={file} updateFile={updateFile}/>
   </ExpandableFileForm>

--- a/app/javascript/components/upload/ClusteringFileForm.jsx
+++ b/app/javascript/components/upload/ClusteringFileForm.jsx
@@ -74,7 +74,7 @@ export default function ClusteringFileForm({
         </div>
         <div className="col-md-6">
           <TextFormField label= {obsmKeyNameMessage()} fieldName="obsm_key_name" file={file}
-            updateFile={updateFile} placeholderText='For example, x_tsne' isDisabled={file.parse_status !== 'unparsed'} />
+            updateFile={updateFile} placeholderText='For example, X_tsne' isDisabled={file.parse_status !== 'unparsed'} />
         </div>
       </div>
     } else {

--- a/app/javascript/components/upload/ClusteringFileForm.jsx
+++ b/app/javascript/components/upload/ClusteringFileForm.jsx
@@ -11,7 +11,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 
 const allowedFileExts = FileTypeExtensions.plainText
-const requiredFields = [{ label: 'Name', propertyName: 'name' }]
+let requiredFields = [{ label: 'Name', propertyName: 'name' }]
 
 /** renders a form for editing/uploading a single cluster file */
 export default function ClusteringFileForm({
@@ -29,8 +29,11 @@ export default function ClusteringFileForm({
   const spatialClusterAssocs = file.spatial_cluster_associations
     .map(id => associatedClusterFileOptions.find(opt => opt.value === id))
 
+  if (isAnnDataExperience) {
+    requiredFields.push({ label: '.obsm key name', propertyName: 'obsm_key_name'})
+  }
   const validationMessages = validateFile({
-    file, allFiles, allowedFileExts, requiredFields
+    file, allFiles, allowedFileExts, requiredFields, isAnnDataExperience
   })
 
   const isLastClustering = (allFiles

--- a/app/javascript/components/upload/ExpandableFileForm.jsx
+++ b/app/javascript/components/upload/ExpandableFileForm.jsx
@@ -172,7 +172,22 @@ export function SaveDeleteButtons({
 
 /** renders a save button for a given file */
 function SaveButton({ file, saveFile, allFiles, validationMessages = {}, isAnnDataExperience }) {
-  const saveDisabled = isAnnDataExperience ? false : Object.keys(validationMessages).length > 0
+  let saveDisabled
+  const validationMessageKeys = Object.keys(validationMessages)
+  if (isAnnDataExperience) {
+    let annDataValidationMessageKeys
+    // ignore file selection error, unless this is the AnnData upload form
+    if (file.file_type === 'AnnData') {
+      annDataValidationMessageKeys = validationMessageKeys
+    } else {
+      annDataValidationMessageKeys = validationMessageKeys.filter(key => {
+        return key !== 'uploadSelection'
+      })
+    }
+    saveDisabled = annDataValidationMessageKeys.length > 0
+  } else {
+    saveDisabled = validationMessageKeys.length > 0
+  }
 
   // show parsing in the save button for cluster and expression fragments if AnnData file is parsing
   let showParsingForFragment = false

--- a/app/javascript/components/upload/FileUploadControl.jsx
+++ b/app/javascript/components/upload/FileUploadControl.jsx
@@ -102,7 +102,7 @@ export default function FileUploadControl({
 
       // Prevent saving via '', if validation errors were detected
       const remoteLocation = issues.errors.length === 0 ? trimmedPath : ''
-      updateFile(file._id, {remote_location: remoteLocation})
+      updateFile(file._id, {remote_location: remoteLocation, hasRemoteFile: true})
     } catch (error) {
       // Catch file access error and allow user to proceed - validation will be handled server-side or in ingest
       setFileValidation({ validating: false, issues: {}, fileName: trimmedPath })

--- a/app/javascript/components/upload/FileUploadControl.jsx
+++ b/app/javascript/components/upload/FileUploadControl.jsx
@@ -162,7 +162,7 @@ export default function FileUploadControl({
       file={file}
     />
     &nbsp;
-    {!isFileOnServer && showUploadButton &&
+    {!isFileOnServer && (showUploadButton && !file.hasRemoteFile) &&
       <button className={buttonClass} id={`fileButton-${file._id}`}
               data-testid="file-input-btn">
         {buttonText}
@@ -174,7 +174,7 @@ export default function FileUploadControl({
         />
       </button>
     }
-    {!isFileOnServer && showBucketPath &&
+    {!isFileOnServer && (showBucketPath || file.hasRemoteFile ) &&
       // we can't use TextFormField since we need a custom onBlur event
       // onBlur is the React equivalent of onfocusout, which will fire after the user is done updating the input
       <input className="form-control"
@@ -185,7 +185,7 @@ export default function FileUploadControl({
              onBlur={handleBucketLocationEntry}/>
     }
     &nbsp;&nbsp;
-    { !isFileOnServer && showBucketPath && googleBucketLink }
+    { !isFileOnServer && (showBucketPath || file.hasRemoteFile ) && googleBucketLink }
 
     &nbsp;&nbsp;
     { !isFileOnServer && uploadToggle }

--- a/app/javascript/components/upload/UploadWizard.jsx
+++ b/app/javascript/components/upload/UploadWizard.jsx
@@ -508,7 +508,12 @@ export function RawUploadWizard({ studyAccession, name }) {
   function deleteFileFromForm(fileId) {
     setFormState(prevFormState => {
       const newFormState = _cloneDeep(prevFormState)
-      newFormState.files = newFormState.files.filter(f => f._id != fileId)
+      if (isAnnDataExperience) {
+        // AnnData UX delete should empty all forms
+        newFormState.files = []
+      } else {
+        newFormState.files = newFormState.files.filter(f => f._id != fileId)
+      }
       return newFormState
     })
   }

--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -255,12 +255,8 @@ export function addObjectPropertyToForm(obj, propertyName, formData, nested) {
   }
 
   if (DEEPLY_NESTED_PROPS.includes(propertyName)) {
-    obj[propertyName].forEach(fragment => {
-      Object.keys(fragment).forEach(fragmentKey => {
-        const nestedPropString = `${propString}[][${fragmentKey}]`
-        appendFormData(formData, nestedPropString, fragment[fragmentKey])
-      })
-    })
+    // encode as JSON string and decode server-side to avoid losing associations of values when iterating
+    appendFormData(formData, propString, JSON.stringify(obj[propertyName]))
   } else if (obj[propertyName] && typeof obj[propertyName] === 'object' && !Array.isArray(obj[propertyName])) {
     // handle nesting for _attributes fields, except for nested id hashes on embedded documents
     Object.keys(obj[propertyName]).forEach(subKey => {

--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -128,7 +128,7 @@ export function formatFileForApi(file, chunkStart, chunkEnd) {
       data.append('study_file[upload]', file.uploadSelection)
     }
   }
-  if (file.uploadSelection || file.remote_location) {
+  if (file.uploadSelection || (file.remote_location && file.hasRemoteFile)) {
     data.append('study_file[parse_on_upload]', true)
   }
   // set name attribute if using remote_location

--- a/app/javascript/lib/validation/validate-file.js
+++ b/app/javascript/lib/validation/validate-file.js
@@ -150,7 +150,10 @@ async function validateRemoteFile(
   const startTime = performance.now()
 
   const requestStart = performance.now()
-  const response = await fetchBucketFile(bucketName, fileName, MAX_SYNC_CSFV_BYTES)
+  // special handling for AnnData to only read 100 bytes of file
+  // since we're not validating, we're just determining if the file exists
+  const maxBytes = fileType === 'AnnData' ? 100 : MAX_SYNC_CSFV_BYTES
+  const response = await fetchBucketFile(bucketName, fileName, maxBytes)
   let fileInfo, issues, perfTime, readRemoteTime
   if (response.ok) {
     const content = await response.text()

--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -100,8 +100,12 @@ class AnnDataFileInfo
       keys = %i[_id data_type]
       matcher = hash_from_keys(fragment, *keys)
       existing_frag = find_fragment(**matcher)
-      idx = existing_frag ? data_fragments.index(existing_frag) : data_fragments.size
-      form_data[:data_fragments].insert(idx, fragment)
+      if existing_frag
+        idx = data_fragments.index(existing_frag)
+        form_data[:data_fragments][idx] = fragment
+      else
+        form_data[:data_fragments] << fragment
+      end
     end
     form_data
   end

--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -10,14 +10,15 @@ class AnnDataFileInfo
     cluster: 'cluster_form_info_attributes'
   }.freeze
 
-  # permitted list of data_fragment strong parameters
+  # permitted list of data_fragment parameters for sanitizing/validation by data type
   # allows nesting of StudyFile-like objects inside data_fragments
-  DATA_FRAGMENT_PARAMS = [
-    :_id, :data_type, :name, :description, :obsm_key_name, :x_axis_label, :y_axis_label, :x_axis_min, :x_axis_max,
-    :y_axis_min, :y_axis_max, :z_axis_min, :z_axis_max, :taxon_id,
-    { spatial_cluster_associations: [] },
-    { expression_file_info: ExpressionFileInfo.attribute_names }
-  ].freeze
+  DATA_FRAGMENT_PARAMS = {
+    cluster: %i[
+      _id data_type name description obsm_key_name x_axis_label y_axis_label x_axis_min x_axis_max y_axis_min
+      y_axis_max z_axis_min z_axis_max taxon_id parse_status spatial_cluster_associations
+    ],
+    expression: %i[_id data_type taxon_id description expression_file_info]
+  }.freeze
 
   # required keys for data_fragments, by type
   REQUIRED_FRAGMENT_KEYS = {
@@ -38,11 +39,17 @@ class AnnDataFileInfo
   # }
   # { _id: '6033f531e241391884633748', data_type: :expression, description: 'log(TMP) expression' }
   field :data_fragments, type: Array, default: []
+  before_validation :sanitize_fragments!
   validate :validate_fragments
 
   # collect data frame key_names for clustering data inside AnnData flle
   def obsm_key_names
-    data_fragments.map { |f| f[:obsm_key_name] }.compact
+    data_fragments.map { |f| f.with_indifferent_access[:obsm_key_name] }.compact
+  end
+
+  # helper to automatically call :with_indifferent_access on all data_fragments
+  def safe_data_fragments
+    data_fragments.map(&:with_indifferent_access)
   end
 
   # handle AnnData upload form data and merge into appropriate fields so that we can make a single update! call
@@ -50,7 +57,10 @@ class AnnDataFileInfo
     merged_data = form_data.with_indifferent_access
     # merge in existing information about AnnData file, using form data first if present
     anndata_info_attributes = form_data[:ann_data_file_info_attributes] || attributes.with_indifferent_access
-
+    # gotcha to reparse data_fragments from string-encoded JSON form data
+    if anndata_info_attributes[:data_fragments].is_a?(String)
+      anndata_info_attributes[:data_fragments] = JSON.parse(anndata_info_attributes[:data_fragments]).map(&:with_indifferent_access)
+    end
     # merge :reference_anndata_file parameter, if present
     if merged_data[:reference_anndata_file].present? || new_record?
       reference_file = merged_data[:reference_anndata_file].nil? ? true : merged_data[:reference_anndata_file] == 'true'
@@ -121,7 +131,7 @@ class AnnDataFileInfo
 
   # get all fragments of a specific data type
   def fragments_by_type(data_type)
-    data_fragments.select { |fragment| fragment[:data_type].to_s == data_type.to_s }
+    safe_data_fragments.select { |fragment| fragment[:data_type].to_s == data_type.to_s }
   end
 
   # mirror of study_file.get_cluster_domain_ranges for data_fragment
@@ -152,6 +162,20 @@ class AnnDataFileInfo
     else
       :presence
     end
+  end
+
+  # reject any extraneous values added from React forms
+  def sanitize_fragments!
+    sanitized_fragments = []
+    safe_data_fragments.each do |fragment|
+      sanitized_fragment = {}
+      data_type = fragment[:data_type].to_sym
+      fragment.each_pair do |key, value|
+        sanitized_fragment[key] = value if DATA_FRAGMENT_PARAMS[data_type].include?(key.to_sym)
+      end
+      sanitized_fragments << sanitized_fragment
+    end
+    self.data_fragments = sanitized_fragments
   end
 
   # ensure all fragments have required keys and are unique

--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -164,8 +164,10 @@ class AnnDataFileInfo
         next if missing_keys.empty? && missing_values.empty?
 
         all_missing = (missing_keys + missing_values.map(&:to_s)).uniq
+        obsm_key = fragment[:obsm_key_name]
         errors.add(:base,
-                   "#{data_type} form missing one or more required entries: #{all_missing.join(',')}")
+                   "#{data_type} form #{obsm_key.present? ? "(#{obsm_key}) " : nil}" \
+                        "missing one or more required entries: #{all_missing.join(', ')}")
       end
       # check for uniqueness
       keys.each do |key|

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -122,7 +122,11 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
       # this must be done with a fresh StudyFile reference, otherwise upload_file_name may not overwrite
       new_name = "DELETE-#{SecureRandom.uuid}"
       file_reference = StudyFile.find(object.id)
-      file_reference.update!(queued_for_deletion: true, upload_file_name: new_name, name: new_name, file_type: 'DELETE')
+      file_reference.update!(queued_for_deletion: true,
+                             upload_file_name: new_name,
+                             remote_location: new_name,
+                             name: new_name,
+                             file_type: 'DELETE')
 
       # reset initialized if needed
       if study.cluster_groups.empty? || study.genes.empty? || study.cell_metadata.empty?

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -290,12 +290,11 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
     case fragment_type
     when "cluster"
       cluster_group = ClusterGroup.find_by(study_file_id:, study_id:, name: fragment[:name])
-
       data_arrays = DataArray.where(
         linear_data_type: 'ClusterGroup', linear_data_id: cluster_group.id, study_id:, study_file_id:
       )
       cluster_group.delete
-      data_arrays.delete
+      data_arrays.delete_all
     end
   end
 end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -721,7 +721,7 @@ class IngestJob
             ingest_cluster: true, name:, cluster_file: cluster_gs_url, domain_ranges:, ingest_anndata: false,
             extract: nil, obsm_keys: nil
           )
-          job = IngestJob.new(study:, study_file:, user:, action:, params_object: cluster_params)
+          job = IngestJob.new(study:, study_file:, user:, action:, persist_on_fail:, params_object: cluster_params)
           job.delay.push_remote_and_launch_ingest
         end
       when 'metadata'
@@ -732,7 +732,7 @@ class IngestJob
           ingest_cell_metadata: true, cell_metadata_file: metadata_gs_url,
           ingest_anndata: false, extract: nil, obsm_keys: nil, study_accession: study.accession
         )
-        job = IngestJob.new(study:, study_file:, user:, action:, params_object: metadata_params)
+        job = IngestJob.new(study:, study_file:, user:, action:, persist_on_fail:, params_object: metadata_params)
         job.delay.push_remote_and_launch_ingest
       when 'processed_expression'
         Rails.logger.info "Launching AnnData processed expression ingest for #{study_file.upload_file_name}"
@@ -745,7 +745,7 @@ class IngestJob
           matrix_file: matrix_gs_url, matrix_file_type: 'mtx', gene_file: features_gs_url, barcode_file: barcodes_gs_url,
           ingest_anndata: false, extract: nil, obsm_keys: nil
         )
-        job = IngestJob.new(study:, study_file:, user:, action:, params_object: exp_params)
+        job = IngestJob.new(study:, study_file:, user:, action:, persist_on_fail:, params_object: exp_params)
         job.delay.push_remote_and_launch_ingest
       end
     end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -337,7 +337,7 @@ class IngestJob
     if done? && !failed?
       Rails.logger.info "IngestJob poller: #{pipeline_name} is done!"
       Rails.logger.info "IngestJob poller: #{pipeline_name} status: #{current_status}"
-      unless special_action?
+      unless special_action? || action == :ingest_anndata
         study_file.update(parse_status: 'parsed')
         study_file.bundled_files.each { |sf| sf.update(parse_status: 'parsed') }
       end

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1388,7 +1388,8 @@ class StudyFile
               @cluster.update(name:)
             end
           else
-            FileParseService.run_parse_job(self, study, study.user, obsm_key: fragment)
+            persist_on_fail = remote_location.present?
+            FileParseService.run_parse_job(self, study, study.user, persist_on_fail:, obsm_key: fragment)
           end
         end
       end

--- a/test/api/study_files_controller_test.rb
+++ b/test/api/study_files_controller_test.rb
@@ -212,6 +212,7 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
         },
         extra_expression_form_info_attributes: {
           _id: exp_frag_id,
+          taxon_id: BSON::ObjectId.new.to_s,
           description: 'expression description',
           y_axis_title: 'log(TPM) expression'
         },

--- a/test/api/study_files_controller_test.rb
+++ b/test/api/study_files_controller_test.rb
@@ -196,6 +196,7 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
   test 'should create and update AnnData file' do
     cluster_frag_id = BSON::ObjectId.new.to_s
     exp_frag_id = BSON::ObjectId.new.to_s
+    taxon_id = BSON::ObjectId.new.to_s
     ann_data_params = {
       study_file: {
         upload_file_name: 'data.h5ad',
@@ -212,7 +213,7 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
         },
         extra_expression_form_info_attributes: {
           _id: exp_frag_id,
-          taxon_id: BSON::ObjectId.new.to_s,
+          taxon_id: taxon_id,
           description: 'expression description',
           y_axis_title: 'log(TPM) expression'
         },
@@ -243,12 +244,19 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
     update_attributes = {
       study_file: {
         description: 'updated',
+        file_type: 'AnnData',
         ann_data_file_info_attributes: {
           data_fragments:
             [
-              { _id: cluster_frag_id, name: 'UMAP', obsm_key_name: 'X_umap', description: 'updated' },
-              { _id: exp_frag_id, y_axis_title: 'log(TPM) expression', description: 'updated' }
-            ]
+              {
+                _id: cluster_frag_id, data_type: 'cluster', name: 'UMAP', obsm_key_name: 'X_umap',
+                description: 'updated'
+              },
+              {
+                _id: exp_frag_id, data_type: 'expression', taxon_id: taxon_id, y_axis_title: 'log(TPM) expression',
+                description: 'updated'
+              }
+            ].to_json
         }
       }
     }

--- a/test/integration/external/import_service_config/hca_test.rb
+++ b/test/integration/external/import_service_config/hca_test.rb
@@ -162,17 +162,19 @@ module ImportServiceConfig
       AdminConfiguration.stub :find_or_create_ws_user_group!, owner_group do
         ImportService.stub :copy_file_to_bucket, file_mock do
           ApplicationController.stub :firecloud_client, fc_client_mock do
-            study, study_file = @configuration.import_from_service
-            file_mock.verify
-            fc_client_mock.verify
-            assert study.persisted?
-            assert study_file.persisted?
-            assert_equal study.external_identifier, @attributes[:study_id]
-            assert_equal study_file.external_identifier, @attributes[:file_id]
-            # trim off query params to prevent test failures when catalog/version updates
-            trimmed_access_url = access_url.split('?').first
-            trimmed_external_url = study_file.external_link_url.split('?').first
-            assert_equal trimmed_external_url, trimmed_access_url
+            @configuration.stub :taxon_from, Taxon.new(common_name: 'human') do
+              study, study_file = @configuration.import_from_service
+              file_mock.verify
+              fc_client_mock.verify
+              assert study.persisted?
+              assert study_file.persisted?
+              assert_equal study.external_identifier, @attributes[:study_id]
+              assert_equal study_file.external_identifier, @attributes[:file_id]
+              # trim off query params to prevent test failures when catalog/version updates
+              trimmed_access_url = access_url.split('?').first
+              trimmed_external_url = study_file.external_link_url.split('?').first
+              assert_equal trimmed_external_url, trimmed_access_url
+            end
           end
         end
       end

--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -160,14 +160,16 @@ module ImportServiceConfig
       AdminConfiguration.stub :find_or_create_ws_user_group!, owner_group do
         ImportService.stub :copy_file_to_bucket, file_mock do
           ApplicationController.stub :firecloud_client, fc_client_mock do
-            study, study_file = @configuration.import_from_service
-            file_mock.verify
-            fc_client_mock.verify
-            assert study.persisted?
-            assert study_file.persisted?
-            assert_equal study.external_identifier, @attributes[:study_id]
-            assert_equal study_file.external_identifier, @attributes[:file_id]
-            assert_equal study_file.external_link_url, access_url
+            @configuration.stub :taxon_from, Taxon.new(common_name: 'human') do
+              study, study_file = @configuration.import_from_service
+              file_mock.verify
+              fc_client_mock.verify
+              assert study.persisted?
+              assert study_file.persisted?
+              assert_equal study.external_identifier, @attributes[:study_id]
+              assert_equal study_file.external_identifier, @attributes[:file_id]
+              assert_equal study_file.external_link_url, access_url
+            end
           end
         end
       end

--- a/test/models/ann_data_file_info_test.rb
+++ b/test/models/ann_data_file_info_test.rb
@@ -76,6 +76,27 @@ class AnnDataFileInfoTest < ActiveSupport::TestCase
     assert_equal 'log(TPM) expression', expr_fragment[:y_axis_label]
   end
 
+  test 'should decode serialized JSON form data' do
+    data_fragments = [
+      {
+        _id: generate_id, data_type: 'expression', taxon_id: generate_id
+      }.with_indifferent_access,
+      {
+        _id: generate_id, data_type: 'cluster', name: 'UMAP', description: 'UMAP description', obsm_key_name: 'X_umap'
+      }.with_indifferent_access
+    ]
+    form_params = {
+      ann_data_file_info_attributes: {
+        _id: generate_id,
+        reference_file: false,
+        data_fragments: data_fragments.to_json
+      }
+    }
+    merged_data = AnnDataFileInfo.new.merge_form_data(form_params)
+    safe_fragments = merged_data.dig(:ann_data_file_info_attributes, :data_fragments).map(&:with_indifferent_access)
+    assert_equal data_fragments, safe_fragments
+  end
+
   test 'should extract specified data fragment from form data' do
     taxon_id = BSON::ObjectId.new.to_s
     description = 'this is the description'

--- a/test/models/ann_data_file_info_test.rb
+++ b/test/models/ann_data_file_info_test.rb
@@ -119,6 +119,16 @@ class AnnDataFileInfoTest < ActiveSupport::TestCase
       assert message.include?('are not unique')
     end
     ann_data_info.data_fragments = [
+      { _id: generate_id, data_type: :cluster, name: '', obsm_key_name: 'X_umap' },
+      { _id: generate_id, data_type: :cluster, name: nil, obsm_key_name: 'X_tsne' }
+    ]
+    assert_not ann_data_info.valid?
+    error_messages = ann_data_info.errors.messages_for(:data_fragments)
+    assert_equal 2, error_messages.count
+    error_messages.each do |message|
+      assert message.match(/cluster fragment missing name in form for (X_umap|X_tsne)/)
+    end
+    ann_data_info.data_fragments = [
       { _id: generate_id, data_type: :cluster, name: 'UMAP', obsm_key_name: 'X_umap' },
       { _id: generate_id, data_type: :cluster, name: 'tSNE', obsm_key_name: 'X_tsne' },
       { _id: generate_id, data_type: :expression, y_axis_title: 'log(TPM) expression' }


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update addresses several form validation/state issues with the AnnData UX.  These issues include:

* Not being able to update the form after initially saving (unless the page is reloaded), due to a [file validation error](https://broad-institute.sentry.io/issues/4681656120/)
* Form components for "data fragments" (like clustering, expression) not enforcing required fields, leading to ingest errors like `ingest_pipeline.py ingest_cluster: error: the following arguments are required: --name`
* Server-side validation of AnnData form data fragments not enforcing presence of required values
* Accidental re-parsing of AnnData files using the `remote_location` feature when updating forms, leading to parse failures and deletion of data
* Accidental removal of AnnData files on parse failure when using `remote_location` feature (should persist in bucket)
* Updates after the initial save not persisting correctly, or being applied to the wrong elements

Now, the required fields are enforced both client- and server-side.  This will prevent the above ingest error from occurring as the file cannot be saved in an invalid state.  Secondly, form data is correctly merged after the initial save to account for the `reference_anndata_file` value still being present in the form.  This allows updates to the form after the initial save, and no longer requires a page refresh to correctly set the state.  Additionally, updates to the forms that do not specify new data (like adding clustering entries) will not re-launch parse jobs if the AnnData file was specified with the `remote_location` feature.  `AnnData` files specified with the `remote_location` will also no longer be removed on parse failure.  Lastly, instead of using the Rails-specific nested form structure for `data_fragments`, the UI will now serialize the data into JSON-encoded strings that are then deserialized back into the native structures server-side.  This preserves their structure as encoded in the forms, and prevents any updates from being lost or misattributed.

Demo of form bug fixes:

https://github.com/broadinstitute/single_cell_portal_core/assets/729968/a8b6af39-eb62-40b8-8167-57d64c289e7d

Note: there is a corner case where adding additional clustering via the UI while the AnnData file is still parsing will not launch new jobs.  I was not able to fix that problem, and given the potential rareness of this issue, I decided to not let it block this PR.  This issue is tracked in SCP-5499.

#### MANUAL TESTING
1. Boot all services and sign in
2. Create a new study, and select the AnnData UX
3. Note the Save buttons being disabled with the proper error messages in the Expression & Clustering forms
4. Download a copy of `compliant_pbmc3K.h5ad` from [here](https://console.cloud.google.com/storage/browser/_details/broad-singlecellportal-staging-testing-data/anndata/compliant_pbmc3K.h5ad;tab=live_object?project=broad-singlecellportal-staging) if you don't have a valid AnnData file locally
5. Select a species in the Expression form, and specify `X_umap` for the `obsm_key_name` in the clustering form, but do not set any other values
6. Note the form validation still states that `library_preparation_protocol` is still required in the Expression form, and `name` is still required in the Cluster form
7. Upload the AnnData file (or place in bucket and use GS URL feature) and click save
8. Note the save fails with the correct error messages
9. Provide the missing data and retry the upload/save, noting that it succeeds