### PR TITLE
Enable AnnData subsampling (SCP-5140)

### DIFF
--- a/app/models/data_array.rb
+++ b/app/models/data_array.rb
@@ -30,7 +30,7 @@ class DataArray
   index({ study_id: 1, linear_data_id: 1}, { unique: false, background: true })
 
   validates_presence_of :name, :cluster_name, :array_type, :array_index, :values
-  validates_uniqueness_of :name, scope: [:study_id, :cluster_name, :linear_data_name, :linear_data_id, :array_type,
+  validates_uniqueness_of :name, scope: [:study_id, :cluster_name, :linear_data_type, :linear_data_id, :array_type,
                                          :array_index, :subsample_threshold, :subsample_annotation]
 
   # maximum number of entries for values array (to avoid MongoDB max document size problems)

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -392,7 +392,7 @@ class IngestJob
       study_file.update(parse_status: 'parsed') # reset parse flag
       cluster_name = cluster_name_by_file_type
       cluster = ClusterGroup.find_by(name: cluster_name, study:, study_file:)
-      cluster.find_subsampled_data_arrays.delete_all
+      cluster.find_subsampled_data_arrays&.delete_all
       cluster.update(subsampled: false, is_subsampling: false)
     else
       create_study_file_copy
@@ -404,10 +404,10 @@ class IngestJob
           ApplicationController.firecloud_client.delete_workspace_file(study.bucket_id, bundled_file.bucket_location)
         end
       end
-      subject = "Error: #{study_file.file_type} file: '#{study_file.upload_file_name}' parse has failed"
-      user_email_content = generate_error_email_body
-      SingleCellMailer.notify_user_parse_fail(user.email, subject, user_email_content, study).deliver_now
     end
+    subject = "Error: #{study_file.file_type} file: '#{study_file.upload_file_name}' parse has failed"
+    user_email_content = generate_error_email_body
+    SingleCellMailer.notify_user_parse_fail(user.email, subject, user_email_content, study).deliver_now
   end
 
   # TODO (SCP-4709, SCP-4710) Processed and Raw expression files

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -594,7 +594,7 @@ class IngestJob
       end
     when 'AnnData'
       # TODO (SCP-5140): subsampling logic works but MongoDB throws index uniqueness violations due to same study_file_id
-      return if study_file.is_anndata?
+      # return if study_file.is_anndata?
 
       file_info = study_file.ann_data_file_info
       if file_info.has_clusters? && file_info.has_metadata?

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1413,8 +1413,9 @@ class Study
 
   # return the cells found in a single expression matrix
   def expression_matrix_cells(study_file)
+    filename = study_file.is_viz_anndata? ? 'h5ad_frag.matrix.processed.mtx.gz' : study_file.upload_file_name
     query = {
-      name: "#{study_file.upload_file_name} Cells", array_type: 'cells', linear_data_type: 'Study',
+      name: "#{filename} Cells", cluster_name: filename, array_type: 'cells', linear_data_type: 'Study',
       linear_data_id: self.id, study_file_id: study_file.id, cluster_group_id: nil, subsample_annotation: nil,
       subsample_threshold: nil
     }

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1412,8 +1412,8 @@ class Study
   end
 
   # return the cells found in a single expression matrix
-  def expression_matrix_cells(study_file)
-    filename = study_file.is_viz_anndata? ? 'h5ad_frag.matrix.processed.mtx.gz' : study_file.upload_file_name
+  def expression_matrix_cells(study_file, matrix_type: 'processed')
+    filename = study_file.is_viz_anndata? ? "h5ad_frag.matrix.#{matrix_type}.mtx.gz" : study_file.upload_file_name
     query = {
       name: "#{filename} Cells", cluster_name: filename, array_type: 'cells', linear_data_type: 'Study',
       linear_data_id: self.id, study_file_id: study_file.id, cluster_group_id: nil, subsample_annotation: nil,

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.31.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.33.0'
 
     # Docker image for image pipeline jobs
     config.image_pipeline_docker_image = 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_c2b090043'

--- a/db/migrate/20240807161035_subsample_ann_data_files.rb
+++ b/db/migrate/20240807161035_subsample_ann_data_files.rb
@@ -1,0 +1,45 @@
+class SubsampleAnnDataFiles < Mongoid::Migration
+  def self.up
+    anndata_files = StudyFile.where(file_type: 'AnnData', 'ann_data_file_info.reference_file' => false).pluck(:id)
+    clusters = ClusterGroup.where(:study_file_id.in => anndata_files, :points.gte => 1000, subsampled: false)
+    clusters.each do |cluster|
+      study = cluster.study
+      study_file = cluster.study_file
+      user = study.user
+      metadata_parsed = study.metadata_file.present? && study.metadata_file.parsed?
+      if metadata_parsed && cluster.can_subsample? && !cluster.is_subsampling?
+        job_identifier = "#{study_file.bucket_location}:#{study_file.id} (#{cluster.name})"
+        cluster.update(is_subsampling: true)
+        fragment = study_file.ann_data_file_info.find_fragment(
+          data_type: :cluster, name: cluster.name
+        ).with_indifferent_access
+        cluster_file = RequestUtils.data_fragment_url(
+          study_file, 'cluster', file_type_detail: fragment[:obsm_key_name]
+        )
+        cell_metadata_file = RequestUtils.data_fragment_url(study_file, 'metadata')
+        subsample_params = AnnDataIngestParameters.new(
+          subsample: true, ingest_anndata: false, extract: nil, obsm_keys: nil, name: cluster.name,
+          cluster_file:, cell_metadata_file:
+        )
+        Rails.logger.info "Launching subsampling ingest run for #{job_identifier} via migration"
+        submission = ApplicationController.life_sciences_api_client.run_pipeline(
+          study_file:, user:, action: :ingest_subsample, params_object: subsample_params
+        )
+        job = IngestJob.new(
+          pipeline_name: submission.name, study:, study_file:, user:, action: :ingest_subsample,
+          params_object: subsample_params, reparse: false, persist_on_fail: true
+        )
+        job.delay.poll_for_completion
+      end
+    end
+  end
+
+  def self.down
+    anndata_files = StudyFile.where(file_type: 'AnnData', 'ann_data_file_info.reference_file' => false).pluck(:id)
+    clusters = ClusterGroup.where(:study_file_id.in => anndata_files, :points.gte => 1000, subsampled: true)
+    clusters.each do |cluster|
+      cluster.find_subsampled_data_arrays.delete_all
+      cluster.update(subsampled: false)
+    end
+  end
+end

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -604,20 +604,24 @@ class IngestJobTest < ActiveSupport::TestCase
   end
 
   test 'should handle ingest failure by action' do
+    study = FactoryBot.create(:detached_study,
+                              name_prefix: 'IngestJob Fail Test',
+                              user: @user,
+                              test_array: @@studies_to_clean)
     # test subsampling fail logic
     cluster_file = FactoryBot.create(
-      :cluster_file, name: 'UMAP.txt', study: @basic_study,
+      :cluster_file, name: 'UMAP.txt', study:,
       cell_input: { x: [1, 2, 3], y: [1, 2, 3], cells: %w[cellA cellB cellC] }
     )
-    cluster = @basic_study.cluster_groups.by_name('UMAP.txt')
+    cluster = study.cluster_groups.by_name('UMAP.txt')
     cluster.update(is_subsampling: true)
     job = IngestJob.new(
-      pipeline_name: SecureRandom.uuid, study: @basic_study, study_file: cluster_file, user: @user,
+      pipeline_name: SecureRandom.uuid, study:, study_file: cluster_file, user: @user,
       action: :ingest_subsample
     )
     job.handle_ingest_failure
     cluster_file.reload
-    @basic_study.reload
+    study.reload
     cluster.reload
     assert cluster_file.parsed?
     assert cluster.present?
@@ -626,26 +630,26 @@ class IngestJobTest < ActiveSupport::TestCase
 
     # normal fail
     failed_file = FactoryBot.create(
-      :cluster_file, name: 'tSNE.txt', study: @basic_study,
+      :cluster_file, name: 'tSNE.txt', study:,
       cell_input: { x: [1, 2, 3], y: [1, 2, 3], cells: %w[cellA cellB cellC] }
     )
     pipeline_name = SecureRandom.uuid
     failed_job = IngestJob.new(
-      pipeline_name: , study: @basic_study, study_file: failed_file, user: @user, action: :ingest_cluster
+      pipeline_name: , study:, study_file: failed_file, user: @user, action: :ingest_cluster
     )
     error_log = "parse_logs/#{failed_file.id}/user_log.txt"
     mock = Minitest::Mock.new
     mock.expect :execute_gcloud_method, true,
-                [:copy_workspace_file, 0, @basic_study.bucket_id, failed_file.bucket_location, failed_file.parse_fail_bucket_location]
-    mock.expect :delete_workspace_file, true, [@basic_study.bucket_id, failed_file.bucket_location]
-    mock.expect :workspace_file_exists?, true, [@basic_study.bucket_id, error_log]
+                [:copy_workspace_file, 0, study.bucket_id, failed_file.bucket_location, failed_file.parse_fail_bucket_location]
+    mock.expect :delete_workspace_file, true, [study.bucket_id, failed_file.bucket_location]
+    mock.expect :workspace_file_exists?, true, [study.bucket_id, error_log]
     mock.expect(
       :execute_gcloud_method,
       StringIO.new("error"),
-      [:read_workspace_file, 0, @basic_study.bucket_id, error_log]
+      [:read_workspace_file, 0, study.bucket_id, error_log]
     )
     mock.expect :execute_gcloud_method, true,
-                [:delete_workspace_file, 0, @basic_study.bucket_id, error_log]
+                [:delete_workspace_file, 0, study.bucket_id, error_log]
     metadata = {
       pipeline: {
         actions: [

--- a/test/models/study_test.rb
+++ b/test/models/study_test.rb
@@ -184,4 +184,21 @@ class StudyTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test 'should load expression matrix cells by file type' do
+    genes = %w[farsa phex]
+    cells = %w[cellA cellB cellC]
+    expression_input = genes.index_with(cells.map {|c| [c, rand.floor(3)]})
+    dense_matrix = FactoryBot.create(:expression_file, study: @study, name: 'dense_matrix.tsv', expression_input:)
+    ann_data_file = FactoryBot.create(:ann_data_file,
+                                      study: @study,
+                                      name: 'test.h5ad',
+                                      reference_file: false,
+                                      cell_input: cells,
+                                      expression_input:)
+    assert_equal cells, @study.expression_matrix_cells(dense_matrix)
+    assert_equal cells, @study.expression_matrix_cells(ann_data_file)
+    assert_equal cells, @study.expression_matrix_cells(ann_data_file, matrix_type: 'processed')
+    assert_empty @study.expression_matrix_cells(ann_data_file, matrix_type: 'raw')
+  end
 end

--- a/test/services/azul_search_service_test.rb
+++ b/test/services/azul_search_service_test.rb
@@ -150,7 +150,7 @@ class AzulSearchServiceTest < ActiveSupport::TestCase
     summary = AzulSearchService.get_file_summary_info(projects)
     assert_equal projects.count, summary.count
     found_projects = summary.map { |project| project[:accession] }
-    assert_equal projects, found_projects
+    assert_equal projects.sort, found_projects.sort
     manifests = summary.map { |project| project[:studyFiles].detect { |file| file[:file_type] == 'Project Manifest' } }
     assert_equal 3, manifests.count
     other_files = summary.map { |project| project[:studyFiles].reject { |file| file[:file_type] == 'Project Manifest' } }


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This applies fixes from https://github.com/broadinstitute/scp-ingest-pipeline/pull/355 to enable subsampling of AnnData files.  As previously noted, it was an improperly scoped query that resulted in incorrect IDs being reused that led to the `DataArray` index violations.  Since AnnData files can have multiple clusterings, this prevented subsampling in general until the issue was addressed.  Now, any AnnData file can be subsampled like other plain text SCP formatted files.  This also includes a backfill migration to identify any previously ingested AnnData files and subsample them, if necessary.

Most importantly, this update changes the behavior if a file has ingested successfully but then fails to subsample.  Previously, the failure would trigger a delete cascade that would remove any data that was ingested from that file.  In the case of AnnData files, this would mean _**all study data**_ is removed.  Since there are multiple AnnData studies on production that have already been successfully ingested that have visualizations enabled, this could potentially be highly disruptive to those study owners.  Now, only subsampled data will be removed if that job fails, and all other full-resolution data will be left if place since it has already been validated and can still be viewed.  This applies to normal cluster files as well.

#### MANUAL TESTING
The simplest way to test this is to run the backfill migration to add subsamples to any previously ingested AnnData files.  Once the subsampling jobs have completed, you can skip to step 5 below.  If you do not have any in your local instance:
1. Boot all services and sign in
2. Create a new study and chose the AnnData upload UX
3. Download [compliant_pbmc3K.h5ad](https://console.cloud.google.com/storage/browser/_details/fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/test_Data/ingest_manual_test/compliant_pbmc3K.h5ad;tab=live_object) and add it to the study, specifying two clustering objects with the `obsm_key_names` of `X_umap` and `X_tsne`
4. Wait for all ingest processes to complete, including subsampling (the entire process should take 7-10 minutes)
5. In a Rails console session, validate that the clusterings have been subsampled (depending on the file you used, your counts may not be the same but they should be greater than 0 and the same for both clusterings):
```
study = Study.find_by(accession: <accession of above study>)
study.cluster_groups.each do |cluster|
  puts "#{cluster.name} subsampling status: #{cluster.subsampled}"
  puts "#{cluster.name} number of subsampled arrays: #{cluster.find_subsampled_data_arrays.count}"
end
=>
UMAP subsampling status: true
UMAP number of subsampled arrays: 45        
tSNE subsampling status: true
tSNE number of subsampled arrays: 45
```