### PR TITLE
Sort DE table by Scanpy score by default (SCP-5695)

### DIFF
--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -224,13 +224,8 @@ function DifferentialExpressionTable({
     pageSize: numRows
   }
 
-  const defaultSorting = [
-    { id: 'significance', desc: false },
-    { id: 'size', desc: true }
-  ]
-
   const [rowSelection, setRowSelection] = useState({})
-  const [sorting, setSorting] = React.useState(defaultSorting)
+  const [sorting, setSorting] = React.useState([])
   const [pagination, setPagination] = React.useState(defaultPagination)
 
   const logProps = {
@@ -350,7 +345,7 @@ function DifferentialExpressionTable({
   /** Put DE table back to its original state */
   function resetDifferentialExpression() {
     setRowSelection({})
-    setSorting(defaultSorting)
+    setSorting([])
     setPagination(defaultPagination)
     handleClear()
   }

--- a/test/js/explore/differential-expression-panel.test.js
+++ b/test/js/explore/differential-expression-panel.test.js
@@ -106,7 +106,7 @@ describe('Differential expression panel', () => {
     // screen.debug(deTable) // Print DE table HTML
 
     const firstGeneAfterSort = container.querySelector('.de-gene-row td')
-    expect(firstGeneAfterSort).toHaveTextContent('HLA-DPA1')
+    expect(firstGeneAfterSort).toHaveTextContent('CD74')
 
     // Confirm base case for "Find genes"
     const deSearchBox = container.querySelector('.de-search-box')


### PR DESCRIPTION
This refines row order in the differential expression table, which better aligns our UI with computed and published results.

### Overview
[Previously](https://github.com/broadinstitute/single_cell_portal_core/pull/1768), the DE table was sorted by adjusted p-value and then log<sub>2</sub>(fold change).  This was suggested in an SCP demo, and ranking by significance then size is a helpfully transparent way to sort DE results.  However, when SCP computes DE, the underlying Scanpy results are sorted by a "score" metric.  

Scanpy score is not shown in the DE table UI, but if users tried to reproduce SCP results, they might be confused by the different sort order in their Scanpy results and SCP's DE UI table.  Perhaps more valuably, sorting by Scanpy also makes SCP's DE UI table more consistent with published results, which often focus on top DE genes as sorted by Scanpy score.

Now, the SCP UI table uses Scanpy score to sort rows of genes in the DE table.  This simplifies the code and user interpretation, and likely better captures Scanpy's methodological nuance in surfacing the most relevant genes.

### Video
Here's how the new and old DE table sorting looks, and how it compares with results in a corresponding publication.

https://github.com/broadinstitute/single_cell_portal_core/assets/1334561/b2aa2091-0885-421c-92f0-f297b1e6488d

### Test
Automated tests were updated to account for these changes.  If you'd like to manually test:
1.  Go to "Human milk" study
2. Click "Differential expression"
3. Select "LC1"
4. Confirm first genes are CLDN4, JUN, and KLF6

This satisfies SCP-5695.