### PR TITLE
Expanding automated exploratory differential expression calculations (SCP-5621)

### DIFF
--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -4,7 +4,7 @@ class DifferentialExpressionService
   # possible cell type analogs
   CELL_TYPE_MATCHER = /cell.*type/i
   # possible clustering algorithm results
-  CLUSTERING_MATCHER = /(clust|seurat|leiden|louvain|_snn_res)/i
+  CLUSTERING_MATCHER = /(clust|seurat|leiden|louvain|snn_res)/i
   # union of all allowed annotations
   ALLOWED_ANNOTS = Regexp.union(CELL_TYPE_MATCHER, CLUSTERING_MATCHER)
   # specific annotations to exclude from automation

--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -182,7 +182,7 @@ class DifferentialExpressionService
     study_results = {}
     accessions.each do |accession|
       begin
-        jobs = DifferentialExpressionService.run_differential_expression_on_all(accession, skip_existing: true)
+        jobs = run_differential_expression_on_all(accession, skip_existing: true)
         if jobs > 0
           total_jobs += jobs
           study_results[accession] = jobs

--- a/lib/study_cleanup_tools.rb
+++ b/lib/study_cleanup_tools.rb
@@ -62,13 +62,9 @@ module StudyCleanupTools
 
     # these were corrupted during a partial Terra outage, and for now, cleaning them out is more difficult
     # than just leaving them be.  Otherwise the deletion attempt hangs for several minutes
-    corrupted_workspace_names = ['upload-wizard-test-pb6y0',
-    'download-agreement-686b0d44c83659cd70616a3f0874fde5',
-    'testing-study-6ec03b371c7cf59262df98424ff516e1',
-    'new-study-99f2a94b-f8a6-4efb-aa3b-4ecef24e1dad',
-    'testing-study-jdwjl', 
-    'test-study-06387e09-6661-45b5-bc1b-4fc507bd19ea',
-    'main-validation-study-szzob',]
+    corrupted_workspace_names = %w[upload-wizard-test-pb6y0 main-validation-study-hnds4 main-validation-study-szzob
+      testing-study-jdwjl testing-study-6ec03b371c7cf59262df98424ff516e1 new-study-99f2a94b-f8a6-4efb-aa3b-4ecef24e1dad
+      test-study-06387e09-6661-45b5-bc1b-4fc507bd19ea download-agreement-686b0d44c83659cd70616a3f0874fde5]
     workspaces.each do |workspace|
       ws_attr = workspace.dig('workspace')
       ws_name = ws_attr['name']

--- a/test/services/differential_expression_service_test.rb
+++ b/test/services/differential_expression_service_test.rb
@@ -280,9 +280,14 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
   end
 
   test 'should determine annotation eligibility by name' do
-    %w[cell_type__ontology_label clust seurat leiden louvain _snn_res].each do |name|
+    %w[cell_type cell_type__ontology_label clust clustering seurat leiden louvain _snn_res].each do |name|
       assert DifferentialExpressionService.annotation_eligible?(name)
+      assert DifferentialExpressionService.annotation_eligible?(name.upcase)
+      assert DifferentialExpressionService.annotation_eligible?(name.capitalize)
     end
-    assert_not DifferentialExpressionService.annotation_eligible?('enrichment__cell_type')
+    disallowed = 'enrichment__cell_type'
+    assert_not DifferentialExpressionService.annotation_eligible?(disallowed)
+    assert_not DifferentialExpressionService.annotation_eligible?(disallowed.upcase)
+    assert_not DifferentialExpressionService.annotation_eligible?(disallowed.capitalize)
   end
 end

--- a/test/services/differential_expression_service_test.rb
+++ b/test/services/differential_expression_service_test.rb
@@ -278,4 +278,11 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
                       computational_method: 'wilcoxon')
     assert_not DifferentialExpressionService.study_eligible?(@basic_study)
   end
+
+  test 'should determine annotation eligibility by name' do
+    %w[cell_type__ontology_label clust seurat leiden louvain _snn_res].each do |name|
+      assert DifferentialExpressionService.annotation_eligible?(name)
+    end
+    assert_not DifferentialExpressionService.annotation_eligible?('enrichment__cell_type')
+  end
 end

--- a/test/services/differential_expression_service_test.rb
+++ b/test/services/differential_expression_service_test.rb
@@ -42,12 +42,17 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
                         {
                           name: 'cell_type__ontology_label',
                           type: 'group',
-                          values: ['B cell', 'B cell', 'T cell', 'B cell', 'T cell', ]
+                          values: ['B cell', 'B cell', 'T cell', 'B cell', 'T cell']
                         },
                         {
                           name: 'cell_type',
                           type: 'group',
                           values: %w[CL_0000236 CL_0000236 CL_0000084 CL_0000236 CL_0000084]
+                        },
+                        {
+                          name: 'seurat_clusters',
+                          type: 'group',
+                          values: %w[1 1 2 1 2]
                         },
                         { name: 'species', type: 'group', values: %w[dog cat dog dog cat] },
                         { name: 'disease', type: 'group', values: %w[none none measles measles measles] }
@@ -218,16 +223,20 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
 
   test 'should run differential expression job on all eligible annotations' do
     DataArray.create!(@all_cells_array_params)
-    job_mock = Minitest::Mock.new
-    job_mock.expect(:push_remote_and_launch_ingest, Delayed::Job.new)
+    job_mock_one = Minitest::Mock.new
+    job_mock_two = Minitest::Mock.new
+    job_mock_one.expect(:push_remote_and_launch_ingest, Delayed::Job.new)
+    job_mock_two.expect(:push_remote_and_launch_ingest, Delayed::Job.new)
     mock = Minitest::Mock.new
-    mock.expect(:delay, job_mock)
-    # only cell_type__ontology_label should be marked as eligible
+    mock.expect(:delay, job_mock_one)
+    mock.expect(:delay, job_mock_two)
+    # cell_type__ontology_label and seurat_clusters should be marked as eligible
     IngestJob.stub :new, mock do
       jobs_launched = DifferentialExpressionService.run_differential_expression_on_all(@basic_study.accession)
-      assert_equal 1 , jobs_launched
+      assert_equal 2, jobs_launched
       mock.verify
-      job_mock.verify
+      job_mock_one.verify
+      job_mock_two.verify
     end
   end
 
@@ -247,10 +256,12 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
   end
 
   test 'should find eligible annotations' do
-    expected_annotation = { annotation_name: 'cell_type__ontology_label', annotation_scope: 'study' }
+    cell_type = { annotation_name: 'cell_type__ontology_label', annotation_scope: 'study' }
+    seurat = { annotation_name: 'seurat_clusters', annotation_scope: 'study' }
     eligible_annotations = DifferentialExpressionService.find_eligible_annotations(@basic_study)
-    assert_equal 1, eligible_annotations.count
-    assert_includes eligible_annotations, expected_annotation
+    assert_equal 2, eligible_annotations.count
+    assert_includes eligible_annotations, cell_type
+    assert_includes eligible_annotations, seurat
   end
 
   test 'should determine study eligibility' do
@@ -280,7 +291,7 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
   end
 
   test 'should determine annotation eligibility by name' do
-    %w[cell_type cell_type__ontology_label clust clustering seurat leiden louvain _snn_res].each do |name|
+    %w[cell_type cell_type__ontology_label clust clustering seurat leiden louvain snn_res].each do |name|
       assert DifferentialExpressionService.annotation_eligible?(name)
       assert DifferentialExpressionService.annotation_eligible?(name.upcase)
       assert DifferentialExpressionService.annotation_eligible?(name.capitalize)
@@ -289,5 +300,31 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
     assert_not DifferentialExpressionService.annotation_eligible?(disallowed)
     assert_not DifferentialExpressionService.annotation_eligible?(disallowed.upcase)
     assert_not DifferentialExpressionService.annotation_eligible?(disallowed.capitalize)
+  end
+
+  test 'should backfill new annotations' do
+    # create existing result to ensure this is not regenerated
+    DataArray.create!(@all_cells_array_params)
+    cluster = @basic_study.cluster_groups.by_name(@cluster_file.name)
+    annotation = { annotation_name: 'cell_type__ontology_label', annotation_scope: 'study' }
+    DifferentialExpressionResult.create(
+      study: @basic_study, cluster_group: cluster, matrix_file_id: @raw_matrix.id, cluster_name: cluster.name,
+      annotation_name: annotation[:annotation_name], annotation_scope: annotation[:annotation_scope],
+      computational_method: 'wilcoxon', one_vs_rest_comparisons: ['B cell', 'T cell']
+    )
+
+    @basic_study.reload
+    job_mock = Minitest::Mock.new
+    job_mock.expect(:push_remote_and_launch_ingest, Delayed::Job.new)
+    mock = Minitest::Mock.new
+    mock.expect(:delay, job_mock)
+    IngestJob.stub :new, mock do
+      # restrict to this study to prevent any dangling studies being picked up
+      stats = DifferentialExpressionService.backfill_new_results(study_accessions: [@basic_study.accession])
+      assert_equal 1, stats[:total_jobs]
+      assert_equal 1, stats[@basic_study.accession]
+      mock.verify
+      job_mock.verify
+    end
   end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update expands the annotation eligibility for automated differential expression calculations to cover "raw" annotations.  These are annotations that are potentially the output from popular clustering algorithms, such as Seurat, Leiden, Louvain, etc.   The belief is that these annotations (like cell type analog annotations) carry a lower risk of false positives when calculating differential expression, and the benefit of extending exploratory differential expression results to a much larger cohort of annotations outweighs any potential risks.  This will also cover any annotations that use the phrase `clust` in the name, following the same logic as above.

An analysis of available data on production showed that including these new annotation will potentially add 174 new studies and 1,408 result sets.  Using our existing differential expression ingests as a benchmark (820 jobs in 2023 at a cost of $77.57), the projected cost is ~$133 to backfill these results.  Our current success rate for automated differential expression ingest is ~72%, which would mean that we can expect approx. 1,013 new result sets.  Given that we have 432 active results across 154 studies now, this would constitute an increase of well over 2x in total results while roughly doubling the number of studies.

Due to technological constraints on processing background jobs, we can't add these results via an automated migration.  However, there is the new `DifferentialExpressionService.backfill_new_results` method that will detect and validate any newly eligible annotations across an entire instance of SCP and launch ingest processes.  This can be done manually from the Rails console at any time.  The method logs progress while validating jobs, and upon completion will output statistics on how many total jobs were run, as well as new results per study (this does not account for failures, only submissions).

Example truncated output:
```
SCP13 has annotations eligible for DE; validating inputs
Checking DE job for SCP13: Major Cell Types (CLUSTER--group--study)                                                                         
  Skipping DE job for SCP13: Major Cell Types (CLUSTER--group--study) due to: SCP13 has no parsed raw counts data                           
Checking DE job for SCP13: Major Cell Types (SUB-CLUSTER--group--study)                                                                     
  Skipping DE job for SCP13: Major Cell Types (SUB-CLUSTER--group--study) due to: SCP13 has no parsed raw counts data                       
...

SCP66 has annotations eligible for DE; validating inputs
Checking DE job for SCP66: Epithelial Cells UMAP (Epithelial Cell Subclusters--group--cluster)
==> DE job for SCP66: Epithelial Cells UMAP (Epithelial Cell Subclusters--group--cluster) successfully launched
SCP66 yielded 1 differential expression jobs; 0 skipped
SCP72 has annotations eligible for DE; validating inputs
Checking DE job for SCP72: Cluster 1 (seurat_clusters--group--study)
==> DE job for SCP72: Cluster 1 (seurat_clusters--group--study) successfully launched
SCP72 yielded 1 differential expression jobs; 0 skipped
...

Total new backfill jobs: 5 across 4 studies
=> {"SCP66"=>1, "SCP72"=>1, "SCP82"=>2, "SCP105"=>1, :total_jobs=>5}
```

Also, this update adds a new workspace (`main-validation-study-hnds4`) to the list of "corrupted" test Terra workspaces.  This will prevent automated cleanup of the affected workspace to prevent CI jobs from hanging on cleanup after running all tests.

#### MANUAL TESTING
1. Boot all services, including `Delayed::Job` workers
2. Open a Rails console session and initiate the backfill process:
```
DifferentialExpressionService.backfill_new_results
```
3. Note log output like above (you will see many studies fail validation for various reasons, like not having raw counts data, or only 1 label for an annotation)
4. You should see a job launch for the `Human milk - differential expression` study on the `Epithelial Cells UMAP (Epithelial Cell Subclusters--group--cluster)` cluster/annotation
5. Wait for the DE jobs to finish computing for the above study (this should take 6-8 minutes)
6. Open your copy of this study in your local instance, and select the `Epithelial Cells UMAP` cluster and `Epithelial Cell Subclusters` annotation
7. Click `Differential expression`, and confirm you see groups for this annotation
8. Select `Cycling Lactocytes` and load the genes table
9. Click `STMN1` and confirm you get a plot like below:
![Screenshot 2024-05-02 at 10 39 52 AM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/50dbbaac-3fbb-499b-9db9-28440256d4fa)
