### PR TITLE
Fix some UI bugs due to false positive in XSS detection (SCP-5620)

### DIFF
--- a/app/controllers/api/v1/concerns/api_caching.rb
+++ b/app/controllers/api/v1/concerns/api_caching.rb
@@ -3,7 +3,7 @@ module Api
     module Concerns
       module ApiCaching
         extend ActiveSupport::Concern
-        XSS_MATCHER = /(xss|script)/
+        XSS_MATCHER = /(xssdetected|script3E)/
 
         # check Rails cache for JSON response based off url/params
         # cache expiration is still handled by CacheRemovalJob

--- a/test/api/visualization/annotations_controller_test.rb
+++ b/test/api/visualization/annotations_controller_test.rb
@@ -202,4 +202,14 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
     ))
     assert_response :bad_request
   end
+
+  test 'should not reject legit requests' do
+    # Ensure XSS detection does not return a false-positive for a URL that
+    # contains merely the substring "script", as in "description".
+    sign_in_and_update @user
+    execute_http_request(:get, api_v1_study_annotations_facets_path(
+      @basic_study, cluster: 'description', annotations: 'not-found--group--study'
+    ))
+    assert_response :not_found # we expect 404 (Not Found), not 400 (Bad request)
+  end
 end


### PR DESCRIPTION
This helps ensure we don't break user-facing views for legitimate HTTP requests, via refined XSS scan handling.

Previously, our new XSS detection used a regular expression that was a bit too broad.  By classifying any request that contained the substring e.g. "script", we unintentionally rejected requests related to annotations that e.g. contain the legitimate string "description".  So for certain studies, cell filtering requests failed, and some other kinds would have too.

Now, the XSS regex has been narrowed, which still lets us classify many known true XSS-related examples as positives, while classifying true non-XSS-related examples as negatives.

### Test
1.  Disable Vite service worker caching (e.g. close the Terminal tab where you're running `VITE_FRONTEND_SERVICE_WORKER_CACHE=true DISABLE_SENTRY=false bin/vite dev`)
1.  Go to "Cellular and transcriptional diversity over the course of human lactation" study
2. Wait for a while until all (uncached, slower-than-normal) facets load
3. Confirm you don't see a disabled "Filter plotted cells" button or other obvious problems with cell filtering

This relates to SCP-5620.