### PR TITLE
Add secondary cleanup for deleted files, only extract raw_counts when specified (SCP-5782, SCP-5783)

### DIFF
--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -113,7 +113,7 @@ class FileParseService
           else
             params_object = AnnDataIngestParameters.new(
               anndata_file: study_file.gs_url, obsm_keys: study_file.ann_data_file_info.obsm_key_names,
-              file_size: study_file.upload_file_size
+              file_size: study_file.upload_file_size, extract_raw_counts: study_file.is_raw_counts_file?
             )
           end
           # TODO extract and parse Raw Exp Data (SCP-4710)

--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -79,11 +79,19 @@ class AnnDataIngestParameters
                             mem_range === file_size
                           end&.first || 'n2d-highmem-4'
     end
-    self.extract << 'raw_counts' if @ingest_anndata && @extract_raw_counts
+    append_raw_counts_extract!
   end
 
   # get the particular file (either source AnnData or fragment) being processed by this job
   def associated_file
     anndata_file || cluster_file || cell_metadata_file || matrix_file
+  end
+
+  private
+
+  def append_raw_counts_extract!
+    if @ingest_anndata && @extract_raw_counts && !@extract.include?('raw_counts')
+      self.extract << 'raw_counts'
+    end
   end
 end

--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -13,6 +13,7 @@ class AnnDataIngestParameters
   # ingest_anndata: gate primary validation/extraction of AnnData file
   # anndata_file: GS URL for AnnData file
   # extract: array of values for different file type extractions
+  # extract_raw_counts: T/F for whether to add raw_counts to extraction
   # obsm_keys: data slots containing clustering information
   # ingest_cluster: gate ingesting an extracted cluster file
   # cluster_file: GS URL for extracted cluster file
@@ -32,7 +33,8 @@ class AnnDataIngestParameters
     cluster_file: nil,
     name: nil,
     domain_ranges: nil,
-    extract: %w[cluster metadata processed_expression raw_counts],
+    extract: %w[cluster metadata processed_expression],
+    extract_raw_counts: false,
     cell_metadata_file: nil,
     ingest_cell_metadata: false,
     study_accession: nil,
@@ -46,7 +48,7 @@ class AnnDataIngestParameters
   }.freeze
 
   # values that are available as methods but not as attributes (and not passed to command line)
-  NON_ATTRIBUTE_PARAMS = %i[file_size machine_type].freeze
+  NON_ATTRIBUTE_PARAMS = %i[file_size machine_type extract_raw_counts].freeze
 
   # GCE machine types and file size ranges for handling fragment extraction
   # produces a hash with entries like { 'n2-highmem-4' => 0..24.gigabytes }
@@ -77,6 +79,7 @@ class AnnDataIngestParameters
                             mem_range === file_size
                           end&.first || 'n2d-highmem-4'
     end
+    self.extract << 'raw_counts' if @ingest_anndata && @extract_raw_counts
   end
 
   # get the particular file (either source AnnData or fragment) being processed by this job

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -355,18 +355,23 @@ class IngestJob
       end
       study.reload # refresh cached instance of study
       study_file.reload # refresh cached instance of study_file
-      set_study_state_after_ingest
-      study_file.invalidate_cache_by_file_type # clear visualization caches for file
-      log_to_mixpanel
-      subject = "#{study_file.file_type} file: '#{study_file.upload_file_name}' has completed parsing"
-      message = generate_success_email_array
-      if special_action?
-        # don't email users for 'special actions' like DE or image pipeline, instead notify admins
-        qa_config = AdminConfiguration.find_by(config_type: 'QA Dev Email')
-        email = qa_config.present? ? qa_config.value : User.find_by(admin: true)&.email
-        SingleCellMailer.notify_user_parse_complete(email, subject, message, study).deliver_now unless email.blank?
-      elsif action != :ingest_anndata # don't email users on "extract" AnnData jobs
-        SingleCellMailer.notify_user_parse_complete(user.email, subject, message, study).deliver_now
+      # check if another process marked file for deletion, can happen if this is an AnnData file
+      if study_file.queued_for_deletion
+        run_secondary_cleanup
+      else
+        set_study_state_after_ingest
+        study_file.invalidate_cache_by_file_type # clear visualization caches for file
+        log_to_mixpanel
+        subject = "#{study_file.file_type} file: '#{study_file.upload_file_name}' has completed parsing"
+        message = generate_success_email_array
+        if special_action?
+          # don't email users for 'special actions' like DE or image pipeline, instead notify admins
+          qa_config = AdminConfiguration.find_by(config_type: 'QA Dev Email')
+          email = qa_config.present? ? qa_config.value : User.find_by(admin: true)&.email
+          SingleCellMailer.notify_user_parse_complete(email, subject, message, study).deliver_now unless email.blank?
+        elsif action != :ingest_anndata # don't email users on "extract" AnnData jobs
+          SingleCellMailer.notify_user_parse_complete(user.email, subject, message, study).deliver_now
+        end
       end
     elsif done? && failed?
       Rails.logger.error "IngestJob poller: #{pipeline_name} has failed."
@@ -562,6 +567,22 @@ class IngestJob
       cluster.update!(indexed: false)
       cluster.reload
       cluster.create_all_cell_indices!
+    end
+  end
+
+  # check if an AnnData file has failed in a separate ingest process and perform necessary cleanups
+  # can happen as all primary AnnData ingests (expression, metadata, clustering) happen in parallel
+  # will lead to orphaned data that prevents all future uploads
+  def run_secondary_cleanup
+    Rails.logger.info "Checking for secondary cleanup on #{study_file.id} after #{pipeline_name} completion"
+    study_file.reload
+    if study_file.queued_for_deletion
+      Rails.logger.info "Performing secondary cleanup on #{study_file.id} due to upstream failure"
+      [ClusterGroup, CellMetadatum, Gene, DataArray].each do |model|
+        Rails.logger.info "Removing all #{model} records for #{study_file.id}"
+        model.where(study_id: study.id, study_file_id: study_file.id).delete_all
+      end
+      Rails.logger.info "Secondary cleanup for #{study_file.id} complete"
     end
   end
 

--- a/test/models/ann_data_ingest_parameters_test.rb
+++ b/test/models/ann_data_ingest_parameters_test.rb
@@ -5,6 +5,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
   before(:all) do
     @extract_params = {
       anndata_file: 'gs://bucket_id/test.h5ad',
+      extract_raw_counts: true,
       file_size: 100.gigabytes
     }
 
@@ -105,5 +106,10 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
     assert params.valid?
     params.machine_type = 'foo'
     assert_not params.valid?
+  end
+
+  test 'should not extract raw counts unless specified' do
+    params = AnnDataIngestParameters.new(anndata_file: 'gs://bucket_id/test.h5ad', file_size: 100.gigabytes)
+    assert_equal AnnDataIngestParameters::PARAM_DEFAULTS[:extract], params.extract
   end
 end


### PR DESCRIPTION
#### BACKGROUND
In the AnnData UX, after a file finishes the extraction phase, the 3 main datatypes (expression, metadata, clustering) are all ingested in parallel (if specified).  While this is the most performant way to process data, it leads to corner cases where one process fails (expression ingest, for instance) but the other processes succeed.  Because the data cleanup happens immediately upon detection of the failure, any processes that are still writing data will not be affected.  This leads to a case where orphaned data exists in the database that cannot be cleaned up by the user, and effectively blocks all further ingests using the AnnData UX.

#### CHANGES
Now, upon successful completion of an ingest process, a "secondary cleanup" check is run to determine if the file has been queued for deletion by another ingest run.  This will in practice only apply to AnnData files, as other file types are ingested atomically, and ancillary processes like subsampling or differential expression have their own cleanup policies.  Additionally, this will skip sending a "success" email to a user with a file that is in the process of being deleted, meaning the last email the user gets about the file is the failure that caused the delete cascade.

Additionally, this fixes a bug where AnnData files that were not marked as having raw counts data were still extracting raw cell names.  Now, the `raw_counts` extraction only happens when specified.

#### MANUAL TESTING
TL;DR - this is nearly impossible to test manually.  It relies on having a file where only one data type fails to validate, but the jobs are spaced out just so that one fails before the others succeed.  That being said, I was able to get it to work using the following steps, though it requires manually changing the polling interval for some jobs.

1. Download a copy of [trimmed_compliant_pbmc3K.h5ad](https://console.cloud.google.com/storage/browser/_details/broad-singlecellportal-staging-testing-data/anndata/trimmed_compliant_pbmc3K.h5ad;tab=live_object?project=broad-singlecellportal-staging) from the testing bucket.  This AnnData file has duplicate gene entries, but all other data is valid.
2. In `app/models/ingest_job.rb`, modify the `else` block in `poll_for_completion` to change the `run_at` value for expression jobs.  This makes the polling happen much quicker, and will allow the expression job to (hopefully) fail before the clustering & metadata:
```
# app/models/ingest_job.rb, line 385
else
  run_at = action == :ingest_expression ? 10.seconds.from_now : run_at
  Rails.logger.info "IngestJob poller: #{pipeline_name} is not done; queuing check for #{run_at}"
  delay(run_at: run_at).poll_for_completion
end
```
3. Boot all services (including DelayedJob) and sign in
4. Create a new study and upload the file, specifying a clustering in the `X_umap` or `X_tsne` slots, but select **No** for raw counts data
5. In `development.log`, look for the job parameters and note that `raw_counts` is not listed in `extract`:
```
Remote found for trimmed_compliant_pbmc3K.h5ad:66d8c20b01de553d34536123, launching Ingest job
Request object sent to Google Life Sciences API, excluding 'environment' parameters:
---
:actions:
  :commands:
  - python
  - ingest_pipeline.py
  - "--study-id"
  - 66d8bcf394ec8f692a4ebea8
  - "--study-file-id"
  - 66d8c20b01de553d34536123
  - "--user-metrics-uuid"
  - c6a08597-c735-4c93-b069-4b4a74b708ee
  - ingest_anndata
  - "--ingest-anndata"
  - "--anndata-file"
  - gs://fc-b04eabc0-55c0-4047-9a02-5d0f98a8f528/trimmed_compliant_pbmc3K.h5ad
  - "--obsm-keys"
  - '["X_umap"]'
  - "--extract"
  - '["cluster", "metadata", "processed_expression"]'
  :image_uri: gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.35.0
...
```
6. Wait for the expression job to fail, looking for an email (or log message) that states **'trimmed_compliant_pbmc3K.h5ad' has failed during parsing. Duplicate values are not allowed. There are 1 duplicates in the gene file.**
7. In development.log, once the cluster/metadata jobs complete, look for the similar messages:
```
IngestJob poller: projects/342448556558/locations/us-central1/operations/16392329314662791330 is done!
IngestJob poller: projects/342448556558/locations/us-central1/operations/16392329314662791330 status: Completed
Checking for secondary cleanup on 66d8c20b01de553d34536123 after projects/342448556558/locations/us-central1/operations/16392329314662791330 completion
Performing secondary cleanup on 66d8c20b01de553d34536123 due to upstream failure
Removing all ClusterGroup records for 66d8c20b01de553d34536123
Removing all CellMetadatum records for 66d8c20b01de553d34536123
Removing all Gene records for 66d8c20b01de553d34536123
Removing all DataArray records for 66d8c20b01de553d34536123
Secondary cleanup for 66d8c20b01de553d34536123 complete
...
IngestJob poller: projects/342448556558/locations/us-central1/operations/3261380939259729291 is done!
IngestJob poller: projects/342448556558/locations/us-central1/operations/3261380939259729291 status: Completed
Checking for secondary cleanup on 66d8c20b01de553d34536123 after projects/342448556558/locations/us-central1/operations/3261380939259729291 completion
Performing secondary cleanup on 66d8c20b01de553d34536123 due to upstream failure
Removing all ClusterGroup records for 66d8c20b01de553d34536123
Removing all CellMetadatum records for 66d8c20b01de553d34536123
Removing all Gene records for 66d8c20b01de553d34536123
Removing all DataArray records for 66d8c20b01de553d34536123
Secondary cleanup for 66d8c20b01de553d34536123 complete
```
8. Load the "Study Details" page for this study, and confirm the study is still empty (no genes, clusters, or metadata)