### PR TITLE
Only use refColorMap in multi-plot context (SCP-5692)

### DIFF
--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -25,6 +25,7 @@ export default function ScatterTab({
   function updateScatterColor(color) {
     updateExploreParamsWithDefaults({ scatterColor: color }, false)
   }
+  const hasMultipleRefs = exploreParamsWithDefaults?.spatialGroups?.length > 0
 
   // identify any repeat graphs
   const newContextMap = getNewContextMap(scatterParams, plotlyContextMap.current)
@@ -68,6 +69,7 @@ export default function ScatterTab({
               isRefCluster={isRefCluster}
               refClusterRendered={refClusterRendered}
               setRefClusterRendered={setRefClusterRendered}
+              hasMultipleRefs={hasMultipleRefs}
             />
           </div>,
           rowDivider

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -47,7 +47,7 @@ function RawScatterPlot({
   isAnnotatedScatter=false, isCorrelatedScatter=false, isCellSelecting=false, plotPointsSelected, dataCache,
   canEdit, bucketId, expressionFilter=[0, 1], setCountsByLabelForDe, hiddenTraces=[],
   isSplitLabelArrays, updateExploreParams, filteredCells, refColorMap, setRefColorMap, isRefCluster, refClusterRendered,
-  setRefClusterRendered
+  setRefClusterRendered, hasMultipleRefs
 }) {
   const [countsByLabel, setCountsByLabel] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -198,7 +198,7 @@ function RawScatterPlot({
       refColorMap,
       setRefColorMap,
       isRefCluster,
-      refClusterRendered
+      hasMultipleRefs
     })
     if (isRG) {
       setCountsByLabel(labelCounts)
@@ -719,7 +719,7 @@ function getPlotlyTraces({
   refColorMap,
   setRefColorMap,
   isRefCluster,
-  refClusterRendered
+  hasMultipleRefs
 }) {
   const unfilteredTrace = {
     type: is3D ? 'scatter3d' : 'scattergl',
@@ -755,7 +755,12 @@ function getPlotlyTraces({
       groupTrace.type = unfilteredTrace.type
       groupTrace.mode = unfilteredTrace.mode
       groupTrace.opacity = unfilteredTrace.opacity
-      const color = getColorForLabel(groupTrace.name, customColors, editedCustomColors, refColorMap, labelIndex)
+      let color
+      if (hasMultipleRefs) {
+        color = getColorForLabel(groupTrace.name, customColors, editedCustomColors, refColorMap, labelIndex)
+      } else {
+        color = getColorForLabel(groupTrace.name, customColors, editedCustomColors, {}, labelIndex)
+      }
       if (isRefCluster) {
         updateRefColorMap(setRefColorMap, color, groupTrace.name)
       }


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug introduced in #2070 where color assignments becomes skewed when switching back and forth between clustering plots in a non-spatial context.  Additionally, colors did not map correctly in a single- or multi-gene view.  Now, color assignments always reset between plots and are consistent across all gene-based views.

Note: this does not fix and existing bug with correlation scatter plots where color assignments are not consistent.

#### MANUAL TESTING
1. Boot as normal and load the `Human milk - differential expression` example study
2. Search for `CLDN4`
3. Confirm that `LC1` and `LC2` are pink & grey respectively and match in the scatter & violin tabs
4. Switch to the `Epithelial cells UMAP` and confirm `LC1` and `LC2` are now red & blue in both tabs
5. (Optional) re-check the steps from #2070 and confirm that spatial plot color assignments are still correct