### PR TITLE
Conditionally position bookmark icon (SCP-5630)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -335,6 +335,10 @@ export default function ExploreDisplayPanelManager({
     setRenderForcer({})
   }, 300)
 
+  // decide how to position the bookmark icon, depending on menu elements shown
+  const subsampleMenuShown = !!(exploreInfo?.cluster?.isSubsampled)
+  const offsetBookmark = !showCellFiltering || subsampleMenuShown
+  const useBookmarkContainer = hasSpatialGroups && exploreParams?.genes?.length === 0
   return (
     <>
       <div>
@@ -497,8 +501,8 @@ export default function ExploreDisplayPanelManager({
               exploreParams={exploreParamsWithDefaults}
               updateExploreParams={updateExploreParams}
               allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}/>
-            <div id={!showCellFiltering ? 'bookmark-container' : ''} className={!showCellFiltering ? 'row' : ''}>
-              <div className={!showCellFiltering ? 'col-xs-12' : ''}>
+            <div id={useBookmarkContainer ? 'bookmark-container' : ''} className={offsetBookmark ? 'row' : ''}>
+              <div className={offsetBookmark ? 'col-xs-12' : ''}>
                 <button className="action action-with-bg"
                         onClick={clearExploreParams}
                         title="Reset all view options"

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -336,9 +336,11 @@ export default function ExploreDisplayPanelManager({
   }, 300)
 
   // decide how to position the bookmark icon, depending on menu elements shown
-  const subsampleMenuShown = !!(exploreInfo?.cluster?.isSubsampled)
-  const offsetBookmark = !showCellFiltering || subsampleMenuShown
-  const useBookmarkContainer = hasSpatialGroups && exploreParams?.genes?.length === 0
+  const subsampleMenuShown = !!(exploreInfo?.cluster?.numPoints > 100_000)
+  const noButtons = !showCellFiltering && !studyHasDe
+  const useRowClass = noButtons || hasSpatialGroups || subsampleMenuShown
+  const genesSearched = exploreParams?.genes?.length > 0
+  const useBookmarkContainer = noButtons && !subsampleMenuShown && !genesSearched
   return (
     <>
       <div>
@@ -501,8 +503,8 @@ export default function ExploreDisplayPanelManager({
               exploreParams={exploreParamsWithDefaults}
               updateExploreParams={updateExploreParams}
               allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}/>
-            <div id={useBookmarkContainer ? 'bookmark-container' : ''} className={offsetBookmark ? 'row' : ''}>
-              <div className={offsetBookmark ? 'col-xs-12' : ''}>
+            <div id={useBookmarkContainer ? 'bookmark-container' : ''} className={useRowClass ? 'row' : ''}>
+              <div className={useRowClass ? 'col-xs-12' : ''}>
                 <button className="action action-with-bg"
                         onClick={clearExploreParams}
                         title="Reset all view options"


### PR DESCRIPTION
#### BACKGROUND & CHANGES
The position of the bookmark star icon can be affected numerous ways depending on what the lowest element is in the "Options" panel.  This could lead to either the icon wrapping to another line, or being positioned too close/far to the last element in the panel.  This update adds conditional logic to determine what html/css markup is necessary so that the positioning of this and the "Get link" & "Reset view" links are consistent.  There are 3 main scenarios to account for:

1. There are buttons for cell filtering or differential expression shown
![filter_cells](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/764bc6f7-6c35-467b-b0f5-5e0eedb96cd7)

2. The subsampling menu is shown
![subsample](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/b3424fca-fdbd-4e43-8264-d7212d253342)

3. Genes have been searched
![color_scale](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/9bdb393f-0632-494c-8321-c0b78a7e95c6)

#### MANUAL TESTING
1. Boot as normal, sign in and load 3 studies in separate panels:
    * Human milk - differential expression
    * Any study with spatial data, or a study with cell filtering and differential expression disabled
    * Any study with subsampled clustering
2. Confirm that the bookmark icon position is consistent across all three studies
3. Search for one or more genes in all 3 studies and confirm positioning remains consistent