### PR TITLE
Prevent resetting parse status on update for "bucket path" files (SCP-5736)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -438,7 +438,8 @@ module Api
       end
 
       def complete_upload_process(study_file, parse_on_upload)
-        study_file.update!(status: 'uploaded', parse_status: 'unparsed') # set status to uploaded on full create
+        # set status to uploaded on full create, unless file is parsed and this is just an update
+        study_file.update!(status: 'uploaded', parse_status: 'unparsed') unless study_file.parsed?
         if parse_on_upload
           if study_file.parseable?
             persist_on_fail = study_file.remote_location.present?

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1406,8 +1406,8 @@ class StudyFile
 
             if prev_ids[curr_id]["name"] != name
               @cluster = ClusterGroup.find_by(
-                study_id: study.id, study_file_id: id, name: prev_ids.dig(curr_id, 'name'
-              ))
+                study_id: study.id, study_file_id: id, name: prev_ids.dig(curr_id, 'name')
+              )
               # before updating, check if the defaults also need to change
               if study.default_cluster == @cluster
                 study.default_options[:cluster] = name

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1405,7 +1405,9 @@ class StudyFile
             name = cluster_data_fragment&.[](:name) || fragment # fallback if we can't find data_fragment
 
             if prev_ids[curr_id]["name"] != name
-              @cluster = ClusterGroup.find_by(study:, study_file:, name: prev_ids.dig(curr_id, 'name'))
+              @cluster = ClusterGroup.find_by(
+                study_id: study.id, study_file_id: id, name: prev_ids.dig(curr_id, 'name'
+              ))
               # before updating, check if the defaults also need to change
               if study.default_cluster == @cluster
                 study.default_options[:cluster] = name

--- a/test/api/study_files_controller_test.rb
+++ b/test/api/study_files_controller_test.rb
@@ -270,4 +270,23 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
       assert_equal 'updated', fragment[:description]
     end
   end
+
+  test 'should not reset parse status on update when using bucket path' do
+    study_file = FactoryBot.create(:cluster_file,
+                                   name: 'clusterNew.txt',
+                                   study: @study,
+                                   remote_location: 'clusterNew.txt')
+    description = 'This is an update'
+    study_file_attributes = {
+      study_file: {
+        description:
+      }
+    }
+    execute_http_request(:patch, api_v1_study_study_file_path(study_id: @study.id, id: study_file.id),
+                         request_payload: study_file_attributes)
+    assert_response :success
+    study_file.reload
+    assert_equal description, study_file.description
+    assert study_file.parsed?
+  end
 end

--- a/test/api/study_files_controller_test.rb
+++ b/test/api/study_files_controller_test.rb
@@ -274,12 +274,12 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
   test 'should not reset parse status on update when using bucket path' do
     study_file = FactoryBot.create(:cluster_file,
                                    name: 'clusterNew.txt',
-                                   study: @study,
-                                   remote_location: 'clusterNew.txt')
+                                   study: @study)
     description = 'This is an update'
     study_file_attributes = {
       study_file: {
-        description:
+        description:,
+        remote_location: 'clusterNew.txt'
       }
     }
     execute_http_request(:patch, api_v1_study_study_file_path(study_id: @study.id, id: study_file.id),


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug with updating study files where any file that was created using the "bucket path" option will have the `parse_status` flag set to `unparsed`.  This can have side effects for AnnData or metadata files that will cause the "All Cells" array to not load.  This will break visualizations in some cases, depending on the path the user takes.  Now, files are only marked as "unparsed" if they haven't yet been ingested.

This also fixes a bug with updating existing clusterings in the AnnData UX where the file does not save correctly.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Find an AnnData file in the Rails console that has been uploaded and parsed using the "bucket path" option (or create a new one if you don't have any):
```
file = StudyFile.where(file_type: 'AnnData', parse_status: 'parsed', 'options.upload_trigger' => 'bucket', 'ann_data_file_info.reference_file' => false).sample
file.parsed?
=> true
```
3. Confirm that the "all cells" array loads for this file/study:
```
study = file.study
study.all_cells_array.count
=> 2638
```
4. Load this file in the upload wizard, update some attribute of the file (like the description) and click save
5. Back in the Rails console, reload the file/study and confirm it is still marked as "parsed" and that the "all cells" array loads:
```
file.reload
study.reload
file.parsed?
=> true
study.all_cells_array.count
=> 2638
```