### PR TITLE
Hide profile warning in public studies; log whether study public (SCP-5699)

### DIFF
--- a/app/controllers/api/v1/visualization/explore_controller.rb
+++ b/app/controllers/api/v1/visualization/explore_controller.rb
@@ -159,7 +159,8 @@ module Api
             hasImageCache: study.cluster_groups.where(has_image_cache: true).pluck(:name),
             clusterPointAlpha: study.default_cluster_point_alpha,
             colorProfile: study.default_color_profile,
-            bucketId: study.bucket_id
+            bucketId: study.bucket_id,
+            isPublic: study.public
           }
         end
       end

--- a/app/javascript/components/explore/ExploreView.jsx
+++ b/app/javascript/components/explore/ExploreView.jsx
@@ -31,6 +31,7 @@ function RoutableExploreTab({ studyAccession }) {
     // set window.SCP.isDifferentialExpressionEnabled so that we can track differential expression visibility globally
     if (window.SCP && !window.SCP.isTest) {
       window.SCP.isDifferentialExpressionEnabled = exploreResponse.differentialExpression.length > 0
+      window.SCP.isPublic = exploreResponse.isPublic
     }
     // after the explore info is received, fetch the user-specific study data, but do it
     // after a timeout to ensure the visualization data gets fetched first

--- a/app/javascript/components/explore/GenomeView.jsx
+++ b/app/javascript/components/explore/GenomeView.jsx
@@ -46,7 +46,7 @@ function GenomeView({
   useEffect(() => {
     if (trackFileList && trackFileList.tracks.length && isVisible) {
       // show profile warning from non-existent token due to incomplete Terra registration
-      if (!userHasTerraProfile()) {
+      if (!userHasTerraProfile() && !window.SCP.isPublic) {
         setShowProfileWarning(true)
       }
 

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -408,6 +408,12 @@ export function log(name, props = {}) {
   } else {
     isDifferentialExpressionEnabled = !!window.SCP?.isDifferentialExpressionEnabled
   }
+  let isPublic // track whether study is publicly visible
+  if ('isPublic' in props) {
+    isPublic = props.isPublic
+  } else {
+    isPublic = !!window.SCP?.isPublic
+  }
 
   // track A/B feature test assignments on all events
   const abTests = window.SCP?.abTests || []
@@ -420,6 +426,7 @@ export function log(name, props = {}) {
     logger: 'app-frontend',
     scpVersion: version,
     isDifferentialExpressionEnabled,
+    isPublic,
     isServiceWorkerCacheEnabled,
     abTests
   }, getDefaultProperties())


### PR DESCRIPTION
This fixes an incorrect warning in IGV.  It also improves observability by logging `isPublic` for the study in Explore events.

Here's how the old bug and new fix look.

https://github.com/user-attachments/assets/a4139961-3aaf-48e4-87ab-c2c9413b23ce

### Test
1.  Go to a public study with igv.js multiome visualizations
2. Confirm no warning message appears below IGV

This satisfies SCP-5699.