### PR TITLE
Adding integration for Rawls#checkBucketReadAccess after study creation (SCP-5625)

### DIFF
--- a/test/integration/external/fire_cloud_client_test.rb
+++ b/test/integration/external/fire_cloud_client_test.rb
@@ -246,6 +246,14 @@ class FireCloudClientTest < ActiveSupport::TestCase
     assert delete_confirmation, 'Entities did not delete successfully'
   end
 
+  def test_check_bucket_read_access
+    workspace_name = "workspace-#{@random_test_seed}"
+    # since the timing is arbitrary, we can't be sure that issuing a request will then result in success downstream
+    # instead, validate that access either is granted (true), or that the FastPass has been requested (false)
+    read_access = client.check_bucket_read_access(@fire_cloud_client.project, workspace_name)
+    assert_includes [true, false], read_access
+  end
+
   ##
   #
   # WORKFLOW & CONFIGURATION TESTS (only a subset can be run as submissions require user authentication)

--- a/test/integration/external/fire_cloud_client_test.rb
+++ b/test/integration/external/fire_cloud_client_test.rb
@@ -250,7 +250,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
     workspace_name = "workspace-#{@random_test_seed}"
     # since the timing is arbitrary, we can't be sure that issuing a request will then result in success downstream
     # instead, validate that access either is granted (true), or that the FastPass has been requested (false)
-    read_access = client.check_bucket_read_access(@fire_cloud_client.project, workspace_name)
+    read_access = @fire_cloud_client.check_bucket_read_access(@fire_cloud_client.project, workspace_name)
     assert_includes [true, false], read_access
   end
 


### PR DESCRIPTION
#### BACKGROUND
Terra uses groups for managing access to resources, including workspaces, buckets, etc.  An [upstream change](https://cloud.google.com/iam/docs/access-change-propagation) in how permissions propagate in Google meant that policies managed by groups - while always eventually consistent - could take up to several hours to take effect.  This led to users creating studies in non-default billing projects sometimes being unable to upload files for 3-5 hours (this appears to not be a problem in our [default billing project](https://app.terra.bio/#billing?selectedName=single-cell-portal&type=project) as the main service account is a direct owner and inherits that permission on all workspaces/buckets in that project).  Terra solved this problem by creating the FastPass service, which will add direct user grants to buckets upon request (this is what happens whenever a user signs into a workspace via the Terra UI).  These policies take effect within 2-7 minutes, which unblocks the user.  These policies are then eventually removed by a background polling mechanism.

#### CHANGES
Now when a user creates a study (regardless of the billing project), a background process will issue a request to this Rawls [API endpoint](https://rawls.dsde-prod.broadinstitute.org/#/workspaces/readBucket) that initiates the FastPass process.  If the response is `200`, this means that bucket access for the service account has already been established.  A `403` response indicates that the policy hasn't made it to the bucket yet, and Terra will add the service account directly as a user.  In either case, no further action is required, and a user will be able to add a file.  All other error scenarios follow standard reporting paths (Sentry, ingest auto-upload failure emails).

#### MANUAL TESTING
1. Boot all services (including DelayedJob) and sign in
2. Open `development.log` in the Console app
3. Create a new study in a non-default project where your service account is not a direct owner, like `single-cell-portal-test`
4. In the logfile, look for an entry like the following:
```
Checking bucket access on single-cell-portal-test/fastpass-test with tracking identifier: default-service-account@broad-singlecellportal-bistlin.iam.gserviceaccount.com

Permissions not yet synchronized for single-cell-portal-test/fastpass-test, FastPass request initiated
```
5. Open a new Rails console session and load the new study:
```
study = Study.last
```
6. Check the bucket access policy again, and confirm that you get `true` as the response (calling `study.check_bucket_read_access` with the suffix `_without_delay` will run this process in the foreground instead of the normal background process):
```
study.check_bucket_read_access_without_delay
=> true
```