### PR TITLE
Adding migration to update BQ schema for `has_<modality>` columns

### DIFF
--- a/db/migrate/20240604150237_add_brain_modality_columns_to_big_query.rb
+++ b/db/migrate/20240604150237_add_brain_modality_columns_to_big_query.rb
@@ -1,0 +1,22 @@
+class AddBrainModalityColumnsToBigQuery < Mongoid::Migration
+  # note this operation is safe to run even if your BQ table already has the given column
+  def self.up
+    columns = %w[has_morphology has_electrophysiology]
+    client = BigQueryClient.new.client
+    [CellMetadatum::BIGQUERY_DATASET, 'cell_metadata_test'].each do |dataset_name|
+      dataset = client.dataset(dataset_name)
+      if dataset.present? # ensure test dataset exists to avoid migration failure
+        table = dataset.table(CellMetadatum::BIGQUERY_TABLE)
+        columns.each do |column_name|
+          table.schema {|s| s.boolean(column_name, mode: :nullable)}
+        end
+      end
+    end
+  end
+
+  def self.down
+    # BigQuery does not support column deletions except by dropping and recreating the table,
+    # so we'll cross that bridge when/if we come to it
+    # See https://cloud.google.com/bigquery/docs/manually-changing-schemas
+  end
+end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds the requisite `has_<modality>` columns to all associated BigQuery tables for the Alexandria convention as defined in #1995.  This is done via a migration that will add the columns if not present, and exits silently if they do.  This must be run manually for local dev environments, but executes automatically on deployments to remote hosts.

#### MANUAL TESTING
1. Pull branch and initialize environment with `./rails_local_setup.rb && source config/secrets/.source_env.bash`
2. Run the pending migration:
```
bin/rails db:migrate
...
==  AddBrainModalityColumnsToBigQuery: migrating ==============================
==  AddBrainModalityColumnsToBigQuery: migrated (4.7502s) =====================
```
3. To verify, enter a Rails console session and inspect the table schema:
```
client = BigQueryClient.new.client
dataset = client.dataset(CellMetadatum::BIGQUERY_DATASET)
table = dataset.table(CellMetadatum::BIGQUERY_TABLE)
table.schema.fields.select {|f| f.name =~ /has_/ }
=> 
[#<Google::Cloud::Bigquery::Schema::Field:0x00000001071fb1b8                 
  @gapi=#<Google::Apis::BigqueryV2::TableFieldSchema:0x0000000107634720 @mode="NULLABLE", @name="has_electrophysiology", @type="BOOLEAN">,
  @original_json="{\"mode\":\"NULLABLE\",\"name\":\"has_electrophysiology\",\"type\":\"BOOLEAN\"}">,
 #<Google::Cloud::Bigquery::Schema::Field:0x00000001071f1618                 
  @gapi=#<Google::Apis::BigqueryV2::TableFieldSchema:0x00000001075f5598 @mode="NULLABLE", @name="has_morphology", @type="BOOLEAN">,
  @original_json="{\"mode\":\"NULLABLE\",\"name\":\"has_morphology\",\"type\":\"BOOLEAN\"}">]
```
