### PR TITLE
Omit subsample parameter if cluster is not subsampled (SCP-5438)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -99,6 +99,14 @@ export function handleClusterSwitchForFiltering(cellFilteringSelection, newCellF
   }
 }
 
+/** get the appropriate subsampling value, accounting for number of points & subsampling status **/
+export function getSubsampleThreshold(exploreParams, exploreInfo) {
+  if (exploreInfo?.cluster && !exploreInfo.cluster.isSubsampled) {
+    return null
+  }
+  return exploreParams?.subsample || (exploreInfo?.cluster?.numPoints > 100_000 ? 100_000 : null)
+}
+
 /** wrapper function with error handling/state setting for retrieving cell facet data */
 function getCellFacetingData(cluster, annotation, setterFunctions, context, prevCellFaceting) {
   const [
@@ -122,7 +130,7 @@ function getCellFacetingData(cluster, annotation, setterFunctions, context, prev
     const allAnnots = exploreInfo?.annotationList.annotations
     if (allAnnots && allAnnots.length > 0) {
       if (!prevCellFaceting?.isFullyLoaded) {
-        const subsample = exploreParams?.subsample || (exploreInfo?.cluster?.numPoints > 100_000 ? 100_000 : null)
+        const subsample = getSubsampleThreshold(exploreParams, exploreInfo)
         initCellFaceting(
           cluster, annotation, studyAccession, allAnnots, prevCellFaceting, subsample
         ).then(newCellFaceting => {

--- a/test/js/explore/explore-display-tabs.test.js
+++ b/test/js/explore/explore-display-tabs.test.js
@@ -30,7 +30,7 @@ import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import * as UserProvider from '~/providers/UserProvider'
 import ExploreDisplayTabs, {
-  getEnabledTabs, handleClusterSwitchForFiltering
+  getEnabledTabs, handleClusterSwitchForFiltering, getSubsampleThreshold
 } from 'components/explore/ExploreDisplayTabs'
 import ExploreDisplayPanelManager from '~/components/explore/ExploreDisplayPanelManager'
 import PlotTabs from 'components/explore/PlotTabs'
@@ -498,5 +498,34 @@ describe('explore tabs are activated based on study info and parameters', () => 
         ]
       })
     )
+  })
+
+  it('Loads correct subsampling threshold', async () => {
+    const subsampleExploreInfo = {
+      cluster: {
+        isSubsampled: true,
+        numPoints: 212345
+      }
+    }
+    const exploreInfo = {
+      cluster: {
+        isSubsampled: false,
+        numPoints: 212345
+      }
+    }
+    const exploreWithSubsample = {
+      cluster: 'foo',
+      subsample: 100000
+    }
+    const exploreWithoutSubsample = { cluster: 'foo'}
+
+    let subsampleThreshold = getSubsampleThreshold(exploreWithSubsample, subsampleExploreInfo)
+    expect(subsampleThreshold).toEqual(exploreWithSubsample.subsample)
+    subsampleThreshold = getSubsampleThreshold(exploreWithoutSubsample, subsampleExploreInfo)
+    expect(subsampleThreshold).toEqual(100000)
+    subsampleThreshold = getSubsampleThreshold(exploreWithSubsample, exploreInfo)
+    expect(subsampleThreshold).toBeNull()
+    subsampleThreshold = getSubsampleThreshold(exploreWithoutSubsample, exploreInfo)
+    expect(subsampleThreshold).toBeNull()
   })
 })


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes another corner case with AnnData files not being subsampled where cell filtering does not work anymore now that the subsample selector has been hidden.  The issue is that the subsample parameter is still set to `100000` and is not correctly honoring the `isSubsampled` flag.  Now, it will always default to `null` if the cluster is not subsampled.

#### MANUAL TESTING
1. In a Rails console, find a cluster that is indexed and subsampled over 100K points and set `subsampled: false` :
```
cluster = ClusterGroup.where(indexed: true, subsampled: true, :points.gt => 100000).sample
cluster.update(subsampled: false)
```
2. Load the Explore tab for the above study and open the network tab in Chrome Dev Tools
3. Confirm that cell filtering works, and that the `facets` requests have a `subsample` value of `null`
4. Reset the cluster:
```
cluster.update(subsampled: true)
```