### PR TITLE
Fix cell filtering after changing to categorical annotation (SCP-5552)

### DIFF
--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -42,6 +42,7 @@ function getHasNondefaultSelection(selectionMap, facets) {
     const [selectedFacet, selection] = entries[i]
 
     const facet = facets.find(f => f.annotation === selectedFacet)
+    if (!facet) {return false}
     let normDefault = facet.defaultSelection
     let normSelection = selection
     if (facet.type === 'group') {


### PR DESCRIPTION
This fixes a bug that breaks Study Overview after changing to a different categorical annotation, then cell filtering.

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/7e3f8f5a-4107-494a-9472-7a9dea471623

### Test
1.  Go to e.g. "Cellular and transcriptional diversity over the course of human lactation" ([SCP303](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP303/cellular-and-transcriptional-diversity-over-the-course-of-human-lactation) on staging).
2.  Change "Annotation" menu to "milk_stage"
3. Click "Filter plotted cells"
4. Confirm no red error box replaces plots

This satisfies SCP-5552.