### PR TITLE
Fix occasional Explore UI break due to cell filtering (SCP-5508)

### DIFF
--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -595,7 +595,7 @@ export function CellFilteringPanel({
   // Needed to propagate facets from URL to initial checkbox states
   useEffect(() => {
     setCheckedMap(defaultCheckedMap)
-  }, Object.values(defaultCheckedMap).join(','))
+  }, [Object.values(defaultCheckedMap).join(',')])
 
   /** Top header for the "Filter" section, including all-facet controls */
   function FilterSectionHeader({ hasNondefaultSelection, handleResetFilters, isAllListsCollapsed, setIsAllListsCollapsed }) {

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -589,7 +589,7 @@ export function CellFilteringPanel({
 
   const [checkedMap, setCheckedMap] = useState(defaultCheckedMap)
   const [colorByFacet, setColorByFacet] = useState(shownAnnotation)
-  const shownFacets = facets.filter(facet => facet.groups.length > 1)
+  const shownFacets = facets.filter(facet => facet.groups?.length > 1)
   const [isAllListsCollapsed, setIsAllListsCollapsed] = useState(false)
 
   // Needed to propagate facets from URL to initial checkbox states

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -145,10 +145,10 @@ function FacetTools({
 /** Determine if user has deselected any filters */
 function getHasNondefaultSelection(checkedMap, facets) {
   let numTotalFilters = 0
-  facets.forEach(facet => numTotalFilters += facet.groups.length)
+  facets.forEach(facet => numTotalFilters += facet.groups?.length)
   let numCheckedFilters = 0
   Object.entries(checkedMap).forEach(([_, filters]) => {
-    numCheckedFilters += filters.length
+    numCheckedFilters += filters?.length
   })
 
   const hasNondefaultSelection = numTotalFilters !== numCheckedFilters

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -70,7 +70,7 @@ export function handleClusterSwitchForFiltering(cellFilteringSelection, newCellF
     const existingSelectionFacets = Object.keys(cellFilteringSelection)
     const updatedSelectionFacets =
       newCellFaceting.facets.filter(
-        nf => !nf.isSelectedAnnotation && !existingSelectionFacets.includes(nf.annotation)
+        nf => !nf.isSelectedAnnotation && !existingSelectionFacets.includes(nf.annotation) && 'groups' in nf
       )
     if (updatedSelectionFacets.length > 0) {
       updatedSelectionFacets.forEach(uf => cellFilteringSelection[uf.annotation] = uf.groups)

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -557,7 +557,7 @@ export async function initCellFaceting(
   cellFaceting.perfTimes = perfTimes
 
   // Below line is worth keeping, but only uncomment to debug in development
-  window.SCP.cellFaceting = cellFaceting
+  // window.SCP.cellFaceting = cellFaceting
   return cellFaceting
 }
 

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -557,7 +557,7 @@ export async function initCellFaceting(
   cellFaceting.perfTimes = perfTimes
 
   // Below line is worth keeping, but only uncomment to debug in development
-  // window.SCP.cellFaceting = cellFaceting
+  window.SCP.cellFaceting = cellFaceting
   return cellFaceting
 }
 


### PR DESCRIPTION
This fixes a bug where clicking "Filter plotted cells" sometimes breaks the Explore UI.

On Friday morning, I noticed a distinct increase in "Cannot read properties of undefined (reading 'length') in t" [errors in Mixpanel](https://mixpanel.com/s/4pgbDa).  The increase coincided with the [deployment of SCP 1.65.0](https://github.com/broadinstitute/single_cell_portal_core/releases/tag/1.65.0) around 1:00 PM last Wednesday.  So the bug is likely caused by a change to cell filtering code in 1.65.0, i.e. either #1965 or #1972.  I suspect the latter.

### Test
1.  Go to "Cellular and transcriptional diversity over the course of human lactation"
2. In "Clustering", select "Epithelial Cell UMAP"
3. Click "Filter plotted cells"
4. Confirm Explore UI does not replace scatter plots with red error message

I plan to write a regression test in this PR or the next, but given the impact of this bug I think it'd be worth reviewing and deploying today.

While manually testing this I encountered a few odd UI quirks due to overzealous updates related to `useEffect` or standard component state propagation.  I suspect that exists on production and will be fixed by SCP-5490.

This satisfies SCP-5508.