### PR TITLE
Remove user annotations from global gene search requests (SCP-5617)

### DIFF
--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -136,8 +136,7 @@ module Api
               cluster: @cluster,
               selected_annotation: @annotation,
               boxpoints: params[:boxpoints],
-              consensus: params[:consensus],
-              current_user: current_api_user
+              consensus: params[:consensus]
             )
             render json: render_data, status: :ok
           end

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -8,8 +8,7 @@ class ExpressionVizService
                                              cluster:,
                                              selected_annotation:,
                                              boxpoints:,
-                                             consensus:,
-                                             current_user:)
+                                             consensus:)
     render_data = {}
     return render_data if cluster.nil?
 
@@ -27,7 +26,8 @@ class ExpressionVizService
       render_data[:values] = load_annotation_based_data_array_scatter(study, genes[0], cluster, selected_annotation, subsample)
     end
     render_data[:gene_names] = genes.map{ |g| g['name'] }
-    render_data[:annotation_list] = AnnotationVizService.get_study_annotation_options(study, current_user)
+    # set user to nil to skip loading UserAnnotation objects in global gene search
+    render_data[:annotation_list] = AnnotationVizService.get_study_annotation_options(study, nil)
     render_data[:rendered_cluster] = cluster.name
     render_data[:rendered_annotation] = "#{selected_annotation[:name]}--#{selected_annotation[:type]}--#{selected_annotation[:scope]}"
     render_data[:rendered_subsample] = subsample

--- a/test/services/expression_viz_service_test.rb
+++ b/test/services/expression_viz_service_test.rb
@@ -104,8 +104,7 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
       cluster: cluster,
       selected_annotation: annotation,
       boxpoints: 'All',
-      consensus: 'nil',
-      current_user: @user
+      consensus: 'nil'
     )
     expected_values = %w(dog cat)
     assert_equal expected_values, rendered_data[:values].keys
@@ -129,8 +128,7 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
       cluster: cluster,
       selected_annotation: annotation,
       boxpoints: 'All',
-      consensus: 'mean',
-      current_user: @user
+      consensus: 'mean'
     )
     assert_equal [0.0, 4.75], rendered_data[:values]['dog'][:y]
 
@@ -144,8 +142,7 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
       cluster: cluster,
       selected_annotation: annotation,
       boxpoints: 'All',
-      consensus: 'nil',
-      current_user: @user
+      consensus: 'nil'
     )
     assert_equal [1.1, 2.2, 3.3], rendered_data[:values][:x]
   end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update removes all user-scoped annotations from the `Annotation` dropdown on global gene search requests.  The reasoning is that due to caching, these annotation lists are stored along with the plot data for performance.  However, user annotations have permissions associated with them, meaning the first user that requests a particular study/gene will then cache the list of annotations they can see of _all_ subsequent requests for that study/gene.  If the user is an admin, this means that _all_ users can see _all_ user annotations for that study/gene.  While some user annotations are made public, not all are, so this constitutes a small data leak.  Additionally, computing the list of available user annotations for admins is a costly operation, and removing these from global gene search has the added benefit of speeding up search requests for admin users.

#### MANUAL TESTING
1. Boot as normal and sign in with an admin account
2. Ensure that you have at least one saved user annotation on the `Human milk - differential expression` study
3. Run a search for that study's accession, and then click over to the `Search genes` tab
4. Search for a gene, and then in the `Annotation` dropdown, validate that you do not see any user annotations listed