### PR TITLE
Address error when decoding malformed query parameters (SCP-5601)

### DIFF
--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -32,7 +32,7 @@ class RequestUtils
   # this prevents long parameter lists from being split in the middle due to maximum filename length limits
   # and resulting in invalid % encoding issue when trying to clear selected cache entries
   def self.construct_params_digest(params)
-    sorted_params = params.reject { |name, value| CACHE_PATH_EXCLUDE_LIST.include?(name) || value.empty? }
+    sorted_params = params.reject { |name, value| CACHE_PATH_EXCLUDE_LIST.include?(name) || value.blank? }
                           .sort_by { |key, _| key }.flatten
     return '' if sorted_params.empty? # gotcha to prevent converting empty string into hexdigest
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This addresses a [bug](https://broad-institute.sentry.io/issues/5087899085/?project=1424198) when attempting to decode malformed query string parameters for caching.  Specifically, a security scan that was attempting to exploit a known XSS vulnerability ended up injecting junk values along with some HTML-encoded values into the query string (the actual value was `xssdetected(%27%7B%7Bxssdetected(%26quot;-738101893%26quot;)%7D%7D%27)`).

After decoding, this resulted in some parameters with `nil` values instead of empty strings, which caused a `NoMethodError` when trying to check `empty?`.  Now, `blank?` is used, which covers both `nil?` and `empty?`. 

#### MANUAL TESTING
1. Boot as normal and ensure caching is turned on
2. Find the accession for the `Human milk - differential expression` study in the Rails console:
```
accession = Study.find_by(name: 'Human milk - differential expression').accession
```
3. In a separate terminal, run the following `cURL` command to ensure that no error is thrown, and you see a `200` response 
```
ACCESSION="<accession from above>"
curl --insecure --header 'Accept: application/json' --head "https://localhost:3000/single_cell/api/v1/studies/$ACCESSION/clusters/All%20Cells%20UMAP?genes=TNC&cluster=All+Cells+UMAP&spatialGroups=--&annotation=General_Celltype--group--study&subsample=xssdetected(%27%7B%7Bxssdetected(%26quot;-738101893%26quot;)%7D%7D%27)&hiddenTraces=--Filtered--&facets=milk_stage--group--study:early%7Clate_2%7Clate_3%7Clate_4%7Cmature%7CNA%7Ctransitional+%7Ctransitional"

HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Cache-Control: no-store, must-revalidate, private, max-age=0
...
```