### PR TITLE
Fixing scatter plot legends in spatial UX (SCP-5626)

### DIFF
--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -613,7 +613,7 @@ function UnfoundGenesContainer({ unfoundGenes, searchedGenes, setSearchedGenes }
 export default function DifferentialExpressionPanel({
   deGroup, deGenes, searchGenes,
   exploreInfo, exploreParamsWithDefaults, setShowDeGroupPicker, setDeGenes, setDeGroup,
-  countsByLabel, hasOneVsRestDe, hasPairwiseDe, isAuthorDe, deHeaders, deGroupB, setDeGroupB, numRows=50
+  countsByLabelForDe, hasOneVsRestDe, hasPairwiseDe, isAuthorDe, deHeaders, deGroupB, setDeGroupB, numRows=50
 }) {
   const clusterName = exploreParamsWithDefaults?.cluster
   const bucketId = exploreInfo?.bucketId
@@ -742,7 +742,7 @@ export default function DifferentialExpressionPanel({
           setDeGenes={setDeGenes}
           deGroup={deGroup}
           setDeGroup={setDeGroup}
-          countsByLabel={countsByLabel}
+          countsByLabelForDe={countsByLabelForDe}
           deObjects={deObjects}
           setDeFilePath={setDeFilePath}
           isAuthorDe={isAuthorDe}
@@ -760,7 +760,7 @@ export default function DifferentialExpressionPanel({
           setDeGenes={setDeGenes}
           deGroup={deGroup}
           setDeGroup={setDeGroup}
-          countsByLabel={countsByLabel}
+          countsByLabelForDe={countsByLabelForDe}
           deObjects={deObjects}
           setDeFilePath={setDeFilePath}
           deGroupB={deGroupB}

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -195,7 +195,7 @@ function getIsAuthorDe(exploreInfo, exploreParams) {
  *  */
 export default function ExploreDisplayPanelManager({
   studyAccession, exploreInfo, setExploreInfo, exploreParams, updateExploreParams, clearExploreParams,
-  exploreParamsWithDefaults, routerLocation, searchGenes, countsByLabel, setShowUpstreamDifferentialExpressionPanel,
+  exploreParamsWithDefaults, routerLocation, searchGenes, countsByLabelForDe, setShowUpstreamDifferentialExpressionPanel,
   setShowDifferentialExpressionPanel, showUpstreamDifferentialExpressionPanel, togglePanel, shownTab,
   showDifferentialExpressionPanel, setIsCellSelecting, currentPointsSelected, isCellSelecting, deGenes,
   setDeGenes, setShowDeGroupPicker,
@@ -546,7 +546,7 @@ export default function ExploreDisplayPanelManager({
           exploreInfo={exploreInfo}
           studyAccession={studyAccession}
         />}
-        {panelToShow === 'differential-expression' && countsByLabel && annotHasDe &&
+        {panelToShow === 'differential-expression' && countsByLabelForDe && annotHasDe &&
           <>
             <DifferentialExpressionPanel
               deGroup={deGroup}
@@ -565,7 +565,7 @@ export default function ExploreDisplayPanelManager({
               deHeaders={deHeaders}
               deGroupB={deGroupB}
               setDeGroupB={setDeGroupB}
-              countsByLabel={countsByLabel}
+              countsByLabelForDe={countsByLabelForDe}
               togglePanel={togglePanel}
             />
           </>

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -249,6 +249,9 @@ export default function ExploreDisplayTabs({
   const [clusterCanFilter, setClusterCanFilter] = useState(true)
   const [filterErrorText, setFilterErrorText] = useState(null)
 
+  // map of colors for maintaining associations in spatial UX
+  const [refColorMap, setRefColorMap] = useState({})
+
   const {
     enabledTabs, disabledTabs, isGeneList, isGene, isMultiGene, hasIdeogramOutputs
   } = getEnabledTabs(exploreInfo, exploreParamsWithDefaults, cellFaceting)
@@ -556,7 +559,9 @@ export default function ExploreDisplayTabs({
                     setCountsByLabelForDe,
                     dataCache,
                     filteredCells,
-                    cellFilteringSelection
+                    cellFilteringSelection,
+                    refColorMap,
+                    setRefColorMap
                   }}/>
               </div>
             }

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -251,6 +251,8 @@ export default function ExploreDisplayTabs({
 
   // map of colors for maintaining associations in spatial UX
   const [refColorMap, setRefColorMap] = useState({})
+  // state tracker to ensure that spatial/secondary plots update with correct color map after main plot finishes
+  const [refClusterRendered, setRefClusterRendered] = useState(false)
 
   const {
     enabledTabs, disabledTabs, isGeneList, isGene, isMultiGene, hasIdeogramOutputs
@@ -561,7 +563,9 @@ export default function ExploreDisplayTabs({
                     filteredCells,
                     cellFilteringSelection,
                     refColorMap,
-                    setRefColorMap
+                    setRefColorMap,
+                    refClusterRendered,
+                    setRefClusterRendered
                   }}/>
               </div>
             }

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -235,7 +235,7 @@ export default function ExploreDisplayTabs({
   const [panelToShow, setPanelToShow] = useState(initialPanel)
 
   // Hash of trace label names to the number of points in that trace
-  const [countsByLabel, setCountsByLabel] = useState(null)
+  const [countsByLabelForDe, setCountsByLabelForDe] = useState(null)
   const showDifferentialExpressionTable = (showViewOptionsControls && deGenes !== null)
   const plotContainerClass = 'explore-plot-tab-content'
 
@@ -511,10 +511,9 @@ export default function ExploreDisplayTabs({
                     showRelatedGenesIdeogram,
                     showViewOptionsControls
                   }}
+                  setCountsByLabelForDe={setCountsByLabelForDe}
                   isCellSelecting={isCellSelecting}
                   plotPointsSelected={plotPointsSelected}
-                  countsByLabel={countsByLabel}
-                  setCountsByLabel={setCountsByLabel}
                   updateExploreParams={updateExploreParams}
                 />
               </div>
@@ -525,14 +524,13 @@ export default function ExploreDisplayTabs({
                   studyAccession={studyAccession}
                   {...exploreParamsWithDefaults}
                   isCorrelatedScatter={true}
+                  setCountsByLabelForDe={setCountsByLabelForDe}
                   dimensionProps={{
                     numColumns: 1,
                     numRows: 1
                   }}
                   isCellSelecting={isCellSelecting}
                   plotPointsSelected={plotPointsSelected}
-                  countsByLabel={countsByLabel}
-                  setCountsByLabel={setCountsByLabel}
                   updateExploreParams={updateExploreParams}
                 />
               </div>
@@ -555,8 +553,7 @@ export default function ExploreDisplayTabs({
                     showViewOptionsControls,
                     showDifferentialExpressionTable,
                     scatterColor: exploreParamsWithDefaults.scatterColor,
-                    countsByLabel,
-                    setCountsByLabel,
+                    setCountsByLabelForDe,
                     dataCache,
                     filteredCells,
                     cellFilteringSelection
@@ -660,7 +657,7 @@ export default function ExploreDisplayTabs({
             exploreParamsWithDefaults={exploreParamsWithDefaults}
             routerLocation={routerLocation}
             searchGenes={searchGenes}
-            countsByLabel={countsByLabel}
+            countsByLabelForDe={countsByLabelForDe}
             setShowUpstreamDifferentialExpressionPanel={setShowUpstreamDifferentialExpressionPanel}
             showDifferentialExpressionPanel={showDifferentialExpressionPanel}
             setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}

--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -14,7 +14,7 @@ const MAX_PLOTS = PLOTLY_CONTEXT_NAMES.length
 export default function ScatterTab({
   exploreInfo, exploreParamsWithDefaults, updateExploreParamsWithDefaults, studyAccession, isGene, isMultiGene,
   plotPointsSelected, isCellSelecting, showRelatedGenesIdeogram, showViewOptionsControls, showDifferentialExpressionTable,
-  scatterColor, countsByLabel, setCountsByLabel, dataCache, filteredCells, cellFilteringSelection
+  scatterColor, setCountsByLabelForDe, dataCache, filteredCells, cellFilteringSelection
 }) {
   // maintain the map of plotly contexts to the params that generated the corresponding visualization
   const plotlyContextMap = useRef({})
@@ -47,8 +47,8 @@ export default function ScatterTab({
           <div className={isTwoColRow ? 'col-md-6' : 'col-md-12'} key={key}>
             <ScatterPlot
               {...{
-                studyAccession, plotPointsSelected, isCellSelecting, updateScatterColor,
-                countsByLabel, setCountsByLabel, updateExploreParams: updateExploreParamsWithDefaults
+                studyAccession, plotPointsSelected, isCellSelecting, updateScatterColor, setCountsByLabelForDe,
+                updateExploreParams: updateExploreParamsWithDefaults
               }}
               {...params}
               dataCache={dataCache}

--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -14,7 +14,7 @@ const MAX_PLOTS = PLOTLY_CONTEXT_NAMES.length
 export default function ScatterTab({
   exploreInfo, exploreParamsWithDefaults, updateExploreParamsWithDefaults, studyAccession, isGene, isMultiGene,
   plotPointsSelected, isCellSelecting, showRelatedGenesIdeogram, showViewOptionsControls, showDifferentialExpressionTable,
-  scatterColor, setCountsByLabelForDe, dataCache, filteredCells, cellFilteringSelection
+  scatterColor, setCountsByLabelForDe, dataCache, filteredCells, cellFilteringSelection, refColorMap, setRefColorMap
 }) {
   // maintain the map of plotly contexts to the params that generated the corresponding visualization
   const plotlyContextMap = useRef({})
@@ -62,6 +62,8 @@ export default function ScatterTab({
                 showRelatedGenesIdeogram, showViewOptionsControls,
                 showDifferentialExpressionTable
               }}
+              refColorMap={refColorMap}
+              setRefColorMap={setRefColorMap}
             />
           </div>,
           rowDivider

--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -36,7 +36,7 @@ export default function ScatterTab({
   return <div className="row">
     {
       scatterParams.map((params, index) => {
-        const isRefCluster = params.cluster === exploreParamsWithDefaults.cluster && !isGene
+        const isRefCluster = params.cluster === exploreParamsWithDefaults.cluster && params.genes.length === 0
         const isTwoColRow = isTwoColumn && !(index === 0 && firstRowSingleCol)
         const key = getKeyFromScatterParams(params)
         let rowDivider = <span key={`d${index}`}></span>

--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -14,13 +14,13 @@ const MAX_PLOTS = PLOTLY_CONTEXT_NAMES.length
 export default function ScatterTab({
   exploreInfo, exploreParamsWithDefaults, updateExploreParamsWithDefaults, studyAccession, isGene, isMultiGene,
   plotPointsSelected, isCellSelecting, showRelatedGenesIdeogram, showViewOptionsControls, showDifferentialExpressionTable,
-  scatterColor, setCountsByLabelForDe, dataCache, filteredCells, cellFilteringSelection, refColorMap, setRefColorMap
+  scatterColor, setCountsByLabelForDe, dataCache, filteredCells, cellFilteringSelection, refColorMap, setRefColorMap,
+  refClusterRendered, setRefClusterRendered
 }) {
   // maintain the map of plotly contexts to the params that generated the corresponding visualization
   const plotlyContextMap = useRef({})
   const { scatterParams, isTwoColumn, isMultiRow, firstRowSingleCol } =
     getScatterParams(exploreParamsWithDefaults, isGene, isMultiGene)
-
   /** helper function for Scatter plot color updates */
   function updateScatterColor(color) {
     updateExploreParamsWithDefaults({ scatterColor: color }, false)
@@ -36,6 +36,7 @@ export default function ScatterTab({
   return <div className="row">
     {
       scatterParams.map((params, index) => {
+        const isRefCluster = params.cluster === exploreParamsWithDefaults.cluster
         const isTwoColRow = isTwoColumn && !(index === 0 && firstRowSingleCol)
         const key = getKeyFromScatterParams(params)
         let rowDivider = <span key={`d${index}`}></span>
@@ -64,6 +65,9 @@ export default function ScatterTab({
               }}
               refColorMap={refColorMap}
               setRefColorMap={setRefColorMap}
+              isRefCluster={isRefCluster}
+              refClusterRendered={refClusterRendered}
+              setRefClusterRendered={setRefClusterRendered}
             />
           </div>,
           rowDivider

--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -36,7 +36,7 @@ export default function ScatterTab({
   return <div className="row">
     {
       scatterParams.map((params, index) => {
-        const isRefCluster = params.cluster === exploreParamsWithDefaults.cluster
+        const isRefCluster = params.cluster === exploreParamsWithDefaults.cluster && !isGene
         const isTwoColRow = isTwoColumn && !(index === 0 && firstRowSingleCol)
         const key = getKeyFromScatterParams(params)
         let rowDivider = <span key={`d${index}`}></span>

--- a/app/javascript/components/visualization/PlotTitle.jsx
+++ b/app/javascript/components/visualization/PlotTitle.jsx
@@ -32,7 +32,7 @@ export function getTitleTexts(cluster, genes, consensus, subsample, isCorrelated
   let titleText = cluster
   let detailText = ''
 
-  if (genes.length) {
+  if (genes?.length) {
     const geneList = formatGeneList(genes)
     if (isCorrelatedScatter) {
       geneList.splice(1, 0, <span key="vs"> vs. </span>)

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -801,7 +801,7 @@ function getPlotlyTraces({
 }
 
 
-// handler to merge in new entries to the refColorMap (used for keeping track of trace colors across spatial plots
+// handler to merge in new entries to the refColorMap (used for keeping track of trace colors across spatial plots)
 function updateRefColorMap(setRefColorMap, color, traceName) {
   const colorEntry = {}
   colorEntry[traceName] = color

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -45,10 +45,11 @@ window.Plotly = Plotly
 function RawScatterPlot({
   studyAccession, cluster, annotation, subsample, consensus, genes, scatterColor, dimensionProps,
   isAnnotatedScatter=false, isCorrelatedScatter=false, isCellSelecting=false, plotPointsSelected, dataCache,
-  canEdit, bucketId, expressionFilter=[0, 1],
-  countsByLabel, setCountsByLabel, hiddenTraces=[], isSplitLabelArrays, updateExploreParams,
+  canEdit, bucketId, expressionFilter=[0, 1], setCountsByLabelForDe, hiddenTraces=[],
+  isSplitLabelArrays, updateExploreParams,
   filteredCells
 }) {
+  const [countsByLabel, setCountsByLabel] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
   const [bulkCorrelation, setBulkCorrelation] = useState(null)
   const [labelCorrelations, setLabelCorrelations] = useState(null)
@@ -189,6 +190,7 @@ function RawScatterPlot({
     })
     if (isRG) {
       setCountsByLabel(labelCounts)
+      setCountsByLabelForDe(labelCounts)
     }
     return traces
   }

--- a/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
+++ b/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
@@ -147,10 +147,10 @@ function getMatchingDeOption(
 /** Pick groups of cells for pairwise differential expression (DE) */
 export function PairwiseDifferentialExpressionGroupPicker({
   bucketId, clusterName, annotation, deGenes, deGroup, setDeGroup,
-  setDeGenes, countsByLabel, deObjects, setDeFilePath,
+  setDeGenes, countsByLabelForDe, deObjects, setDeFilePath,
   deGroupB, setDeGroupB, hasOneVsRestDe, significanceMetric
 }) {
-  const groups = getLegendSortedLabels(countsByLabel)
+  const groups = getLegendSortedLabels(countsByLabelForDe)
 
   const defaultGroupsB = []
   const [deGroupsB, setDeGroupsB] = useState(defaultGroupsB)
@@ -251,9 +251,9 @@ export function PairwiseDifferentialExpressionGroupPicker({
 /** Pick groups of cells for one-vs-rest-only differential expression (DE) */
 export function OneVsRestDifferentialExpressionGroupPicker({
   bucketId, clusterName, annotation, deGenes, deGroup, setDeGroup, setDeGenes,
-  countsByLabel, deObjects, setDeFilePath, isAuthorDe
+  countsByLabelForDe, deObjects, setDeFilePath, isAuthorDe
 }) {
-  let groups = getLegendSortedLabels(countsByLabel)
+  let groups = getLegendSortedLabels(countsByLabelForDe)
   groups = groups.filter(group => {
     const deOption = getMatchingDeOption(deObjects, group, clusterName, annotation)
     return deOption !== undefined

--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
@@ -210,7 +210,7 @@ export default function ScatterPlotLegend({
   updateHiddenTraces, customColors, editedCustomColors, setEditedCustomColors, setCustomColors,
   enableColorPicking=false, activeTraceLabel, setActiveTraceLabel,
   isSplitLabelArrays, updateIsSplitLabelArrays, hasArrayLabels,
-  externalLink, saveCustomColors, originalLabels, titleTexts, plotWidth
+  externalLink, saveCustomColors, originalLabels, titleTexts, plotWidth, refColorMap
 }) {
   // is the user currently in color-editing mode
   const [showColorControls, setShowColorControls] = useState(false)
@@ -282,7 +282,7 @@ export default function ScatterPlotLegend({
   /** create mapping of labels and colors of full label list (used for filtered legends) */
   const fullLabelsMappedToColor = labels.map((label, i) => {
     const colorIndex = getColorIndex(label, i)
-    const iconColor = getColorForLabel(label, customColors, editedCustomColors, colorIndex)
+    const iconColor = getColorForLabel(label, customColors, editedCustomColors, refColorMap, colorIndex)
     return { label, iconColor }
   })
 
@@ -439,7 +439,7 @@ export default function ScatterPlotLegend({
           const colorIndex = getColorIndex(label, i)
           const iconColor = showLegendSearch ?
             getColorForLabelIcon(label) :
-            getColorForLabel(label, customColors, editedCustomColors, colorIndex)
+            getColorForLabel(label, customColors, editedCustomColors, refColorMap, colorIndex)
           return (
             <LegendEntry
               key={label}

--- a/app/javascript/lib/plot.js
+++ b/app/javascript/lib/plot.js
@@ -272,7 +272,7 @@ PlotUtils.sortTraceByExpression = function(trace) {
 /**
  * Get color for the label, which can be applied to e.g. the icon or the trace
  */
-PlotUtils.getColorForLabel = function(label, customColors={}, editedCustomColors={}, i) {
+PlotUtils.getColorForLabel = function(label, customColors={}, editedCustomColors={}, refColorMap={}, i) {
   if ((label === UNSPECIFIED_ANNOTATION_NAME) &&
     !editedCustomColors[label] && !customColors[label]) {
     return 'rgba(80, 80, 80, 0.4)'
@@ -282,7 +282,7 @@ PlotUtils.getColorForLabel = function(label, customColors={}, editedCustomColors
     !editedCustomColors[label] && !customColors[label]) {
     return FILTERED_TRACE_COLOR
   }
-  return editedCustomColors[label] ?? customColors[label] ?? PlotUtils.getColorBrewerColor(i)
+  return editedCustomColors[label] ?? customColors[label] ?? refColorMap[label] ?? PlotUtils.getColorBrewerColor(i)
 }
 
 /** Sort annotation labels lexicographically, but always put the unspecified annotations last */

--- a/test/js/explore/differential-expression-panel.test.js
+++ b/test/js/explore/differential-expression-panel.test.js
@@ -60,7 +60,7 @@ describe('Differential expression panel', () => {
     const setDeGenes = function() {}
     const setDeGroup = function() {}
 
-    const countsByLabel = {
+    const countsByLabelForDe = {
       'LC2': 35398,
       'GPMNB macrophages': 5318,
       'LC1': 4427,
@@ -88,7 +88,7 @@ describe('Differential expression panel', () => {
         setShowDeGroupPicker={setShowDeGroupPicker}
         setDeGenes={setDeGenes}
         setDeGroup={setDeGroup}
-        countsByLabel={countsByLabel}
+        countsByLabelForDe={countsByLabelForDe}
         deHeaders={deHeaders}
       />
     ))
@@ -174,7 +174,7 @@ describe('Differential expression panel', () => {
     const setDeFilePath = function() {}
     const setDeGroupB = function() {}
 
-    const countsByLabel = {
+    const countsByLabelForDe = {
       'LC2': 35398,
       'GPMNB macrophages': 5318,
       'LC1': 4427,
@@ -200,7 +200,7 @@ describe('Differential expression panel', () => {
         setDeGenes={setDeGenes}
         deGroup={deGroup}
         setDeGroup={setDeGroup}
-        countsByLabel={countsByLabel}
+        countsByLabelForDe={countsByLabelForDe}
         deObjects={deObjects}
         setDeFilePath={setDeFilePath}
         deGroupB={deGroupB}

--- a/test/js/explore/scatter-tab.test.js
+++ b/test/js/explore/scatter-tab.test.js
@@ -179,6 +179,8 @@ describe('getNewContextMap correctly assigns contexts', () => {
         dataCache={createCache()}
         setCountsByLabel={function() {}}
         countsByLabel={[]}
+        setRefColorMap={jest.fn()}
+        setRefClusterRendered={jest.fn()}
       />
     ))
 

--- a/test/js/visualization/scatter-plot.test-data.js
+++ b/test/js/visualization/scatter-plot.test-data.js
@@ -2,7 +2,7 @@
 
 export const COUNTS_BY_LABEL = {
   'A.Rather.Long.Label.With.Several.Periods': 17,
-  'A': 34,
+  'A': 32,
   'An_underscored_label': 19,
   'B label with space and number 4': 18,
   'B': 18,
@@ -33,6 +33,21 @@ export const COUNTS_BY_LABEL = {
   'C 25': 1,
   'C 26': 1
 }
+
+const colorBrewerList = [
+  '#e41a1c', '#377eb8', '#4daf4a', '#984ea3', '#ff7f00', '#a65628',
+  '#f781bf', '#999999', '#66c2a5', '#fc8d62', '#8da0cb', '#e78ac3',
+  '#a6d854', '#ffd92f', '#e5c494', '#b3b3b3', '#8dd3c7', '#bebada',
+  '#fb8072', '#80b1d3', '#fdb462', '#b3de69', '#fccde5', '#d9d9d9',
+  '#bc80bd', '#ccebc5', '#ffed6f'
+]
+
+const refColorMap = {}
+Object.keys(COUNTS_BY_LABEL).map((label, index) => {
+  refColorMap[label] = colorBrewerList[index % 27]
+})
+
+export const REF_COLOR_MAP = refColorMap
 
 export const BASIC_PLOT_DATA = {
   scatter: {
@@ -193,8 +208,6 @@ export const MANY_LABELS_MOCKS = {
             'C 24',
             'C 25',
             'C 26'
-
-
           ],
           scope: 'cluster',
           cluster_name: 'cluster_many_long_odd_labels.tsv'
@@ -378,8 +391,6 @@ export const MANY_LABELS_MOCKS = {
         'A',
         'A',
         'A',
-        'A',
-        'A',
         'B label with space and number 4',
         'B label with space and number 4',
         'B label with space and number 4',
@@ -439,7 +450,9 @@ export const MANY_LABELS_MOCKS = {
         'C 21',
         'C 22',
         'C 23',
-        'C 24'
+        'C 24',
+        'C 25',
+        'C 26'
       ],
       cells: [
         'AH_1',

--- a/test/js/visualization/scatter-plot.test.js
+++ b/test/js/visualization/scatter-plot.test.js
@@ -16,7 +16,7 @@ import * as LayoutUtils from 'lib/layout-utils'
 
 import '@testing-library/jest-dom/extend-expect'
 
-import { BASIC_PLOT_DATA, MANY_LABELS_MOCKS, COUNTS_BY_LABEL } from './scatter-plot.test-data'
+import { BASIC_PLOT_DATA, MANY_LABELS_MOCKS, COUNTS_BY_LABEL, REF_COLOR_MAP } from './scatter-plot.test-data'
 
 const CACHE_PERF_PARAMS = {
   legacyBackend: 0,
@@ -62,7 +62,7 @@ it('shows custom legend with default group scatter plot', async () => {
   const fakeLog = jest.spyOn(MetricsApi, 'log')
   fakeLog.mockImplementation(() => {})
 
-  const countsByLabel = COUNTS_BY_LABEL
+  const refColorMap = REF_COLOR_MAP
 
   const getTextSizeSpy = jest.spyOn(LayoutUtils, 'getTextSize')
   getTextSizeSpy.mockImplementation(() => [10, 10])
@@ -82,8 +82,9 @@ it('shows custom legend with default group scatter plot', async () => {
         consensus: null,
         genes: [],
         dimensionProps: BASIC_DIMENSION_PROPS,
-        setCountsByLabel() {},
-        countsByLabel,
+        setCountsByLabelForDe() {},
+        refColorMap,
+        setRefColorMap() {},
         hiddenTraces: exploreParams.hiddenTraces,
         updateExploreParams: newParams => setExploreParams(newParams)
       }}/>
@@ -123,7 +124,7 @@ it('shows custom legend with default group scatter plot', async () => {
       numPoints: 19,
       numLabels: 31,
       wasShown: true,
-      iconColor: '#377eb8',
+      iconColor: '#4daf4a',
       hasCorrelations: false
     }
   )
@@ -132,6 +133,7 @@ it('shows custom legend with default group scatter plot', async () => {
 it('shows cluster external link', async () => {
   const scatterData = BASIC_PLOT_DATA.scatter
   const countsByLabel = COUNTS_BY_LABEL
+  const refColorMap = REF_COLOR_MAP
   const originalLabels = Object.keys(countsByLabel)
 
   const getTextSizeSpy = jest.spyOn(LayoutUtils, 'getTextSize')
@@ -146,10 +148,13 @@ it('shows cluster external link', async () => {
     hasArrayLabels={scatterData.hasArrayLabels}
     externalLink={BASIC_PLOT_DATA.externalLink}
     originalLabels={originalLabels}
+    refColorMap={refColorMap}
     titleTexts={titleTexts}
   />))
 
-  const { container } = render(<ScatterPlot/>)
+  const { container } = render((<ScatterPlot { ...{
+    annotation: { name: 'Category', type: 'group', scope: 'cluster'}, genes: []
+  }} />))
 
   await waitFor(() => {
     container.querySelectorAll('#study-scatter-1-legend').length > 0
@@ -162,6 +167,7 @@ it('shows cluster external link', async () => {
 it('shows legend search', async () => {
   const scatterData = BASIC_PLOT_DATA.scatter
   const countsByLabel = COUNTS_BY_LABEL
+  const refColorMap = REF_COLOR_MAP
   const originalLabels = Object.keys(countsByLabel)
 
   jest
@@ -183,6 +189,7 @@ it('shows legend search', async () => {
       hasArrayLabels={scatterData.hasArrayLabels}
       externalLink={BASIC_PLOT_DATA.externalLink}
       originalLabels={originalLabels}
+      refColorMap={refColorMap}
       titleTexts={titleTexts}
     />))
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes issues discovered with scatter plot legends when viewing multiple plots in the spatial UX.  Whenever a user selects a new spatial plot, every legend shown then updates the counts to use data from the newest spatial plot.  Additionally, if certain labels are missing from the newest plot, those legend entries are still shown but with a count of 0.

The cause was from a shared `useState` reference in `ExploreDisplayTabs` for setting label counts (this was done so it could be shared with various components in the differential expression UX).  Now, counts are managed at the `ScatterPlot` level instead of `ExploreDisplayTabs`.  Additionally, color assignments are now tracked using the main, non-spatial plot as the control.  Any additional spatial plots will use that color map to ensure that labels keep the same color assignment across all plots.

Note: you may see a brief flicker as colors are reassigned, this has to do with waiting for the main plot to finish rendering.

#### MANUAL TESTING
The easiest way to test this PR is to ingest data from [SCP1375](https://singlecell.broadinstitute.org/single_cell/study/SCP1375) (this is the study where the above bugs were found).  Only 4 files are needed for testing:
- [metadata.csv](https://singlecell.broadinstitute.org/single_cell/data/public/SCP1375/integrative-in-situ-mapping-of-single-cell-transcriptional-states-and-tissue-histopathology-in-an-alzheimer-disease-model?filename=metadata.csv) (Metadata file)
- [top_level_umap.csv](https://singlecell.broadinstitute.org/single_cell/data/public/SCP1375/integrative-in-situ-mapping-of-single-cell-transcriptional-states-and-tissue-histopathology-in-an-alzheimer-disease-model?filename=top_level_umap.csv) (Normal clustering)
- [spatial_8months-control-replicate_1.csv](https://singlecell.broadinstitute.org/single_cell/data/public/SCP1375/integrative-in-situ-mapping-of-single-cell-transcriptional-states-and-tissue-histopathology-in-an-alzheimer-disease-model?filename=spatial_8months-control-replicate_1.csv) (Spatial transcriptomics)
- [spatial_13months-disease-replicate_2.csv](https://singlecell.broadinstitute.org/single_cell/data/public/SCP1375/integrative-in-situ-mapping-of-single-cell-transcriptional-states-and-tissue-histopathology-in-an-alzheimer-disease-model?filename=spatial_13months-disease-replicate_2.csv) (Spatial transcriptomics)

1.  Boot all services and sign in
2. Create a new study and ingest the 4 files above, making sure to upload the last two cluster files as spatial
3. Once all clustering/metadata have ingested, go to the Explore tab for this study (click "View study" at the top left of the upload wizard)
4. Load `top_level_umap.csv` and `top_level_cell_type` as the annotation
5. In the Spatial groups menu, select `spatial_8months-control-replicate_1.csv`
6. Confirm the count for `Astro` is **6789** for `top_level_umap.csv` and **919** for `spatial_8months-control-replicate_1.csv`
7. Confirm that `spatial_8months-control-replicate_1.csv` does not have the group `LHb`, and the color for `Micro` and the remaining labels match in both plots
8. Add `spatial_13months-disease-replicate_2.csv` from the spatial groups menu
9. Confirm the count for `Astro` is **927** and that it has the `LHb` group with a count of **65** and the correct color 
10. Change the annotation multiple times (including back to a value you've already selected) and confirm that color assignments match across all plots.
    * If you select `Hide all` in the legend for the main plot then scroll to the bottom and select the last entry, this is a quick way to ensure that assignments have stayed consistent across all plots.