### PR TITLE
Reject XSS-based requests to avoid caching invalid requests (SCP-5620)

### DIFF
--- a/app/controllers/api/v1/api_base_controller.rb
+++ b/app/controllers/api/v1/api_base_controller.rb
@@ -75,6 +75,9 @@ module Api
         # (e.g. those under the api/v1/studies/ path)
         module StudyControllerResponses
           def self.extended(base)
+            base.response 400 do
+              key :description, 'Bad request'
+            end
             base.response 401 do
               key :description, ApiBaseController.unauthorized
             end

--- a/app/controllers/api/v1/concerns/api_caching.rb
+++ b/app/controllers/api/v1/concerns/api_caching.rb
@@ -3,6 +3,7 @@ module Api
     module Concerns
       module ApiCaching
         extend ActiveSupport::Concern
+        XSS_MATCHER = /(xss|script)/
 
         # check Rails cache for JSON response based off url/params
         # cache expiration is still handled by CacheRemovalJob
@@ -33,6 +34,13 @@ module Api
             Rails.root.join('tmp/caching-dev.txt').exist?
           else
             true
+          end
+        end
+
+        # ignore obvious malicious/bogus requests that can lead to invalid cache path entries
+        def validate_cache_request
+          if request.fullpath =~ XSS_MATCHER
+            head 400 and return
           end
         end
       end

--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -94,9 +94,6 @@ module Api
             response 200 do
               key :description, annotation_description_doc
             end
-            response 400 do
-              key :description, 'Bad request'
-            end
             extend SwaggerResponses::StudyControllerResponses
           end
         end
@@ -144,9 +141,6 @@ module Api
             end
             response 200 do
               key :description, '2-column TSV of cell names and their values for the requested annotation.  Column headers are NAME (the cell name) and the name of the returned annotation'
-            end
-            response 400 do
-              key :description, 'Bad request'
             end
             extend SwaggerResponses::StudyControllerResponses
           end
@@ -240,9 +234,6 @@ module Api
                   end
                 end
               end
-            end
-            response 400 do
-              key :description, 'Bad request'
             end
             extend SwaggerResponses::StudyControllerResponses
           end
@@ -339,9 +330,6 @@ module Api
             end
             response 200 do
               key :description, '2-column TSV of column header names from the gene list file.  Column headers are NAME (the cell name) and the name of the gene list'
-            end
-            response 400 do
-              key :description, 'Bad request'
             end
             extend SwaggerResponses::StudyControllerResponses
           end

--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -14,6 +14,7 @@ module Api
         before_action :set_study
         before_action :check_study_view_permission
         # don't cache the annotation list, since it is user dependent
+        before_action :validate_cache_request, except: :index
         before_action :check_api_cache!, except: :index
         after_action :write_api_cache!, except: :index
 
@@ -93,6 +94,9 @@ module Api
             response 200 do
               key :description, annotation_description_doc
             end
+            response 400 do
+              key :description, 'Bad request'
+            end
             extend SwaggerResponses::StudyControllerResponses
           end
         end
@@ -140,6 +144,9 @@ module Api
             end
             response 200 do
               key :description, '2-column TSV of cell names and their values for the requested annotation.  Column headers are NAME (the cell name) and the name of the returned annotation'
+            end
+            response 400 do
+              key :description, 'Bad request'
             end
             extend SwaggerResponses::StudyControllerResponses
           end
@@ -233,6 +240,9 @@ module Api
                   end
                 end
               end
+            end
+            response 400 do
+              key :description, 'Bad request'
             end
             extend SwaggerResponses::StudyControllerResponses
           end
@@ -329,6 +339,9 @@ module Api
             end
             response 200 do
               key :description, '2-column TSV of column header names from the gene list file.  Column headers are NAME (the cell name) and the name of the gene list'
+            end
+            response 400 do
+              key :description, 'Bad request'
             end
             extend SwaggerResponses::StudyControllerResponses
           end

--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -16,6 +16,7 @@ module Api
         before_action :set_current_api_user!
         before_action :set_study
         before_action :check_study_view_permission
+        before_action :validate_cache_request
         before_action :check_api_cache!
         after_action :write_api_cache!
 
@@ -119,6 +120,9 @@ module Api
             end
             response 200 do
               key :description, 'Scatter plot visualization of cluster, suitable for rendering in Plotly'
+            end
+            response 400 do
+              key :description, 'Bad request'
             end
             extend SwaggerResponses::StudyControllerResponses
           end

--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -121,9 +121,6 @@ module Api
             response 200 do
               key :description, 'Scatter plot visualization of cluster, suitable for rendering in Plotly'
             end
-            response 400 do
-              key :description, 'Bad request'
-            end
             extend SwaggerResponses::StudyControllerResponses
           end
         end

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -94,9 +94,6 @@ module Api
             response 200 do
               key :description, 'JSON plot data to be fed to JS visualization'
             end
-            response 400 do
-              key :description, 'Bad request'
-            end
             extend SwaggerResponses::StudyControllerResponses
           end
         end

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -10,6 +10,7 @@ module Api
         before_action :set_study
         before_action :check_study_view_permission
         before_action :check_gene_limit
+        before_action :validate_cache_request
         before_action :check_api_cache!
         before_action :set_cluster
         before_action :set_genes
@@ -92,6 +93,9 @@ module Api
             end
             response 200 do
               key :description, 'JSON plot data to be fed to JS visualization'
+            end
+            response 400 do
+              key :description, 'Bad request'
             end
             extend SwaggerResponses::StudyControllerResponses
           end

--- a/test/api/visualization/annotations_controller_test.rb
+++ b/test/api/visualization/annotations_controller_test.rb
@@ -194,4 +194,12 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected,
                  Api::V1::Visualization::AnnotationsController.convert_annotation_param('species--group--study')
   end
+
+  test 'should reject bogus requests' do
+    sign_in_and_update @user
+    execute_http_request(:get, api_v1_study_annotations_facets_path(
+      @basic_study, cluster: 'xssdetected', annotations: 'not-found--group--study'
+    ))
+    assert_response :bad_request
+  end
 end

--- a/test/api/visualization/clusters_controller_test.rb
+++ b/test/api/visualization/clusters_controller_test.rb
@@ -186,4 +186,12 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_aspect, viz_data.dig(:axes, :aspects)
     assert_equal expected_ranges, viz_data.dig(:userSpecifiedRanges)
   end
+
+  test 'should reject bogus requests' do
+    sign_in_and_update @user
+    execute_http_request(:get, api_v1_study_cluster_path(
+      @basic_study, 'xssdetected', {annotation_name: 'species', annotation_scope: 'study', annotation_type: 'group'}
+    ))
+    assert_response :bad_request
+  end
 end

--- a/test/api/visualization/expression_controller_test.rb
+++ b/test/api/visualization/expression_controller_test.rb
@@ -103,4 +103,13 @@ class ExpressionControllerTest < ActionDispatch::IntegrationTest
     ), user: @user)
     assert_response :unprocessable_entity
   end
+
+  test 'should reject bogus requests' do
+    sign_in_and_update @user
+    execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'violin', {
+      cluster: 'xssdetected',
+      genes: 'PTEN'
+    }), user: @user)
+    assert_response :bad_request
+  end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
Some new security scans of DSP-based applications have resulted in some visualization routes caching responses with parameters containing XSS-based values like `script` or `xssdetected`.  While this update doesn't address the underlying issue (which would entail a large amount of work as it involves using the [`require-trusted-types-for`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for) CSP header and associated core JS package updates, like jQuery and React), this does prevent attempting to cache these obviously bogus requests.  The goal is to prevent incidences of the "[cache path bug](https://broad-institute.sentry.io/issues/5184436549/?project=1424198)" where percent-encoded values get broken by a `/` path terminator, causing errors any time a visualization cache is cleared.  Since this affects all users/studies portal-wide, preventing this error from occurring is paramount.

#### MANUAL TESTING
1. Boot as normal
2. Ensure caching is turned on for your local instance
3. Load the Swagger documentation for any visualization API endpoint that accepts parameters, like [loading cluster viz data](https://localhost:3000/single_cell/api/v1#/Visualization/study_cluster_path).
4. Enter a valid study accession, but for `cluster_name` use either `xssdetected` or `script` and then submit the request
5. Ensure you receive a `400: Bad Request` response, and in the server log output find the corresponding entry to note that neither `check_api_cache!` nor `write_api_cache!` are invoked:
```
Started GET "/single_cell/api/v1/studies/SCP13/clusters/xssdetected" for 127.0.0.1 at 2024-04-29 15:15:58 -0400
Processing by Api::V1::Visualization::ClustersController#show as JSON
  Parameters: {"study_id"=>"SCP13", "cluster_name"=>"xssdetected"}
Filter chain halted as :validate_cache_request rendered or redirected
Completed 400 Bad Request in 41ms (MongoDB: 0.0ms | Allocations: 1645)
```
6. Enter a valid request (like for the `_default` cluster) and ensure you get a `200` response, and that either `:check_api_cache!` or `write_api_cache!` are invoked:
```
Started GET "/single_cell/api/v1/studies/SCP13/clusters/_default" for 127.0.0.1 at 2024-04-29 15:16:56 -0400
Processing by Api::V1::Visualization::ClustersController#show as JSON
  Parameters: {"study_id"=>"SCP13", "cluster_name"=>"_default"}
Writing to API cache: _single_cell_api_v1_studies_SCP13_clusters__default_4803421a30c68e74735896abc8eeef5bf578466df8cd2ad940a9b39906615017
Completed 200 OK in 1066ms (Views: 18.4ms | MongoDB: 0.9ms | Allocations: 62097)
```
7. Enter a Rails console session, and confirm you can clear the caches for the above study without error:
```
CacheRemovalJob.new('SCP13').perform
=> 55

```