### PR TITLE
Handle nil values in LabelSorter, refine ordering (SCP-5714)

### DIFF
--- a/lib/label_sorter.rb
+++ b/lib/label_sorter.rb
@@ -5,8 +5,8 @@ class LabelSorter
   attr_reader :lowercase, :natural_types, :type_order
 
   def initialize(str)
-    @str = str
-    @lowercase = str.downcase
+    @str = str.to_s # safeguard against nil or non-string values
+    @lowercase = @str.downcase
     @natural_types = @lowercase.scan(/\d+|\D+/).map { |s| s =~ /\d/ ? s.to_i : s }
     @type_order = @natural_types.map { |el| el.is_a?(Integer) ? :i : :s }.join
   end
@@ -24,6 +24,11 @@ class LabelSorter
   end
 
   def self.natural_sort(values)
-    values.map { |v| new(v) }.sort.map { |el| el.to_s }
+    sorted = values.map { |v| new(v) }.sort.map { |el| el.to_s }
+    # move any blank/Unspecified entries to the end to allow use of first color for actual label
+    if sorted.first.blank? || sorted.first == AnnotationVizService::MISSING_VALUE_LABEL
+      sorted << sorted.shift
+    end
+    sorted
   end
 end

--- a/test/api/visualization/annotations_controller_test.rb
+++ b/test/api/visualization/annotations_controller_test.rb
@@ -191,14 +191,13 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
       {
         name: 'cell_type', type: 'group', scope: 'study', values: %w(big --Unspecified--),
         identifier: 'cell_type--group--study',
-        color_map: { '--Unspecified--' => '#e41a1c', big: '#377eb8' }.with_indifferent_access
+        color_map: { big: '#e41a1c', '--Unspecified--' => '#377eb8' }.with_indifferent_access
       },
       {
         name: 'nCount_RNA', type: 'numeric', scope: 'study', values: [],
         identifier: 'nCount_RNA--numeric--study'
       }
     ]
-    expected_annotations[2][:values][1] = '--Unspecified--'
     assert_equal expected_annotations, annotations
     assert_empty Api::V1::Visualization::AnnotationsController.get_facet_annotations(
       @basic_study, cluster, 'does-not-exist--group--study'

--- a/test/lib/label_sorter_test.rb
+++ b/test/lib/label_sorter_test.rb
@@ -28,4 +28,14 @@ class LabelSorterTest < ActiveSupport::TestCase
     assert_equal 1, last <=> first
     assert_equal 1, last <=> middle
   end
+
+  test 'should move blank or unspecified to the end' do
+    random = @labels.take(10).shuffle
+    blank_label = [''] + random
+    sorted = LabelSorter.natural_sort(blank_label)
+    assert sorted.last.blank?
+    unspecified = [AnnotationVizService::MISSING_VALUE_LABEL] + random
+    sorted = LabelSorter.natural_sort(unspecified)
+    assert_equal AnnotationVizService::MISSING_VALUE_LABEL, sorted.last
+  end
 end

--- a/test/services/expression_viz_service_test.rb
+++ b/test/services/expression_viz_service_test.rb
@@ -241,9 +241,9 @@ class ExpressionVizServiceTest < ActiveSupport::TestCase
     # cells A & B belong to 'bar', and cell C belongs to the blank label
     expected_output = {
       bar: {
-        y: [0.0, 3.0], cells: %w(A B), annotations: [], name: 'bar', color: @color_list[1]
+        y: [0.0, 3.0], cells: %w(A B), annotations: [], name: 'bar', color: @color_list[0]
       }, "#{AnnotationVizService::MISSING_VALUE_LABEL}": {
-        y: [1.5], cells: %w(C), annotations: [], name: AnnotationVizService::MISSING_VALUE_LABEL, color: @color_list[0]
+        y: [1.5], cells: %w(C), annotations: [], name: AnnotationVizService::MISSING_VALUE_LABEL, color: @color_list[1]
       }
     }
     assert_equal expected_output.with_indifferent_access, violin_data.with_indifferent_access


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes two issues recently discovered with `LabelSorter` and `--Unspecified--` values in group-based annotations:

First, there are some legacy studies on production ([SCP542](https://singlecell.broadinstitute.org/single_cell/study/SCP542/pan-cancer-cell-line-heterogeneity?cluster=tSNE%20Head%20and%20Neck%20Cancer&spatialGroups=--&annotation=Discrete_cluster_minpts5_eps1.8--group--study&subsample=all#study-visualize) & [SCP820](https://singlecell.broadinstitute.org/single_cell/study/SCP820/hbv-liverconsortium-smartseq2?cluster=All%20Cells&spatialGroups=--&annotation=sortDate--group--study&subsample=all#study-visualize)) that have invalid data in the unique values array for some group-based annotations, specifically `NaN`.  This was due to previous issues ([here](https://github.com/broadinstitute/scp-ingest-pipeline/pull/81) and [here](https://github.com/broadinstitute/scp-ingest-pipeline/pull/114)) in `scp-ingest-pipeline` where `NaN` was returned by `pandas` instead of blank strings (both studies predate these fixes).  The new natural sorting `LabelSorter` class throws an error when trying to call `downcase` on these values, as seen in the UI.

Secondly, for studies that have `--Unspecified--` labels, these are incorrectly sorted into the first position of the color map server-side, and then reassigned to the semi-transparent light grey color by the front end and shifted to the end of the legend.  This means that the first available color for group-based annotations (red) is never used in this case.

Now, these `NaN` values are correctly converted to blank strings, and any `--Unspecified--` entries are automatically moved to the end of the color map, making the red label color available again for the first entry.

#### MANUAL TESTING
The data used in the original PR to [fix cell filtering for blank labels](https://github.com/broadinstitute/single_cell_portal_core/pull/1926) works very well in this case, if you have a local copy (sourced from [SCP2407](https://singlecell.broadinstitute.org/single_cell/study/SCP2407/single-cell-atlas-of-the-liver-myeloid-compartment-before-and-after-cure-of-chronic-viral-hepatitis?cluster=all_tsne&spatialGroups=--&annotation=celltype_subcluster--group--study&subsample=all#study-visualize)).  However, any group-based annotation that has `--Unspecified--` values will work.
1. In a Rails console session, load the `celltype_subcluster` annotation from your copy of SCP2407 (if using):
```
study = Study.find_by(accession: <your accession>)
meta = study.cell_metadata.by_name_and_type('celltype_subcluster', 'group')
```
2. (Optional) if not using SCP2407, find any metadatum locally that has a blank value in the unique values array that has many labels:
```
meta = CellMetadatum.where(:values.in => ['']).sort_by { |m| m.values.count }.last
```
3. Change the blank entry to `NaN` to reproduce the data integrity error:
```
blank_idx = meta.values.index('')
meta.values[blank_idx] = Float::NAN
meta.save
```
4. Boot as normal and load the same study/annotation that you just edited
5. Confirm there is no error in the UI, and that the first label shown in the legend uses the color red
6. Back in the Rails console, revert the values array:
```
meta.values[blank_idx] = ''
meta.save
```