### PR TITLE
Prevent clearing bookmark form on save

### DIFF
--- a/app/javascript/components/bookmarks/BookmarkManager.jsx
+++ b/app/javascript/components/bookmarks/BookmarkManager.jsx
@@ -20,6 +20,7 @@ import { log } from '~/lib/metrics-api'
 export default function BookmarkManager({bookmarks, studyAccession, clearExploreParams}) {
   const location = useLocation()
   const [allBookmarks, setAllBookmarks] = useState(bookmarks)
+  console.log(`allBookmarks: ${allBookmarks.length}`)
   const [saveText, setSaveText] = useState('Save')
   const [saveDisabled, setSaveDisabled] = useState(false)
   const [bookmarkSaved, setBookmarkSaved] = useState(null)
@@ -205,7 +206,7 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
       enableSaveButton(true)
       setShowError(false)
       updateBookmarkList(bookmark)
-      resetForm()
+      setShowError(false)
       log(logEvent)
     } catch (error) {
       enableSaveButton(true)

--- a/app/javascript/components/bookmarks/BookmarkManager.jsx
+++ b/app/javascript/components/bookmarks/BookmarkManager.jsx
@@ -20,7 +20,6 @@ import { log } from '~/lib/metrics-api'
 export default function BookmarkManager({bookmarks, studyAccession, clearExploreParams}) {
   const location = useLocation()
   const [allBookmarks, setAllBookmarks] = useState(bookmarks)
-  console.log(`allBookmarks: ${allBookmarks.length}`)
   const [saveText, setSaveText] = useState('Save')
   const [saveDisabled, setSaveDisabled] = useState(false)
   const [bookmarkSaved, setBookmarkSaved] = useState(null)


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug with saving new bookmarks where the action completes and the bookmark is created, but the form empties and does not properly store the state unless the page is refreshed.  This appears to be a problem with multiple code paths simultaneously trying to set the currently loaded bookmark (both `updateBookmarkList` and `resetForm` call `setCurrentBookmark`) which ends up clobbering the value with the "default" bookmark.  Now, the form is left unchanged after a successful save to prevent this from happening.

#### MANUAL TESTING
1. Boot as normal and sign in, then load any study with visualizations
2. Bookmark the default view, and confirm the form does not reset on save
3. Load a different visualization and confirm the form empties and the star icon shows nothing is saved
4. Click "Reset view" and confirm that the star icon shows the default view is already bookmarked, and that the values shown in the form are correct