### PR TITLE
Prevent unsetting cell_count for studies (SCP-5587)

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -55,7 +55,7 @@ class SiteController < ApplicationController
 
     # determine study/cell count based on viewable to user
     @study_count = @viewable.count
-    @cell_count = @viewable.map(&:cell_count).inject(&:+)
+    @cell_count = @viewable.map(&:cell_count).compact.inject(0, &:+)
 
     if @cell_count.nil?
       @cell_count = 0

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -738,6 +738,7 @@ class Study
   validate :prevent_firecloud_attribute_changes, on: :update
   validates_presence_of :firecloud_project, :firecloud_workspace
   validates_uniqueness_of :external_identifier, allow_blank: true
+  validates :cell_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   # callbacks
   before_validation :set_url_safe_name

--- a/app/views/site/_study_settings_general.html.erb
+++ b/app/views/site/_study_settings_general.html.erb
@@ -23,6 +23,6 @@
   </div>
   <div class="col-md-4">
     <%= f.label :cell_count %><br/>
-    <%= f.text_field :cell_count, class: 'form-control' %>
+    <%= f.number_field :cell_count, class: 'form-control', min: 0 %>
   </div>
 </div>


### PR DESCRIPTION
#### BACKGROUND
A recent outage on production lasting 35 minutes was inadvertently caused by a user clearing out the value for `cell_count` in their study settings panel.  This resulted in a `nil` value being saved, which caused an [unrecoverable error](https://broad-institute.sentry.io/issues/5165673065) to repeatedly trigger on the home page.  Since this is also the page that the portal load balancer uses for heath checks, it caused the portal to become unreachable when traffic was shunted away (a pre-existing issue that requires significant resources to address).

#### CHANGES
This update addresses the issue at multiple levels.  First, the `cell_count` attribute now has a validation that ensures only integers >= 0 are ever stored as values.  Secondly, the form field for `cell_count` is now a number field that has a default minimum value of `0` (you can't go lower using the native controls unless you manually enter a negative number).  Trying to enter text in that field is disallowed.  Lastly, the calculation on the homepage calls `compact` to remove any potential `nil`values before calling `inject`.

If a user attempts to manually save a blank or negative entry for `cell_count`, the following error is show:
![Screenshot 2024-04-09 at 5 04 27 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/b54719cc-34d0-4cae-a3a4-a78aa00e7863)

An alert modal with the same text is also displayed.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Load any study and go to the settings tab
3. Attempt to save either a negative or blank number and confirm you see the aforementioned error
4. Go back to the home page and confirm no error is thrown