### PR TITLE
Add concurrency groups to deployment jobs (SCP-5633)

### DIFF
--- a/.github/actions/docker-build-env-setup/action.yml
+++ b/.github/actions/docker-build-env-setup/action.yml
@@ -11,7 +11,7 @@ runs:
       uses: ./.github/actions/install-vault-and-utils
     - name: Detect changes to Dockerfile
       id: changed-dockerfile
-      uses: tj-actions/changed-files@v35.4.4
+      uses: tj-actions/changed-files@v44.3.0
       with:
         files: Dockerfile
     - name: Rebuild local image if Dockerfile changed

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Configure gcloud container and activate service account
         uses: ./.github/actions/configure-gcloud-container
         with:

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -28,7 +28,7 @@ jobs:
       group: production-deployment
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install vault and other utilities
         uses: ./.github/actions/install-vault-and-utils
       - name: Configure gcloud container and activate service account

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -24,6 +24,8 @@ env:
 jobs:
   Deploy-To-Production:
     runs-on: ubuntu-20.04
+    concurrency:
+      group: production-deployment
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -20,6 +20,8 @@ env:
 jobs:
   Deploy-To-Staging:
     runs-on: ubuntu-20.04
+    concurrency:
+      group: staging-deployment
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -24,7 +24,7 @@ jobs:
       group: staging-deployment
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Configure gcloud container and activate service account
         uses: ./.github/actions/configure-gcloud-container
         with:

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build image and setup env
         id: build-image-setup-env
         uses: ./.github/actions/docker-build-env-setup
@@ -35,7 +35,7 @@ jobs:
                                   -e test -v $DOCKER_IMAGE_TAG \
                                   -n single-cell-portal-test
       - name: Preserve all test logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-logs

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build image and setup env
         id: build-image-setup-env
         uses: ./.github/actions/docker-build-env-setup
@@ -53,7 +53,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
       - name: Preserve all test logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-logs


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This adds concurrency groups to both the [staging](https://github.com/broadinstitute/single_cell_portal_core/actions/workflows/deploy-to-staging.yml) & [production](https://github.com/broadinstitute/single_cell_portal_core/actions/workflows/deploy-to-production.yml) deployment workflows.  This will prevent concurrent runs of either workflow, as two simultaneous deployments to the same host will always cause the downstream one to fail.  Additionally, the concurrency group allows for only one pending job.  Any additional pending jobs will be cancelled.  Since the outcome of any deployment is identical - it pull the specified branch on the specified host and restarts the container - it will not matter that a later workflow is cancelled provided _any_ deployment runs after the final merge.

This also updates all of our Github Actions workflows to use the most current versions of dependent actions available.  This is in regards to the deprecation of Node.js v16 in GHA.  We still will run our version of Node inside the Docker container.

#### MANUAL TESTING
This can only be tested after this PR is merged, as any changes to the workflow YAML will not yet be integrated.  Once it is merged, then a manual deployment to staging should be pended until the first deployment finishes, and any subsequent merges/deployments will be cancelled until there are no other pending jobs.