### PR TITLE
Fix tests after changing machine_type mappings (SCP-5733)

### DIFF
--- a/test/models/ann_data_ingest_parameters_test.rb
+++ b/test/models/ann_data_ingest_parameters_test.rb
@@ -58,7 +58,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
     cmd = '--ingest-anndata --anndata-file gs://bucket_id/test.h5ad --obsm-keys ["X_umap", "X_tsne"] --extract ' \
           '["cluster", "metadata", "processed_expression"]'
     assert_equal cmd, extraction.to_options_array.join(' ')
-    assert_equal 'n2d-highmem-16', extraction.machine_type
+    assert_equal 'n2d-highmem-32', extraction.machine_type
   end
 
   test 'should validate cluster params' do
@@ -98,7 +98,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
 
   test 'should set default machine type and allow override' do
     params = AnnDataIngestParameters.new(@extract_params)
-    assert_equal 'n2d-highmem-16', params.machine_type
+    assert_equal 'n2d-highmem-32', params.machine_type
     new_machine = 'n2d-highmem-80'
     params.machine_type = new_machine
     assert_equal new_machine, params.machine_type


### PR DESCRIPTION
Fix for automated test where expected `machine_type` value changed after modifying the logic for generating the `machine_type` mapping to AnnData file sizes iin #2089 

