### PR TITLE
Add language re: DE outputs in private studies for reviewers (SCP-5576)

### DIFF
--- a/app/views/site/_study_settings_sharing.html.erb
+++ b/app/views/site/_study_settings_sharing.html.erb
@@ -36,5 +36,11 @@
     associated Terra workspace.  If enabled, you can send the access URL & PIN to your corresponding editor to allow
     reviewers to view your study.
   </p>
+  <% unless @study.public? %>
+    <p class="text-danger">
+      NOTE: Due to current limitations with reviewer access in private studies, certain client-side visualizations will
+      not function properly.  This includes viewing any differential expression outputs, or rendering BAM files in IGV.
+    </p>
+  <% end %>
   <%= f.fields_for :reviewer_access %>
 </div>


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds conditional language to the anonymous reviewer form for private studies to indicate that client-side visualizations will not work for reviewers.  This is a related UX to SCP-5033, where any non-Terra or admin users cannot read files directly from the workspace bucket in private studies.  Identical text has been added to the [Zendesk documentation](https://broadinstitute.zendesk.com/knowledge/editor/01HB6EDZVPFRJ29FWHSH2KPEX5/en-us?brand_id=360005514392&return_to=%2Fhc%2Fen-us%2Farticles%2F4414535335323) for setting up reviewer access.

The text is as follows:

> NOTE: Due to current limitations with reviewer access in private studies, certain client-side visualizations will not function properly.  This includes viewing any differential expression outputs, or rendering BAM files in IGV.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Load any private study and go to the `Settings` tab
3. Click `Sharing/Access` from the lefthand nav and confirm you see the text above in red