### PR TITLE
Omit subsampling options unless cluster is subsampled (SCP-5438)

### DIFF
--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -67,7 +67,7 @@ class ClusterVizService
   # only options allowed are 1000, 10000, 20000, and 100000
   # will only provide options if subsampling has completed for a cluster
   def self.subsampling_options(cluster)
-    return [] if cluster.nil? || cluster.is_subsampling?
+    return [] if cluster.nil? || cluster.is_subsampling? || !cluster.subsampled
 
     ClusterGroup::SUBSAMPLE_THRESHOLDS.select { |sample| sample < cluster.points }
   end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug with the "Subsampling" dropdown where clusters that have not been subsampled still show an option for 100K.  Currently, AnnData files are not subsampled, and this leads to a default scatter plot with all points being labelled as "--Unspecified--".  Now, the dropdown menu will not render unless the cluster has been subsampled.

#### MANUAL TESTING
You will need to turn off caching temporarily for this to work properly (make sure it says `no longer being cached`):

```
bin/rails dev:cache
...
Development mode is no longer being cached.
```
1. In a Rails console, load any subsampled cluster that has more than 100K points and set `subsampled: false`:
```
cluster = ClusterGroup.where(:points.gte => 100_000, subsampled: true).sample
cluster.update(subsampled: false)
```
2. Load the Explore tab for that study/cluster and confirm you no longer see the subsampling menu
3. Reset the cluster back to the correct state:
```
cluster.update(subsampled: true)
```