### PR TITLE
Enable linking to numeric cell facets, restore for categorical (SCP-5531)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -200,7 +200,7 @@ function getFacetsParam(initFacets, selection) {
         }
       })
     } else {
-      // Add numeric cell facet to URL parameter
+      // TODO (SCP-5531): Enable URL parameters for numeric cell facets
       minimalSelection[facet] = selection[facet]
     }
   })
@@ -250,7 +250,8 @@ function parseFacetsParam(initFacets, facetsParam) {
         const min = parseFloat(rawMin)
         const max = parseFloat(rawMax)
         const numericFilters = [[operator, [min, max]]]
-        const includeNa = Boolean(numericFiltersAndIncludeNa.slice(-1)[0])
+        const rawIncludeNa = numericFiltersAndIncludeNa.slice(-1)[0]
+        const includeNa = rawIncludeNa === 'true'
         selection[facet] = [numericFilters, includeNa]
       }
     }

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -206,6 +206,9 @@ function getFacetsParam(initFacets, selection) {
   })
 
   Object.entries(minimalSelection).forEach(([facet, filters]) => {
+    // TODO (SCP-5513): Screen numeric facets with constant value, then remove line below
+    if (filters === undefined) {return}
+
     const innerParam = `${facet}:${filters.join('|')}`
     innerParams.push(innerParam)
   })

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -249,10 +249,15 @@ function parseFacetsParam(initFacets, facetsParam) {
       const numericFiltersAndIncludeNa = facets[facet]
       if (numericFiltersAndIncludeNa) {
         const rawNumericFilters = numericFiltersAndIncludeNa.slice(0, -1)
-        const [operator, rawMin, rawMax] = rawNumericFilters[0].split(',')
-        const min = parseFloat(rawMin)
-        const max = parseFloat(rawMax)
-        const numericFilters = [[operator, [min, max]]]
+        const [operator, rawVal, rawVal2] = rawNumericFilters[0].split(',')
+        const value = parseFloat(rawVal)
+        const value2 = parseFloat(rawVal2)
+        let numericFilters
+        if (['between', 'not between'].includes(operator)) {
+          numericFilters = [[operator, [value, value2]]]
+        } else {
+          numericFilters = [[operator, value]]
+        }
         const rawIncludeNa = numericFiltersAndIncludeNa.slice(-1)[0]
         const includeNa = rawIncludeNa === 'true'
         selection[facet] = [numericFilters, includeNa]

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -181,8 +181,10 @@ function getFacetsParam(initFacets, selection) {
   })
 
   const innerParams = []
+
   Object.entries(initSelection).forEach(([facet, filters]) => {
-    if (facet.type === 'group') {
+    const facetObj = initFacets.find(f => f.annotation === facet)
+    if (facetObj.type === 'group') {
       filters.forEach(filter => {
         // Unlike `selection`, which specifies all filters that are selected
         // (i.e., checked and not applied), the `facets` parameter species only

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -200,8 +200,8 @@ function getFacetsParam(initFacets, selection) {
         }
       })
     } else {
-      // TODO (SCP-5531): Enable URL parameters for numeric cell facets
-      // minimalSelection[facet] = selection[facet]
+      // Add numeric cell facet to URL parameter
+      minimalSelection[facet] = selection[facet]
     }
   })
 
@@ -232,15 +232,28 @@ function parseFacetsParam(initFacets, facetsParam) {
   // it into the more verbose `selection` object which specifies filters
   // that are _not_ applied.
   Object.entries(initFacets).forEach(([facet, filters]) => {
-    filters.forEach(filter => {
-      if (!facets[facet]?.includes(filter)) {
-        if (facet in selection) {
-          selection[facet].push(filter)
-        } else {
-          selection[facet] = [filter]
-        }
+    if (facet.includes('group')) {
+        filters?.forEach(filter => {
+          if (!facets[facet]?.includes(filter)) {
+            if (facet in selection) {
+              selection[facet].push(filter)
+            } else {
+              selection[facet] = [filter]
+            }
+          }
+        })
+    } else {
+      const numericFiltersAndIncludeNa = facets[facet]
+      if (numericFiltersAndIncludeNa) {
+        const rawNumericFilters = numericFiltersAndIncludeNa.slice(0, -1)
+        const [operator, rawMin, rawMax] = rawNumericFilters[0].split(',')
+        const min = parseFloat(rawMin)
+        const max = parseFloat(rawMax)
+        const numericFilters = [[operator, [min, max]]]
+        const includeNa = Boolean(numericFiltersAndIncludeNa.slice(-1)[0])
+        selection[facet] = [numericFilters, includeNa]
       }
-    })
+    }
   })
 
   return selection

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -680,3 +680,100 @@ export async function initCellFaceting(
   return cellFaceting
 }
 
+/** Parse `facets` URL parameter into cell filtering selection object */
+export function parseFacetsParam(initFacets, facetsParam) {
+  const selection = {}
+
+  // Convert the `facets` parameter value, which is a string,
+  // into an object that has the same shape as `selections`
+  const facets = {}
+  const innerParams = facetsParam.split(';')
+  innerParams.forEach(innerParam => {
+    const [facet, rawFilters] = innerParam.split(':')
+    const filters = rawFilters.split('|')
+    facets[facet] = filters
+  })
+
+  // Take the complement of the minimal `facets` object, transforming
+  // it into the more verbose `selection` object which specifies filters
+  // that are _not_ applied.
+  Object.entries(initFacets).forEach(([facet, filters]) => {
+    if (facet.includes('group')) {
+        filters?.forEach(filter => {
+          if (!facets[facet]?.includes(filter)) {
+            if (facet in selection) {
+              selection[facet].push(filter)
+            } else {
+              selection[facet] = [filter]
+            }
+          }
+        })
+    } else {
+      const numericFiltersAndIncludeNa = facets[facet]
+      if (numericFiltersAndIncludeNa) {
+        const rawNumericFilters = numericFiltersAndIncludeNa.slice(0, -1)
+        const [operator, rawVal, rawVal2] = rawNumericFilters[0].split(',')
+        const value = parseFloat(rawVal)
+        const value2 = parseFloat(rawVal2)
+        let numericFilters
+        if (['between', 'not between'].includes(operator)) {
+          numericFilters = [[operator, [value, value2]]]
+        } else {
+          numericFilters = [[operator, value]]
+        }
+        const rawIncludeNa = numericFiltersAndIncludeNa.slice(-1)[0]
+        const includeNa = rawIncludeNa === 'true'
+        selection[facet] = [numericFilters, includeNa]
+      }
+    }
+  })
+
+  return selection
+}
+
+/** Construct `facets` URL parameter value, for cell filtering */
+export function getFacetsParam(initFacets, selection) {
+  const minimalSelection = {}
+
+  const initSelection = {}
+  initFacets.filter(f => !f.isSelectedAnnotation)?.forEach(facet => {
+    initSelection[facet.annotation] = facet.defaultSelection
+  })
+
+  const innerParams = []
+
+  Object.entries(initSelection).forEach(([facet, filters]) => {
+    const facetObj = initFacets.find(f => f.annotation === facet)
+    if (facetObj.type === 'group') {
+      filters.forEach(filter => {
+        // Unlike `selection`, which specifies all filters that are selected
+        // (i.e., checked and not applied), the `facets` parameter species only
+        // filters that are _not_ selected, i.e. they're unchecked and applied.
+        //
+        // This makes the `facets` parameter much clearer.
+        if (!selection[facet].includes(filter)) {
+          if (facet in minimalSelection) {
+            minimalSelection[facet].push(filter)
+          } else {
+            minimalSelection[facet] = [filter]
+          }
+        }
+      })
+    } else {
+      // Add numeric cell facet to `facets` URL parameter
+      minimalSelection[facet] = selection[facet]
+    }
+  })
+
+  Object.entries(minimalSelection).forEach(([facet, filters]) => {
+    // TODO (SCP-5513): Screen numeric facets with constant value, then remove line below
+    if (filters === undefined) {return}
+
+    const innerParam = `${facet}:${filters.join('|')}`
+    innerParams.push(innerParam)
+  })
+
+  const facetParams = innerParams.join(';')
+  return facetParams
+}
+

--- a/test/js/lib/cell-faceting.test.js
+++ b/test/js/lib/cell-faceting.test.js
@@ -2,7 +2,7 @@ import { allAnnots, facetData } from './cell-faceting.test-data'
 import * as ScpApi from 'lib/scp-api'
 
 import {
-  initCellFaceting, filterCells, applyNumericFilters
+  initCellFaceting, filterCells, applyNumericFilters, parseFacetsParam
 } from 'lib/cell-faceting'
 
 // Test functionality to filter cells shown in plots across annotation facets
@@ -180,5 +180,35 @@ describe('Cell faceting', () => {
     console.log('filterCellsResult', filterCellsResult)
     // All cells in this example are neurons,
     expect(filterCellsResult[0]).toHaveLength(2)
+  })
+
+  it('parses facets URL parameter for cell filtering selection', () => {
+    const facetsParam =
+      'cell_type__ontology_label--group--study:epithelial cell|macrophage;' + // a non-default selection
+      'time_post_partum_days--numeric--study:between,3,323|true;' +
+      'time_post_partum_weeks--numeric--study:between,0.43,46.14|true;' +
+      'week_delivered--numeric--study:between,37,42|true;' +
+      'BMI_during_study--numeric--study:between,21.66,33.3|false;' + // a non-default selection
+      'BMI_pre_pregnancy--numeric--study:between,18.84,34.01|true'
+
+    const initFacets = {
+      'cell_type__ontology_label--group--study': [
+        'epithelial cell', 'macrophage', 'neutrophil', 'T cell', 'dendritic cell', 'fibroblast', 'B cell', 'eosinophil'
+      ],
+      'BMI_during_study--numeric--study': [
+        [null, 6450], [18.89, 1686], [20.31, 5639], [29.86, 1389], [33.3, 952]
+      ]
+    }
+
+    const expectedSelection = {
+      'BMI_during_study--numeric--study': [[['between', [21.66, 33.3]]], false],
+      'cell_type__ontology_label--group--study': [
+        'neutrophil', 'T cell', 'dendritic cell', 'fibroblast', 'B cell', 'eosinophil'
+      ]
+    }
+
+    const selection = parseFacetsParam(initFacets, facetsParam)
+
+    expect(selection).toEqual(expectedSelection)
   })
 })


### PR DESCRIPTION
This updates the URL as a user adjusts numeric cell facets, so they can link to results.  

It also fixes URL parameter handling for categorical cell facets.

Here's how it looks:

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/2b5c2a0d-f272-4096-bbba-6bd1f9f17db2

### Test
A new automated tests verifies behavior.  To manually test:
1.  Apply numeric and categorical cell filters
2.  Refresh page
3.  Confirm previously-selected filters are automatically applied

This satisfies SCP-5531.