### PR TITLE
Fix TypeError due to missing function on formRef (SCP-5585)

### DIFF
--- a/app/javascript/components/bookmarks/BookmarkManager.jsx
+++ b/app/javascript/components/bookmarks/BookmarkManager.jsx
@@ -89,9 +89,14 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
     setCurrentBookmark(findExistingBookmark())
   }
 
+  /** helper to determine if the bookmark form can be hidden/toggled **/
+  function formCanToggle() {
+    return isUserLoggedIn() && formRef.current?.state?.show
+  }
+
   /** close open form if changing tabs */
   function closeBookmarkForm() {
-    if (isUserLoggedIn() && formRef.current?.state?.show) {
+    if (formCanToggle()) {
       formRef.current.handleHide()
     }
   }
@@ -109,9 +114,9 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
     }
   }
 
-  /** close and reopen bookmark form to fix positioning issues */
+  /** close and reopen bookmark form if currently open to fix positioning issues */
   function reopenBookmarkForm() {
-    if (formRef && formRef.current) {
+    if (formCanToggle()) {
       formRef.current.handleToggle()
       formRef.current.handleToggle()
     }


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes an issue where resizing the screen while viewing a study when a user is not logged in throws a `TypeError` due to a missing function in the `BookmarkManager` component.  Since the user is not signed in, the ref is never rendered into the DOM.  Now, a state check is performed before calling `handleToggle` to ensure that the form is in fact open and can be hidden or toggled.  While this error had no user-facing impacts, it was very frequent, comprising ~18% (3.7K) of errors and ~10% (51) of session replays over the last month in Sentry.

#### MANUAL TESTING
1. Boot as normal and load any study with visualizations
2. Open the JS console
3. Resize the screen, and confirm that no `TypeError` is thrown
4. Log in, then open the bookmark form by clicking the star icon
5. Resize the screen again, confirming that the form repositions after you finish resizing