### PR TITLE
Fix slider when min, max have long decimal values (SCP-5555)

### DIFF
--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -9,7 +9,7 @@ import crossfilter from 'crossfilter2'
 import { getIdentifierForAnnotation } from '~/lib/cluster-utils'
 import { fetchAnnotationFacets } from '~/lib/scp-api'
 import { log } from '~/lib/metrics-api'
-
+import { round } from '~/lib/metrics-perf'
 
 const CELL_TYPE_REGEX = new RegExp(/cell.*type/i)
 
@@ -324,12 +324,14 @@ function mergeFacetsResponses(newRawFacets, prevCellFaceting) {
   return [mergedRawFacets, nullFacets]
 }
 
-/** Get minimum and maximum bounds of value range for numeric filters */
+/** Get minimum and maximum value range for numeric filters, rounded to 2 decimal places */
 export function getMinMaxValues(filters) {
   const firstValue = filters[0][0]
   const hasNull = firstValue === null
-  const minValue = hasNull ? filters[1][0] : firstValue
-  const maxValue = filters.slice(-1)[0][0]
+  const rawMinValue = hasNull ? filters[1][0] : firstValue
+  const minValue = round(rawMinValue, 2)
+  const rawMaxValue = filters.slice(-1)[0][0]
+  const maxValue = round(rawMaxValue, 2)
   return [minValue, maxValue, hasNull]
 }
 

--- a/test/js/explore/cell-filtering-panel.test-data.js
+++ b/test/js/explore/cell-filtering-panel.test-data.js
@@ -4342,7 +4342,7 @@ export const cellFaceting = {
           6450
         ],
         [
-          18.84,
+          18.8356789, // Synthetic value to test rounding for long values (SCP-5555)
           1686
         ],
         [

--- a/test/js/explore/cell-filtering-panel.test.js
+++ b/test/js/explore/cell-filtering-panel.test.js
@@ -210,7 +210,11 @@ describe('"Cell filtering" panel', () => {
     const sliderSelection = histogram.querySelector('.selection')
     const sliderOffset = sliderSelection.getAttribute('x')
     const sliderWidth = sliderSelection.getAttribute('width')
-    expect(sliderOffset).toEqual('24')
+
+    // Confirm minimum value of 18.8356789 in test data gets rounded to 2
+    // decimal places; without which this offset becomes "24.044423180157942" (SCP-5555)
+    const expectedOffset = '24'
+    expect(sliderOffset).toEqual(expectedOffset)
     expect(sliderWidth).toEqual('155')
 
     // Confirm clicking "N/A" checkbox calls filtering code


### PR DESCRIPTION
This rounds long decimal values, to fix two related bugs in the slider of numeric cell facets:

### Overview
1.  Long decimal values get truncated from view.  This was the case previously for all long numbers, but the recent layout robustness improvement did not cover numbers that include long fractional segments, e.g. full-precision floats like 16.167313586858402.

2.  In cases of bug 1, slider resize doesn't work.  Values can still be changed via the manual input fields, but broken input-by-slider is quite inconvenient in these cases.

Rounding the minimum and maximum values to 2 decimal places (e.g. 0.345678912 -> 0.35) fixes both issues.  For context, we do somewhat similarly for gene expression values -- rounding to 3 decimal places at ingest.

### Video
Here's how it looks, before and after.

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/4fd34520-092a-470f-a96b-70a112c85113

(The fact that the "--Filtered--" scatter plot legend doesn't appear is a separate bug, with a fix under development.  This dataset presents two previously untested scenarios, with this one being more prevalent.)

### Test
Automated tests have been updated to confirm this fix.  To manually test:
1.  Go to a study that has a numeric annotation with a maximum or minimum that has long decimal values.  [SCP390 on staging](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP390/multi-species-asos-reproducing-scp2126-on-staging) is an example.
2. Click "Filter plotted cells".
3. Find the numeric cell facet that has long decimal values.
4. Confirm the long values are rounded to 2 decimal places.
5. Resize the slider.
6. Confirm slider resizes, and that new selection boundaries are shown in the two input fields.  ("--Filtered--" may not appear in the legend due to a separate bug.)

This satisfies SCP-5555.