### PR TITLE
Fixing bookmark icon positioning in spatial studies (SCP-5615)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -497,22 +497,24 @@ export default function ExploreDisplayPanelManager({
               exploreParams={exploreParamsWithDefaults}
               updateExploreParams={updateExploreParams}
               allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}/>
-            <div id='bookmark-container'>
-              <button className="action action-with-bg"
-                      onClick={clearExploreParams}
-                      title="Reset all view options"
-                      data-analytics-name="explore-view-options-reset">
-                <FontAwesomeIcon icon={faUndo}/> Reset view</button>
-              <button onClick={copyLink}
-                      className="action action-with-bg"
-                      data-toggle="tooltip"
-                      title="Copy a link to this visualization to the clipboard">
-                <FontAwesomeIcon icon={faLink}/> Get link</button>
-              {exploreInfo?.bookmarks &&
-                <BookmarkManager
-                  bookmarks={exploreInfo.bookmarks}
-                  studyAccession={studyAccession}/>
-              }
+            <div id={!showCellFiltering ? 'bookmark-container' : ''} className={!showCellFiltering ? 'row' : ''}>
+              <div className={!showCellFiltering ? 'col-xs-12' : ''}>
+                <button className="action action-with-bg"
+                        onClick={clearExploreParams}
+                        title="Reset all view options"
+                        data-analytics-name="explore-view-options-reset">
+                  <FontAwesomeIcon icon={faUndo}/> Reset view</button>
+                <button onClick={copyLink}
+                        className="action action-with-bg"
+                        data-toggle="tooltip"
+                        title="Copy a link to this visualization to the clipboard">
+                  <FontAwesomeIcon icon={faLink}/> Get link</button>
+                {exploreInfo?.bookmarks &&
+                  <BookmarkManager
+                    bookmarks={exploreInfo.bookmarks}
+                    studyAccession={studyAccession}/>
+                }
+              </div>
             </div>
           </>
         }

--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -277,6 +277,11 @@
   }
 }
 
+#bookmark-container {
+  position: relative;
+  top: -20px;
+}
+
 #bookmarks-list-wrapper {
   max-height: 500px;
   overflow-y: scroll;


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes an existing issue where the bookmark icon line wraps when viewing spatial studies.  Now, the positioning of the bookmark icon mimics that of all other studies.  It is worth noting that at smaller viewports, the bookmark/get link icons will wrap automatically, but now the behavior for spatial & non-spatial studies is the same.

#### MANUAL TESTING
1. Boot as normal
2. In two tabs, load a spatial & non-spatial study
3. Confirm the position of the bookmark icon is the same, and that both wrap at the same viewport width.