### PR TITLE
Reformat any study-based URL with correct url_safe_name (SCP-5619)

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -71,7 +71,7 @@ class SiteController < ApplicationController
   def legacy_study
     study = Study.any_of({url_safe_name: params[:identifier]},{accession: params[:identifier]}).first
     if study.present?
-      fixed_path = RequestUtils.format_study_url(study, request.fullpath, params)
+      fixed_path = RequestUtils.format_study_url(study, request.fullpath)
       redirect_to fixed_path and return
     else
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
@@ -622,10 +622,6 @@ class SiteController < ApplicationController
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
                   alert: "You either do not have permission to perform that action, or #{params[:accession]} does not " \
                          "exist.  #{SCP_SUPPORT_EMAIL}" and return
-    end
-    unless @study.url_safe_name == params[:study_name]
-      fixed_path = RequestUtils.format_study_url(@study, request.fullpath, params)
-      redirect_to fixed_path
     end
   end
 

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -71,9 +71,8 @@ class SiteController < ApplicationController
   def legacy_study
     study = Study.any_of({url_safe_name: params[:identifier]},{accession: params[:identifier]}).first
     if study.present?
-      redirect_to merge_default_redirect_params(view_study_path(accession: study.accession,
-                                                                study_name: study.url_safe_name,
-                                                                scpbr: params[:scpbr])) and return
+      fixed_path = RequestUtils.format_study_url(study, request.fullpath, params)
+      redirect_to fixed_path and return
     else
       redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
                   alert: "You either do not have permission to perform that action, or #{params[:identifier]} does not exist.  #{SCP_SUPPORT_EMAIL}" and return
@@ -624,11 +623,9 @@ class SiteController < ApplicationController
                   alert: "You either do not have permission to perform that action, or #{params[:accession]} does not " \
                          "exist.  #{SCP_SUPPORT_EMAIL}" and return
     end
-    # Check if current url_safe_name matches model
     unless @study.url_safe_name == params[:study_name]
-      redirect_to merge_default_redirect_params(view_study_path(accession: params[:accession],
-                                                                study_name: @study.url_safe_name,
-                                                                scpbr:params[:scpbr])) and return
+      fixed_path = RequestUtils.format_study_url(@study, request.fullpath, params)
+      redirect_to fixed_path
     end
   end
 

--- a/app/lib/request_utils.rb
+++ b/app/lib/request_utils.rb
@@ -102,6 +102,15 @@ class RequestUtils
     id_string
   end
 
+  # correct any inconsistencies in study-based URLs
+  def self.format_study_url(study, fullpath, params)
+    if params[:identifier].present?
+      fullpath.gsub(/#{params[:identifier]}/, "#{study.accession}/#{study.url_safe_name}")
+    else
+      fullpath.gsub(/#{params[:study_name]}/, study.url_safe_name)
+    end
+  end
+
   # return the hostname (and port, if present) for this instance
   # e.g. "localhost", "localhost:3000", "singlecell.broadinstitute.org"
   def self.get_hostname

--- a/test/controllers/site_controller_test.rb
+++ b/test/controllers/site_controller_test.rb
@@ -62,6 +62,7 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
     assert_equal(correct_study_url, path, "Url is #{path}. Expected #{correct_study_url}")
     path_with_params = legacy_study_path(identifier: @study.accession, genes: 'GAD1')
     get path_with_params
+    assert_response 302
     follow_redirect!
     assert_equal request.query_string, 'genes=GAD1', "did not preserve query parameters: #{request.fullpath}"
   end

--- a/test/integration/external/hca_azul_client_test.rb
+++ b/test/integration/external/hca_azul_client_test.rb
@@ -4,8 +4,8 @@ class HcaAzulClientTest < ActiveSupport::TestCase
 
   before(:all) do
     @hca_azul_client = ApplicationController.hca_azul_client
-    @project_shortname = 'ImmuneCellExhaustianHIV'
-    @project_id = '0fd8f918-62d6-4b8b-ac35-4c53dd601f71'
+    @project_shortname = 'ProstateCellAtlas'
+    @project_id = '53c53cd4-8127-4e12-bc7f-8fe1610a715c'
     @facets = [
       {
         id: 'disease',

--- a/test/lib/request_utils_test.rb
+++ b/test/lib/request_utils_test.rb
@@ -197,29 +197,18 @@ class RequestUtilsTest < ActionDispatch::IntegrationTest
 
   test 'should properly format incorrect study url' do
     identifier = "#{@public_study.accession}/#{@public_study.url_safe_name}"
+    base_path = "/single_cell/study/#{identifier}"
     params = {
-      study_name: 'foo',
-      accession: @public_study.accession,
       genes: 'GAD1',
       facets: 'species--group--study%3Ahuman'
     }
-    legacy_params = {
-      identifier: @public_study.accession,
-      genes: 'GAD1',
-      facets: 'species--group--study%3Ahuman'
-    }
-    expected_path = "/single_cell/study/#{identifier}?genes=#{params[:genes]}&facets=#{params[:facets]}"
-    bad_path = "/single_cell/study/#{params[:accession]}/#{params[:study_name]}?genes=#{params[:genes]}&facets=#{params[:facets]}"
-    legacy_path = "/single_cell/study/#{legacy_params[:identifier]}?genes=#{legacy_params[:genes]}&facets=#{legacy_params[:facets]}"
-    assert_equal expected_path, RequestUtils.format_study_url(@public_study, bad_path, params)
-    assert_equal expected_path, RequestUtils.format_study_url(@public_study, legacy_path, legacy_params)
-    # sanity check that properly formatted urls aren't changed
-    valid_params = {
-      study_name: @public_study.url_safe_name,
-      accession: @public_study.accession,
-      genes: 'GAD1',
-      facets: 'species--group--study%3Ahuman'
-    }
-    assert_equal expected_path, RequestUtils.format_study_url(@public_study, expected_path, valid_params)
+    expected_path = "#{base_path}?genes=#{params[:genes]}&facets=#{params[:facets]}"
+    legacy_path = "/single_cell/study/#{@public_study.accession}?genes=#{params[:genes]}&facets=#{params[:facets]}"
+    assert_equal expected_path, RequestUtils.format_study_url(@public_study, legacy_path)
+    # validation checks
+    assert_equal base_path, RequestUtils.format_study_url(@public_study, "(@#&%@#HF(")
+    assert_raises SecurityError do
+      RequestUtils.format_study_url(@public_study, "https://malicious-host.com#{base_path}")
+    end
   end
 end

--- a/test/lib/request_utils_test.rb
+++ b/test/lib/request_utils_test.rb
@@ -194,4 +194,32 @@ class RequestUtilsTest < ActionDispatch::IntegrationTest
       assert_equal path, RequestUtils.data_fragment_url(file, 'cluster',  gs_url: false, file_type_detail:)
     end
   end
+
+  test 'should properly format incorrect study url' do
+    identifier = "#{@public_study.accession}/#{@public_study.url_safe_name}"
+    params = {
+      study_name: 'foo',
+      accession: @public_study.accession,
+      genes: 'GAD1',
+      facets: 'species--group--study%3Ahuman'
+    }
+    legacy_params = {
+      identifier: @public_study.accession,
+      genes: 'GAD1',
+      facets: 'species--group--study%3Ahuman'
+    }
+    expected_path = "/single_cell/study/#{identifier}?genes=#{params[:genes]}&facets=#{params[:facets]}"
+    bad_path = "/single_cell/study/#{params[:accession]}/#{params[:study_name]}?genes=#{params[:genes]}&facets=#{params[:facets]}"
+    legacy_path = "/single_cell/study/#{legacy_params[:identifier]}?genes=#{legacy_params[:genes]}&facets=#{legacy_params[:facets]}"
+    assert_equal expected_path, RequestUtils.format_study_url(@public_study, bad_path, params)
+    assert_equal expected_path, RequestUtils.format_study_url(@public_study, legacy_path, legacy_params)
+    # sanity check that properly formatted urls aren't changed
+    valid_params = {
+      study_name: @public_study.url_safe_name,
+      accession: @public_study.accession,
+      genes: 'GAD1',
+      facets: 'species--group--study%3Ahuman'
+    }
+    assert_equal expected_path, RequestUtils.format_study_url(@public_study, expected_path, valid_params)
+  end
 end

--- a/test/models/delete_queue_job_test.rb
+++ b/test/models/delete_queue_job_test.rb
@@ -68,7 +68,7 @@ class DeleteQueueJobTest < ActiveSupport::TestCase
 
   test 'should destroy differential expression results on file deletion' do
     study = FactoryBot.create(:study,
-                              name_prefix: 'DiffExp DeleteQueueJon Test',
+                              name_prefix: 'DiffExp DeleteQueue Test',
                               user: @user,
                               test_array: @@studies_to_clean)
     cells = %w[A B C D E F G]


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes an issue when supplying the incorrect value for `url_safe_name` on a study causes all requests to redirect to the default view, losing any potential state/parameters.  Now, any request with a valid accession will use that alone for setting the study, ignoring any value for `url_safe_name`.  In the case that only one is provided - accession or name - then the URL will be rewritten with both while preserving all query parameters.

Previous versions of this update attempted to correct the `url_safe_name` in both scenarios, but this lead to cases where the app could get stuck in an infinite redirect loop.  Also, this approach was vulnerable to injection as it relied on user input.  Now, urls are manually reconstructed in the case where one value is completely absent, and does not leverage user input.  Since `url_safe_name` is no longer relied upon, bookmarks with incorrect names will still function correctly.  This also potentially opens the door for removing `url_safe_name` entirely if we so choose, but that is a much larger refactoring and out-of-scope.

#### MANUAL TESTING
1. Boot as normal and load the `Human milk - differential expression` study (or any study with visualizations and cell filtering enabled)
2. Search for at least one gene and perform at least one cell filtering action
3. Edit the url to change the name of the study to something different, leaving the accession intact and then submit
4. Confirm that you are redirected to the same view and name is ignored
5. Back in the url bar, completely remove either the name or accession and submit
6. Confirm the study reloads with both values and state is preserved