### PR TITLE
Fix setting tab parameter for analytics (SCP-5634)

### DIFF
--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -385,11 +385,14 @@ function getAnalyticsPageName() {
  * gets the tab name for analytics
  */
 function getTabProperty() {
-  if (window.location.href?.match(/\?tab=/)) {
-    return window.location.href.split('?tab=')[1]
-  } else {
-    return window.location.hash?.replace(/#/, '')
+  let tabParam = window.location.hash?.replace(/#/, '')
+  if (window.location.search) {
+    const searchParams = new URLSearchParams(window.location.search)
+    if (searchParams.has('tab')) {
+      tabParam = searchParams.get('tab')
+    }
   }
+  return tabParam
 }
 
 /**

--- a/app/javascript/lib/metrics-api.js
+++ b/app/javascript/lib/metrics-api.js
@@ -384,7 +384,7 @@ function getAnalyticsPageName() {
 /**
  * gets the tab name for analytics
  */
-function getTabProperty() {
+export function getTabProperty() {
   let tabParam = window.location.hash?.replace(/#/, '')
   if (window.location.search) {
     const searchParams = new URLSearchParams(window.location.search)

--- a/test/js/metrics-api.test.js
+++ b/test/js/metrics-api.test.js
@@ -167,6 +167,13 @@ describe('Library for client-side usage analytics', () => {
     expect(enabledTab).toBeUndefined()
 
     global.window.location = {
+      hash: '#study-visualize',
+      pathname: '/single_cell/study/SCP1234'
+    }
+    enabledTab = getTabProperty()
+    expect(enabledTab).toEqual('study-visualize')
+
+    global.window.location = {
       search: '?cluster=foo&genes=bar&tab=distribution',
       pathname: '/single_cell/study/SCP1234'
     }

--- a/test/js/metrics-api.test.js
+++ b/test/js/metrics-api.test.js
@@ -5,7 +5,7 @@ const fetch = require('node-fetch')
 import { screen, render, fireEvent } from '@testing-library/react'
 import React from 'react';
 
-import {logClick, logClickLink, logMenuChange, setMetricsApiMockFlag} from 'lib/metrics-api'
+import { logClick, logClickLink, logMenuChange, setMetricsApiMockFlag, getTabProperty } from 'lib/metrics-api'
 import {logToSentry} from 'lib/sentry-logging'
 import * as SCPContextProvider from '~/providers/SCPContextProvider'
 import * as Sentry from '@sentry/react'
@@ -157,4 +157,20 @@ describe('Library for client-side usage analytics', () => {
     expect(numDroppedWhenInfo).toEqual(1)
   })
 
+  it('sets tab parameter correctly', () => {
+    delete global.window.location
+    global.window = Object.create(window)
+    global.window.location = {
+      pathname: '/single_cell/study/SCP1234'
+    }
+    let enabledTab = getTabProperty()
+    expect(enabledTab).toBeUndefined()
+
+    global.window.location = {
+      search: '?cluster=foo&genes=bar&tab=distribution',
+      pathname: '/single_cell/study/SCP1234'
+    }
+    enabledTab = getTabProperty()
+    expect(enabledTab).toEqual('distribution')
+  })
 })


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug with setting the `tab` property on client-side Mixpanel events.  The issue was an improperly scoped regular expression that relied on the `tab` search parameter to be in the first position (i.e. directly after the `?` character).  Now, the native `URLSearchParams` class is used to parse the entire search string and determine if the `tab` parameter has been specified.  If not, it will default to the value of `window.location.hash`, if present.

#### MANUAL TESTING
1. Boot as normal and load any study that has clustering & expression data
2. Open the Chrome Dev Tools > Network tab
3. Query for a gene and then click into the `Distribution` tab and wait for the plot to load
4. In the network tab, find the entry for `plot:violin` and confirm that you see the tab parameter is correctly set:
![Screenshot 2024-08-13 at 2 21 58 PM](https://github.com/user-attachments/assets/e65795e3-d1fb-48a1-b2e5-5669f827fc49)

(Note: if the violin plot renders before you click into the `Distribution` tab, this may be set to `scatter` or `#study-visualize`, depending on your URL state).