### PR TITLE
Adding machine type & failure properties to ingestSummary event

### DIFF
--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -1011,6 +1011,7 @@ class IngestJob
       trigger:,
       jobStatus: job_status,
       numFilesExtracted: num_files_extracted,
+      machineType: params_object.machine_type,
       error: error_action,
       exitCode: code
     }

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -156,9 +156,7 @@ class IngestJobTest < ActiveSupport::TestCase
         }
       }
     }.with_indifferent_access
-    mock.expect :metadata, mock_metadata
-    mock.expect :metadata, mock_metadata
-    mock.expect :metadata, mock_metadata
+    3.times {mock.expect :metadata, mock_metadata  }
     mock.expect :error, { code: 1, message: 'mock message' } # simulate error
     mock.expect :done?, true
 
@@ -219,9 +217,7 @@ class IngestJobTest < ActiveSupport::TestCase
         }
       }
     }.with_indifferent_access
-    mock.expect :metadata, mock_metadata
-    mock.expect :metadata, mock_metadata
-    mock.expect :metadata, mock_metadata
+    3.times {mock.expect :metadata, mock_metadata  }
     mock.expect :error, nil
     mock.expect :done?, true
 
@@ -273,9 +269,7 @@ class IngestJobTest < ActiveSupport::TestCase
         }
       }
     }.with_indifferent_access
-    mock.expect :metadata, mock_metadata
-    mock.expect :metadata, mock_metadata
-    mock.expect :metadata, mock_metadata
+    3.times {mock.expect :metadata, mock_metadata  }
     mock.expect :error, nil
     mock.expect :done?, true
 
@@ -338,11 +332,8 @@ class IngestJobTest < ActiveSupport::TestCase
     }.with_indifferent_access
 
     pipeline_mock = MiniTest::Mock.new
-    pipeline_mock.expect :metadata, metadata_mock
-    pipeline_mock.expect :metadata, metadata_mock
-    pipeline_mock.expect :metadata, metadata_mock
-    pipeline_mock.expect :metadata, metadata_mock
-    pipeline_mock.expect :error, nil
+    4.times {pipeline_mock.expect :metadata, metadata_mock }
+    2.times {pipeline_mock.expect :error, nil  }
 
     operations_mock = Minitest::Mock.new
     operations_mock.expect :operations, [pipeline_mock]
@@ -356,7 +347,9 @@ class IngestJobTest < ActiveSupport::TestCase
         studyAccession: @basic_study.accession,
         trigger: ann_data_file.upload_trigger,
         jobStatus: 'success',
-        numFilesExtracted: 1
+        numFilesExtracted: 1,
+        error: nil,
+        exitCode: 0
       }
       job_props = job.anndata_summary_props
       assert_equal expected_job_props, job_props
@@ -412,7 +405,9 @@ class IngestJobTest < ActiveSupport::TestCase
       studyAccession: @basic_study.accession,
       trigger: ann_data_file.upload_trigger,
       jobStatus: 'success',
-      numFilesExtracted: 1
+      numFilesExtracted: 1,
+      error: nil,
+      exitCode: 0
     }
     metrics_mock = Minitest::Mock.new
     metrics_mock.expect :call, true, ['ingestSummary', mock_job_props, @user]
@@ -426,6 +421,39 @@ class IngestJobTest < ActiveSupport::TestCase
           assert ann_data_file.has_anndata_summary?
         end
       end
+    end
+  end
+
+  test 'should report failure step in ingestSummary' do
+    ann_data_file = FactoryBot.create(:ann_data_file, name: 'failed.h5ad', study: @basic_study)
+    now = DateTime.now.in_time_zone
+    actions = [
+      { commands: ['python', 'ingest_pipeline.py', '--study-file-id', ann_data_file.id.to_s, 'ingest_cell_metadata'] }
+    ]
+    events = [{ timestamp: now.to_s, containerStopped: { exitStatus: 65 } }.with_indifferent_access]
+    pipeline = { actions: }
+    failed_metadata = { pipeline:, events:, startTime: (now - 1.hour).to_s, endTime: now.to_s }.with_indifferent_access
+    failed_pipeline = Minitest::Mock.new
+    6.times { failed_pipeline.expect(:metadata, failed_metadata) }
+    3.times { failed_pipeline.expect(:error, true) }
+    operations_mock = Minitest::Mock.new
+    operations_mock.expect :operations, [failed_pipeline]
+    client_mock = Minitest::Mock.new
+    client_mock.expect :list_pipelines, operations_mock
+    ApplicationController.stub :life_sciences_api_client, client_mock do
+      cell_metadata_file = RequestUtils.data_fragment_url(ann_data_file, 'metadata')
+      metadata_params = AnnDataIngestParameters.new(
+        ingest_cell_metadata: true, cell_metadata_file:, ingest_anndata: false, extract: nil, obsm_keys: nil,
+        study_accession: @basic_study.accession
+      )
+      metadata_job = IngestJob.new(study: @basic_study, study_file: ann_data_file, user: @user,
+                                   action: :ingest_metadata, params_object: metadata_params)
+      props = metadata_job.anndata_summary_props.with_indifferent_access
+      assert_equal 3_600_000, props[:perfTime]
+      assert_equal 'failed', props[:jobStatus]
+      assert_equal 0, props[:numFilesExtracted]
+      assert_equal 'ingest_cell_metadata', props[:error]
+      assert_equal 65, props[:exitCode]
     end
   end
 

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -348,6 +348,7 @@ class IngestJobTest < ActiveSupport::TestCase
         trigger: ann_data_file.upload_trigger,
         jobStatus: 'success',
         numFilesExtracted: 1,
+        machineType: params_object.machine_type,
         error: nil,
         exitCode: 0
       }
@@ -406,6 +407,7 @@ class IngestJobTest < ActiveSupport::TestCase
       trigger: ann_data_file.upload_trigger,
       jobStatus: 'success',
       numFilesExtracted: 1,
+      machineType: metadata_params.machine_type,
       error: nil,
       exitCode: 0
     }


### PR DESCRIPTION
#### BACKGROUND & CHANGES
In an effort to make the `ingestSummary` Mixpanel event for AnnData ingest more useful, we are adding three new properties:

1. `machineType`: GCE instance type, e.g. `n2d-highmem-8`
2. `error`: ingest process that failed (if present), e.g. `ingest_cell_metadata`, `ingest_anndata`, etc.
3. `exitCode`: exit code from process that terminated the instance - `0` for success, non-zero for failures

Along with existing properties, these new fields will afford us better insight into how and why AnnData ingests either succeed or fail.  For instance, the `error` and `exitCode` fields will let us determine which type of extracted data fails most frequently, and if those failures are memory-related (`137` or `139`), or in the case of metadata files if they are JSON schema errors (`65`).  The `machineType` field will be useful in conjunction with memory-related exit codes as it will allow us to plot file size against machine types to better ascertain where we should be scaling up to the next available machine type.

There could be future work done in `scp-ingest-pipeline` to differentiate other failure states with unique exit codes, if desired.   Since many of our handled exceptions exit with `1`, we could chose to pick different codes for more common errors to allow us better visibility into how ofter these happen, which could then drive future development into CSFV to prevent these upload from proceeding to ingest.

#### MANUAL TESTING
1. Boot all services and sign in
2. Go to the Feature Flags control panel and deactivate `clientside_validation` for your user account (otherwise you will not be able to upload the invalid AnnData file later)
3. Create a new study and select the AnnData upload UX
4. Upload the AnnData file `test/test_data/anndata_test_bad_header_no_species.h5ad` and specify that you have clustering in the `X_umap` slot (this doesn't exist and will throw an error to be caught later)
5. After a few minutes, you should see the `ingestSummary` event in the logs with the following properties:
```
jobStatus: "failed", 
numFilesExtracted: 0, 
machineType: "n2d-highmem-4",
error: "ingest_anndata",
exitCode: 1
``` 