### PR TITLE
Fix overshot slider for numeric cell filtering (SCP-5500)

### DIFF
--- a/app/javascript/components/explore/NumericCellFacet.jsx
+++ b/app/javascript/components/explore/NumericCellFacet.jsx
@@ -677,7 +677,10 @@ export function NumericCellFacet({
     const [newValue, newValue2] =
       parseValuesFromBrushSelection(brushSelection, xScale, precision)
 
-    if (newValue > max || newValue < min || newValue2 > max || newValue2 < min) {
+    if (
+      newValue > max || newValue < min || newValue2 > max || newValue2 < min ||
+      Number.isNaN(newValue) || Number.isNaN(newValue2)
+    ) {
       // Prevent handlebar misdisplay if crosshair-select moves out-of-bounds
       // See "overshot_slider.mov"
       // in https://github.com/broadinstitute/single_cell_portal_core/pull/1988#pullrequestreview-1920037002

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,7 +27,6 @@ module.exports = {
     '^~/(.*)$': '$1', // strip off the ~/, as jest doesn't need it since it has configured module directories
     '@single-cell-portal/igv': '<rootDir>/test/js/jest-mocks/igv-mock.js', // mock igv as jest has trouble parsing it
     'ideogram': '<rootDir>/test/js/jest-mocks/file-mock.js', // mock igv as jest has trouble parsing it
-    '\\.css$': '<rootDir>/test/js/jest-mocks/file-mock.js', // mock CSS files as jest has trouble parsing them
-    '^d3$': '<rootDir>/node_modules/d3/dist/d3.min.js' // Fix "export" bug upon `yarn test`
+    '\\.css$': '<rootDir>/test/js/jest-mocks/file-mock.js' // mock CSS files as jest has trouble parsing them
   }
 }


### PR DESCRIPTION
This prevents misdisplay if numeric filter crosshair-select moves out-of-bounds, a bug fix that regressed mid-PR in #1988.

Here's how the fix looks.

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/a300f33f-2330-45f7-b4c0-8c5d1a708647

### Test
Automatically testing drag interactions for React components in Jest is remarkably difficult, and turns out to be infeasible here.  To manually test:

1.  Go to a study with numeric annotations, e.g. "Cellular and transcriptional diversity over the course of human lactation" ([SCP303](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP303/cellular-and-transcriptional-diversity-over-the-course-of-human-lactation) on staging).
2.  Click "Filter plotted cells".
3.  Find a numeric annotation, e.g. "BMI during study".
4. Drag the right handlebar substantially to the left
5. In an area of the histogram not covered by the slider, click down and drag your cursor beyond the right edge of the slider
6. Confirm handlebar stop at right edge of slider, and value in right input does not exceed maximum (nor say "NaN")

This relates to SCP-5500.