### PR TITLE
Remove docker tag input for staging deployments

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,12 +1,6 @@
 name: Deploy to staging SCP instance
 on:
   workflow_run:
-    inputs:
-      docker_image_tag:
-        type: string
-        description: 'Docker image tag to use'
-        default: 'development'
-        required: true
     workflows: ["Build and publish single-cell-portal Docker image"]
     types:
       - completed
@@ -62,5 +56,4 @@ jobs:
         shell: bash
         run: |
           bin/deploy-github.sh -b ${{ github.ref_name }} -e staging -g $GOOGLE_PROJECT -G $IMAGE_NAME -h $REMOTE_HOST \
-                               -p $CONFIG_FILENAME -s $DEFAULT_SA_KEYFILE -r $READONLY_SA_KEYFILE \
-                               -v ${{ github.event.inputs.docker_image_tag }}
+                               -p $CONFIG_FILENAME -s $DEFAULT_SA_KEYFILE -r $READONLY_SA_KEYFILE


### PR DESCRIPTION
This removed the `docker_image_tag` input for staging deployments.  This was a last-minute include to address the issue of not being able to deploy to staging using anything other than the `development` Docker image tag, but the idea didn't work.  This is out-of-scope for current work and so will simply be ticketed to address later.