### PR TITLE
Address upload chooser issues in Firefox/Safari browsers (SCP-5654)

### DIFF
--- a/app/javascript/components/upload/UploadExperienceSplitter.jsx
+++ b/app/javascript/components/upload/UploadExperienceSplitter.jsx
@@ -7,7 +7,11 @@ import { navigate } from '@reach/router'
 function RawUploadExperienceSplitter({
   setIsAnnDataExperience, setOverrideExperienceMode
 }) {
-  navigate('?tab=fileuploadchoice')
+  const splitterPath = '?tab=fileuploadchoice'
+  if (window.location.search !== splitterPath) {
+    navigate('?tab=fileuploadchoice')
+  }
+
 
   return <div className="top-margin margin-left">
     <div className="row">

--- a/app/javascript/components/upload/UploadExperienceSplitter.jsx
+++ b/app/javascript/components/upload/UploadExperienceSplitter.jsx
@@ -9,7 +9,7 @@ function RawUploadExperienceSplitter({
 }) {
   const splitterPath = '?tab=fileuploadchoice'
   if (window.location.search !== splitterPath) {
-    navigate('?tab=fileuploadchoice')
+    navigate(splitterPath)
   }
 
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes an issue with Firefox & Safari browsers (most notably Firefox) where users creating new studies could not upload any data.  Firefox was throwing the following exception when trying to load the `UploadExperienceSplitter`:

```
Too many calls to Location or History APIs within a short timeframe.
DOMException: The operation is insecure.
```

This is most likely due to React rendering the component multiple times which then calls `navigate` repeatedly.  This manifests as an error in Firefox, and as continuous page reloads in Safari.  Chrome appears unaffected.  Adding an `if` clause before `navigate` prevents the repetitive calls to the Location API, which prevents the above issues in both browsers.

#### MANUAL TESTING
1. Boot as normal and sign in using Firefox as your browser
2. Create a new study, or load the upload wizard for any study that does not have any files
3. Confirm you see the chooser for classic/AnnData and do not experience any errors if you let the page sit for ~10s
4. Confirm you are able to add files to forms (it is not necessary to complete an upload)
5. (Optional) Try the same in Safari and confirm you do not see repeated page reloads on the chooser tab