### PR TITLE
Skip content-type/accept header check on status endpoint (SCP-5589)

### DIFF
--- a/app/controllers/api/v1/status_controller.rb
+++ b/app/controllers/api/v1/status_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class StatusController < ApiBaseController
+      skip_before_action :validate_content_type!
+
       respond_to :json
 
       swagger_path '/status' do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
As part of the effort of de-fanging the load balancer health check, this update makes the status API endpoint allow all `Content-Type` and `Accept` headers.  Previously, if a request did not have a valid `Accept` header, it would respond `406`.  This is a new requirement as the load balancer health check makes a normal `GET` with an `Accept: text/html` header, and we can't change this.  This would end up having the health check deem the portal "unhealthy" and redirect traffic away.  

The reason for moving the health check to the status endpoint is to isolate any problems that might happen on the home page and prevent them from bringing down the entire portal via the health check (as was seen in the recent outage caused by the [cell_count](https://github.com/broadinstitute/single_cell_portal_core/pull/2011) bug).  We will still be notified by UptimeRobot of any issues on the home page (and we won't change this polling), but normal usage would be able to continue for users on any other page.

There will be an additional PR once this is merged/deployed to reconfigure the load balancer health check rules in Terraform.

#### MANUAL TESTING
1. Boot as normal
2. In a separate terminal window, run the following `cURL` command and confirm you get an `OK` response:
```
% curl --head "https://localhost:3000/single_cell/api/v1/status" -H  "accept: text/html"

HTTP/1.1 200 OK
Content-Type: application/json
Cache-Control: no-store, must-revalidate, private, max-age=0
X-Request-Id: b74b918e-8d17-4d76-8ce4-e602054e82fc
X-Runtime: 0.183001
Strict-Transport-Security: max-age=0; includeSubDomains
X-MiniProfiler-Original-Cache-Control: no-cache

```