### PR TITLE
Fix pagination control UI in DE table (SCP-5504)

### DIFF
--- a/app/javascript/styles/_differentialExpression.scss
+++ b/app/javascript/styles/_differentialExpression.scss
@@ -32,8 +32,25 @@
   margin-right: -8px;
 }
 
-.pagination {
-  margin: -10px 0 12px 0;
+.right-panel {
+  .pagination {
+    text-align: center;
+    display: block;
+    margin: -10px 0 12px 0;
+    button {
+      border: none;
+      color: $action-color;
+      background-color: #fff;
+      border-radius: 3px;
+      cursor: pointer;
+      margin: 0 0.2em;
+      padding-top: 3px;
+      min-width: 30px;
+    }
+    .currentPage {
+      margin: 0 0.2em 0 0.2em;
+    }
+  }
 }
 
 .de-download-button {


### PR DESCRIPTION
This fixes a UI bug in #1981, in which pagination UI at the bottom of the DE table lost styling.

Compare the bottom of the two screenshots below for the bug and its fix.

### Before
<img width="383" alt="Screenshot 2024-02-14 at 12 42 00 PM" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/981bc416-1a2d-4156-96a2-effa0ce02568">

### After
<img width="383" alt="Screenshot 2024-02-14 at 12 41 48 PM" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/7c213e82-9b55-4a86-b570-e5e26f5c09f3">

### Test
1.  Go to home page.
2. Confirm pagination controls are placed well.
3. Go to a study with DE results, e.g. SCP303 if testing on staging.
4. Click "Differential expression".
5. Confirm pagination controls at bottom are styled well.

This relates to SCP-5504.