### PR TITLE
Make IGV filtering instant (SCP-5662)

### DIFF
--- a/app/javascript/components/explore/GenomeView.jsx
+++ b/app/javascript/components/explore/GenomeView.jsx
@@ -132,6 +132,35 @@ function getOriginalChrFeatures(trackIndex, igvBrowser) {
   return originalChrFeatures
 }
 
+/** Determine if feature is in genomic frame */
+function getIsFeatureInFrame(feature, igvBrowser) {
+  const frame = igvBrowser.referenceFrameList[0]
+
+  const isFeatureInFrame = (
+    // Contained:
+    // Frame:     --------
+    // Feature:     ----
+    (feature.start >= frame.start && feature.end <= frame.end) ||
+
+    // Overlaps start
+    // Frame:     --------
+    // Feature:  ----
+    (feature.start <= frame.start && feature.end >= frame.start) ||
+
+    // Overlaps end
+    // Frame:     --------
+    // Feature:         ----
+    (feature.start <= frame.end && feature.end >= frame.end) ||
+
+    // Spans
+    // Frame:     --------
+    // Feature: ------------
+    (feature.start <= frame.start && feature.end >= frame.end)
+  )
+
+  return isFeatureInFrame
+}
+
 // /**
 //    * TODO: Consider maturing this filtering by "score", which is a
 //    * dimension that is _not_ an annotation yet is still often applicable
@@ -167,7 +196,9 @@ export function filterIgvFeatures(filteredCellNames) {
   const igvBrowser = window.igvBrowser
 
   const originalChrFeatures = getOriginalChrFeatures(trackIndex, igvBrowser)
-  const filteredFeatures = originalChrFeatures.filter(feature => filteredCellNames.has(feature.name))
+  const filteredFeatures = originalChrFeatures.filter(
+    feature => filteredCellNames.has(feature.name) && getIsFeatureInFrame(feature, igvBrowser)
+  )
 
   updateTrack(trackIndex, filteredFeatures, igv, igvBrowser)
 }

--- a/cell-filtering-igv/index.html
+++ b/cell-filtering-igv/index.html
@@ -12,10 +12,7 @@ More context: https://github.com/broadinstitute/single_cell_portal_core/pull/202
 
   /** Render update to reflect newly-selected features in IGV track */
   function updateTrack(trackIndex, filteredFeatures, igv, igvBrowser) {
-    // How many layers of features can be stacked / piled up.
-    // TODO (SCP-5662): eliminate this constraint
-    const maxRows = 20
-    igv.FeatureUtils.packFeatures(filteredFeatures, maxRows)
+    igv.FeatureUtils.packFeatures(filteredFeatures)
     igvBrowser.trackViews[trackIndex].track.featureSource.featureCache = new igv.FeatureCache(filteredFeatures, igvBrowser.genome)
     igvBrowser.trackViews[trackIndex].track.clearCachedFeatures()
     igvBrowser.trackViews[trackIndex].track.updateViews()
@@ -37,23 +34,63 @@ function getOriginalChrFeatures(trackIndex, igvBrowser) {
   return originalChrFeatures
 }
 
-  function filterAtac(scoreSelection) {
+/** Determine if feature is in genomic frame */
+function getIsFeatureInFrame(feature, igvBrowser) {
+  const frame = igvBrowser.referenceFrameList[0]
+
+  const isFeatureInFrame = (
+    // Contained:
+    // Frame:     --------
+    // Feature:     ----
+    (feature.start >= frame.start && feature.end <= frame.end) ||
+
+    // Overlaps start
+    // Frame:     --------
+    // Feature:  ----
+    (feature.start <= frame.start && feature.end >= frame.start) ||
+
+    // Overlaps end
+    // Frame:     --------
+    // Feature:         ----
+    (feature.start <= frame.end && feature.end >= frame.end) ||
+
+    // Spans
+    // Frame:     --------
+    // Feature: ------------
+    (feature.start <= frame.start && feature.end >= frame.end)
+  )
+
+  return isFeatureInFrame
+}
+
+  function filterAtac() {
     const trackIndex = 4 // Track index
     const igvBrowser = window.igvBrowser
 
+    const scoreSelection = new Set([])
+
     const originalChrFeatures = getOriginalChrFeatures(trackIndex, igvBrowser)
 
-    if (!scoreSelection) {
-      scoreSelection = new Set([2])
-    }
     const inputs = document.querySelectorAll('.filters input')
     inputs.forEach(input => {
       if (input.checked) {
-        selection[input.value] = 1
+        scoreSelection.add(parseInt(input.value))
       }
     })
 
-    const filteredFeatures = originalChrFeatures.filter(feature => scoreSelection.has(feature.score))
+    console.log('scoreSelection')
+    console.log(scoreSelection)
+
+    if (scoreSelection.size === 0) {
+      return scoreSelection.originalChrFeatures
+    }
+
+    const filteredFeatures = originalChrFeatures.filter(
+      feature => scoreSelection.has(feature.score) && getIsFeatureInFrame(feature, igvBrowser)
+    )
+
+    console.log('filteredFeatures.length')
+    console.log(filteredFeatures.length)
 
     updateTrack(trackIndex, filteredFeatures, igv, igvBrowser)
   }

--- a/cell-filtering-igv/index.html
+++ b/cell-filtering-igv/index.html
@@ -63,37 +63,31 @@ function getIsFeatureInFrame(feature, igvBrowser) {
   return isFeatureInFrame
 }
 
-  function filterAtac() {
-    const trackIndex = 4 // Track index
-    const igvBrowser = window.igvBrowser
+function filterAtac() {
+  const trackIndex = 4 // Track index
+  const igvBrowser = window.igvBrowser
 
-    const scoreSelection = new Set([])
+  const scoreSelection = new Set([])
 
-    const originalChrFeatures = getOriginalChrFeatures(trackIndex, igvBrowser)
+  const originalChrFeatures = getOriginalChrFeatures(trackIndex, igvBrowser)
 
-    const inputs = document.querySelectorAll('.filters input')
-    inputs.forEach(input => {
-      if (input.checked) {
-        scoreSelection.add(parseInt(input.value))
-      }
-    })
-
-    console.log('scoreSelection')
-    console.log(scoreSelection)
-
-    if (scoreSelection.size === 0) {
-      return scoreSelection.originalChrFeatures
+  const inputs = document.querySelectorAll('.filters input')
+  inputs.forEach(input => {
+    if (input.checked) {
+      scoreSelection.add(parseInt(input.value))
     }
+  })
 
-    const filteredFeatures = originalChrFeatures.filter(
-      feature => scoreSelection.has(feature.score) && getIsFeatureInFrame(feature, igvBrowser)
-    )
-
-    console.log('filteredFeatures.length')
-    console.log(filteredFeatures.length)
-
-    updateTrack(trackIndex, filteredFeatures, igv, igvBrowser)
+  if (scoreSelection.size === 0) {
+    return scoreSelection.originalChrFeatures
   }
+
+  const filteredFeatures = originalChrFeatures.filter(
+    feature => scoreSelection.has(feature.score) && getIsFeatureInFrame(feature, igvBrowser)
+  )
+
+  updateTrack(trackIndex, filteredFeatures, igv, igvBrowser)
+}
     </script>
 </head>
 

--- a/test/js/explore/genome-view.test.js
+++ b/test/js/explore/genome-view.test.js
@@ -53,22 +53,23 @@ describe('IGV genome browser in Explore tab', () => {
 
     const filteredCellNames = new Set(['GAT-1', 'TAC-1', 'AGA-1'])
     const features = [
-      { name: 'GAT-1', score: 1 },
-      { name: 'TAC-1', score: 1 },
-      { name: 'AGA-1', score: 2 },
-      { name: 'AAA-1', score: 2 },
-      { name: 'TTT-1', score: 3 },
-      { name: 'CCC-1', score: 4 },
-      { name: 'GGG-1', score: 5 }
+      { name: 'GAT-1', score: 1, start: 125, end: 130 },
+      { name: 'TAC-1', score: 1, start: 125, end: 130 },
+      { name: 'AGA-1', score: 2, start: 97, end: 102 },
+      { name: 'AAA-1', score: 2, start: 125, end: 130 },
+      { name: 'TTT-1', score: 3, start: 125, end: 130 },
+      { name: 'CCC-1', score: 4, start: 125, end: 130 },
+      { name: 'GGG-1', score: 5, start: 125, end: 130 }
     ]
 
     const filteredFeatures = [
-      { name: 'GAT-1', score: 1 },
-      { name: 'TAC-1', score: 1 },
-      { name: 'AGA-1', score: 2 }
+      { name: 'GAT-1', score: 1, start: 125, end: 130 },
+      { name: 'TAC-1', score: 1, start: 125, end: 130 },
+      { name: 'AGA-1', score: 2, start: 97, end: 102 }
     ]
 
     const igvBrowser = {
+      referenceFrameList: [{ start: 100, end: 200 }],
       tracks: [{ trackView: { viewports: [{ featureCache: { chr: 'chr9' } }] } }],
       trackViews: [
         {}, {}, {}, {}, {


### PR DESCRIPTION
This drastically speeds up IGV filtering by cell annotations, making novel genome browser functionality a delight to use.

Here's how it looks!

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/c257354e-4bd9-4b67-804b-b71187daf90b

### Overview
[Previously](https://github.com/broadinstitute/single_cell_portal_core/pull/2053), filtering in IGV was new and transformative, but painfully slow.  It took 10-30 seconds to filter.  That was drastically faster than writing code, running it, and uploading new tracks. But that's still much slower than users expect in a web app.

Now, IGV filtering is instant.  This is achieved by only applying filter logic to genomic features that are in-frame, i.e. in the current genomic window in igv.js.  These genomic features are typically fully contained in the frame, but can also merely partly overlap at left (i.e. upstream) or right (downstream) of the genomic coordinates in view.

### Next steps
Filtering is fast now, but still brittle.  For example, panning to left or right or zooming out will not show genomic features that should be there.  Searching for a new gene also still makes things go awry in the genome browser.  This PR doesn't fully satisfy SCP-5662, but helps show this prototype filtering to stakeholders.  Robustness improvements are next.

### Test
An automated test was updated to account for this change.  If you'd like to manually test:
1. Go to a multiome study
2. Search a gene
3. Apply filters
4. Confirm genomic features in IGV track update, and quickly

This relates to SCP-5662.
