### PR TITLE
Prevent rendering spatial plots with missing cluster-based annotations (SCP-5671)

### DIFF
--- a/app/javascript/components/upload/MetadataStep.jsx
+++ b/app/javascript/components/upload/MetadataStep.jsx
@@ -34,7 +34,6 @@ function MetadataForm({
   updateFile,
   saveFile,
   deleteFile,
-  bucketName,
   isAnnDataExperience
 }) {
   const userState = useContext(UserContext)
@@ -42,6 +41,7 @@ function MetadataForm({
   const conventionRequired = featureFlagState && featureFlagState.convention_required
 
   const file = formState.files.find(metadataFileFilter)
+  const bucketName = formState.study.bucket_id
   const validationMessages = validateFile({
     file,
     allFiles: formState.files,

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -611,7 +611,7 @@ function RawScatterPlot({
       { ErrorComponent }
       { hasMissingAnnot &&
         <div className="alert-warning text-center error-boundary">
-          {cluster} does not have the requested annotation {loadedAnnotation}
+          "{cluster}" does not have the requested annotation "{loadedAnnotation}"
         </div>
       }
       { !hasMissingAnnot &&

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -344,11 +344,8 @@ function RawScatterPlot({
     scatter = updateScatterLayout(scatter)
 
     if (scatter.annotParams.identifier !== loadedAnnotation) {
-      const missingAnnot = new Error(`${cluster} does not have the requested annotation ${loadedAnnotation}`)
       setHasMissingAnnot(true)
       setIsLoading(false)
-      setShowError(true)
-      setError(missingAnnot)
     } else {
       setHasMissingAnnot(false)
       const annotIsNumeric = scatter.annotParams.type === 'numeric'
@@ -613,6 +610,11 @@ function RawScatterPlot({
   return (
     <div className="plot">
       { ErrorComponent }
+      { hasMissingAnnot &&
+        <div className="alert-warning text-center error-boundary">
+          {cluster} does not have the requested annotation {loadedAnnotation}
+        </div>
+      }
       { !hasMissingAnnot &&
         <PlotTitle
           titleTexts={titleTexts}
@@ -624,7 +626,7 @@ function RawScatterPlot({
         id={graphElementId}
         data-testid={graphElementId}
       >
-        { hasLegend &&
+        { !hasMissingAnnot && hasLegend &&
           <ScatterPlotLegend
             name={scatterData.annotParams.name}
             height={scatterData.height}
@@ -652,7 +654,7 @@ function RawScatterPlot({
         }
       </div>
       <p className="help-block">
-        { scatterData && scatterData.description &&
+        { scatterData && scatterData.description && !hasMissingAnnot &&
           <span style={descriptionStyle}>{scatterData.description}</span>
         }
       </p>

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -66,7 +66,6 @@ function RawScatterPlot({
   const [originalLabels, setOriginalLabels] = useState([])
   const [hasMissingAnnot, setHasMissingAnnot] = useState(null)
   const loadedAnnotation = [annotation.name, annotation.type, annotation.scope].join('--')
-
   const flags = getFeatureFlagsWithDefaults()
 
   // Uncomment when running Image Pipeline
@@ -776,11 +775,6 @@ function getPlotlyTraces({
       groupTrace.opacity = unfilteredTrace.opacity
       let color = getColorForLabel(groupTrace.name, customColors, editedCustomColors, refColorMap, labelIndex)
       if (isRefCluster) {
-        updateRefColorMap(setRefColorMap, color, groupTrace.name)
-      } else if (!isRefCluster && refClusterRendered) {
-        // don't re-use an existing color if extra plots have new groups
-        const newIndex = Object.keys(refColorMap).length + 1
-        color = getColorForLabel(groupTrace.name, customColors, editedCustomColors, refColorMap, newIndex)
         updateRefColorMap(setRefColorMap, color, groupTrace.name)
       }
       groupTrace.marker = {

--- a/test/js/explore/scatter-tab.test.js
+++ b/test/js/explore/scatter-tab.test.js
@@ -168,7 +168,7 @@ describe('getNewContextMap correctly assigns contexts', () => {
         exploreParamsWithDefaults={{
           cluster: 'clusterA',
           spatialGroups: ['spatialClusterA'],
-          annotation: { name: 'foo', type: 'group' },
+          annotation: { name: 'biosample_id', type: 'group', scope: 'study' },
           genes: ['farsa']
         }}
         updateExploreParamsWithDefaults={() => {}}

--- a/test/js/search/annotated-scatter-plot.test.js
+++ b/test/js/search/annotated-scatter-plot.test.js
@@ -48,7 +48,7 @@ describe('Annotated scatter plot in global gene search', () => {
         studyAccession={study.accession}
         genes={study.gene_matches}
         cluster=''
-        annotation={{name: '', type: '', scope: ''}}
+        annotation={{name: 'Intensity', type: 'numeric', scope: 'cluster'}}
         isAnnotatedScatter={study.is_default_annotation_numeric}
       />
     )


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes an issue where spatial plots will break when trying to load a cluster-based annotation that is available for the main scatter plot, but missing for the spatial plot(s).  Now, instead of an error, a warning is shown instead telling the user that the requested annotation is not available for the given spatial plot.

This also fixes an unrelated bug where the "Use bucket path" feature was not able to correctly validate/browse metadata files.

Quick demo:

https://github.com/broadinstitute/single_cell_portal_core/assets/729968/bdaee530-f377-4da6-8e0a-10da579f360c

#### MANUAL TESTING
The easiest way to test this is with two scatter plots from [SCP1756](https://singlecell.broadinstitute.org/single_cell/study/SCP1756) (you can also add the metadata but it is not strictly necessary):

- [umap_1month.txt](https://singlecell.broadinstitute.org/single_cell/data/public/SCP1756/cortical-organoids-atlas?filename=umap_1month.txt) (normal clustering)
- [umap_1month-org1-Slide-seq.txt](https://singlecell.broadinstitute.org/single_cell/data/public/SCP1756/cortical-organoids-atlas?filename=umap_1month-org1-Slide-seq.txt) (spatial)
- [meta_all.txt](https://singlecell.broadinstitute.org/single_cell/data/public/SCP1756/cortical-organoids-atlas?filename=meta_all.txt)

1. Create a new study with the above scatter plots, ensuring that `umap_1month-org1-Slide-seq.txt` is uploaded as spatial
2. Once ingested, go to the Explore tab for the new study and load the `umap_1month-org1-Slide-seq.txt` as an extra spatial scatter plot
3. Select the `CellType` cluster-based annotation and confirm that it loads correctly
4. Select the `Cluster` annotation and confirm that you see the warning that the spatial plot does not have the requested annotation 
