### PR TITLE
Allowing automated DE calculation for AnnData with raw counts (SCP-5775)

### DIFF
--- a/app/lib/cluster_viz_service.rb
+++ b/app/lib/cluster_viz_service.rb
@@ -240,16 +240,13 @@ class ClusterVizService
   # * *raises*
   #   - (ArgumentError) => if requested parameters do not validate
   def self.raw_matrix_for_cluster_cells(study, cluster)
-    raw_counts_matrices = StudyFile.where(study_id: study.id,
-                                          parse_status: 'parsed',
-                                          queued_for_deletion: false,
-                                          'expression_file_info.is_raw_counts' => true)
+    raw_counts_matrices = study.expression_matrices.select { |matrix| matrix.is_raw_counts_file? }
     raise ArgumentError, "#{study.accession} has no parsed raw counts data" if raw_counts_matrices.empty?
 
     cluster_cells = cluster.concatenate_data_arrays('text', 'cells')
     # if the intersection of cluster_cells and matrix_cells is complete, then this will return a matrix file
     raw_matrix = raw_counts_matrices.detect do |matrix|
-      matrix_cells = study.expression_matrix_cells(matrix)
+      matrix_cells = study.expression_matrix_cells(matrix, matrix_type: 'raw')
       (cluster_cells & matrix_cells) == cluster_cells
     end
     raise ArgumentError, "#{cluster.name} does not have all cells in a single raw counts matrix" if raw_matrix.nil?

--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -40,7 +40,7 @@ class DifferentialExpressionParameters
   validates :annotation_file, :cluster_file, :matrix_file_path,
             format: { with: Parameterizable::GS_URL_REGEXP, message: 'is not a valid GS url' }
   validates :annotation_scope, inclusion: %w[cluster study]
-  validates :matrix_file_type, inclusion: %w[dense mtx]
+  validates :matrix_file_type, inclusion: %w[dense mtx h5ad]
   validates :machine_type, inclusion: Parameterizable::GCE_MACHINE_TYPES
   validates :gene_file, :barcode_file,
             presence: true,

--- a/app/models/life_sciences_api_client.rb
+++ b/app/models/life_sciences_api_client.rb
@@ -23,7 +23,7 @@ class LifeSciencesApiClient
     ingest_cluster: %w[Cluster AnnData],
     ingest_cell_metadata: %w[Metadata AnnData],
     ingest_subsample: %w[Cluster AnnData],
-    differential_expression: %w[Cluster],
+    differential_expression: %w[Cluster AnnData],
     ingest_differential_expression: ['Differential Expression'],
     render_expression_arrays: %w[Cluster],
     image_pipeline: %w[Cluster],

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.34.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.35.0'
 
     # Docker image for image pipeline jobs
     config.image_pipeline_docker_image = 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_c2b090043'

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -195,15 +195,18 @@ FactoryBot.define do
           file.build_expression_file_info(library_preparation_protocol: "10x 5' v3")
           file.expression_file_info.save
           file.ann_data_file_info.has_expression = true
-          # TODO: update this when raw count ingest enabled for AnnData
-          FactoryBot.create(:data_array,
-                            array_type: 'cells',
-                            array_index: 0,
-                            name: 'h5ad_frag.matrix.processed.mtx.gz Cells',
-                            cluster_name: 'h5ad_frag.matrix.processed.mtx.gz',
-                            values: evaluator.cell_input,
-                            study_file: file
-          )
+          file.ann_data_file_info.has_raw_counts = true
+          %w[raw processed].each do |matrix_type|
+            FactoryBot.create(:data_array,
+                              array_type: 'cells',
+                              array_index: 0,
+                              name: "h5ad_frag.matrix.#{matrix_type}.mtx.gz Cells",
+                              cluster_name: "h5ad_frag.matrix.#{matrix_type}.mtx.gz",
+                              values: evaluator.cell_input,
+                              study_file: file
+            )
+          end
+
           evaluator.expression_input.each do |gene, expression|
             FactoryBot.create(:gene_with_expression,
                               expression_input: expression,
@@ -212,14 +215,17 @@ FactoryBot.define do
           end
         end
         evaluator.coordinate_input.each do |entry|
-          entry.each do |cluster_name, axes|
+          entry.each do |name, axes|
             file.ann_data_file_info.has_clusters = true
             axes_and_cells = axes.merge(cells: evaluator.cell_input)
             FactoryBot.create(:cluster_group_with_cells,
-                              name: cluster_name,
+                              name:,
                               cell_input: axes_and_cells,
                               cluster_type: "#{axes.keys.size}d",
                               study_file: file)
+            file.ann_data_file_info.data_fragments << {
+              _id: BSON::ObjectId.new.to_s, data_type: :cluster, obsm_key_name: "X_#{name}", name:
+            }.with_indifferent_access
           end
         end
         # gotcha to save updates to ann_data_file_info

--- a/test/models/differential_expression_parameters_test.rb
+++ b/test/models/differential_expression_parameters_test.rb
@@ -24,6 +24,16 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
       gene_file: 'gs://test_bucket/genes.tsv',
       barcode_file: 'gs://test_bucket/barcodes.tsv'
     }
+
+    @anndata_options = {
+      annotation_name: 'Category',
+      annotation_scope: 'cluster',
+      annotation_file: 'gs://test_bucket/metadata.tsv',
+      cluster_file: 'gs://test_bucket/cluster.tsv',
+      cluster_name: 'UMAP',
+      matrix_file_path: 'gs://test_bucket/matrix.h5ad',
+      matrix_file_type: 'h5ad'
+    }
   end
 
   test 'should instantiate and validate parameters' do
@@ -31,6 +41,8 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
     assert dense_params.valid?
     sparse_params = DifferentialExpressionParameters.new(@sparse_options)
     assert sparse_params.valid?
+    anndata_params = DifferentialExpressionParameters.new(@anndata_options)
+    assert anndata_params.valid?
 
     # test conditional validations
     dense_params.annotation_file = ''
@@ -60,6 +72,17 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
     sparse_params = DifferentialExpressionParameters.new(@sparse_options)
     options_array = sparse_params.to_options_array
     sparse_params.attributes.each do |name, value|
+      expected_name = Parameterizable.to_cli_opt(name)
+      assert_includes options_array, expected_name
+      assert_includes options_array, value
+    end
+    assert_includes options_array, DifferentialExpressionParameters::PARAMETER_NAME
+
+    anndata_params = DifferentialExpressionParameters.new(@anndata_options)
+    options_array = anndata_params.to_options_array
+    anndata_params.attributes.each do |name, value|
+      next if value.blank? # gene_file and barcode_file will not be set
+
       expected_name = Parameterizable.to_cli_opt(name)
       assert_includes options_array, expected_name
       assert_includes options_array, value

--- a/test/models/study_test.rb
+++ b/test/models/study_test.rb
@@ -199,6 +199,6 @@ class StudyTest < ActiveSupport::TestCase
     assert_equal cells, @study.expression_matrix_cells(dense_matrix)
     assert_equal cells, @study.expression_matrix_cells(ann_data_file)
     assert_equal cells, @study.expression_matrix_cells(ann_data_file, matrix_type: 'processed')
-    assert_empty @study.expression_matrix_cells(ann_data_file, matrix_type: 'raw')
+    assert_equal cells, @study.expression_matrix_cells(ann_data_file, matrix_type: 'raw')
   end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
Building on #2114 and #2113, this update now allow automatic differential expression calculations on AnnData files.  The business logic flow is the same as for normal plain test files - raw counts, annotation and clustering data are all required.  Some small updates to `DifferentialExpressionService` were made to better account for the case where all data is sourced from the same study file.  The extracted "fragment" files are still used for clustering/metadata, but the original AnnData file is used as the raw counts matrix.  There is no backfill migration for existing AnnData files as we do not know if they contain raw counts data in the `raw` slot.  All new uploads that specify they contain raw counts will have differential expression results generated.

#### MANUAL TESTING
The simplest way to test this is to use the study you created in #2114.  Failing that, you can simply upload a new AnnData file and specify that it has raw counts.  Differential expression results will be created once all the source data has ingested.  If you are using an existing AnnData study:

1. Open a Rails console session and load the study you created previously
```
accession = <your study accession>
study = Study.find_by(accession:)
```
2. Confirm the study is eligible for DE, and has annotations that qualify:
```
DifferentialExpressionService.study_eligible?(study)
=> true

DifferentialExpressionService.find_eligible_annotations(study)
=> [{:annotation_name=>"louvain", :annotation_scope=>"study"}]
```
3. Launch DE jobs on all eligible annotations (your output may be slightly different depending on source data)
```
DifferentialExpressionService.run_differential_expression_on_all(study.accession)

...
SCP157 has annotations eligible for DE; validating inputs
Checking DE job for SCP157: UMAP with spaces (louvain--group--study)
==> Dry run found job SCP157: UMAP with spaces (louvain--group--study)
Checking DE job for SCP157: tSNE with spaces (louvain--group--study)
==> Dry run found job SCP157: tSNE with spaces (louvain--group--study)
SCP157 yielded 2 differential expression jobs; 0 skipped
```
4. Wait until the job(s) complete and verify that you get an email and can view the results using the normal DE UX