### PR TITLE
Removing Google Analytics tracking (SCP-5670)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -651,20 +651,6 @@ function flipToggleSwitch(toggle) {
     jqToggle.html(newText)
 }
 
-// function to call Google Analytics whenever AJAX call is made
-// must be called manually from every AJAX success or js page render
-function gaTracker(id){
-    $.getScript('https://www.google-analytics.com/analytics.js'); // jQuery shortcut
-    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-    ga('create', id, 'auto');
-    ga('send', 'pageview');
-}
-
-function gaTrack(path, title) {
-    ga('set', { page: path, title: title });
-    ga('send', 'pageview');
-}
-
 // decode an HTML-encoded string
 function unescapeHTML(encodedStr) {
     return $("<div/>").html(encodedStr).text();

--- a/app/javascript/components/explore/GenomeView.jsx
+++ b/app/javascript/components/explore/GenomeView.jsx
@@ -453,8 +453,7 @@ async function initializeIgv(containerId, tracks, gtfFiles, uniqueGenes, queried
     return markup
   })
 
-  // Log igv.js initialization in Google Analytics
-  ga('send', 'event', 'igv', 'initialize')
+  // Log igv.js initialization
   log('igv:initialize')
 }
 

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -241,9 +241,6 @@ function logClickButton(target) {
   const props = getStandardClickProps(target)
   const { eventName, updatedProps } = getEventPropsWithTabsApplied(target, props, 'click:button')
   log(eventName, updatedProps)
-
-  // Google Analytics fallback: remove once Bard and Mixpanel are ready for SCP
-  ga('send', 'event', 'click', 'button') // eslint-disable-line no-undef
 }
 
 /**

--- a/app/javascript/lib/scp-api-metrics.js
+++ b/app/javascript/lib/scp-api-metrics.js
@@ -49,7 +49,6 @@ export function logScatterPlot(
  * Log create user annotation metrics
  */
 export function logCreateUserAnnotation() {
-  ga('send', 'event', 'engaged_user_action', 'create_custom_cell_annotation')
   log('create-custom-cell-annotation')
 }
 
@@ -98,5 +97,4 @@ export function logDownloadAuthorization(perfTimes, fileIds, azulFiles) {
   const numAzulFiles = getNumAzulFiles(azulFiles)
   const props = { perfTimes, 'numSCPFiles': fileIds.length, numAzulFiles }
   log('download-authorization', props)
-  ga('send', 'event', 'advanced-search', 'download-authorization') // eslint-disable-line no-undef, max-len
 }

--- a/app/javascript/lib/search-metrics.js
+++ b/app/javascript/lib/search-metrics.js
@@ -62,12 +62,6 @@ export function logFilterSearch(facet, terms) {
   const defaultProps = { facet, terms }
   const props = Object.assign(defaultProps, { numTerms })
   log('search-filter', props)
-
-  // Google Analytics fallback: remove once Bard and Mixpanel are ready for SCP
-  ga( // eslint-disable-line no-undef
-    'send', 'event', 'advanced-search', 'search-filter',
-    'num-terms', numTerms
-  )
 }
 
 /**
@@ -173,11 +167,6 @@ export function logSearch(type, searchParams, perfTimes, searchResults) {
     gaEventCategory += `-${preset}`
   }
 
-  // Google Analytics fallback: remove once Bard and Mixpanel are ready for SCP
-  ga( // eslint-disable-line no-undef
-    'send', 'event', gaEventCategory, 'study-search',
-    'num-terms', numTerms
-  )
 }
 
 /**

--- a/app/views/layouts/_external_resources_view.html.erb
+++ b/app/views/layouts/_external_resources_view.html.erb
@@ -6,12 +6,3 @@
                 data: {toggle: 'tooltip'} %>
   <% end %>
 </p>
-
-<script nonce="<%= content_security_policy_script_nonce %>">
-
-    $('.external-resource-link').on('click', function() {
-        var linkHref = $(this).attr('href');
-        gaTrack(linkHref, 'Single Cell Portal | External Resource Click');
-    });
-
-</script>

--- a/app/views/layouts/_ga_script.js.erb
+++ b/app/views/layouts/_ga_script.js.erb
@@ -1,1 +1,0 @@
-gaTrack('<%= javascript_safe_url(request.fullpath) %>', 'Single Cell Portal');

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,7 @@
       window.MAX_GENE_SEARCH = <%= StudySearchService::MAX_GENE_SEARCH %>;
       window.MAX_GENE_SEARCH_MSG = '<%= StudySearchService::MAX_GENE_SEARCH_MSG %>';
 
+      window.SCP.analyticsPageName = '<%= get_page_name %>';
       window.SCP.currentStudyAccession = '<%= @study&.accession %>';
 
       // if we had search forms to preserve, recall and resubmit

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,6 @@
     /*! js-cookie v2.2.1 | MIT */
     !function(a){var b;if("function"==typeof define&&define.amd&&(define(a),b=!0),"object"==typeof exports&&(module.exports=a(),b=!0),!b){var c=window.Cookies,d=window.Cookies=a();d.noConflict=function(){return window.Cookies=c,d}}}(function(){function a(){for(var a=0,b={};a<arguments.length;a++){var c=arguments[a];for(var d in c)b[d]=c[d]}return b}function b(a){return a.replace(/(%[0-9A-Z]{2})+/g,decodeURIComponent)}function c(d){function e(){}function f(b,c,f){if("undefined"!=typeof document){f=a({path:"/"},e.defaults,f),"number"==typeof f.expires&&(f.expires=new Date(1*new Date+864e5*f.expires)),f.expires=f.expires?f.expires.toUTCString():"";try{var g=JSON.stringify(c);/^[\{\[]/.test(g)&&(c=g)}catch(j){}c=d.write?d.write(c,b):encodeURIComponent(c+"").replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g,decodeURIComponent),b=encodeURIComponent(b+"").replace(/%(23|24|26|2B|5E|60|7C)/g,decodeURIComponent).replace(/[\(\)]/g,escape);var h="";for(var i in f)f[i]&&(h+="; "+i,!0!==f[i]&&(h+="="+f[i].split(";")[0]));return document.cookie=b+"="+c+h}}function g(a,c){if("undefined"!=typeof document){for(var e={},f=document.cookie?document.cookie.split("; "):[],g=0;g<f.length;g++){var h=f[g].split("="),i=h.slice(1).join("=");c||'"'!==i.charAt(0)||(i=i.slice(1,-1));try{var j=b(h[0]);if(i=(d.read||d)(i,j)||b(i),c)try{i=JSON.parse(i)}catch(k){}if(e[j]=i,a===j)break}catch(k){}}return a?e[a]:e}}return e.set=f,e.get=function(a){return g(a,!1)},e.getJSON=function(a){return g(a,!0)},e.remove=function(b,c){f(b,"",a(c,{expires:-1}))},e.defaults={},e.withConverter=c,e}return c(function(){})});
   </script>
-  <script nonce="<%= content_security_policy_script_nonce %>" src="https://www.google-analytics.com/analytics.js"></script>
   <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
 
       window.SCP = {};
@@ -22,8 +21,6 @@
       window.MAX_GENE_SEARCH = <%= StudySearchService::MAX_GENE_SEARCH %>;
       window.MAX_GENE_SEARCH_MSG = '<%= StudySearchService::MAX_GENE_SEARCH_MSG %>';
 
-      window.SCP.gaTrackingId = '<%= ENV['GA_TRACKING_ID'] %>';
-      window.SCP.analyticsPageName = '<%= get_page_name %>';
       window.SCP.currentStudyAccession = '<%= @study&.accession %>';
 
       // if we had search forms to preserve, recall and resubmit
@@ -63,10 +60,6 @@
       // stats for search UI
       window.SCP.studyStats = <%= ReportTimePoint.get_latest_report(ReportTimePoint::STUDY_COUNTS).value.to_json.html_safe %>;
 
-      window.ga=window.ga||function() {(ga.q=ga.q||[]).push(arguments)}; ga.l=+new Date
-      ga('create', window.SCP.gaTrackingId, 'auto')
-      ga('set', 'userId', window.SCP.userId)
-
   </script>
 
   <%= stylesheet_link_tag 'application', media: 'all' %>
@@ -103,9 +96,6 @@
   %>
 
   <%= nonced_javascript_include_tag "https://cdn.datatables.net/plug-ins/1.10.15/sorting/natural.js" %>
-  <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
-      gaTrack('<%= javascript_safe_url(request.fullpath) %>', 'Single Cell Portal');
-  </script>
 
 <% if DeploymentNotification.present?  %>
      <%= render '/layouts/nav', :deployment_notification => @deployment_notification  %>
@@ -225,15 +215,6 @@
 
     // enable default behaviors
     enableDefaultActions();
-
-    // listener to track downloads for reporting
-    $('.dl-link').click(function() {
-        var url = $(this).attr('href');
-        $.ajax({
-            url: '<%= log_action_path %>?url_string=' + url,
-            dataType: 'script'
-        });
-    });
 
     // adjusting margins on page when notification banner is present
     $(document).ready(function() {


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update removes Google Analytics integration and any associated methods/libraries.  Our GA tracking has been disabled since July of last year, and all associated data is scheduled to be purged on July 1, 2024.  Since the vast majority of analytics has moved to Mixpanel, GA is no longer strictly necessary.  We will lose historical data, but that has been exported from GA to our shared portal drive: https://drive.google.com/drive/u/0/folders/133c49urwFi8hCOf3ueD5dRR0Tn67N9IL

The only remaining utility in GA was being able to get counts on numbers of users in various countries for inclusion in proposals.  There is a ticket in the backlog (SCP-5134) to ask about adding this to Mixpanel user tracking.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Open the Dev Tools > Network tab and enter `google-analytics.com` in the filter box
3. Click around the application and confirm you do not see any requests to the `/collect` endpoint for GA
4. Confirm normal tracking to Mixpanel (filter by `event`) is still enabled, and that normal functionality (search, visualizations) is not impacted