### PR TITLE
Using persistent color maps for group-based annotations (SCP-5694)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -249,11 +249,6 @@ export default function ExploreDisplayTabs({
   const [clusterCanFilter, setClusterCanFilter] = useState(true)
   const [filterErrorText, setFilterErrorText] = useState(null)
 
-  // map of colors for maintaining associations in spatial UX
-  const [refColorMap, setRefColorMap] = useState({})
-  // state tracker to ensure that spatial/secondary plots update with correct color map after main plot finishes
-  const [refClusterRendered, setRefClusterRendered] = useState(false)
-
   const {
     enabledTabs, disabledTabs, isGeneList, isGene, isMultiGene, hasIdeogramOutputs
   } = getEnabledTabs(exploreInfo, exploreParamsWithDefaults, cellFaceting)
@@ -561,11 +556,7 @@ export default function ExploreDisplayTabs({
                     setCountsByLabelForDe,
                     dataCache,
                     filteredCells,
-                    cellFilteringSelection,
-                    refColorMap,
-                    setRefColorMap,
-                    refClusterRendered,
-                    setRefClusterRendered
+                    cellFilteringSelection
                   }}/>
               </div>
             }

--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -14,8 +14,7 @@ const MAX_PLOTS = PLOTLY_CONTEXT_NAMES.length
 export default function ScatterTab({
   exploreInfo, exploreParamsWithDefaults, updateExploreParamsWithDefaults, studyAccession, isGene, isMultiGene,
   plotPointsSelected, isCellSelecting, showRelatedGenesIdeogram, showViewOptionsControls, showDifferentialExpressionTable,
-  scatterColor, setCountsByLabelForDe, dataCache, filteredCells, cellFilteringSelection, refColorMap, setRefColorMap,
-  refClusterRendered, setRefClusterRendered
+  scatterColor, setCountsByLabelForDe, dataCache, filteredCells, cellFilteringSelection
 }) {
   // maintain the map of plotly contexts to the params that generated the corresponding visualization
   const plotlyContextMap = useRef({})
@@ -25,7 +24,6 @@ export default function ScatterTab({
   function updateScatterColor(color) {
     updateExploreParamsWithDefaults({ scatterColor: color }, false)
   }
-  const hasMultipleRefs = exploreParamsWithDefaults?.spatialGroups?.length > 0
 
   // identify any repeat graphs
   const newContextMap = getNewContextMap(scatterParams, plotlyContextMap.current)
@@ -37,7 +35,6 @@ export default function ScatterTab({
   return <div className="row">
     {
       scatterParams.map((params, index) => {
-        const isRefCluster = params.cluster === exploreParamsWithDefaults.cluster && params.genes.length === 0
         const isTwoColRow = isTwoColumn && !(index === 0 && firstRowSingleCol)
         const key = getKeyFromScatterParams(params)
         let rowDivider = <span key={`d${index}`}></span>
@@ -64,12 +61,6 @@ export default function ScatterTab({
                 showRelatedGenesIdeogram, showViewOptionsControls,
                 showDifferentialExpressionTable
               }}
-              refColorMap={refColorMap}
-              setRefColorMap={setRefColorMap}
-              isRefCluster={isRefCluster}
-              refClusterRendered={refClusterRendered}
-              setRefClusterRendered={setRefClusterRendered}
-              hasMultipleRefs={hasMultipleRefs}
             />
           </div>,
           rowDivider

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -390,6 +390,7 @@ function RawScatterPlot({
 
       scatter.hasArrayLabels =
         scatter.annotParams.type === 'group' && scatter.data.annotations.some(annot => annot?.includes('|'))
+    }
 
     if (clusterResponse) {
       concludeRender(scatter)

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -341,6 +341,10 @@ function RawScatterPlot({
       (clusterResponse ? clusterResponse : [scatterData, null])
     scatter = updateScatterLayout(scatter)
     const annotIsNumeric = scatter.annotParams.type === 'numeric'
+    if (isRefCluster && scatter.annotParams.color_map) {
+      setRefColorMap(scatter.annotParams.color_map)
+    }
+
     const layout = scatter.layout
 
     if (filteredCells) {
@@ -755,15 +759,7 @@ function getPlotlyTraces({
       groupTrace.type = unfilteredTrace.type
       groupTrace.mode = unfilteredTrace.mode
       groupTrace.opacity = unfilteredTrace.opacity
-      let color
-      if (hasMultipleRefs) {
-        color = getColorForLabel(groupTrace.name, customColors, editedCustomColors, refColorMap, labelIndex)
-      } else {
-        color = getColorForLabel(groupTrace.name, customColors, editedCustomColors, {}, labelIndex)
-      }
-      if (isRefCluster) {
-        updateRefColorMap(setRefColorMap, color, groupTrace.name)
-      }
+      const color = getColorForLabel(groupTrace.name, customColors, editedCustomColors, refColorMap, labelIndex)
       groupTrace.marker = {
         size: pointSize,
         color
@@ -816,16 +812,6 @@ function getPlotlyTraces({
   })
 
   return [traces, countsByLabel, isRefGroup]
-}
-
-
-// handler to merge in new entries to the refColorMap (used for keeping track of trace colors across spatial plots)
-function updateRefColorMap(setRefColorMap, color, traceName) {
-  const colorEntry = {}
-  colorEntry[traceName] = color
-  setRefColorMap(prevColorMap => ({
-    ...prevColorMap, ...colorEntry
-  }))
 }
 
 /** makes the data trace attributes (cells, trace name) available via hover text */

--- a/app/javascript/components/visualization/StudyViolinPlot.jsx
+++ b/app/javascript/components/visualization/StudyViolinPlot.jsx
@@ -329,7 +329,7 @@ function getViolinTraces(
             color: '#000000',
             opacity: 0.8
           },
-          fillcolor: getColorBrewerColor(index),
+          fillcolor: traceData.color,
           line: {
             color: '#000000',
             width: 1.5
@@ -346,7 +346,7 @@ function getViolinTraces(
           y: dist,
           boxpoints: showPoints,
           marker: {
-            color: getColorBrewerColor(index),
+            color: traceData.color,
             size: 2,
             line: {
               color: plotlyDefaultLineColor

--- a/app/javascript/lib/plot.js
+++ b/app/javascript/lib/plot.js
@@ -272,7 +272,7 @@ PlotUtils.sortTraceByExpression = function(trace) {
 /**
  * Get color for the label, which can be applied to e.g. the icon or the trace
  */
-PlotUtils.getColorForLabel = function(label, customColors={}, editedCustomColors={}, refColorMap={}, i) {
+PlotUtils.getColorForLabel = function(label, customColors={}, editedCustomColors={}, colorMap={}, i) {
   if ((label === UNSPECIFIED_ANNOTATION_NAME) &&
     !editedCustomColors[label] && !customColors[label]) {
     return 'rgba(80, 80, 80, 0.4)'
@@ -282,7 +282,7 @@ PlotUtils.getColorForLabel = function(label, customColors={}, editedCustomColors
     !editedCustomColors[label] && !customColors[label]) {
     return FILTERED_TRACE_COLOR
   }
-  return editedCustomColors[label] ?? customColors[label] ?? refColorMap[label] ?? PlotUtils.getColorBrewerColor(i)
+  return editedCustomColors[label] ?? customColors[label] ?? colorMap[label] ?? PlotUtils.getColorBrewerColor(i)
 }
 
 /** Sort annotation labels lexicographically, but always put the unspecified annotations last */

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -86,7 +86,7 @@ class AnnotationVizService
       annotation = {name: source[:name], type: type, scope: scope, values: sanitize_values_array(source[:values].to_a, type),
                     identifier: "#{source[:name]}--#{type}--#{scope}"}
     end
-    if type == 'group'
+    if annotation && type == 'group'
       annotation[:color_map] = AnnotationVizService.color_map(annotation[:values])
     end
     annotation

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -222,7 +222,7 @@ class AnnotationVizService
   # this allows for labels to maintain the same color across multiple plots, regardless of whether or not the
   # group is represented
   def self.annotation_color_map(values)
-    values.sort.map.with_index do |value, index|
+    values.sort_by!(&:downcase).map.with_index do |value, index|
       { "#{value}" => COLORBREWER_SET[index % COLORBREWER_SET.size] }
     end.reduce({}, :merge)
   end

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -4,6 +4,11 @@ class AnnotationVizService
   # global label for dealing with blank/nil group-based annotation values
   MISSING_VALUE_LABEL = '--Unspecified--'.freeze
 
+  # main list of group-based color codes, same as colorBrewerList in app/javascript/lib/plot.js
+  COLORBREWER_SET = %w(#e41a1c #377eb8 #4daf4a #984ea3 #ff7f00 #a65628 #f781bf #999999
+    #66c2a5 #fc8d62 #8da0cb #e78ac3 #a6d854 #ffd92f #e5c494 #b3b3b3 #8dd3c7
+    #bebada #fb8072 #80b1d3 #fdb462 #b3de69 #fccde5 #d9d9d9 #bc80bd #ccebc5 #ffed6f)
+
   # Retrieves an object representing the selected annotation. If nil is passed for the last four
   # arguments, it will get the study's default annotation instead
   # Params:
@@ -80,6 +85,9 @@ class AnnotationVizService
     elsif source.is_a?(Hash)
       annotation = {name: source[:name], type: type, scope: scope, values: sanitize_values_array(source[:values].to_a, type),
                     identifier: "#{source[:name]}--#{type}--#{scope}"}
+    end
+    if type == 'group'
+      annotation[:color_map] = AnnotationVizService.annotation_color_map(annotation[:values])
     end
     annotation
   end
@@ -208,5 +216,18 @@ class AnnotationVizService
         select_options: de_result.result_files
       }
     end
+  end
+
+  # create a global color map for a given group-based annotation
+  # this allows for labels to maintain the same color across multiple plots, regardless of whether or not the
+  # group is represented
+  def self.annotation_color_map(values)
+    values.sort.map.with_index do |value, index|
+      { "#{value}" => COLORBREWER_SET[index % COLORBREWER_SET.size] }
+    end.reduce({}, :merge)
+  end
+
+  def self.conditional_label_sort()
+
   end
 end

--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -87,7 +87,7 @@ class AnnotationVizService
                     identifier: "#{source[:name]}--#{type}--#{scope}"}
     end
     if type == 'group'
-      annotation[:color_map] = AnnotationVizService.annotation_color_map(annotation[:values])
+      annotation[:color_map] = AnnotationVizService.color_map(annotation[:values])
     end
     annotation
   end
@@ -221,13 +221,9 @@ class AnnotationVizService
   # create a global color map for a given group-based annotation
   # this allows for labels to maintain the same color across multiple plots, regardless of whether or not the
   # group is represented
-  def self.annotation_color_map(values)
-    values.sort_by!(&:downcase).map.with_index do |value, index|
+  def self.color_map(values)
+    values.sort_by(&:downcase).map.with_index do |value, index|
       { "#{value}" => COLORBREWER_SET[index % COLORBREWER_SET.size] }
     end.reduce({}, :merge)
-  end
-
-  def self.conditional_label_sort()
-
   end
 end

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -309,7 +309,9 @@ class ExpressionVizService
   def self.initialize_plotly_objects_by_annotation(annotation)
     values = {}
     annotation[:values].each do |value|
-      values["#{value}"] = {y: [], cells: [], annotations: [], name: "#{value}" }
+      values["#{value}"] = {
+        y: [], cells: [], annotations: [], name: "#{value}", color: annotation.dig(:color_map, value)
+      }
     end
     values
   end

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -66,10 +66,6 @@ class ClusterGroup
   # fixed values to subsample at
   SUBSAMPLE_THRESHOLDS = [MAX_THRESHOLD, 20000, 10000, 1000].freeze
 
-  COLORBREWER_SET = %w(#e41a1c #377eb8 #4daf4a #984ea3 #ff7f00 #a65628 #f781bf #999999
-    #66c2a5 #fc8d62 #8da0cb #e78ac3 #a6d854 #ffd92f #e5c494 #b3b3b3 #8dd3c7
-    #bebada #fb8072 #80b1d3 #fdb462 #b3de69 #fccde5 #d9d9d9 #bc80bd #ccebc5 #ffed6f)
-
   # Constants for scoping values for AnalysisParameter inputs/outputs
   ASSOCIATED_MODEL_METHOD = %w(name)
   ASSOCIATED_MODEL_DISPLAY_METHOD = %w(name)

--- a/test/api/visualization/annotations_controller_test.rb
+++ b/test/api/visualization/annotations_controller_test.rb
@@ -59,6 +59,8 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
                                              'ACTA2' => Hash[marker_cluster_list.zip([6,5,4])]
                                            }
                                          ])
+
+    @color_map = AnnotationVizService::COLORBREWER_SET
   end
 
   teardown do
@@ -176,12 +178,26 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
       @basic_study, cluster, annotation_param
     )
     assert_equal 4, annotations.size
-    expected_annotations = @basic_study.cell_metadata.map do |meta|
+    expected_annotations = [
       {
-        name: meta.name, type: meta.annotation_type, scope: 'study', values: meta.values,
-        identifier: meta.annotation_select_value
+        name: 'species', type: 'group', scope: 'study', values: %w(dog cat),
+        identifier: 'species--group--study', color_map: { cat: '#e41a1c', dog: '#377eb8' }.with_indifferent_access
+      },
+      {
+        name: 'disease', type: 'group', scope: 'study', values: %w(none measles),
+        identifier: 'disease--group--study',
+        color_map: { measles: '#e41a1c', none: '#377eb8' }.with_indifferent_access
+      },
+      {
+        name: 'cell_type', type: 'group', scope: 'study', values: %w(big --Unspecified--),
+        identifier: 'cell_type--group--study',
+        color_map: { '--Unspecified--' => '#e41a1c', big: '#377eb8' }.with_indifferent_access
+      },
+      {
+        name: 'nCount_RNA', type: 'numeric', scope: 'study', values: [],
+        identifier: 'nCount_RNA--numeric--study'
       }
-    end
+    ]
     expected_annotations[2][:values][1] = '--Unspecified--'
     assert_equal expected_annotations, annotations
     assert_empty Api::V1::Visualization::AnnotationsController.get_facet_annotations(

--- a/test/api/visualization/clusters_controller_test.rb
+++ b/test/api/visualization/clusters_controller_test.rb
@@ -94,7 +94,10 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
       "pointAlpha"=>1.0,
       "cluster"=>"clusterA.txt",
       "genes"=>[],
-      "annotParams"=>{"name"=>"foo", "type"=>"group", "scope"=>"cluster", "values"=>["bar", "baz"], "identifier"=>"foo--group--cluster"},
+      "annotParams"=>{
+        "name"=>"foo", "type"=>"group", "scope"=>"cluster", "values"=>["bar", "baz"],
+        "identifier"=>"foo--group--cluster", "color_map"=>{"bar"=>"#e41a1c", "baz"=>"#377eb8"}
+      },
       "subsample"=>"all",
       "isSplitLabelArrays"=>false,
       "consensus"=>nil,

--- a/test/api/visualization/expression_controller_test.rb
+++ b/test/api/visualization/expression_controller_test.rb
@@ -86,7 +86,8 @@ class ExpressionControllerTest < ActionDispatch::IntegrationTest
       genes: 'PTEN'
     }), user: @user)
     assert_equal 200, response.status
-    assert_equal({"y"=>[0.0, 3.0], "cells"=>["A", "B"], "annotations"=>[], "name"=>"bar"}, json['values']['bar'])
+    expected = { y: [0.0, 3.0], cells: %w(A B), annotations: [], name: 'bar', color: '#e41a1c' }.with_indifferent_access
+    assert_equal expected, json['values']['bar']
 
     execute_http_request(:get, api_v1_study_expression_path(@empty_study, 'violin', {
       cluster: 'clusterA.txt',

--- a/test/js/explore/scatter-tab.test.js
+++ b/test/js/explore/scatter-tab.test.js
@@ -179,8 +179,6 @@ describe('getNewContextMap correctly assigns contexts', () => {
         dataCache={createCache()}
         setCountsByLabel={function() {}}
         countsByLabel={[]}
-        setRefColorMap={jest.fn()}
-        setRefClusterRendered={jest.fn()}
       />
     ))
 

--- a/test/js/visualization/scatter-plot.test.js
+++ b/test/js/visualization/scatter-plot.test.js
@@ -84,7 +84,6 @@ it('shows custom legend with default group scatter plot', async () => {
         dimensionProps: BASIC_DIMENSION_PROPS,
         setCountsByLabelForDe() {},
         refColorMap,
-        setRefColorMap() {},
         hiddenTraces: exploreParams.hiddenTraces,
         updateExploreParams: newParams => setExploreParams(newParams)
       }}/>
@@ -124,7 +123,7 @@ it('shows custom legend with default group scatter plot', async () => {
       numPoints: 19,
       numLabels: 31,
       wasShown: true,
-      iconColor: '#4daf4a',
+      iconColor: '#377eb8',
       hasCorrelations: false
     }
   )

--- a/test/services/annotation_viz_service_test.rb
+++ b/test/services/annotation_viz_service_test.rb
@@ -141,4 +141,12 @@ class AnnotationVizServiceTest < ActiveSupport::TestCase
     assert_equal 'study', species_label_annot[:scope]
 
   end
+
+  test 'should compute color map for group-based annotation' do
+    labels = %w(A B C D E F G)
+    map = AnnotationVizService.color_map(labels)
+    labels.each_with_index do |label, index|
+      assert_equal AnnotationVizService::COLORBREWER_SET[index], map[label]
+    end
+  end
 end

--- a/test/services/expression_viz_service_test.rb
+++ b/test/services/expression_viz_service_test.rb
@@ -62,6 +62,7 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
         annotation: 'species--group--study'
     }
     @basic_study.update(default_options: defaults)
+    @color_list = AnnotationVizService::COLORBREWER_SET
   end
 
   # convenience method to load all gene expression data for a given study like requests to expression_controller
@@ -131,6 +132,9 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
       consensus: 'mean'
     )
     assert_equal [0.0, 4.75], rendered_data[:values]['dog'][:y]
+    rendered_data[:values].values.sort_by {|e| e[:name] }.each_with_index do |data, index|
+      assert_equal AnnotationVizService::COLORBREWER_SET[index], data[:color]
+    end
 
     # confirm it works for numeric annotations
     annot_name, annot_type, annot_scope = ['Intensity', 'numeric', 'cluster']
@@ -223,8 +227,8 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
     violin_data = ExpressionVizService.load_expression_boxplot_data_array_scores(@basic_study, gene, cluster, annotation)
     # cells A & C belong to 'dog', and cell B belongs to 'cat' from default metadata annotation
     expected_output = {
-        dog: {y: [0.0, 1.5], cells: %w(A C), annotations: [], name: 'dog'},
-        cat: {y: [3.0], cells: %w(B), annotations: [], name: 'cat'}
+        dog: {y: [0.0, 1.5], cells: %w(A C), annotations: [], name: 'dog', color: @color_list[1] },
+        cat: {y: [3.0], cells: %w(B), annotations: [], name: 'cat', color: @color_list[0] }
     }
     assert_equal expected_output.with_indifferent_access, violin_data.with_indifferent_access
   end
@@ -236,8 +240,11 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
     violin_data = ExpressionVizService.load_expression_boxplot_data_array_scores(@basic_study, gene, cluster, annotation)
     # cells A & B belong to 'bar', and cell C belongs to the blank label
     expected_output = {
-      bar: {y: [0.0, 3.0], cells: %w(A B), annotations: [], name: 'bar'},
-      "#{AnnotationVizService::MISSING_VALUE_LABEL}": {y: [1.5], cells: %w(C), annotations: [], name: AnnotationVizService::MISSING_VALUE_LABEL}
+      bar: {
+        y: [0.0, 3.0], cells: %w(A B), annotations: [], name: 'bar', color: @color_list[0]
+      }, "#{AnnotationVizService::MISSING_VALUE_LABEL}": {
+        y: [1.5], cells: %w(C), annotations: [], name: AnnotationVizService::MISSING_VALUE_LABEL, color: @color_list[1]
+      }
     }
     assert_equal expected_output.with_indifferent_access, violin_data.with_indifferent_access
   end
@@ -280,8 +287,8 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
     # cells A & C belong to 'dog', and cell B belongs to 'cat' from default metadata annotation
     # expression values for A: [0,0].mean (0), B: [1.5,8].mean (4.75), C: [0,3].mean (1.5)
     expected_set_expression = {
-        dog: {y: [0.0, 4.75], cells: %w(A C), annotations:[], name: 'dog'},
-        cat: {y: [1.5], cells: %w(B), annotations:[], name: 'cat'}
+        dog: {y: [0.0, 4.75], cells: %w(A C), annotations:[], name: 'dog', color: @color_list[1] },
+        cat: {y: [1.5], cells: %w(B), annotations:[], name: 'cat', color: @color_list[0] }
     }
     assert_equal expected_set_expression.with_indifferent_access, gene_set_violin.with_indifferent_access
   end

--- a/test/services/expression_viz_service_test.rb
+++ b/test/services/expression_viz_service_test.rb
@@ -241,9 +241,9 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
     # cells A & B belong to 'bar', and cell C belongs to the blank label
     expected_output = {
       bar: {
-        y: [0.0, 3.0], cells: %w(A B), annotations: [], name: 'bar', color: @color_list[0]
+        y: [0.0, 3.0], cells: %w(A B), annotations: [], name: 'bar', color: @color_list[1]
       }, "#{AnnotationVizService::MISSING_VALUE_LABEL}": {
-        y: [1.5], cells: %w(C), annotations: [], name: AnnotationVizService::MISSING_VALUE_LABEL, color: @color_list[1]
+        y: [1.5], cells: %w(C), annotations: [], name: AnnotationVizService::MISSING_VALUE_LABEL, color: @color_list[0]
       }
     }
     assert_equal expected_output.with_indifferent_access, violin_data.with_indifferent_access


### PR DESCRIPTION
#### BACKGROUND
Currently, SCP dynamically assigns colors when viewing group-based annotations in scatter/violin plots based on the labels represented.  These colors always start with red and cycle through a [fixed array](https://github.com/broadinstitute/single_cell_portal_core/blob/development/app/javascript/lib/plot.js#L5) of values.  This can lead to situations where a given label does not have the same color in different scatter/violin plots, as that clustering may not have all the same labels represented as others.  While the plots are internally consistent, this could be confusing to users if a population changes color across plots.

#### CHANGES
Now, all group-based annotations will have a consistent color scheme across scatter & violin plots, regardless of labels represented.  These colors are computed server-side and returned as part of the `annotParams` object.  User-defined custom colors can still override this in scatter plots.

Brief demo:

https://github.com/broadinstitute/single_cell_portal_core/assets/729968/436fc679-0571-413b-b7aa-03caa6241a8f

It is worth noting that this will change the appearance of some default plots used in normal testing, such as the `Human milk - differential expression` study.  In the default `All Cells UMAP`, the color for the `T cells` label used to be `#fc8d62`, but is now `#8da0cb` as the `removed` label shifts this down one value, even though that population is not included in the plots.

Note: when viewing spatial clusters using cluster-based annotations that share names & labels, situations can arise where colors are not the same across plots for a given label.  The plots will still be internally consistent, which is an improvement over #2072, where colors could be repeated inside a given plot.  This currently affects only 4 studies on production, so the scope is very limited.

#### MANUAL TESTING
1. Boot as normal and load the `Human milk - differential expression` study
2. Note the color for `LC1` and `LC2` are pink and grey, respectively
3. Load the `Epithelial cells UMAP` clustering and note the colors stay the same for `LC1` and `LC2`
4. Search for the gene `CLDN4`
5. Note the colors remain the same for `LC1` and `LC2` in the scatter & violin plots