### PR TITLE
Fix expression scatter plot upon legend filter (SCP-5762)

### DIFF
--- a/app/javascript/lib/plot.js
+++ b/app/javascript/lib/plot.js
@@ -25,6 +25,7 @@ const SPECIAL_LEGEND_ENTRIES = [UNSPECIFIED_ANNOTATION_NAME, FILTERED_TRACE_NAME
  * central memory CD4-positive, alpha-beta T cell
  */
 export function safenLabels(labels) {
+  if (!labels) {return labels} // Prevents erroring gene exp scatter on legend filter
   if (Array.isArray(labels)) {
     return labels.map(label => label.replaceAll(',', '-'))
   } else {

--- a/test/js/explore/plot-utils.test.js
+++ b/test/js/explore/plot-utils.test.js
@@ -1,4 +1,4 @@
-import PlotUtils from 'lib/plot'
+import PlotUtils, { safenLabels } from 'lib/plot'
 
 describe('Plot grouping function cache', () => {
   it('makes traces based on the annotation groups', async () => {
@@ -164,5 +164,11 @@ describe('Plot grouping function cache', () => {
     expect(trace2[0]).toEqual({
       ...data
     })
+  })
+
+  it('does not error when raw labels are undefined', async () => {
+    // This prevents erroring gene expression scatter plots up applying a legend filter
+    const safeLabels = safenLabels(undefined)
+    expect(safeLabels).toBeUndefined()
   })
 })


### PR DESCRIPTION
This fixes a bug in #2099 where applying a legend filter caused the gene expression scatter plot to break.

### Test
An automated test prevents regression.  To manually test:
* Go to a study with visualizations initialized
* Search for a gene
* Click on a legend entry beside the reference cluster scatter plot
* Confirm gene expression scatter plot does not updated

This satisfies SCP-5762.