### PR TITLE
Adding `raw_counts` extraction phase for AnnData files (SCP-5102)

### DIFF
--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -32,7 +32,7 @@ class AnnDataIngestParameters
     cluster_file: nil,
     name: nil,
     domain_ranges: nil,
-    extract: %w[cluster metadata processed_expression],
+    extract: %w[cluster metadata processed_expression raw_counts],
     cell_metadata_file: nil,
     ingest_cell_metadata: false,
     study_accession: nil,

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -1027,14 +1027,12 @@ class IngestJob
     message = ["Total parse time: #{get_total_runtime}"]
     case action
     when :ingest_expression
-      # since genes are not ingested for raw count matrices, report number of cells ingested
-      if study_file.is_raw_counts_file?
-        cells = study.expression_matrix_cells(study_file).count
-        message << "Cells ingested: #{cells}"
-      else
-        genes = Gene.where(study_id: study.id, study_file_id: study_file.id).count
-        message << "Gene-level entries created: #{genes}"
-      end
+      count_genes = !study_file.is_raw_counts_file? || study_file.is_viz_anndata?
+      count_cells = study_file.is_raw_counts_file?
+      genes = Gene.where(study_id: study.id, study_file_id: study_file.id).count
+      cells = study.expression_matrix_cells(study_file, matrix_type: 'raw').count
+      message << "Gene-level entries created: #{genes}" if count_genes
+      message << "Cells ingested: #{cells}" if count_cells
     when :ingest_cell_metadata
       use_metadata_convention = study_file.use_metadata_convention
       if use_metadata_convention

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -729,6 +729,7 @@ class IngestJob
     study_file.ann_data_file_info.has_clusters = ClusterGroup.where(study:, study_file:).exists?
     study_file.ann_data_file_info.has_metadata = CellMetadatum.where(study:, study_file:).exists?
     study_file.ann_data_file_info.has_expression = Gene.where(study:, study_file:).exists?
+    study_file.ann_data_file_info.has_raw_counts = study.expression_matrix_cells(study_file, matrix_type: 'raw').any?
     study_file.save
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.33.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.34.0'
 
     # Docker image for image pipeline jobs
     config.image_pipeline_docker_image = 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_c2b090043'

--- a/test/models/ann_data_ingest_parameters_test.rb
+++ b/test/models/ann_data_ingest_parameters_test.rb
@@ -56,7 +56,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
     end
 
     cmd = '--ingest-anndata --anndata-file gs://bucket_id/test.h5ad --obsm-keys ["X_umap", "X_tsne"] --extract ' \
-          '["cluster", "metadata", "processed_expression"]'
+          '["cluster", "metadata", "processed_expression", "raw_counts"]'
     assert_equal cmd, extraction.to_options_array.join(' ')
     assert_equal 'n2d-highmem-32', extraction.machine_type
   end

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -236,7 +236,7 @@ class IngestJobTest < ActiveSupport::TestCase
         studyAccession: @basic_study.accession,
         jobStatus: 'success',
         referenceAnnDataFile: false,
-        extractedFileTypes: %w[cluster metadata processed_expression],
+        extractedFileTypes: %w[cluster metadata processed_expression raw_counts],
         machineType: 'n2d-highmem-4',
         bootDiskSizeGb: 300,
         exitStatus: 0


### PR DESCRIPTION
#### BACKGROUND & CHANGES
Building on #2113 and [359](https://github.com/broadinstitute/scp-ingest-pipeline/pull/359), this update adds end-to-end integration for raw counts extraction of AnnData files.  When a user uploads an AnnData file for parsing we will extract the list of cells corresponding to both the raw and processed matrices.  This is part of an effort to enable exploratory differential expression for AnnData files.  New AnnData uploads that specify they have raw counts information will now be marked as eligible for differential expression.  

Note: there is not a backfill migration for existing AnnData files as we do not know whether they have raw counts data in the `adata.raw` slot.  Study owner outreach will be required in order to identify potential raw counts files.  Also, while these new AnnData studies will be eligible for differential expression, there is still work to be done in order to fully enable this.  Once that has completed and we have identified any potential existing studies w/ raw counts data, we can run a backfill migration to add differential expression results.

#### MANUAL TESTING
1. Boot all services and sign in
2. Create a new study and select the AnnData UX
3. Upload any valid AnnData file, such as [compliant_pbmc3K.h5ad](https://console.cloud.google.com/storage/browser/_details/fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/test_Data/ingest_manual_test/compliant_pbmc3K.h5ad;tab=live_object), making sure to specify "Yes" for "I have raw count data in the adata.raw slot"
4. Wait for the main parsing jobs to complete (3-5 minutes, you do not need to wait for subsampling)
5. Open a Rails console session and load the above study:
```
study = Study.last # or load by accession if you used an existing study
study_file = study.study_files.last
```
6. Confirm that the study has both raw & processed data and that the study is now eligible for DE (your counts/annotations may be different if you used a different AnnData file):
```
study.has_raw_counts_matrices?
=> true

study.has_visualization_matrices?
=> true

study.has_expression_data?
=> true

study.expression_matrix_cells(study_file, matrix_type: 'raw').count
=> 2638

study.expression_matrix_cells(study_file, matrix_type: 'processed').count
=> 2638

DifferentialExpressionService.study_eligible?(study)
=> true

DifferentialExpressionService.find_eligible_annotations(study)
=> [{:annotation_name=>"louvain", :annotation_scope=>"study"}]
```