### PR TITLE
Removing line breaks from workflow syntax, fixing gcloud scp command (SCP-5659)

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -63,6 +63,4 @@ jobs:
           if [[ "${{ github.event.inputs.rollback }}" = "Y" ]]; then
             ROLLBACK="-R"
           fi
-          bin/deploy-github.sh -b master -e production -g ${{ env.GOOGLE_CLOUD_PROJECT }} -h ${{ env.REMOTE_HOST }} \
-                               -p ${{ env.CONFIG_FILENAME }} -s ${{ env.DEFAULT_SA_KEYFILE }} \
-                               -r ${{ env.READONLY_SA_KEYFILE }} $ROLLBACK
+          bin/deploy-github.sh -b master -e production -g ${{ env.GOOGLE_CLOUD_PROJECT }} -h ${{ env.REMOTE_HOST }} -p ${{ env.CONFIG_FILENAME }} -s ${{ env.DEFAULT_SA_KEYFILE }} -r ${{ env.READONLY_SA_KEYFILE }} $ROLLBACK

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -55,6 +55,4 @@ jobs:
       - name: Run deploy script
         shell: bash
         run: |
-          bin/deploy-github.sh -b ${{ github.ref_name }} -e staging -g ${{ env.GOOGLE_CLOUD_PROJECT }} \ 
-                               -h ${{ env.REMOTE_HOST }} -p ${{ env.CONFIG_FILENAME }} -s ${{ env.DEFAULT_SA_KEYFILE }} \
-                               -r ${{ env.READONLY_SA_KEYFILE }}
+          bin/deploy-github.sh -b ${{ github.ref_name }} -e staging -g ${{ env.GOOGLE_CLOUD_PROJECT }} -h ${{ env.REMOTE_HOST }} -p ${{ env.CONFIG_FILENAME }} -s ${{ env.DEFAULT_SA_KEYFILE }} -r ${{ env.READONLY_SA_KEYFILE }}

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -37,8 +37,7 @@ jobs:
           READONLY_SA: 'read-only-sa-keyfile'
           CI: true
         run: |
-          bin/load_env_secrets.sh -p $SCP_CONFIG -s $DEFAULT_SA -r $READONLY_SA -g $GOOGLE_CLOUD_PROJECT -e test \
-                                  -v $DOCKER_IMAGE_TAG -n single-cell-portal-test
+          bin/load_env_secrets.sh -p $SCP_CONFIG -s $DEFAULT_SA -r $READONLY_SA -g $GOOGLE_CLOUD_PROJECT -e test -v $DOCKER_IMAGE_TAG -n single-cell-portal-test
       - name: Preserve all test logs
         uses: actions/upload-artifact@v4
         if: always()

--- a/bin/deploy-github.sh
+++ b/bin/deploy-github.sh
@@ -46,6 +46,7 @@ function main {
         DESTINATION_BASE_DIR="$OPTARG"
         ;;
       h)
+        echo "SETTING DESTINATION_HOST to $OPTARG"
         DESTINATION_HOST="$OPTARG"
         ;;
       S)
@@ -87,11 +88,11 @@ function main {
   # construct SSH command using gcloud and Identity Aware Proxy to access VM via authenticated Docker container
   BASE_SSH="gcloud compute ssh"
   SSH_ARGS="$SSH_USER@$DESTINATION_HOST --tunnel-through-iap --project $GOOGLE_CLOUD_PROJECT --zone $COMPUTE_ZONE"
-  SSH_COMMAND="$BASE_SSH  $SSH_ARGS --verbosity error --command "
+  SSH_COMMAND="$BASE_SSH $SSH_ARGS --verbosity error --command "
 
   # copy command using gcloud compute scp
   BASE_COPY="gcloud compute scp"
-  COPY_ARGS=
+  COPY_ARGS=""
 
   # exit if all config is not present
   if [[ -z "$CONFIG_FILENAME" ]] || [[ -z "$DEFAULT_SA_KEYFILE" ]] || [[ -z "$READONLY_SA_KEYFILE" ]]; then
@@ -194,7 +195,7 @@ function copy_file_to_remote {
   LOCAL_FILEPATH="$1"
   REMOTE_FILEPATH="$2"
   $SSH_COMMAND "mkdir -p \$(dirname $REMOTE_FILEPATH)"
-  BASE_COPY="gcloud compute scp "
+  BASE_COPY="gcloud compute scp"
   COPY_ARGS="$LOCAL_FILEPATH $SSH_USER@$DESTINATION_HOST:$REMOTE_FILEPATH --tunnel-through-iap --project $GOOGLE_CLOUD_PROJECT --zone $COMPUTE_ZONE"
   COPY_CMD="$BASE_COPY $COPY_ARGS"
   $COPY_CMD

--- a/bin/deploy-github.sh
+++ b/bin/deploy-github.sh
@@ -204,5 +204,5 @@ function copy_file_to_remote {
 function set_remote_environment_vars {
   echo "PASSENGER_APP_ENV='$PASSENGER_APP_ENV' PORTAL_SECRETS_PATH='$PORTAL_SECRETS_PATH' DESTINATION_BASE_DIR='$DESTINATION_BASE_DIR'"
 }
-
+echo "params: $@"
 main "$@"

--- a/bin/deploy-github.sh
+++ b/bin/deploy-github.sh
@@ -193,10 +193,9 @@ function run_remote_command {
 function copy_file_to_remote {
   LOCAL_FILEPATH="$1"
   REMOTE_FILEPATH="$2"
-  CONTAINER_PATH="/tmp/$(basename $LOCAL_FILEPATH)"
   $SSH_COMMAND "mkdir -p \$(dirname $REMOTE_FILEPATH)"
-  BASE_COPY="docker run --rm -v $LOCAL_FILEPATH:$CONTAINER_PATH:rw $GCLOUD_CONFIG_IMAGE gcloud compute scp "
-  COPY_ARGS="$CONTAINER_PATH $SSH_USER@$DESTINATION_HOST:$REMOTE_FILEPATH --tunnel-through-iap --project $GOOGLE_CLOUD_PROJECT --zone $COMPUTE_ZONE"
+  BASE_COPY="gcloud compute scp "
+  COPY_ARGS="$LOCAL_FILEPATH $SSH_USER@$DESTINATION_HOST:$REMOTE_FILEPATH --tunnel-through-iap --project $GOOGLE_CLOUD_PROJECT --zone $COMPUTE_ZONE"
   COPY_CMD="$BASE_COPY $COPY_ARGS"
   $COPY_CMD
 }

--- a/bin/deploy-github.sh
+++ b/bin/deploy-github.sh
@@ -46,7 +46,6 @@ function main {
         DESTINATION_BASE_DIR="$OPTARG"
         ;;
       h)
-        echo "SETTING DESTINATION_HOST to $OPTARG"
         DESTINATION_HOST="$OPTARG"
         ;;
       S)
@@ -204,5 +203,4 @@ function copy_file_to_remote {
 function set_remote_environment_vars {
   echo "PASSENGER_APP_ENV='$PASSENGER_APP_ENV' PORTAL_SECRETS_PATH='$PORTAL_SECRETS_PATH' DESTINATION_BASE_DIR='$DESTINATION_BASE_DIR'"
 }
-echo "params: $@"
 main "$@"


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This removes any line breaks from `bash` commands inside workflow steps.  This is to prevent early termination that results in arguments being dropped.  Additionally, this fixes an issue with the `gcloud compute scp` command that was still referencing the old Docker container implementation.

#### MANUAL TESTING
N/A
