### PR TITLE
include '.h5Seurat' as valid Seurat extension (SCP-5756)

### DIFF
--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -333,7 +333,7 @@ const sequenceExtensions = [
 const baiExtensions = ['.bai']
 const tbiExtensions = ['.tbi']
 const annDataExtensions = ['.h5', '.h5ad', '.hdf5']
-const seuratExtensions = ['.Rds', '.rds', '.RDS', '.seuratdata', '.h5seurat', '.seuratdisk', '.Rda', '.rda']
+const seuratExtensions = ['.Rds', '.rds', '.RDS', '.seuratdata', '.h5seurat', '.h5Seurat', '.seuratdisk', '.Rda', '.rda']
 const miscExtensions = baseMiscExtensions.concat(mtxExtensions, annDataExtensions, seuratExtensions)
 
 export const FileTypeExtensions = {


### PR DESCRIPTION
BACKGROUND & CHANGES  

A study owner [noted in Zendesk](https://broadinstitute.zendesk.com/agent/tickets/321099) that '.h5seurat' (all lowercase) is valid while '.h5Seurat' is not. Both file extensions are [programmatically generated by the SeuratDisk code](https://github.com/mojaveazure/seurat-disk/issues/72), and not the analyst. This change adds '.h5Seurat' as a valid extension for Seurat files.
  
MANUAL TESTING  

Pull branch and sign in
Choose a study and navigate to the Miscellaneous tab in the upload wizard
Confirm that files ending in '.h5Seurat' are uploadable and no longer yield the following error message:

> Error found. Re-choose the file after correcting <filename>.
> 
> Allowed extensions are .Rds, .rds, .RDS, .seuratdata, .h5seurat, .seuratdisk, .Rda, .rda