### PR TITLE
Prevent clobbering trace color when filtering violin plots (SCP-5708)

### DIFF
--- a/app/javascript/components/visualization/StudyViolinPlot.jsx
+++ b/app/javascript/components/visualization/StudyViolinPlot.jsx
@@ -79,6 +79,7 @@ export async function filterResults(
       annotations: [],
       cells: [],
       name: group,
+      color: results.values[group].color,
       y: []
     }
     const cellNames = results.values[group].cells


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug with cell filtering in violin plots introduced in #2076 where traces lose their original color and become all grey.  This was caused by not preserving the `traceData.color` property when performing the filtering.  Now, the original colors persist regardless of filtering state.

#### MANUAL TESTING
1. Boot as normal and load the `Human milk - differential expression` study
2. Query for `CLDN4`, open the Distribution tab and wait for the violin plot to load
3. Open the cell filtering panel and filter out `epithelial cell` from `Cell type` at the top
4. Confirm that the trace colors are preserved when filtered
5. Re-select `epithelial cell` and confirm `LC1` and `LC2` are back with their original pink & grey colors