### PR TITLE
Adding missing ruby version (SCP-5478)

### DIFF
--- a/webapp.conf
+++ b/webapp.conf
@@ -53,7 +53,7 @@ server {
     proxy_read_timeout	300;
 
     # If this is a Ruby app, specify a Ruby version:
-    passenger_ruby	/usr/bin/ruby3.1;
+    passenger_ruby	/usr/bin/ruby3.2;
     # For Ruby 2.0
     # passenger_ruby /usr/bin/ruby2.0;
     # For Ruby 1.9.3 (you can ignore the "1.9.1" suffix)


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates the ruby version in `webapp.conf` to the correct new version of `3.2`.  Because the local `docker-compose` setup doesn't actually use nginx, this was missed.

#### MANUAL TESTING
N/A - deploying to staging will confirm.