### PR TITLE
Bookmarks followup work (SCP-5516)

### DIFF
--- a/app/javascript/components/bookmarks/BookmarkManager.jsx
+++ b/app/javascript/components/bookmarks/BookmarkManager.jsx
@@ -8,6 +8,7 @@ import { useLocation } from '@reach/router'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faLink, faUndo } from '@fortawesome/free-solid-svg-icons'
 import useErrorMessage from '~/lib/error-message'
+import useResizeEffect from '~/hooks/useResizeEffect'
 import { log } from '~/lib/metrics-api'
 
 /**
@@ -141,6 +142,10 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
       closeBookmarkForm()
     }
   },[hash])
+
+  useResizeEffect(() => {
+    reopenBookmarkForm()
+  }, 50)
 
   /** convenience handler for performing formState updates */
   function handleFormUpdate(event) {

--- a/app/javascript/components/bookmarks/BookmarkManager.jsx
+++ b/app/javascript/components/bookmarks/BookmarkManager.jsx
@@ -31,6 +31,8 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
     path: getBookmarkPath()
   }
 
+  const formRef = useRef('bookmarkForm')
+
   /** copies the url to the clipboard */
   function copyLink() {
     navigator.clipboard.writeText(location.href)
@@ -86,9 +88,16 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
     setCurrentBookmark(findExistingBookmark())
   }
 
+  /** close open form if changing tabs */
+  function closeBookmarkForm() {
+    if (isUserLoggedIn() && formRef.current?.state?.show) {
+      formRef.current.handleHide()
+    }
+  }
+
   /** wrapper to close both bookmark form & modal */
   function closeAllComponents() {
-    formRef.current.handleHide()
+    closeBookmarkForm()
     setShowBookmarksModal(false)
   }
 
@@ -129,7 +138,7 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
   /** close form if use changes to different top-level tab */
   useEffect(() => {
     if (hash !== '#study-visualize') {
-      formRef.current.handleHide()
+      closeBookmarkForm()
     }
   },[hash])
 
@@ -249,9 +258,8 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
   const loginNotice = <a href='/single_cell/users/auth/google_oauth2' data-method='post'
                          className={`fa-lg action far fa-star`} data-analytics-name='bookmark-login-notice'
                          id='bookmark-login-notice' data-toggle='tooltip' data-placement='left'
-                         data-original-title='Click to sign in, then bookmark this view' />
+                         data-original-title='Click to sign in, then bookmark this view'/>
 
-  const formRef = useRef('bookmarkForm')
   const bookmarkForm = <Popover data-analytics-name='bookmark-form-popover' id='bookmark-form-popover'>
     <form id='bookmark-form' onSubmit={handleSaveBookmark}>
       { ErrorComponent }

--- a/app/javascript/components/bookmarks/BookmarkManager.jsx
+++ b/app/javascript/components/bookmarks/BookmarkManager.jsx
@@ -63,7 +63,6 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
       setAllBookmarks(prevBookmarks => [...prevBookmarks, bookmark])
     }
     setServerBookmarksLoaded(false)
-    setCurrentBookmark(bookmark)
   }
 
   /** remove a deleted bookmark from the list */
@@ -93,20 +92,9 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
     }
   }
 
-  function formIsUpdating() {
-    return saveDisabled || (bookmarkSaved && deleteDisabled)
-  }
-
   /** whenever the user changes a cluster/annotation, reset the bookmark form with the current URL params */
   useEffect(() => {
-    if (formIsUpdating()) {
-      //
-      handleLoadBookmarks().then(() => {
-        resetForm()
-      })
-    } else {
-      resetForm()
-    }
+    resetForm()
     document.addEventListener("keydown", closeOnEscape, false)
     // remove listener on unmount
     return () => {
@@ -209,24 +197,19 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
     setShowBookmarksModal(!showBookmarksModal)
   }
 
-  /** handler to call API to set bookmarks */
-  async function handleLoadBookmarks() {
-    try {
-      const serverUserBookmarks = await fetchBookmarks()
-      setServerBookmarks(serverUserBookmarks)
-      setServerBookmarksLoaded(true)
-    } catch (error) {
-      setShowBookmarksModal(false)
-      setServerBookmarks([])
-      setServerBookmarksLoaded(false)
-    }
-  }
-
   /** load all user bookmarks from server and open/close modal */
   async function loadServerBookmarks() {
     toggleBookmarkModal()
     if (!serverBookmarksLoaded) {
-      await handleLoadBookmarks()
+      try {
+        const serverUserBookmarks = await fetchBookmarks()
+        setServerBookmarks(serverUserBookmarks)
+        setServerBookmarksLoaded(true)
+      } catch (error) {
+        setShowBookmarksModal(false)
+        setServerBookmarks([])
+        setServerBookmarksLoaded(false)
+      }
     }
   }
 

--- a/app/javascript/components/bookmarks/BookmarksList.jsx
+++ b/app/javascript/components/bookmarks/BookmarksList.jsx
@@ -4,11 +4,12 @@ import LoadingSpinner from '~/lib/LoadingSpinner'
 import { navigate } from '@reach/router'
 import { log } from '~/lib/metrics-api'
 
-export default function BookmarksList({serverBookmarks, serverBookmarksLoaded, studyAccession, showModal, toggleModal}) {
+export default function BookmarksList({serverBookmarks,serverBookmarksLoaded, studyAccession, showModal,
+  toggleModal, closeAllComponents}) {
 
   /** determine whether to reload study or not when selecting bookmark */
   function loadBookmark(bookmark) {
-    toggleModal()
+    closeAllComponents()
     if (bookmark.study_accession === studyAccession) {
       navigate(bookmark.path)
     } else {
@@ -16,7 +17,8 @@ export default function BookmarksList({serverBookmarks, serverBookmarksLoaded, s
     }
     log('load-bookmark')
   }
-  return <Modal id='bookmarks-list-modal' data-testid='bookmarks-list-modal' className='modal fade' show={showModal}>
+
+  return <Modal id='bookmarks-list-modal' data-testid='bookmarks-list-modal' className='modal' show={showModal}>
     <Modal.Header><h4>My Bookmarks</h4></Modal.Header>
     <Modal.Body>
       <div id='bookmarks-list-wrapper'>

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -11,7 +11,7 @@ class Bookmark
   field :study_accession, type: String
   field :description, type: String
 
-  validates :name, :path, presence: true, uniqueness: { scope: :user_id }
+  validates :name, :path, presence: true, uniqueness: { scope: %i[user_id study_accession] }
   validates :study_accession, presence: true
   before_validation :sanitize_path, :set_name
 

--- a/test/js/explore/bookmarks.test.js
+++ b/test/js/explore/bookmarks.test.js
@@ -65,7 +65,7 @@ describe('Bookmarks manager', () => {
     )
     const bookmarkManager = container.querySelector('#bookmark-manager')
     fireEvent.click(bookmarkManager)
-    const allBookarks = await screen.getByText('See bookmarks')
+    const allBookarks = await screen.getByText('All bookmarks')
     fireEvent.click(allBookarks)
     const modal = await screen.getByTestId('bookmarks-list-modal')
     expect(modal).toBeVisible()

--- a/test/models/bookmark_test.rb
+++ b/test/models/bookmark_test.rb
@@ -25,18 +25,19 @@ class BookmarkTest < ActiveSupport::TestCase
     assert bookmark.valid?
     invalid_view = Bookmark.new(
       name: 'My Favorite Study',
+      study_accession: @study.accession,
       path: "/single_cell/study/#{@study.accession}",
       user: @user
     )
     assert_not invalid_view.valid?
     errors = invalid_view.errors.full_messages
-    assert_equal 3, errors.count
-    not_unique = errors.select { |e| e.match(/(Name|Path) is already taken/) }
-    blank = errors.select { |e| e == "Study accession can't be blank" }
-    assert_equal 2, not_unique.count
-    assert_equal 1, blank.count
+    assert_equal 2, errors.count
+    errors.each do |error|
+      assert error.match(/(Name|Path) is already taken/)
+    end
     invalid_view.name = nil
     invalid_view.path = nil
+    invalid_view.study_accession = nil
     assert_not invalid_view.valid?
     errors = invalid_view.errors.full_messages
     assert_equal 3, errors.count


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update addresses several small paper cuts with using the bookmarks feature:

* Changing top-level tabs doesn't dismiss the open bookmarks form
* Open form can lose connection to star icon in certain scenarios
* Cannot close bookmark form or modal using escape key
* Users cannot reuse names of bookmarks across different studies 

#### MANUAL TESTING
1. Boot as normal and sign in
2. Go to any study with visualizations
3. Open the form, and then resize the page, confirming the form moves with the star icon (there's a small lag, this is to prevent the function from firing continuously on resizing)
4. Keeping the form open, click the Download tab and confirm the form closes
5. Go back to the Explore tab, reopen the form, and press escape, confirming the form closes
6. Create a bookmark with a specific name, and the go to a different study and create a bookmark with the same name, confirming it completes

(P.S. I know I'm technically out but I didn't want to leave this until I got back... feel free to make any updates to this branch as necessary!)