### PR TITLE
Fix global search UI bugs in filter clear button, pagination controls (SCP-5504)

### DIFF
--- a/app/javascript/styles/_resultsPanel.scss
+++ b/app/javascript/styles/_resultsPanel.scss
@@ -110,22 +110,24 @@
     color: #6C6B6B;
   }
 }
-.pagination {
-  text-align: center;
-  display: block;
-  margin: 10px;
-  button {
-    border: none;
-    color: $action-color;
-    background-color: #fff;
-    border-radius: 3px;
-    cursor: pointer;
-    margin: 0 0.2em;
-    padding-top: 3px;
-    min-width: 30px;
-  }
-  .currentPage {
-    margin: 0 0.2em 0 0.2em;
+.results-panel {
+  .pagination {
+    text-align: center;
+    display: block;
+    margin: 10px;
+    button {
+      border: none;
+      color: $action-color;
+      background-color: #fff;
+      border-radius: 3px;
+      cursor: pointer;
+      margin: 0 0.2em;
+      padding-top: 3px;
+      min-width: 30px;
+    }
+    .currentPage {
+      margin: 0 0.2em 0 0.2em;
+    }
   }
 }
 

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -74,7 +74,7 @@ nav.search-links, #search-panel {
       color: #fff;
     }
 
-    .facet-clear {
+    .facet-clear, .cell-filter-clear {
       float: right;
       padding: 0px;
       background-color: $action-color;


### PR DESCRIPTION
This fixes a distracting visual bug in global faceted search, and a subtle bug in the default home page view.

Previously, most "x" icons to clear filters in global faceted search had an unsightly background color.  This became apparent after the user had applied a filter in global search.  Separately, in the results panel, the pagination controls were shifted too high.  This was a subtler effect, but the fix is noticeable.  These regressions were likely caused by styling changes for the DE table and cell filtering in the Explore UI.

### Before
Clear button with bad background:
<img width="870" alt="Bad_clear_top__SCP_2024-02-13" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/e6d6c478-e5c7-4a8e-bf6c-c5cee3d8162a">

Pagination controls too high at top:
<img width="877" alt="Bad_pagination_top__SCP_2024-02-13" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/faaf6a86-4351-4dd2-bcb7-661af01fc518">

Pagination controls too high at bottom:
<img width="879" alt="Bad_pagination_bottom__SCP_2024-02-13" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/e85522e5-65aa-46da-b111-e3db37b8c28b">

### After
Clear button with good background:
<img width="862" alt="Good_clear_top__SCP_2024-02-13" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/c4cb9413-07c8-41e3-bb4f-38bd53048a2b">

Pagination controls placed well at top:
<img width="890" alt="Good_pagination_top__SCP_2024-02-13" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/d878a142-720e-4b98-8217-d58e1a0ac742">

Pagination controls placed well at bottom:
<img width="876" alt="Good_pagination_bottom__SCP_2024-02-13" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/67522799-2540-4ca5-8172-ca07050c7fb8">

### Test
1.  Go to home page
2. Click "organ" facet
3. Select first filter, click "Apply"
4. Confirm "x" clear icon has dark blue background
5. Confirm pagination controls appear as shown in "After" screenshots above

This relates to Developer's Choice Days work, SCP-5504.