### PR TITLE
Skip `check_bucket_read_access` in smoke test (SCP-5625)

### DIFF
--- a/test/integration/external/fire_cloud_client_test.rb
+++ b/test/integration/external/fire_cloud_client_test.rb
@@ -247,6 +247,7 @@ class FireCloudClientTest < ActiveSupport::TestCase
   end
 
   def test_check_bucket_read_access
+    skip if @smoke_test
     workspace_name = "workspace-#{@random_test_seed}"
     # since the timing is arbitrary, we can't be sure that issuing a request will then result in success downstream
     # instead, validate that access either is granted (true), or that the FastPass has been requested (false)


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update skips `test_check_bucket_read_access` during Terra orchestration smoke tests, since the API endpoint is pointing to the incorrect environment.

#### MANUAL TESTING
1. Pull branch and load all environment secrets with `./rails_local_setup.rb && source config/secrets/.source_env.bash`
2. Run the smoke test:
```
ORCH_SMOKE_TEST=true bin/rails test test/integration/external/fire_cloud_client_test.rb
```
3. Confirm you do not see any failures, and that the entry for `test_check_bucket_read_access` shows that it was skipped:
```
.fire_cloud_client_test.rb:249 test_check_bucket_read_access starting
fire_cloud_client_test.rb:249 test_check_bucket_read_access completed (0.0 sec)
S [next test starts here]
...

Finished in 198.607242s, 0.1057 runs/s, 0.3927 assertions/s.

21 runs, 78 assertions, 0 failures, 0 errors, 7 skips <= you should see 7 skips
```