### PR TITLE
Adding internal Terra workspaces for studies (SCP-4949)

### DIFF
--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -430,6 +430,15 @@ module Api
             end
           end
 
+          # remove internal workspace in all cases
+          begin
+            ApplicationController.firecloud_client.delete_workspace(FireCloudClient::PORTAL_NAMESPACE, @study.internal_workspace)
+          rescue => e
+            ErrorTracker.report_exception(e, current_user, @study, params)
+            MetricsService.report_error(e, request, current_user, @study)
+            logger.error "Unable to delete internal workspace: #{@study.internal_workspace}; #{e.message}"
+          end
+
           # queue jobs to delete study caches & study itself
           CacheRemovalJob.new(@study.accession).delay(queue: :cache).perform
           DeleteQueueJob.new(@study).delay.perform

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -745,9 +745,9 @@ module Api
         rescue => e
           ErrorTracker.report_exception(e, current_user, @study, params)
           MetricsService.report_error(e, request, current_user, @study)
-          logger.error "#{Time.zone.now}: error syncing files in workspace bucket #{@study.firecloud_workspace} due to error: #{e.message}"
-          redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
-                      alert: "We were unable to sync with your workspace bucket due to an error: #{view_context.simple_format(e.message)}.  #{SCP_SUPPORT_EMAIL}" and return
+          error_msg = "Error syncing files in workspace bucket #{@study.firecloud_workspace} due to error: #{e.message}"
+          logger.error error_msg
+          render json: { error: error_msg }, status: 500
         end
 
         # refresh study state before continuing as new records may have been inserted

--- a/app/lib/import_service.rb
+++ b/app/lib/import_service.rb
@@ -144,8 +144,12 @@ class ImportService
     # first check if a study already exists using this external_identifer to prevent accidental workspace deletion
     return false if Study.where(external_identifier: study.external_identifier, :id.ne => study.id).exists?
 
-    if ApplicationController.firecloud_client.workspace_exists?(study.firecloud_project, study.firecloud_workspace)
-      ApplicationController.firecloud_client.delete_workspace(study.firecloud_project, study.firecloud_workspace)
+    [:study, :internal].each do |workspace_type|
+      ws_namespace, ws_name = study.workspace_attrs(workspace_type)
+      client = study.workspace_client(ws_namespace)
+      if client.workspace_exists?(ws_namespace, ws_name)
+        client.delete_workspace(ws_namespace, ws_name)
+      end
     end
   end
 end

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -267,17 +267,22 @@ class AdminConfiguration
   end
 
   def self.find_or_create_ws_user_group!
-    groups = ApplicationController.firecloud_client.get_user_groups
-    ws_owner_group = groups.detect {|group| group['groupName'] == FireCloudClient::WS_OWNER_GROUP_NAME &&
-        group['role'] == 'Admin'}
-    # create group if not found
-    if ws_owner_group.present?
-      ws_owner_group
-    else
-      # create and return group
-      ApplicationController.firecloud_client.create_user_group(FireCloudClient::WS_OWNER_GROUP_NAME)
-      ApplicationController.firecloud_client.get_user_group(FireCloudClient::WS_OWNER_GROUP_NAME)
-    end
+    find_or_create_group!(FireCloudClient::WS_OWNER_GROUP_NAME)
+  end
+
+  def self.find_or_create_admin_read_group!
+    find_or_create_group!(FireCloudClient::ADMIN_READ_GROUP_NAME)
+  end
+
+  def self.find_or_create_group!(group_name)
+    client = ApplicationController.firecloud_client
+    groups = client.get_user_groups
+    requested_group = groups.detect { |group| group['groupName'] == group_name && group['role'] == 'Admin' }
+    # return group if found, or create and return
+    return requested_group if requested_group.present?
+
+    client.create_user_group(group_name)
+    client.get_user_group(group_name)
   end
 
   # getter to return all configuration options as a hash

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -270,8 +270,8 @@ class AdminConfiguration
     find_or_create_group!(FireCloudClient::WS_OWNER_GROUP_NAME)
   end
 
-  def self.find_or_create_admin_read_group!
-    find_or_create_group!(FireCloudClient::ADMIN_READ_GROUP_NAME)
+  def self.find_or_create_admin_internal_group!
+    find_or_create_group!(FireCloudClient::ADMIN_INTERNAL_GROUP_NAME)
   end
 
   def self.find_or_create_group!(group_name)

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -50,6 +50,8 @@ class FireCloudClient
   # groups the portal service account needs to be a member of
   # defaults to the Terra billing project this instance is configured against, plus "-sa-owner-group"
   WS_OWNER_GROUP_NAME = "#{PORTAL_NAMESPACE}-sa-owner-group".freeze
+  # name of user group for admin read access to visualization workspaces
+  ADMIN_READ_GROUP_NAME = "#{PORTAL_NAMESPACE}-admin-read-group".freeze
 
   ##
   # SERVICE NAMES AND DESCRIPTIONS

--- a/app/models/fire_cloud_client.rb
+++ b/app/models/fire_cloud_client.rb
@@ -50,8 +50,8 @@ class FireCloudClient
   # groups the portal service account needs to be a member of
   # defaults to the Terra billing project this instance is configured against, plus "-sa-owner-group"
   WS_OWNER_GROUP_NAME = "#{PORTAL_NAMESPACE}-sa-owner-group".freeze
-  # name of user group for admin read access to visualization workspaces
-  ADMIN_READ_GROUP_NAME = "#{PORTAL_NAMESPACE}-admin-read-group".freeze
+  # name of user group for admin access to internal workspaces
+  ADMIN_INTERNAL_GROUP_NAME = "#{PORTAL_NAMESPACE}-admin-internal-group".freeze
 
   ##
   # SERVICE NAMES AND DESCRIPTIONS
@@ -388,6 +388,7 @@ class FireCloudClient
   end
 
   # passthru to determine if a workspace exists
+  # bypasses :process_firecloud_request to avoid needless error reporting
   #
   # * *params*
   #   - +workspace_namespace+ (String) => namespace of workspace
@@ -397,7 +398,8 @@ class FireCloudClient
   #   - +Boolean+
   def workspace_exists?(workspace_namespace, workspace_name)
     begin
-      get_workspace(workspace_namespace, workspace_name)
+      path = "#{api_root}/api/workspaces/#{uri_encode(workspace_namespace)}/#{uri_encode(workspace_name)}"
+      RestClient::Request.execute(method: :get, url: path, headers: get_default_headers)
       true
     rescue RestClient::NotFound
       false

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -709,7 +709,7 @@ class Study
   # VALIDATIONS & CALLBACKS
   #
   ###
-  validate  :assign_accession, on: :create
+  validate :assign_accession, on: :create
 
   # custom validator since we need everything to pass in a specific order (otherwise we get orphaned FireCloud workspaces)
   validate :initialize_with_new_workspace, on: :create, if: Proc.new {|study| !study.use_existing_workspace && !study.detached}

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -750,12 +750,12 @@ class Study
   validates_uniqueness_of :name, on: :update, message: ": %{value} has already been taken.  Please choose another name."
   validates_presence_of   :name, on: :update
   validate :prevent_firecloud_attribute_changes, on: :update
-  validates_presence_of :firecloud_project, :firecloud_workspace, :internal_workspace
   validates_uniqueness_of :external_identifier, allow_blank: true
   validates :cell_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validate  :assign_accession, on: :create
   validate  :set_internal_workspace_name, on: :create
   validate  :create_internal_workspace, on: :create, unless: proc { |study| study.detached }
+  validates_presence_of :firecloud_project, :firecloud_workspace, :internal_workspace
 
   # callbacks
   before_validation :set_url_safe_name
@@ -1983,7 +1983,7 @@ class Study
       errors.add(requested_workspace, ": We encountered an error when attempting to set workspace permissions.  Please try again, or chose a different project.")
       return false
     else
-      Rails.logger.info "'#{name}' acls ok for user workspace #{workspace_attrs.join('/')}"
+      Rails.logger.info "'#{name}' acls ok for #{workspace_type} workspace #{workspace_attrs(workspace_type).join('/')}"
     end
     # assign bucket ID
     set_bucket_id(workspace['bucketName'], type: workspace_type)
@@ -1991,6 +1991,7 @@ class Study
 
   # handler to create a workspace for a study, either user-facing or internal
   def create_terra_workspace(type = :study)
+    set_internal_workspace_name if type == :internal
     ws_namespace, ws_name = workspace_attrs(type)
     workspace_client(ws_namespace).create_workspace(ws_namespace, ws_name)
   end

--- a/app/views/single_cell_mailer/notify_admin_parse_launch_fail.html.erb
+++ b/app/views/single_cell_mailer/notify_admin_parse_launch_fail.html.erb
@@ -9,6 +9,8 @@
   <li>Study: <%= @study.accession %></li>
   <li>Workspace: <%= link_to @study.workspace_url, @study.workspace_url %></li>
   <li>Bucket:  <%= link_to @study.google_bucket_url, @study.google_bucket_url %></li>
+  <li>Internal workspace: <%= link_to @study.workspace_url(:internal), @study.workspace_url(:internal) %></li>
+  <li>Internal bucket:  <%= link_to @study.google_bucket_url(:internal), @study.google_bucket_url(:internal) %></li>
   <li>File: <%= @study_file.upload_file_name %></li>
   <li>File Type: <%= @study_file.file_type %></li>
   <li>Uploaded/synced on: <%= @study_file.created_at.to_s(:db) %></li>

--- a/app/views/studies/new.html.erb
+++ b/app/views/studies/new.html.erb
@@ -8,7 +8,9 @@
     If you do not already have a Terra account, you will receive an invitation email after you create your study.
     While you can interact with your uploaded files directly through the Single Cell Portal, you must complete the Terra
     registration process before you can see or use your files in your Terra workspace.  You will also receive an email
-    letting you know that the Single Cell Portal service account has shared the study workspace with you.</p>
+    letting you know that the Single Cell Portal service account has shared the study workspace with you.  Additionally,
+    all SCP studies are assigned a second "internal" workspace where additional assets are stored.  You will not need
+    to access this workspace, but you will see a notification that it has been shared with you.</p>
   <p>You may also create a study based on an existing workspace you already own.  To do so, select <strong>'Yes'</strong>
     under <strong>'Use Existing Workspace'</strong> and then provide the name in the text box.</p>
   <h4>Billing projects</h4>
@@ -42,7 +44,8 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h4 class="text-center">Creating study and provisioning workspace... Please wait<br/></h4>
+        <h4 class="text-center">Creating study and provisioning workspaces... Please wait<br/></h4>
+        <p class="text-center help-block">This may take up to a minute to complete.  Please do not refresh the page.</p>
       </div>
       <div class="modal-body">
         <div class="spinner-target" id="create-study-spinner"></div>

--- a/db/migrate/20240725140706_create_internal_workspaces.rb
+++ b/db/migrate/20240725140706_create_internal_workspaces.rb
@@ -1,0 +1,25 @@
+class CreateInternalWorkspaces < Mongoid::Migration
+  def self.up
+    accessions = Study.where(queued_for_deletion: false, detached: false).pluck(:accession)
+    accessions.each do |accession|
+      study = Study.find_by(accession:)
+      study.delay.add_internal_workspace # run in background so as not to be blocking on deployment
+    end
+  end
+
+  # rollback doesn't need to be non-blocking
+  def self.down
+    assigned = Study.where(queued_for_deletion: false, detached: false, :internal_workspace.nin => [nil, ''])
+    workspaces = assigned.pluck(:internal_workspace)
+    client = ApplicationController.firecloud_client
+    project = FireCloudClient::PORTAL_NAMESPACE
+    workspaces.each do |workspace|
+      begin
+        client.delete_workspace(project, workspace)
+      rescue RestClient::Exception => e
+        Rails.logger.error "error deleting #{workspace}: #{e.message}"
+      end
+    end
+    assigned.update_all(internal_workspace: nil, internal_bucket_id: nil)
+  end
+end

--- a/db/migrate/20240729151158_add_admins_to_internal_group.rb
+++ b/db/migrate/20240729151158_add_admins_to_internal_group.rb
@@ -1,0 +1,9 @@
+class AddAdminsToInternalGroup < Mongoid::Migration
+  def self.up
+    User.where(admin: true).map(&:add_to_admin_group)
+  end
+
+  def self.down
+    User.where(admin: true).map(&:remove_from_admin_group)
+  end
+end

--- a/lib/study_cleanup_tools.rb
+++ b/lib/study_cleanup_tools.rb
@@ -70,7 +70,9 @@ module StudyCleanupTools
       ws_name = ws_attr['name']
       ws_project = ws_attr['namespace']
       ws_owner = ws_attr['createdBy']
-      existing_study = Study.find_by(firecloud_project: ws_project, firecloud_workspace: ws_name)
+      existing_study = Study.where(firecloud_project: ws_project).any_of(
+        { firecloud_workspace: ws_name }, { internal_workspace: ws_name }
+      )
       if existing_study.present?
         puts "skipping #{ws_project}/#{ws_name} as it belongs to #{existing_study.accession}"
         next

--- a/test/api/studies_controller_test.rb
+++ b/test/api/studies_controller_test.rb
@@ -135,7 +135,7 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
     puts 'creating ACL...'
     user_acl = ApplicationController.firecloud_client.create_workspace_acl(@user.email, 'WRITER', true, true)
     ApplicationController.firecloud_client.update_workspace_acl(FireCloudClient::PORTAL_NAMESPACE, workspace_name, user_acl)
-    share_user = FactoryBot.create(:api_user)
+    share_user = FactoryBot.create(:api_user, test_array: @@users_to_clean)
     share_acl = ApplicationController.firecloud_client.create_workspace_acl(share_user.email, 'READER', true, false)
     ApplicationController.firecloud_client.update_workspace_acl(FireCloudClient::PORTAL_NAMESPACE, workspace_name, share_acl)
     # validate acl set
@@ -160,6 +160,7 @@ class StudiesControllerTest < ActionDispatch::IntegrationTest
     # call sync
     puts 'syncing study...'
     execute_http_request(:post, sync_api_v1_study_path(id: sync_study.id))
+    assert_response 200
     assert json['study_shares'].detect {|share| share['email'] == share_user.email}.present?, "Did not create share for #{share_user.email}"
     assert json['study_files']['unsynced'].detect {|file| file['name'] == metadata_filename},
            "Did not find unsynced study file for #{metadata_filename}"

--- a/test/detached_helper.rb
+++ b/test/detached_helper.rb
@@ -64,7 +64,7 @@ end
 
 # helper to mock all calls to Terra orchestration API when saving a new study & creating workspace
 # useful for when we don't want the study to be detached, but still want to save to the database
-def assign_workspace_mock!(mock, group, study_name)
+def assign_workspace_mock!(mock, group, study_name, skip_entities: false)
   workspace = { name: study_name, bucketName: SecureRandom.uuid }.with_indifferent_access
   owner_acl = { acl: { group[:groupEmail] => { accessLevel: 'OWNER' } } }.with_indifferent_access
   compute_acl = { acl: { @user.email => { accessLevel: 'WRITER', canCompute: true } } }.with_indifferent_access
@@ -75,17 +75,17 @@ def assign_workspace_mock!(mock, group, study_name)
   mock.expect :create_workspace, workspace, [String, String, true]
   mock.expect :create_workspace_acl, Hash, [String, String, true, false]
   mock.expect :update_workspace_acl, owner_acl, [String, String, Hash]
-  mock.expect :create_workspace_acl, Hash, [String, String, true, true]
   mock.expect :get_workspace_acl, owner_acl, [String, String]
-  mock.expect :update_workspace_acl, compute_acl, [String, String, Hash]
-  mock.expect :import_workspace_entities_file, true, [String, String, File]
-  # internal workspace mocks
-  mock.expect :create_workspace, workspace, [String, String, true]
   mock.expect :create_workspace_acl, Hash, [String, String, true, false]
   mock.expect :update_workspace_acl, owner_acl, [String, String, Hash]
   mock.expect :get_workspace_acl, owner_acl, [String, String]
   mock.expect :create_workspace_acl, Hash, [String, String, true, false]
   mock.expect :update_workspace_acl, admin_acl, [String, String, Hash]
+  mock.expect :create_workspace_acl, Hash, [String, String, true, true]
+  mock.expect :update_workspace_acl, compute_acl, [String, String, Hash]
+  mock.expect :import_workspace_entities_file, true, [String, String, File] unless skip_entities
+  # internal workspace mocks
+  mock.expect :create_workspace, workspace, [String, String, true]
   mock.expect :create_workspace_acl, Hash, [String, String, false, false]
   mock.expect :update_workspace_acl, user_read_acl, [String, String, Hash]
 end

--- a/test/detached_helper.rb
+++ b/test/detached_helper.rb
@@ -68,12 +68,24 @@ def assign_workspace_mock!(mock, group, study_name)
   workspace = { name: study_name, bucketName: SecureRandom.uuid }.with_indifferent_access
   owner_acl = { acl: { group[:groupEmail] => { accessLevel: 'OWNER' } } }.with_indifferent_access
   compute_acl = { acl: { @user.email => { accessLevel: 'WRITER', canCompute: true } } }.with_indifferent_access
+  user_read_acl = { acl: { @user.email => { accessLevel: 'READER' } } }.with_indifferent_access
+  admin_group = "#{FireCloudClient::ADMIN_INTERNAL_GROUP_NAME}@firecloud.org"
+  admin_acl = { acl: { admin_group => { accessLevel: 'WRITER' } } }.with_indifferent_access
+  # user workspace mocks
   mock.expect :create_workspace, workspace, [String, String, true]
   mock.expect :create_workspace_acl, Hash, [String, String, true, false]
-  mock.expect :update_workspace_acl, Hash, [String, String, Hash]
-  mock.expect :get_workspace_acl, owner_acl, [String, String]
+  mock.expect :update_workspace_acl, owner_acl, [String, String, Hash]
   mock.expect :create_workspace_acl, Hash, [String, String, true, true]
-  mock.expect :update_workspace_acl, Hash, [String, String, Hash]
-  mock.expect :get_workspace_acl, compute_acl, [String, String]
+  mock.expect :get_workspace_acl, owner_acl, [String, String]
+  mock.expect :update_workspace_acl, compute_acl, [String, String, Hash]
   mock.expect :import_workspace_entities_file, true, [String, String, File]
+  # internal workspace mocks
+  mock.expect :create_workspace, workspace, [String, String, true]
+  mock.expect :create_workspace_acl, Hash, [String, String, true, false]
+  mock.expect :update_workspace_acl, owner_acl, [String, String, Hash]
+  mock.expect :get_workspace_acl, owner_acl, [String, String]
+  mock.expect :create_workspace_acl, Hash, [String, String, true, false]
+  mock.expect :update_workspace_acl, admin_acl, [String, String, Hash]
+  mock.expect :create_workspace_acl, Hash, [String, String, false, false]
+  mock.expect :update_workspace_acl, user_read_acl, [String, String, Hash]
 end

--- a/test/detached_helper.rb
+++ b/test/detached_helper.rb
@@ -71,21 +71,23 @@ def assign_workspace_mock!(mock, group, study_name, skip_entities: false)
   user_read_acl = { acl: { @user.email => { accessLevel: 'READER' } } }.with_indifferent_access
   admin_group = "#{FireCloudClient::ADMIN_INTERNAL_GROUP_NAME}@firecloud.org"
   admin_acl = { acl: { admin_group => { accessLevel: 'WRITER' } } }.with_indifferent_access
-  # user workspace mocks
+  # we don't actually know in what order acls will be assigned as workspace creation happens in parallel
+  # since Minitest cares about parameters for :expect, use a Set for the share/compute permissions to avoid
+  # MockExpectationError from unexpected arguments
+  permission_set = Set[true, false]
   mock.expect :create_workspace, workspace, [String, String, true]
-  mock.expect :create_workspace_acl, Hash, [String, String, true, false]
+  mock.expect :create_workspace_acl, Hash, [String, String, permission_set, permission_set]
   mock.expect :update_workspace_acl, owner_acl, [String, String, Hash]
   mock.expect :get_workspace_acl, owner_acl, [String, String]
-  mock.expect :create_workspace_acl, Hash, [String, String, true, false]
+  mock.expect :create_workspace_acl, Hash, [String, String, permission_set, permission_set]
   mock.expect :update_workspace_acl, owner_acl, [String, String, Hash]
   mock.expect :get_workspace_acl, owner_acl, [String, String]
-  mock.expect :create_workspace_acl, Hash, [String, String, true, false]
+  mock.expect :create_workspace_acl, Hash, [String, String, permission_set, permission_set]
   mock.expect :update_workspace_acl, admin_acl, [String, String, Hash]
-  mock.expect :create_workspace_acl, Hash, [String, String, true, true]
+  mock.expect :create_workspace_acl, Hash, [String, String, permission_set, permission_set]
   mock.expect :update_workspace_acl, compute_acl, [String, String, Hash]
   mock.expect :import_workspace_entities_file, true, [String, String, File] unless skip_entities
-  # internal workspace mocks
   mock.expect :create_workspace, workspace, [String, String, true]
-  mock.expect :create_workspace_acl, Hash, [String, String, false, false]
+  mock.expect :create_workspace_acl, Hash, [String, String, permission_set, permission_set]
   mock.expect :update_workspace_acl, user_read_acl, [String, String, Hash]
 end

--- a/test/factories/study.rb
+++ b/test/factories/study.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
     # create a study but mark as detached, so a Terra workspace is not created
     factory :detached_study do
       detached { true }
+      internal_workspace { "#{accession}-test-internal-#{SecureRandom.alphanumeric(5)}" }
       bucket_id { SecureRandom.alphanumeric(16) } # needed to prevent test errors when mocking/stubbing GCS calls
       internal_bucket_id { SecureRandom.alphanumeric(16) } # needed to prevent test errors when mocking/stubbing GCS calls
     end

--- a/test/factories/study.rb
+++ b/test/factories/study.rb
@@ -33,6 +33,7 @@ FactoryBot.define do
     factory :detached_study do
       detached { true }
       bucket_id { SecureRandom.alphanumeric(16) } # needed to prevent test errors when mocking/stubbing GCS calls
+      internal_bucket_id { SecureRandom.alphanumeric(16) } # needed to prevent test errors when mocking/stubbing GCS calls
     end
   end
 end

--- a/test/integration/external/import_service_config/hca_test.rb
+++ b/test/integration/external/import_service_config/hca_test.rb
@@ -158,22 +158,25 @@ module ImportServiceConfig
       # for study to save, we need to mock all Terra orchestration API calls for creating workspace & setting acls
       fc_client_mock = Minitest::Mock.new
       owner_group = { groupEmail: 'sa-owner-group@firecloud.org' }.with_indifferent_access
+      admin_group = { groupEmail: "#{FireCloudClient::ADMIN_INTERNAL_GROUP_NAME}@firecloud.org" }.with_indifferent_access
       assign_workspace_mock!(fc_client_mock, owner_group, study_name)
       AdminConfiguration.stub :find_or_create_ws_user_group!, owner_group do
-        ImportService.stub :copy_file_to_bucket, file_mock do
-          ApplicationController.stub :firecloud_client, fc_client_mock do
-            @configuration.stub :taxon_from, Taxon.new(common_name: 'human') do
-              study, study_file = @configuration.import_from_service
-              file_mock.verify
-              fc_client_mock.verify
-              assert study.persisted?
-              assert study_file.persisted?
-              assert_equal study.external_identifier, @attributes[:study_id]
-              assert_equal study_file.external_identifier, @attributes[:file_id]
-              # trim off query params to prevent test failures when catalog/version updates
-              trimmed_access_url = access_url.split('?').first
-              trimmed_external_url = study_file.external_link_url.split('?').first
-              assert_equal trimmed_external_url, trimmed_access_url
+        AdminConfiguration.stub :find_or_create_admin_internal_group!, admin_group do
+          ImportService.stub :copy_file_to_bucket, file_mock do
+            ApplicationController.stub :firecloud_client, fc_client_mock do
+              @configuration.stub :taxon_from, Taxon.new(common_name: 'human') do
+                study, study_file = @configuration.import_from_service
+                file_mock.verify
+                fc_client_mock.verify
+                assert study.persisted?
+                assert study_file.persisted?
+                assert_equal study.external_identifier, @attributes[:study_id]
+                assert_equal study_file.external_identifier, @attributes[:file_id]
+                # trim off query params to prevent test failures when catalog/version updates
+                trimmed_access_url = access_url.split('?').first
+                trimmed_external_url = study_file.external_link_url.split('?').first
+                assert_equal trimmed_external_url, trimmed_access_url
+              end
             end
           end
         end

--- a/test/models/study_test.rb
+++ b/test/models/study_test.rb
@@ -240,7 +240,7 @@ class StudyTest < ActiveSupport::TestCase
     mock = Minitest::Mock.new
     owner_group = { groupEmail: 'sa-owner-group@firecloud.org' }.with_indifferent_access
     admin_group = { groupEmail: "#{FireCloudClient::ADMIN_INTERNAL_GROUP_NAME}@firecloud.org" }.with_indifferent_access
-    assign_workspace_mock!(mock, owner_group, @study.firecloud_workspace)
+    assign_workspace_mock!(mock, owner_group, @study.firecloud_workspace, skip_entities: true)
     AdminConfiguration.stub :find_or_create_ws_user_group!, owner_group do
       AdminConfiguration.stub :find_or_create_admin_internal_group!, admin_group do
         ApplicationController.stub :firecloud_client, mock do

--- a/test/services/cluster_viz_service_test.rb
+++ b/test/services/cluster_viz_service_test.rb
@@ -122,6 +122,7 @@ class ClusterVizServiceTest < ActiveSupport::TestCase
                           cells: cells
                       })
     cluster = @study.cluster_groups.by_name(cluster_name)
+    cluster.update(subsampled: true)
     options = ClusterVizService.subsampling_options(cluster)
     assert_equal [1000], options
   end


### PR DESCRIPTION
#### BACKGROUND
The first step of future scaling work related to pre-rendering of visualization data was to determine where such data would be held.  Currently, all SCP studies have an associated Terra workspace where all uploaded files are stored, along with any internal SCP assets, such as ingest log files and some existing rendered data in the form of differential expression outputs.  After evaluating several different options, the decision was made to add a second Terra workspace to all SCP studies where all internal assets will be stored.  Read access can then be granted to users for these internal workspace (write access for admins) to enable future visualization requests. 

#### CHANGES
Now, all studies will have a second Terra workspace created after the primary user-facing one has been successfully provisioned.  These workspaces will have deterministic names of `{accession}-{environment}-internal` (in the `test` environment, a 5-character slug is appended to avoid naming collisions during CI).  A backfill migration has been added to assign these workspaces to all existing studies.  Additionally, the code used for provisioning & accessing associated workspaces has been substantively refactored to make it more maintainable and reusable.  Some existing validations have been refined (or removed if they were deemed redundant) to help speed up the process of provisioning both workspaces.  Additionally, a migration was added to create the new admin internal group and add all existing admins to this group.  Group membership is managed via a `before_save` hook to add or remove a user if their admin privileges change.

It is worth noting that it takes roughly 35 seconds to provision a Terra workspace.  This means that new study creation can take up to 70 seconds to complete.  Also, given that there are 1600+ studies on production with active Terra workspaces, it will take roughly 2h40m to create all necessary internal workspaces.  Since this is done in the background, it will not affect deployments and should not represent meaningful load on the server while processing.

Parallelization is an option for improving the performance on this, however given the OOO re: accession assignment and other validations, this has the potential for race conditions that could lead to studies being "stuck" or problems in getting new accessions.  Given the relative sparsity of study creation, I opted to [ticket](https://broadworkbench.atlassian.net/browse/SCP-5731) the performance improvements in favor of moving forward with the larger pre-rendering epic.

Lastly, this work only focuses on assigning internal workspaces to new and existing studies.  Forthcoming work will address integrating these workspaces into the normal ingest UX, as well as migrating existing data to the new internal buckets.

#### MANUAL TESTING
1. Boot all services including DelayedJob
2. In a separate terminal, run the backfill migration(s) with `bin/rails db:migrate`
3. Look for log messages like the following in `development.log`
```
FireCloud API request (POST) https://api.firecloud.org/api/workspaces with tracking identifier: default-service-account@broad-singlecellportal-bistlin.iam.gserviceaccount.com
SCP13 Terra internal workspace SCP13-development-internal creation successful
Checking service account permissions for single-cell-portal-development/SCP13-development-internal
FireCloud API request (GET) https://api.firecloud.org/api/groups with tracking identifier: default-service-account@broad-singlecellportal-bistlin.iam.gserviceaccount.com
FireCloud API request (PATCH) https://api.firecloud.org/api/workspaces/single-cell-portal-development/SCP13-development-internal/acl?inviteUsersNotFound=true with tracking identifier: default-service-account@broad-singlecellportal-bistlin.iam.gserviceaccount.com
FireCloud API request (GET) https://api.firecloud.org/api/workspaces/single-cell-portal-development/SCP13-development-internal/acl with tracking identifier: default-service-account@broad-singlecellportal-bistlin.iam.gserviceaccount.com
Setting workspaces acls for single-cell-portal-development/SCP13-development-internal
FireCloud API request (GET) https://api.firecloud.org/api/groups with tracking identifier: default-service-account@broad-singlecellportal-bistlin.iam.gserviceaccount.com
FireCloud API request (PATCH) https://api.firecloud.org/api/workspaces/single-cell-portal-development/SCP13-development-internal/acl?inviteUsersNotFound=true with tracking identifier: default-service-account@broad-singlecellportal-bistlin.iam.gserviceaccount.com
FireCloud API request (PATCH) https://api.firecloud.org/api/workspaces/single-cell-portal-development/SCP13-development-internal/acl?inviteUsersNotFound=true with tracking identifier: default-service-account@broad-singlecellportal-bistlin.iam.gserviceaccount.com
FireCloud API request (PATCH) https://api.firecloud.org/api/workspaces/single-cell-portal-development/SCP13-development-internal/acl?inviteUsersNotFound=true with tracking identifier: default-service-account@broad-singlecellportal-bistlin.iam.gserviceaccount.com
Workspace acls for single-cell-portal-development/SCP13-development-internal configured successfully
SCP13 Terra internal workspace acls assigned successfully
SCP13 Terra internal workspace creation complete
Checking bucket access on single-cell-portal-development/SCP13-development-internal with tracking identifier: default-service-account@broad-singlecellportal-bistlin.iam.gserviceaccount.com
...
```
4. In a browser, sign in and click the "Create study" button in the top navbar
5. Create a new study and confirm that it completes successfully after ~1m and that you are taken to the upload wizard
6. In a separate Rails console session, validate that your admin account is now a member of the new internal admin group
```
user = User.find_by(email: <your admin email>)
group_email = "#{FireCloudClient::ADMIN_INTERNAL_GROUP_NAME}@firecloud.org"
groups = user.user_groups
groups.include?(group_email)
=> true
```