### PR TITLE
Match server- and client-side label sorting (SCP-5703)

### DIFF
--- a/app/lib/annotation_viz_service.rb
+++ b/app/lib/annotation_viz_service.rb
@@ -222,7 +222,7 @@ class AnnotationVizService
   # this allows for labels to maintain the same color across multiple plots, regardless of whether or not the
   # group is represented
   def self.color_map(values)
-    values.sort_by(&:downcase).map.with_index do |value, index|
+    LabelSorter.natural_sort(values).map.with_index do |value, index|
       { "#{value}" => COLORBREWER_SET[index % COLORBREWER_SET.size] }
     end.reduce({}, :merge)
   end

--- a/lib/label_sorter.rb
+++ b/lib/label_sorter.rb
@@ -1,0 +1,29 @@
+# natural sorting to handling complex strings with numbers, like biosample_id entries
+# adapted from https://rosettacode.org/wiki/Natural_sorting#Ruby
+class LabelSorter
+  include Comparable
+  attr_reader :lowercase, :natural_types, :type_order
+
+  def initialize(str)
+    @str = str
+    @lowercase = str.downcase
+    @natural_types = @lowercase.scan(/\d+|\D+/).map { |s| s =~ /\d/ ? s.to_i : s }
+    @type_order = @natural_types.map {|el| el.is_a?(Integer) ? :i : :s }.join
+  end
+
+  def <=> (other)
+    if type_order.start_with?(other.type_order) || other.type_order.start_with?(type_order)
+      natural_types <=> other.natural_types
+    else
+      lowercase <=> other.lowercase
+    end
+  end
+
+  def to_s
+    @str.dup
+  end
+
+  def self.natural_sort(values)
+    values.map { |v| new(v) }.sort.map { |el| el.to_s }
+  end
+end

--- a/lib/label_sorter.rb
+++ b/lib/label_sorter.rb
@@ -1,4 +1,4 @@
-# natural sorting to handling complex strings with numbers, like biosample_id entries
+# natural sorting of complex labels with strings and integers, like biosample_id entries
 # adapted from https://rosettacode.org/wiki/Natural_sorting#Ruby
 class LabelSorter
   include Comparable
@@ -8,7 +8,7 @@ class LabelSorter
     @str = str
     @lowercase = str.downcase
     @natural_types = @lowercase.scan(/\d+|\D+/).map { |s| s =~ /\d/ ? s.to_i : s }
-    @type_order = @natural_types.map {|el| el.is_a?(Integer) ? :i : :s }.join
+    @type_order = @natural_types.map { |el| el.is_a?(Integer) ? :i : :s }.join
   end
 
   def <=> (other)

--- a/test/lib/label_sorter_test.rb
+++ b/test/lib/label_sorter_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class LabelSorterTest < ActiveSupport::TestCase
+  before(:all) do
+    # these labels are already in the correct order
+    @labels = %w(CS13 CS14 CS15 CS22_2_hypo CS22_hypo GW7_Lane1 GW7_Lane2 GW8_1 GW8_2 GW10 GW12_01 GW12_02 GW15_A GW15_M
+                 GW15_P GW16_hypo GW18_A GW18_hypo GW18_Lane1 GW18_Lane2 GW18_Lane3 GW18_M GW18_P GW19_hypo GW20_34_hypo
+                 GW20_A GW20_M GW20_P GW22T_hypo1 GW25_3V_hypo)
+  end
+
+  test 'should naturally sort list of complex labels' do
+    unsorted = @labels.shuffle
+    sorted = LabelSorter.natural_sort(unsorted)
+    assert_equal @labels, sorted
+  end
+
+  test 'should compare labels' do
+    first = LabelSorter.new('Biosample_3_A_4')
+    middle = LabelSorter.new('Biosample_3_A_10')
+    last = LabelSorter.new('Biosample_12_B_1')
+    assert_equal 0, first <=> first
+    assert_equal 0, middle <=> middle
+    assert_equal 0, last <=> last
+    assert_equal -1, first <=> middle
+    assert_equal -1, first <=> last
+    assert_equal -1, middle <=> last
+    assert_equal 1, middle <=> first
+    assert_equal 1, last <=> first
+    assert_equal 1, last <=> middle
+  end
+end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a bug introduced in #2076 where the server-side sorting of group-based annotations differed from the sorting of those same labels client-side.  This led to corner cases where colors seems to repeat prematurely when handling complex label entries, like those from `biosample_id`.  The problem was that the sorting server-side was purely lexical, where as the client-side sorting used the JS method `localeCompare`, which handles numbers/punctation much more naturally.

Now, the `LabelSorter` class replicates the functionality of `localeCompare` by extracting numeric values contained inside labels and ignoring non-word characters, and then sorts these internal values naturally.  This in turn makes the order of color maps more predictable, and repeats of nearby labels are now less likely.  It is worth noting that _any_ annotation with more that 27 unique labels will repeat colors - this fix only makes the likelihood of those repeats being close or next to each other in the legend far less likely.

#### MANUAL TESTING
Using clustering &  metadata from [SCP2247](https://singlecell.broadinstitute.org/single_cell/study/SCP2247/neuronal-diversity-in-the-human-hypothalamus) makes this much easier to test.

1. Boot as normal and load your copy of SCP2247 with the `biosample_id` annotation
2. Confirm that the colors for `GW7_Lane1` and `GW7_Lane2` are brown and pink, respectively
3. Compare against the [default clustering on production](https://singlecell.broadinstitute.org/single_cell/study/SCP2247/neuronal-diversity-in-the-human-hypothalamus) and confirm the plots are identical