### PR TITLE
Updating to rails-baseimage:2.2.2 (SCP-5498)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use SCP base Rails image, configure only project-specific items here
-FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:2.2.1
+FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:2.2.2
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-3.1.3'


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates to `rails-baseimage:2.2.2`, which applies normal security patches to the underlying ubuntu 20.04 Docker image.  Also, this image was built using the new Github Actions automation in [broadinstitute/scp-rails-baseimage](https://github.com/broadinstitute/scp-rails-baseimage/actions/runs/7713490532/job/21023499101).