### PR TITLE
Ignore author DE studies on backfill (SCP-5682)

### DIFF
--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -181,6 +181,10 @@ class DifferentialExpressionService
     total_jobs = 0
     study_results = {}
     accessions.each do |accession|
+      if study.differential_expression_results.author.any?
+        log_message "#{accession} has author-uploaded results, skipping"
+      end
+      author
       begin
         jobs = run_differential_expression_on_all(accession, skip_existing: true)
         if jobs > 0

--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -181,10 +181,14 @@ class DifferentialExpressionService
     total_jobs = 0
     study_results = {}
     accessions.each do |accession|
-      if study.differential_expression_results.author.any?
+      study = Study.find_by(accession:)
+      next if study.nil?
+
+      if study_has_author_de?(study)
         log_message "#{accession} has author-uploaded results, skipping"
+        next
       end
-      author
+
       begin
         jobs = run_differential_expression_on_all(accession, skip_existing: true)
         if jobs > 0


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug with differential expression backfill where studies that have author-uploaded DE results are not correctly ignored.  Current policy is that any author-uploaded DE results supersede automatic calculations, meaning that previous automatic results are deleted, and future calculations are skipped (see [here](https://github.com/broadinstitute/single_cell_portal_core/blob/development/app/lib/differential_expression_service.rb#L298)).  However, the `DifferentialExpressionService.backfill_new_results` method did not honor this check.  Now, any study with author-uploaded DE results will be ignored when running future backfill operations.

#### MANUAL TESTING
If you haven't uploaded a `Differential Expression` file, please follow the steps from #1874 to add this file to an existing study.

1. Open a Rails console session and find a study that has author DE files (your accession will be different):
```
DifferentialExpressionResult.where(is_author_de: true).first.study.accession
=> "SCP66"
```
2. Run the backfill for this study only and confirm that no jobs are launched:
```
DifferentialExpressionService.backfill_new_results(study_accessions: ["SCP66"])

SCP66 has author-uploaded results, skipping
Total new backfill jobs: 0 across 0 studies
=> {:total_jobs=>0}                       

```