### PR TITLE
Proof of concept: dynamic filtering in igv.js (SCP-5586)

### DIFF
--- a/cell-filtering-igv/index.html
+++ b/cell-filtering-igv/index.html
@@ -19,6 +19,10 @@
 
     import igv from "./igv.esm.js"
 
+    import accessToken from './access-token.esm.js'
+
+    console.log('accessToken', accessToken)
+
     const options =
         {
             // Example of fully specifying a reference .  We could alternatively use  "genome: 'hg19'"
@@ -36,7 +40,8 @@
                         // type: "variant",
                         format: "bed",
                         url: "https://storage.googleapis.com/fc-bcc55e6c-bec3-4b2e-9fb2-5e1526ddfcd2/reference_data_dev/nemo_atac/10x_multiome_mouse_brain/M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz",
-                        indexURL: "https://storage.googleapis.com/fc-bcc55e6c-bec3-4b2e-9fb2-5e1526ddfcd2/reference_data_dev/nemo_atac/10x_multiome_mouse_brain/M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz.tbi"
+                        indexURL: "https://storage.googleapis.com/fc-bcc55e6c-bec3-4b2e-9fb2-5e1526ddfcd2/reference_data_dev/nemo_atac/10x_multiome_mouse_brain/M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz.tbi",
+                        headers: {'Authorization': `Bearer ${accessToken}`}
                     },
                     {
                         name: "Genes",
@@ -56,8 +61,11 @@
 
     igv.createBrowser(igvDiv, options)
         .then(function (browser) {
+            window.igvBrowser = browser
             console.log("Created IGV browser")
         })
+
+    window.igv = igv
 
 </script>
 

--- a/cell-filtering-igv/index.html
+++ b/cell-filtering-igv/index.html
@@ -20,7 +20,8 @@
   // API proof via console:
   // originalFeaturesChr12 = igvBrowser.trackViews[3].track.featureSource.featureCache.allFeatures[12]
   // filteredFeatures = igvBrowser.trackViews[3].track.featureSource.featureCache.allFeatures[12].filter(feature => feature.score !== 1)
-  // igv.FeatureUtils.packFeatures(filteredFeatures)
+  // maxRows = 20
+  // igv.FeatureUtils.packFeatures(filteredFeatures, maxRows)
   // igvBrowser.trackViews[3].track.featureSource.featureCache = new igv.FeatureCache$1(filteredFeatures, igvBrowser.genome)
   // igvBrowser.trackViews[3].track.clearCachedFeatures()
   // igvBrowser.trackViews[3].track.updateViews()
@@ -36,7 +37,7 @@
                     fastaURL: "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/1kg_v37/human_g1k_v37_decoy.fasta",
                     cytobandURL: "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/b37/b37_cytoband.txt"
                 },
-            locus: "12:6,645,244-6,645,975", // 732 bp in GAPDH, close enough to see ATAC-seq fragments
+            locus: "12:6,642,682-6,648,537", // 5856 bp around GAPDH
             tracks:
                 [
                     {
@@ -46,6 +47,7 @@
                         url: "./M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz",
                         indexURL: "./M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz.tbi",
                         visibilityWindow: 100_000,
+                        height: 350
                     },
                     {
                         name: "Genes",

--- a/cell-filtering-igv/index.html
+++ b/cell-filtering-igv/index.html
@@ -48,7 +48,6 @@
   <li><label>4 <input type="checkbox" value="4" onChange="filterAtac()" checked/></label></li>
   <li><label>5 <input type="checkbox" value="5" onChange="filterAtac()" checked/></label></li>
 </ul>
-<button onClick="filterAtacSeq()">Filter</button>
 <div id="igvDiv" style="padding-top: 10px;padding-bottom: 10px; border:1px solid lightgray"></div>
 
 <script type="module">

--- a/cell-filtering-igv/index.html
+++ b/cell-filtering-igv/index.html
@@ -1,20 +1,22 @@
-
 <!DOCTYPE html>
-<html lang="en">
+<html>
+<!--
+This is a static page derived from https://igv.org/web/release/2.15.5/examples/cram-vcf.html
+
+More context: https://github.com/broadinstitute/single_cell_portal_core/pull/2021
+-->
 <head>
-    <meta charset="utf-8">
-    <meta content="Jim Robinson" name="author">
-    <link href=img/favicon.ico rel="shortcut icon">
-    <title>igv.js</title>
-    <style>.filters li { display: inline} </style>
-    <script>
-
-  function checkFeature(feature, selection) {
-    return (feature.score in selection)
-  }
-
+  <title>igv.js</title>
+  <style>.filters li { display: inline} </style>
+  <script>
+  /**
+   * Apply crude faceted search in igv.js
+   *
+   * This is a proof of concept.  Lots is hard-coded and brittle, intentionally, as an
+   * engineering experiment to demonstrate that genomic features can be arbitrarily
+   * filtered directly in client-side JS in the browser.
+   */
   function filterAtac() {
-  // API proof via console:
     const ti = 4 // Track index
     if (typeof originalFeaturesChr12 === 'undefined') {
       originalFeaturesChr12 = igvBrowser.trackViews[ti].track.featureSource.featureCache.allFeatures[12]
@@ -28,7 +30,10 @@
     })
 
     filteredFeatures = originalFeaturesChr12.filter(feature => feature.score in selection)
+
+    // How many layers of features can be stacked / piled up.
     maxRows = 20
+
     igv.FeatureUtils.packFeatures(filteredFeatures, maxRows)
     igvBrowser.trackViews[ti].track.featureSource.featureCache = new igv.FeatureCache$1(filteredFeatures, igvBrowser.genome)
     igvBrowser.trackViews[ti].track.clearCachedFeatures()
@@ -77,7 +82,6 @@
                     },
                     {
                         name: "ATAC fragments",
-                        // type: "variant",
                         format: "bed",
                         url: "./M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz",
                         indexURL: "./M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz.tbi",
@@ -106,7 +110,5 @@
     window.igv = igv
 
 </script>
-
 </body>
-
 </html>

--- a/cell-filtering-igv/index.html
+++ b/cell-filtering-igv/index.html
@@ -6,26 +6,52 @@
     <meta content="Jim Robinson" name="author">
     <link href=img/favicon.ico rel="shortcut icon">
     <title>igv.js</title>
+    <script>
 
+  function checkFeature(feature, selection) {
+    return (feature.score in selection)
+  }
+
+  function filterAtac() {
+  // API proof via console:
+    const ti = 4 // Track index
+    originalFeaturesChr12 = igvBrowser.trackViews[ti].track.featureSource.featureCache.allFeatures[12]
+    selection = {}
+    inputs = document.querySelectorAll('.filters input')
+    inputs.forEach(input => {
+      console.log('input, input.checked', input, input.checked)
+      if (input.checked) {
+        selection[input.value] = 1
+      }
+    })
+
+    filteredFeatures =
+      igvBrowser.trackViews[ti].track.featureSource.featureCache.allFeatures[12]
+        .filter(feature => feature.score in selection)
+    maxRows = 20
+    igv.FeatureUtils.packFeatures(filteredFeatures, maxRows)
+    igvBrowser.trackViews[ti].track.featureSource.featureCache = new igv.FeatureCache$1(filteredFeatures, igvBrowser.genome)
+    igvBrowser.trackViews[ti].track.clearCachedFeatures()
+    igvBrowser.trackViews[ti].track.updateViews()
+  }
+    </script>
 </head>
 
 <body>
 
 <h1>Ad-hoc filtering in IGV</h1>
-
+<ul class="filters">
+  <span>Score</span>
+  <li><label>1 <input type="checkbox" value="1" onChange="filterAtac()" checked/></label></li>
+  <li><label>2 <input type="checkbox" value="2" onChange="filterAtac()" checked/></label></li>
+  <li><label>3 <input type="checkbox" value="3" onChange="filterAtac()" checked/></label></li>
+  <li><label>4 <input type="checkbox" value="4" onChange="filterAtac()" checked/></label></li>
+  <li><label>5 <input type="checkbox" value="5" onChange="filterAtac()" checked/></label></li>
+</ul>
+<button onClick="filterAtacSeq()">Filter</button>
 <div id="igvDiv" style="padding-top: 10px;padding-bottom: 10px; border:1px solid lightgray"></div>
 
 <script type="module">
-
-  // API proof via console:
-  // originalFeaturesChr12 = igvBrowser.trackViews[3].track.featureSource.featureCache.allFeatures[12]
-  // filteredFeatures = igvBrowser.trackViews[3].track.featureSource.featureCache.allFeatures[12].filter(feature => feature.score !== 1)
-  // maxRows = 20
-  // igv.FeatureUtils.packFeatures(filteredFeatures, maxRows)
-  // igvBrowser.trackViews[3].track.featureSource.featureCache = new igv.FeatureCache$1(filteredFeatures, igvBrowser.genome)
-  // igvBrowser.trackViews[3].track.clearCachedFeatures()
-  // igvBrowser.trackViews[3].track.updateViews()
-
     import igv from "./igv.esm.js"
 
     const options =
@@ -41,24 +67,29 @@
             tracks:
                 [
                     {
+                        name: "Genes",
+                        type: "annotation",
+                        format: "bed",
+                        url: "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz",
+                        indexURL: "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz.tbi",
+                        visibilityWindow: 300000000,
+                        displayMode: "EXPANDED",
+                        height: 150
+                    },
+                    {
                         name: "Test",
                         // type: "variant",
                         format: "bed",
                         url: "./M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz",
                         indexURL: "./M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz.tbi",
                         visibilityWindow: 100_000,
-                        height: 350
+                        height: 300,
+                        featureHeight: 7,
+                        expandedVGap: 1,
+                        displayMode: 'SQUISHED',
+                        colorBy: 'score'
+
                     },
-                    {
-                        name: "Genes",
-                        type: "annotation",
-                        format: "bed",
-                        url: "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz",
-                        indexURL: "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz.tbi",
-                        order: Number.MAX_VALUE,
-                        visibilityWindow: 300000000,
-                        displayMode: "EXPANDED"
-                    }
                 ]
 
         }

--- a/cell-filtering-igv/index.html
+++ b/cell-filtering-igv/index.html
@@ -18,14 +18,12 @@
 <script type="module">
 
   // API proof via console:
-
   // originalFeaturesChr12 = igvBrowser.trackViews[3].track.featureSource.featureCache.allFeatures[12]
   // filteredFeatures = igvBrowser.trackViews[3].track.featureSource.featureCache.allFeatures[12].filter(feature => feature.score !== 1)
   // igv.FeatureUtils.packFeatures(filteredFeatures)
   // igvBrowser.trackViews[3].track.featureSource.featureCache = new igv.FeatureCache$1(filteredFeatures, igvBrowser.genome)
   // igvBrowser.trackViews[3].track.clearCachedFeatures()
   // igvBrowser.trackViews[3].track.updateViews()
-
 
     import igv from "./igv.esm.js"
 
@@ -46,7 +44,8 @@
                         // type: "variant",
                         format: "bed",
                         url: "./M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz",
-                        indexURL: "./M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz.tbi"
+                        indexURL: "./M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz.tbi",
+                        visibilityWindow: 100_000,
                     },
                     {
                         name: "Genes",

--- a/cell-filtering-igv/index.html
+++ b/cell-filtering-igv/index.html
@@ -19,10 +19,6 @@
 
     import igv from "./igv.esm.js"
 
-    import accessToken from './access-token.esm.js'
-
-    console.log('accessToken', accessToken)
-
     const options =
         {
             // Example of fully specifying a reference .  We could alternatively use  "genome: 'hg19'"
@@ -32,16 +28,15 @@
                     fastaURL: "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/1kg_v37/human_g1k_v37_decoy.fasta",
                     cytobandURL: "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/b37/b37_cytoband.txt"
                 },
-            locus: "8:128,750,948-128,751,025",
+            locus: "12:6,642,682-6,648,537", // GAPDH
             tracks:
                 [
                     {
                         name: "Test",
                         // type: "variant",
                         format: "bed",
-                        url: "https://storage.googleapis.com/fc-bcc55e6c-bec3-4b2e-9fb2-5e1526ddfcd2/reference_data_dev/nemo_atac/10x_multiome_mouse_brain/M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz",
-                        indexURL: "https://storage.googleapis.com/fc-bcc55e6c-bec3-4b2e-9fb2-5e1526ddfcd2/reference_data_dev/nemo_atac/10x_multiome_mouse_brain/M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz.tbi",
-                        headers: {'Authorization': `Bearer ${accessToken}`}
+                        url: "./M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz",
+                        indexURL: "./M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz.tbi"
                     },
                     {
                         name: "Genes",

--- a/cell-filtering-igv/index.html
+++ b/cell-filtering-igv/index.html
@@ -15,7 +15,9 @@
   function filterAtac() {
   // API proof via console:
     const ti = 4 // Track index
-    originalFeaturesChr12 = igvBrowser.trackViews[ti].track.featureSource.featureCache.allFeatures[12]
+    if (typeof originalFeaturesChr12 === 'undefined') {
+      originalFeaturesChr12 = igvBrowser.trackViews[ti].track.featureSource.featureCache.allFeatures[12]
+    }
     selection = {}
     inputs = document.querySelectorAll('.filters input')
     inputs.forEach(input => {
@@ -25,9 +27,7 @@
       }
     })
 
-    filteredFeatures =
-      igvBrowser.trackViews[ti].track.featureSource.featureCache.allFeatures[12]
-        .filter(feature => feature.score in selection)
+    filteredFeatures = originalFeaturesChr12.filter(feature => feature.score in selection)
     maxRows = 20
     igv.FeatureUtils.packFeatures(filteredFeatures, maxRows)
     igvBrowser.trackViews[ti].track.featureSource.featureCache = new igv.FeatureCache$1(filteredFeatures, igvBrowser.genome)

--- a/cell-filtering-igv/index.html
+++ b/cell-filtering-igv/index.html
@@ -1,0 +1,66 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta content="Jim Robinson" name="author">
+    <link href=img/favicon.ico rel="shortcut icon">
+    <title>igv.js</title>
+
+</head>
+
+<body>
+
+<h1>VCF variants and CRAM alignments</h1>
+
+<div id="igvDiv" style="padding-top: 10px;padding-bottom: 10px; border:1px solid lightgray"></div>
+
+<script type="module">
+
+    import igv from "./igv.esm.js"
+
+    const options =
+        {
+            // Example of fully specifying a reference .  We could alternatively use  "genome: 'hg19'"
+            reference:
+                {
+                    id: "hg19",
+                    fastaURL: "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/1kg_v37/human_g1k_v37_decoy.fasta",
+                    cytobandURL: "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/b37/b37_cytoband.txt"
+                },
+            locus: "8:128,750,948-128,751,025",
+            tracks:
+                [
+                    {
+                        name: "Test",
+                        // type: "variant",
+                        format: "bed",
+                        url: "https://storage.googleapis.com/fc-bcc55e6c-bec3-4b2e-9fb2-5e1526ddfcd2/reference_data_dev/nemo_atac/10x_multiome_mouse_brain/M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz",
+                        indexURL: "https://storage.googleapis.com/fc-bcc55e6c-bec3-4b2e-9fb2-5e1526ddfcd2/reference_data_dev/nemo_atac/10x_multiome_mouse_brain/M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz.tbi"
+                    },
+                    {
+                        name: "Genes",
+                        type: "annotation",
+                        format: "bed",
+                        url: "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz",
+                        indexURL: "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz.tbi",
+                        order: Number.MAX_VALUE,
+                        visibilityWindow: 300000000,
+                        displayMode: "EXPANDED"
+                    }
+                ]
+
+        }
+
+    var igvDiv = document.getElementById("igvDiv")
+
+    igv.createBrowser(igvDiv, options)
+        .then(function (browser) {
+            console.log("Created IGV browser")
+        })
+
+</script>
+
+</body>
+
+</html>

--- a/cell-filtering-igv/index.html
+++ b/cell-filtering-igv/index.html
@@ -11,11 +11,21 @@
 
 <body>
 
-<h1>VCF variants and CRAM alignments</h1>
+<h1>Ad-hoc filtering in IGV</h1>
 
 <div id="igvDiv" style="padding-top: 10px;padding-bottom: 10px; border:1px solid lightgray"></div>
 
 <script type="module">
+
+  // API proof via console:
+
+  // originalFeaturesChr12 = igvBrowser.trackViews[3].track.featureSource.featureCache.allFeatures[12]
+  // filteredFeatures = igvBrowser.trackViews[3].track.featureSource.featureCache.allFeatures[12].filter(feature => feature.score !== 1)
+  // igv.FeatureUtils.packFeatures(filteredFeatures)
+  // igvBrowser.trackViews[3].track.featureSource.featureCache = new igv.FeatureCache$1(filteredFeatures, igvBrowser.genome)
+  // igvBrowser.trackViews[3].track.clearCachedFeatures()
+  // igvBrowser.trackViews[3].track.updateViews()
+
 
     import igv from "./igv.esm.js"
 
@@ -28,7 +38,7 @@
                     fastaURL: "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/1kg_v37/human_g1k_v37_decoy.fasta",
                     cytobandURL: "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/b37/b37_cytoband.txt"
                 },
-            locus: "12:6,642,682-6,648,537", // GAPDH
+            locus: "12:6,645,244-6,645,975", // 732 bp in GAPDH, close enough to see ATAC-seq fragments
             tracks:
                 [
                     {

--- a/cell-filtering-igv/index.html
+++ b/cell-filtering-igv/index.html
@@ -6,6 +6,7 @@
     <meta content="Jim Robinson" name="author">
     <link href=img/favicon.ico rel="shortcut icon">
     <title>igv.js</title>
+    <style>.filters li { display: inline} </style>
     <script>
 
   function checkFeature(feature, selection) {
@@ -21,7 +22,6 @@
     selection = {}
     inputs = document.querySelectorAll('.filters input')
     inputs.forEach(input => {
-      console.log('input, input.checked', input, input.checked)
       if (input.checked) {
         selection[input.value] = 1
       }
@@ -77,13 +77,15 @@
                         height: 150
                     },
                     {
-                        name: "Test",
+                        name: "ATAC fragments",
                         // type: "variant",
                         format: "bed",
                         url: "./M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz",
                         indexURL: "./M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz.tbi",
+                        // url: "./Library-8-20230710_atac.fragments.possorted.bed.gz",
+                        // indexURL: "./Library-8-20230710_atac.fragments.possorted.bed.gz.tbi",
                         visibilityWindow: 100_000,
-                        height: 300,
+                        height: 250,
                         featureHeight: 7,
                         expandedVGap: 1,
                         displayMode: 'SQUISHED',


### PR DESCRIPTION
This demonstrates basic faceted search in igv.js.  It's a first step towards a new mode of genome exploration.

### Overview
Historically, the popular IGV web genome browser has supported filtered views on data by having users select from different _pre-computed, static_ files.  This is fast in the UI, but generally quite limited.  It also requires bespoke, track-specific data engineering and lots of storage.

Now, we have a working example of how users can filter views in IGV _dynamically_.  This proof of concept shows a basic set of filters, using the `score` attribute from a _single_ BED file track of ATAC-seq fragment features.  The filters are crude and slow in this experimental stage, but they work.

Ultimately, this aims to enrich exploring single-cell data in a very granular, genomic context by letting users apply easy faceted search techniques.  Its application here is for a particular kind of chromatin accessibility data, but the engineering would apply to any genomic features in igv.js.

Here's how the early work looks!

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/978964e2-0671-4641-824f-378ac2a64173

### Next steps
Given this proof, we can likely apply the approach SCP uses for [cell filtering for violin plots](#1965) to enable cell filtering in genome browsers.  This work required updating underlying igv.js code, which is crudely patched here, and will need to be integrated more robustly (cf. #655).  We'll also need to enable uploading ATAC fragment files in SCP.  These tasks are tracked in SCP-5612, SCP-5613, and SCP-5614.  

The filters are sometimes very slow.  Speeding them up would fit as part of NeMO / BICAN 10x multiome optimizations.  That might be easiest to do by refining or simply skipping a tree indexing step in the igv.js `packFeatures` call.

### Test
If you'd like, this is how you can manually verify this proof of concept.  

The steps below use a very basic, standalone development environment.  After a one-time set-up, this helps speed up iteration time for low-level isolated experiments with igv.js.

1.  Install [Simple Web Server](https://simplewebserver.org/) (SWS)
2. In the SWS UI, set "Folder path" to `path/to/your/single_cell_portal_core/cell-filtering-igv`
3. Save [this igv.esm.js.txt file](https://github.com/broadinstitute/single_cell_portal_core/files/15098557/igv.esm.js.txt) to `single_cell_portal_core/cell-filtering-igv/`, and rename it to `igv.esm.js`.  (Click "* igv.js change details" below for more information on how this file was generated; tasks noted in "Next steps" will robustify this.)
4. Save [M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz](https://storage.googleapis.com/fc-bcc55e6c-bec3-4b2e-9fb2-5e1526ddfcd2/reference_data_dev/nemo_atac/10x_multiome_mouse_brain/M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz) and [M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz.tbi](M_Brain_Chromium_Nuc_Isolation_vs_SaltyEZ_vs_ComplexTissueDP_atac_fragments.bed.gz) to `single_cell_portal_core/cell-filtering-igv/`
5. In your web browser, go to http://127.0.0.1:8080
6. Confirm igv.js shows an "ATAC fragments" track with many red features (i.e., fragments that have "Score: 1")
7. At top of page, click the checkbox to the right of "1" to filter out those genomic features
8. Wait 10-30 seconds, confirm red features disappear
9. Click the "2" checkbox
10. Wait ~10 seconds, confirm blue features disappear

<details>
<summary>* igv.js change details</summary>

* Save https://igv.org/web/release/2.15.5/dist/igv.esm.js to your `single_cell_portal_core/cell-filtering-igv/` directory
* Open `igv.esm.js` in your editor, scroll to the bottom of the file
* Change
 
```
const index = {
  TrackUtils,
  IGVGraphics,
  MenuUtils,
```

to 

```
const index = {
  TrackUtils,
  FeatureUtils,
  FeatureCache$1,
  IGVGraphics,
  MenuUtils,
```

* Save
</details>

### Further details
This satisfies SCP-5586.  More context is available in the [2024-04-23 SCP demo video](https://drive.google.com/file/d/1dHKgSIA0TH8lrB8NTZGuX3arQY0u9hQw/view?t=13m50s).