### PR TITLE
Enabling cell filtering on subsampled data (SCP-5608)

### DIFF
--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -405,11 +405,6 @@ module Api
         def self.find_missing_annotations(annotations, requested)
           requested.split(',').reject { |id| annotations.detect { |annot| annot[:identifier] == id } }
         end
-
-        # create a subsampled array of annotations, using source cluster cells and study "all cells" array
-        def self.subsample_map(cells, subsampled_index, annotations)
-
-        end
       end
     end
   end

--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -278,7 +278,7 @@ module Api
           if params[:subsample] == 'all' || params[:subsample].nil?
             subsample_threshold = nil
           else
-            subsample_threshold = params[:subsample_threshold].to_i
+            subsample_threshold = params[:subsample].to_i
           end
           subsample_annotation = params[:loaded_annotation]
           # use new cell index arrays to load data much faster
@@ -297,11 +297,6 @@ module Api
               linear_data_id: data_obj.id, study_id: @study.id, study_file_id:, subsample_annotation: nil,
               subsample_threshold: nil
             }
-            # for subsampled cluster-based annotations, load correct array to allow direct mapping
-            if subsample_threshold && annot_scope == 'cluster'
-              array_query[:subsample_threshold] = subsample_threshold
-              array_query[:subsample_annotation] = subsample_annotation
-            end
 
             annotation_arrays[identifier] = DataArray.concatenate_arrays(array_query)
             facets << { annotation: identifier, groups: annotation[:values] }
@@ -314,7 +309,7 @@ module Api
             facets.map do |facet|
               annotation = facet[:annotation]
               _, annotation_type, annotation_scope = annotation.split('--')
-              if annotation_scope == 'study'
+              if annotation_scope == 'study' || subsample_threshold.present?
                 label = annotation_arrays[annotation][value] || '--Unspecified--'
               else
                 label = annotation_arrays[annotation][index] || '--Unspecified--'

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -253,11 +253,8 @@ export default function ExploreDisplayPanelManager({
     }
   }
 
-  /** Toggle cell filtering panel, and remove subsampling if needed */
+  /** Toggle cell filtering panel */
   function toggleCellFilterPanel() {
-    if (isSubsampled) {
-      updateClusterParams({ subsample: 'All Cells' })
-    }
     togglePanel('cell-filtering')
   }
 

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -123,7 +123,7 @@ function getCellFacetingData(cluster, annotation, setterFunctions, context, prev
     if (allAnnots && allAnnots.length > 0) {
       if (!prevCellFaceting?.isFullyLoaded) {
         initCellFaceting(
-          cluster, annotation, studyAccession, allAnnots, prevCellFaceting
+          cluster, annotation, studyAccession, allAnnots, prevCellFaceting, exploreParams?.subsample
         ).then(newCellFaceting => {
           const initSelection = {}
           if (!cellFilteringSelection) {
@@ -342,7 +342,7 @@ export default function ExploreDisplayTabs({
       cellFilteringSelection
     }
     getCellFacetingData(newCluster, newAnnot, setterFunctions, context)
-  }, [exploreParams?.cluster, exploreParams?.annotation])
+  }, [exploreParams?.cluster, exploreParams?.annotation, exploreParams?.subsample])
 
 
   /** Update filtered cells to only those that match filter selections */

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -122,7 +122,7 @@ function getCellFacetingData(cluster, annotation, setterFunctions, context, prev
     const allAnnots = exploreInfo?.annotationList.annotations
     if (allAnnots && allAnnots.length > 0) {
       if (!prevCellFaceting?.isFullyLoaded) {
-        const subsample = exploreParams?.subsample || exploreInfo?.cluster?.numPoints > 100_000 ? 100_000 : null
+        const subsample = exploreParams?.subsample || (exploreInfo?.cluster?.numPoints > 100_000 ? 100_000 : null)
         initCellFaceting(
           cluster, annotation, studyAccession, allAnnots, prevCellFaceting, subsample
         ).then(newCellFaceting => {

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -122,8 +122,9 @@ function getCellFacetingData(cluster, annotation, setterFunctions, context, prev
     const allAnnots = exploreInfo?.annotationList.annotations
     if (allAnnots && allAnnots.length > 0) {
       if (!prevCellFaceting?.isFullyLoaded) {
+        const subsample = exploreParams?.subsample || exploreInfo?.cluster?.numPoints > 100_000 ? 100_000 : null
         initCellFaceting(
-          cluster, annotation, studyAccession, allAnnots, prevCellFaceting, exploreParams?.subsample
+          cluster, annotation, studyAccession, allAnnots, prevCellFaceting, subsample
         ).then(newCellFaceting => {
           const initSelection = {}
           if (!cellFilteringSelection) {

--- a/app/javascript/components/visualization/StudyViolinPlot.jsx
+++ b/app/javascript/components/visualization/StudyViolinPlot.jsx
@@ -40,9 +40,9 @@ function ViolinPlotTitle({ cluster, annotation, genes, consensus }) {
 
 
 /** Get array of names for all cells in clustering */
-async function getAllCellNames(studyAccession, cluster, annotation) {
+async function getAllCellNames(studyAccession, cluster, annotation, subsample='All') {
   const clusterData = await fetchCluster({
-    studyAccession, cluster, annotation, subsample: 'All'
+    studyAccession, cluster, annotation, subsample
   })
   const allCellNames = clusterData[0].data.cells
   return allCellNames
@@ -51,14 +51,14 @@ async function getAllCellNames(studyAccession, cluster, annotation) {
 /** Filter cells in violin plot */
 export async function filterResults(
   studyAccession, cluster, annotation, gene,
-  results, cellFaceting, filteredCells
+  results, cellFaceting, filteredCells, subsample
 ) {
   const flags = getFeatureFlagsWithDefaults()
   const showCellFiltering = flags?.show_cell_facet_filtering
   if (!showCellFiltering) {return results}
 
   if (gene in window.SCP.violinCellIndexes === false) {
-    const allCellNames = await getAllCellNames(studyAccession, cluster, annotation)
+    const allCellNames = await getAllCellNames(studyAccession, cluster, annotation, subsample)
     await workSetViolinCellIndexes(gene, results, allCellNames)
   }
 
@@ -145,7 +145,7 @@ function RawStudyViolinPlot({
 
     results = await filterResults(
       studyAccession, cluster, annotation, genes[0],
-      results, cellFaceting, filteredCells
+      results, cellFaceting, filteredCells, subsample
     )
 
     const startTime = performance.now()

--- a/app/javascript/lib/cell-faceting.js
+++ b/app/javascript/lib/cell-faceting.js
@@ -595,7 +595,7 @@ function getFilterableAnnotationsForClusterAndStudy(annotations, clusterName) {
 
 /** Get 5 default annotation facets: 1 for selected, and 4 others */
 export async function initCellFaceting(
-  selectedCluster, selectedAnnot, studyAccession, allAnnots, prevCellFaceting
+  selectedCluster, selectedAnnot, studyAccession, allAnnots, prevCellFaceting, subsample=null
 ) {
   let perfTimes = {}
   const timeStart = Date.now()
@@ -637,7 +637,7 @@ export async function initCellFaceting(
   const facetsToFetch = getFacetsToFetch(allRelevanceSortedFacets, prevCellFaceting)
 
   const timeFetchStart = Date.now()
-  const newRawFacets = await fetchAnnotationFacets(studyAccession, facetsToFetch, selectedCluster)
+  const newRawFacets = await fetchAnnotationFacets(studyAccession, facetsToFetch, selectedCluster, selectedAnnotId, subsample)
   perfTimes.fetch = Date.now() - timeFetchStart
 
   // Below line is worth keeping, but only uncomment to debug in development.

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -156,10 +156,13 @@ export async function createUserAnnotation(
  * @param {Array<String>} annotations Array of annotation identifiers,
  *  e.g. ['cell_type__ontology_label--group--study', 'disease__ontology_label']
  * @param {String} cluster Name of requested cluster
+ * @param {String} loadedAnnot Name of loaded annotation (if subsampling)
+ * @param {String} subsample Subsampling threshold
  */
-export async function fetchAnnotationFacets(studyAccession, annotations, cluster) {
+export async function fetchAnnotationFacets(studyAccession, annotations, cluster,
+  loadedAnnot, subsample) {
   annotations = encodeURIComponent(annotations.join(','))
-  const params = `annotations=${annotations}&cluster=${cluster}`
+  const params = `annotations=${annotations}&cluster=${cluster}&loaded_annotation=${loadedAnnot}&subsample=${subsample}`
   const apiUrl = `/studies/${studyAccession}/annotations/facets?${params}`
   const [annotationFacets] = await scpApi(apiUrl, defaultInit())
   return annotationFacets

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -446,7 +446,8 @@ class ClusterGroup
                         "#{subsample_annotation}:#{subsample_threshold}"
       create_cell_name_index!(study_cells, subsample_annotation:, subsample_threshold:)
     end
-    index_status = DataArray.where(index_query).any?
+    # determine if any indices
+    index_status = DataArray.any_of(index_query).any? || ClusterGroup.find(id).use_default_index
     update!(is_indexing: false, indexed: index_status)
   end
 

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -449,7 +449,7 @@ class ClusterGroup
 
   # load indexed cell name array, or use default enumerator if identical to metadata file
   def cell_index_array(subsample_annotation: nil, subsample_threshold: nil)
-    if subsample_annotation
+    if subsample_annotation && subsample_threshold
       concatenate_data_arrays('index', 'cells', subsample_threshold, subsample_annotation)
     else
       use_default_index ? 0.upto(points - 1) : concatenate_data_arrays('index', 'cells')

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -385,8 +385,8 @@ class ClusterGroup
   # index the cells from this cluster against the 'all cells' array at the study level
   # study_cells.index_with.with_index creates hash of cell names => array index position
   # averts CPU saturation of calling Array#index on very large arrays
-  def cell_name_index(study_cells)
-    cluster_cells = concatenate_data_arrays('text', 'cells')
+  def cell_name_index(study_cells, subsample_annotation: nil, subsample_threshold: nil)
+    cluster_cells = concatenate_data_arrays('text', 'cells', subsample_annotation, subsample_threshold)
     # if cluster cells & study cells are identical, return empty array so we can set #use_default_index
     return [] if cluster_cells == study_cells
 
@@ -395,39 +395,65 @@ class ClusterGroup
   end
 
   # create all necessary data array entries for cell_name_index
-  def create_cell_name_index!
-    return nil unless can_index?
-
-    update!(is_indexing: true)
+  def create_cell_name_index!(subsample_annotation: nil, subsample_threshold: nil)
     study_cells = study.all_cells_array
-    cell_index = cell_name_index(study_cells)
+    cell_index = cell_name_index(study_cells, subsample_annotation:, subsample_threshold:)
     # if some cells are not indexed, don't create array as this will break things downstream
     index_count = cell_index.compact.size
+    expected_cells = subsample_threshold || points
     if cell_index.empty?
       Rails.logger.info "using default cell index for #{study.accession}:#{name}"
       update!(is_indexing: false, indexed: true, use_default_index: true)
-    elsif index_count != points
-      Rails.logger.info "aborting cell index for #{study.accession}:#{name} - #{points - index_count} cells not found"
+    elsif index_count != expected_cells
+      Rails.logger.info "aborting cell index for #{study.accession}:#{name} - #{expected_cells - index_count} cells not found"
       update!(is_indexing: false)
     else
       cell_index.each_slice(DataArray::MAX_ENTRIES).with_index do |slice, index|
         begin
           DataArray.create!(
             name: 'index', array_type: 'cells', array_index: index, values: slice, linear_data_type: 'ClusterGroup',
-            linear_data_id: id, study_id: study.id, study_file_id:, cluster_name: name
+            linear_data_id: id, study_id: study.id, study_file_id:, cluster_name: name,
+            subsample_annotation:, subsample_threshold:
           )
         rescue => e
           update!(is_indexing: false)
-          ErrorTracker.report_exception(e, nil, study, self, { job: :create_cell_name_index! })
+          context = { job: :create_cell_name_index!, subsample_annotation:, subsample_threshold: }
+          ErrorTracker.report_exception(e, nil, study, self, context)
         end
       end
-      update!(is_indexing: false, indexed: true)
     end
   end
 
+  # create all necessary cell index arrays, both full-resolution and subsampled
+  def create_all_cell_indices!
+    return nil unless can_index?
+
+    update!(is_indexing: true)
+    subsampled_annotations = DataArray.where(
+      study_id:, study_file_id:, subsample_threshold: 100000,
+      :subsample_annotation.ne => nil, array_type: 'cells', name: 'text'
+    ).pluck(:subsample_annotation, :subsample_threshold)
+    all_indexes = [[nil, nil]] + subsampled_annotations
+    all_indexes.each do |subsample_annotation, subsample_threshold|
+      next if DataArray.where(
+        study_id:, study_file_id:, linear_data_type: 'ClusterGroup', linear_data_id: id,
+        name: 'index', array_type: 'cells', subsample_annotation:, subsample_threshold:
+      ).exists?
+
+      Rails.logger.info "creating cell_name_index on #{study.accession}:#{name} with " \
+                        "#{subsample_annotation}:#{subsample_threshold}"
+      create_cell_name_index!(subsample_annotation:, subsample_threshold:)
+    end
+    update!(is_indexing: false, indexed: true)
+  end
+
   # load indexed cell name array, or use default enumerator if identical to metadata file
-  def cell_index_array
-    use_default_index ? 0.upto(points - 1) : concatenate_data_arrays('index', 'cells')
+  def cell_index_array(subsample_annotation: nil, subsample_threshold: nil)
+    if subsample_annotation
+      concatenate_data_arrays('index', 'cells', subsample_threshold, subsample_annotation)
+    else
+      use_default_index ? 0.upto(points - 1) : concatenate_data_arrays('index', 'cells')
+    end
   end
 
   ##

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -541,6 +541,12 @@ class IngestJob
     when :ingest_cluster
       cluster = ClusterGroup.find_by(study:, study_file:, name: cluster_name_by_file_type)
       cluster.create_all_cell_indices!
+    when :ingest_subsample
+      # gotcha to unset the 'indexed' flag as this will block generating new indices
+      cluster = ClusterGroup.find_by(study:, study_file:, name: cluster_name_by_file_type)
+      cluster.update!(indexed: false)
+      cluster.reload
+      cluster.create_all_cell_indices!
     end
   end
 

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -539,7 +539,7 @@ class IngestJob
       study.create_all_cluster_cell_indices!
     when :ingest_cluster
       cluster = ClusterGroup.find_by(study:, study_file:, name: cluster_name_by_file_type)
-      cluster.create_cell_name_index!
+      cluster.create_all_cell_indices!
     end
   end
 

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -429,6 +429,7 @@ class IngestJob
       create_cell_name_indexes
     when :ingest_subsample
       set_subsampling_flags
+      create_cell_name_indexes
     when :differential_expression
       create_differential_expression_results
     when :ingest_differential_expression

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1405,9 +1405,9 @@ class Study
     return nil if cluster_groups.empty?
 
     cluster_groups.each do |cluster_group|
-      Rails.logger.info "creating cell index for #{accession}:#{cluster_group.name}"
+      Rails.logger.info "creating all cell name indices for #{accession}:#{cluster_group.name}"
       cluster_group.create_all_cell_indices!
-      Rails.logger.info "finished cell index for #{accession}:#{cluster_group.name}"
+      Rails.logger.info "finished cell name index for #{accession}:#{cluster_group.name}"
     end
   end
 

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1406,7 +1406,7 @@ class Study
 
     cluster_groups.each do |cluster_group|
       Rails.logger.info "creating cell index for #{accession}:#{cluster_group.name}"
-      cluster_group.create_cell_name_index!
+      cluster_group.create_all_cell_indices!
       Rails.logger.info "finished cell index for #{accession}:#{cluster_group.name}"
     end
   end

--- a/db/migrate/20240709215119_create_subsampled_cluster_indices.rb
+++ b/db/migrate/20240709215119_create_subsampled_cluster_indices.rb
@@ -3,6 +3,7 @@ class CreateSubsampledClusterIndices < Mongoid::Migration
     accessions = Study.pluck(:accession)
     accessions.each do |accession|
       study = Study.find_by(accession:)
+      study.cluster_groups.update_all(indexed: false, is_indexing: false)
       study.delay.create_all_cluster_cell_indices!
     end
   end
@@ -16,6 +17,5 @@ class CreateSubsampledClusterIndices < Mongoid::Migration
       :study_id.in => study_ids, :study_file_id.in => cluster_file_ids, :subsample_annotation.ne => nil,
       :subsample_threshold.ne => nil
     ).delete_all
-    ClusterGroup.update_all(indexed: false, is_indexing: false)
   end
 end

--- a/db/migrate/20240709215119_create_subsampled_cluster_indices.rb
+++ b/db/migrate/20240709215119_create_subsampled_cluster_indices.rb
@@ -1,0 +1,21 @@
+class CreateSubsampledClusterIndices < Mongoid::Migration
+  def self.up
+    accessions = Study.pluck(:accession)
+    accessions.each do |accession|
+      study = Study.find_by(accession:)
+      study.delay.create_all_cluster_cell_indices!
+    end
+  end
+
+  def self.down
+    cluster_file_ids = StudyFile.where(file_type: 'Cluster').pluck(:id)
+    cluster_ids = ClusterGroup.pluck(:id)
+    study_ids = Study.pluck(:id)
+    DataArray.where(
+      name: 'index', array_type: 'cells', linear_data_type: 'ClusterGroup', :linear_data_id.in => cluster_ids,
+      :study_id.in => study_ids, :study_file_id.in => cluster_file_ids, :subsample_annotation.ne => nil,
+      :subsample_threshold.ne => nil
+    ).delete_all
+    ClusterGroup.update_all(indexed: false, is_indexing: false)
+  end
+end

--- a/test/factories/cluster_group.rb
+++ b/test/factories/cluster_group.rb
@@ -69,7 +69,7 @@ FactoryBot.define do
                             study_file: evaluator.study_file)
         end
         cluster.set_point_count!
-        cluster.create_cell_name_index!
+        cluster.create_all_cell_indices!
       end
     end
   end


### PR DESCRIPTION
#### BACKGROUND
Currently, cell filtering only operates on full-resolution clustering & annotation data.  While this is fine for studies with around 100K cells and below, it quickly becomes unusable at higher cell counts, even causing crashes.  This is even more noticeable for violin plots over 100K cells.  The original reason for not using subsampled data was that there is no guarantee that the same cells were sampled across annotations, meaning that the same index would not necessarily be the same cell across annotations.

#### CHANGES
Now, subsampled data can be used during cell filtering.  The critical realization is that once the subsampled cell name indices are generated the 100K level for qualifying clusters/annotations, these indices could still be used with the full resolution annotation arrays.  There will only ever be one subsampled list of cells used at any given time - the cluster/annotation currently being viewed - and the data returned from the annotation facets endpoint is the index of a label for a given cell in the list of unique values for every annotation listed.  This means that the subsampled data still maps correctly to annotations, and the vast majority of our cell filtering logic remains unchanged.

Also, the backend automation for generating indices was refactored to generate all qualifying arrays after successful parsing/subsampling.  A backfill migration has also been added to generate these new indices for existing data.  Minor changes were made to the indexing logic to make it more performant (i.e. "all cells" arrays are shared between index computations rather than being reloaded every time).  A query on production found ~4200 qualifying annotations, but since all of these indexes will be single arrays, there hopefully will not be CPU saturation issues like with the initial backfill.  Test runs on staging should shed light on whether this will be a potential issue or not.

Note: due to [existing logic](https://github.com/broadinstitute/single_cell_portal_core/blob/development/app/javascript/components/explore/plot-data-cache.js#L335) with plot caching, changing filters will cause subsampled plots to re-fetch data from the API.  This is expected.

#### MANUAL TESTING
If you do not have an existing study over 100K cells, SCP2247 is a good candidate as it only has one cluster of 155K cells, and a mix of cluster- and study-based annotations.  The expression data is not strictly necessary, but it does allow you to verify that expression-based plots work.
- [UMAP](https://singlecell.broadinstitute.org/single_cell/data/public/SCP2247/neuronal-diversity-in-the-human-hypothalamus?filename=KaZhouAll_mt10_SCP_UMAP_coords_meta.csv)
- [Metadata](https://singlecell.broadinstitute.org/single_cell/data/public/SCP2247/neuronal-diversity-in-the-human-hypothalamus?filename=KaZhouAll_mt10_SCP_metadata.csv)
- [Processed mtx](https://singlecell.broadinstitute.org/single_cell/data/public/SCP2247/neuronal-diversity-in-the-human-hypothalamus?filename=matrix.mtx)
    - [genes](https://singlecell.broadinstitute.org/single_cell/data/public/SCP2247/neuronal-diversity-in-the-human-hypothalamus?filename=genes.tsv)
    - [barcodes](https://singlecell.broadinstitute.org/single_cell/data/public/SCP2247/neuronal-diversity-in-the-human-hypothalamus?filename=barcodes.tsv)

1. Start all services, including DelayedJob
2. In a separate terminal, run the migration to backfill data (if you have a study with more that 100K cells) with `bin/rails db:migrate`
3. If using SCP2247 source data, upload the necessary files and wait for them to ingest (should take 5-10m)
4. Once subsampling completes, note the similar messages in `development.log`):
```
creating cell name index on SCP105:KaZhouAll_mt10_SCP_UMAP_coords_meta.csv with Study--group--cluster:100000
creating cell name index on SCP105:KaZhouAll_mt10_SCP_UMAP_coords_meta.csv with biosample_id--group--study:100000
creating cell name index on SCP105:KaZhouAll_mt10_SCP_UMAP_coords_meta.csv with celltype--group--cluster:100000
creating cell name index on SCP105:KaZhouAll_mt10_SCP_UMAP_coords_meta.csv with disease--group--study:100000
creating cell name index on SCP105:KaZhouAll_mt10_SCP_UMAP_coords_meta.csv with disease__ontology_label--group--study:100000
...
```
5. Open the explore tab for the study, load the `celltype` annotation and then click the `Filter plotted cells` button, noting that the subsample menu stays at `100000`
6. Scroll down to `Seurat clusters` and deselect the value `12`
7. Note the bottom-center teardrop-like population filters most of the bottom half like this:
![Screenshot 2024-07-11 at 2 17 44 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/56ef8a57-fbb4-4d04-95b5-487688e0bcf3)
8. Compare this to [SCP2247 on production](https://singlecell.broadinstitute.org/single_cell/study/SCP2247/neuronal-diversity-in-the-human-hypothalamus?cluster=KaZhouAll_mt10_SCP_UMAP_coords_meta.csv&spatialGroups=--&annotation=celltype--group--cluster&subsample=all&facets=seurat_clusters--group--cluster%3A12#study-visualize) and note the plots look the same
9. Reselect `12` to unfilter
10. If you uploaded expression data locally, query for `CFAP53` and note the elevated expression in the same area
11. Click to the `Distribution` tab and note the high expression for the `Ependymal` group
12. Re-click `12` in the cell filtering panel and note how the violin thins out, and the maximum expression went from `16` down to `10`.
![Screenshot 2024-07-11 at 2 34 39 PM](https://github.com/broadinstitute/single_cell_portal_core/assets/729968/544e8ae1-924f-49d1-9f46-c032c42a8eba)
13. Compare this against [SCP2247 on production](https://singlecell.broadinstitute.org/single_cell/study/SCP2247/neuronal-diversity-in-the-human-hypothalamus?genes=CFAP53&cluster=KaZhouAll_mt10_SCP_UMAP_coords_meta.csv&spatialGroups=--&annotation=celltype--group--cluster&subsample=all&tab=distribution&facets=seurat_clusters--group--cluster%3A12#study-visualize) and note the plots are the same (you may have to re-click `12` in the filtering panel as it sometimes does not apply)