### PR TITLE
Friendly gene search for CELLxGENE AnnData, via Ingest 1.30.0 (SCP-5571)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.29.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.30.0'
 
     # Docker image for image pipeline jobs
     config.image_pipeline_docker_image = 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_c2b090043'


### PR DESCRIPTION
This enables human-friendly gene search for CELLxGENE AnnData studies, e.g. [SCP2560](https://singlecell.broadinstitute.org/single_cell/study/SCP2560), via [Ingest Pipeline 1.30.0](https://github.com/broadinstitute/scp-ingest-pipeline/pull/342).