### PR TITLE
Adding raw counts info to AnnData upload UX (SCP-5110)

### DIFF
--- a/app/javascript/components/upload/AnnDataExpressionStep.jsx
+++ b/app/javascript/components/upload/AnnDataExpressionStep.jsx
@@ -15,15 +15,14 @@ const DEFAULT_NEW_PROCESSED_FILE = {
 }
 
 export const fileTypes = ['Expression Matrix', 'MM Coordinate Matrix']
-export const processedFileFilter = file => fileTypes.includes(file.file_type) &&
-  !file.expression_file_info?.is_raw_counts
+export const annDataExpFilter = file => fileTypes.includes(file.file_type)
 
 export default {
   title: 'Expression matrices',
   header: 'Expression matrices',
   name: 'combined expression matrices',
   component: ExpressionUploadForm,
-  fileFilter: processedFileFilter
+  fileFilter: annDataExpFilter
 }
 
 /** form for uploading a parent expression file and any children */
@@ -37,24 +36,24 @@ function ExpressionUploadForm({
   isAnnDataExperience
 }) {
   const fragmentType = isAnnDataExperience ? 'expression' : null
-  const processedParentFiles = matchingFormFiles(
-    formState.files, processedFileFilter, isAnnDataExperience, fragmentType
+  const annDataExpFiles = matchingFormFiles(
+    formState.files, annDataExpFilter, isAnnDataExperience, fragmentType
   )
   const fileMenuOptions = serverState.menu_options
 
   const featureFlagState = serverState.feature_flags
 
   useEffect(() => {
-    if (processedParentFiles.length === 0) {
+    if (annDataExpFiles.length === 0) {
       addNewFile(DEFAULT_NEW_PROCESSED_FILE)
     }
-  }, [processedParentFiles.length])
+  }, [annDataExpFiles.length])
 
   return <div>
     <div className="row">
       <div className="col-md-12">
         {getExpressionFileInfoMessage(isAnnDataExperience, 'Processed')}
-        { processedParentFiles.map(file => {
+        { annDataExpFiles.map(file => {
           return <ExpressionFileForm
             key={file.oldId ? file.oldId : file._id}
             file={file}

--- a/app/javascript/components/upload/AnnDataExpressionStep.jsx
+++ b/app/javascript/components/upload/AnnDataExpressionStep.jsx
@@ -9,7 +9,8 @@ const DEFAULT_NEW_PROCESSED_FILE = {
   expression_file_info: {
     is_raw_counts: false,
     biosample_input_type: 'Whole cell',
-    modality: 'Transcriptomic: unbiased'
+    modality: 'Transcriptomic: unbiased',
+    raw_counts_associations: []
   },
   file_type: 'Expression Matrix'
 }

--- a/app/javascript/components/upload/ExpressionFileForm.jsx
+++ b/app/javascript/components/upload/ExpressionFileForm.jsx
@@ -39,9 +39,8 @@ export default function ExpressionFileForm({
   const speciesOptions = fileMenuOptions.species.map(spec => ({ label: spec.common_name, value: spec.id }))
   const selectedSpecies = speciesOptions.find(opt => opt.value === file.taxon_id)
   const isMtxFile = file.file_type === 'MM Coordinate Matrix'
-  // check if is_raw_counts is a string or boolean
-  const isRawCountsFile = typeof file.expression_file_info.is_raw_counts === 'string' ?
-    file.expression_file_info.is_raw_counts === 'true' : file.expression_file_info.is_raw_counts
+const rawCountsInfo = file.expression_file_info.is_raw_counts
+const isRawCountsFile = rawCountsInfo === 'true' || rawCountsInfo
   const [showRawCountsUnits, setShowRawCountsUnits] = useState(isRawCountsFile)
 
   const allowedFileExts = isMtxFile ? FileTypeExtensions.mtx : FileTypeExtensions.plainText

--- a/app/javascript/components/upload/ExpressionFileForm.jsx
+++ b/app/javascript/components/upload/ExpressionFileForm.jsx
@@ -42,7 +42,7 @@ export default function ExpressionFileForm({
   // check if is_raw_counts is a string or boolean
   const isRawCountsFile = typeof file.expression_file_info.is_raw_counts === 'string' ?
     file.expression_file_info.is_raw_counts === 'true' : file.expression_file_info.is_raw_counts
-  const [showRawCountsUnits, setShowRawCountsUnits] = useState(isRawCountsFile || isAnnDataExperience)
+  const [showRawCountsUnits, setShowRawCountsUnits] = useState(isRawCountsFile)
 
   const allowedFileExts = isMtxFile ? FileTypeExtensions.mtx : FileTypeExtensions.plainText
   let requiredFields = showRawCountsUnits ? RAW_COUNTS_REQUIRED_FIELDS : REQUIRED_FIELDS
@@ -122,9 +122,9 @@ export default function ExpressionFileForm({
     }
 
     { isAnnDataExperience &&
-      <div className="form-group row">
-        <div className="col-sm-4">
-          <label>I have raw count data in the <strong>adata.raw</strong> slot</label><br/>
+      <div className="row">
+        <div className="form-radio col-sm-4">
+          <label className="labeled-select">I have raw count data in the <strong>adata.raw</strong> slot</label>
           <label className="sublabel">
             <input type="radio"
                    name={`anndata-raw-counts-${file._id}`}

--- a/app/javascript/components/upload/RawCountsStep.jsx
+++ b/app/javascript/components/upload/RawCountsStep.jsx
@@ -72,7 +72,6 @@ function RawCountsUploadForm({
  * Retrieve the expression file info message for when in classic upload mode
 */
 export function getExpressionFileInfoMessage(isAnnDataExperience, expressionType) {
-  console.log(`expressionType: ${expressionType}`)
   if (!isAnnDataExperience) {
     let message = ''
     if (expressionType === 'Raw') {

--- a/app/javascript/styles/_forms.scss
+++ b/app/javascript/styles/_forms.scss
@@ -206,3 +206,7 @@ hr.divider {
   width: 24px;
   height: 24px;
 }
+
+.form-radio {
+  padding-bottom: 30px;
+}

--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -41,6 +41,7 @@ class AnnDataFileInfo
   field :data_fragments, type: Array, default: []
   before_validation :sanitize_fragments!
   validate :validate_fragments
+  after_validation :update_expression_file_info
 
   # collect data frame key_names for clustering data inside AnnData flle
   def obsm_key_names
@@ -139,6 +140,16 @@ class AnnDataFileInfo
     fragment = find_fragment(data_type: :cluster, name:)
     axes = %i[x_axis_min x_axis_max y_axis_min y_axis_max z_axis_min z_axis_max]
     hash_from_keys(fragment, *axes, transform: :to_f)
+  end
+
+  # persist information in expression fragment back to expression_file_info object
+  def update_expression_file_info
+    exp_fragment = find_fragment(data_type: :expression).with_indifferent_access
+    return nil if reference_file || exp_fragment.nil?
+
+    exp_info = study_file.expression_file_info
+    info_update = exp_fragment[:expression_file_info]
+    exp_info.update(info_update)
   end
 
   private

--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -135,6 +135,12 @@ class AnnDataFileInfo
     safe_data_fragments.select { |fragment| fragment[:data_type].to_s == data_type.to_s }
   end
 
+  # get the index of a fragment by BSON ObjectId (for making in-place updates)
+  def fragment_index_of(fragment)
+    id = fragment[:_id] || fragment['_id']
+    safe_data_fragments.index { |frag| frag[:_id] == id }
+  end
+
   # mirror of study_file.get_cluster_domain_ranges for data_fragment
   def get_cluster_domain_ranges(name)
     fragment = find_fragment(data_type: :cluster, name:)
@@ -145,11 +151,11 @@ class AnnDataFileInfo
   # persist information in expression fragment back to expression_file_info object
   def update_expression_file_info
     exp_fragment = find_fragment(data_type: :expression) || fragments_by_type(:expression).first
-    return nil if reference_file || exp_fragment.nil?
+    exp_info = study_file&.expression_file_info
+    return nil if reference_file || exp_fragment.nil? || exp_info.nil?
 
-    exp_info = study_file.expression_file_info
     info_update = exp_fragment.with_indifferent_access[:expression_file_info]
-    exp_info.assign_attributes(**info_update) if info_update.present?
+    exp_info.assign_attributes(**info_update) if info_update
   end
 
   private
@@ -194,6 +200,7 @@ class AnnDataFileInfo
     REQUIRED_FRAGMENT_KEYS.each do |data_type, keys|
       fragments = fragments_by_type(data_type)
       fragments.each do |fragment|
+        unset_units_in_exp_fragment(fragment) if data_type == :expression
         missing_keys = keys.map(&:to_s) - fragment.keys.map(&:to_s)
         missing_values = keys.select { |key| fragment[key].blank? }
         next if missing_keys.empty? && missing_values.empty?
@@ -211,6 +218,19 @@ class AnnDataFileInfo
           errors.add(:base, "#{key} are not unique in #{data_type} fragments: #{values}")
         end
       end
+    end
+  end
+
+  # unset units in expression fragment since form data won't have value
+  # element must be replaced by index in order to persist
+  def unset_units_in_exp_fragment(fragment)
+    exp_info = fragment[:expression_file_info]
+    return nil unless exp_info
+
+    unless exp_info[:is_raw_counts]
+      exp_info.delete(:units)
+      frag_idx = fragment_index_of(fragment)
+      data_fragments[frag_idx][:expression_file_info] = exp_info
     end
   end
 end

--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -144,12 +144,16 @@ class AnnDataFileInfo
 
   # persist information in expression fragment back to expression_file_info object
   def update_expression_file_info
-    exp_fragment = find_fragment(data_type: :expression).with_indifferent_access
+    exp_fragment = find_fragment(data_type: :expression) || fragments_by_type(:expression).first
     return nil if reference_file || exp_fragment.nil?
 
     exp_info = study_file.expression_file_info
-    info_update = exp_fragment[:expression_file_info]
-    exp_info.update(info_update)
+    info_update = exp_fragment.with_indifferent_access[:expression_file_info]
+    return nil if info_update.nil? # in case expression_file_info form data is not present
+
+    info_update.each do |attr, val|
+      exp_info.send("#{attr}=", val)
+    end
   end
 
   private

--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -149,11 +149,7 @@ class AnnDataFileInfo
 
     exp_info = study_file.expression_file_info
     info_update = exp_fragment.with_indifferent_access[:expression_file_info]
-    return nil if info_update.nil? # in case expression_file_info form data is not present
-
-    info_update.each do |attr, val|
-      exp_info.send("#{attr}=", val)
-    end
+    exp_info.assign_attributes(**info_update) if info_update.present?
   end
 
   private

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1510,7 +1510,7 @@ class Study
     study_files.any_of(
       { :file_type.in => ['Expression Matrix', 'MM Coordinate Matrix'] },
       { file_type: 'AnnData', 'ann_data_file_info.has_expression' => true },
-      { file_type: 'AnnData', 'ann_data_file_info.has_raw_counts' => true },
+      { file_type: 'AnnData', 'ann_data_file_info.has_raw_counts' => true }
     )
   end
 

--- a/db/migrate/20240819173109_sync_exp_file_info_for_ann_data.rb
+++ b/db/migrate/20240819173109_sync_exp_file_info_for_ann_data.rb
@@ -1,0 +1,11 @@
+class SyncExpFileInfoForAnnData < Mongoid::Migration
+  def self.up
+    StudyFile.where(file_type: 'AnnData').each do |study_file|
+      study_file.ann_data_file_info.update_expression_file_info
+    end
+  end
+
+  def self.down
+    # non-reversible
+  end
+end

--- a/test/api/study_files_controller_test.rb
+++ b/test/api/study_files_controller_test.rb
@@ -215,7 +215,7 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
           _id: exp_frag_id,
           taxon_id: taxon_id,
           description: 'expression description',
-          y_axis_title: 'log(TPM) expression'
+          y_axis_title: 'log(TPM) expression',
         },
         metadata_form_info_attributes: {
           use_metadata_convention: false # check that override is in place to enforce convention
@@ -254,7 +254,7 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
               },
               {
                 _id: exp_frag_id, data_type: 'expression', taxon_id: taxon_id, y_axis_title: 'log(TPM) expression',
-                description: 'updated'
+                description: 'updated', expression_file_info: { biosample_input_type: 'Single nuclei' }
               }
             ].to_json
         }
@@ -269,6 +269,7 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
     ann_data.ann_data_file_info.data_fragments.each do |fragment|
       assert_equal 'updated', fragment[:description]
     end
+    assert_equal 'Single nuclei', ann_data.expression_file_info.biosample_input_type
   end
 
   test 'should not reset parse status on update when using bucket path' do

--- a/test/api/study_files_controller_test.rb
+++ b/test/api/study_files_controller_test.rb
@@ -215,7 +215,7 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
           _id: exp_frag_id,
           taxon_id: taxon_id,
           description: 'expression description',
-          y_axis_title: 'log(TPM) expression',
+          y_axis_title: 'log(TPM) expression'
         },
         metadata_form_info_attributes: {
           use_metadata_convention: false # check that override is in place to enforce convention

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -192,6 +192,8 @@ FactoryBot.define do
                             study_file: file)
         end
         if evaluator.expression_input.any?
+          file.build_expression_file_info(library_preparation_protocol: "10x 5' v3")
+          file.expression_file_info.save
           file.ann_data_file_info.has_expression = true
           # TODO: update this when raw count ingest enabled for AnnData
           FactoryBot.create(:data_array,


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds in raw count information fields to the AnnData expression upload UX.  This is required work for eventual extraction of raw counts cell names (and downstream enabling differential expression calculations using AnnData files).  There is no extraction job being run now - this only persists form data in the database.  The values are stored both in the `AnnDataFileInfo#data_fragments` and `ExpressionFileInfo` documents, and updates propagate to both when saving.  This also includes a backfill migration to ensure that existing data is correct (we had not been updating the `ExpressionFileInfo` document previously).

Short demo of new forms:

https://github.com/user-attachments/assets/93738d53-c07b-4818-8da0-f6c8df699ee4

#### MANUAL TESTING
1. Boot as normal and sign in
2. Load the upload wizard for any study that already has an AnnData file ingested
3. In the Expression tab, select "Yes" for "I have raw count data in the **adata.raw** slot" and specify units
4. Click "Save" in the form
5. In a Rails console session, validate that the data has been persisted correctly (your values may be slightly different but should match what you see in the forms):
```
study = Study.find(<id of study from URL bar>)
study_file = study.study_files.last
study_file.expression_file_info.attributes
=> 
{"_id"=>BSON::ObjectId('66b12aca94ec8f1dd7897d23'),                                
 "biosample_input_type"=>"Whole cell",                                             
 "modality"=>"Transcriptomic: unbiased",                                           
 "raw_counts_associations"=>[],                                                    
 "library_preparation_protocol"=>"10x 5' v3",                                      
 "is_raw_counts"=>true,                                                            
 "units"=>"raw counts"}     

study_file.ann_data_file_info.find_fragment(data_type: :expression)
=> 
{"_id"=>"66b12ab7debe3074889dc6e4",                                             
 "taxon_id"=>"6033f530e241391884633745",                                        
 "expression_file_info"=>
  {"library_preparation_protocol"=>"10x 5' v3",
   "biosample_input_type"=>"Whole cell",
   "modality"=>"Transcriptomic: unbiased",
   "is_raw_counts"=>true,
   "units"=>"raw counts"},
 "data_type"=>"expression"}
```