### PR TITLE
Cell filtering by numeric annotations: refined UI (SCP-5500)

### DIFF
--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -181,7 +181,7 @@ function GroupCellFacet({
   facet,
   selectionMap, handleCheck,
   handleCheckAllFiltersInFacet, handleResetFacet, updateFilteredCells,
-  isAllListsCollapsed, hasNondefaultSelection, isFullyCollapsed, setIsFullyCollapsed,
+  hasNondefaultSelection, isFullyCollapsed, setIsFullyCollapsed,
   shownFilters, sortKey, setSortKey
 }) {
   return (

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -333,7 +333,7 @@ function GroupCellFilter({
 function CellFacet({
   facet,
   selectionMap, handleCheck, handleNumericChange,
-  handleCheckAllFiltersInFacet, updateFilteredCells,
+  handleCheckAllFiltersInFacet, handleResetFacet, updateFilteredCells,
   isAllListsCollapsed, hasNondefaultSelection
 }) {
   if (
@@ -418,6 +418,7 @@ function CellFacet({
         facet={facet}
         selectionMap={selectionMap}
         handleCheckAllFiltersInFacet={handleCheckAllFiltersInFacet}
+        handleResetFacet={handleResetFacet}
         isFullyCollapsed={isFullyCollapsed}
         setIsFullyCollapsed={setIsFullyCollapsed}
         sortKey={sortKey}
@@ -474,7 +475,8 @@ function includesSortIconClass(domClasses) {
 
 /** Get stylized name of facet, optional tooltip, collapse controls */
 function FacetHeader({
-  facet, selectionMap, handleCheckAllFiltersInFacet, isFullyCollapsed, setIsFullyCollapsed,
+  facet, selectionMap, handleCheckAllFiltersInFacet, handleResetFacet,
+  isFullyCollapsed, setIsFullyCollapsed,
   sortKey, setSortKey
 }) {
   const [facetName, rawFacetName] = parseAnnotationName(facet.annotation)
@@ -532,6 +534,16 @@ function FacetHeader({
           }
         }}
       />
+      }
+      {facet.type === 'numeric' &&
+        <a
+          onClick={() => handleResetFacet()}
+          className="reset-facet"
+          data-toggle="tooltip"
+          data-original-title="Reset selection"
+        >
+          <FontAwesomeIcon icon={faUndo}/>
+        </a>
       }
       <span
         className={`cell-facet-header cell-facet-header-${facet.type} ${toggleClass}`}
@@ -687,6 +699,12 @@ export function CellFilteringPanel({
     updateFilteredCells(selectionMap)
   }
 
+  function handleResetFacet(event) {
+    const facetName = event.target.name.split(':')[0].replace('facet-', '')
+    // selectionMap[facetName]
+    console.log('in handleResetFacet, facetName, facets', facetName, facets)
+  }
+
   /** Reset all filters to initial, selected state */
   function handleResetFilters() {
     const initSelection = {}
@@ -787,6 +805,7 @@ export function CellFilteringPanel({
                     handleCheck={handleCheck}
                     handleNumericChange={handleNumericChange}
                     handleCheckAllFiltersInFacet={handleCheckAllFiltersInFacet}
+                    handleResetFacet={handleResetFacet}
                     updateFilteredCells={updateFilteredCells}
                     isAllListsCollapsed={isAllListsCollapsed}
                     hasNondefaultSelection={hasNondefaultSelection}

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -403,7 +403,6 @@ export function CellFilteringPanel({
   Object.entries(cellFilteringSelection).forEach(([key, value]) => {
     defaultSelectionMap[key] = value
   })
-  // console.log('in CellFilteringPanel, defaultSelectionMap["time_post_partum_days--numeric--study"].toString()', defaultSelectionMap['time_post_partum_days--numeric--study'].toString())
 
   const [selectionMap, setSelectionMap] = useState(defaultSelectionMap)
   const [colorByFacet, setColorByFacet] = useState(shownAnnotation)
@@ -414,17 +413,7 @@ export function CellFilteringPanel({
   // Needed to propagate facets from URL to initial checkbox states
   useEffect(() => {
     setSelectionMap(defaultSelectionMap)
-    // console.log('in useEffect1, defaultSelectionMap["time_post_partum_days--numeric--study"].toString()', defaultSelectionMap['time_post_partum_days--numeric--study'].toString())
   }, [Object.values(defaultSelectionMap).join(',')])
-
-  useEffect(() => {
-    // setSelectionMap(defaultSelectionMap)
-    // console.log('in useEffect2, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
-  }, [Object.values(selectionMap).join(',')])
-
-  // useEffect(() => {
-  //   setSelectionMap(selectionMap)
-  // }, [Object.values(selectionMap).join(',')])
 
   /** Top header for the "Filter" section, including all-facet controls */
   function FilterSectionHeader({
@@ -514,21 +503,12 @@ export function CellFilteringPanel({
 
   /** Propagate change in a numeric cell filter */
   function handleNumericChange(facetName, newValues) {
-    // console.log('facetName, newValues.toString()', facetName, newValues.toString())
     selectionMap[facetName] = newValues.slice()
     const newSelectionMap = Object.assign({}, selectionMap)
     setSelectionMap(newSelectionMap)
 
     // update the filtered cells based on the checked condition of the filters
     updateFilteredCells(newSelectionMap)
-  }
-
-  // console.log('in CellFilteringPanel, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
-  const days = selectionMap['time_post_partum_days--numeric--study']
-  // console.log('days[0][0][1][0]', days[0][0][1][0])
-  if (days[0][0][1][0] === 5) {
-    // debugger()
-    debugger
   }
 
   const currentlyInUseAnnotations = { colorBy: '', facets: [] }

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faArrowLeft
 } from '@fortawesome/free-solid-svg-icons'
-
+import _isEqual from 'lodash/isEqual'
 
 import {
   FacetHeader, FacetTools, tooltipAttrs
@@ -37,21 +37,17 @@ export function CellFilteringPanelHeader({
 
 /** Determine if user has deselected any filters */
 function getHasNondefaultSelection(selectionMap, facets) {
-  let numTotalFilters = 0
-  facets
-    .filter(f => f.type === 'group')
-    .forEach(facet => numTotalFilters += facet.groups?.length)
-  let numCheckedFilters = 0
+  const entries = Object.entries(selectionMap)
+  for (let i = 0; i < entries.length; i++) {
+    const [selectedFacet, selection] = entries[i]
 
-  Object.entries(selectionMap)
-    .filter(([f, _]) => f.includes('--group--'))
-    .forEach(([_, filters]) => {
-      numCheckedFilters += filters?.length
-    })
+    const facet = facets.find(f => f.annotation === selectedFacet)
+    if (!_isEqual(facet.defaultSelection, selection)) {
+      return true
+    }
+  }
 
-  const hasNondefaultSelection = numTotalFilters !== numCheckedFilters
-
-  return hasNondefaultSelection
+  return false
 }
 
 /** determine if the filter is checked or not */
@@ -472,7 +468,7 @@ export function CellFilteringPanel({
   function handleResetFilters() {
     const initSelection = {}
     facets.forEach(facet => {
-      initSelection[facet.annotation] = facet.groups
+      initSelection[facet.annotation] = facet.defaultSelection
     })
 
     setSelectionMap(initSelection)
@@ -505,7 +501,6 @@ export function CellFilteringPanel({
 
   /** Propagate change in a numeric cell filter */
   function handleNumericChange(facetName, newValues) {
-    console.log('facetName, newValues', facetName, newValues)
     selectionMap[facetName] = newValues
     setSelectionMap(selectionMap)
 

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -2,22 +2,18 @@
 import React, { useState, useEffect } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
-  faArrowLeft, faChevronDown, faChevronRight, faUndo,
-  faSortAlphaDown, faSortAmountDown
+  faArrowLeft
 } from '@fortawesome/free-solid-svg-icons'
-import _isEqual from 'lodash/isEqual'
 
+
+import {
+  FacetHeader, FacetTools, tooltipAttrs
+} from '~/components/explore/FacetComponents'
+import LoadingSpinner from '~/lib/LoadingSpinner'
 import { NumericCellFacet } from '~/components/explore/NumericCellFacet'
 import Select from '~/lib/InstrumentedSelect'
-import LoadingSpinner from '~/lib/LoadingSpinner'
 import { annotationKeyProperties, clusterSelectStyle } from '~/lib/cluster-utils'
-import { log } from '~/lib/metrics-api'
 import { getFeatureFlagsWithDefaults } from '~/providers/UserProvider'
-
-const tooltipAttrs = {
-  'data-toggle': 'tooltip',
-  'data-delay': '{"show": 150}' // Avoid flurry of tooltips on passing hover
-}
 
 /** Top content for cell facet filtering panel shown at right in Explore tab */
 export function CellFilteringPanelHeader({
@@ -39,111 +35,6 @@ export function CellFilteringPanelHeader({
   )
 }
 
-/**
- * Very brief notes on terms in SCP metadata convention, derived from:
- * https://singlecell.zendesk.com/hc/en-us/articles/360060609852-Required-Metadata
- */
-const conventionalMetadataGlossary = {
-  'biosample_id': 'Unique identifier for each sample in the study',
-  'donor_id': 'Unique identifier for each biosample donor in the study',
-  'species__ontology_label': 'Taxon name, from NCBITaxon',
-  'disease__ontology_label': 'Disease name, from Mondo or PATO',
-  'organ__ontology_label': 'Organ name, from Uberon',
-  'library_preparation_protocol__ontology_label': 'From EFO',
-  'sex': 'One of "female", "male", "mixed", or "unknown"',
-  'cell_type__ontology_label': 'From Cell Ontology',
-  'ethnicity__ontology_label': 'From Human Ancestry Ontology'
-}
-
-/** Determine if annotation is conventional from its raw name */
-function getIsConventionalAnnotation(rawName) {
-  return (
-    rawName.includes('__ontology_label') ||
-    ['donor_id', 'biosample_id'].includes(rawName)
-  )
-}
-
-/** Convert e.g. "cell_type__ontology_label" to "Cell type" */
-function parseAnnotationName(annotationIdentifier) {
-  const rawName = annotationIdentifier.split('--')[0]
-  const sansOntologyName = rawName.replace('__ontology_label', '')
-  const sentenceCased = sansOntologyName[0].toUpperCase() + sansOntologyName.slice(1)
-  const spaced = sentenceCased.replace(/_/g, ' ')
-  let upId = spaced
-  if (spaced.slice(-3) === ' id') {
-    // e.g. Donor id -> Donor ID
-    upId = upId.slice(0, -3) + upId.slice(-3).toUpperCase()
-  }
-  let ynLess = upId
-  if (upId.slice('-3').toUpperCase() === ' YN') {
-    ynLess = ynLess.slice(0, -3)
-  }
-  const displayName = ynLess
-  return [displayName, rawName]
-}
-
-/** UI control to update how filters are sorted */
-function SortFiltersIcon({ sortKey, setSortKey }) {
-  const icon = sortKey === 'count' ? faSortAmountDown : faSortAlphaDown
-  const nextSortKey = sortKey === 'count' ? 'label' : 'count'
-
-  return (
-    <span
-      onClick={() => {
-        setSortKey(nextSortKey)
-        log('sort-filters', { sortKey })
-      }}
-      className={`sort-filters sort-filters-${sortKey}`}
-      data-analytics-name={`sort-filters sort-filters-${sortKey}`}
-      {...tooltipAttrs}
-      data-original-title={`Sorted by ${sortKey}; click to sort by ${nextSortKey}`}
-    >
-      <FontAwesomeIcon icon={icon}/>
-    </span>
-  )
-}
-
-/** Toggle icon for collapsing a list; for each filter list, and all filter lists */
-function FacetTools({
-  isCollapsed, whatToToggle,
-  isLoaded,
-  sortKey,
-  setSortKey,
-  facet=null,
-  isRoot=false, hasNondefaultSelection, handleResetFilters
-}) {
-  return (
-    <span className="facet-tools">
-      {!isLoaded &&
-      <span
-        {...tooltipAttrs}
-        data-original-title="Loading data..."
-        style={{ position: 'relative', top: '-5px', left: '-20px', cursor: 'default' }}
-      >
-        <LoadingSpinner height='14px'/>
-      </span>
-      }
-      {isLoaded && !isRoot && !isCollapsed && facet.type === 'group' &&
-      <SortFiltersIcon
-        facet={facet}
-        sortKey={sortKey}
-        setSortKey={setSortKey}
-      />
-      }
-      {isRoot &&
-        <ResetFiltersButton
-          hasNondefaultSelection={hasNondefaultSelection}
-          handleResetFilters={handleResetFilters}
-        />
-      }
-      <CollapseToggleChevron
-        isCollapsed={isCollapsed}
-        whatToToggle={whatToToggle}
-      />
-    </span>
-  )
-}
-
 /** Determine if user has deselected any filters */
 function getHasNondefaultSelection(selectionMap, facets) {
   let numTotalFilters = 0
@@ -161,47 +52,6 @@ function getHasNondefaultSelection(selectionMap, facets) {
   const hasNondefaultSelection = numTotalFilters !== numCheckedFilters
 
   return hasNondefaultSelection
-}
-
-/** Button to reset all filters to their default, initial state */
-function ResetFiltersButton({ hasNondefaultSelection, handleResetFilters }) {
-  const isResetEligible = hasNondefaultSelection
-  const resetDisplayClass = isResetEligible ? '' : 'hide-reset'
-
-  return (
-    <a
-      onClick={() => handleResetFilters()}
-      className={`reset-cell-filters ${resetDisplayClass}`}
-      data-analytics-name="reset-cell-filters"
-      data-toggle="tooltip"
-      data-original-title="Reset filter selections"
-    >
-      <FontAwesomeIcon icon={faUndo}/>
-    </a>
-  )
-}
-
-/** Toggle icon for collapsing a list; for each filter list, and all filter lists */
-function CollapseToggleChevron({ isCollapsed, whatToToggle }) {
-  let toggleIcon
-  let toggleIconTooltipText
-  if (!isCollapsed) {
-    toggleIcon = <FontAwesomeIcon className="chevron-down" icon={faChevronDown} />
-    toggleIconTooltipText = `Hide ${whatToToggle}`
-  } else {
-    toggleIcon = <FontAwesomeIcon className="chevron-right" icon={faChevronRight} />
-    toggleIconTooltipText = `Show ${whatToToggle}`
-  }
-
-  return (
-    <span
-      className="facet-toggle-chevron"
-      data-original-title={toggleIconTooltipText}
-      {...tooltipAttrs}
-    >
-      {toggleIcon}
-    </span>
-  )
 }
 
 /** determine if the filter is checked or not */
@@ -330,6 +180,45 @@ function GroupCellFilter({
   )
 }
 
+/** Facet header and filters for categorical (i.e., group-based) annotations */
+function GroupCellFacet({
+  facet,
+  selectionMap, handleCheck,
+  handleCheckAllFiltersInFacet, handleResetFacet, updateFilteredCells,
+  isAllListsCollapsed, hasNondefaultSelection, isFullyCollapsed, setIsFullyCollapsed,
+  shownFilters, sortKey, setSortKey
+}) {
+  return (
+    <>
+      <FacetHeader
+        facet={facet}
+        selectionMap={selectionMap}
+        handleCheckAllFiltersInFacet={handleCheckAllFiltersInFacet}
+        handleResetFacet={handleResetFacet}
+        isFullyCollapsed={isFullyCollapsed}
+        setIsFullyCollapsed={setIsFullyCollapsed}
+        sortKey={sortKey}
+        setSortKey={setSortKey}
+      />
+      {facet.type === 'group' && shownFilters.map((filter, i) => {
+        return (
+          <GroupCellFilter
+            facet={facet}
+            filter={filter}
+            isChecked={isChecked}
+            selectionMap={selectionMap}
+            handleCheck={handleCheck}
+            updateFilteredCells={updateFilteredCells}
+            hasNondefaultSelection={hasNondefaultSelection}
+            key={i}
+          />
+        )
+      })
+      }
+    </>
+  )
+}
+
 /** Facet name and collapsible list of filter checkboxes */
 function CellFacet({
   facet,
@@ -415,30 +304,22 @@ function CellFacet({
       key={facet.annotation}
       style={facetStyle}
     >
-      <FacetHeader
-        facet={facet}
-        selectionMap={selectionMap}
-        handleCheckAllFiltersInFacet={handleCheckAllFiltersInFacet}
-        handleResetFacet={handleResetFacet}
-        isFullyCollapsed={isFullyCollapsed}
-        setIsFullyCollapsed={setIsFullyCollapsed}
-        sortKey={sortKey}
-        setSortKey={setSortKey}
-      />
-      {facet.type === 'group' && shownFilters.map((filter, i) => {
-        return (
-          <GroupCellFilter
+      {facet.type === 'group' &&
+          <GroupCellFacet
             facet={facet}
-            filter={filter}
-            isChecked={isChecked}
             selectionMap={selectionMap}
             handleCheck={handleCheck}
+            handleCheckAllFiltersInFacet={handleCheckAllFiltersInFacet}
+            handleResetFacet={handleResetFacet}
             updateFilteredCells={updateFilteredCells}
+            isAllListsCollapsed={isAllListsCollapsed}
             hasNondefaultSelection={hasNondefaultSelection}
-            key={i}
+            isFullyCollapsed={isFullyCollapsed}
+            setIsFullyCollapsed={setIsFullyCollapsed}
+            shownFilters={shownFilters}
+            sortKey={sortKey}
+            setSortKey={setSortKey}
           />
-        )
-      })
       }
       {facet.type === 'numeric' &&
           <NumericCellFacet
@@ -449,6 +330,7 @@ function CellFacet({
             handleNumericChange={handleNumericChange}
             updateFilteredCells={updateFilteredCells}
             hasNondefaultSelection={hasNondefaultSelection}
+            handleResetFacet={handleResetFacet}
             key={facet}
           />
       }
@@ -462,143 +344,6 @@ function CellFacet({
         </a>
       }
     </div>
-  )
-}
-
-/** Determine if a list of DOM classes includes one used for the sort-icon */
-function includesSortIconClass(domClasses) {
-  return (
-    domClasses.includes('fa-sort-alpha-down') ||
-    domClasses.includes('fa-sort-amount-down') ||
-    domClasses.includes('sort-filters')
-  )
-}
-
-/** Determine if this numeric facet has a non-default selection */
-function getNumericHasNondefaultSelection(facet, selectionMap) {
-  const defaultSelection = facet.defaultSelection
-  const selection = selectionMap[facet.annotation]
-  const numericHasNondefaultSelection = !_isEqual(selection, defaultSelection)
-  return numericHasNondefaultSelection
-}
-
-/** Get stylized name of facet, optional tooltip, collapse controls */
-function FacetHeader({
-  facet, selectionMap, handleCheckAllFiltersInFacet, handleResetFacet,
-  isFullyCollapsed, setIsFullyCollapsed,
-  sortKey, setSortKey
-}) {
-  const [facetName, rawFacetName] = parseAnnotationName(facet.annotation)
-  const isConventional = getIsConventionalAnnotation(rawFacetName)
-
-  const facetNameStyle = {}
-  const tooltipableFacetNameStyle = {
-    width: 'content-fit'
-  }
-
-  const loadingClass = !facet.isLoaded ? 'loading' : ''
-  if (!facet.isLoaded) {
-    facetNameStyle.color = '#777'
-    facetNameStyle.cursor = 'default'
-  }
-
-  let title = 'Author annotation'
-  if (isConventional) {
-    title = 'Conventional annotation'
-    const note = conventionalMetadataGlossary[rawFacetName]
-    if (note) {
-      title += `.  ${note}`
-    }
-  }
-  title += `.  Name in data: ${rawFacetName}`
-
-  const toggleClass = `cell-filters-${isFullyCollapsed ? 'hidden' : 'shown'}`
-
-  // Assess if facet-level checkbox should be indeterminate, i.e. "-",
-  // which is a common state in hierarchical checkboxes to indicate that
-  // some lower checkboxes are checked, and some are not.
-  const allFiltersInFacet = facet.groups
-  const allCheckedFiltersInFacet = selectionMap[facet.annotation]
-  const isFacetCheckboxSelected = allFiltersInFacet?.length === allCheckedFiltersInFacet?.length
-  const isIndeterminate = !(
-    allCheckedFiltersInFacet?.length === 0 ||
-    isFacetCheckboxSelected
-  )
-
-  let numericHasNondefaultSelection
-  if (facet.type === 'numeric') {
-    numericHasNondefaultSelection = getNumericHasNondefaultSelection(facet, selectionMap)
-  }
-
-  return (
-    <>
-      {facet.type === 'group' &&
-      <input
-        type="checkbox"
-        className="cell-facet-header-checkbox"
-        data-analytics-name={`facet-${facet.annotation}`}
-        name={`facet-${facet.annotation}`}
-        onChange={event => {
-          handleCheckAllFiltersInFacet(event)
-        }}
-        checked={isFacetCheckboxSelected}
-        ref={input => {
-          if (input) {
-            input.indeterminate = isIndeterminate
-          }
-        }}
-      />
-      }
-      {facet.type === 'numeric' &&
-        <a
-          onClick={() => {
-            handleResetFacet(facet.annotation)
-          }}
-          className="reset-facet"
-          data-toggle="tooltip"
-          data-original-title="Reset selection"
-          style={{ 'visibility': numericHasNondefaultSelection ? 'visible' : 'hidden' }}
-        >
-          <FontAwesomeIcon icon={faUndo}/>
-        </a>
-      }
-      <span
-        className={`cell-facet-header cell-facet-header-${facet.type} ${toggleClass}`}
-        onClick={event => {
-          const domClasses = Array.from(event.target.classList)
-          const parentDomClasses = Array.from(event.target.parentNode.classList)
-          if (
-            includesSortIconClass(domClasses) ||
-            domClasses.length === 0 && (
-              // Accounts for click on the sort icon SVG `path` element itself
-              includesSortIconClass(parentDomClasses)
-            )
-          ) {
-            // Don't toggle facet collapse on sort icon click
-            return
-          }
-          setIsFullyCollapsed(!isFullyCollapsed)
-        }}
-      >
-        <span className={`cell-facet-name ${loadingClass}`}>
-          <span
-            style={tooltipableFacetNameStyle}
-            data-original-title={title}
-            {...tooltipAttrs}
-          >
-            {facetName}
-          </span>
-        </span>
-        <FacetTools
-          sortKey={sortKey}
-          setSortKey={setSortKey}
-          isCollapsed={isFullyCollapsed}
-          whatToToggle="filter list"
-          facet={facet}
-          isLoaded={facet.isLoaded}
-        />
-      </span>
-    </>
   )
 }
 

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -42,7 +42,7 @@ function getHasNondefaultSelection(selectionMap, facets) {
     const [selectedFacet, selection] = entries[i]
 
     const facet = facets.find(f => f.annotation === selectedFacet)
-    if (!_isEqual(facet.defaultSelection, selection)) {
+    if (!_isEqual(facet?.defaultSelection, selection)) {
       return true
     }
   }

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -760,6 +760,7 @@ export function CellFilteringPanel({
 
   /** Propagate change in a numeric cell filter */
   function handleNumericChange(facetName, newValues) {
+    console.log('facetName, newValues', facetName, newValues)
     selectionMap[facetName] = newValues
     setSelectionMap(selectionMap)
 

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -525,7 +525,7 @@ function FacetHeader({
     isFacetCheckboxSelected
   )
 
-  let numericHasNondefaultSelection = null
+  let numericHasNondefaultSelection
   if (facet.type === 'numeric') {
     numericHasNondefaultSelection = getNumericHasNondefaultSelection(facet, selectionMap)
   }
@@ -551,7 +551,9 @@ function FacetHeader({
       }
       {facet.type === 'numeric' &&
         <a
-          onClick={() => handleResetFacet()}
+          onClick={() => {
+            handleResetFacet(facet.annotation)
+          }}
           className="reset-facet"
           data-toggle="tooltip"
           data-original-title="Reset selection"
@@ -714,10 +716,11 @@ export function CellFilteringPanel({
     updateFilteredCells(selectionMap)
   }
 
-  function handleResetFacet(event) {
-    const facetName = event.target.name.split(':')[0].replace('facet-', '')
-    // selectionMap[facetName]
-    console.log('in handleResetFacet, facetName, facets', facetName, facets)
+  /** Reset numeric facet to default values, i.e. clear facet */
+  function handleResetFacet(facetName) {
+    const facet = facets.find(f => f.annotation === facetName)
+    const defaultSelection = facet.defaultSelection
+    handleNumericChange(facetName, defaultSelection)
   }
 
   /** Reset all filters to initial, selected state */

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -326,6 +326,8 @@ function CellFacet({
             handleNumericChange={handleNumericChange}
             updateFilteredCells={updateFilteredCells}
             hasNondefaultSelection={hasNondefaultSelection}
+            isFullyCollapsed={isFullyCollapsed}
+            setIsFullyCollapsed={setIsFullyCollapsed}
             handleResetFacet={handleResetFacet}
             key={facet}
           />

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -42,7 +42,14 @@ function getHasNondefaultSelection(selectionMap, facets) {
     const [selectedFacet, selection] = entries[i]
 
     const facet = facets.find(f => f.annotation === selectedFacet)
-    if (!_isEqual(facet?.defaultSelection, selection)) {
+    let normDefault = facet.defaultSelection
+    let normSelection = selection
+    if (facet.type === 'group') {
+      // Normalize categorical filters, given order doesn't matter for them
+      normDefault = new Set(normDefault)
+      normSelection = new Set(normSelection)
+    }
+    if (!_isEqual(normDefault, normSelection)) {
       return true
     }
   }

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -403,7 +403,7 @@ export function CellFilteringPanel({
   Object.entries(cellFilteringSelection).forEach(([key, value]) => {
     defaultSelectionMap[key] = value
   })
-  console.log('in CellFilteringPanel, defaultSelectionMap["time_post_partum_days--numeric--study"].toString()', defaultSelectionMap['time_post_partum_days--numeric--study'].toString())
+  // console.log('in CellFilteringPanel, defaultSelectionMap["time_post_partum_days--numeric--study"].toString()', defaultSelectionMap['time_post_partum_days--numeric--study'].toString())
 
   const [selectionMap, setSelectionMap] = useState(defaultSelectionMap)
   const [colorByFacet, setColorByFacet] = useState(shownAnnotation)
@@ -414,12 +414,12 @@ export function CellFilteringPanel({
   // Needed to propagate facets from URL to initial checkbox states
   useEffect(() => {
     setSelectionMap(defaultSelectionMap)
-    console.log('in useEffect1, defaultSelectionMap["time_post_partum_days--numeric--study"].toString()', defaultSelectionMap['time_post_partum_days--numeric--study'].toString())
+    // console.log('in useEffect1, defaultSelectionMap["time_post_partum_days--numeric--study"].toString()', defaultSelectionMap['time_post_partum_days--numeric--study'].toString())
   }, [Object.values(defaultSelectionMap).join(',')])
 
   useEffect(() => {
     // setSelectionMap(defaultSelectionMap)
-    console.log('in useEffect2, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
+    // console.log('in useEffect2, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
   }, [Object.values(selectionMap).join(',')])
 
   // useEffect(() => {
@@ -514,7 +514,7 @@ export function CellFilteringPanel({
 
   /** Propagate change in a numeric cell filter */
   function handleNumericChange(facetName, newValues) {
-    console.log('facetName, newValues.toString()', facetName, newValues.toString())
+    // console.log('facetName, newValues.toString()', facetName, newValues.toString())
     selectionMap[facetName] = newValues.slice()
     const newSelectionMap = Object.assign({}, selectionMap)
     setSelectionMap(newSelectionMap)
@@ -523,9 +523,9 @@ export function CellFilteringPanel({
     updateFilteredCells(newSelectionMap)
   }
 
-  console.log('in CellFilteringPanel, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
+  // console.log('in CellFilteringPanel, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
   const days = selectionMap['time_post_partum_days--numeric--study']
-  console.log('days[0][0][1][0]', days[0][0][1][0])
+  // console.log('days[0][0][1][0]', days[0][0][1][0])
   if (days[0][0][1][0] === 5) {
     // debugger()
     debugger

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -187,7 +187,7 @@ function GroupCellFilter({
 function GroupCellFacet({
   facet,
   selectionMap, handleCheck,
-  handleCheckAllFiltersInFacet, handleResetFacet, updateFilteredCells,
+  handleCheckAllFiltersInFacet, updateFilteredCells,
   hasNondefaultSelection, isFullyCollapsed, setIsFullyCollapsed,
   shownFilters, sortKey, setSortKey
 }) {
@@ -197,7 +197,6 @@ function GroupCellFacet({
         facet={facet}
         selectionMap={selectionMap}
         handleCheckAllFiltersInFacet={handleCheckAllFiltersInFacet}
-        handleResetFacet={handleResetFacet}
         isFullyCollapsed={isFullyCollapsed}
         setIsFullyCollapsed={setIsFullyCollapsed}
         sortKey={sortKey}
@@ -226,7 +225,7 @@ function GroupCellFacet({
 function CellFacet({
   facet,
   selectionMap, handleCheck, handleNumericChange,
-  handleCheckAllFiltersInFacet, handleResetFacet, updateFilteredCells,
+  handleCheckAllFiltersInFacet, updateFilteredCells,
   isAllListsCollapsed, hasNondefaultSelection
 }) {
   if (
@@ -301,6 +300,8 @@ function CellFacet({
     return <></>
   }
 
+  const selection = selectionMap[facet.annotation]
+
   return (
     <div
       className="cell-facet"
@@ -313,7 +314,6 @@ function CellFacet({
             selectionMap={selectionMap}
             handleCheck={handleCheck}
             handleCheckAllFiltersInFacet={handleCheckAllFiltersInFacet}
-            handleResetFacet={handleResetFacet}
             updateFilteredCells={updateFilteredCells}
             isAllListsCollapsed={isAllListsCollapsed}
             hasNondefaultSelection={hasNondefaultSelection}
@@ -329,14 +329,14 @@ function CellFacet({
             facet={facet}
             filters={shownFilters}
             isChecked={isChecked}
+            selection={selection}
             selectionMap={selectionMap}
             handleNumericChange={handleNumericChange}
             updateFilteredCells={updateFilteredCells}
             hasNondefaultSelection={hasNondefaultSelection}
             isFullyCollapsed={isFullyCollapsed}
             setIsFullyCollapsed={setIsFullyCollapsed}
-            handleResetFacet={handleResetFacet}
-            key={facet}
+            key={facet.annotation}
           />
       }
       {facet.type === 'group' && !isFullyCollapsed && filters.length > numFiltersPartlyCollapsed &&
@@ -403,6 +403,7 @@ export function CellFilteringPanel({
   Object.entries(cellFilteringSelection).forEach(([key, value]) => {
     defaultSelectionMap[key] = value
   })
+  console.log('in CellFilteringPanel, defaultSelectionMap["time_post_partum_days--numeric--study"].toString()', defaultSelectionMap['time_post_partum_days--numeric--study'].toString())
 
   const [selectionMap, setSelectionMap] = useState(defaultSelectionMap)
   const [colorByFacet, setColorByFacet] = useState(shownAnnotation)
@@ -413,7 +414,17 @@ export function CellFilteringPanel({
   // Needed to propagate facets from URL to initial checkbox states
   useEffect(() => {
     setSelectionMap(defaultSelectionMap)
+    console.log('in useEffect1, defaultSelectionMap["time_post_partum_days--numeric--study"].toString()', defaultSelectionMap['time_post_partum_days--numeric--study'].toString())
   }, [Object.values(defaultSelectionMap).join(',')])
+
+  useEffect(() => {
+    // setSelectionMap(defaultSelectionMap)
+    console.log('in useEffect2, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
+  }, [Object.values(selectionMap).join(',')])
+
+  // useEffect(() => {
+  //   setSelectionMap(selectionMap)
+  // }, [Object.values(selectionMap).join(',')])
 
   /** Top header for the "Filter" section, including all-facet controls */
   function FilterSectionHeader({
@@ -466,13 +477,6 @@ export function CellFilteringPanel({
     updateFilteredCells(selectionMap)
   }
 
-  /** Reset numeric facet to default values, i.e. clear facet */
-  function handleResetFacet(facetName) {
-    const facet = facets.find(f => f.annotation === facetName)
-    const defaultSelection = facet.defaultSelection
-    handleNumericChange(facetName, defaultSelection)
-  }
-
   /** Reset all filters to initial, selected state */
   function handleResetFilters() {
     const initSelection = {}
@@ -500,7 +504,7 @@ export function CellFilteringPanel({
         return item !== event.target.value
       })
     }
-    // update the selectionMap state with the filter in it's updated condition
+    // update the selectionMap state with the filter in its updated condition
     selectionMap[facetName] = updatedList
     setSelectionMap(selectionMap)
 
@@ -510,11 +514,21 @@ export function CellFilteringPanel({
 
   /** Propagate change in a numeric cell filter */
   function handleNumericChange(facetName, newValues) {
-    selectionMap[facetName] = newValues
-    setSelectionMap(selectionMap)
+    console.log('facetName, newValues.toString()', facetName, newValues.toString())
+    selectionMap[facetName] = newValues.slice()
+    const newSelectionMap = Object.assign({}, selectionMap)
+    setSelectionMap(newSelectionMap)
 
     // update the filtered cells based on the checked condition of the filters
-    updateFilteredCells(selectionMap)
+    updateFilteredCells(newSelectionMap)
+  }
+
+  console.log('in CellFilteringPanel, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
+  const days = selectionMap['time_post_partum_days--numeric--study']
+  console.log('days[0][0][1][0]', days[0][0][1][0])
+  if (days[0][0][1][0] === 5) {
+    // debugger()
+    debugger
   }
 
   const currentlyInUseAnnotations = { colorBy: '', facets: [] }
@@ -573,7 +587,6 @@ export function CellFilteringPanel({
                     handleCheck={handleCheck}
                     handleNumericChange={handleNumericChange}
                     handleCheckAllFiltersInFacet={handleCheckAllFiltersInFacet}
-                    handleResetFacet={handleResetFacet}
                     updateFilteredCells={updateFilteredCells}
                     isAllListsCollapsed={isAllListsCollapsed}
                     hasNondefaultSelection={hasNondefaultSelection}

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -5,6 +5,7 @@ import {
   faArrowLeft, faChevronDown, faChevronRight, faUndo,
   faSortAlphaDown, faSortAmountDown
 } from '@fortawesome/free-solid-svg-icons'
+import _isEqual from 'lodash/isEqual'
 
 import { NumericCellFacet } from '~/components/explore/NumericCellFacet'
 import Select from '~/lib/InstrumentedSelect'
@@ -473,6 +474,14 @@ function includesSortIconClass(domClasses) {
   )
 }
 
+/** Determine if this numeric facet has a non-default selection */
+function getNumericHasNondefaultSelection(facet, selectionMap) {
+  const defaultSelection = facet.defaultSelection
+  const selection = selectionMap[facet.annotation]
+  const numericHasNondefaultSelection = !_isEqual(selection, defaultSelection)
+  return numericHasNondefaultSelection
+}
+
 /** Get stylized name of facet, optional tooltip, collapse controls */
 function FacetHeader({
   facet, selectionMap, handleCheckAllFiltersInFacet, handleResetFacet,
@@ -516,6 +525,11 @@ function FacetHeader({
     isFacetCheckboxSelected
   )
 
+  let numericHasNondefaultSelection = null
+  if (facet.type === 'numeric') {
+    numericHasNondefaultSelection = getNumericHasNondefaultSelection(facet, selectionMap)
+  }
+
   return (
     <>
       {facet.type === 'group' &&
@@ -541,6 +555,7 @@ function FacetHeader({
           className="reset-facet"
           data-toggle="tooltip"
           data-original-title="Reset selection"
+          style={{ 'visibility': numericHasNondefaultSelection ? 'visible' : 'hidden' }}
         >
           <FontAwesomeIcon icon={faUndo}/>
         </a>

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -182,20 +182,24 @@ function getFacetsParam(initFacets, selection) {
 
   const innerParams = []
   Object.entries(initSelection).forEach(([facet, filters]) => {
-    filters.forEach(filter => {
-      // Unlike `selection`, which specifies all filters that are selected
-      // (i.e., checked and not applied), the `facets` parameter species only
-      // filters that are _not_ selected, i.e. they're unchecked and applied.
-      //
-      // This makes the `facets` parameter much clearer.
-      if (facet.type === 'group' && !selection[facet].includes(filter)) {
-        if (facet in minimalSelection) {
-          minimalSelection[facet].push(filter)
-        } else {
-          minimalSelection[facet] = [filter]
+    if (facet.type === 'group') {
+      filters.forEach(filter => {
+        // Unlike `selection`, which specifies all filters that are selected
+        // (i.e., checked and not applied), the `facets` parameter species only
+        // filters that are _not_ selected, i.e. they're unchecked and applied.
+        //
+        // This makes the `facets` parameter much clearer.
+        if (!selection[facet].includes(filter)) {
+          if (facet in minimalSelection) {
+            minimalSelection[facet].push(filter)
+          } else {
+            minimalSelection[facet] = [filter]
+          }
         }
-      }
-    })
+      })
+    } else {
+      // minimalSelection[facet] = selection[facet]
+    }
   })
 
   Object.entries(minimalSelection).forEach(([facet, filters]) => {
@@ -210,6 +214,8 @@ function getFacetsParam(initFacets, selection) {
 /** Parse `facets` URL parameter into cell filtering selection object */
 function parseFacetsParam(initFacets, facetsParam) {
   const selection = {}
+
+  console.log('initFacets', initFacets)
 
   // Convert the `facets` parameter value, which is a string,
   // into an object that has the same shape as `selections`

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -176,7 +176,7 @@ function getFacetsParam(initFacets, selection) {
   const minimalSelection = {}
 
   const initSelection = {}
-  initFacets.filter(f => !f.isSelectedAnnotation).forEach(facet => {
+  initFacets.filter(f => !f.isSelectedAnnotation)?.forEach(facet => {
     initSelection[facet.annotation] = facet.defaultSelection
   })
 

--- a/app/javascript/components/explore/FacetComponents.jsx
+++ b/app/javascript/components/explore/FacetComponents.jsx
@@ -177,7 +177,6 @@ export function FacetHeader({
   facet, selectionMap, handleCheckAllFiltersInFacet, handleResetFacet,
   isFullyCollapsed, setIsFullyCollapsed,
   sortKey, setSortKey,
-  clearBrush, sliderId, brush,
   numericHasNondefaultSelection
 }) {
   const [facetName, rawFacetName] = parseAnnotationName(facet.annotation)
@@ -239,7 +238,6 @@ export function FacetHeader({
       {facet.type === 'numeric' &&
         <a
           onClick={() => {
-            // clearBrush(sliderId, brush)
             handleResetFacet(facet)
           }}
           className="reset-facet"

--- a/app/javascript/components/explore/FacetComponents.jsx
+++ b/app/javascript/components/explore/FacetComponents.jsx
@@ -185,7 +185,8 @@ export function FacetTools({
 export function FacetHeader({
   facet, selectionMap, handleCheckAllFiltersInFacet, handleResetFacet,
   isFullyCollapsed, setIsFullyCollapsed,
-  sortKey, setSortKey
+  sortKey, setSortKey,
+  clearBrush, sliderId, brush
 }) {
   const [facetName, rawFacetName] = parseAnnotationName(facet.annotation)
   const isConventional = getIsConventionalAnnotation(rawFacetName)
@@ -252,6 +253,7 @@ export function FacetHeader({
         <a
           onClick={() => {
             handleResetFacet(facet.annotation)
+            clearBrush(sliderId, brush)
           }}
           className="reset-facet"
           data-toggle="tooltip"

--- a/app/javascript/components/explore/FacetComponents.jsx
+++ b/app/javascript/components/explore/FacetComponents.jsx
@@ -217,8 +217,6 @@ export function FacetHeader({
     isFacetCheckboxSelected
   )
 
-  console.log('in FacetComponents, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
-
   return (
     <>
       {facet.type === 'group' &&

--- a/app/javascript/components/explore/FacetComponents.jsx
+++ b/app/javascript/components/explore/FacetComponents.jsx
@@ -3,7 +3,6 @@
  */
 
 import React from 'react'
-import _isEqual from 'lodash/isEqual'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faChevronDown, faChevronRight, faUndo,
@@ -113,14 +112,6 @@ function includesSortIconClass(domClasses) {
   )
 }
 
-/** Determine if this numeric facet has a non-default selection */
-function getNumericHasNondefaultSelection(facet, selectionMap) {
-  const defaultSelection = facet.defaultSelection
-  const selection = selectionMap[facet.annotation]
-  const numericHasNondefaultSelection = !_isEqual(selection, defaultSelection)
-  return numericHasNondefaultSelection
-}
-
 /** Convert e.g. "cell_type__ontology_label" to "Cell type" */
 function parseAnnotationName(annotationIdentifier) {
   const rawName = annotationIdentifier.split('--')[0]
@@ -186,7 +177,8 @@ export function FacetHeader({
   facet, selectionMap, handleCheckAllFiltersInFacet, handleResetFacet,
   isFullyCollapsed, setIsFullyCollapsed,
   sortKey, setSortKey,
-  clearBrush, sliderId, brush
+  clearBrush, sliderId, brush,
+  numericHasNondefaultSelection
 }) {
   const [facetName, rawFacetName] = parseAnnotationName(facet.annotation)
   const isConventional = getIsConventionalAnnotation(rawFacetName)
@@ -225,10 +217,7 @@ export function FacetHeader({
     isFacetCheckboxSelected
   )
 
-  let numericHasNondefaultSelection
-  if (facet.type === 'numeric') {
-    numericHasNondefaultSelection = getNumericHasNondefaultSelection(facet, selectionMap)
-  }
+  console.log('in FacetComponents, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
 
   return (
     <>
@@ -252,8 +241,8 @@ export function FacetHeader({
       {facet.type === 'numeric' &&
         <a
           onClick={() => {
-            handleResetFacet(facet.annotation)
-            clearBrush(sliderId, brush)
+            // clearBrush(sliderId, brush)
+            handleResetFacet(facet)
           }}
           className="reset-facet"
           data-toggle="tooltip"

--- a/app/javascript/components/explore/FacetComponents.jsx
+++ b/app/javascript/components/explore/FacetComponents.jsx
@@ -1,0 +1,302 @@
+/**
+ * Code shared by group cell facets, numeric cell facets, and/or cell filtering panel
+ */
+
+import React from 'react'
+import _isEqual from 'lodash/isEqual'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import {
+  faChevronDown, faChevronRight, faUndo,
+  faSortAlphaDown, faSortAmountDown
+} from '@fortawesome/free-solid-svg-icons'
+
+import LoadingSpinner from '~/lib/LoadingSpinner'
+import { log } from '~/lib/metrics-api'
+
+export const tooltipAttrs = {
+  'data-toggle': 'tooltip',
+  'data-delay': '{"show": 150}' // Avoid flurry of tooltips on passing hover
+}
+
+/** Button to reset all filters to their default, initial state */
+function ResetFiltersButton({ hasNondefaultSelection, handleResetFilters }) {
+  const isResetEligible = hasNondefaultSelection
+  const resetDisplayClass = isResetEligible ? '' : 'hide-reset'
+
+  return (
+    <a
+      onClick={() => handleResetFilters()}
+      className={`reset-cell-filters ${resetDisplayClass}`}
+      data-analytics-name="reset-cell-filters"
+      data-toggle="tooltip"
+      data-original-title="Reset filter selections"
+    >
+      <FontAwesomeIcon icon={faUndo}/>
+    </a>
+  )
+}
+
+/** Toggle icon for collapsing a list; for each filter list, and all filter lists */
+function CollapseToggleChevron({ isCollapsed, whatToToggle }) {
+  let toggleIcon
+  let toggleIconTooltipText
+  if (!isCollapsed) {
+    toggleIcon = <FontAwesomeIcon className="chevron-down" icon={faChevronDown} />
+    toggleIconTooltipText = `Hide ${whatToToggle}`
+  } else {
+    toggleIcon = <FontAwesomeIcon className="chevron-right" icon={faChevronRight} />
+    toggleIconTooltipText = `Show ${whatToToggle}`
+  }
+
+  return (
+    <span
+      className="facet-toggle-chevron"
+      data-original-title={toggleIconTooltipText}
+      {...tooltipAttrs}
+    >
+      {toggleIcon}
+    </span>
+  )
+}
+
+/** UI control to update how filters are sorted */
+function SortFiltersIcon({ sortKey, setSortKey }) {
+  const icon = sortKey === 'count' ? faSortAmountDown : faSortAlphaDown
+  const nextSortKey = sortKey === 'count' ? 'label' : 'count'
+
+  return (
+    <span
+      onClick={() => {
+        setSortKey(nextSortKey)
+        log('sort-filters', { sortKey })
+      }}
+      className={`sort-filters sort-filters-${sortKey}`}
+      data-analytics-name={`sort-filters sort-filters-${sortKey}`}
+      {...tooltipAttrs}
+      data-original-title={`Sorted by ${sortKey}; click to sort by ${nextSortKey}`}
+    >
+      <FontAwesomeIcon icon={icon}/>
+    </span>
+  )
+}
+
+/**
+ * Very brief notes on terms in SCP metadata convention, derived from:
+ * https://singlecell.zendesk.com/hc/en-us/articles/360060609852-Required-Metadata
+ */
+const conventionalMetadataGlossary = {
+  'biosample_id': 'Unique identifier for each sample in the study',
+  'donor_id': 'Unique identifier for each biosample donor in the study',
+  'species__ontology_label': 'Taxon name, from NCBITaxon',
+  'disease__ontology_label': 'Disease name, from Mondo or PATO',
+  'organ__ontology_label': 'Organ name, from Uberon',
+  'library_preparation_protocol__ontology_label': 'From EFO',
+  'sex': 'One of "female", "male", "mixed", or "unknown"',
+  'cell_type__ontology_label': 'From Cell Ontology',
+  'ethnicity__ontology_label': 'From Human Ancestry Ontology'
+}
+
+/** Determine if annotation is conventional from its raw name */
+function getIsConventionalAnnotation(rawName) {
+  return (
+    rawName.includes('__ontology_label') ||
+    ['donor_id', 'biosample_id'].includes(rawName)
+  )
+}
+
+/** Determine if a list of DOM classes includes one used for the sort-icon */
+function includesSortIconClass(domClasses) {
+  return (
+    domClasses.includes('fa-sort-alpha-down') ||
+    domClasses.includes('fa-sort-amount-down') ||
+    domClasses.includes('sort-filters')
+  )
+}
+
+/** Determine if this numeric facet has a non-default selection */
+function getNumericHasNondefaultSelection(facet, selectionMap) {
+  const defaultSelection = facet.defaultSelection
+  const selection = selectionMap[facet.annotation]
+  const numericHasNondefaultSelection = !_isEqual(selection, defaultSelection)
+  return numericHasNondefaultSelection
+}
+
+/** Convert e.g. "cell_type__ontology_label" to "Cell type" */
+function parseAnnotationName(annotationIdentifier) {
+  const rawName = annotationIdentifier.split('--')[0]
+  const sansOntologyName = rawName.replace('__ontology_label', '')
+  const sentenceCased = sansOntologyName[0].toUpperCase() + sansOntologyName.slice(1)
+  const spaced = sentenceCased.replace(/_/g, ' ')
+  let upId = spaced
+  if (spaced.slice(-3) === ' id') {
+    // e.g. Donor id -> Donor ID
+    upId = upId.slice(0, -3) + upId.slice(-3).toUpperCase()
+  }
+  let ynLess = upId
+  if (upId.slice('-3').toUpperCase() === ' YN') {
+    ynLess = ynLess.slice(0, -3)
+  }
+  const displayName = ynLess
+  return [displayName, rawName]
+}
+
+/** Toggle icon for collapsing a list; for each filter list, and all filter lists */
+export function FacetTools({
+  isCollapsed, whatToToggle,
+  isLoaded,
+  sortKey,
+  setSortKey,
+  facet=null,
+  isRoot=false, hasNondefaultSelection, handleResetFilters
+}) {
+  return (
+    <span className="facet-tools">
+      {!isLoaded &&
+      <span
+        {...tooltipAttrs}
+        data-original-title="Loading data..."
+        style={{ position: 'relative', top: '-5px', left: '-20px', cursor: 'default' }}
+      >
+        <LoadingSpinner height='14px'/>
+      </span>
+      }
+      {isLoaded && !isRoot && !isCollapsed && facet.type === 'group' &&
+      <SortFiltersIcon
+        facet={facet}
+        sortKey={sortKey}
+        setSortKey={setSortKey}
+      />
+      }
+      {isRoot &&
+        <ResetFiltersButton
+          hasNondefaultSelection={hasNondefaultSelection}
+          handleResetFilters={handleResetFilters}
+        />
+      }
+      <CollapseToggleChevron
+        isCollapsed={isCollapsed}
+        whatToToggle={whatToToggle}
+      />
+    </span>
+  )
+}
+
+/** Get stylized name of facet, optional tooltip, collapse controls */
+export function FacetHeader({
+  facet, selectionMap, handleCheckAllFiltersInFacet, handleResetFacet,
+  isFullyCollapsed, setIsFullyCollapsed,
+  sortKey, setSortKey
+}) {
+  const [facetName, rawFacetName] = parseAnnotationName(facet.annotation)
+  const isConventional = getIsConventionalAnnotation(rawFacetName)
+
+  const facetNameStyle = {}
+  const tooltipableFacetNameStyle = {
+    width: 'content-fit'
+  }
+
+  const loadingClass = !facet.isLoaded ? 'loading' : ''
+  if (!facet.isLoaded) {
+    facetNameStyle.color = '#777'
+    facetNameStyle.cursor = 'default'
+  }
+
+  let title = 'Author annotation'
+  if (isConventional) {
+    title = 'Conventional annotation'
+    const note = conventionalMetadataGlossary[rawFacetName]
+    if (note) {
+      title += `.  ${note}`
+    }
+  }
+  title += `.  Name in data: ${rawFacetName}`
+
+  const toggleClass = `cell-filters-${isFullyCollapsed ? 'hidden' : 'shown'}`
+
+  // Assess if facet-level checkbox should be indeterminate, i.e. "-",
+  // which is a common state in hierarchical checkboxes to indicate that
+  // some lower checkboxes are checked, and some are not.
+  const allFiltersInFacet = facet.groups
+  const allCheckedFiltersInFacet = selectionMap[facet.annotation]
+  const isFacetCheckboxSelected = allFiltersInFacet?.length === allCheckedFiltersInFacet?.length
+  const isIndeterminate = !(
+    allCheckedFiltersInFacet?.length === 0 ||
+    isFacetCheckboxSelected
+  )
+
+  let numericHasNondefaultSelection
+  if (facet.type === 'numeric') {
+    numericHasNondefaultSelection = getNumericHasNondefaultSelection(facet, selectionMap)
+  }
+
+  return (
+    <>
+      {facet.type === 'group' &&
+      <input
+        type="checkbox"
+        className="cell-facet-header-checkbox"
+        data-analytics-name={`facet-${facet.annotation}`}
+        name={`facet-${facet.annotation}`}
+        onChange={event => {
+          handleCheckAllFiltersInFacet(event)
+        }}
+        checked={isFacetCheckboxSelected}
+        ref={input => {
+          if (input) {
+            input.indeterminate = isIndeterminate
+          }
+        }}
+      />
+      }
+      {facet.type === 'numeric' &&
+        <a
+          onClick={() => {
+            handleResetFacet(facet.annotation)
+          }}
+          className="reset-facet"
+          data-toggle="tooltip"
+          data-original-title="Reset selection"
+          style={{ 'visibility': numericHasNondefaultSelection ? 'visible' : 'hidden' }}
+        >
+          <FontAwesomeIcon icon={faUndo}/>
+        </a>
+      }
+      <span
+        className={`cell-facet-header cell-facet-header-${facet.type} ${toggleClass}`}
+        onClick={event => {
+          const domClasses = Array.from(event.target.classList)
+          const parentDomClasses = Array.from(event.target.parentNode.classList)
+          if (
+            includesSortIconClass(domClasses) ||
+            domClasses.length === 0 && (
+              // Accounts for click on the sort icon SVG `path` element itself
+              includesSortIconClass(parentDomClasses)
+            )
+          ) {
+            // Don't toggle facet collapse on sort icon click
+            return
+          }
+          setIsFullyCollapsed(!isFullyCollapsed)
+        }}
+      >
+        <span className={`cell-facet-name ${loadingClass}`}>
+          <span
+            style={tooltipableFacetNameStyle}
+            data-original-title={title}
+            {...tooltipAttrs}
+          >
+            {facetName}
+          </span>
+        </span>
+        <FacetTools
+          sortKey={sortKey}
+          setSortKey={setSortKey}
+          isCollapsed={isFullyCollapsed}
+          whatToToggle="filter list"
+          facet={facet}
+          isLoaded={facet.isLoaded}
+        />
+      </span>
+    </>
+  )
+}

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -514,9 +514,22 @@ export function NumericCellFacet({
   const isLikelyAllIntegers = Number.isInteger(min) && Number.isInteger(max)
   const precision = isLikelyAllIntegers ? 0 : 2 // Round to integer, or 2 decimal places
 
+  /** Handler for the start of a brush event from D3 */
+  function handleBrushStart(event) {
+    const d3BrushSelection = event.selection
+    console.log('in handleBrushStart, d3BrushSelection', d3BrushSelection)
+    if (d3BrushSelection[0] === d3BrushSelection[1]) {
+      // Reset slider upon plain click (i.e., without drag) outside selection
+      moveBrush(sliderId, brush, min, max, xScale)
+    }
+  }
+
   /** Handler for the end of a brush event from D3 */
   function handleBrushEnd(event) {
     const d3BrushSelection = event.selection
+
+    if (d3BrushSelection === null) {return}
+
     const extent = d3BrushSelection.map(xScale.invert)
     const newValue1 = round(extent[0], precision)
     const newValue2 = round(extent[1], precision)
@@ -547,6 +560,7 @@ export function NumericCellFacet({
         [extentStartX, 0],
         [sliderWidth, svgHeight]
       ])
+      .on('start', handleBrushStart)
       .on('end', handleBrushEnd)
       .on('brush', event => {
         const d3BrushSelection = event.selection

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -14,6 +14,7 @@ function initBrush(brush, sliderId) {
   d3.select(`#${sliderId}`).append('g').attr('class', 'brush').call(brush)
 }
 
+/** Reset slider for this numeric cell facet */
 function clearBrush(sliderId, brush) {
   d3.select(`#${sliderId} .brush`).call(brush.move, null)
 }
@@ -21,7 +22,6 @@ function clearBrush(sliderId, brush) {
 /** Move D3 brush slider */
 function moveBrush(sliderId, brush, value1, value2, xScale) {
   const [px1, px2] = [value1, value2].map(xScale)
-  console.log('px1, px2, value1, value2', px1, px2, value1, value2)
   d3.select(`#${sliderId} .brush`).call(brush.move, [px1, px2])
 }
 
@@ -107,7 +107,6 @@ function getHistogramBars(filters) {
 /** SVG histogram showing distribution of numeric annotation values */
 function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight }) {
   useEffect(() => {
-    console.log('in Histogram useEffect')
     initBrush(brush, sliderId)
   },
   [filters.join(',')]
@@ -248,7 +247,6 @@ function NumericQueryBuilder({
   facet, operator, inputValue, inputValue2, includeNa, inputBorder, inputBorder2, hasNull,
   setOperator, updateInputValue, updateIncludeNa
 }) {
-  console.log(`in NumericQueryBuilder for ${ facet.annotation }, inputValue, inputValue2`, inputValue, inputValue2)
   return (
     <div>
       <OperatorMenu
@@ -409,7 +407,7 @@ export function NumericCellFacet({
 
   const sliderId = `numeric-filter-histogram-slider___${facet.annotation}`
 
-  console.log(`re-rendering NumericCellFacet for ${ facet.annotation}`)
+  // console.log(`re-rendering NumericCellFacet for ${ facet.annotation}`)
 
   useEffect(() => {
     const [rawOp, raw1, raw2, rawIncludeNa] = parseSelectionMap(facet, selectionMap)

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -331,7 +331,8 @@ function parseSelectionMap(facet, selectionMap) {
 /** Cell filter component for continuous numeric annotation dimension */
 export function NumericCellFacet({
   facet, filters, isChecked, selectionMap, handleNumericChange,
-  hasNondefaultSelection, handleResetFacet
+  hasNondefaultSelection, handleResetFacet,
+  isFullyCollapsed, setIsFullyCollapsed
 }) {
   const [rawOp, raw1, raw2, rawIncludeNa] = parseSelectionMap(facet, selectionMap)
   const [operator, setOperator] = useState(rawOp) // e.g. 'between'
@@ -422,6 +423,8 @@ export function NumericCellFacet({
       <FacetHeader
         facet={facet}
         selectionMap={selectionMap}
+        isFullyCollapsed={isFullyCollapsed}
+        setIsFullyCollapsed={setIsFullyCollapsed}
         handleResetFacet={handleResetFacet}
         clearBrush={clearBrush}
         sliderId={sliderId}

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -284,8 +284,9 @@ function NumericQueryBuilder({
 
 /** Get D3 scale to convert between numeric annotation values and pixels */
 function getXScale(bars, svgWidth, hasNull) {
-  const valueDomain = [1]
-  const pxRange = [1]
+  const firstBar = bars[hasNull ? 1 : 0]
+  const valueDomain = [firstBar.start]
+  const pxRange = [0]
   const barStartIndex = hasNull ? 1 : 0
   for (let i = barStartIndex; i < bars.length; i++) {
     const bar = bars[i]
@@ -378,12 +379,14 @@ export function NumericCellFacet({
 
   const [svgWidth, svgHeight] = getHistogramSvgDimensions(bars)
   const xScale = getXScale(bars, svgWidth, hasNull)
+  const barWidth = bars[0].width
+  const extentStartX = hasNull ? barWidth + 1 : 0
 
   const brush =
     d3
       .brushX()
       .extent([
-        [0, 0],
+        [extentStartX, 0],
         [svgWidth, svgHeight]
       ])
       .on('end', handleBrushEnd)

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -6,6 +6,7 @@ import { round } from '~/lib/metrics-perf'
 import { getMinMaxValues } from '~/lib/cell-faceting.js'
 
 const HISTOGRAM_BAR_MAX_HEIGHT = 20
+const SLIDER_HANDLEBAR_WIDTH = 6
 
 /**
  * Get SVG for handlebar UI, as an affordance for resizing
@@ -16,17 +17,18 @@ function handlebarPath(d) {
   const sweepFlag = d.type === 'e' ? 1 : 0
   const x = sweepFlag ? 1 : -1
   const y = HISTOGRAM_BAR_MAX_HEIGHT
+  const width = SLIDER_HANDLEBAR_WIDTH
 
   // Construct an SVG arc
   // Docs: https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#arcs
   const start = `M${ .5 * x },${ y}`
-  const rx = 6
-  const ry = 6
+  const rx = width
+  const ry = width
   const xAxisRotation = 0
   const largeArcFlag = 0
-  const arc1X = (6.5 * x)
+  const arc1X = ((width + 0.5) * x)
   const arc1Y = y + 6
-  const arc1EndLine = `V${ 2 * y - 6}`
+  const arc1EndLine = `V${ 2 * y - width}`
   const arc2X = 0.5 * x
   const arc2Y = 2 * y
   const arc1 = `A${rx},${ry} ${xAxisRotation} ${largeArcFlag} ${sweepFlag} ${arc1X},${arc1Y}`
@@ -35,10 +37,10 @@ function handlebarPath(d) {
   /* eslint-disable */
   // Each handlebar has two vertical lines in it, resembling notched grooves
   const notches = (
-    "M" + (2.5 * x) + "," + (y + 8) +
-    "V" + (2 * y - 8) +
-    "M" + (4.5 * x) + "," + (y + 8) +
-    "V" + (2 * y - 8)
+    "M" + (2.5 * x) + "," + (y + (width + 2)) +
+    "V" + (2 * y - (width + 2)) +
+    "M" + (4.5 * x) + "," + (y + (width + 2)) +
+    "V" + (2 * y - (width + 2))
   )
   /* eslint-enable */
 
@@ -236,7 +238,7 @@ function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight, operat
       {['between', 'not between'].includes(operator) &&
       <svg
         height={svgHeight}
-        width={svgWidth}
+        width={svgWidth + SLIDER_HANDLEBAR_WIDTH + 1}
         style={{ position: 'absolute', top: 0, left: 0 }}
         className="numeric-filter-histogram-slider"
         id={sliderId}
@@ -444,13 +446,13 @@ export function NumericCellFacet({
       setInputBorder2(rawIsNaN ? 'red' : null)
       setInputValue2(newDisplayValue)
       updateNumericFilter(operator, inputValue, newFilterValue, includeNa, facet, handleNumericChange)
-      moveBrush(sliderId, brush, resizeHandles, inputValue, newFilterValue, xScale)
+      moveBrush(sliderId, brush, inputValue, newFilterValue, xScale)
     } else {
       if (rawIsNaN) {newFilterValue = min}
       setInputBorder(rawIsNaN ? 'red' : null)
       setInputValue(newDisplayValue)
       updateNumericFilter(operator, newFilterValue, inputValue2, includeNa, facet, handleNumericChange)
-      moveBrush(sliderId, brush, resizeHandles, newFilterValue, inputValue2, xScale)
+      moveBrush(sliderId, brush, newFilterValue, inputValue2, xScale)
     }
   }
 

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -56,6 +56,19 @@ function handlebarPath(d) {
   /* eslint-enable */
 }
 
+/** Set slider to default pixel range, without updating numeric filter */
+function setFullSlider(sliderId, brush) {
+  // Get default full pixel domain for slider, e.g. [23, 179]
+  const brushDom = document.querySelector(`#${sliderId} .brush`)
+  const extent = brushDom.__brush.extent
+  const pxMin = extent[0][0]
+  const pxMax = extent[1][0]
+  const defaultPxDomain = [pxMin, pxMax]
+
+  const brushD3Node = d3.select(`#${sliderId} .brush`)
+  brushD3Node.call(brush.move, defaultPxDomain, 'skipUpdateNumericFilter')
+}
+
 /** Initialize D3 brush component, for draggable selections */
 function initBrush(brush, sliderId) {
   const brushDom = document.querySelector(`#${sliderId} .brush`)
@@ -71,11 +84,13 @@ function initBrush(brush, sliderId) {
     .attr('stroke-width', 0.5)
     .attr('cursor', 'ew-resize')
     .attr('d', handlebarPath)
+
+  setFullSlider(sliderId, brush)
 }
 
 /** Reset slider for this numeric cell facet */
 function clearBrush(sliderId, brush) {
-  d3.select(`#${sliderId} .brush`).call(brush.move, null)
+  setFullSlider(sliderId, brush)
 }
 
 /** Move D3 brush slider */
@@ -87,7 +102,6 @@ function moveBrush(sliderId, brush, value1, value2, xScale) {
 
 /** Handle move event, which is fired after brush.end */
 function handleBrushMoved(sliderId, d3BrushSelection) {
-  // console.log('in handleBrushMoved, d3BrushSelection', d3BrushSelection)
   d3.selectAll(`#${sliderId} .handlebar`)
     .attr('display', null)
     .attr('transform', (d, i) => {
@@ -498,7 +512,9 @@ export function NumericCellFacet({
     // setInputValue(newValue1)
     // setInputValue2(newValue2)
     handleBrushMoved(sliderId, d3BrushSelection)
-    updateNumericFilter(operator, newValue1, newValue2, includeNa, facet, handleNumericChange)
+    if (event.sourceEvent !== 'skipUpdateNumericFilter') {
+      updateNumericFilter(operator, newValue1, newValue2, includeNa, facet, handleNumericChange)
+    }
   }
 
   const [svgWidth, svgHeight] = getHistogramSvgDimensions(bars)

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -179,7 +179,7 @@ const operators = [
 ]
 
 /** Get options for numeric filter operators */
-function OperatorMenu({ operator, setOperator }) {
+function OperatorMenu({ operator, updateOperator }) {
   const widthsByOperator = {
     'between': 80,
     'not between': 100,
@@ -195,7 +195,7 @@ function OperatorMenu({ operator, setOperator }) {
     <select
       style={{ width: menuWidth }}
       value={operator}
-      onChange={event => {setOperator(event.target.value)}}
+      onChange={event => {updateOperator(event)}}
     >
       {operators.map((operator, i) => {
         return (
@@ -245,13 +245,13 @@ function updateNumericFilter(operator, inputValue, inputValue2, includeNa, facet
 /** Enables manual input of numbers, by which cells get filtered */
 function NumericQueryBuilder({
   facet, operator, inputValue, inputValue2, includeNa, inputBorder, inputBorder2, hasNull,
-  setOperator, updateInputValue, updateIncludeNa
+  updateOperator, updateInputValue, updateIncludeNa
 }) {
   return (
     <div>
       <OperatorMenu
         operator={operator}
-        setOperator={setOperator}
+        updateOperator={updateOperator}
       />
       <NumericQueryInput
         value={inputValue}
@@ -375,6 +375,13 @@ export function NumericCellFacet({
     }
   }
 
+  /** Propagate change in operator selected from menu locally and upstream */
+  function updateOperator(event) {
+    const newOperator = event.target.value
+    updateNumericFilter(newOperator, inputValue, inputValue2, includeNa, facet, handleNumericChange)
+    setOperator(newOperator)
+  }
+
   /** Propagate change in "N/A" checkbox locally and upstream */
   function updateIncludeNa() {
     setIncludeNa(!includeNa)
@@ -449,7 +456,7 @@ export function NumericCellFacet({
           inputBorder={inputBorder}
           inputBorder2={inputBorder2}
           hasNull={hasNull}
-          setOperator={setOperator}
+          updateOperator={updateOperator}
           updateInputValue={updateInputValue}
           updateIncludeNa={updateIncludeNa}
         />

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import * as d3 from 'd3'
 
 import { FacetHeader } from '~/components/explore/FacetComponents'
@@ -109,7 +109,7 @@ function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight, operat
   useEffect(() => {
     initBrush(brush, sliderId)
   },
-  [filters.join(',')]
+  [filters.join(','), operator]
   )
 
   return (
@@ -133,35 +133,36 @@ function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight, operat
           )
         })}
       </svg>
-      {
-      // This enables per-bar counts on hover, but doesn't yet work with slider
-      /* <div style={{ position: 'absolute', top: 0 }} key={2}>
-        {bars.map((bar, i) => {
-          let criteria
-          if (bar.start === null) {
-            criteria = 'N/A'
-          } else {
-            const briefStart = round(bar.start, 2)
-            const briefEnd = round(bar.end, 2)
-            criteria = `${briefStart}&nbsp;-&nbsp;${briefEnd}`
-          }
-          const tooltipContent = `<span>${criteria}:<br/>${bar.count}&nbsp;cells</span>`
+      {!['between', 'not between'].includes(operator) &&
+        <div style={{ position: 'absolute', top: 0 }} key={2}>
+          {bars.map((bar, i) => {
+            let criteria
+            if (bar.start === null) {
+              criteria = 'N/A'
+            } else {
+              const briefStart = round(bar.start, 2)
+              const briefEnd = round(bar.end, 2)
+              criteria = `${briefStart}&nbsp;-&nbsp;${briefEnd}`
+            }
+            const tooltipContent = `<span>${criteria}:<br/>${bar.count}&nbsp;cells</span>`
 
-          return (
-            <span
-              style={{
-                display: 'inline-block',
-                width: bar.width + 1,
-                height: HISTOGRAM_BAR_MAX_HEIGHT
-              }}
-              data-toggle="tooltip"
-              data-html={true}
-              data-original-title={tooltipContent}
-              key={i}
-            >
-            </span>
-          )
-        })} */}
+            return (
+              <span
+                style={{
+                  display: 'inline-block',
+                  width: bar.width + 1,
+                  height: HISTOGRAM_BAR_MAX_HEIGHT
+                }}
+                data-toggle="tooltip"
+                data-html={true}
+                data-original-title={tooltipContent}
+                key={i}
+              >
+              </span>
+            )
+          })}
+        </div>
+      }
       {['between', 'not between'].includes(operator) &&
       <svg
         height={svgHeight}
@@ -338,9 +339,8 @@ function parseSelection(selection) {
 
 /** Cell filter component for continuous numeric annotation dimension */
 export function NumericCellFacet({
-  facet, filters, isChecked, selectionMap, handleNumericChange,
-  hasNondefaultSelection, handleResetFacet,
-  isFullyCollapsed, setIsFullyCollapsed
+  facet, filters, selectionMap, handleNumericChange,
+  handleResetFacet, isFullyCollapsed, setIsFullyCollapsed
 }) {
   const selection = selectionMap[facet.annotation] // e.g. [['between', [20, 40]], true]
   const [rawOp, raw1, raw2, rawIncludeNa] = parseSelection(selection)
@@ -466,6 +466,7 @@ export function NumericCellFacet({
           brush={brush}
           svgWidth={svgWidth}
           svgHeight={svgHeight}
+          operator={operator}
         />
         <NumericQueryBuilder
           facet={facet}

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -133,7 +133,9 @@ function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight }) {
           )
         })}
       </svg>
-      <div style={{ position: 'absolute', top: 0 }} key={2}>
+      {
+      // This enables per-bar counts on hover, but doesn't yet work with slider
+      /* <div style={{ position: 'absolute', top: 0 }} key={2}>
         {bars.map((bar, i) => {
           let criteria
           if (bar.start === null) {
@@ -159,8 +161,7 @@ function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight }) {
             >
             </span>
           )
-        })}
-      </div>
+        })} */}
       <svg
         height={svgHeight}
         width={svgWidth}

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -413,12 +413,13 @@ function getXScale(bars, svgWidth, hasNull) {
   for (let i = barStartIndex; i < bars.length; i++) {
     const bar = bars[i]
     valueDomain.push(bar.start)
-    const x = bar.x + (hasNull ? 0 : SLIDER_HANDLEBAR_WIDTH + 1)
+    const x = bar.x + (hasNull ? 0 : SLIDER_HANDLEBAR_WIDTH + 2)
     pxRange.push(x)
   }
   const lastBar = bars.slice(-1)[0]
   valueDomain.push(lastBar.end)
-  pxRange.push(svgWidth + (hasNull ? 0 : SLIDER_HANDLEBAR_WIDTH + 1))
+  pxRange.push(svgWidth + (hasNull ? 0 : SLIDER_HANDLEBAR_WIDTH))
+
   const xScale = d3.scaleLinear().domain(valueDomain).range(pxRange)
   return xScale
 }

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import * as d3 from 'd3'
 import _isEqual from 'lodash/isEqual'
+import SVGBrush from 'react-svg-brush'
 
 import { FacetHeader } from '~/components/explore/FacetComponents'
 import { round } from '~/lib/metrics-perf'
@@ -183,13 +184,17 @@ function getHistogramBars(filters) {
   return bars
 }
 
-/** SVG histogram showing distribution of numeric annotation values */
-function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight, operator }) {
+/** Get `left` and `width` style properties for slider / brush */
+function getSliderStyle(bars, svgWidth) {
   const barWidth = bars[0].width
   const hasNull = bars[0].isNull
   const sliderLeft = hasNull ? 0 : -1 * (SLIDER_HANDLEBAR_WIDTH + 1)
   const sliderWidth = svgWidth + (hasNull ? barWidth : 2 * SLIDER_HANDLEBAR_WIDTH + 2)
+  return [sliderLeft, sliderWidth]
+}
 
+/** SVG histogram showing distribution of numeric annotation values */
+function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight, operator }) {
   return (
     <>
       <svg
@@ -241,7 +246,7 @@ function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight, operat
           })}
         </div>
       }
-      {['between', 'not between'].includes(operator) &&
+      {/* {['between', 'not between'].includes(operator) &&
       <svg
         height={svgHeight}
         width={sliderWidth}
@@ -249,7 +254,7 @@ function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight, operat
         className="numeric-filter-histogram-slider"
         id={sliderId}
       ></svg>
-      }
+      } */}
     </>
   )
 }
@@ -497,12 +502,12 @@ function getNumericHasNondefaultSelection(facet, selection) {
   const defaultSelection = facet.defaultSelection
   // const selection = selectionMap[facet.annotation]
   const numericHasNondefaultSelection = !_isEqual(selection.toString(), defaultSelection.toString())
-  if (facet.annotation.includes('time_post_partum')) {
-    console.log(
-      'facet, selection, ***, defaultSelection, ***, hasDefaultSelection',
-      facet.annotation, selection.toString(), '***', defaultSelection.toString(), '***', !numericHasNondefaultSelection
-    )
-  }
+  // if (facet.annotation.includes('time_post_partum')) {
+  //   console.log(
+  //     'facet, selection, ***, defaultSelection, ***, hasDefaultSelection',
+  //     facet.annotation, selection.toString(), '***', defaultSelection.toString(), '***', !numericHasNondefaultSelection
+  //   )
+  // }
   return numericHasNondefaultSelection
 }
 
@@ -511,12 +516,12 @@ export function NumericCellFacet({
   facet, filters, selection, selectionMap, handleNumericChange,
   isFullyCollapsed, setIsFullyCollapsed
 }) {
-  if (facet.annotation.includes('time_post_partum')) {
-    console.log(
-      'facet.annotation, selection.toString(), ***',
-      facet.annotation, selection.toString()
-    )
-  }
+  // if (facet.annotation.includes('time_post_partum')) {
+  //   console.log(
+  //     'facet.annotation, selection.toString(), ***',
+  //     facet.annotation, selection.toString()
+  //   )
+  // }
   // `selection` is e.g. [['between', [20, 40]], true]
   // const [rawOp, raw1, raw2, rawIncludeNa] = parseSelection(selection)
   const [operator, inputValue, inputValue2, includeNa] = parseSelection(selection)
@@ -531,7 +536,7 @@ export function NumericCellFacet({
 
   const bars = getHistogramBars(filters)
 
-  console.log('in NumericCellFacet, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
+  // console.log('in NumericCellFacet, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
 
   // Whether to include cells with "not available" (N/A, `null`) numeric value
   // const [includeNa, setIncludeNa] = useState(rawIncludeNa) // e.g. true
@@ -540,40 +545,40 @@ export function NumericCellFacet({
   const xScale = getXScale(bars, svgWidth, hasNull)
   const barWidth = bars[0].width
   const extentStartX = hasNull ? 2 * barWidth + 2 : SLIDER_HANDLEBAR_WIDTH + 2
-  const sliderWidth = hasNull ? svgWidth : svgWidth + SLIDER_HANDLEBAR_WIDTH
+  const extentWidth = hasNull ? svgWidth : svgWidth + SLIDER_HANDLEBAR_WIDTH
 
   const numericHasNondefaultSelection = getNumericHasNondefaultSelection(facet, selection)
 
-  /** get brush object */
-  function getBrushObj() {
-    console.log('in getBrushObj, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
-    return d3
-      .brushX()
-      .extent([
-        [extentStartX, 0],
-        [sliderWidth, svgHeight]
-      ])
-      .on('start', handleBrushStart)
-      .on('end', handleBrushEnd, 'foo')
-      .on('brush', event => {
-        handleBrushMoved(sliderId, event)
-      })
-  }
-  let brush = getBrushObj()
+  // /** get brush object */
+  // function getBrushObj() {
+  //   console.log('in getBrushObj, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
+  //   return d3
+  //     .brushX()
+  //     .extent([
+  //       [extentStartX, 0],
+  //       [extentWidth, svgHeight]
+  //     ])
+  //     .on('start', handleBrushStart)
+  //     .on('end', handleBrushEnd, 'foo')
+  //     .on('brush', event => {
+  //       handleBrushMoved(sliderId, event)
+  //     })
+  // }
+  // let brush = getBrushObj()
 
   const sliderId = `numeric-filter-histogram-slider___${facet.annotation}`
 
-  useEffect(() => {
-    initBrush(brush, sliderId)
-  },
-  [filters.join(','), operator, resetState]
-  )
+  // useEffect(() => {
+  //   initBrush(brush, sliderId)
+  // },
+  // [filters.join(','), operator, resetState]
+  // )
 
-  useEffect(() => {
-    // setSelectionMap(defaultSelectionMap)
-    console.log('in NumericCellFacet useEffect, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
-    brush = getBrushObj()
-  }, [Object.values(selectionMap).join(',')])
+  // useEffect(() => {
+  //   // setSelectionMap(defaultSelectionMap)
+  //   console.log('in NumericCellFacet useEffect, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
+  //   brush = getBrushObj()
+  // }, [Object.values(selectionMap).join(',')])
 
 
   /** Propagate change in numeric input locally and upstream */
@@ -647,9 +652,10 @@ export function NumericCellFacet({
   }
 
   /** Handler for the end of a brush event from D3 */
-  function handleBrushEnd(event, fooParam) {
-    const d3BrushSelection = event.selection
+  function handleBrushEnd(event) {
+    const d3BrushSelection = [event.selection[0][0], event.selection[1][0]]
 
+    console.log('in handleBrushEnd, d3BrushSelection', d3BrushSelection)
     // if (d3BrushSelection === null) {
     //   moveBrush(sliderId, brush, min, max, xScale)
     //   return
@@ -661,9 +667,9 @@ export function NumericCellFacet({
     // handleBrushMoved(sliderId, d3BrushSelection)
     // if (event.sourceEvent !== 'skipUpdateNumericFilter') {
     // debugger
-    console.log('days fooParam', fooParam)
-    console.log('in handleBrushEnd, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
-    console.log('in handleBrushEnd, newValue1, newValue2', newValue1, newValue2)
+    // console.log('days fooParam', fooParam)
+    // console.log('in handleBrushEnd, selectionMap["time_post_partum_days--numeric--study"].toString()', selectionMap['time_post_partum_days--numeric--study'].toString())
+    // console.log('in handleBrushEnd, newValue1, newValue2', newValue1, newValue2)
     updateNumericFilter(operator, newValue1, newValue2, includeNa, facet, handleNumericChange)
 
     // }
@@ -690,10 +696,11 @@ export function NumericCellFacet({
 
   /** Handle move event, which is fired after brush.end */
   function handleBrushMoved(
-    sliderId, event
+    event
   ) {
     const d3BrushSelection = event.selection
     if (!d3BrushSelection) {return}
+    console.log('d3BrushSelection', d3BrushSelection)
 
     if (d3BrushSelection[0] === d3BrushSelection[1]) {
     // Hide handlebars on slide-start mousedown
@@ -734,6 +741,9 @@ export function NumericCellFacet({
     moveBrush(sliderId, brush, def1, def2, xScale, 'skipUpdateNumericFilter')
   }
 
+  const [sliderLeft, sliderWidth] = getSliderStyle(bars, svgWidth)
+
+
   return (
     <>
       <FacetHeader
@@ -753,11 +763,49 @@ export function NumericCellFacet({
           sliderId={sliderId}
           filters={filters}
           bars={bars}
-          brush={brush}
+          // brush={brush}
           svgWidth={svgWidth}
           svgHeight={svgHeight}
           operator={operator}
         />
+        <svg
+          height={svgHeight}
+          width={sliderWidth}
+          style={{ position: 'absolute', top: 0, left: sliderLeft }}
+          className="numeric-filter-histogram-slider"
+          id={sliderId}
+        >
+          <SVGBrush
+          //      .brushX()
+          // .extent([
+          //   [extentStartX, 0],
+          //   [sliderWidth, svgHeight]
+          // ])
+          // .on('start', handleBrushStart)
+          // .on('end', handleBrushEnd, 'foo')
+          // .on('brush', event => {
+          //   handleBrushMoved(sliderId, event)
+          // })
+          // Defines the boundary of the brush.
+          // Strictly uses the format [[x0, y0], [x1, y1]] for both 1d and 2d brush.
+          // Note: d3 allows the format [x, y] for 1d brush.
+            extent={[
+              [extentStartX, 0],
+              [sliderWidth, svgHeight]
+            ]}
+            // Obtain mouse positions relative to the current svg during mouse events.
+            // By default, getEventMouse returns [event.clientX, event.clientY]
+            getEventMouse={event => {
+              const { clientX, clientY } = event
+              const { left, top } = document.querySelector(`#${sliderId}`).getBoundingClientRect()
+              return [clientX - left, clientY - top]
+            }}
+            brushType="x"
+            // onBrushStart={handleBrushStart}
+            // onBrush={handleBrushMoved}
+            onBrushEnd={handleBrushEnd}
+          />
+        </svg>
         <NumericQueryBuilder
           facet={facet}
           operator={operator}

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -425,6 +425,9 @@ export function NumericCellFacet({
         facet={facet}
         selectionMap={selectionMap}
         handleResetFacet={handleResetFacet}
+        clearBrush={clearBrush}
+        sliderId={sliderId}
+        brush={brush}
       />
       <div style={{ marginLeft: 20, position: 'relative' }}>
         <Histogram

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -16,6 +16,7 @@ function initBrush(brush, sliderId) {
 /** Move D3 brush slider */
 function moveBrush(sliderId, brush, value1, value2, xScale) {
   const [px1, px2] = [value1, value2].map(xScale)
+  console.log('px1, px2, value1, value2', px1, px2, value1, value2)
   d3.select(`#${sliderId} .brush`).call(brush.move, [px1, px2])
 }
 
@@ -203,6 +204,7 @@ function OperatorMenu({ operator, setOperator }) {
 
 /** A visually economical input field for numeric query builder */
 function NumericQueryInput({ value, border, updateInputValue, facet, filterName }) {
+  // Visually indicate that more digits are specified than are shown
   const fadeOverflowClass = value >= 100_000 ? 'fade-overflow' : ''
 
   const style = border ? { border: `1px solid ${border}` } : {}
@@ -224,7 +226,7 @@ function NumericQueryInput({ value, border, updateInputValue, facet, filterName 
   )
 }
 
-/** Assembly and propagate numeric cell filter change */
+/** Assemble and propagate numeric cell filter change */
 function updateNumericFilter(operator, inputValue, inputValue2, includeNa, facet, handleNumericChange) {
   let value
   if (['between', 'not between'].includes(operator)) {
@@ -284,10 +286,10 @@ function NumericQueryBuilder({
 
 /** Get D3 scale to convert between numeric annotation values and pixels */
 function getXScale(bars, svgWidth, hasNull) {
-  const firstBar = bars[hasNull ? 1 : 0]
+  const barStartIndex = hasNull ? 1 : 0
+  const firstBar = bars[barStartIndex]
   const valueDomain = [firstBar.start]
   const pxRange = [0]
-  const barStartIndex = hasNull ? 1 : 0
   for (let i = barStartIndex; i < bars.length; i++) {
     const bar = bars[i]
     valueDomain.push(bar.start)
@@ -367,13 +369,11 @@ export function NumericCellFacet({
   /** Handler for the end of a brush event from D3 */
   function handleBrushEnd(event) {
     const selection = event.selection
-    // console.log('selection', selection)
     const extent = selection.map(xScale.invert)
-    console.log('in handleBrushEnd, extent', extent)
     const newValue1 = round(extent[0], 2)
     const newValue2 = round(extent[1], 2)
-    if (newValue1 !== inputValue) {setInputValue(newValue1)}
-    if (newValue2 !== inputValue2) {setInputValue2(newValue2)}
+    setInputValue(newValue1)
+    setInputValue2(newValue2)
     updateNumericFilter(operator, newValue1, newValue2, includeNa, facet, handleNumericChange)
   }
 

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -56,10 +56,11 @@ function handlebarPath(d) {
   /* eslint-enable */
 }
 
-/** Set slider to default pixel range, without updating numeric filter */
+/** Set slider to default pixel range, without duplicative filter update */
 function setFullSlider(sliderId, brush) {
   // Get default full pixel domain for slider, e.g. [23, 179]
   const brushDom = document.querySelector(`#${sliderId} .brush`)
+  if (!brushDom) {return}
   const extent = brushDom.__brush.extent
   const pxMin = extent[0][0]
   const pxMax = extent[1][0]
@@ -102,6 +103,7 @@ function moveBrush(sliderId, brush, value1, value2, xScale) {
 
 /** Handle move event, which is fired after brush.end */
 function handleBrushMoved(sliderId, d3BrushSelection) {
+  if (!d3BrushSelection) {return}
   d3.selectAll(`#${sliderId} .handlebar`)
     .attr('display', null)
     .attr('transform', (d, i) => {
@@ -202,8 +204,8 @@ function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight, operat
 
   const barWidth = bars[0].width
   const hasNull = bars[0].isNull
-  const sliderLeft = hasNull ? barWidth : 0
-  const sliderWidth = svgWidth + sliderLeft + 1
+  const sliderLeft = hasNull ? barWidth : 1
+  const sliderWidth = svgWidth + sliderLeft
 
   return (
     <>
@@ -520,7 +522,7 @@ export function NumericCellFacet({
   const [svgWidth, svgHeight] = getHistogramSvgDimensions(bars)
   const xScale = getXScale(bars, svgWidth, hasNull)
   const barWidth = bars[0].width
-  const extentStartX = hasNull ? 2 * barWidth + 1 : 0
+  const extentStartX = hasNull ? 2 * barWidth + 2 : 0
 
   const brush =
     d3

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -5,16 +5,16 @@ import { round } from '~/lib/metrics-perf'
 import { getMinMaxValues } from '~/lib/cell-faceting.js'
 
 /** Initialize D3 brush component, for draggable selections */
-function initBrush(svgRef, width, height) {
-  console.log('in initBrush, svgRef', svgRef)
+function initBrush(sliderId, width, height) {
+  // console.log('in initBrush, svgRef', svgRef)
 
   /** Handler for the end of a brush event from D3 */
   function brushEnded(event) {
-    const s = event.selection
+    const selection = event.selection
     // Consume the brush action
-    if (s) {
-      d3.select('.brush').call(brush.move, null)
-    }
+    // if (selection) {
+    //   d3.select('.brush').call(brush.move, null)
+    // }
   }
 
   /** Create a brush for selecting regions to zoom on */
@@ -28,7 +28,7 @@ function initBrush(svgRef, width, height) {
       .on('end', brushEnded)
 
   // Zoom brush
-  d3.select(svgRef.current).append('g').attr('class', 'brush').call(brush)
+  d3.select(`#${sliderId}`).append('g').attr('class', 'brush').call(brush)
 
   console.log('exit initBrush')
 }
@@ -92,9 +92,7 @@ function getHistogramBars(filters) {
 }
 
 /** SVG histogram showing distribution of numeric annotation values */
-function Histogram({ filters }) {
-  const svgRef = useRef(null)
-
+function Histogram({ facet, filters }) {
   const maxHeight = 20
 
   const [bars, maxValue, maxCount, minValue] = getHistogramBars(filters)
@@ -118,10 +116,12 @@ function Histogram({ filters }) {
   const svgHeight = maxHeight + 2
   const svgWidth = lastBar.x + lastBar.width
 
+  const sliderId = `numeric-filter-histogram-slider___${facet.annotation}`
+
 
   useEffect(() => {
     console.log('in Histogram useEffect')
-    initBrush(svgRef, svgWidth, svgHeight)
+    initBrush(sliderId, svgWidth, svgHeight)
   },
   [filters.join(',')]
   )
@@ -133,7 +133,6 @@ function Histogram({ filters }) {
         width={svgWidth}
         style={{ borderBottom: '1px solid #AAA  ' }}
         className="numeric-filter-histogram"
-        ref={svgRef}
       >
         {barRectAttrs.map((attrs, i) => {
           return (
@@ -177,6 +176,13 @@ function Histogram({ filters }) {
           )
         })}
       </div>
+      <svg
+        height={svgHeight}
+        width={svgWidth}
+        style={{ position: 'absolute', top: 0, left: 0 }}
+        className="numeric-filter-histogram-slider"
+        id={sliderId}
+      ></svg>
     </>
   )
 }
@@ -293,6 +299,7 @@ function NumericQueryBuilder({ selectionMap, filters, handleNumericChange, facet
     }
   }
 
+
   /** Propagate change in "N/A" checkbox locally and upstream */
   function updateIncludeNa() {
     setIncludeNa(!includeNa)
@@ -347,7 +354,7 @@ export function NumericCellFacet({
 }) {
   return (
     <div style={{ marginLeft: 20, position: 'relative' }}>
-      <Histogram filters={filters} />
+      <Histogram facet={facet} filters={filters} />
       <NumericQueryBuilder
         selectionMap={selectionMap}
         filters={filters}

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -382,7 +382,7 @@ function NumericQueryBuilder({
         filterName="value"
       />
       {['between', 'not between'].includes(operator) &&
-      <span>
+      <>
         <span style={{ marginLeft: '4px' }}>and</span>
         <NumericQueryInput
           value={inputValue2}
@@ -392,7 +392,7 @@ function NumericQueryBuilder({
           style={inputStyle2}
           filterName="value2"
         />
-      </span>
+      </>
       }
       {hasNull &&
       <div>
@@ -523,16 +523,18 @@ export function NumericCellFacet({
   /**
    * Get width and font size for input, to help keep full value glanceable
    */
-  function getInputStyle(inputValue, precision) {
-    let width = 45
+  function getInputStyle(inputValue, operator, precision) {
+    let width = 35
     let fontSize = 13
 
-    const roundedNumber = round(parseFloat(inputValue), precision)
-    const numDigits = getNumDigits(roundedNumber)
+    const roundedNumber = round(inputValue, precision)
+    const stringValue = roundedNumber.toString()
+    let numDigits = getNumDigits(stringValue)
+    if (stringValue.includes('.')) {numDigits -= 0.75}
 
-    if (numDigits > 5) {
-      fontSize = 12
-      width += 5.25 * (numDigits - 5)
+    if (numDigits > 3) {
+      if (numDigits > 5) {fontSize = 12}
+      width += 5.75 * (numDigits - 3)
     }
 
     const style = {
@@ -635,12 +637,8 @@ export function NumericCellFacet({
 
   // console.log(`re-rendering NumericCellFacet for ${ facet.annotation}`)
 
-  let inputStyle = {}
-  let inputStyle2 = {}
-  if (operator === 'between') {
-    inputStyle = getInputStyle(inputValue, precision)
-    inputStyle2 = getInputStyle(inputValue2, precision)
-  }
+  const inputStyle = getInputStyle(inputValue, operator, precision)
+  const inputStyle2 = getInputStyle(inputValue2, operator, precision)
 
   useEffect(() => {
     const selection = selectionMap[facet.annotation]

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -33,6 +33,10 @@ function initBrush(sliderId, width, height) {
   console.log('exit initBrush')
 }
 
+function moveBrush(sliderId, value1, value2) {
+  d3.select(`#${sliderId} .brush`).call(brush.move, null)
+}
+
 /** Get histogram to show with numeric filter */
 function getHistogramBars(filters) {
   const [minValue, maxValue, hasNull] = getMinMaxValues(filters)
@@ -257,7 +261,65 @@ function updateNumericFilter(operator, inputValue, inputValue2, includeNa, facet
 }
 
 /** Enables manual input of numbers, by which cells get filtered */
-function NumericQueryBuilder({ selectionMap, filters, handleNumericChange, facet }) {
+function NumericQueryBuilder({
+  facet, operator, inputValue, inputValue2, includeNa, inputBorder, inputBorder2, hasNull,
+  setOperator, updateInputValue, updateIncludeNa
+}) {
+  return (
+    <div>
+      <OperatorMenu
+        operator={operator}
+        setOperator={setOperator}
+      />
+      <NumericQueryInput
+        value={inputValue}
+        border={inputBorder}
+        updateInputValue={updateInputValue}
+        facet={facet}
+        filterName="value"
+      />
+      {['between', 'not between'].includes(operator) &&
+      <span>
+        <span style={{ marginLeft: '4px' }}>and</span>
+        <NumericQueryInput
+          value={inputValue2}
+          border={inputBorder2}
+          updateInputValue={updateInputValue}
+          facet={facet}
+          filterName="value2"
+        />
+      </span>
+      }
+      {hasNull &&
+      <div>
+        <label style={{ fontWeight: 'normal' }}>
+          <input
+            type="checkbox"
+            className="na-filter"
+            checked={includeNa}
+            onChange={updateIncludeNa}
+            style={{ marginRight: '5px' }}
+          />N/A</label>
+      </div>
+      }
+    </div>
+  )
+}
+
+/** Cell filter component for continuous numeric annotation dimension */
+export function NumericCellFacet({
+  facet, filters, isChecked, selectionMap, handleNumericChange,
+  hasNondefaultSelection
+}) {
+  // const brush =
+  //   d3
+  //     .brushX()
+  //     .extent([
+  //       [0, 0],
+  //       [width, height]
+  //     ])
+  //     .on('end', brushEnded)
+
   // E.g. [['between', [20, 40]], true]
   // or more generally: [[<operator>, [<inputValue>, <inputValue2>]], <includeNa>]
   const facetSelection = selectionMap[facet.annotation]
@@ -307,59 +369,20 @@ function NumericQueryBuilder({ selectionMap, filters, handleNumericChange, facet
   }
 
   return (
-    <div>
-      <OperatorMenu
-        operator={operator}
-        setOperator={setOperator}
-      />
-      <NumericQueryInput
-        value={inputValue}
-        border={inputBorder}
-        updateInputValue={updateInputValue}
-        facet={facet}
-        filterName="value"
-      />
-      {['between', 'not between'].includes(operator) &&
-      <span>
-        <span style={{ marginLeft: '4px' }}>and</span>
-        <NumericQueryInput
-          value={inputValue2}
-          border={inputBorder2}
-          updateInputValue={updateInputValue}
-          facet={facet}
-          filterName="value2"
-        />
-      </span>
-      }
-      {hasNull &&
-      <div>
-        <label style={{ fontWeight: 'normal' }}>
-          <input
-            type="checkbox"
-            className="na-filter"
-            checked={includeNa}
-            onChange={updateIncludeNa}
-            style={{ marginRight: '5px' }}
-          />N/A</label>
-      </div>
-      }
-    </div>
-  )
-}
-
-/** Cell filter component for continuous numeric annotation dimension */
-export function NumericCellFacet({
-  facet, filters, isChecked, selectionMap, handleNumericChange,
-  hasNondefaultSelection
-}) {
-  return (
     <div style={{ marginLeft: 20, position: 'relative' }}>
       <Histogram facet={facet} filters={filters} />
       <NumericQueryBuilder
-        selectionMap={selectionMap}
-        filters={filters}
-        handleNumericChange={handleNumericChange}
         facet={facet}
+        operator={operator}
+        inputValue={inputValue}
+        inputValue2={inputValue2}
+        includeNa={includeNa}
+        inputBorder={inputBorder}
+        inputBorder2={inputBorder2}
+        hasNull={hasNull}
+        setOperator={setOperator}
+        updateInputValue={updateInputValue}
+        updateIncludeNa={updateIncludeNa}
       />
     </div>
   )

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -546,7 +546,7 @@ function get1DBrushSelection(brushEvent) {
 
 /** Return whether value or not a number, roughly */
 function isRoughNaN(value) {
-  return isNaN(value) || value === '' || value === ' '
+  return isNaN(value) || value === ' '
 }
 
 /** Cell filter component for continuous numeric annotation dimension */
@@ -586,8 +586,8 @@ export function NumericCellFacet({
 
 
   useEffect(() => {
-    setInputValue(raw1)
-    setInputValue2(raw2)
+    if (raw1 !== '') {setInputValue(raw1)}
+    if (raw2 !== '') {setInputValue2(raw2)}
   }, [selection.toString()])
 
   /** Propagate manual changes to numeric input UI fields */
@@ -597,7 +597,7 @@ export function NumericCellFacet({
     const newDisplayValue = rawValue
 
     const rawIsNaN = isRoughNaN(rawValue)
-    if (!rawIsNaN) {
+    if (!rawIsNaN && rawValue !== '') {
       newFilterValue = parseFloat(rawValue)
     }
 
@@ -606,16 +606,18 @@ export function NumericCellFacet({
     if (isValue2) {
       if (rawIsNaN) {newFilterValue = max}
       setInputValue2(newDisplayValue)
-      if (newFilterValue < max || newFilterValue > max) {
-        setInputBorder2('orange')
-      } else {
-        setInputBorder2(rawIsNaN ? 'red' : null)
-        updateNumericFilter(operator, inputValue, newFilterValue, includeNa, facet, handleNumericChange)
+      if (rawValue !== '') {
+        if (newFilterValue < min || newFilterValue > max) {
+          setInputBorder2('orange')
+        } else {
+          setInputBorder2(rawIsNaN ? 'red' : null)
+          updateNumericFilter(operator, inputValue, newFilterValue, includeNa, facet, handleNumericChange)
+        }
       }
     } else {
       if (rawIsNaN) {newFilterValue = min}
-      setInputValue(newDisplayValue)
-      if (newFilterValue < max || newFilterValue > max) {
+      if (rawValue !== '') {setInputValue(newDisplayValue)}
+      if (newFilterValue < min || newFilterValue > max) {
         setInputBorder('orange')
       } else {
         setInputBorder(rawIsNaN ? 'red' : null)

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import * as d3 from 'd3'
+import { scaleLinear } from 'd3-scale'
 import _isEqual from 'lodash/isEqual'
 import SVGBrush from 'react-svg-brush'
 
@@ -346,7 +346,7 @@ function getXScale(bars, svgWidth, hasNull) {
   valueDomain.push(lastBar.end)
   pxRange.push(svgWidth + (hasNull ? 0 : SLIDER_HANDLEBAR_WIDTH))
 
-  const xScale = d3.scaleLinear().domain(valueDomain).range(pxRange)
+  const xScale = scaleLinear().domain(valueDomain).range(pxRange)
   return xScale
 }
 

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -367,13 +367,7 @@ function NumericQueryBuilder({
   precision,
   updateOperator, updateInputValue, updateIncludeNa
 }) {
-  const inputStyle = getInputStyle(inputValue, operator, precision)
-  const inputStyle2 = getInputStyle(inputValue2, operator, precision)
-  const andStyle = { marginLeft: '4px' }
-  if (inputStyle.isLargest && inputStyle2.isLargest) {
-    andStyle.marginLeft = '3px'
-    andStyle.marginRight = '-1px'
-  }
+  const styles = getResponsiveStyles(inputValue, inputValue2, operator, precision)
 
   return (
     <div className="cell-facet-numeric-query-builder">
@@ -386,18 +380,18 @@ function NumericQueryBuilder({
         border={inputBorder}
         updateInputValue={updateInputValue}
         facet={facet}
-        style={inputStyle}
+        style={styles.input}
         filterName="value"
       />
       {['between', 'not between'].includes(operator) &&
       <>
-        <span style={andStyle}>and</span>
+        <span style={styles.and}>and</span>
         <NumericQueryInput
           value={inputValue2}
           border={inputBorder2}
           updateInputValue={updateInputValue}
           facet={facet}
-          style={inputStyle2}
+          style={styles.input2}
           filterName="value2"
         />
       </>
@@ -465,7 +459,6 @@ function getInputStyle(inputValue, operator, precision) {
   const stringValue = roundedNumber.toString()
   let numDigits = getNumDigits(stringValue)
   if (stringValue.includes('.')) {numDigits -= 0.75}
-  let isLargest = false
 
   if (
     numDigits > 4 &&
@@ -476,16 +469,34 @@ function getInputStyle(inputValue, operator, precision) {
   } else if (numDigits > 7) {
     fontSize = 11
     width += 5.5 * (numDigits - 4)
-    isLargest = true
   }
 
   const style = {
     width: `${width}px`,
     fontSize: `${fontSize}px`,
-    isLargest // Not a standard style, but a helpful prop
+    numDigits // Not a standard style, but a helpful prop
   }
 
   return style
+}
+
+/** Make big input numbers fit on one more more often */
+function getResponsiveStyles(inputValue, inputValue2, operator, precision) {
+  const inputStyle = getInputStyle(inputValue, operator, precision)
+  const inputStyle2 = getInputStyle(inputValue2, operator, precision)
+  const andStyle = { marginLeft: '4px' }
+  const totalDigits = inputStyle.numDigits + inputStyle2.numDigits
+  if (totalDigits > 14) {
+    andStyle.marginLeft = '2px'
+    andStyle.marginRight = '-2px'
+    if (totalDigits > 16) {andStyle.fontSize = 11.5}
+  }
+  const styles = {
+    input: inputStyle,
+    input2: inputStyle2,
+    and: andStyle
+  }
+  return styles
 }
 
 /**
@@ -661,6 +672,7 @@ export function NumericCellFacet({
     setInputValue(raw1)
     setInputValue2(raw2)
     setIncludeNa(rawIncludeNa)
+    moveBrush(sliderId, brush, raw1, raw2, xScale, 'skipUpdateNumericFilter')
   }, [Object.values(selectionMap).join(',')])
 
   return (

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -395,11 +395,12 @@ function getXScale(bars, svgWidth, hasNull) {
   for (let i = barStartIndex; i < bars.length; i++) {
     const bar = bars[i]
     valueDomain.push(bar.start)
-    pxRange.push(bar.x)
+    const x = bar.x + (hasNull ? 0 : SLIDER_HANDLEBAR_WIDTH + 1)
+    pxRange.push(x)
   }
   const lastBar = bars.slice(-1)[0]
   valueDomain.push(lastBar.end)
-  pxRange.push(svgWidth)
+  pxRange.push(svgWidth + (hasNull ? 0 : SLIDER_HANDLEBAR_WIDTH + 1))
   const xScale = d3.scaleLinear().domain(valueDomain).range(pxRange)
   return xScale
 }

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -407,12 +407,15 @@ export function NumericCellFacet({
     updateNumericFilter(operator, inputValue, inputValue2, !includeNa, facet, handleNumericChange)
   }
 
+  const isLikelyAllIntegers = Number.isInteger(min) && Number.isInteger(max)
+  const precision = isLikelyAllIntegers ? 0 : 2 // Round to integer, or 2 decimal places
+
   /** Handler for the end of a brush event from D3 */
   function handleBrushEnd(event) {
     const selection = event.selection
     const extent = selection.map(xScale.invert)
-    const newValue1 = round(extent[0], 2)
-    const newValue2 = round(extent[1], 2)
+    const newValue1 = round(extent[0], precision)
+    const newValue2 = round(extent[1], precision)
     // setInputValue(newValue1)
     // setInputValue2(newValue2)
     updateNumericFilter(operator, newValue1, newValue2, includeNa, facet, handleNumericChange)

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -350,15 +350,16 @@ function NumericQueryBuilder({
         operator={operator}
         updateOperator={updateOperator}
       />
-      <NumericQueryInput
-        value={inputValue}
-        border={inputBorder}
-        updateInputValue={updateInputValue}
-        facet={facet}
-        style={styles.input}
-        filterName="value"
-      />
-      {['between', 'not between'].includes(operator) &&
+      <div className="cell-facet-numeric-inputs-container">
+        <NumericQueryInput
+          value={inputValue}
+          border={inputBorder}
+          updateInputValue={updateInputValue}
+          facet={facet}
+          style={styles.input}
+          filterName="value"
+        />
+        {['between', 'not between'].includes(operator) &&
       <>
         <span style={styles.and}>and</span>
         <NumericQueryInput
@@ -370,7 +371,8 @@ function NumericQueryBuilder({
           filterName="value2"
         />
       </>
-      }
+        }
+      </div>
       {hasNull &&
       <div>
         <label className="cell-filter-label" style={{ fontWeight: 'normal' }}>

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -607,7 +607,6 @@ export function NumericCellFacet({
       } else {
         setInputBorder2(rawIsNaN ? 'red' : null)
         updateNumericFilter(operator, inputValue, newFilterValue, includeNa, facet, handleNumericChange)
-        moveBrush(sliderId, brush, inputValue, newFilterValue, xScale, 'skipUpdateNumericFilter')
       }
     } else {
       if (rawIsNaN) {newFilterValue = min}
@@ -617,7 +616,6 @@ export function NumericCellFacet({
       } else {
         setInputBorder(rawIsNaN ? 'red' : null)
         updateNumericFilter(operator, newFilterValue, inputValue2, includeNa, facet, handleNumericChange)
-        moveBrush(sliderId, brush, newFilterValue, inputValue2, xScale, 'skipUpdateNumericFilter')
       }
     }
   }
@@ -670,6 +668,8 @@ export function NumericCellFacet({
     const [newValue1, newValue2] =
       parseValuesFromBrushSelection(brushSelection, xScale, precision)
 
+    console.log('in handleBrushEnd, newValue1, newValue2', newValue1, newValue2)
+
     if (event.sourceEvent !== 'skipUpdateNumericFilter') {
       updateNumericFilter(operator, newValue1, newValue2, includeNa, facet, handleNumericChange)
     }
@@ -695,10 +695,9 @@ export function NumericCellFacet({
   // }, [selection.toString()])
 
   /** Handle move event, which is fired after brush.end */
-  function handleBrushMoved(event) {
+  function handleBrushMove(event) {
     const brushSelection = get1DBrushSelection(event)
     if (!brushSelection) {return}
-    console.log('handleBrushMoved, brushSelection', brushSelection)
 
     // if (brushSelection[0] === brushSelection[1]) {
     // // Hide handlebars on slide-start mousedown
@@ -706,18 +705,8 @@ export function NumericCellFacet({
     //   return
     // }
 
-    // d3.selectAll(`#${sliderId} .handlebar`)
-    //   .attr('display', null)
-    //   .attr('transform', (d, i) => {
-    //     const handlebarX = brushSelection[i]
-    //     const handlebarY = -1 * (HISTOGRAM_BAR_MAX_HEIGHT - 1)
-    //     return `translate(${ handlebarX }, ${handlebarY})`
-    //   })
-
     if (setBrushSelection) {
       // Update inputs but not filter while moving slider
-      // const [newValue1, newValue2] =
-      //   parseValuesFromBrushSelection(brushSelection, xScale, precision)
 
       setBrushSelection(brushSelection)
     }
@@ -744,13 +733,16 @@ export function NumericCellFacet({
     // brush = getBrushObj()
     // setResetState(!resetState)
     updateNumericFilter(defOp, def1, def2, defIncludeNa, facet, handleNumericChange)
-    moveBrush(sliderId, brush, def1, def2, xScale, 'skipUpdateNumericFilter')
+    // moveBrush(sliderId, brush, def1, def2, xScale, 'skipUpdateNumericFilter')
   }
 
   const [sliderLeft, sliderWidth] = getSliderStyle(bars, svgWidth)
 
+  useEffect(() => {
+    setBrushSelection([inputValue, inputValue2].map(xScale))
+  }, [inputValue, inputValue2])
+
   const [brushSelection, setBrushSelection] = useState([inputValue, inputValue2].map(xScale))
-  console.log('brushSelection A', brushSelection)
 
   const handlebarY = -1 * (HISTOGRAM_BAR_MAX_HEIGHT - 1)
 
@@ -796,6 +788,16 @@ export function NumericCellFacet({
               d={getHandlebarPath({ type: 'w' })}
               transform={`translate(${ brushSelection[0] }, ${handlebarY})`}
             />
+            <path
+              className="handlebar"
+              fill="#EEE"
+              fillOpacity="0.8"
+              stroke="#000"
+              strokeWidth="0.5"
+              cursor="ew-resize"
+              d={getHandlebarPath({ type: 'e' })}
+              transform={`translate(${ brushSelection[1] }, ${handlebarY})`}
+            />
             <SVGBrush
             // Defines the boundary of the brush.
             // Strictly uses the format [[x0, y0], [x1, y1]] for both 1d and 2d brush.
@@ -817,18 +819,8 @@ export function NumericCellFacet({
               }}
               brushType="x"
               // onBrushStart={handleBrushStart}
-              onBrush={handleBrushMoved}
+              onBrush={handleBrushMove}
               onBrushEnd={handleBrushEnd}
-            />
-            <path
-              className="handlebar"
-              fill="#EEE"
-              fillOpacity="0.8"
-              stroke="#000"
-              strokeWidth="0.5"
-              cursor="ew-resize"
-              d={getHandlebarPath({ type: 'e' })}
-              transform={`translate(${ brushSelection[1] }, ${handlebarY})`}
             />
           </svg>
         </div>

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -278,10 +278,10 @@ function NumericQueryBuilder({
       }
       {hasNull &&
       <div>
-        <label style={{ fontWeight: 'normal' }}>
+        <label className="cell-filter-label" style={{ fontWeight: 'normal' }}>
           <input
             type="checkbox"
-            className="na-filter"
+            className="numeric-na-filter"
             checked={includeNa}
             onChange={updateIncludeNa}
             style={{ marginRight: '5px' }}

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -85,7 +85,7 @@ function moveBrush(sliderId, brush, value1, value2, xScale) {
 
 /** Handle move event, which is fired after brush.end */
 function handleBrushMoved(sliderId, d3BrushSelection) {
-  console.log('in handleBrushMoved, d3BrushSelection', d3BrushSelection)
+  // console.log('in handleBrushMoved, d3BrushSelection', d3BrushSelection)
   d3.selectAll(`#${sliderId} .handlebar`)
     .attr('display', null)
     .attr('transform', (d, i) => {
@@ -505,6 +505,10 @@ export function NumericCellFacet({
         [svgWidth, svgHeight]
       ])
       .on('end', handleBrushEnd)
+      .on('brush', event => {
+        const d3BrushSelection = event.selection
+        handleBrushMoved(sliderId, d3BrushSelection)
+      })
 
   const sliderId = `numeric-filter-histogram-slider___${facet.annotation}`
 

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -1,3 +1,22 @@
+/**
+ * @fileoverview Easy, rich query builder for numeric annotations
+ *
+ * Numeric cell facets provide:
+ * - Histogram for seeing distributions you can select from
+ * - Range slider (a.k.a. brush)
+ * - Inputs fields for manual numeric input
+ * - Operator menu
+ * - Support for special (but common) "not available" values, i.e. "N/A"
+ * - Reset button, expand / collapse button
+ *
+ * Each eligible numeric annotation gets one numeric cell facet.  Numeric
+ * facets combine with other ("group" / categorical or numeric facets),
+ * logically joining via the "AND" Boolean operator across facets.
+ *
+ * More context and demo video:
+ * https://github.com/broadinstitute/single_cell_portal_core/pull/1988
+ */
+
 import React, { useState, useEffect } from 'react'
 import { scaleLinear } from 'd3'
 import _isEqual from 'lodash/isEqual'
@@ -295,6 +314,7 @@ function OperatorMenu({ operator, updateOperator }) {
   const menuWidth = `${widthsByOperator[operator] }px`
   return (
     <select
+      className="cell-facet-numeric-operator-menu"
       style={{ width: menuWidth }}
       value={operator}
       onChange={event => {updateOperator(event)}}

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { scaleLinear } from 'd3-scale'
+import { scaleLinear } from 'd3'
 import _isEqual from 'lodash/isEqual'
 import SVGBrush from 'react-svg-brush'
 

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -466,16 +466,24 @@ export function NumericCellFacet({
     const isValue2 = event.target.name.endsWith('value2')
     if (isValue2) {
       if (rawIsNaN) {newFilterValue = max}
-      setInputBorder2(rawIsNaN ? 'red' : null)
       setInputValue2(newDisplayValue)
-      updateNumericFilter(operator, inputValue, newFilterValue, includeNa, facet, handleNumericChange)
-      moveBrush(sliderId, brush, inputValue, newFilterValue, xScale)
+      if (newFilterValue > max) {
+        setInputBorder2('orange')
+      } else {
+        setInputBorder2(rawIsNaN ? 'red' : null)
+        updateNumericFilter(operator, inputValue, newFilterValue, includeNa, facet, handleNumericChange)
+        moveBrush(sliderId, brush, inputValue, newFilterValue, xScale)
+      }
     } else {
       if (rawIsNaN) {newFilterValue = min}
-      setInputBorder(rawIsNaN ? 'red' : null)
       setInputValue(newDisplayValue)
-      updateNumericFilter(operator, newFilterValue, inputValue2, includeNa, facet, handleNumericChange)
-      moveBrush(sliderId, brush, newFilterValue, inputValue2, xScale)
+      if (newFilterValue < min) {
+        setInputBorder('orange')
+      } else {
+        setInputBorder(rawIsNaN ? 'red' : null)
+        updateNumericFilter(operator, newFilterValue, inputValue2, includeNa, facet, handleNumericChange)
+        moveBrush(sliderId, brush, newFilterValue, inputValue2, xScale)
+      }
     }
   }
 
@@ -511,11 +519,19 @@ export function NumericCellFacet({
     const extent = d3BrushSelection.map(xScale.invert)
     const newValue1 = round(extent[0], precision)
     const newValue2 = round(extent[1], precision)
-    // setInputValue(newValue1)
-    // setInputValue2(newValue2)
+
     handleBrushMoved(sliderId, d3BrushSelection)
     if (event.sourceEvent !== 'skipUpdateNumericFilter') {
       updateNumericFilter(operator, newValue1, newValue2, includeNa, facet, handleNumericChange)
+    }
+
+    if (inputBorder !== null && newValue1 >= min) {
+      console.log('setInputBorder(null)')
+      setInputBorder(null)
+    }
+    if (inputBorder2 !== null && newValue2 <= max) {
+      console.log('setInputBorder2(null)')
+      setInputBorder2(null)
     }
   }
 

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -204,8 +204,8 @@ function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight, operat
 
   const barWidth = bars[0].width
   const hasNull = bars[0].isNull
-  const sliderLeft = hasNull ? barWidth : 1
-  const sliderWidth = svgWidth + sliderLeft
+  const sliderLeft = hasNull ? 0 : -1 * (SLIDER_HANDLEBAR_WIDTH + 1)
+  const sliderWidth = svgWidth + (hasNull ? barWidth : 2 * SLIDER_HANDLEBAR_WIDTH + 2)
 
   return (
     <>
@@ -262,7 +262,7 @@ function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight, operat
       <svg
         height={svgHeight}
         width={sliderWidth}
-        style={{ position: 'absolute', top: 0, left: 0 }}
+        style={{ position: 'absolute', top: 0, left: sliderLeft }}
         className="numeric-filter-histogram-slider"
         id={sliderId}
       ></svg>
@@ -526,11 +526,9 @@ export function NumericCellFacet({
     }
 
     if (inputBorder !== null && newValue1 >= min) {
-      console.log('setInputBorder(null)')
       setInputBorder(null)
     }
     if (inputBorder2 !== null && newValue2 <= max) {
-      console.log('setInputBorder2(null)')
       setInputBorder2(null)
     }
   }
@@ -538,14 +536,15 @@ export function NumericCellFacet({
   const [svgWidth, svgHeight] = getHistogramSvgDimensions(bars)
   const xScale = getXScale(bars, svgWidth, hasNull)
   const barWidth = bars[0].width
-  const extentStartX = hasNull ? 2 * barWidth + 2 : 0
+  const extentStartX = hasNull ? 2 * barWidth + 2 : SLIDER_HANDLEBAR_WIDTH + 2
+  const sliderWidth = hasNull ? svgWidth : svgWidth + SLIDER_HANDLEBAR_WIDTH
 
   const brush =
     d3
       .brushX()
       .extent([
         [extentStartX, 0],
-        [svgWidth, svgHeight]
+        [sliderWidth, svgHeight]
       ])
       .on('end', handleBrushEnd)
       .on('brush', event => {

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -105,7 +105,7 @@ function getHistogramBars(filters) {
 }
 
 /** SVG histogram showing distribution of numeric annotation values */
-function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight }) {
+function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight, operator }) {
   useEffect(() => {
     initBrush(brush, sliderId)
   },
@@ -162,6 +162,7 @@ function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight }) {
             </span>
           )
         })} */}
+      {['between', 'not between'].includes(operator) &&
       <svg
         height={svgHeight}
         width={svgWidth}
@@ -169,6 +170,7 @@ function Histogram({ sliderId, filters, bars, brush, svgWidth, svgHeight }) {
         className="numeric-filter-histogram-slider"
         id={sliderId}
       ></svg>
+      }
     </>
   )
 }
@@ -324,7 +326,13 @@ function parseSelectionMap(facet, selectionMap) {
   const facetSelection = selectionMap[facet.annotation] // e.g. ['between', [20, 40]]
   const numericFilter = facetSelection[0] // e.g. ['between', [20, 40]]
   const rawOp = numericFilter[0][0] // e.g. 'between'
-  const [raw1, raw2] = numericFilter[0][1] // e.g. 20, 40
+  let raw1; let raw2
+  if (['between', 'not between'].includes(rawOp)) {
+    [raw1, raw2] = numericFilter[0][1] // e.g. 20, 40
+  } else {
+    raw1 = numericFilter[0][1]
+    raw2 = null
+  }
   const rawIncludeNa = facetSelection[1] // e.g. true
   return [rawOp, raw1, raw2, rawIncludeNa]
 }

--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -430,6 +430,7 @@ export function NumericCellFacet({
         sliderId={sliderId}
         brush={brush}
       />
+      {!isFullyCollapsed &&
       <div style={{ marginLeft: 20, position: 'relative' }}>
         <Histogram
           sliderId={sliderId}
@@ -453,6 +454,7 @@ export function NumericCellFacet({
           updateIncludeNa={updateIncludeNa}
         />
       </div>
+      }
     </>
   )
 }

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -6,9 +6,7 @@
 
 import crossfilter from 'crossfilter2'
 
-import {
-  getGroupAnnotationsForClusterAndStudy, getIdentifierForAnnotation
-} from '~/lib/cluster-utils'
+import { getIdentifierForAnnotation } from '~/lib/cluster-utils'
 import { fetchAnnotationFacets } from '~/lib/scp-api'
 import { log } from '~/lib/metrics-api'
 

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -149,19 +149,19 @@ export function applyNumericFilters(d, rawFilters) {
 
   for (let i = 0; i < numericFilters.length; i++) {
     const [operator, value] = numericFilters[i]
-    if (operator === 'equals') {
+    if (operator === '=') {
       // for fastest querying, exit function immediately upon _any_ condition
       // evaluating to true
       if (d === value) {return true}
-    } else if (operator === 'not equals') {
+    } else if (operator === '!=') {
       if (d !== value) {return true}
-    } else if (operator === 'greater than') {
+    } else if (operator === '>') {
       if (d > value) {return true}
-    } else if (operator === 'greater than or equal to') {
+    } else if (operator === '>=') {
       if (d >= value) {return true}
-    } else if (operator === 'less than') {
+    } else if (operator === '<') {
       if (d < value) {return true}
-    } else if (operator === 'less than or equal to') {
+    } else if (operator === '<=') {
       if (d <= value) {return true}
     } else if (operator === 'between') {
       if (value[0] <= d && d <= value[1]) {return true}

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -207,29 +207,6 @@ input.cell-facet-header-checkbox {
   color: #CCC;
 }
 
-// Used to fade truncated text in inputs, as a visually economical affordance
-// that more content exists in the input, but must be keyed to view
-.fade-overflow {
-  position: relative;
-}
-.fade-overflow:after {
-  position: absolute;
-  left: -2px;
-  bottom: 0;
-  height: 100%;
-  width: 100%;
-  content: "";
-  background: linear-gradient(to left,
-    rgb(255, 255, 255) 5%,
-    rgba(255, 255, 255, 0) 30%
-  );
-  pointer-events: none; /* so the text is still selectable */
-}
-
-.fade-overflow:has(input:focus):after {
-  background: none;
-}
-
 .numeric-query-input {
   font-size: 13px;
   height: 20px;

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -234,3 +234,10 @@ input.cell-facet-header-checkbox {
   width: 45px;
   margin-left: 4px;
 }
+
+.cell-facet .brush .selection {
+  fill: #F00;
+  stroke: #F00;
+  fill-opacity: .3;
+  shape-rendering: crispEdges;
+}

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -210,6 +210,10 @@ input.cell-facet-header-checkbox {
   margin-left: 4px;
 }
 
+.cell-facet-numeric-inputs-container {
+  display: inline-block;
+}
+
 .cell-facet .brush .selection {
   fill-opacity: 0.1;
   fill: $action-color;

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -51,7 +51,7 @@
 }
 
 .cell-facet-header-numeric {
-  margin-left: 18px;
+  // margin-left: 18px;
 }
 
 input.cell-facet-header-checkbox {
@@ -130,6 +130,7 @@ input.cell-facet-header-checkbox {
 .cell-facet .cell-filters-shown .facet-toggle-chevron,
 .cell-facet .cell-filters-shown .sort-filters,
 .cell-facet .cell-facet-header-checkbox,
+.cell-facet .reset-facet,
 .filter-section .reset-cell-filters,
 .filter-section:hover .reset-cell-filters.hide-reset {
   visibility: hidden;
@@ -138,16 +139,17 @@ input.cell-facet-header-checkbox {
 .cell-facet:hover .cell-filters-shown .facet-toggle-chevron,
 .cell-facet:hover .cell-filters-shown .sort-filters,
 .cell-facet:hover .cell-facet-header-checkbox,
+.cell-facet:hover .reset-facet,
 .cell-facet:has(.cell-filters-hidden) .cell-facet-header-checkbox,
 .filter-section:hover .reset-cell-filters {
   visibility: visible;
 }
 
-.reset-cell-filters, .sort-filters {
+.reset-cell-filters, .sort-filters, .reset-facet {
   color: #777;
 }
 
-.reset-cell-filters:hover, .sort-filters:hover {
+.reset-cell-filters:hover, .sort-filters:hover, .reset-facet:hover {
   color: #77D;
 }
 
@@ -240,4 +242,9 @@ input.cell-facet-header-checkbox {
   fill: $action-color;
   stroke: $action-color;
   shape-rendering: crispEdges;
+}
+
+.reset-facet .fa-undo {
+  height: 12px;
+  margin-right: 5px;
 }

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -249,7 +249,7 @@ input.cell-facet-header-checkbox {
   margin-right: 5px;
 }
 
-.brush path.handle {
+.brush path.handlebar {
   fill: #eee;
   stroke: #666;
 }

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -230,3 +230,7 @@ input.cell-facet-header-checkbox {
   fill: #eee;
   stroke: #666;
 }
+
+.brush .handle:not(.handle--e, .handle--w) {
+  display: none;
+}

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -248,3 +248,8 @@ input.cell-facet-header-checkbox {
   height: 12px;
   margin-right: 5px;
 }
+
+.brush path.handle {
+  fill: #eee;
+  stroke: #666;
+}

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -50,10 +50,6 @@
   left: 4px;
 }
 
-.cell-facet-header-numeric {
-  // margin-left: 18px;
-}
-
 input.cell-facet-header-checkbox {
   display: inline;
   margin-right: 5px;

--- a/app/javascript/styles/_cellFiltering.scss
+++ b/app/javascript/styles/_cellFiltering.scss
@@ -236,8 +236,8 @@ input.cell-facet-header-checkbox {
 }
 
 .cell-facet .brush .selection {
-  fill: #F00;
-  stroke: #F00;
-  fill-opacity: .3;
+  fill-opacity: 0.1;
+  fill: $action-color;
+  stroke: $action-color;
   shape-rendering: crispEdges;
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,7 +27,6 @@ module.exports = {
     '^~/(.*)$': '$1', // strip off the ~/, as jest doesn't need it since it has configured module directories
     '@single-cell-portal/igv': '<rootDir>/test/js/jest-mocks/igv-mock.js', // mock igv as jest has trouble parsing it
     'ideogram': '<rootDir>/test/js/jest-mocks/file-mock.js', // mock igv as jest has trouble parsing it
-    '\\.css$': '<rootDir>/test/js/jest-mocks/file-mock.js', // mock CSS files as jest has trouble parsing them
-    '^d3$': '<rootDir>/node_modules/d3/dist/d3.min.js'
+    '\\.css$': '<rootDir>/test/js/jest-mocks/file-mock.js' // mock CSS files as jest has trouble parsing them
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,6 +27,7 @@ module.exports = {
     '^~/(.*)$': '$1', // strip off the ~/, as jest doesn't need it since it has configured module directories
     '@single-cell-portal/igv': '<rootDir>/test/js/jest-mocks/igv-mock.js', // mock igv as jest has trouble parsing it
     'ideogram': '<rootDir>/test/js/jest-mocks/file-mock.js', // mock igv as jest has trouble parsing it
-    '\\.css$': '<rootDir>/test/js/jest-mocks/file-mock.js' // mock CSS files as jest has trouble parsing them
+    '\\.css$': '<rootDir>/test/js/jest-mocks/file-mock.js', // mock CSS files as jest has trouble parsing them
+    '^d3$': '<rootDir>/node_modules/d3/dist/d3.min.js'
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,6 +27,7 @@ module.exports = {
     '^~/(.*)$': '$1', // strip off the ~/, as jest doesn't need it since it has configured module directories
     '@single-cell-portal/igv': '<rootDir>/test/js/jest-mocks/igv-mock.js', // mock igv as jest has trouble parsing it
     'ideogram': '<rootDir>/test/js/jest-mocks/file-mock.js', // mock igv as jest has trouble parsing it
-    '\\.css$': '<rootDir>/test/js/jest-mocks/file-mock.js' // mock CSS files as jest has trouble parsing them
+    '\\.css$': '<rootDir>/test/js/jest-mocks/file-mock.js', // mock CSS files as jest has trouble parsing them
+    '^d3$': '<rootDir>/node_modules/d3/dist/d3.min.js' // Fix "export" bug upon `yarn test`
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-select": "^5.2.2",
     "react-switch": "6.0.0",
     "react-table": "^7.7.0",
+    "react-svg-brush": "^1.0.0",
     "sass": "^1.37.5",
     "spearman-rho": "^1.0.6",
     "spin.js": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
     "crossfilter2": "^1.5.4",
+    "d3": "^7.8.5",
     "exifreader": "4.6.0",
     "fflate": "^0.7.3",
     "ideogram": "1.45.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
     "crossfilter2": "^1.5.4",
-    "d3-scale": "^4.0.2",
+    "d3": "^7.8.5",
     "exifreader": "4.6.0",
     "fflate": "^0.7.3",
     "ideogram": "1.45.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "camelcase-keys": "^6.1.2",
     "core-js": "^3.6.4",
     "crossfilter2": "^1.5.4",
-    "d3": "^7.8.5",
+    "d3-scale": "^4.0.2",
     "exifreader": "4.6.0",
     "fflate": "^0.7.3",
     "ideogram": "1.45.1",

--- a/test/js/explore/cell-filtering-panel.test.js
+++ b/test/js/explore/cell-filtering-panel.test.js
@@ -161,7 +161,7 @@ describe('"Cell filtering" panel', () => {
     expect(firstFilterAfterSort).toHaveTextContent('52')
   })
 
-  it('renders numeric filters', async () => {
+  it('renders numeric cell facet, which is interactive', async () => {
     jest
       .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
       .mockReturnValue({
@@ -198,5 +198,30 @@ describe('"Cell filtering" panel', () => {
     const lastFacet = Array.from(container.querySelectorAll('.cell-facet')).slice(-1)[0]
     const lastFacetName = lastFacet.querySelector('.cell-facet-name')
     expect(lastFacetName).toHaveTextContent('BMI pre pregnancy')
+
+    const sliderId = 'numeric-filter-histogram-slider___BMI_pre_pregnancy--numeric--study'
+    const histogram = container.querySelector(`#${ sliderId}`)
+
+    // Confirm left and right handles for slider
+    const handlebars = histogram.querySelectorAll('.handlebar')
+    expect(handlebars).toHaveLength(2)
+
+    // Confirm slider, and that its layout accounts for special "N/A" bar
+    const sliderSelection = histogram.querySelector('.selection')
+    const sliderOffset = sliderSelection.getAttribute('x')
+    const sliderWidth = sliderSelection.getAttribute('width')
+    expect(sliderOffset).toEqual('24')
+    expect(sliderWidth).toEqual('155')
+
+    // Confirm clicking "N/A" checkbox calls filtering code
+    const naCheckbox = lastFacet.querySelector('.numeric-na-filter')
+    fireEvent.click(naCheckbox)
+    expect(updateFilteredCells).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'BMI_pre_pregnancy--numeric--study': [
+          [['between', [18.84, 34.01]]], false
+        ]
+      })
+    )
   })
 })

--- a/test/js/lib/cell-faceting.test.js
+++ b/test/js/lib/cell-faceting.test.js
@@ -57,9 +57,9 @@ describe('Cell faceting', () => {
   })
 
   it('filters cells by numeric filters', async () => {
-    expect(applyNumericFilters(2, [[['equals', 2]], true])).toStrictEqual(true)
-    expect(applyNumericFilters(2, [[['equals', 1.3]], true])).toStrictEqual(false)
-    expect(applyNumericFilters(20, [[['greater than or equal to', 6]], true])).toStrictEqual(true)
+    expect(applyNumericFilters(2, [[['=', 2]], true])).toStrictEqual(true)
+    expect(applyNumericFilters(2, [[['=', 1.3]], true])).toStrictEqual(false)
+    expect(applyNumericFilters(20, [[['>=', 6]], true])).toStrictEqual(true)
     expect(applyNumericFilters(20, [[['between', [5, 42]]], true])).toStrictEqual(true)
     expect(applyNumericFilters(2, [[['between', [0, 2]]], true])).toStrictEqual(true) // test inclusiveness
     expect(applyNumericFilters(2, [[['between', [0, 2.1]]], true], 2)).toStrictEqual(true) // test inclusiveness

--- a/yarn.lock
+++ b/yarn.lock
@@ -3391,11 +3391,6 @@ commander@2, commander@^2.19.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@7:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
-  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
-
 commander@^8.0.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
@@ -3609,7 +3604,7 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
-"d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.2.0:
+"d3-array@2 - 3", "d3-array@2.10.0 - 3":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
   integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
@@ -3623,12 +3618,7 @@ d3-array@^2.8.0:
   dependencies:
     internmap "^1.0.0"
 
-d3-axis@3:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
-  integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
-
-d3-brush@3, d3-brush@^3.0.0:
+d3-brush@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-3.0.0.tgz#6f767c4ed8dcb79de7ede3e1c0f89e63ef64d31c"
   integrity sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
@@ -3639,33 +3629,12 @@ d3-brush@3, d3-brush@^3.0.0:
     d3-selection "3"
     d3-transition "3"
 
-d3-chord@3:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-3.0.1.tgz#d156d61f485fce8327e6abf339cb41d8cbba6966"
-  integrity sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==
-  dependencies:
-    d3-path "1 - 3"
-
-"d3-color@1 - 3", d3-color@3, d3-color@^3.0.1:
+"d3-color@1 - 3", d3-color@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
-d3-contour@4:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-4.0.2.tgz#bb92063bc8c5663acb2422f99c73cbb6c6ae3bcc"
-  integrity sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==
-  dependencies:
-    d3-array "^3.2.0"
-
-d3-delaunay@6:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz#98169038733a0a5babbeda55054f795bb9e4a58b"
-  integrity sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==
-  dependencies:
-    delaunator "5"
-
-"d3-dispatch@1 - 3", d3-dispatch@3:
+"d3-dispatch@1 - 3":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
   integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
@@ -3675,7 +3644,7 @@ d3-dispatch@^2.0.0:
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-2.0.0.tgz#8a18e16f76dd3fcaef42163c97b926aa9b55e7cf"
   integrity sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==
 
-"d3-drag@2 - 3", d3-drag@3:
+"d3-drag@2 - 3":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
   integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
@@ -3692,26 +3661,10 @@ d3-dispatch@^2.0.0:
     iconv-lite "0.4"
     rw "1"
 
-"d3-dsv@1 - 3", d3-dsv@3:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-3.0.1.tgz#c63af978f4d6a0d084a52a673922be2160789b73"
-  integrity sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
-  dependencies:
-    commander "7"
-    iconv-lite "0.6"
-    rw "1"
-
-"d3-ease@1 - 3", d3-ease@3:
+"d3-ease@1 - 3":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
   integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
-
-d3-fetch@3:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-3.0.1.tgz#83141bff9856a0edb5e38de89cdcfe63d0a60a22"
-  integrity sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==
-  dependencies:
-    d3-dsv "1 - 3"
 
 d3-fetch@^2.0.0:
   version "2.0.0"
@@ -3720,16 +3673,7 @@ d3-fetch@^2.0.0:
   dependencies:
     d3-dsv "1 - 2"
 
-d3-force@3:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
-  integrity sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
-  dependencies:
-    d3-dispatch "1 - 3"
-    d3-quadtree "1 - 3"
-    d3-timer "1 - 3"
-
-"d3-format@1 - 3", d3-format@3:
+"d3-format@1 - 3":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
   integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
@@ -3739,54 +3683,14 @@ d3-format@^2.0.0:
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-2.0.0.tgz#a10bcc0f986c372b729ba447382413aabf5b0767"
   integrity sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==
 
-d3-geo@3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.0.tgz#74fd54e1f4cebd5185ac2039217a98d39b0a4c0e"
-  integrity sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==
-  dependencies:
-    d3-array "2.5.0 - 3"
-
-d3-hierarchy@3:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz#b01cd42c1eed3d46db77a5966cf726f8c09160c6"
-  integrity sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
-
-"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3:
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
   integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
   dependencies:
     d3-color "1 - 3"
 
-"d3-path@1 - 3", d3-path@3, d3-path@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
-  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
-
-d3-polygon@3:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-3.0.1.tgz#0b45d3dd1c48a29c8e057e6135693ec80bf16398"
-  integrity sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==
-
-"d3-quadtree@1 - 3", d3-quadtree@3:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
-  integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
-
-d3-random@3:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
-  integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
-
-d3-scale-chromatic@3:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#15b4ceb8ca2bb0dcb6d1a641ee03d59c3b62376a"
-  integrity sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==
-  dependencies:
-    d3-color "1 - 3"
-    d3-interpolate "1 - 3"
-
-d3-scale@4, d3-scale@^4.0.2:
+d3-scale@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
   integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
@@ -3797,38 +3701,31 @@ d3-scale@4, d3-scale@^4.0.2:
     d3-time "2.1.1 - 3"
     d3-time-format "2 - 4"
 
-"d3-selection@2 - 3", d3-selection@3:
+d3-selection@3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
   integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
 
-d3-shape@3:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.2.0.tgz#a1a839cbd9ba45f28674c69d7f855bcf91dfc6a5"
-  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
-  dependencies:
-    d3-path "^3.1.0"
-
-"d3-time-format@2 - 4", d3-time-format@4:
+"d3-time-format@2 - 4":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
   integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
   dependencies:
     d3-time "1 - 3"
 
-"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@3:
+"d3-time@1 - 3", "d3-time@2.1.1 - 3":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
   integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
   dependencies:
     d3-array "2 - 3"
 
-"d3-timer@1 - 3", d3-timer@3:
+"d3-timer@1 - 3":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
   integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
-"d3-transition@2 - 3", d3-transition@3:
+d3-transition@3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
   integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
@@ -3838,53 +3735,6 @@ d3-shape@3:
     d3-ease "1 - 3"
     d3-interpolate "1 - 3"
     d3-timer "1 - 3"
-
-d3-zoom@3:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
-  integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
-  dependencies:
-    d3-dispatch "1 - 3"
-    d3-drag "2 - 3"
-    d3-interpolate "1 - 3"
-    d3-selection "2 - 3"
-    d3-transition "2 - 3"
-
-d3@^7.8.5:
-  version "7.8.5"
-  resolved "https://registry.yarnpkg.com/d3/-/d3-7.8.5.tgz#fde4b760d4486cdb6f0cc8e2cbff318af844635c"
-  integrity sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==
-  dependencies:
-    d3-array "3"
-    d3-axis "3"
-    d3-brush "3"
-    d3-chord "3"
-    d3-color "3"
-    d3-contour "4"
-    d3-delaunay "6"
-    d3-dispatch "3"
-    d3-drag "3"
-    d3-dsv "3"
-    d3-ease "3"
-    d3-fetch "3"
-    d3-force "3"
-    d3-format "3"
-    d3-geo "3"
-    d3-hierarchy "3"
-    d3-interpolate "3"
-    d3-path "3"
-    d3-polygon "3"
-    d3-quadtree "3"
-    d3-random "3"
-    d3-scale "4"
-    d3-scale-chromatic "3"
-    d3-selection "3"
-    d3-shape "3"
-    d3-time "3"
-    d3-time-format "4"
-    d3-timer "3"
-    d3-transition "3"
-    d3-zoom "3"
 
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
@@ -4022,13 +3872,6 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
-
-delaunator@5:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.0.1.tgz#39032b08053923e924d6094fe2cde1a99cc51278"
-  integrity sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==
-  dependencies:
-    robust-predicates "^3.0.2"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -5494,13 +5337,6 @@ iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
-
-iconv-lite@0.6:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
-  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ideogram@1.45.1:
   version "1.45.1"
@@ -8661,11 +8497,6 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
-robust-predicates@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.2.tgz#d5b28528c4824d20fc48df1928d41d9efa1ad771"
-  integrity sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==
-
 "rollup@>=2.59.0 <2.78.0":
   version "2.77.3"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.77.3.tgz#8f00418d3a2740036e15deb653bed1a90ee0cc12"
@@ -8741,7 +8572,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3179,9 +3179,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001503:
-  version "1.0.30001517"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz#90fabae294215c3495807eb24fc809e11dc2f0a8"
-  integrity sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==
+  version "1.0.30001593"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001593.tgz"
+  integrity sha512-UWM1zlo3cZfkpBysd7AS+z+v007q9G1+fLTUU42rQnY6t2axoogPW/xol6T7juU5EUoOhML4WgBIdG+9yYqAjQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -3390,6 +3390,11 @@ commander@2, commander@^2.19.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@7:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 commander@^8.0.0:
   version "8.3.0"
@@ -3604,7 +3609,7 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
-"d3-array@2 - 3", "d3-array@2.10.0 - 3":
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.2.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
   integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
@@ -3618,7 +3623,12 @@ d3-array@^2.8.0:
   dependencies:
     internmap "^1.0.0"
 
-d3-brush@^3.0.0:
+d3-axis@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
+  integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
+
+d3-brush@3, d3-brush@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-3.0.0.tgz#6f767c4ed8dcb79de7ede3e1c0f89e63ef64d31c"
   integrity sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
@@ -3629,12 +3639,33 @@ d3-brush@^3.0.0:
     d3-selection "3"
     d3-transition "3"
 
-"d3-color@1 - 3", d3-color@^3.0.1:
+d3-chord@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-3.0.1.tgz#d156d61f485fce8327e6abf339cb41d8cbba6966"
+  integrity sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==
+  dependencies:
+    d3-path "1 - 3"
+
+"d3-color@1 - 3", d3-color@3, d3-color@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
-"d3-dispatch@1 - 3":
+d3-contour@4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-4.0.2.tgz#bb92063bc8c5663acb2422f99c73cbb6c6ae3bcc"
+  integrity sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==
+  dependencies:
+    d3-array "^3.2.0"
+
+d3-delaunay@6:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz#98169038733a0a5babbeda55054f795bb9e4a58b"
+  integrity sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==
+  dependencies:
+    delaunator "5"
+
+"d3-dispatch@1 - 3", d3-dispatch@3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
   integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
@@ -3644,7 +3675,7 @@ d3-dispatch@^2.0.0:
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-2.0.0.tgz#8a18e16f76dd3fcaef42163c97b926aa9b55e7cf"
   integrity sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==
 
-"d3-drag@2 - 3":
+"d3-drag@2 - 3", d3-drag@3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
   integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
@@ -3661,10 +3692,26 @@ d3-dispatch@^2.0.0:
     iconv-lite "0.4"
     rw "1"
 
-"d3-ease@1 - 3":
+"d3-dsv@1 - 3", d3-dsv@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-3.0.1.tgz#c63af978f4d6a0d084a52a673922be2160789b73"
+  integrity sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
+  dependencies:
+    commander "7"
+    iconv-lite "0.6"
+    rw "1"
+
+"d3-ease@1 - 3", d3-ease@3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
   integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+d3-fetch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-3.0.1.tgz#83141bff9856a0edb5e38de89cdcfe63d0a60a22"
+  integrity sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==
+  dependencies:
+    d3-dsv "1 - 3"
 
 d3-fetch@^2.0.0:
   version "2.0.0"
@@ -3673,7 +3720,16 @@ d3-fetch@^2.0.0:
   dependencies:
     d3-dsv "1 - 2"
 
-"d3-format@1 - 3":
+d3-force@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
+  integrity sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-quadtree "1 - 3"
+    d3-timer "1 - 3"
+
+"d3-format@1 - 3", d3-format@3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
   integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
@@ -3683,14 +3739,54 @@ d3-format@^2.0.0:
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-2.0.0.tgz#a10bcc0f986c372b729ba447382413aabf5b0767"
   integrity sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==
 
-"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3":
+d3-geo@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.0.tgz#74fd54e1f4cebd5185ac2039217a98d39b0a4c0e"
+  integrity sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==
+  dependencies:
+    d3-array "2.5.0 - 3"
+
+d3-hierarchy@3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz#b01cd42c1eed3d46db77a5966cf726f8c09160c6"
+  integrity sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
+
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
   integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
   dependencies:
     d3-color "1 - 3"
 
-d3-scale@^4.0.2:
+"d3-path@1 - 3", d3-path@3, d3-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
+  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
+
+d3-polygon@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-3.0.1.tgz#0b45d3dd1c48a29c8e057e6135693ec80bf16398"
+  integrity sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==
+
+"d3-quadtree@1 - 3", d3-quadtree@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
+  integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
+
+d3-random@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
+  integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
+
+d3-scale-chromatic@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#15b4ceb8ca2bb0dcb6d1a641ee03d59c3b62376a"
+  integrity sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
+
+d3-scale@4, d3-scale@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
   integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
@@ -3701,31 +3797,38 @@ d3-scale@^4.0.2:
     d3-time "2.1.1 - 3"
     d3-time-format "2 - 4"
 
-d3-selection@3:
+"d3-selection@2 - 3", d3-selection@3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
   integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
 
-"d3-time-format@2 - 4":
+d3-shape@3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.2.0.tgz#a1a839cbd9ba45f28674c69d7f855bcf91dfc6a5"
+  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
+  dependencies:
+    d3-path "^3.1.0"
+
+"d3-time-format@2 - 4", d3-time-format@4:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
   integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
   dependencies:
     d3-time "1 - 3"
 
-"d3-time@1 - 3", "d3-time@2.1.1 - 3":
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
   integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
   dependencies:
     d3-array "2 - 3"
 
-"d3-timer@1 - 3":
+"d3-timer@1 - 3", d3-timer@3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
   integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
-d3-transition@3:
+"d3-transition@2 - 3", d3-transition@3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
   integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
@@ -3735,6 +3838,53 @@ d3-transition@3:
     d3-ease "1 - 3"
     d3-interpolate "1 - 3"
     d3-timer "1 - 3"
+
+d3-zoom@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "2 - 3"
+    d3-transition "2 - 3"
+
+d3@^7.8.5:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-7.8.5.tgz#fde4b760d4486cdb6f0cc8e2cbff318af844635c"
+  integrity sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==
+  dependencies:
+    d3-array "3"
+    d3-axis "3"
+    d3-brush "3"
+    d3-chord "3"
+    d3-color "3"
+    d3-contour "4"
+    d3-delaunay "6"
+    d3-dispatch "3"
+    d3-drag "3"
+    d3-dsv "3"
+    d3-ease "3"
+    d3-fetch "3"
+    d3-force "3"
+    d3-format "3"
+    d3-geo "3"
+    d3-hierarchy "3"
+    d3-interpolate "3"
+    d3-path "3"
+    d3-polygon "3"
+    d3-quadtree "3"
+    d3-random "3"
+    d3-scale "4"
+    d3-scale-chromatic "3"
+    d3-selection "3"
+    d3-shape "3"
+    d3-time "3"
+    d3-time-format "4"
+    d3-timer "3"
+    d3-transition "3"
+    d3-zoom "3"
 
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
@@ -3872,6 +4022,13 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+delaunator@5:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.0.1.tgz#39032b08053923e924d6094fe2cde1a99cc51278"
+  integrity sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==
+  dependencies:
+    robust-predicates "^3.0.2"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -5337,6 +5494,13 @@ iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@0.6:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ideogram@1.45.1:
   version "1.45.1"
@@ -8497,6 +8661,11 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
+robust-predicates@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.2.tgz#d5b28528c4824d20fc48df1928d41d9efa1ad771"
+  integrity sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==
+
 "rollup@>=2.59.0 <2.78.0":
   version "2.77.3"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.77.3.tgz#8f00418d3a2740036e15deb653bed1a90ee0cc12"
@@ -8572,7 +8741,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3391,6 +3391,11 @@ commander@2, commander@^2.19.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+commander@7:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
 commander@^8.0.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
@@ -3604,7 +3609,7 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
-"d3-array@2 - 3", "d3-array@2.10.0 - 3":
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.2.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
   integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
@@ -3618,7 +3623,12 @@ d3-array@^2.8.0:
   dependencies:
     internmap "^1.0.0"
 
-d3-brush@^3.0.0:
+d3-axis@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
+  integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
+
+d3-brush@3, d3-brush@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-3.0.0.tgz#6f767c4ed8dcb79de7ede3e1c0f89e63ef64d31c"
   integrity sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
@@ -3629,12 +3639,33 @@ d3-brush@^3.0.0:
     d3-selection "3"
     d3-transition "3"
 
-"d3-color@1 - 3", d3-color@^3.0.1:
+d3-chord@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-3.0.1.tgz#d156d61f485fce8327e6abf339cb41d8cbba6966"
+  integrity sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==
+  dependencies:
+    d3-path "1 - 3"
+
+"d3-color@1 - 3", d3-color@3, d3-color@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
-"d3-dispatch@1 - 3":
+d3-contour@4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-4.0.2.tgz#bb92063bc8c5663acb2422f99c73cbb6c6ae3bcc"
+  integrity sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==
+  dependencies:
+    d3-array "^3.2.0"
+
+d3-delaunay@6:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz#98169038733a0a5babbeda55054f795bb9e4a58b"
+  integrity sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==
+  dependencies:
+    delaunator "5"
+
+"d3-dispatch@1 - 3", d3-dispatch@3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
   integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
@@ -3644,7 +3675,7 @@ d3-dispatch@^2.0.0:
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-2.0.0.tgz#8a18e16f76dd3fcaef42163c97b926aa9b55e7cf"
   integrity sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==
 
-"d3-drag@2 - 3":
+"d3-drag@2 - 3", d3-drag@3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
   integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
@@ -3661,10 +3692,26 @@ d3-dispatch@^2.0.0:
     iconv-lite "0.4"
     rw "1"
 
-"d3-ease@1 - 3":
+"d3-dsv@1 - 3", d3-dsv@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-3.0.1.tgz#c63af978f4d6a0d084a52a673922be2160789b73"
+  integrity sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
+  dependencies:
+    commander "7"
+    iconv-lite "0.6"
+    rw "1"
+
+"d3-ease@1 - 3", d3-ease@3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
   integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+d3-fetch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-3.0.1.tgz#83141bff9856a0edb5e38de89cdcfe63d0a60a22"
+  integrity sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==
+  dependencies:
+    d3-dsv "1 - 3"
 
 d3-fetch@^2.0.0:
   version "2.0.0"
@@ -3673,7 +3720,16 @@ d3-fetch@^2.0.0:
   dependencies:
     d3-dsv "1 - 2"
 
-"d3-format@1 - 3":
+d3-force@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
+  integrity sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-quadtree "1 - 3"
+    d3-timer "1 - 3"
+
+"d3-format@1 - 3", d3-format@3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
   integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
@@ -3683,14 +3739,54 @@ d3-format@^2.0.0:
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-2.0.0.tgz#a10bcc0f986c372b729ba447382413aabf5b0767"
   integrity sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==
 
-"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3":
+d3-geo@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.0.tgz#74fd54e1f4cebd5185ac2039217a98d39b0a4c0e"
+  integrity sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==
+  dependencies:
+    d3-array "2.5.0 - 3"
+
+d3-hierarchy@3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz#b01cd42c1eed3d46db77a5966cf726f8c09160c6"
+  integrity sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
+
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
   integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
   dependencies:
     d3-color "1 - 3"
 
-d3-scale@^4.0.2:
+"d3-path@1 - 3", d3-path@3, d3-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
+  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
+
+d3-polygon@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-3.0.1.tgz#0b45d3dd1c48a29c8e057e6135693ec80bf16398"
+  integrity sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==
+
+"d3-quadtree@1 - 3", d3-quadtree@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
+  integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
+
+d3-random@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
+  integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
+
+d3-scale-chromatic@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#15b4ceb8ca2bb0dcb6d1a641ee03d59c3b62376a"
+  integrity sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
+
+d3-scale@4, d3-scale@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
   integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
@@ -3701,31 +3797,38 @@ d3-scale@^4.0.2:
     d3-time "2.1.1 - 3"
     d3-time-format "2 - 4"
 
-d3-selection@3:
+"d3-selection@2 - 3", d3-selection@3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
   integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
 
-"d3-time-format@2 - 4":
+d3-shape@3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.2.0.tgz#a1a839cbd9ba45f28674c69d7f855bcf91dfc6a5"
+  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
+  dependencies:
+    d3-path "^3.1.0"
+
+"d3-time-format@2 - 4", d3-time-format@4:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
   integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
   dependencies:
     d3-time "1 - 3"
 
-"d3-time@1 - 3", "d3-time@2.1.1 - 3":
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
   integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
   dependencies:
     d3-array "2 - 3"
 
-"d3-timer@1 - 3":
+"d3-timer@1 - 3", d3-timer@3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
   integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
-d3-transition@3:
+"d3-transition@2 - 3", d3-transition@3:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
   integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
@@ -3735,6 +3838,53 @@ d3-transition@3:
     d3-ease "1 - 3"
     d3-interpolate "1 - 3"
     d3-timer "1 - 3"
+
+d3-zoom@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "2 - 3"
+    d3-transition "2 - 3"
+
+d3@^7.8.5:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-7.8.5.tgz#fde4b760d4486cdb6f0cc8e2cbff318af844635c"
+  integrity sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==
+  dependencies:
+    d3-array "3"
+    d3-axis "3"
+    d3-brush "3"
+    d3-chord "3"
+    d3-color "3"
+    d3-contour "4"
+    d3-delaunay "6"
+    d3-dispatch "3"
+    d3-drag "3"
+    d3-dsv "3"
+    d3-ease "3"
+    d3-fetch "3"
+    d3-force "3"
+    d3-format "3"
+    d3-geo "3"
+    d3-hierarchy "3"
+    d3-interpolate "3"
+    d3-path "3"
+    d3-polygon "3"
+    d3-quadtree "3"
+    d3-random "3"
+    d3-scale "4"
+    d3-scale-chromatic "3"
+    d3-selection "3"
+    d3-shape "3"
+    d3-time "3"
+    d3-time-format "4"
+    d3-timer "3"
+    d3-transition "3"
+    d3-zoom "3"
 
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
@@ -3872,6 +4022,13 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+delaunator@5:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.0.1.tgz#39032b08053923e924d6094fe2cde1a99cc51278"
+  integrity sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==
+  dependencies:
+    robust-predicates "^3.0.2"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -5337,6 +5494,13 @@ iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@0.6:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ideogram@1.45.1:
   version "1.45.1"
@@ -8490,6 +8654,11 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
+robust-predicates@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.2.tgz#d5b28528c4824d20fc48df1928d41d9efa1ad771"
+  integrity sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==
+
 "rollup@>=2.59.0 <2.78.0":
   version "2.77.3"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.77.3.tgz#8f00418d3a2740036e15deb653bed1a90ee0cc12"
@@ -8565,7 +8734,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8320,6 +8320,13 @@ react-select@^5.2.2:
     react-transition-group "^4.3.0"
     use-isomorphic-layout-effect "^1.1.2"
 
+react-svg-brush@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-svg-brush/-/react-svg-brush-1.0.0.tgz#f6b8e20157cd243fb9606436d7c1f7606443b35d"
+  integrity sha512-LqTHN8iVFM33xnAQULxFaxTFnhRpMx/T+FMLcOGJkH6onTMWdmfIDBWr3M52wdKjXslS9elGjRa8RZyTBVzQWQ==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-switch@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/react-switch/-/react-switch-6.0.0.tgz#bd4a2dea08f211b8a32e55e8314fd44bc1ec947e"


### PR DESCRIPTION
This makes it easier and more robust to filter cells by quantitative dimensions.

### Overview
[Previously](https://github.com/broadinstitute/single_cell_portal_core/pull/1980), cell filtering by numeric annotations had basic functionality, but was somewhat tedious and brittle.  Input had to be manually typed in, resetting was hard, non-default operators weren't integrated, etc.

Now, the numeric cell filtering UX is more intuitive and well-rounded, and ready for general availability (GA).  

Refinements include:
* **Range slider**.  Users expect to be able to select numeric ranges by conveniently resizing and moving a slider.  The new custom slider widget enables that with a UI that has clear affordances, economizes vertical real estate, and supports special (but common for SCP) cases like "not applicable" values, a.k.a. "N/A".

* **Reset**.  To clear a numeric selection, you either had to remember your initial values or reload the page.  Now you can simply click a reset / refresh icon beside the facet.  Global reset now works for numeric cell facets, too.  

* **Operators beyond "between"**.  Non-default operators -- i.e. "not between", =, !=, >, >=, <, and <= from the client library are now integrated into the numeric cell filtering UI.  Operators that take 1 parameter (i.e. =, !=, >, >=, <, and <=) show tooltips on histogram bars, but no slider.  The 2-parameter operators show the slider but no histogram bar tooltips.

* **Full values always visible**.  Numeric values in the input fields were previously truncated if they were too large.  A custom fade affordance slightly mitigated that UI accuracy problem, but remained very unintuitive and error-prone.  Now, input fields widen and shrink font to ensure these important values are never even partly hidden from view.  This also helps keep the paired inputs (i.e. range min. and max.) on the same line in typical viewports.  For narrow viewports, input pairs now linebreak together, rather than oddly having min. input on one line and max. input on another.

* **More robust handling for invalid values**.  Typing a values less than the minimum, greater than maximum, or non-numbers changes the input border color, and otherwise reasonably handled.

### Video
Here's how it looks! 

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/1b8e3a7f-a5cc-4e44-805c-d566696002b2

_^ Video 1: Slider resize and reset, and facet-level reset; facets with "N/A"_


https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/96019545-32cd-4576-873c-e9c99bc31146

_^ Video 2: Non-default operators, multiple facets, "Reset all filters", responsive layout; facets without "N/A"_

### Limitations
* No URL parameter integration
* Invalid input only indicated by border color change, lacks error message (e.g. "> max.", "< min.", "Not a number")

### Test
Automated testing was enhanced to verify UI changes.  To manually test:

1.  Go to a study with numeric annotations, e.g. "Cellular and transcriptional diversity over the course of human lactation" ([SCP303](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP303/cellular-and-transcriptional-diversity-over-the-course-of-human-lactation) on staging).  (I'll deploy to staging after SCP demo today.)
2.  Click "Filter plotted cells".
3.  Find a numeric annotation, e.g. "BMI during study".
4.  Resize the slider.
5.  Confirm the scatter plot legend shows a "Filtered" entry.
6. Move the slider, confirm plot "Filtered" entry updates when you stop moving (i.e., when you release your mouse click)
7. Click the reset icon at left in the facet, confirm plot update
8. Resize slider for another facet, confirm plot update

This satisfies SCP-5500.