### PR TITLE
Fixing GOOGLE_CLOUD_PROJECT env var in deploy script

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -63,5 +63,5 @@ jobs:
           if [[ "${{ github.event.inputs.rollback }}" = "Y" ]]; then
             ROLLBACK="-R"
           fi
-          bin/deploy-github.sh -b master -e production -g $GOOGLE_PROJECT -G $IMAGE_NAME -h $REMOTE_HOST \
+          bin/deploy-github.sh -b master -e production -g ${{ env.GOOGLE_CLOUD_PROJECT }} -G $IMAGE_NAME -h $REMOTE_HOST \
                                -p $CONFIG_FILENAME -s $DEFAULT_SA_KEYFILE -r $READONLY_SA_KEYFILE $ROLLBACK

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -55,5 +55,5 @@ jobs:
       - name: Run deploy script
         shell: bash
         run: |
-          bin/deploy-github.sh -b ${{ github.ref_name }} -e staging -g $GOOGLE_PROJECT -G $IMAGE_NAME -h $REMOTE_HOST \
-                               -p $CONFIG_FILENAME -s $DEFAULT_SA_KEYFILE -r $READONLY_SA_KEYFILE
+          bin/deploy-github.sh -b ${{ github.ref_name }} -e staging -g ${{ env.GOOGLE_CLOUD_PROJECT }} -G $IMAGE_NAME \ 
+                               -h $REMOTE_HOST -p $CONFIG_FILENAME -s $DEFAULT_SA_KEYFILE -r $READONLY_SA_KEYFILE


### PR DESCRIPTION
Fixing the name of GOOGLE_CLOUD_PROJECT in script invocation.