### PR TITLE
Don't validate AnnData when added as Documentation/Other files using "bucket path" option

### DIFF
--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -5,7 +5,7 @@ export const PARSEABLE_TYPES = ['Cluster', 'Coordinate Labels', 'Expression Matr
   '10X Genes File', '10X Barcodes File', 'Gene List', 'Metadata', 'Analysis Output', 'AnnData',
   'Differential Expression']
 // file types to ignore in CSFV context (still validated server-side)
-export const UNVALIDATED_TYPES = ['AnnData']
+export const UNVALIDATED_TYPES = ['AnnData', 'Documentation', 'Other']
 export const CSFV_VALIDATED_TYPES = PARSEABLE_TYPES.filter(ft => !UNVALIDATED_TYPES.includes(ft))
 
 const EXPRESSION_INFO_TYPES = ['Expression Matrix', 'MM Coordinate Matrix']

--- a/app/javascript/lib/validation/validate-file.js
+++ b/app/javascript/lib/validation/validate-file.js
@@ -8,6 +8,7 @@ import { logFileValidation } from './log-validation'
 import { fetchBucketFile } from '~/lib/scp-api'
 import { getFeatureFlagsWithDefaults } from '~/providers/UserProvider'
 
+const noContentValidationFileTypes = ['Seurat', 'AnnData', 'Other', 'Documentation']
 
 /** take an array of [category, type, msg] issues, and format it */
 function formatIssues(issues) {
@@ -60,8 +61,6 @@ async function validateLocalFile(file, studyFile, allStudyFiles=[], allowedFileE
 
   let issuesObj
   let notesObj
-
-  const noContentValidationFileTypes = ['Seurat', 'AnnData', 'Other', 'Documentation']
 
   const studyFileType = studyFile.file_type
 
@@ -152,7 +151,8 @@ async function validateRemoteFile(
   const requestStart = performance.now()
   // special handling for AnnData to only read 100 bytes of file
   // since we're not validating, we're just determining if the file exists
-  const maxBytes = fileType === 'AnnData' ? 100 : MAX_SYNC_CSFV_BYTES
+  const maxBytes = noContentValidationFileTypes.includes(fileType) ? 100 : MAX_SYNC_CSFV_BYTES
+
   const response = await fetchBucketFile(bucketName, fileName, maxBytes)
   let fileInfo; let issues; let perfTime; let readRemoteTime
   if (response.ok) {


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes an issue with CSFV and adding Documentation/Other files that are actually AnnData.  The underlying issue is that AnnData files are binary, but not gzipped (though their actual data contents can be) and as such CSFV cannot read them directly.  This causes an error that will clear out form contents, but then because the `remote_path` field is still populated, the user can still click "Save".  This throws a database error because fields like `name` have been unset inside the form data.  The user may not see the CSFV error before trying to save, and as such are unaware that the file failed validation.

Since these files are not ingested, and are purely being added for download, we do not need to validate their contents at all.  Rather, we only need to prove that they exist.  As such, CSFV is being disabled for miscellaneous files using the "bucket path" option, and only file presence is validated.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Go to any study in the upload wizard
3. Under "Miscellaneous", switch to the "Use bucket path" option and then click "Browse bucket"
4. Add an AnnData file to the bucket, then copy the GS URI
5. Back in SCP, add this value to the form and then click outside the text input (this will let CSFV check that the file exists)
6. Confirm you do not see any errors, then click "Save" and confirm the file saves successfully