### PR TITLE
Standardizing name for GOOGLE_CLOUD_PROJECT in workflow inputs (SCP-5659)

### DIFF
--- a/.github/actions/extract-gsm-secret-to-file/action.yml
+++ b/.github/actions/extract-gsm-secret-to-file/action.yml
@@ -1,7 +1,7 @@
 name: 'Extract GSM secret to file'
 description: 'read a secret from Google Secrets Manager and export as a file'
 inputs:
-  google_project:
+  google_cloud_project:
     description: 'Name of GCP project to read secret from'
     required: true
   gsm_secret:
@@ -20,7 +20,7 @@ runs:
     - name: Extract GSM secret to file
       shell: bash
       run: |
-        VALUES=$(gcloud secrets versions access latest --project=${{ inputs.google_project }} --secret=${{ inputs.gsm_secret }})
+        VALUES=$(gcloud secrets versions access latest --project=${{ inputs.google_cloud_project }} --secret=${{ inputs.gsm_secret }})
         if [[ "${{ inputs.output_format }}" = 'env' ]]; then
           echo "### env secrets from ${{ inputs.gsm_secret }} ###" >| ${{ inputs.output_filename }}
           for key in $(echo $VALUES | jq .data | jq --raw-output 'keys[]')

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -14,7 +14,7 @@ env:
   CONFIG_FILENAME: 'scp_config.env'
   DEFAULT_SA_KEYFILE: 'scp_service_account.json'
   READONLY_SA_KEYFILE: 'read_only_service_account.json'
-  GOOGLE_PROJECT: 'broad-singlecellportal'
+  GOOGLE_CLOUD_PROJECT: 'broad-singlecellportal'
   COMPUTE_ZONE: 'us-central1-a'
   REMOTE_HOST: 'singlecell-01'
   ROLLBACK: ''
@@ -34,25 +34,25 @@ jobs:
         uses: ./.github/actions/setup-gcloud
         with:
           service_account_email: '116798894341-compute@developer.gserviceaccount.com'
-          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
+          google_cloud_project: ${{ env.GOOGLE_CLOUD_PROJECT }}
       - name: Extract secrets to env file
         uses: ./.github/actions/extract-gsm-secret-to-file
         with:
-          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
+          google_cloud_project: ${{ env.GOOGLE_CLOUD_PROJECT }}
           gsm_secret: 'scp-config-json'
           output_filename: ${{ env.CONFIG_FILENAME }}
           output_format: 'env'
       - name: Extract secrets to env file
         uses: ./.github/actions/extract-gsm-secret-to-file
         with:
-          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
+          google_cloud_project: ${{ env.GOOGLE_CLOUD_PROJECT }}
           gsm_secret: 'default-sa-keyfile'
           output_filename: ${{ env.DEFAULT_SA_KEYFILE }}
           output_format: 'json'
       - name: Extract secrets to env file
         uses: ./.github/actions/extract-gsm-secret-to-file
         with:
-          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
+          google_cloud_project: ${{ env.GOOGLE_CLOUD_PROJECT }}
           gsm_secret: 'read-only-sa-keyfile'
           output_filename: ${{ env.READONLY_SA_KEYFILE }}
           output_format: 'json'

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -17,7 +17,7 @@ env:
   CONFIG_FILENAME: 'scp_config.env'
   DEFAULT_SA_KEYFILE: 'scp_service_account.json'
   READONLY_SA_KEYFILE: 'read_only_service_account.json'
-  GOOGLE_PROJECT: 'broad-singlecellportal-staging'
+  GOOGLE_CLOUD_PROJECT: 'broad-singlecellportal-staging'
   COMPUTE_ZONE: 'us-central1-a'
   REMOTE_HOST: 'singlecell-01'
 
@@ -36,25 +36,25 @@ jobs:
         uses: ./.github/actions/setup-gcloud
         with:
           service_account_email: '839419950053-compute@developer.gserviceaccount.com'
-          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
+          google_cloud_project: ${{ env.GOOGLE_CLOUD_PROJECT }}
       - name: Extract secrets to env file
         uses: ./.github/actions/extract-gsm-secret-to-file
         with:
-          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
+          google_cloud_project: ${{ env.GOOGLE_CLOUD_PROJECT }}
           gsm_secret: 'scp-config-json'
           output_filename: ${{ env.CONFIG_FILENAME }}
           output_format: 'env'
       - name: Extract secrets to env file
         uses: ./.github/actions/extract-gsm-secret-to-file
         with:
-          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
+          google_cloud_project: ${{ env.GOOGLE_CLOUD_PROJECT }}
           gsm_secret: 'default-sa-keyfile'
           output_filename: ${{ env.DEFAULT_SA_KEYFILE }}
           output_format: 'json'
       - name: Extract secrets to env file
         uses: ./.github/actions/extract-gsm-secret-to-file
         with:
-          google_cloud_project: ${{ env.GOOGLE_PROJECT }}
+          google_cloud_project: ${{ env.GOOGLE_CLOUD_PROJECT }}
           gsm_secret: 'read-only-sa-keyfile'
           output_filename: ${{ env.READONLY_SA_KEYFILE }}
           output_format: 'json'


### PR DESCRIPTION
Fixes a mismatch in configuration/input names for GOOGLE_CLOUD_PROJECT.