### PR TITLE
Fixing extraction to file logic for GSM (SCP-5659)

### DIFF
--- a/.github/actions/extract-gsm-secret-to-file/action.yml
+++ b/.github/actions/extract-gsm-secret-to-file/action.yml
@@ -20,16 +20,16 @@ runs:
     - name: Extract GSM secret to file
       shell: bash
       run: |
-        VALUES=$(gcloud secrets versions access latest --project=${{ inputs.google_cloud_project }} --secret=${{ inputs.gsm_secret }})
         if [[ "${{ inputs.output_format }}" = 'env' ]]; then
+          VALUES=$(gcloud secrets versions access latest --project=${{ inputs.google_cloud_project }} --secret=${{ inputs.gsm_secret }})
           echo "### env secrets from ${{ inputs.gsm_secret }} ###" >| ${{ inputs.output_filename }}
-          for key in $(echo $VALUES | jq .data | jq --raw-output 'keys[]')
+          for key in $(echo $VALUES | jq --raw-output 'keys[]')
           do
             echo "setting value for: $key"
-            curr_val=$(echo $VALUES | jq .data | jq --raw-output .$key)
+            curr_val=$(echo $VALUES | jq --raw-output .$key)
             echo "export $key='$curr_val'" >> ${{ inputs.output_filename }}
           done
         elif [[ "${{ inputs.output_format }}" = 'json' ]]; then
-          JSON_CONTENTS=$(echo $VALUES | jq --raw-output .data)
-          echo $JSON_CONTENTS >| ${{ inputs.output_filename }}
+          # strip newlines with sed as GSM outputs data as raw strings
+          gcloud secrets versions access latest --project=${{ inputs.google_cloud_project }} --secret=${{ inputs.gsm_secret }} | sed "s/\n//g" >| ${{ inputs.output_filename }}
         fi


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug where extracting secrets to a file from GSM fail silently due to data not being formatted the same way it was in Vault.  GSM stores secrets as raw strings, whereas Vault was a true key/value store that natively supported JSON, and namespaced secrets under the `data` key.

#### MANUAL TESTING
The action itself cannot be tested, but you can validate that it works by running the shell code directly:
1. In a new terminal, set up environment variables for `gcloud`
```
GCP_PROJECT=$(gcloud info --format="value(config.project)")
KEYFILE_NAME=default-sa-keyfile
CONFIG_NAME=scp-config-json
```
2. Extract the config to an env file with the following commands (taken directly from the `extract-gsm-secret-to-file` action)
```
VALUES=$(gcloud secrets versions access latest --project=$GCP_PROJECT --secret=$CONFIG_NAME)
echo "### env secrets from $CONFIG_NAME ###" >| ~/Desktop/scp_config.env
for key in $(echo $VALUES | jq --raw-output 'keys[]')
do
  echo "setting value for: $key"
  curr_val=$(echo $VALUES | jq --raw-output .$key)
  echo "export $key='$curr_val'" >> ~/Desktop/scp_config.env
done
```
3. Confirm you see the following console output, and that the resulting file has data and is formatted correctly:
```
setting value for: CODECOV_TOKEN
setting value for: GA_TRACKING_ID
setting value for: GCP_NETWORK_NAME
setting value for: GCP_SUB_NETWORK_NAME
setting value for: GOOGLE_PROJECT_NUMBER
setting value for: LOGSTASH_HOST
setting value for: MIXPANEL_SECRET
setting value for: MONGO_INTERNAL_IP
setting value for: MONGO_LOCALHOST
setting value for: NEMO_API_PASSWORD
setting value for: NEMO_API_USERNAME
setting value for: OAUTH_CLIENT_ID
setting value for: OAUTH_CLIENT_SECRET
setting value for: PORTAL_NAMESPACE
setting value for: PROD_DATABASE_PASSWORD
setting value for: PROD_HOSTNAME
setting value for: SECRET_KEY_BASE
setting value for: SENDGRID_PASSWORD
setting value for: SENDGRID_USERNAME
setting value for: SENTRY_AUTH_TOKEN
setting value for: TCELL_AGENT_API_KEY
setting value for: TCELL_AGENT_APP_ID
setting value for: TEST_USER_PASSWORD
setting value for: T_CELL_SERVER_AGENT_API_KEY
```
4. Export the service account keyfile and confirm it is formatted correctly with no newlines inside the JSON values:
```
gcloud secrets versions access latest --project=$GCP_PROJECT --secret=$KEYFILE_NAME | sed "s/\n//g" >| ~/Desktop/keyfile.json
```