### PR TITLE
Fix React hook issue with consensus collapse in global gene search (SCP-5603)

### DIFF
--- a/app/javascript/components/search/genes/StudyGeneExpressions.jsx
+++ b/app/javascript/components/search/genes/StudyGeneExpressions.jsx
@@ -22,6 +22,7 @@ export default function StudyGeneExpressions({ study }) {
   const termMatches = study.term_matches
   const [clusterParams, setClusterParams] = useState(_clone(emptyDataParams))
   const [annotationList, setAnnotationList] = useState(getNonUserAnnotations(study))
+  const [_, setMorpheusData] = useState(null)
   let controlClusterParams = _clone(clusterParams)
   if (annotationList && !clusterParams.cluster) {
     // if the user hasn't specified anything yet, but we have the study defaults, use those
@@ -46,7 +47,6 @@ export default function StudyGeneExpressions({ study }) {
   } else if (showDotPlot) {
     // render dotPlot for multigene searches that are not collapsed
     const annotationValues = getAnnotationValues(controlClusterParams.annotation, annotationList)
-    const [morpheusData, setMorpheusData] = useState(null)
     studyRenderComponent = <DotPlot studyAccession={study.accession}
       genes={study.gene_matches}
       setMorpheusData={setMorpheusData}


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a new regression in global gene search where the `View as` select no longer worked.  This was due to [this commit](https://github.com/broadinstitute/single_cell_portal_core/pull/2013/commits/7ec50058c7fdb3df30ee58573fe06b5ec7664f5e) where a `useState` hook was not declared at the top level, leading to React render hooks in the wrong order when changing the plot type.

#### MANUAL TESTING
1. Boot as normal and run a search that returns at least one SCP study
2. Click over to `Search genes` and search for two genes
3. Once the dot plot finishes rendering, use the `View as` menu to select `Violin - median`
4. Confirm the plot re-renders as a violin plot and no error is shown