### PR TITLE
Restore CI signal by disabling tests for known issues (SCP-5562)

### DIFF
--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -245,6 +245,7 @@ class HcaAzulClient
     filter_query = format_hash_as_query_string(project_filter)
     base_path += "?filters=#{filter_query}&format=#{format}"
     path = append_catalog(base_path, catalog)
+    byebug
     # since manifest files are generated on-demand, keep making requests until the Status code is 302 (Found)
     # Status 301 means that the manifest is still being generated; if no manifest is ready after 30s, return anyway
     time_slept = 0

--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -245,7 +245,6 @@ class HcaAzulClient
     filter_query = format_hash_as_query_string(project_filter)
     base_path += "?filters=#{filter_query}&format=#{format}"
     path = append_catalog(base_path, catalog)
-    byebug
     # since manifest files are generated on-demand, keep making requests until the Status code is 302 (Found)
     # Status 301 means that the manifest is still being generated; if no manifest is ready after 30s, return anyway
     time_slept = 0

--- a/test/integration/external/hca_azul_client_test.rb
+++ b/test/integration/external/hca_azul_client_test.rb
@@ -163,22 +163,25 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     assert_equal keys, file.keys.sort & keys
   end
 
-  test 'should get HCA metadata tsv link' do
-    skip_if_api_down
-    manifest_info = @hca_azul_client.project_manifest_link(@project_id)
-    assert manifest_info.present?
-    assert_equal 302, manifest_info['Status']
-    # make GET on manifest URL and assert contents are HCA metadata
-    manifest_response = RestClient.get manifest_info['Location']
-    assert_equal 200, manifest_response.code
-    raw_manifest = manifest_response.body.split("\r\n")
-    headers = raw_manifest.first.split("\t")
-    project_id_header = 'project.provenance.document_id'
-    assert headers.include? project_id_header
-    project_idx = headers.index(project_id_header)
-    data_row = raw_manifest.sample.split("\t")
-    assert_equal @project_id, data_row[project_idx]
-  end
+  # TODO: SCP-5564
+  #   - Fix "Global bulk download breaks in default use"
+  #   - Re-enable this test
+  # test 'should get HCA metadata tsv link' do
+  #   skip_if_api_down
+  #   manifest_info = @hca_azul_client.project_manifest_link(@project_id)
+  #   assert manifest_info.present?
+  #   assert_equal 302, manifest_info['Status']
+  #   # make GET on manifest URL and assert contents are HCA metadata
+  #   manifest_response = RestClient.get manifest_info['Location']
+  #   assert_equal 200, manifest_response.code
+  #   raw_manifest = manifest_response.body.split("\r\n")
+  #   headers = raw_manifest.first.split("\t")
+  #   project_id_header = 'project.provenance.document_id'
+  #   assert headers.include? project_id_header
+  #   project_idx = headers.index(project_id_header)
+  #   data_row = raw_manifest.sample.split("\t")
+  #   assert_equal @project_id, data_row[project_idx]
+  # end
 
   test 'should format object for query string' do
     query_object = { 'foo' => { 'bar' => 'baz' } }

--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -48,12 +48,13 @@ module ImportServiceConfig
       assert_equal @branding_group, @configuration.branding_group
     end
 
-    test 'should traverse associations to set ids' do
-      config = ImportServiceConfig::Nemo.new(file_id: @attributes[:file_id])
-      config.traverse_associations!
-      assert_equal @attributes[:study_id], config.study_id
-      assert_equal @attributes[:project_id], config.project_id
-    end
+    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+    # test 'should traverse associations to set ids' do
+    #   config = ImportServiceConfig::Nemo.new(file_id: @attributes[:file_id])
+    #   config.traverse_associations!
+    #   assert_equal @attributes[:study_id], config.study_id
+    #   assert_equal @attributes[:project_id], config.project_id
+    # end
 
     test 'should load defaults' do
       study_defaults = {
@@ -99,24 +100,26 @@ module ImportServiceConfig
       assert_equal %w[human], study['taxonomies']
     end
 
-    test 'should load file analog' do
-      file = @configuration.load_file
-      assert_equal 'human_var_scVI_VLMC.h5ad.tar', file['file_name']
-      assert_equal 'h5ad', file['file_format']
-      assert_equal 'counts', file['data_type']
-    end
+    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+    # test 'should load file analog' do
+    #   file = @configuration.load_file
+    #   assert_equal 'human_var_scVI_VLMC.h5ad.tar', file['file_name']
+    #   assert_equal 'h5ad', file['file_format']
+    #   assert_equal 'counts', file['data_type']
+    # end
 
     test 'should load collection analog' do
       collection = @configuration.load_collection
       assert_equal 'AIBS Internal', collection['short_name']
     end
 
-    test 'should extract association ids' do
-      file = @configuration.load_file
-      study = @configuration.load_study
-      assert_equal @attributes[:study_id], @configuration.id_from(file, :collections)
-      assert_equal @attributes[:project_id], @configuration.id_from(study, :projects)
-    end
+    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+    # test 'should extract association ids' do
+    #   file = @configuration.load_file
+    #   study = @configuration.load_study
+    #   assert_equal @attributes[:study_id], @configuration.id_from(file, :collections)
+    #   assert_equal @attributes[:project_id], @configuration.id_from(study, :projects)
+    # end
 
     test 'should load taxon common names' do
       assert_equal %w[human], @configuration.taxon_names
@@ -127,52 +130,54 @@ module ImportServiceConfig
       assert_equal 'Drop-seq', @configuration.find_library_prep('drop-seq')
     end
 
-    test 'should populate study and study_file' do
-      scp_study = @configuration.populate_study
-      assert_equal 'Human variation study (10x), GRU', scp_study.name
-      assert_not scp_study.public
-      assert scp_study.full_description.present?
-      assert_equal @user_id, scp_study.user_id
-      assert_equal @branding_group_id, scp_study.branding_group_ids.first
-      assert_equal @configuration.service_name, scp_study.imported_from
-      # populate StudyFile, using above study
-      scp_study_file = @configuration.populate_study_file(scp_study.id)
-      assert scp_study_file.use_metadata_convention
-      assert_equal 'human_var_scVI_VLMC.h5ad.tar', scp_study_file.upload_file_name
-      assert_equal "10x 3' v3", scp_study_file.expression_file_info.library_preparation_protocol
-      assert_equal @configuration.service_name, scp_study_file.imported_from
-      assert_not scp_study_file.ann_data_file_info.reference_file
-      @configuration.obsm_keys.each do |obsm_key_name|
-        assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?
-      end
-      assert scp_study_file.ann_data_file_info.find_fragment(data_type: :expression).present?
-    end
+    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+    # test 'should populate study and study_file' do
+    #   scp_study = @configuration.populate_study
+    #   assert_equal 'Human variation study (10x), GRU', scp_study.name
+    #   assert_not scp_study.public
+    #   assert scp_study.full_description.present?
+    #   assert_equal @user_id, scp_study.user_id
+    #   assert_equal @branding_group_id, scp_study.branding_group_ids.first
+    #   assert_equal @configuration.service_name, scp_study.imported_from
+    #   # populate StudyFile, using above study
+    #   scp_study_file = @configuration.populate_study_file(scp_study.id)
+    #   assert scp_study_file.use_metadata_convention
+    #   assert_equal 'human_var_scVI_VLMC.h5ad.tar', scp_study_file.upload_file_name
+    #   assert_equal "10x 3' v3", scp_study_file.expression_file_info.library_preparation_protocol
+    #   assert_equal @configuration.service_name, scp_study_file.imported_from
+    #   assert_not scp_study_file.ann_data_file_info.reference_file
+    #   @configuration.obsm_keys.each do |obsm_key_name|
+    #     assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?
+    #   end
+    #   assert scp_study_file.ann_data_file_info.find_fragment(data_type: :expression).present?
+    # end
 
-    test 'should import from service' do
-      access_url = 'https://data.nemoarchive.org/other/grant/u01_lein/lein/transcriptome/sncell/10x_v3/human/' \
-                   'processed/counts/human_var_scVI_VLMC.h5ad.tar'
-      file_mock = MiniTest::Mock.new
-      file_mock.expect :generation, '123456789'
-      # for study to save, we need to mock all Terra orchestration API calls for creating workspace & setting acls
-      fc_client_mock = Minitest::Mock.new
-      owner_group = { groupEmail: 'sa-owner-group@firecloud.org' }.with_indifferent_access
-      assign_workspace_mock!(fc_client_mock, owner_group, 'human-variation-study-10x-gru')
-      AdminConfiguration.stub :find_or_create_ws_user_group!, owner_group do
-        ImportService.stub :copy_file_to_bucket, file_mock do
-          ApplicationController.stub :firecloud_client, fc_client_mock do
-            @configuration.stub :taxon_from, Taxon.new(common_name: 'human') do
-              study, study_file = @configuration.import_from_service
-              file_mock.verify
-              fc_client_mock.verify
-              assert study.persisted?
-              assert study_file.persisted?
-              assert_equal study.external_identifier, @attributes[:study_id]
-              assert_equal study_file.external_identifier, @attributes[:file_id]
-              assert_equal study_file.external_link_url, access_url
-            end
-          end
-        end
-      end
-    end
+    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+    # test 'should import from service' do
+    #   access_url = 'https://data.nemoarchive.org/other/grant/u01_lein/lein/transcriptome/sncell/10x_v3/human/' \
+    #                'processed/counts/human_var_scVI_VLMC.h5ad.tar'
+    #   file_mock = MiniTest::Mock.new
+    #   file_mock.expect :generation, '123456789'
+    #   # for study to save, we need to mock all Terra orchestration API calls for creating workspace & setting acls
+    #   fc_client_mock = Minitest::Mock.new
+    #   owner_group = { groupEmail: 'sa-owner-group@firecloud.org' }.with_indifferent_access
+    #   assign_workspace_mock!(fc_client_mock, owner_group, 'human-variation-study-10x-gru')
+    #   AdminConfiguration.stub :find_or_create_ws_user_group!, owner_group do
+    #     ImportService.stub :copy_file_to_bucket, file_mock do
+    #       ApplicationController.stub :firecloud_client, fc_client_mock do
+    #         @configuration.stub :taxon_from, Taxon.new(common_name: 'human') do
+    #           study, study_file = @configuration.import_from_service
+    #           file_mock.verify
+    #           fc_client_mock.verify
+    #           assert study.persisted?
+    #           assert study_file.persisted?
+    #           assert_equal study.external_identifier, @attributes[:study_id]
+    #           assert_equal study_file.external_identifier, @attributes[:file_id]
+    #           assert_equal study_file.external_link_url, access_url
+    #         end
+    #       end
+    #     end
+    #   end
+    # end
   end
 end

--- a/test/integration/external/import_service_test.rb
+++ b/test/integration/external/import_service_test.rb
@@ -9,15 +9,16 @@ class ImportServiceTest < ActiveSupport::TestCase
     }
   end
 
-  test 'should call API client method' do
-    client = NemoClient.new
-    nemo_file = ImportService.call_api_client(client, :file, @nemo_attributes[:file_id])
-    assert_equal 'BI006_marm028_Munchkin_M1_rxn1.4.bam.bai', nemo_file['file_name']
-    assert_equal 'bam', nemo_file['file_format']
-    assert_raises ArgumentError do
-      ImportService.call_api_client(FireCloudClient.new, :api_available?)
-    end
-  end
+  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+  # test 'should call API client method' do
+  #   client = NemoClient.new
+  #   nemo_file = ImportService.call_api_client(client, :file, @nemo_attributes[:file_id])
+  #   assert_equal 'BI006_marm028_Munchkin_M1_rxn1.4.bam.bai', nemo_file['file_name']
+  #   assert_equal 'bam', nemo_file['file_format']
+  #   assert_raises ArgumentError do
+  #     ImportService.call_api_client(FireCloudClient.new, :api_available?)
+  #   end
+  # end
 
   test 'should call import from external service' do
     mock = Minitest::Mock.new

--- a/test/integration/external/nemo_client_test.rb
+++ b/test/integration/external/nemo_client_test.rb
@@ -55,13 +55,14 @@ class NemoClientTest < ActiveSupport::TestCase
     end
   end
 
-  test 'should get an entity' do
-    skip_if_api_down
-    entity_type = @identifiers.keys.sample
-    identifier = @identifiers[entity_type]
-    entity = @nemo_client.fetch_entity(entity_type, identifier)
-    assert entity.present?
-  end
+  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+  # test 'should get an entity' do
+  #   skip_if_api_down
+  #   entity_type = @identifiers.keys.sample
+  #   identifier = @identifiers[entity_type]
+  #   entity = @nemo_client.fetch_entity(entity_type, identifier)
+  #   assert entity.present?
+  # end
 
   test 'should get collection' do
     skip_if_api_down
@@ -71,26 +72,28 @@ class NemoClientTest < ActiveSupport::TestCase
     assert_equal 'adey_sciATAC_human_cortex', collection['short_name']
   end
 
-  test 'should get file' do
-    skip_if_api_down
-    identifier = @identifiers[:file]
-    file = @nemo_client.file(identifier)
-    assert file.present?
-    filename = 'human_var_scVI_VLMC.h5ad.tar'
-    assert_equal filename, file['file_name']
-    assert_equal 'h5ad', file['file_format']
-    access_url = file['urls'].first['url']
-    assert_equal filename, access_url.split('/').last
-  end
+  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+  # test 'should get file' do
+  #   skip_if_api_down
+  #   identifier = @identifiers[:file]
+  #   file = @nemo_client.file(identifier)
+  #   assert file.present?
+  #   filename = 'human_var_scVI_VLMC.h5ad.tar'
+  #   assert_equal filename, file['file_name']
+  #   assert_equal 'h5ad', file['file_format']
+  #   access_url = file['urls'].first['url']
+  #   assert_equal filename, access_url.split('/').last
+  # end
 
-  test 'should get grant' do
-    skip_if_api_down
-    identifier = @identifiers[:grant]
-    grant = @nemo_client.grant(identifier)
-    assert grant.present?
-    assert_equal '1U01MH114825-01', grant['grant_number']
-    assert_equal 'NIMH', grant['funding_agency']
-  end
+  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+  # test 'should get grant' do
+  #   skip_if_api_down
+  #   identifier = @identifiers[:grant]
+  #   grant = @nemo_client.grant(identifier)
+  #   assert grant.present?
+  #   assert_equal '1U01MH114825-01', grant['grant_number']
+  #   assert_equal 'NIMH', grant['funding_agency']
+  # end
 
   test 'should get project' do
     skip_if_api_down
@@ -103,32 +106,35 @@ class NemoClientTest < ActiveSupport::TestCase
     assert_equal 'dulac_poa_dev_sn_10x_proj', project['short_name']
   end
 
-  test 'should get publication' do
-    skip_if_api_down
-    identifier = @identifiers[:publication]
-    publication = @nemo_client.publication(identifier)
-    assert publication.present?
-    assert_equal 'eLife', publication['journal']
-    assert_equal 'https://doi.org/10.7554/eLife.64875', publication['doi']
-    assert_equal ["human", "macaques", "house mouse"].sort, publication['taxonomies'].sort
-  end
+  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+  # test 'should get publication' do
+  #   skip_if_api_down
+  #   identifier = @identifiers[:publication]
+  #   publication = @nemo_client.publication(identifier)
+  #   assert publication.present?
+  #   assert_equal 'eLife', publication['journal']
+  #   assert_equal 'https://doi.org/10.7554/eLife.64875', publication['doi']
+  #   assert_equal ["human", "macaques", "house mouse"].sort, publication['taxonomies'].sort
+  # end
 
-  test 'should get sample' do
-    skip_if_api_down
-    identifier = @identifiers[:sample]
-    sample = @nemo_client.sample(identifier)
-    assert sample.present?
-    assert_equal 'marm028_M1', sample['source_sample_id']
-    assert sample['files'].any?
-  end
+  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+  # test 'should get sample' do
+  #   skip_if_api_down
+  #   identifier = @identifiers[:sample]
+  #   sample = @nemo_client.sample(identifier)
+  #   assert sample.present?
+  #   assert_equal 'marm028_M1', sample['source_sample_id']
+  #   assert sample['files'].any?
+  # end
 
-  test 'should get subject' do
-    skip_if_api_down
-    identifier = @identifiers[:subject]
-    subject = @nemo_client.subject(identifier)
-    assert subject.present?
-    assert_equal 'CEMBA180911_4H', subject['source_subject_id']
-    assert_equal 'DNA methylation profiling of genomic DNA in individual mouse brain cell nuclei (RS1.1)',
-                 subject['grant_title']
-  end
+  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+  # test 'should get subject' do
+  #   skip_if_api_down
+  #   identifier = @identifiers[:subject]
+  #   subject = @nemo_client.subject(identifier)
+  #   assert subject.present?
+  #   assert_equal 'CEMBA180911_4H', subject['source_subject_id']
+  #   assert_equal 'DNA methylation profiling of genomic DNA in individual mouse brain cell nuclei (RS1.1)',
+  #                subject['grant_title']
+  # end
 end


### PR DESCRIPTION
This denoises CI by temporarily disabling tests that use broken external services.  New tickets track underlying fixes.

### Overview
For almost two weeks, all CI test runs have failed due to errors in some Rails external integration tests.  The tests failed because upstream APIs made a breaking change, or otherwise broke.  The failures represent a rare user-facing issue, and a handful of non-user-facing issues.  

The user-facing issue is a very low incidence bug in global bulk download.  It's caused by a problem fetching project manifests from HCA Azul.  The other tests report non-user-facing issues with how Import Service integrates with the NeMO API (neither component is in production use).  Given this is not transitory and to keep focus on prioritized work, failing tests are now commented out and note TODOs to tracking tickets.

Tickets below have more details: diagnostics, incidence and severity assessments, workarounds, steps to reproduce, etc.:
* Bulk download issue: SCP-5564
* Import Service issue: SCP-5565

This PR is only intended to quickly restore useful CI signal, and surface information for the underlying issues.  Fixes for those issues are more complex and scoped to those other tickets, which are lined up for triage in sprint planning.

### Test
Confirm GitHub test check -- i.e. "SCP Continuous Integration / Run-All-Tests (pull_request)" -- passes in this PR.

### Further details
Once this is merged, I'll update other open PRs so they show a more accurate CI signal.

This satisfies SCP-5562.