### PR TITLE
Enable ingest of morphology and electrophysiology, via Ingest 1.31.0

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.30.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.31.0'
 
     # Docker image for image pipeline jobs
     config.image_pipeline_docker_image = 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_c2b090043'


### PR DESCRIPTION
This enables some BRAIN RF1-related work, by upgrading to [Ingest Pipeline 1.31.0](https://github.com/broadinstitute/scp-ingest-pipeline/releases/tag/1.31.0).