### PR TITLE
Correctly pass env var for GOOGLE_PROJECT (SCP-5659)

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -34,25 +34,25 @@ jobs:
         uses: ./.github/actions/setup-gcloud
         with:
           service_account_email: '116798894341-compute@developer.gserviceaccount.com'
-          google_cloud_project: $GOOGLE_PROJECT
+          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
       - name: Extract secrets to env file
         uses: ./.github/actions/extract-gsm-secret-to-file
         with:
-          google_cloud_project: $GOOGLE_PROJECT
+          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
           gsm_secret: 'scp-config-json'
           output_filename: ${{ env.CONFIG_FILENAME }}
           output_format: 'env'
       - name: Extract secrets to env file
         uses: ./.github/actions/extract-gsm-secret-to-file
         with:
-          google_cloud_project: $GOOGLE_PROJECT
+          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
           gsm_secret: 'default-sa-keyfile'
           output_filename: ${{ env.DEFAULT_SA_KEYFILE }}
           output_format: 'json'
       - name: Extract secrets to env file
         uses: ./.github/actions/extract-gsm-secret-to-file
         with:
-          google_cloud_project: $GOOGLE_PROJECT
+          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
           gsm_secret: 'read-only-sa-keyfile'
           output_filename: ${{ env.READONLY_SA_KEYFILE }}
           output_format: 'json'

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -36,7 +36,7 @@ jobs:
         uses: ./.github/actions/setup-gcloud
         with:
           service_account_email: '839419950053-compute@developer.gserviceaccount.com'
-          google_cloud_project: $GOOGLE_PROJECT
+          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
       - name: Extract secrets to env file
         uses: ./.github/actions/extract-gsm-secret-to-file
         with:
@@ -47,14 +47,14 @@ jobs:
       - name: Extract secrets to env file
         uses: ./.github/actions/extract-gsm-secret-to-file
         with:
-          google_cloud_project: $GOOGLE_PROJECT
+          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
           gsm_secret: 'default-sa-keyfile'
           output_filename: ${{ env.DEFAULT_SA_KEYFILE }}
           output_format: 'json'
       - name: Extract secrets to env file
         uses: ./.github/actions/extract-gsm-secret-to-file
         with:
-          google_cloud_project: $GOOGLE_PROJECT
+          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
           gsm_secret: 'read-only-sa-keyfile'
           output_filename: ${{ env.READONLY_SA_KEYFILE }}
           output_format: 'json'


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug where the value of `$GOOGLE_PROJECT` is not properly passed to underlying actions when attempting to configure/authenticate gcloud commands.  It's not immediately obvious why it worked before and is suddenly failing, but using the `${{ env.VAR_NAME }}` syntax will correctly pass the value rather than relying on `$VAR_NAME`.

#### MANUAL TESTING
N/A - we can't test changes to workflows until they have merged.