### PR TITLE
Add CosMX and Xenium to library_preparation_protocol dropdown (SCP-5664)

### DIFF
--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -47,7 +47,8 @@ class ExpressionFileInfo
                                 '10x scATAC-seq', # scATAC-seq
                                 '10x TCR enrichment', # targeted transcriptomic
                                 '10x Visium', # spatial transcriptomic
-                                'CEL-seq2', # scRNAseq
+                                '10x Xenium', # spatial transcriptomics
+				'CEL-seq2', # scRNAseq
                                 'Drop-ChIP', # scChIP-seq
                                 'Drop-seq', # scRNAseq
                                 'dsc-ATAC-seq', # scATAC-seq
@@ -55,6 +56,7 @@ class ExpressionFileInfo
                                 'inDrop', # scRNAseq
                                 'MARS-seq', # scRNAseq
                                 'MERFISH', # spatial transcriptomic
+				'Nanostring CosMx', #spatial transcriptomic
                                 'osmFISH', # spatial transcriptomic
                                 'scATAC-seq/Fluidigm', # scATAC-seq
                                 'sci-ATAC-seq', # scATAC-seq


### PR DESCRIPTION
### BACKGROUND & CHANGES
A study owner [noted in Zendesk](https://broadinstitute.zendesk.com/agent/tickets/319986) that "Nanostring CosMx" and "10x Xenium" were not available in our library_preparation_protocol dropdown. This change makes those protocols available as options.

MANUAL TESTING
Pull branch and sign in
Choose a study and navigate to the Expression matrices tab in the upload wizard
Confirm that "Nanostring CosMx" and "10x Xenium" are available in the library_preparation_protocol dropdown.