### PR TITLE
Get organizational profile from user (SCP-5527)

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -102,10 +102,16 @@ class ProfilesController < ApplicationController
     user_accepted = tos_params[:action] == 'accept'
     if user_accepted
       # record user acceptance, which tracks the email, the date, and the version of the ToS
-      TosAcceptance.create(email: @user.email)
+
       organization = tos_params[:organization]
       organizational_email = tos_params[:organizational_email]
       @user.update(organization:, organizational_email:)
+
+      if @user.errors
+        message = @user.errors.errors[0].message
+        render json: {errors: message}, status: :bad_request and return
+      end
+      TosAcceptance.create(email: @user.email)
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), notice: 'Terms of Service response successfully recorded.' and return
     else
       sign_out @user

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -144,7 +144,7 @@ class ProfilesController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:admin_email_delivery, :use_short_session)
+    params.require(:user).permit(:admin_email_delivery, :use_short_session, :organization, :organizational_email)
   end
 
   def study_share_params

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -104,8 +104,8 @@ class ProfilesController < ApplicationController
       # record user acceptance, which tracks the email, the date, and the version of the ToS
       TosAcceptance.create(email: @user.email)
       organization = tos_params[:organization]
-      organization_email = tos_params[:organization_email]
-      @user.update(organization:, organization_email:)
+      organizational_email = tos_params[:organizational_email]
+      @user.update(organization:, organizational_email:)
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), notice: 'Terms of Service response successfully recorded.' and return
     else
       sign_out @user
@@ -163,6 +163,6 @@ class ProfilesController < ApplicationController
   end
 
   def tos_params
-    params.require(:tos).permit(:action, :organization, :organization_email)
+    params.require(:tos).permit(:action, :organization, :organizational_email)
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -103,6 +103,9 @@ class ProfilesController < ApplicationController
     if user_accepted
       # record user acceptance, which tracks the email, the date, and the version of the ToS
       TosAcceptance.create(email: @user.email)
+      organization = tos_params[:organization]
+      organization_email = tos_params[:organization_email]
+      @user.update(organization:, organization_email:)
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), notice: 'Terms of Service response successfully recorded.' and return
     else
       sign_out @user
@@ -160,6 +163,6 @@ class ProfilesController < ApplicationController
   end
 
   def tos_params
-    params.require(:tos).permit(:action)
+    params.require(:tos).permit(:action, :organization, :organization_email)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,8 +37,8 @@ class User
          :recoverable, :rememberable, :trackable, :validatable, :timeoutable,
          :omniauthable, :omniauth_providers => [:google_oauth2]
 
-  validates_format_of :email, :with => Devise.email_regexp, message: 'is not a valid email address.'
-  validates_format_of :organizational_email, :with => Devise.email_regexp, allow_blank: true, message: 'is not a valid email address.'
+  validates_format_of :email, :with => Devise.email_regexp, message: 'is not a valid email address'
+  validates_format_of :organizational_email, :with => Devise.email_regexp, allow_blank: true, message: 'Invalid email address'
 
   ## Database authenticatable
   field :email,              type: String, default: ""

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,7 +98,7 @@ class User
   field :metrics_uuid, type: String
 
   field :organization, type: String, default: ""
-  field :organization_email, type: String, default: ""
+  field :organizational_email, type: String, default: ""
 
   # feature_flags should be a hash of true/false values.  If unspecified for a given flag, the
   # default_value from the FeatureFlag should be used.  Accordingly, the helper method feature_flags_with_defaults

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,7 @@ class User
          :omniauthable, :omniauth_providers => [:google_oauth2]
 
   validates_format_of :email, :with => Devise.email_regexp, message: 'is not a valid email address.'
+  validates_format_of :organizational_email, :with => Devise.email_regexp, allow_blank: true, message: 'is not a valid email address.'
 
   ## Database authenticatable
   field :email,              type: String, default: ""

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -97,6 +97,9 @@ class User
   field :api_access_token, type: Hash
   field :metrics_uuid, type: String
 
+  field :organization, type: String, default: ""
+  field :organization_email, type: String, default: ""
+
   # feature_flags should be a hash of true/false values.  If unspecified for a given flag, the
   # default_value from the FeatureFlag should be used.  Accordingly, the helper method feature_flags_with_defaults
   # is provided

--- a/app/views/profiles/accept_tos.html.erb
+++ b/app/views/profiles/accept_tos.html.erb
@@ -5,8 +5,12 @@
 <%= form_for :tos, url: record_tos_action_path, html: {class: 'form', id: 'tos-form'} do |f| %>
   <%= f.hidden_field :action, value: 'accept' %>
   <div class="col-md-3">
-  <%= f.label :institution %>
-  <%= f.text_field :institution, class: 'form-control' %>
+  <%= f.label :organization %>
+  <%= f.text_field :organization, class: 'form-control' %>
+  </div>
+  <div class="col-md-3">
+  <%= f.label :organization_email, "Organization email (if different from sign-in email)" %>
+  <%= f.text_field :organization_email, class: 'form-control' %>
   </div>
   <br/>
   <%= link_to "Accept", '#', class: 'btn btn-lg btn-success submit-tos', id: 'accept-tos', data: {accept: 'accept'} %>

--- a/app/views/profiles/accept_tos.html.erb
+++ b/app/views/profiles/accept_tos.html.erb
@@ -4,6 +4,11 @@
 </div>
 <%= form_for :tos, url: record_tos_action_path, html: {class: 'form', id: 'tos-form'} do |f| %>
   <%= f.hidden_field :action, value: 'accept' %>
+  <div class="col-md-3">
+  <%= f.label :institution %>
+  <%= f.text_field :institution, class: 'form-control' %>
+  </div>
+  <br/>
   <%= link_to "Accept", '#', class: 'btn btn-lg btn-success submit-tos', id: 'accept-tos', data: {accept: 'accept'} %>
   <%= link_to "Cancel", '#', class: 'btn btn-lg btn-danger submit-tos', id: 'deny-tos', data: {accept: 'deny'} %>
 <% end %>

--- a/app/views/profiles/accept_tos.html.erb
+++ b/app/views/profiles/accept_tos.html.erb
@@ -8,8 +8,8 @@
   <%= f.label :organization %>
   <%= f.text_field :organization, class: 'form-control' %>
   </div>
-  <div class="col-md-3">
-  <%= f.label :organizational_email, "Organizational email (if different from sign-in email)" %>
+  <div class="col-md-3" >
+  <%= f.label :organizational_email, "Organizational email (if different from sign-in)" %>
   <%= f.text_field :organizational_email, class: 'form-control' %>
   </div>
   <br/>

--- a/app/views/profiles/accept_tos.html.erb
+++ b/app/views/profiles/accept_tos.html.erb
@@ -9,8 +9,8 @@
   <%= f.text_field :organization, class: 'form-control' %>
   </div>
   <div class="col-md-3">
-  <%= f.label :organization_email, "Organization email (if different from sign-in email)" %>
-  <%= f.text_field :organization_email, class: 'form-control' %>
+  <%= f.label :organizational_email, "Organizational email (if different from sign-in email)" %>
+  <%= f.text_field :organizational_email, class: 'form-control' %>
   </div>
   <br/>
   <%= link_to "Accept", '#', class: 'btn btn-lg btn-success submit-tos', id: 'accept-tos', data: {accept: 'accept'} %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -21,6 +21,24 @@
 
   <div class="tab-content top-pad">
     <div class="tab-pane active in" id="profile-emails" role="tabpanel">
+    <%= form_for(@user, url: update_profile_path, html: {class: 'form', id: 'update-user-organization',
+                                                           data: { remote: true }}) do |f| %>
+      <div class="row">
+        <div class="form-group">
+          <h3 style="margin-left: 15px">Organizational profile</h3>
+          <div class="col-md-3">
+            <%= f.label :organization %>
+            <%= f.text_field :organization, class: 'form-control' %>
+          </div>
+            <div class="col-md-3">
+            <%= f.label :organizational_email, "Organizational email (if different from sign-in)" %>
+            <%= f.text_field :organizational_email, class: 'form-control' %>
+          </div>
+          <%= f.submit 'Update', class: 'btn btn-lg btn-success', style: "margin-left: 15px; margin-top: 15px", id: 'update-organizational' %>
+        </div>
+      </div>
+      <% end %>
+
       <%= form_for(@user, url: update_profile_path, html: {class: 'form', id: 'update-user-session',
                                                            data: { remote: true }}) do |f| %>
         <%= hidden_field_tag :toggle_id, "toggle_user_use_short_session" %>


### PR DESCRIPTION
This adds optional inputs for "Organization" and "Organizational email" to our ToS, and a way to update them in "My profile".

Previously, we had no well-structured data on our users' business identity.  Users often sign in to Single Cell Portal with a Google account that is not linked to their corporate / institutional email address.  Now, two new optional fields shown in the SCP Terms of Service -- which users accept upon their first sign-in -- help us gather that data.  These values can be changed in the "My profile" page, under a new "Organizational profile" area.

Here's how it looks:

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/b0a5efdd-f263-40fd-b816-ca8e9c711f93

### Test
1.  Sign in with an account that is not your main account in your SCP instance
2. If you do not see the SCP Terms of Service page upon signing in, then delete records for this user account and its associated ToS acceptance.  Sign in again after running commands below, if needed.
```
rails console -e development
user = User.find_by(email: <email address for non-main account>)
user.delete
user_tos = TosAcceptance.find_by(email: <email address for non-main account>)
user_tos.delete
```
3.  Enter values for "Organization" and "Organizational email"
4. Click "Accept"
5. After new page loads, in menu at top-right of page, click "My profile"
6. Confirm values you entered appear in "Organization" and "Organizational email" fields
7. Change values in those fields, click "Update"
8. Reload page
9. Confirm your changes appear

This satisfies SCP-5527.