### PR TITLE
Fix error content not showing for bookmarks, Mixpanel logging (SCP-5431)

### DIFF
--- a/app/javascript/components/bookmarks/BookmarkManager.jsx
+++ b/app/javascript/components/bookmarks/BookmarkManager.jsx
@@ -8,6 +8,7 @@ import { useLocation } from '@reach/router'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faLink, faUndo } from '@fortawesome/free-solid-svg-icons'
 import useErrorMessage from '~/lib/error-message'
+import { log } from '~/lib/metrics-api'
 
 /**
  * Component to bookmark views in Explore tab, as well as existing link/reset buttons
@@ -138,6 +139,7 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
     enableSaveButton(false)
     const saveProps = [currentBookmark]
     const saveFunc = bookmarkSaved ? updateBookmark : createBookmark
+    const logEvent = bookmarkSaved ? 'update-bookmark' : 'create-bookmark'
     if (bookmarkSaved) {
       saveProps.unshift(currentBookmark._id)
     }
@@ -147,6 +149,7 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
       setShowError(false)
       resetForm()
       updateBookmarkList(bookmark)
+      log(logEvent)
     } catch (error) {
       enableSaveButton(true)
       handleErrorContent(error)
@@ -167,6 +170,7 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
         setDeleteDisabled(false)
         setShowError(false)
         removeBookmarkFromList(toDelete)
+        log('delete-bookmark')
       } catch (error) {
         setDeleteDisabled(false)
         handleErrorContent(error)

--- a/app/javascript/components/bookmarks/BookmarkManager.jsx
+++ b/app/javascript/components/bookmarks/BookmarkManager.jsx
@@ -125,7 +125,7 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
   function formatErrorMessages(error) {
     if (error.errors) {
       return Object.keys(error.errors).map(key => {
-        return `${key} ${errors[key][0]}`
+        return `${key} ${error.errors[key][0]}`
       }).join(', ')
     } else {
       return error.message


### PR DESCRIPTION
This fixes a bug where error messages do not show render into the form when returned from the server.  This also adds basic Mixpanel logging for creating/updating/deleting bookmarks, which was missing from the original PR.

Note: this does not address known paper cuts, which are tracked in SCP-5516.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Go to any study with visualizations
3. Bookmark a view (providing a name), then select a different annotation and reuse the name
4. Confirm you see an error message in the form like below:
![bookmark-error](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/e8897a71-263a-4960-b8de-aaa7048ae5f5)
5. Correct the error and save, update, and then delete the bookmark, confirming you see corresponding `event` requests in the network tab of Chrome DevTools for `create-bookmark`, `update-bookmark`, and `delete-bookmark`.