### PR TITLE
Migrating secrets for local development from vault to Google Secret Manager (SCP-5643)

### DIFF
--- a/bin/vault-gsm-migration.sh
+++ b/bin/vault-gsm-migration.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-# vault-gsm-secret-migration.sh
+# vault-gsm-migration.sh
 # script to pull out core SCP-specific secrets from vault and import them into Google Secret Manager (GSM)
 # this will allow the use of ./rails_local_setup.rb with GSM
 # require gcloud, vault, and jq to be installed and configured

--- a/bin/vault-gsm-secret-migration.sh
+++ b/bin/vault-gsm-secret-migration.sh
@@ -1,0 +1,124 @@
+#! /bin/bash
+
+# vault-gsm-secret-migration.sh
+# script to pull out core SCP-specific secrets from vault and import them into Google Secret Manager (GSM)
+# this will allow the use of ./rails_local_setup.rb with GSM
+# require gcloud, vault, and jq to be installed and configured
+
+function authenticate_vault {
+  TOKEN_PATH="$1"
+  vault login -method=github token=$(cat "$TOKEN_PATH")
+}
+
+function extract_secret_from_vault {
+  SECRET_PATH="$1"
+  vault read -field=data -format=json "$SECRET_PATH" | jq
+}
+
+function delete_gsm_secret {
+  SECRET_NAME="$1"
+  gcloud secrets delete "$SECRET_NAME" --quiet
+}
+
+function copy_secret_to_gsm {
+  VAULT_PATH="$1"
+  SECRET_NAME="$2"
+  GOOGLE_PROJECT="$3"
+  extract_secret_from_vault "$VAULT_PATH" | gcloud secrets create "$SECRET_NAME" --project="$GOOGLE_PROJECT" \
+                                            --replication-policy=automatic --data-file=-
+}
+
+function exit_with_error {
+  echo "### ERROR: $1 ###"
+  exit 1
+}
+
+function main {
+  GOOGLE_PROJECT=$(gcloud info --format="value(config.project)")
+  BASEPATH="secret/kdux/scp/development/$(whoami)"
+  ROLLBACK="false"
+  while getopts "t:p:b:rh" OPTION; do
+    case $OPTION in
+      t)
+        VAULT_TOKEN="$OPTARG"
+        ;;
+      p)
+        GOOGLE_PROJECT="$OPTARG"
+        echo "setting GOOGLE_PROJECT to $GOOGLE_PROJECT"
+        ;;
+      b)
+        BASEPATH="$OPTARG"
+        echo "setting BASEPATH to $BASEPATH"
+        ;;
+      r)
+        ROLLBACK="true"
+        ;;
+      h)
+        echo "$usage"
+        exit 0
+        ;;
+      *)
+        echo "unrecognized option"
+        echo "$usage"
+        exit 1
+        ;;
+    esac
+  done
+
+  # set up names/paths
+  GSM_CONFIG_NAME="scp-config-json" # main configuration JSON
+  GSM_DEFAULT_SA_NAME="default-sa-keyfile" # primary service account keyfile
+  GSM_READONLY_SA_NAME="read-only-sa-keyfile" # read-only service account keyfile
+  GSM_MONGO_USER_NAME="mongo-user" # MongoDB user credentials
+
+  if [[ "$ROLLBACK" = "true" ]]; then
+    echo "Rolling back GSM migration"
+    echo -n "Deleting $GSM_CONFIG_NAME... "
+    delete_gsm_secret "$GSM_CONFIG_NAME"
+    echo -n "Deleting $GSM_DEFAULT_SA_NAME... "
+    delete_gsm_secret "$GSM_DEFAULT_SA_NAME"
+    echo -n "Deleting $GSM_READONLY_SA_NAME... "
+    delete_gsm_secret "$GSM_READONLY_SA_NAME"
+    echo -n "Deleting $GSM_MONGO_USER_NAME... "
+    delete_gsm_secret "$GSM_MONGO_USER_NAME"
+    echo "Rollback complete!"
+    exit 0
+  fi
+
+  # vault paths
+  CONFIG_PATH="$BASEPATH/scp_config.json"
+  DEFAULT_KEYFILE="$BASEPATH/scp_service_account.json"
+  READONLY_KEYFILE="$BASEPATH/read_only_service_account.json"
+  MONGO_CREDS="$BASEPATH/mongo/user"
+
+  authenticate_vault "$VAULT_TOKEN" || exit_with_error "cannot authenticate into vault"
+
+  echo -n "Copying $CONFIG_PATH from vault... "
+  copy_secret_to_gsm "$CONFIG_PATH" "$GSM_CONFIG_NAME" "$GOOGLE_PROJECT" || exit_with_error "failed to copy $CONFIG_PATH"
+  echo -n "Copying $DEFAULT_KEYFILE from vault... "
+  copy_secret_to_gsm "$DEFAULT_KEYFILE" "$GSM_DEFAULT_SA_NAME" "$GOOGLE_PROJECT" || exit_with_error "failed to copy $DEFAULT_KEYFILE"
+  echo -n "Copying $READONLY_KEYFILE from vault... "
+  copy_secret_to_gsm "$READONLY_KEYFILE" "$GSM_READONLY_SA_NAME" "$GOOGLE_PROJECT" || exit_with_error "failed to copy $READONLY_KEYFILE"
+  echo -n "Copying $MONGO_CREDS from vault... "
+  copy_secret_to_gsm "$MONGO_CREDS" "$GSM_MONGO_USER_NAME" "$GOOGLE_PROJECT" || exit_with_error "failed to copy $MONGO_CREDS"
+
+  echo "All required secrets migrated to GSM"
+  exit 0
+}
+
+usage=$(
+cat <<EOF
+USAGE:
+  $(basename $0) -t VAULT_TOKEN [<options>]
+
+  -t VAULT_TOKEN  set the path to token used to authenticate into vault (no default)
+
+  [OPTIONS]
+  -p PROJECT      set the GCP project in which to create secrets (defaults to '$(gcloud info --format="value(config.project)")')
+  -b BASEPATH     set the base vault path for retrieving secrets (defaults to 'secret/kdux/scp/development/$(whoami)')
+  -r              roll back migration and delete SCP secrets in GSM
+  -h              print this message
+EOF
+)
+
+main "$@"

--- a/rails_local_setup.rb
+++ b/rails_local_setup.rb
@@ -56,7 +56,7 @@ CONFIG_DIR = File.expand_path('.') + "/config"
 
 
 # load raw secrets from Google Secrets Manager (GSM)
-puts 'Processing secret parameters from Vault'
+puts 'Loading main configuration from GSM'
 base_gsm_command = "gcloud secrets versions access latest --project=#{google_project}"
 secret_string = `#{base_gsm_command} --secret=#{config_secret}`
 secret_data_hash = JSON.parse(secret_string)
@@ -73,7 +73,7 @@ source_file_string += "export MONGODB_USERNAME=#{mongo_user_hash['username']}\n"
 source_file_string += "export MONGODB_PASSWORD=#{mongo_user_hash['password']}\n"
 source_file_string += "export DATABASE_HOST=#{secret_data_hash['MONGO_LOCALHOST']}\n"
 
-puts 'Processing service account info'
+puts 'Processing service account keyfile'
 service_account_string = `#{base_gsm_command} --secret=#{default_sa_keyfile}`
 service_account_hash = JSON.parse(service_account_string)
 
@@ -82,7 +82,7 @@ puts "Setting google cloud project: #{service_account_hash['project_id']}"
 source_file_string += "export GOOGLE_CLOUD_PROJECT=#{service_account_hash['project_id']}\n"
 source_file_string += "export SERVICE_ACCOUNT_KEY=#{output_dir}/.scp_service_account.json\n"
 
-puts 'Processing read-only service account info'
+puts 'Processing read-only service account keyfile'
 readonly_string = `#{base_gsm_command} --secret=#{read_only_sa_keyfile}`
 readonly_hash = JSON.parse(readonly_string)
 File.open("#{CONFIG_DIR}/.read_only_service_account.json", 'w') { |file| file.write(readonly_hash.to_json) }


### PR DESCRIPTION
#### BACKGROUND & CHANGES
DSP is migrating off of using Vault for storing secrets in favor of Google Secret Manager as part of FedRAMP compliance.  This update adds a local migration script to copy necessary secrets from Vault over to GSM, and updates local configuration scripts to reference these instead of Vault.

Note: this does not change anything regarding CI/CD and associated scripts.  As such, there are still many references to Vault in scripts and in README.md.  These will be addressed in SCP-5659.  This only adds the base migration script and allows local development using GSM.

#### MANUAL TESTING
1. First enable the Secrets Manager API in your developer project:
    * Go to https://console.cloud.google.com/apis/library/secretmanager.googleapis.com
    * Ensure your project is selected in the dropdown menu at the top
    * Enable the API
2. Ensure you are [logged into](https://cloud.google.com/sdk/gcloud/reference/auth/login) `gcloud` and have your developer project loaded
3. Pull this branch, and then run the migration script, confirming you see similar output:
```
$ bin/vault-gsm-migration.sh -t (github token path)

... (vault log messages)

Copying secret/kdux/scp/development/{your username}/scp_config.json from vault... Created version [1] of the secret [scp-config-json].
Copying secret/kdux/scp/development/{your username}/scp_service_account.json from vault... Created version [1] of the secret [default-sa-keyfile].
Copying secret/kdux/scp/development/{your username}/read_only_service_account.json from vault... Created version [1] of the secret [read-only-sa-keyfile].
Copying secret/kdux/scp/development/{your username}/mongo/user from vault... Created version [1] of the secret [mongo-user].
All required secrets migrated to GSM
```
4. Confirm the secrets exist in GSM
```
$ gcloud secrets list 

NAME                  CREATED              REPLICATION_POLICY  LOCATIONS
default-sa-keyfile    2024-06-05T16:59:10  automatic           -
mongo-user            2024-06-05T16:59:15  automatic           -
read-only-sa-keyfile  2024-06-05T16:59:13  automatic           -
scp-config-json       2024-06-05T16:59:08  automatic           -
```
5. Start your local server using the `rails_local_setup.rb` script and confirm that everything functions normally
6. (Optional) try the rollback option on the script with `-r` and confirm all secrets are deleted:
```
$ bin/vault-gsm-migration.sh -r

Rolling back GSM migration
Deleting scp-config-json... Deleted secret [scp-config-json].
Deleting default-sa-keyfile... Deleted secret [default-sa-keyfile].
Deleting read-only-sa-keyfile... Deleted secret [read-only-sa-keyfile].
Deleting mongo-user... Deleted secret [mongo-user].
Rollback complete!

$ gcloud secrets list
Listed 0 items.
```
6. (Optional) Re-run the migration