### PR TITLE
Fix cell filtering when numeric annotation has same value for all cells (SCP-5554)

### DIFF
--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -215,6 +215,11 @@ export function filterCells(
           const numericFilters = selection[facet] // e.g. [0, 20]
 
           if (numericFilters === undefined) {
+            // Some numeric annotations can have 1 (and only 1) value repeated
+            // for every cell.  Such annotations are not eligible as facets,
+            // because filtering requires > 1 value.
+            //
+            // TODO (SCP-5513): Screen numeric facets with constant value
             continue
           }
 

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -92,17 +92,18 @@ function logFilterCells(t0Counts, t0, filterableCells, results, selection) {
   const filterPerfTime = t1 - t0
   const numCellsBefore = filterableCells.length
   const numCellsAfter = results.length
-  const numFacetsSelected = Object.keys(selection).length
+  const numFacets = Object.keys(selection).length
   const numFiltersSelected = Object.values(selection).reduce((numFilters, selectedFiltersForThisFacet) => {
     // return accumulator (an integer) + current value (an array, specifically its length)
     return numFilters + selectedFiltersForThisFacet?.length
   }, 0)
+
   const filterLogProps = {
     'perfTime': filterPerfTime,
     'perfTime:counts': perfTimeCounts,
     numCellsBefore,
     numCellsAfter,
-    numFacetsSelected,
+    numFacets,
     numFiltersSelected
   }
 
@@ -212,6 +213,10 @@ export function filterCells(
           // Example via console interface:
           // window.SCP.updateFilteredCells({'time_post_partum_days--numeric--study': [[0.5, 9]]})
           const numericFilters = selection[facet] // e.g. [0, 20]
+
+          if (numericFilters === undefined) {
+            continue
+          }
 
           fn = function(d) {
             return applyNumericFilters(d, numericFilters)
@@ -466,7 +471,7 @@ function getFilterCounts(annotationFacets, cellsByFacet, facets, selection) {
     Object.entries(filterCounts).forEach(([facet, countsByFilter]) => {
       Object.entries(countsByFilter).forEach(([filter, count]) => {
         let newCount = count
-        if (!(facet in selection && selection[facet].includes(filter))) {
+        if (!(facet in selection && selection[facet]?.includes(filter))) {
           newCount = 0
         }
         filterCounts[facet][filter] = newCount

--- a/test/js/lib/cell-faceting.test.js
+++ b/test/js/lib/cell-faceting.test.js
@@ -68,4 +68,117 @@ describe('Cell faceting', () => {
     expect(applyNumericFilters(10, [[['between', [0, 2]], ['between', [8, 20]]], true])).toStrictEqual(true)
     expect(applyNumericFilters(5, [[['between', [0, 2]], ['between', [8, 20]]], true])).toStrictEqual(false)
   })
+
+  it('filters cells even when a raw data has numeric annotation with 1 value for all cells', async () => {
+    // This tests a fix for a bug in cell filtering that was first observed in production SCP2126.
+    // The bug causes cell filtering to fail when any filter is changed.  It is caused by
+    // a numeric facet ("Weeks post dose") that has the same number (4) for all cells.  Cell filtering
+    // requires a set of cells to have > 1 value.  This tests special handling when that constraint is
+    // violated in numeric annotations.
+    //
+    // Once ticket SCP-5572 is resolved, this test will be obsolete and should be deleted.
+
+    const allAnnotsScp5554 = [
+      {
+        'name': 'sex',
+        'type': 'group',
+        'values': [
+          'female',
+          'male'
+        ],
+        'scope': 'study',
+        'is_differential_expression_enabled': false
+      },
+      {
+        'name': 'cell_type__ontology_label',
+        'type': 'group',
+        'values': [
+          'neuron',
+          'fibroblast'
+        ],
+        'scope': 'study',
+        'is_differential_expression_enabled': false
+      },
+      {
+        'name': 'weeks_post_dose',
+        'type': 'numeric',
+        'values': [],
+        'scope': 'study',
+        'is_differential_expression_enabled': false
+      }
+    ]
+
+    const constantNumericValue = 4
+    const facetDataScp5554 = {
+      'cells': [
+        [1, 1, constantNumericValue],
+        [0, 1, constantNumericValue],
+        [1, 0, constantNumericValue],
+        [0, 0, constantNumericValue]
+      ],
+      'facets': [
+        {
+          'annotation': 'cell_type__ontology_label--group--study',
+          'groups': [
+            'neuron',
+            'fibroblast'
+          ]
+        },
+        {
+          'annotation': 'sex--group--study',
+          'groups': [
+            'female',
+            'male'
+          ]
+        },
+        {
+          'annotation': 'weeks_post_dose--numeric--study',
+          'groups': []
+        }
+      ]
+    }
+
+
+    const fetchAnnotationFacets = jest.spyOn(ScpApi, 'fetchAnnotationFacets')
+    // pass in a clone of the response since it may get modified by the cache operations
+    fetchAnnotationFacets.mockImplementation(() => Promise.resolve(
+      facetDataScp5554
+    ))
+
+    // Test client-side cell faceting setup functionality
+    const selectedCluster = 'scp_clustering_mouse_thalamus.tsv'
+    const selectedAnnot = { name: 'Category', type: 'group', scope: 'study' }
+    const studyAccession = 'SCP174'
+
+    const cellFaceting = await initCellFaceting(
+      selectedCluster, selectedAnnot, studyAccession, allAnnotsScp5554
+    )
+
+    const cellsByFacet = cellFaceting.cellsByFacet
+    const facets = cellFaceting.facets
+    const filterableCells = cellFaceting.filterableCells
+
+    const expectedFilterableCells3 = {
+      'allCellsIndex': 3,
+      'facetIndex': [0, 0, 4]
+    }
+
+    expect(filterableCells[3]).toMatchObject(expectedFilterableCells3)
+
+    // Test actual cell faceting
+    const selections = {
+      'cell_type__ontology_label--group--study': ['neuron'],
+
+      // The `undefined` value below is how problematic facets -- i.e. numeric
+      // annotations with 1 value for all cells -- get passed in to `filterCells`.
+      // https://github.com/broadinstitute/single_cell_portal_core/pull/1996
+      'weeks_post_dose--numeric--study': undefined
+    }
+    const filterCellsResult = filterCells(
+      selections, cellsByFacet, facets, filterableCells, facets
+    )
+    console.log('filterCellsResult', filterCellsResult)
+    // All cells in this example are neurons,
+    expect(filterCellsResult[0]).toHaveLength(2)
+  })
 })


### PR DESCRIPTION
This fixes a rare bug that breaks cell filtering when a numeric facet has a constant value.

Previously in that case, the plot would not update when the cell filtering selection changed.  No points changed to the filtered faint-grey color, and the "--Filtered--" scatter plot legend did not appear.  The bug seems very uncommon, but essentially breaks cell filtering when it occurs.

These simple changes fix the most severe problem, but an upstream change would A) fix related minor issues elsewhere, and B) speed up the exploration UX.  That potential future work is detailed in SCP-5572.  

A Mixpanel property name was also refined.  I had explored a more ambitious refinement of cell filtering analytics, as part of a more complex frontend fix for this bug, but it became apparent the changes would be more involved and out-of-scope.  SCP-5573 tracks those analytics refinements.

### Test
A unit test verifies this fix.  To manually test:
1.  Go to a study that has a numeric annotation with the same value for all cells.  [SCP390 on staging](https://singlecell-staging.broadinstitute.org/single_cell/study/SCP390/multi-species-asos-reproducing-scp2126-on-staging) is an example.
2. Deselect any categorical filter
3. Confirm the plot updates, and "--Filtered--" appears at bottom of the scatter plot legend

This satisfies SCP-5554.