### PR TITLE
Prevent/clean up duplicate cell index arrays (SCP-5706)

### DIFF
--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -275,7 +275,7 @@ module Api
             render json: { error: "Cannot find annotations: #{missing.join(', ')}" }, status: :not_found and return
           end
 
-          if params[:subsample] == 'all' || params[:subsample].nil?
+          if params[:subsample] == 'all' || params[:subsample] == 'null' || params[:subsample].nil?
             subsample_threshold = nil
           else
             subsample_threshold = params[:subsample].to_i

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -429,7 +429,7 @@ class ClusterGroup
     all_indexes = [[nil, nil]] + subsampled_annotations
     index_query = {
       study_id:, study_file_id:, linear_data_type: 'ClusterGroup', linear_data_id: id, name: 'index',
-      array_type: 'cells', cluster_name: name
+      array_type: 'cells'
     }
     study_cells = study.all_cells_array
     all_indexes.each do |subsample_annotation, subsample_threshold|

--- a/db/migrate/20240718141220_remove_invalid_index_arrays.rb
+++ b/db/migrate/20240718141220_remove_invalid_index_arrays.rb
@@ -13,9 +13,12 @@ class RemoveInvalidIndexArrays < Mongoid::Migration
       arrays = DataArray.where(query)
       if arrays.any?
         count = arrays.count
-        Rails.logger.info "#{cluster.name} has #{count} invalid arrays"
+        Rails.logger.info "#{cluster.name} in #{study.accession} has #{count} invalid arrays"
         bad_arrays += count
         arrays.delete_all
+        Rails.logger.info "re-indexing #{cluster.name}"
+        cluster.update(indexed: false)
+        cluster.create_all_cell_indices!
       end
     end
     puts "Completed: total arrays removed: #{bad_arrays}"

--- a/db/migrate/20240718141220_remove_invalid_index_arrays.rb
+++ b/db/migrate/20240718141220_remove_invalid_index_arrays.rb
@@ -1,0 +1,27 @@
+class RemoveInvalidIndexArrays < Mongoid::Migration
+  def self.up
+    # clean out any duplicate cell name index arrays that were a result of the cluster changing names
+    bad_arrays = 0
+    ClusterGroup.where(indexed: true, use_default_index: false).each do |cluster|
+      study = cluster.study
+      study_file = cluster.study_file
+      query = {
+        study_id: study.id, study_file_id: study_file.id, linear_data_type: 'ClusterGroup',
+        linear_data_id: cluster.id, name: 'index', array_type: 'cells',
+        :cluster_name.ne => cluster.name
+      }
+      arrays = DataArray.where(query)
+      if arrays.any?
+        count = arrays.count
+        Rails.logger.info "#{cluster.name} has #{count} invalid arrays"
+        bad_arrays += count
+        arrays.delete_all
+      end
+    end
+    puts "Completed: total arrays removed: #{bad_arrays}"
+  end
+
+  def self.down
+    # non-reversible
+  end
+end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug introduced in #2078 where the creation of subsampled cell index arrays also mistakenly re-created full-resolution index arrays on clusters that have been renamed since the original indexes were created.  This is a rather narrow corner, but the result was that the duplicate arrays caused cell counts in the cell filtering UX to be double what they should have been.  It appears that the filtering worked correctly still, and only the counts were incorrect.  This impacted a handful of studies on staging, and would have also impacted a several on production had this not been caught during release testing (8 studies, 26 total clusters as of today).

#### MANUAL TESTING
Testing this is somewhat cumbersome as it normally would require rolling back and re-running migrations.  However, since the fix in this branch does not do this, we must first recreate the original error state before continuing.

**SETUP BEFORE PULLING**:
1. Enter the Rails console, and load your copy of the `Human milk - differential expression` study and the `All Cells UMAP` default cluster:
```
accession = <accession of your study>
study = Study.find_by(accession:)
cluster = study.default_cluster
```
2. Confirm that you have the correct number of entries in the cell index. _Note: if you already have `96956` cells here, you can skip down to the **TESTING FIX** section._
```
cluster.cell_index_array.count
=> 48478
```
3. Rename the cluster and set it to unindexed so we can recreate the error:
```
cluster.update(name: 'foo', indexed: false, is_indexing: false)
```
4. Recreate the cell name indexes and confirm that you now have duplicate entries:
```
cluster.create_all_cell_indices!
=> true
cluster.cell_index_array.count
=> 96956
```
5. Now rename the cluster back to the original name:
```
cluster.update(name: 'All Cells UMAP')
```

**TESTING FIX**
1. Pull branch and run the new migration with `bin/rails db:migrate`
2. Confirm you see messages in the `development.log` like the following:
```
Migrating to RemoveInvalidIndexArrays (20240718141220)
All Cells UMAP in SCP66 has 1 invalid arrays
re-indexing All Cells UMAP
creating cell name index on SCP66:All Cells UMAP with :
...
```
3. Back in a Rails console session, confirm we have the correct number of cells in the index for the study:
```
accession = <accession of your study>
study = Study.find_by(accession:)
cluster = study.default_cluster
cluster.cell_index_array.count
=> 48478
```