### PR TITLE
Allow overriding machine_type in AnnDataIngestParameters (SCP-5579)

### DIFF
--- a/test/models/ann_data_ingest_parameters_test.rb
+++ b/test/models/ann_data_ingest_parameters_test.rb
@@ -95,4 +95,15 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
               "--barcode-file #{@fragment_basepath}/h5ad_frag.barcodes.processed.tsv.gz"
     assert_equal exp_cmd, exp_ingest.to_options_array.join(' ')
   end
+
+  test 'should set default machine type and allow override' do
+    params = AnnDataIngestParameters.new(@extract_params)
+    assert_equal 'n2d-highmem-16', params.machine_type
+    new_machine = 'n2d-highmem-32'
+    params.machine_type = new_machine
+    assert_equal new_machine, params.machine_type
+    assert params.valid?
+    params.machine_type = 'foo'
+    assert_not params.valid?
+  end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update allows admins that are running AnnData ingest processes via the Rails console to manually specify the `machine_type` for the corresponding ingest run.  This is to help address failed jobs that exited with a `137` error code, denoting an out-of-memory exception.  Now, instead of the autoscaled VM, an admin can specify a larger machine, provided it is a valid `n2` or `n2d` machine type.

#### MANUAL TESTING
1. Enter a Rails console session and create a mock `AnnDataIngestParameters` object:
```
extract_params = { anndata_file: 'gs://bucket_id/test.h5ad', file_size: 100.megabytes }
params = AnnDataIngestParameters.new(**extract_params)
=> 
#<AnnDataIngestParameters:0x000000010f422f60                                       
...
```
2. Confirm the `machine_type` is the default `n2d-highmem-4` type:
```
params.machine_type
=> "n2d-highmem-4"
```
3. Set the `machine_type` to a larger machine, like `n2d-highmem-16` and confirm the params are still valid:
```
params.machine_type = 'n2d-highmem-16'
=> "n2d-highmem-16"

params.valid?
=> true
```
4. Confirm that `machine_type` only accepts valid machine names:
```
params.machine_type = 'foo'
=> "foo"

params.valid?
=> false
```