### PR TITLE
Filter global gene search using existing search parameters (SCP-5428, SCP-5511)

### DIFF
--- a/app/controllers/api/v1/study_search_results_objects.rb
+++ b/app/controllers/api/v1/study_search_results_objects.rb
@@ -65,7 +65,7 @@ module Api
           if @preset_search.present? && @preset_search.accession_list.include?(study.accession)
             study_obj[:preset_match] = true
           end
-          if @gene_results.present?
+          if @gene_results.present? && @gene_results[:genes_by_study].any?
             study_obj[:gene_matches] = @gene_results[:genes_by_study][study.id].uniq
             study_obj[:can_visualize_clusters] = study.can_visualize_clusters?
             study_obj[:default_annotation_id] = study.default_annotation

--- a/app/javascript/components/search/controls/KeywordSearch.jsx
+++ b/app/javascript/components/search/controls/KeywordSearch.jsx
@@ -35,7 +35,7 @@ export default function KeywordSearch({ keywordPrompt }) {
       <p>&quot;single cell&quot; Smith</p>
     </ul>
     <p>* Structured data for authors is new in SCP, and many studies lack it, so author search results may be limited.</p>
-    <p>You can find studies directly by entering their accessions as terms: "SCP1 SCP101 SCP1234"</p>
+    <p>You can find studies directly by entering their accessions as terms: SCP1 SCP101 SCP1234</p>
   </div>)
 
   const textSearchLink = <a className="action advanced-opts"

--- a/app/javascript/components/search/controls/KeywordSearch.jsx
+++ b/app/javascript/components/search/controls/KeywordSearch.jsx
@@ -35,6 +35,7 @@ export default function KeywordSearch({ keywordPrompt }) {
       <p>&quot;single cell&quot; Smith</p>
     </ul>
     <p>* Structured data for authors is new in SCP, and many studies lack it, so author search results may be limited.</p>
+    <p>You can find studies directly by entering their accessions as terms: "SCP1 SCP101 SCP1234"</p>
   </div>)
 
   const textSearchLink = <a className="action advanced-opts"

--- a/app/javascript/components/search/genes/StudyGeneExpressions.jsx
+++ b/app/javascript/components/search/genes/StudyGeneExpressions.jsx
@@ -45,8 +45,10 @@ export default function StudyGeneExpressions({ study }) {
   } else if (showDotPlot) {
     // render dotPlot for multigene searches that are not collapsed
     const annotationValues = getAnnotationValues(controlClusterParams.annotation, annotationList)
+    const [morpheusData, setMorpheusData] = useState(null)
     studyRenderComponent = <DotPlot studyAccession={study.accession}
       genes={study.gene_matches}
+      setMorpheusData={setMorpheusData}
       {...controlClusterParams}
       annotationValues={annotationValues}/>
   } else if (isNumericAnnotation) {

--- a/app/javascript/components/search/genes/StudyGeneExpressions.jsx
+++ b/app/javascript/components/search/genes/StudyGeneExpressions.jsx
@@ -112,6 +112,7 @@ export default function StudyGeneExpressions({ study }) {
                 updateClusterParams={updateClusterParams}/>
               <AnnotationSelector
                 annotationList={annotationList}
+                shownAnnotation={controlClusterParams.annotation}
                 {...controlClusterParams}
                 updateClusterParams={updateClusterParams}/>
               <SubsampleSelector

--- a/app/javascript/components/search/results/SearchQueryDisplay.jsx
+++ b/app/javascript/components/search/results/SearchQueryDisplay.jsx
@@ -75,6 +75,7 @@ export const ClearAllButton = () => {
     })
     const emptySearchParams = {
       terms: '',
+      genes: '',
       facets: emptyFilters
     }
     selectionContext.updateSelection(emptySearchParams, true)

--- a/app/javascript/providers/GeneSearchProvider.jsx
+++ b/app/javascript/providers/GeneSearchProvider.jsx
@@ -4,7 +4,7 @@ import _isEqual from 'lodash/isEqual'
 import { navigate, useLocation } from '@reach/router'
 import * as queryString from 'query-string'
 
-import { fetchSearch, buildSearchQueryString } from '~/lib/scp-api'
+import { fetchSearch, buildSearchQueryString, buildFacetsFromQueryString } from '~/lib/scp-api'
 import { buildParamsFromQuery as buildStudyParamsFromQuery } from '~/providers/StudySearchProvider'
 
 /*
@@ -16,6 +16,8 @@ import { buildParamsFromQuery as buildStudyParamsFromQuery } from '~/providers/S
 export const emptySearch = {
   params: {
     genes: '',
+    terms: '',
+    facets: {},
     genePage: 1
   },
 
@@ -72,6 +74,8 @@ export function PropsGeneSearchProvider(props) {
       'gene', {
         page: searchParams.page,
         genes: searchParams.genes,
+        terms: searchParams.terms,
+        facets: searchParams.facets,
         preset: searchParams.preset
       }).then(results => {
       setSearchState({
@@ -122,6 +126,8 @@ export function buildParamsFromQuery(query, preset) {
   return {
     page: queryParams.genePage ? parseInt(queryParams.genePage) : 1,
     genes: cleanGeneParams,
+    terms: queryParams.terms ? queryParams.terms : '',
+    facets: buildFacetsFromQueryString(queryParams.facets),
     preset: preset ? preset : queryString.preset_search
   }
 }


### PR DESCRIPTION
#### BACKGROUND
Advanced search offers a powerful tool for discovering data in SCP.  Additionally, global gene search allows users to browse gene expression profiles across multiple studies at once.  While both are available from the home page, and use the same area of the application, their results are not tied together.  This makes refining the results for global gene search impossible.

#### CHANGES
This update now applies all existing search criteria to global gene searches and executes a parallel gene-scoped search alongside the study-scoped one.  Additionally, any queries that would also result in a search in Azul are now dropped from the gene-specific search.  The result is that the study-based search remains the same, but the gene-based search now includes all SCP-based results that match that query.  Additionally, any studies that do not contain the requested gene(s) are filtered as usual.   There are some added bug fixes as well (SCP-5511) to improve the overall UX.  Lastly, help text was updated for keyword search to note that studies can be directly loaded by entering their study accession.

#### KNOWN ISSUES
There is an existing issue where clicking the clear button on the gene search bar does not clear out any results, or update the search query parameters.  This is identical to the behavior of study-based gene search, and is expected.  Also, using the "Clear All" button does not empty the gene search bar.  Additionally, clicking over to the study search results and then back to the gene search will result in re-running the gene search.  This is because the violin plots have been dynamically removed from the DOM as a result of the routing and need to be re-rendered.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Run a faceted search for `species: Homo sapiens` and `cell type: B cell`
3. Confirm that you see results from Azul as well as the `Human milk - differential expression` example study (and potentially `Human all genes` if you have that in your local instance as well)
4. Click "Search genes" and confirm you see the same SCP studies as in the normal search results
5. Search for `CLDN4` and confirm you see a violin plot in the `Human milk - differential expression` study with high expression in the `LC1` cell type, and that the annotation dropdown has `General_Celltype` set already
6. Change the selected cluster/annotation and confirm no other plots are affected
7. Click "Clear All" and confirm that the results revert back to a normal empty search