### PR TITLE
Cell filtering: fix panel state on cluster change, initial links (SCP-5591, SCP-5610)

### DIFF
--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -40,9 +40,8 @@ function getHasNondefaultSelection(selectionMap, facets) {
   const entries = Object.entries(selectionMap)
   for (let i = 0; i < entries.length; i++) {
     const [selectedFacet, selection] = entries[i]
-
     const facet = facets.find(f => f.annotation === selectedFacet)
-    if (!facet) {return false}
+    if (!facet) {continue}
     let normDefault = facet.defaultSelection
     let normSelection = selection
     if (facet.type === 'group') {
@@ -50,6 +49,7 @@ function getHasNondefaultSelection(selectionMap, facets) {
       normDefault = new Set(normDefault)
       normSelection = new Set(normSelection)
     }
+
     if (!_isEqual(normDefault, normSelection)) {
       return true
     }

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -47,6 +47,12 @@ export function getHasNondefaultSelection(selectionMap, facets) {
     if (facet.type === 'group') {
       // Normalize categorical filters, given order doesn't matter for them
       normDefault = new Set(normDefault)
+      if (normDefault.size === 1) {
+        // Skip considering ineligible categorical facets, like those with
+        // only 1 group.
+        continue
+      }
+
       normSelection = new Set(normSelection)
     }
 

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -36,7 +36,7 @@ export function CellFilteringPanelHeader({
 }
 
 /** Determine if user has deselected any filters */
-function getHasNondefaultSelection(selectionMap, facets) {
+export function getHasNondefaultSelection(selectionMap, facets) {
   const entries = Object.entries(selectionMap)
   for (let i = 0; i < entries.length; i++) {
     const [selectedFacet, selection] = entries[i]

--- a/app/javascript/components/explore/CellFilteringPanel.jsx
+++ b/app/javascript/components/explore/CellFilteringPanel.jsx
@@ -301,7 +301,7 @@ function CellFacet({
     return <></>
   }
 
-  const selection = selectionMap[facet.annotation]
+  const selection = selectionMap[facet.annotation] ?? facet.defaultSelection
 
   return (
     <div

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -135,7 +135,6 @@ function getCellFacetingData(cluster, annotation, setterFunctions, context, prev
             setCellFaceting(newCellFaceting)
           }
 
-
           // The cell filtering UI is initialized in batches of 5 facets
           // This recursively loads the next 5 facets until faceting is fully loaded.
           getCellFacetingData(cluster, annotation, setterFunctions, context, newCellFaceting)
@@ -330,6 +329,8 @@ export default function ExploreDisplayTabs({
     if (!thisCellFaceting) {return}
     if (!selection) {
       setFilteredCells(null)
+      setCellFilterCounts(null)
+      setCellFilteringSelection(null)
       updateExploreParams({ facets: null })
       return
     }

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -329,8 +329,6 @@ export default function ExploreDisplayTabs({
     if (!thisCellFaceting) {return}
     if (!selection) {
       setFilteredCells(null)
-      setCellFilterCounts(null)
-      setCellFilteringSelection(null)
       updateExploreParams({ facets: null })
       return
     }

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -71,9 +71,26 @@ export function handleClusterSwitchForFiltering(cellFilteringSelection, newCellF
   if (cellFilteringSelection) {
     const existingSelectionFacets = Object.keys(cellFilteringSelection)
     const updatedSelectionFacets =
-      newCellFaceting.facets.filter(
-        nf => !nf.isSelectedAnnotation && !existingSelectionFacets.includes(nf.annotation) && 'groups' in nf
-      )
+      newCellFaceting.facets.filter(nf => {
+        const nfAnnot = nf.annotation
+        return (
+          !nf.isSelectedAnnotation &&
+          nf.type === 'group' &&
+          nf.isLoaded &&
+          (
+            !existingSelectionFacets.includes(nfAnnot) ||
+            (
+              // Handle cases where same annotation name exists in previous
+              // and current clusterings, but the annotation has a different
+              // number of groups.  E.g. "Cell type" in default and non-default
+              // clustering in SCP1671.
+              nfAnnot in cellFilteringSelection &&
+              cellFilteringSelection[nfAnnot].length !== nf.groups.length
+            )
+          )
+        )
+      })
+
     if (updatedSelectionFacets.length > 0) {
       updatedSelectionFacets.forEach(uf => cellFilteringSelection[uf.annotation] = uf.groups)
     }
@@ -329,6 +346,7 @@ export default function ExploreDisplayTabs({
     if (!thisCellFaceting) {return}
     if (!selection) {
       setFilteredCells(null)
+      setCellFilteringSelection(null)
       updateExploreParams({ facets: null })
       return
     }

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -324,12 +324,13 @@ export default function ExploreDisplayTabs({
   }, [exploreParams?.cluster, exploreParams?.annotation])
 
 
-  /** Update filtered cells to only those that match annotation group value filter selections */
+  /** Update filtered cells to only those that match filter selections */
   function updateFilteredCells(selection, overrideCellFaceting) {
     const thisCellFaceting = overrideCellFaceting ?? cellFaceting
     if (!thisCellFaceting) {return}
     if (!selection) {
       setFilteredCells(null)
+      updateExploreParams({ facets: null })
       return
     }
 

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -694,11 +694,11 @@ export function parseFacetsParam(initFacets, facetsParam) {
     facets[facet] = filters
   })
 
-  // Take the complement of the minimal `facets` object, transforming
-  // it into the more verbose `selection` object which specifies filters
-  // that are _not_ applied.
   Object.entries(initFacets).forEach(([facet, filters]) => {
     if (facet.includes('group')) {
+      // Take the complement of the minimal `facets` object, transforming
+      // it into the more verbose `selection` object which specifies filters
+      // that are _not_ applied.
         filters?.forEach(filter => {
           if (!facets[facet]?.includes(filter)) {
             if (facet in selection) {
@@ -760,8 +760,10 @@ export function getFacetsParam(initFacets, selection) {
         }
       })
     } else {
-      // Add numeric cell facet to `facets` URL parameter
-      minimalSelection[facet] = selection[facet]
+      if (initSelection[facet] !== selection[facet]) {
+        // Add numeric cell facet to `facets` URL parameter
+        minimalSelection[facet] = selection[facet]
+      }
     }
   })
 

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -5,6 +5,7 @@
  */
 
 import crossfilter from 'crossfilter2'
+import _isEqual from 'lodash/isEqual'
 
 import { getIdentifierForAnnotation } from '~/lib/cluster-utils'
 import { fetchAnnotationFacets } from '~/lib/scp-api'
@@ -760,7 +761,7 @@ export function getFacetsParam(initFacets, selection) {
         }
       })
     } else {
-      if (initSelection[facet] !== selection[facet]) {
+      if (!_isEqual(initSelection[facet], selection[facet])) {
         // Add numeric cell facet to `facets` URL parameter
         minimalSelection[facet] = selection[facet]
       }

--- a/test/js/explore/cell-filtering-panel.test.js
+++ b/test/js/explore/cell-filtering-panel.test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, fireEvent, screen, waitFor } from '@testing-library/react'
 
 import * as UserProvider from '~/providers/UserProvider'
-import { CellFilteringPanel } from '~/components/explore/CellFilteringPanel'
+import { CellFilteringPanel, getHasNondefaultSelection } from '~/components/explore/CellFilteringPanel'
 import {
   annotationList, cellFaceting, cellFilteringSelection, cellFilterCounts
 } from './cell-filtering-panel.test-data'
@@ -227,5 +227,57 @@ describe('"Cell filtering" panel', () => {
         ]
       })
     )
+  })
+
+  it('handles absent facet in getHasNondefaultSelection', async () => {
+    // If an annotation is shown in the legend, then it is included in
+    // `selectionMap` but omitted in `facets`.  Poor handling of that in
+    // `hasNondefaultSelection` caused the "reset all facets" button to be
+    // unexpectedly hidden when page loaded with `facets` URL parameter.
+    // This regression test confirms the fix.
+
+    const selectionMap = {
+      'cell_type__ontology_label--group--study': [
+        'epithelial cell', 'macrophage', 'neutrophil', 'T cell', 'dendritic cell', 'fibroblast', 'B cell', 'eosinophil'
+      ],
+      'General_Celltype--group--study': [
+        'LC2', 'GPMNB macrophages', 'neutrophils', 'B cells', 'T cells', 'CSN1S1 macrophages', 'dendritic cells',
+        'LC1', 'eosinophils', 'fibroblasts'
+      ],
+      'infant_sick_YN--group--study': [
+        'no', 'NA', 'yes'
+      ],
+      'time_post_partum_days--numeric--study': [
+        [['between', [144, 323]]], true
+      ]
+    }
+    const facets =
+    [
+      {
+        'annotation': 'cell_type__ontology_label--group--study',
+        'type': 'group',
+        'defaultSelection': [
+          'epithelial cell', 'macrophage', 'neutrophil', 'B cell', 'T cell', 'dendritic cell', 'eosinophil', 'fibroblast'
+        ]
+      },
+      {
+        'annotation': 'infant_sick_YN--group--study',
+        'type': 'group',
+        'defaultSelection': [
+          'no', 'NA', 'yes'
+        ]
+      },
+      {
+        'annotation': 'time_post_partum_days--numeric--study',
+        'type': 'numeric',
+        'defaultSelection': [
+          [['between', [3, 323]]], true
+        ]
+      }
+    ]
+
+    const hasNondefaultSelection = getHasNondefaultSelection(selectionMap, facets)
+
+    expect(hasNondefaultSelection).toEqual(true)
   })
 })


### PR DESCRIPTION
This fixes issues with panel state and certain links, which manifest in some non-default cell filtering scenarios.

### Overview
#### Fix panel state after "Clustering" change
Previously, in some studies, changing the "Clustering" menu would set the cell filtering panel into a subtly incorrect state.  Annotations in the default cluster -- but not the new cluster -- would still appear as available facets and filters in the panel.  Cell filtering in those residual annotations would hide the whole plot, or include an "undefined" trace after a clustering change.

Now, only annotations in the current cluster are shown in the cell filtering panel.  That prevents issues caused by errant residual annotations.  This fixes SCP-5591.

Here's a view of the problem, and its fix.

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/68f235e1-8cd5-4136-9ef7-2d5fa8943fe1

#### Fix initial cell filtering links
Previously, in #2009, changing your cell filtering selection updated your browser address bar with a URL that specified your selection for _all_ numeric facets -- even ones that were not changed.  Handling for those URLs assumed _all_ numeric facets would be so specified.  However, prior to PR 2009, _no_ numeric facets were specified -- only categorical facets were loadable via URL.  So those old-style URLs (with only categorical facets specified) broke the page when they were loaded.  

Although high severity when it occurred, this had very low incidence, in practice essentially only affecting views linked from a [feature announcement](https://singlecell.broadinstitute.org/single_cell/features/2024-01-04-filter-plotted-cells-for-a-deeper-dive-into-study-data) and [documentation](https://singlecell.zendesk.com/hc/en-us/articles/21415002866587-Filter-plotted-cells).  Incidence was 2-3 study views per day out of 1686, or 0.2% of study page views.  

Now, old cell filtering URLs work as expected.  URLs minted in the last two weeks work as well, including those with changed numeric facets.  This fixes SCP-5610.  These changes also fix two other `facets` URL loading UX bugs.  PR 2009 also broke sparkbars when when loading via `facets` URL parameter.  And the "reset all facets" button seems to have never worked in that particular scenario.  Those now also work seamlessly with URLs.

Here's how it looks:

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/090886ba-6223-4431-bdbc-7f86405f4209

### Test
If you'd like to manually verify these fixes, steps are below.

For panel state after "Clustering" change:
1.  Go to "Cellular and transcriptional diversity over the course of human lactation" study
2.  Click "Filter plotted cells"
3.  Deselect "Cell type: epithelial"
4.  Click "<-" button to exit panel
5.  Click "Filter plotted cells"
6.  Confirm "Cell type: epithelial" is selected, and plot shows default state
7.  Exit panel
8.  Select "Epithelial Cells UMAP" in "Clustering"
9.  Confirm no "Cell type" facet is not shown

For initial cell filtering links:
1.  Note the accession for your "Cellular and transcriptional diversity over the course of human lactation" study
2. In your browser address bar, paste: https://localhost:3000/single_cell/study/$YOUR_STUDY_ACCESSION/cellular-and-transcriptional-diversity-over-the-course-of-human-lactation?genes=TNC&cluster=All%20Cells%20UMAP&spatialGroups=--&annotation=General_Celltype--group--study&subsample=all&hiddenTraces=--Filtered--&facets=milk_stage--group--study%3Alate_1%7Clate_2%7Clate_3%7Clate_4%7Cmature%7CNA%7Ctransitional%20%7Ctransitional#study-visualize
3. Confirm plots appear as shown in in 2nd image in [related documentation](https://singlecell.broadinstitute.org/single_cell/features/2024-01-04-filter-plotted-cells-for-a-deeper-dive-into-study-data)

This satisfies SCP-5591 and SCP-5610.