### PR TITLE
Adding language regarding cookies banner in Terra ToS (SCP-5623)

### DIFF
--- a/app/views/exceptions/terra_tos.html
+++ b/app/views/exceptions/terra_tos.html
@@ -4,14 +4,29 @@
       <div class="bs-callout bs-callout-danger">
         <h3 class="text-danger text-center">Required action</h3>
         <p class="lead text-center">
-          Terra has updated their Terms of Service.  Please accept the new <a href='https://app.terra.bio' target='_blank'>Terra Terms of Service</a>.  Single
+          Terra has updated their Terms of Service.  Please accept the new
+          <a href='https://app.terra.bio' target='_blank'>Terra Terms of Service</a>.  Single
           Cell Portal will not work properly until you do so.  You can accept the new Terra Terms of Service like so:
           <ol>
             <li>Go to <a href='https://app.terra.bio' target='_blank'>Terra</a>.</li>
             <li>Log in with your Google account.</li>
-            <li><i>After you have logged in on Terra</i>, the <a href='https://app.terra.bio#terms-of-service' target='_blank'>Terra Terms of Service</a> will load.</li>
-            <li>In Terra, click "ACCEPT" for the new Terms.  Note: there is also an "AGREE" button at the very bottom of the page about cookies.  You will need to click "ACCEPT" terms on the form in the middle of the page; agreeing to cookies is not needed to use Single Cell Portal.</li>
-            <li>In SCP, click the Single Cell Portal icon at top left of the page to go to the home page.  You can now use Single Cell Portal.</li>
+            <li>
+              <i>After you have logged in on Terra</i>, the
+              <a href='https://app.terra.bio#terms-of-service' target='_blank'>Terra Terms of Service</a> will load.
+            </li>
+            <li>
+              In Terra, click "ACCEPT" for the new Terms.
+              <ul>
+                <li><strong>Note: there is also an "AGREE" button at the very bottom of the page about cookies. If you see this
+                  banner you will first need to accept or reject this agreement before you can view the "ACCEPT" button
+                  for the Terra Terms of Service.</strong>
+                </li>
+              </ul>
+            </li>
+            <li>
+              In SCP, click the Single Cell Portal icon at top left of the page to go to the home page.  You can now use
+              Single Cell Portal.
+            </li>
           </ol>
         </p>
       </div>


### PR DESCRIPTION
#### BACKGROUND & CHANGES
Updates to the layout of the Terra Terms of Service page have made it such that the banner about accepting/rejecting cookies covers the "Accept" button for the terms.  This update adds a disclaimer to our instructions telling users that they need to either agree/decline to this before they can actually accept the Terra terms.

New instructions:
![Screenshot 2024-05-07 at 1 05 37 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/439f2ffb-f768-4723-a801-faa4f0ad735f)

#### MANUAL TESTING
1. Boot as normal
2. Go to https://localhost:3000/single_cell/terra_tos
3. Confirm you see the text as shown above 