### PR TITLE
Add larger machine types AnnData ingest flexibility (SCP-5733)

### DIFF
--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -50,7 +50,7 @@ class AnnDataIngestParameters
 
   # GCE machine types and file size ranges for handling fragment extraction
   # produces a hash with entries like { 'n2-highmem-4' => 0..4.gigabytes }
-  EXTRACT_MACHINE_TYPES = [4, 8, 16, 32].map.with_index do |cores, index|
+  EXTRACT_MACHINE_TYPES = [4, 8, 16, 32, 48, 64, 80, 96].map.with_index do |cores, index|
     floor = index == 0 ? 0 : (cores / 2).gigabytes
     limit = (cores * 8).gigabytes
     # ranges that use '...' exclude the given end value.

--- a/app/models/concerns/parameterizable.rb
+++ b/app/models/concerns/parameterizable.rb
@@ -18,7 +18,7 @@ module Parameterizable
   # https://cloud.google.com/compute/docs/general-purpose-machines
   GCE_MACHINE_TYPES = %w[n2 n2d].map do |family|
     %w[standard highmem highcpu].map do |series|
-      [2, 4, 8, 16, 32, 64, 96].map do |cores|
+      [2, 4, 8, 16, 32, 48, 64, 80, 96].map do |cores|
         [family, series, cores].join('-')
       end
     end

--- a/test/models/ann_data_ingest_parameters_test.rb
+++ b/test/models/ann_data_ingest_parameters_test.rb
@@ -99,7 +99,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
   test 'should set default machine type and allow override' do
     params = AnnDataIngestParameters.new(@extract_params)
     assert_equal 'n2d-highmem-16', params.machine_type
-    new_machine = 'n2d-highmem-32'
+    new_machine = 'n2d-highmem-80'
     params.machine_type = new_machine
     assert_equal new_machine, params.machine_type
     assert params.valid?


### PR DESCRIPTION
[Zendesk 320848](https://broadinstitute.zendesk.com/agent/tickets/320848), study owner uploaded 58G AnnData. Ingest job throws 139 error code using n2d-highmem-32 machine. Testing suggests n2d-highmem-48 will work but n2d-highmem-48 renders the job params invalid.

Adding larger machine types 48, 64, 80, 96 as valid params for greater flexibility in ingest.

MANUAL TESTING
Enter a Rails console session and create a mock `AnnDataIngestParameters` object:
```
extract_params = { anndata_file: 'gs://bucket_id/test.h5ad', file_size: 50.gigabytes }
params = AnnDataIngestParameters.new(**extract_params)
=> 
#<AnnDataIngestParameters:0x000000010e9b07d0                                      
...
```
Confirm the `machine_type` is `n2d-highmem-8`, the default for a file of 50G:
```
params.machine_type
=> "n2d-highmem-8"
```
Set the `machine_type` to a larger machine, like `n2d-highmem-80` and confirm the params are still valid:
```
params.machine_type = 'n2d-highmem-80'
=> "n2d-highmem-80"

params.valid?
=> true
```
Confirm that `machine_type` only accepts valid machine size values:
```
params.machine_type = 'n2d-highmem-192'
=> "n2d-highmem-192"

params.valid?
=> false
```