### PR TITLE
Restore HCA bulk download functionality (SCP-5564)

### DIFF
--- a/app/lib/azul_search_service.rb
+++ b/app/lib/azul_search_service.rb
@@ -236,39 +236,29 @@ class AzulSearchService
   def self.get_file_summary_info(accessions)
     client = ApplicationController.hca_azul_client
     file_query = { 'project' => { 'is' => accessions } }
-    if client.query_too_large?(file_query)
-      # cut query in half to prevent HTTP 413
-      queries = accessions.each_slice((accessions.size / 2.0).round).map { |list| { 'project' => { 'is' => list } } }
-    else
-      queries = [{ 'project' => { 'is' => accessions } }]
+    results = client.projects(query: file_query)
+    results['hits'].map do |entry|
+      entry_hash = entry.with_indifferent_access
+      project_hash = entry_hash[:projects].first # there will only ever be one project here
+      accession = project_hash[:projectShortname]
+      result = {
+        study_source: 'HCA',
+        name: project_hash[:projectTitle],
+        accession:,
+        description: project_hash[:projectDescription],
+        studyFiles: [
+          {
+            project_id: project_hash[:projectId],
+            file_type: 'Project Manifest',
+            count: 1,
+            upload_file_size: 1.megabyte, # placeholder filesize as we don't know until manifest is downloaded
+            name: "#{accession}.tsv"
+          }
+        ]
+      }.with_indifferent_access
+      project_file_info = extract_file_information(entry_hash)
+      result[:studyFiles] += project_file_info if project_file_info.any?
+      result
     end
-    all_results = []
-    Parallel.map(queries, in_threads: queries.size) do |query|
-      results = client.projects(query: query)
-      results['hits'].map do |entry|
-        entry_hash = entry.with_indifferent_access
-        project_hash = entry_hash[:projects].first # there will only ever be one project here
-        accession = project_hash[:projectShortname]
-        result = {
-          study_source: 'HCA',
-          name: project_hash[:projectTitle],
-          accession: accession,
-          description: project_hash[:projectDescription],
-          studyFiles: [
-            {
-              project_id: project_hash[:projectId],
-              file_type: 'Project Manifest',
-              count: 1,
-              upload_file_size: 1.megabyte, # placeholder filesize as we don't know until manifest is downloaded
-              name: "#{accession}.tsv"
-            }
-          ]
-        }.with_indifferent_access
-        project_file_info = extract_file_information(entry_hash)
-        result[:studyFiles] += project_file_info if project_file_info.any?
-        all_results << result
-      end
-    end
-    all_results
   end
 end

--- a/app/models/hca_azul_client.rb
+++ b/app/models/hca_azul_client.rb
@@ -241,10 +241,11 @@ class HcaAzulClient
     base_path = "#{api_root}/fetch/manifest/files"
     project_filter = { 'projectId' => { 'is' => [project_id] } }
     path = append_catalog(base_path, catalog)
+    payload = create_query_filters(project_filter)
     # since manifest files are generated on-demand, keep making requests until the Status code is 302 (Found)
     # Status 301 means that the manifest is still being generated; if no manifest is ready after 30s, return anyway
     time_slept = 0
-    manifest_info = process_api_request(:put, path, payload: create_query_filters(project_filter))
+    manifest_info = process_api_request(:put, path, payload:)
     while manifest_info['Status'] == 301
       break if time_slept >= MAX_MANIFEST_TIMEOUT
 
@@ -252,7 +253,7 @@ class HcaAzulClient
       Rails.logger.info "Manifest still generating for #{project_id} (#{format}), retrying in #{interval}"
       sleep interval
       time_slept += interval
-      manifest_info = process_api_request(:get, path)
+      manifest_info = process_api_request(:put, path, payload:)
     end
     manifest_info
   end

--- a/test/integration/external/hca_azul_client_test.rb
+++ b/test/integration/external/hca_azul_client_test.rb
@@ -89,7 +89,7 @@ class HcaAzulClientTest < ActiveSupport::TestCase
   end
 
   test 'should get projects' do
-    # skip_if_api_down
+    skip_if_api_down
     raw_projects = @hca_azul_client.projects(size: 1)
     projects = get_entries_from_response(raw_projects, :projects)
     assert projects.size == 1

--- a/test/integration/external/hca_azul_client_test.rb
+++ b/test/integration/external/hca_azul_client_test.rb
@@ -89,7 +89,7 @@ class HcaAzulClientTest < ActiveSupport::TestCase
   end
 
   test 'should get projects' do
-    skip_if_api_down
+    # skip_if_api_down
     raw_projects = @hca_azul_client.projects(size: 1)
     projects = get_entries_from_response(raw_projects, :projects)
     assert projects.size == 1
@@ -166,31 +166,21 @@ class HcaAzulClientTest < ActiveSupport::TestCase
   # TODO: SCP-5564
   #   - Fix "Global bulk download breaks in default use"
   #   - Re-enable this test
-  # test 'should get HCA metadata tsv link' do
-  #   skip_if_api_down
-  #   manifest_info = @hca_azul_client.project_manifest_link(@project_id)
-  #   assert manifest_info.present?
-  #   assert_equal 302, manifest_info['Status']
-  #   # make GET on manifest URL and assert contents are HCA metadata
-  #   manifest_response = RestClient.get manifest_info['Location']
-  #   assert_equal 200, manifest_response.code
-  #   raw_manifest = manifest_response.body.split("\r\n")
-  #   headers = raw_manifest.first.split("\t")
-  #   project_id_header = 'project.provenance.document_id'
-  #   assert headers.include? project_id_header
-  #   project_idx = headers.index(project_id_header)
-  #   data_row = raw_manifest.sample.split("\t")
-  #   assert_equal @project_id, data_row[project_idx]
-  # end
-
-  test 'should format object for query string' do
-    query_object = { 'foo' => { 'bar' => 'baz' } }
-    expected_response = '%7B%22foo%22%3A%7B%22bar%22%3A%22baz%22%7D%7D'
-    formatted_query = @hca_azul_client.format_hash_as_query_string(query_object)
-    assert_equal expected_response, formatted_query
-    # assert we can get back to original object, but as JSON
-    query_as_json = CGI.unescape(formatted_query)
-    assert_equal query_object.to_json, query_as_json
+  test 'should get HCA metadata tsv link' do
+    skip_if_api_down
+    manifest_info = @hca_azul_client.project_manifest_link(@project_id)
+    assert manifest_info.present?
+    assert_equal 302, manifest_info['Status']
+    # make GET on manifest URL and assert contents are HCA metadata
+    manifest_response = RestClient.get manifest_info['Location']
+    assert_equal 200, manifest_response.code
+    raw_manifest = manifest_response.body.split("\r\n")
+    headers = raw_manifest.first.split("\t")
+    project_id_header = 'project.provenance.document_id'
+    assert headers.include? project_id_header
+    project_idx = headers.index(project_id_header)
+    data_row = raw_manifest.sample.split("\t")
+    assert_equal @project_id, data_row[project_idx]
   end
 
   test 'should format query object from search facets' do
@@ -304,13 +294,6 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     assert_raises ArgumentError do
       @hca_azul_client.append_catalog(path, bad_catalog)
     end
-  end
-
-  test 'should determine if query is too large' do
-    accession_list = 1.upto(500).map { |n| "FakeHCAProject#{n}" }
-    query = { project: { is: accession_list } }
-    assert @hca_azul_client.query_too_large?(query)
-    assert_not @hca_azul_client.query_too_large?({ project: { is: accession_list.take(10) } })
   end
 
   test 'should not retry any error status code' do

--- a/test/integration/external/hca_azul_client_test.rb
+++ b/test/integration/external/hca_azul_client_test.rb
@@ -192,6 +192,14 @@ class HcaAzulClientTest < ActiveSupport::TestCase
     assert_equal expected_query, query
   end
 
+  test 'should create query filters object' do
+    project_id = SecureRandom.uuid
+    query = { 'projectId' => { 'is' => [project_id] } }
+    query_object = @hca_azul_client.create_query_filters(query)
+    expected_query = "{\"filters\":\"{\\\"projectId\\\":{\\\"is\\\":[\\\"#{project_id}\\\"]}}\"}"
+    assert_equal expected_query, query_object
+  end
+
   test 'should format numeric facet query' do
     age_facet = [
       {

--- a/test/services/azul_search_service_test.rb
+++ b/test/services/azul_search_service_test.rb
@@ -242,20 +242,4 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
     expected_term_match = { total: 2, terms: { lung: 2 } }.with_indifferent_access
     assert_equal expected_term_match, AzulSearchService.get_search_term_weights(result, %w[lung])
   end
-
-  test 'should split large queries into two requests' do
-    accession_list = 1.upto(500).map { |n| "FakeHCAProject#{n}" }
-    query = { 'project' => { 'is' => accession_list } }
-    project_result = @human_tcell_response['hits'].first
-    mock_query_result = { 'hits' => Array.new(250, project_result) }
-    mock = Minitest::Mock.new
-    mock.expect :query_too_large?, true, [query]
-    mock.expect :projects, mock_query_result, [Hash]
-    mock.expect :projects, mock_query_result, [Hash]
-    ApplicationController.stub :hca_azul_client, mock do
-      results = AzulSearchService.get_file_summary_info(accession_list)
-      mock.verify
-      assert results.count == 500
-    end
-  end
 end


### PR DESCRIPTION
#### BACKGROUND
SCP's bulk download feature allows users to export data from both the portal and from HCA's Azul service with a single `cURL` command.  Upstream changes in Azul broke this functionality, such that any download request that contained projects from Azul would never succeed, effectively blocking users from exporting data.

#### CHANGES
This change adapts to the new format for the `/fetch/manifest/files` Azul endpoint, which is now a `PUT` request, instead of a `GET`.  In addition, Azul now accepts query filters in request bodies, in addition to query string parameters, though entities like `size` and `catalog` are still query string based.  Using request bodies has a large benefit in that we are no longer bound by the 8KB length limit for query string parameters, and as such no longer need to split large queries into separate requests.  All associated client bindings that support queries now use this format, and have switched to `POST` or `PUT` methods.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Run a search for `disease: HIV infectious disease` and `species: Homo sapiens`
3. Confirm you see entries from Azul, including `An Atlas of Immune Cell Exhaustion in HIV-Infected Individuals Revealed by Single-Cell Transcriptomics.`
4. Click `Download`, select at least one HCA project, then authorize and paste the `cURL` command into a new terminal window
5. Confirm the request succeeds, that you get a manifest for the HCA project, and that files begin exporting (it is not necessary to fully export all data to validate this fix)