### PR TITLE
Generalize global search footer note (SCP-5577)

### DIFF
--- a/app/javascript/components/search/results/ResultsPanel.jsx
+++ b/app/javascript/components/search/results/ResultsPanel.jsx
@@ -78,11 +78,7 @@ const FacetResultsFooter = ({ studySearchState }) => {
         <div className="">
           <p>Our advanced search is metadata-powered.
           By selecting filters, your search <b>targets only studies that use ontology terms</b> in their metadata file.
-          Currently, almost 25% of public studies supply that metadata.</p>
-          {/*
-            84 of 353 studies as of 2021-06-22,
-            per https://docs.google.com/spreadsheets/d/1FSpP2XTrG9FqAqD9X-BHxkCZae9vxZA3cQLow8mn-bk
-          */}
+          Many, but not all, public studies supply that metadata.</p>
           Learn more about our search capability on our{' '}
           <a className= "link-darker-blue" href="https://singlecell.zendesk.com/hc/en-us/articles/360061006431-Search-Studies"
             target="_blank" rel="noreferrer">documentation


### PR DESCRIPTION
This refines the footer with text that is less specific, but more correct and lower effort to maintain.

### Before
<img width="1512" alt="Old_advanced_search_footer_text__SCP_2024-04-04" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/ed1026d8-fbde-4da4-b4c6-f87ab1662ab8">

### After
<img width="1512" alt="New_advanced_search_footer_text__SCP_2024-04-04" src="https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/d03fc2d0-3509-4017-98b1-ae3d9fcfb15e">


This satisfies SCP-5577.