### PR TITLE
Ignore differential expression jobs when computing ingestSummary event (SCP-5778)

### DIFF
--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -88,6 +88,7 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
           delete_user_annotations(study:, study_file: object)
           delete_parsed_data(object.id, study.id, ClusterGroup, CellMetadatum, Gene, DataArray)
           delete_fragment_files(study:, study_file: object)
+          delete_differential_expression_results(study:, study_file: object)
           # reset default options/counts
           study.reload
           study.cell_count = study.all_cells_array.size

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -226,7 +226,7 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
     when 'Cluster'
       cluster = ClusterGroup.find_by(study:, study_file: study_file)
       results = DifferentialExpressionResult.where(study:, cluster_group: cluster)
-    when 'Expression Matrix', 'MM Coordinate Matrix'
+    when 'Expression Matrix', 'MM Coordinate Matrix', 'AnnData'
       results = DifferentialExpressionResult.where(study:, matrix_file_id: study_file.id)
     when 'Differential Expression'
       results = DifferentialExpressionResult.where(study_file: object)

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -1010,7 +1010,7 @@ class IngestJob
     # discard the job that corresponds with this ingest process
     still_processing = remaining_jobs.reject do |job|
       ingest_job = DelayedJobAccessor.dump_job_handler(job).object
-      ingest_job.params_object.associated_file == fragment
+      ingest_job.params_object.is_a?(AnnDataIngestParameters) && ingest_job.params_object.associated_file == fragment
     end.any?
 
     # only continue if there are no more jobs and a summary has not been sent yet


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug that prevented both email delivery and Mixpanel reporting of the `ingestSummary` event.  The underlying issue was that the `ingestSummary` event dumps any in-process ingest jobs from the `Delayed::Job` queue to determine if there are any left that correspond to the current AnnData file.  This then threw an error because the DE jobs use a different parameters class that doesn't support the `associated_file` method.  Now, any remaining DE jobs are ignored as they do not correspond with the `ingestSummary` event and are reported elsewhere.  Additionally, this adds DE output file cleanup when you delete non-reference AnnData files.

#### MANUAL TESTING
As this is a race condition at its core, the only way to properly test is to upload a new AnnData file that has raw counts data and wait for all parse jobs (including differential expression) to complete.  This should take 3-5 minutes using the `compliant_pbmc3K.h5ad` AnnData file.  You should receive the following emails:

- Metadata w/ ~15 annotations created
- Expression w/ both genes & cells extracted
- For every clustering obsm_key provided:
  - parse completion
  - subsampling
  - differential expression for `louvain` annotation

If you use the above file and specify the only the `X_umap` slot, this will end up being 6 emails total.