### PR TITLE
Adding bookmarks to home page search results (SCP-5604)

### DIFF
--- a/app/javascript/components/HomePageContent.jsx
+++ b/app/javascript/components/HomePageContent.jsx
@@ -10,7 +10,7 @@ import ResultsPanel from '~/components/search/results/ResultsPanel'
 import StudyDetails from '~/components/search/results/StudySearchResult'
 import StudySearchProvider, { StudySearchContext } from '~/providers/StudySearchProvider'
 import SearchFacetProvider from '~/providers/SearchFacetProvider'
-import UserProvider, { isUserLoggedIn } from '~/providers/UserProvider'
+import UserProvider from '~/providers/UserProvider'
 import BookmarkManager from '~/components/bookmarks/BookmarkManager'
 import ErrorBoundary from '~/lib/ErrorBoundary'
 
@@ -35,25 +35,19 @@ const LinkableSearchTabs = function(props) {
   // the queryParams object does not support the more typical hasOwnProperty test
   return (
     <div>
-      <nav className="nav search-links" data-analytics-name="search" role="tablist">
-        <Link to={`${basePath}/app/studies${location.search}`}
-          className={showGenesTab ? '' : 'active'}>
-          <span className="fas fa-book"></span> Search studies
-        </Link>
-        <Link to={`${basePath}/app/genes${location.search}`}
-          className={showGenesTab ? 'active' : ''}>
-          <span className="fas fa-dna"></span> Search genes
-        </Link>
-        { isUserLoggedIn() &&
-          <span className='margin-left'>
-            <BookmarkManager eagerLoadBookmarks={true} />
+        <nav className="nav search-links" data-analytics-name="search" role="tablist">
+          <Link to={`${basePath}/app/studies${location.search}`}
+                className={showGenesTab ? '' : 'active'}>
+            <span className="fas fa-book"></span> Search studies
+          </Link>
+          <Link to={`${basePath}/app/genes${location.search}`}
+                className={showGenesTab ? 'active' : ''}>
+            <span className="fas fa-dna"></span> Search genes
+          </Link>
+          <span id='home-page-bookmark'>
+            <BookmarkManager eagerLoad={true} />
           </span>
-        }
-        { !isUserLoggedIn() &&
-          <BookmarkManager eagerLoadBookmarks={true} />
-        }
-
-      </nav>
+        </nav>
       <div className="tab-content top-pad">
         <Router basepath={basePath}>
           <GeneSearchView path="app/genes"/>

--- a/app/javascript/components/HomePageContent.jsx
+++ b/app/javascript/components/HomePageContent.jsx
@@ -10,7 +10,8 @@ import ResultsPanel from '~/components/search/results/ResultsPanel'
 import StudyDetails from '~/components/search/results/StudySearchResult'
 import StudySearchProvider, { StudySearchContext } from '~/providers/StudySearchProvider'
 import SearchFacetProvider from '~/providers/SearchFacetProvider'
-import UserProvider from '~/providers/UserProvider'
+import UserProvider, { isUserLoggedIn } from '~/providers/UserProvider'
+import BookmarkManager from '~/components/bookmarks/BookmarkManager'
 import ErrorBoundary from '~/lib/ErrorBoundary'
 
 /** include search controls and results */
@@ -43,6 +44,15 @@ const LinkableSearchTabs = function(props) {
           className={showGenesTab ? 'active' : ''}>
           <span className="fas fa-dna"></span> Search genes
         </Link>
+        { isUserLoggedIn() &&
+          <span className='margin-left'>
+            <BookmarkManager eagerLoadBookmarks={true} />
+          </span>
+        }
+        { !isUserLoggedIn() &&
+          <BookmarkManager eagerLoadBookmarks={true} />
+        }
+
       </nav>
       <div className="tab-content top-pad">
         <Router basepath={basePath}>

--- a/app/javascript/components/HomePageContent.jsx
+++ b/app/javascript/components/HomePageContent.jsx
@@ -33,8 +33,8 @@ const LinkableSearchTabs = function(props) {
   const [bookmarks, setBookmarks] = useState([])
   const [hasLoadedBookmarks, setHasLoadedBookmarks] = useState(null)
 
-  async function loadUserBookmarks() {
-    setHasLoadedBookmarks(true) // short-circuit multiple calls to load bookmarks
+  // reload bookmarks from server when user switches tabs
+  async function reloadBookmarks() {
     try {
       const userBookmarks = await fetchBookmarks()
       setBookmarks(userBookmarks)
@@ -46,7 +46,8 @@ const LinkableSearchTabs = function(props) {
 
   useEffect(() => {
     if (isUserLoggedIn() && !hasLoadedBookmarks) {
-      loadUserBookmarks()
+      setHasLoadedBookmarks(true) // short-circuit multiple calls to load bookmarks
+      reloadBookmarks()
     }
   }, [])
 
@@ -54,11 +55,11 @@ const LinkableSearchTabs = function(props) {
   return (
     <div>
         <nav className="nav search-links" data-analytics-name="search" role="tablist">
-          <Link to={`${basePath}/app/studies${location.search}`}
+          <Link to={`${basePath}/app/studies${location.search}`} onClick={reloadBookmarks}
                 className={showGenesTab ? '' : 'active'}>
             <span className="fas fa-book"></span> Search studies
           </Link>
-          <Link to={`${basePath}/app/genes${location.search}`}
+          <Link to={`${basePath}/app/genes${location.search}`} onClick={reloadBookmarks}
                 className={showGenesTab ? 'active' : ''}>
             <span className="fas fa-dna"></span> Search genes
           </Link>

--- a/app/javascript/components/bookmarks/BookmarkManager.jsx
+++ b/app/javascript/components/bookmarks/BookmarkManager.jsx
@@ -14,16 +14,14 @@ import { log } from '~/lib/metrics-api'
  *
  * @param bookmarks {Array} existing user bookmark objects
  * @param studyAccession {String} currently loaded study, if present
- * @param eagerLoad {Boolean} load bookmarks from server on initialization
  */
-export default function BookmarkManager({bookmarks=[], studyAccession='', eagerLoad=false}) {
+export default function BookmarkManager({bookmarks=[], studyAccession=''}) {
   const location = useLocation()
   const [allBookmarks, setAllBookmarks] = useState(bookmarks)
   const [saveText, setSaveText] = useState('Save')
   const [saveDisabled, setSaveDisabled] = useState(false)
   const [bookmarkSaved, setBookmarkSaved] = useState(null)
   const [deleteDisabled, setDeleteDisabled] = useState(false)
-  const [hasEagerLoaded, setHasEagerLoaded] = useState(null)
   const { ErrorComponent, setShowError, setError } = useErrorMessage()
   const DEFAULT_BOOKMARK = {
     name: '',
@@ -245,31 +243,6 @@ export default function BookmarkManager({bookmarks=[], studyAccession='', eagerL
   const [serverBookmarks, setServerBookmarks] = useState([])
   const [serverBookmarksLoaded, setServerBookmarksLoaded] = useState(false)
   const [showBookmarksModal, setShowBookmarksModal] = useState(false)
-
-  /** load bookmarks from server on initialization */
-  async function eagerLoadBookmarks() {
-    setHasEagerLoaded(true) // prevent thundering herd
-    try {
-      const userBookmarks = await fetchBookmarks()
-      setAllBookmarks(userBookmarks)
-      setServerBookmarks(userBookmarks)
-      setServerBookmarksLoaded(true)
-      const existingBookmark = userBookmarks.find(bookmark => bookmark.path === getBookmarkPath())
-      if (existingBookmark) {
-        setCurrentBookmark(existingBookmark)
-        setBookmarkSaved(true)
-      }
-    } catch (error) {
-      handleErrorContent(error)
-      setHasEagerLoaded(false)
-    }
-  }
-
-  useEffect(() => {
-    if (eagerLoad && !hasEagerLoaded && isUserLoggedIn()) {
-      eagerLoadBookmarks()
-    }
-  }, [])
 
   /** toggle bookmarks modal open/close */
   const toggleBookmarkModal = () => {

--- a/app/javascript/components/bookmarks/BookmarkManager.jsx
+++ b/app/javascript/components/bookmarks/BookmarkManager.jsx
@@ -5,8 +5,6 @@ import React, { useEffect, useState, useRef } from 'react'
 import _cloneDeep from 'lodash/clone'
 import { isUserLoggedIn } from '~/providers/UserProvider'
 import { useLocation } from '@reach/router'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faLink, faUndo } from '@fortawesome/free-solid-svg-icons'
 import useErrorMessage from '~/lib/error-message'
 import useResizeEffect from '~/hooks/useResizeEffect'
 import { log } from '~/lib/metrics-api'
@@ -15,9 +13,10 @@ import { log } from '~/lib/metrics-api'
  * Component to bookmark views in Explore tab, as well as existing link/reset buttons
  *
  * @param bookmarks {Array} existing user bookmark objects
- * @param clearExploreParams
+ * @param studyAccession {String} currently loaded study, if present
+ * @param eagerLoadBookmarks {Boolean} load bookmarks from server on initialization
  */
-export default function BookmarkManager({bookmarks, studyAccession, clearExploreParams}) {
+export default function BookmarkManager({bookmarks=[], studyAccession='', eagerLoadBookmarks=false}) {
   const location = useLocation()
   const [allBookmarks, setAllBookmarks] = useState(bookmarks)
   const [saveText, setSaveText] = useState('Save')
@@ -33,11 +32,6 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
   }
 
   const formRef = useRef('bookmarkForm')
-
-  /** copies the url to the clipboard */
-  function copyLink() {
-    navigator.clipboard.writeText(location.href)
-  }
 
   /** Find a matching bookmark using the current URL params, or return default empty bookmark  */
   function findExistingBookmark() {
@@ -92,6 +86,11 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
   /** helper to determine if the bookmark form can be hidden/toggled **/
   function formCanToggle() {
     return isUserLoggedIn() && formRef.current?.state?.show
+  }
+
+  /** helper to hide the study accession form field when bookmarking search results */
+  function hideStudyAccession() {
+    return studyAccession === ''
   }
 
   /** close open form if changing tabs */
@@ -246,6 +245,17 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
   const [serverBookmarksLoaded, setServerBookmarksLoaded] = useState(false)
   const [showBookmarksModal, setShowBookmarksModal] = useState(false)
 
+  if (eagerLoadBookmarks && !serverBookmarksLoaded && isUserLoggedIn()) {
+    setServerBookmarksLoaded(true)
+    fetchBookmarks().then(userBookmarks => {
+      setAllBookmarks(userBookmarks)
+      setServerBookmarks(userBookmarks)
+    }).catch(error => {
+      handleErrorContent(error)
+      setServerBookmarksLoaded(false)
+    })
+  }
+
   /** toggle bookmarks modal open/close */
   const toggleBookmarkModal = () => {
     setShowBookmarksModal(!showBookmarksModal)
@@ -267,9 +277,11 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
     }
   }
 
+  const accessionFormClass = hideStudyAccession() ? 'hidden' : 'form-group'
+  const position = hideStudyAccession() ? 'right' : 'left'
   const loginNotice = <a href='/single_cell/users/auth/google_oauth2' data-method='post'
                          className={`fa-lg action far fa-star`} data-analytics-name='bookmark-login-notice'
-                         id='bookmark-login-notice' data-toggle='tooltip' data-placement='left'
+                         id='bookmark-login-notice' data-toggle='tooltip' data-placement={position}
                          data-original-title='Click to sign in, then bookmark this view'/>
 
   const bookmarkForm = <Popover data-analytics-name='bookmark-form-popover' id='bookmark-form-popover'>
@@ -295,7 +307,7 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
                onChange={handleFormUpdate}
         />
       </div>
-      <div className="form-group">
+      <div className={accessionFormClass}>
         <label htmlFor='bookmark-study-accession'>Study</label>&nbsp;
         <br/>
         <input className="form-control"
@@ -342,19 +354,9 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
 
   const starClass = bookmarkSaved ? 'fas' : 'far'
 
-  return (<div id='bookmark-container'>
-    <button className="action action-with-bg"
-            onClick={clearExploreParams}
-            title="Reset all view options"
-            data-analytics-name="explore-view-options-reset">
-      <FontAwesomeIcon icon={faUndo}/> Reset view</button>
-    <button onClick={copyLink}
-            className="action action-with-bg"
-            data-toggle="tooltip"
-            title="Copy a link to this visualization to the clipboard">
-      <FontAwesomeIcon icon={faLink}/> Get link</button>
+  return (<>
     { isUserLoggedIn() &&
-      <OverlayTrigger trigger={['click']} placement="left" animation={false}
+      <OverlayTrigger trigger={['click']} placement={position} animation={false}
                       overlay={bookmarkForm} ref={formRef}>
       <span className={`fa-lg action ${starClass} fa-star`}
             data-analytics-name='bookmark-manager'
@@ -363,6 +365,6 @@ export default function BookmarkManager({bookmarks, studyAccession, clearExplore
       />
       </OverlayTrigger>
     }
-    { !isUserLoggedIn() && loginNotice }
-  </div>)
+    { !isUserLoggedIn() && loginNotice }</>
+  )
 }

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -263,6 +263,11 @@ export default function ExploreDisplayPanelManager({
     setExploreInfo(newExploreInfo)
   }
 
+  /** copies the url to the clipboard */
+  function copyLink() {
+    navigator.clipboard.writeText(location.href)
+  }
+
   /** handles cluster selection to also populate the default spatial groups */
   function updateClusterParams(newParams) {
     if (newParams.cluster && !newParams.spatialGroups) {
@@ -492,13 +497,24 @@ export default function ExploreDisplayPanelManager({
               exploreParams={exploreParamsWithDefaults}
               updateExploreParams={updateExploreParams}
               allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}/>
-            {exploreInfo?.bookmarks &&
-              <BookmarkManager
-                bookmarks={exploreInfo.bookmarks}
-                studyAccession={studyAccession}
-                clearExploreParams={clearExploreParams}/>
-            }
-
+            <div id='bookmark-container'>
+              <button className="action action-with-bg"
+                      onClick={clearExploreParams}
+                      title="Reset all view options"
+                      data-analytics-name="explore-view-options-reset">
+                <FontAwesomeIcon icon={faUndo}/> Reset view</button>
+              <button onClick={copyLink}
+                      className="action action-with-bg"
+                      data-toggle="tooltip"
+                      title="Copy a link to this visualization to the clipboard">
+                <FontAwesomeIcon icon={faLink}/> Get link</button>
+              {exploreInfo?.bookmarks &&
+                <BookmarkManager
+                  bookmarks={exploreInfo.bookmarks}
+                  studyAccession={studyAccession}
+                  clearExploreParams={clearExploreParams}/>
+              }
+            </div>
           </>
         }
         {showCellFiltering && panelToShow === 'cell-filtering' && clusterCanFilter &&

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -511,8 +511,7 @@ export default function ExploreDisplayPanelManager({
               {exploreInfo?.bookmarks &&
                 <BookmarkManager
                   bookmarks={exploreInfo.bookmarks}
-                  studyAccession={studyAccession}
-                  clearExploreParams={clearExploreParams}/>
+                  studyAccession={studyAccession}/>
               }
             </div>
           </>

--- a/app/javascript/components/search/genes/GeneKeyword.jsx
+++ b/app/javascript/components/search/genes/GeneKeyword.jsx
@@ -39,7 +39,7 @@ export default function GeneKeyword({ placeholder, helpTextContent }) {
 
   useEffect(() => {
     setGeneArray(searchedGenesAsArray)
-  }, [searchedGenesAsArray.join(' ')])
+  }, [searchedGenesAsArray.map(gene => {return gene.label}).join(' ')])
 
   /** handles a user submitting a gene search */
   function handleSubmit(event) {

--- a/app/javascript/components/search/genes/GeneKeyword.jsx
+++ b/app/javascript/components/search/genes/GeneKeyword.jsx
@@ -1,32 +1,45 @@
-import React, { useContext, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSearch } from '@fortawesome/free-solid-svg-icons'
 import Button from 'react-bootstrap/lib/Button'
 import CreatableSelect from 'react-select/creatable'
 
-import { GeneSearchContext } from '~/providers/GeneSearchProvider'
+import { GeneSearchContext, buildParamsFromQuery } from '~/providers/GeneSearchProvider'
 import { StudySearchContext } from '~/providers/StudySearchProvider'
+import { useLocation } from '@reach/router'
 
 /** renders the gene text input
   * This is split into its own component both for modularity, and also because
   * having it inlined in GeneSearchView led to a mysterious infinite-repaint bug in StudyResults
   */
 export default function GeneKeyword({ placeholder, helpTextContent }) {
+  const location = useLocation()
   const geneSearchState = useContext(GeneSearchContext)
   const studySearchState = useContext(StudySearchContext)
-  let geneParamAsArray = []
-  if (geneSearchState.params.genes) {
-    geneParamAsArray = geneSearchState.params.genes.split(' ').map(geneName => ({
-      label: geneName,
-      value: geneName
-    }))
+  const searchedGenesAsArray = getGenesFromLocation()
+
+  // use URL genes param for tracking state of gene search bar
+  function getGenesFromLocation() {
+    const searchParams = buildParamsFromQuery(location.search)
+    if (searchParams.genes) {
+      return searchParams.genes.split(' ').map(geneName => ({
+        label: geneName,
+        value: geneName
+      }))
+    } else {
+      return []
+    }
   }
 
   /** the search control tracks two state variables
     * an array of already entered genes (geneArray),
     * and the current text the user is typing (inputText) */
-  const [geneArray, setGeneArray] = useState(geneParamAsArray)
+  const [geneArray, setGeneArray] = useState(searchedGenesAsArray)
   const [inputText, setInputText] = useState('')
+
+  useEffect(() => {
+    setGeneArray(searchedGenesAsArray)
+  }, [searchedGenesAsArray.join(' ')])
 
   /** handles a user submitting a gene search */
   function handleSubmit(event) {

--- a/app/javascript/components/search/genes/GeneSearchView.jsx
+++ b/app/javascript/components/search/genes/GeneSearchView.jsx
@@ -8,7 +8,7 @@ import StudyGeneExpressions from './StudyGeneExpressions'
 /**
   * Renders a gene search control panel and the associated results
   */
-export default function GeneSearchView() {
+export default function GeneSearchView({bookmarks}) {
   const geneSearchState = useContext(GeneSearchContext)
 
   const showStudySearchResults = !geneSearchState.isLoaded &&
@@ -66,7 +66,8 @@ export default function GeneSearchView() {
           <ResultsPanel
             studySearchState={geneSearchState}
             studyComponent={StudyGeneExpressions}
-            noResultsDisplay={noResultsContent} />
+            noResultsDisplay={noResultsContent}
+            bookmarks={bookmarks}/>
         </div>
         <div className="col-md-12">
           <div id="load-more-genes-target"></div>

--- a/app/javascript/components/search/results/ResultsPanel.jsx
+++ b/app/javascript/components/search/results/ResultsPanel.jsx
@@ -16,7 +16,7 @@ import LoadingSpinner from '~/lib/LoadingSpinner'
  * @studyComponent - the component to use to render individual studies.  If not specified, results/StudySearchResult.js
  * will be used
  */
-const ResultsPanel = ({ studySearchState, studyComponent, noResultsDisplay }) => {
+const ResultsPanel = ({ studySearchState, studyComponent, noResultsDisplay, bookmarks }) => {
   const results = studySearchState.results
 
   let panelContent
@@ -36,7 +36,7 @@ const ResultsPanel = ({ studySearchState, studyComponent, noResultsDisplay }) =>
   } else if (results.studies && results.studies.length > 0) {
     panelContent = (
       <>
-        { <SearchQueryDisplay terms={results.termList} facets={results.facets}/> }
+        { <SearchQueryDisplay terms={results.termList} facets={results.facets} bookmarks={bookmarks}/> }
         <StudyResults
           results={results}
           StudyComponent={studyComponent ? studyComponent : StudySearchResult}

--- a/app/javascript/components/search/results/SearchQueryDisplay.jsx
+++ b/app/javascript/components/search/results/SearchQueryDisplay.jsx
@@ -6,6 +6,7 @@ import _flatten from 'lodash/flatten'
 
 import { getDisplayNameForFacet } from '~/providers/SearchFacetProvider'
 import { SearchSelectionContext } from '~/providers/SearchSelectionProvider'
+import BookmarkManager from '~/components/bookmarks/BookmarkManager'
 
 /** joins texts by wrapping them in a span with itemClass className, and then
  * inserting spans with the joinText
@@ -87,7 +88,7 @@ export const ClearAllButton = () => {
 /** displays a summary of an executed search.
  * e.g. (Text contains (stomach)) AND (Metadata contains (organ: brain))
  */
-export default function SearchQueryDisplay({ terms, facets }) {
+export default function SearchQueryDisplay({ terms, facets, bookmarks }) {
   const hasFacets = facets && facets.length > 0
   const hasTerms = terms && terms.length > 0
   if (!hasFacets && !hasTerms) {
@@ -132,6 +133,7 @@ export default function SearchQueryDisplay({ terms, facets }) {
       <FontAwesomeIcon icon={faSearch}/>: <span className="query-text">
         {termsDisplay}{facetsDisplay}
       </span> <ClearAllButton/>
+      <BookmarkManager bookmarks={bookmarks} />
     </div>
   )
 }

--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -282,6 +282,10 @@
   overflow-y: scroll;
 }
 
+#bookmarks-list-modal {
+  z-index: 9999;
+}
+
 .bookmarks-list-item {
   background-color: #eff2f5;
   padding: 5px;

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -383,3 +383,13 @@ span.text-search {
 .advanced-opts {
   margin-top: 23px;
 }
+
+#home-page-bookmark {
+  a, span.action {
+    padding: 0 5px;
+    font-size: larger;
+  }
+  :hover {
+    background-color: inherit;
+  }
+}

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -12,7 +12,6 @@ class Bookmark
   field :description, type: String
 
   validates :name, :path, presence: true, uniqueness: { scope: %i[user_id study_accession] }
-  validates :study_accession, presence: true
   before_validation :sanitize_path, :set_name
 
   swagger_schema :Bookmark do

--- a/test/js/search/gene-keyword.test.js
+++ b/test/js/search/gene-keyword.test.js
@@ -5,10 +5,15 @@ import { render, fireEvent } from '@testing-library/react'
 import { PropsStudySearchProvider } from 'providers/StudySearchProvider'
 import GeneKeyword from 'components/search/genes/GeneKeyword'
 import { GeneSearchContext } from 'providers/GeneSearchProvider'
-
+import * as Reach from '@reach/router'
 
 describe('Search query display text', () => {
+  const locationMock = jest.spyOn(Reach, 'useLocation')
+
   it('shows blank search form with place holder text present', async () => {
+    locationMock.mockImplementation(() => (
+      { pathname: "/single_cell/app/genes", search: '' }
+    ))
     const { container } = render((
       <GeneKeyword placeholder={'I am a place holder'} />
     ))
@@ -16,6 +21,9 @@ describe('Search query display text', () => {
   })
 
   it('shows study result matches search param', async () => {
+    locationMock.mockImplementation(() => (
+      { pathname: "/single_cell/app/genes", search: 'genes=PTEN' }
+    ))
     const searchState = {
       params: {
         genes: 'PTEN',
@@ -37,6 +45,9 @@ describe('Search query display text', () => {
   })
 
   it('show matching multiple params and strips off surronding quotes on search params', async () => {
+    locationMock.mockImplementation(() => (
+      { pathname: "/single_cell/app/genes", search: 'genes=PTEN,NA' }
+    ))
     const searchState = {
       params: {
         genes: 'PTEN, NA',
@@ -58,6 +69,9 @@ describe('Search query display text', () => {
   })
 
   it('show that searching on no entered genes provides the generic results ', async () => {
+    locationMock.mockImplementation(() => (
+      { pathname: "/single_cell/app/genes", search: '' }
+    ))
     const searchState = {
       params: {
         genes: '',

--- a/test/js/search/gene-search-view.test.js
+++ b/test/js/search/gene-search-view.test.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import * as Reach from '@reach/router'
 import { render } from '@testing-library/react'
 import GeneSearchView from 'components/search/genes/GeneSearchView'
 import { PropsStudySearchProvider } from 'providers/StudySearchProvider'
@@ -6,6 +7,10 @@ import { GeneSearchContext, emptySearch } from 'providers/GeneSearchProvider'
 
 
 describe('Gene search page landing', () => {
+  const locationMock = jest.spyOn(Reach, 'useLocation')
+  locationMock.mockImplementation(() => (
+    { pathname: "/single_cell/app/genes", search: '' }
+  ))
   it('shows study details when empty', async () => {
     const searchState = emptySearch
     searchState.isLoaded = true

--- a/test/js/search/search-query-display.test.js
+++ b/test/js/search/search-query-display.test.js
@@ -7,6 +7,7 @@ import SearchQueryDisplay, { ClearAllButton } from 'components/search/results/Se
 import { PropsStudySearchProvider } from 'providers/StudySearchProvider'
 import KeywordSearch from 'components/search/controls/KeywordSearch'
 import FacetControl from 'components/search/controls/FacetControl'
+import * as Reach from '@reach/router'
 
 
 const oneStringFacet = [
@@ -37,6 +38,11 @@ const orFacets = [
   },
   { id: 'cell_type__custom', filters: [{ id: 'ctc1', name: 'Bergmann' }] }
 ]
+
+const locationMock = jest.spyOn(Reach, 'useLocation')
+locationMock.mockImplementation(() => (
+  { pathname: "/single_cell/", search: '' }
+))
 
 describe('Search query display text', () => {
   it('renders a single facet', async () => {
@@ -100,8 +106,7 @@ describe('Clearing search query', () => {
       links: [{ name: 'NCBI Taxonomy', url: 'https://foo.tdb' }],
       filters: [
         { id: 'NCBITaxon_9606', name: 'Homo Sapiens' }
-      ],
-      links: []
+      ]
     }
     const component = <PropsStudySearchProvider searchParams={{ terms: 'foo', facets: { species: ['NCBITaxon_9606'] } }}>
       <ClearAllButton/>

--- a/test/models/bookmark_test.rb
+++ b/test/models/bookmark_test.rb
@@ -37,12 +37,11 @@ class BookmarkTest < ActiveSupport::TestCase
     end
     invalid_view.name = nil
     invalid_view.path = nil
-    invalid_view.study_accession = nil
     assert_not invalid_view.valid?
     errors = invalid_view.errors.full_messages
-    assert_equal 3, errors.count
+    assert_equal 2, errors.count
     errors.each do |error|
-      assert error.match(/(Name|Path|Study accession) can't be blank/)
+      assert error.match(/(Name|Path) can't be blank/)
     end
   end
 end


### PR DESCRIPTION
#### BACKGOUND & CHANGES
With recent enhancements to [filter global gene search using search criteria](#2013), adding the ability to easily recall searches becomes more important.  This update adds the bookmark feature to the home page search, and can be used to save both study- and gene-based searches.  While the exact results will _not_ be cached, as this is data-dependent, the search parameters will be, allowing for users to easily find updates to existing queries.

#### MANUAL TESTING
1. Boot as normal
2. Run a study-based search
3. Note the bookmark icon appears inline with the query summary
4. Open the bookmark form and then save
5. Click over to `Search genes` and run a gene search, also bookmarking that result
6. From the bookmark for, click `All bookmarks`, and then use the entries to navigate back and forth between both searches