### PR TITLE
Refine `machine_type` scaling for AnnData files during extract, differential expression (SCP-5769)

### DIFF
--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -151,6 +151,7 @@ class DifferentialExpressionService
       de_params[:barcode_file] = barcode_file.gs_url
     elsif raw_matrix.file_type == 'AnnData'
       de_params[:matrix_file_type] = 'h5ad'
+      de_params[:file_size] = raw_matrix.upload_file_size
     else
       de_params[:matrix_file_type] = 'dense'
     end

--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -3,6 +3,10 @@
 class AnnDataIngestParameters
   include ActiveModel::Model
   include Parameterizable
+  include ComputeScaling
+
+  # scaling coefficient for auto-selecting machine_type
+  GB_PER_CORE = 1.75
 
   # default values for parameters, also used as control list for attributes hash
   # attributes marked as true are passed to the command line as a standalone flag with no value
@@ -48,18 +52,6 @@ class AnnDataIngestParameters
   # values that are available as methods but not as attributes (and not passed to command line)
   NON_ATTRIBUTE_PARAMS = %i[file_size machine_type].freeze
 
-  # GCE machine types and file size ranges for handling fragment extraction
-  # produces a hash with entries like { 'n2-highmem-4' => 0..24.gigabytes }
-  # adjust (core * n) to n=4 for faster scaling (ie. n2-highmem-4 for 0 to 16G)
-  NUM_CORES = [4, 8, 16, 32, 48, 64, 80, 96].freeze
-  RAM_PER_CORE = NUM_CORES.map { |core| (core * 6).gigabytes }.freeze
-  EXTRACT_MACHINE_TYPES = NUM_CORES.map.with_index do |cores, index|
-    floor = index == 0 ? 0 : RAM_PER_CORE[index - 1]
-    limit = index == NUM_CORES.count - 1 ? RAM_PER_CORE[index] * 2 : RAM_PER_CORE[index]
-    # ranges that use '...' exclude the given end value.
-    { "n2d-highmem-#{cores}" => floor...limit }
-  end.reduce({}, :merge).freeze
-
   attr_accessor(*PARAM_DEFAULTS.keys)
 
   validates :anndata_file, :cluster_file, :cell_metadata_file, :matrix_file, :gene_file, :barcode_file,
@@ -73,9 +65,7 @@ class AnnDataIngestParameters
     # machine_type default is declared here to allow for autoscaling with optional override
     # see https://ruby-doc.org/core-3.1.0/Range.html#method-i-3D-3D-3D for range detection doc
     if @machine_type.nil?
-      self.machine_type = EXTRACT_MACHINE_TYPES.detect do |_, mem_range|
-                            mem_range === file_size
-                          end&.first || 'n2d-highmem-4'
+      self.machine_type = assign_machine_type
     end
   end
 

--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -5,7 +5,7 @@ class AnnDataIngestParameters
   include Parameterizable
   include ComputeScaling
 
-  # scaling coefficient for auto-selecting machine_type
+  # RAM scaling coefficient for auto-selecting machine_type
   GB_PER_CORE = 1.75
 
   # default values for parameters, also used as control list for attributes hash

--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -65,7 +65,7 @@ class AnnDataIngestParameters
     # machine_type default is declared here to allow for autoscaling with optional override
     # see https://ruby-doc.org/core-3.1.0/Range.html#method-i-3D-3D-3D for range detection doc
     if @machine_type.nil?
-      self.machine_type = assign_machine_type
+      self.machine_type = ingest_anndata ? assign_machine_type : default_machine_type
     end
   end
 

--- a/app/models/concerns/compute_scaling.rb
+++ b/app/models/concerns/compute_scaling.rb
@@ -4,7 +4,7 @@ module ComputeScaling
 
   # GCE machine types and file size ranges
   # produces a hash with entries like { 'n2-highmem-4' => 0..16.gigabytes }
-  # change GB_PER_CORE in parent class to adjust scaling (1-8, lower numbers means more aggressive scaling)
+  # change GB_PER_CORE in parent class to adjust scaling (1-8, higher number means more aggressive scaling)
   def scaled_machine_types
     gb_per_core = defined?(self.class::GB_PER_CORE) && self.class::GB_PER_CORE || 4
     num_cores = [4, 8, 16, 32, 48, 64]

--- a/app/models/concerns/compute_scaling.rb
+++ b/app/models/concerns/compute_scaling.rb
@@ -16,12 +16,17 @@ module ComputeScaling
     end.reduce({}, :merge)
   end
 
+  # default machine_type for parameters class
+  def default_machine_type
+    self.class::PARAM_DEFAULTS[:machine_type] || scaled_machine_types.keys.first
+  end
+
   # set machine_type based on file_size, using class defaults if specified
   def assign_machine_type
     max_file_size = scaled_machine_types.values.last.last
     return scaled_machine_types.keys.last if file_size > max_file_size
 
     scaled_machine = scaled_machine_types.detect { |_, mem_range| mem_range === file_size }&.first
-    scaled_machine || self.class::PARAM_DEFAULTS[:machine_type] || scaled_machine_types.keys.first
+    scaled_machine || default_machine_type
   end
 end

--- a/app/models/concerns/compute_scaling.rb
+++ b/app/models/concerns/compute_scaling.rb
@@ -1,0 +1,27 @@
+# dynamic GCE instance scaling based on input file size
+module ComputeScaling
+  extend ActiveSupport::Concern
+
+  # GCE machine types and file size ranges
+  # produces a hash with entries like { 'n2-highmem-4' => 0..16.gigabytes }
+  # change GB_PER_CORE in parent class to adjust scaling (1-8, lower numbers means more aggressive scaling)
+  def scaled_machine_types
+    num_cores = [4, 8, 16, 32, 48, 64]
+    ram_per_core = num_cores.map { |core| (core * self.class::GB_PER_CORE).gigabytes }.freeze
+    num_cores.map.with_index do |cores, index|
+      floor = index == 0 ? 0 : ram_per_core[index - 1]
+      limit = index == num_cores.count - 1 ? ram_per_core[index] * 2 : ram_per_core[index]
+      # ranges that use '...' exclude the given end value.
+      { "n2d-highmem-#{cores}" => floor...limit }
+    end.reduce({}, :merge)
+  end
+
+  # set machine_type based on file_size, using class defaults if specified
+  def assign_machine_type
+    max_file_size = scaled_machine_types.values.last.last
+    return scaled_machine_types.keys.last if file_size > max_file_size
+
+    scaled_machine = scaled_machine_types.detect { |_, mem_range| mem_range === file_size }&.first
+    scaled_machine || self.class::PARAM_DEFAULTS[:machine_type] || scaled_machine_types.keys.first
+  end
+end

--- a/app/models/concerns/compute_scaling.rb
+++ b/app/models/concerns/compute_scaling.rb
@@ -6,8 +6,9 @@ module ComputeScaling
   # produces a hash with entries like { 'n2-highmem-4' => 0..16.gigabytes }
   # change GB_PER_CORE in parent class to adjust scaling (1-8, lower numbers means more aggressive scaling)
   def scaled_machine_types
+    gb_per_core = defined?(self.class::GB_PER_CORE) && self.class::GB_PER_CORE || 4
     num_cores = [4, 8, 16, 32, 48, 64]
-    ram_per_core = num_cores.map { |core| (core * self.class::GB_PER_CORE).gigabytes }.freeze
+    ram_per_core = num_cores.map { |core| (core * gb_per_core).gigabytes }.freeze
     num_cores.map.with_index do |cores, index|
       floor = index == 0 ? 0 : ram_per_core[index - 1]
       limit = index == num_cores.count - 1 ? ram_per_core[index] * 2 : ram_per_core[index]
@@ -18,11 +19,13 @@ module ComputeScaling
 
   # default machine_type for parameters class
   def default_machine_type
-    self.class::PARAM_DEFAULTS[:machine_type] || scaled_machine_types.keys.first
+    defined?(self.class::PARAM_DEFAULTS) && self.class::PARAM_DEFAULTS[:machine_type] || scaled_machine_types.keys.first
   end
 
   # set machine_type based on file_size, using class defaults if specified
   def assign_machine_type
+    return default_machine_type if file_size.blank?
+
     max_file_size = scaled_machine_types.values.last.last
     return scaled_machine_types.keys.last if file_size > max_file_size
 

--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -7,7 +7,7 @@ class DifferentialExpressionParameters
   # name of Ingest Pipeline CLI parameter that invokes correct parser
   PARAMETER_NAME = '--differential-expression'.freeze
 
-  # scaling coefficient for auto-selecting machine_type
+  # RAM scaling coefficient for auto-selecting machine_type
   GB_PER_CORE = 3.5
 
   # annotation_name: name of annotation to use for DE

--- a/test/models/ann_data_ingest_parameters_test.rb
+++ b/test/models/ann_data_ingest_parameters_test.rb
@@ -5,7 +5,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
   before(:all) do
     @extract_params = {
       anndata_file: 'gs://bucket_id/test.h5ad',
-      file_size: 100.gigabytes
+      file_size: 50.gigabytes
     }
 
     @file_id = BSON::ObjectId.new
@@ -71,6 +71,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
     cluster_cmd = "--ingest-cluster --cluster-file #{@fragment_basepath}/" \
                   'h5ad_frag.cluster.X_umap.tsv.gz --name X_umap --domain-ranges {}'
     assert_equal cluster_cmd, cluster_ingest.to_options_array.join(' ')
+    assert_equal cluster_ingest.default_machine_type, cluster_ingest.machine_type
   end
 
   test 'should validate metadata params' do
@@ -82,6 +83,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
     end
     md_cmd = "--cell-metadata-file #{@fragment_basepath}/h5ad_frag.metadata.tsv.gz --ingest-cell-metadata"
     assert_equal md_cmd, metadata_ingest.to_options_array.join(' ')
+    assert_equal metadata_ingest.default_machine_type, metadata_ingest.machine_type
   end
 
   test 'should validate expression params' do
@@ -94,6 +96,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
               "--gene-file #{@fragment_basepath}/h5ad_frag.features.processed.tsv.gz " \
               "--barcode-file #{@fragment_basepath}/h5ad_frag.barcodes.processed.tsv.gz"
     assert_equal exp_cmd, exp_ingest.to_options_array.join(' ')
+    assert_equal exp_ingest.default_machine_type, exp_ingest.machine_type
   end
 
   test 'should set default machine type and allow override' do
@@ -105,5 +108,11 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
     assert params.valid?
     params.machine_type = 'foo'
     assert_not params.valid?
+  end
+
+  test 'should set default machine type' do
+    params = AnnDataIngestParameters.new
+    assert_equal 'n2d-highmem-4', params.default_machine_type
+    assert_equal 'n2d-highmem-4', params.machine_type
   end
 end

--- a/test/models/ann_data_ingest_parameters_test.rb
+++ b/test/models/ann_data_ingest_parameters_test.rb
@@ -6,7 +6,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
     @extract_params = {
       anndata_file: 'gs://bucket_id/test.h5ad',
       extract_raw_counts: true,
-      file_size: 100.gigabytes
+      file_size: 50.gigabytes
     }
 
     @file_id = BSON::ObjectId.new
@@ -103,7 +103,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
   test 'should set default machine type and allow override' do
     params = AnnDataIngestParameters.new(@extract_params)
     assert_equal 'n2d-highmem-32', params.machine_type
-    new_machine = 'n2d-highmem-80'
+    new_machine = 'n2d-highmem-64'
     params.machine_type = new_machine
     assert_equal new_machine, params.machine_type
     assert params.valid?
@@ -116,7 +116,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
     assert_equal 'n2d-highmem-4', params.default_machine_type
     assert_equal 'n2d-highmem-4', params.machine_type
   end
-  
+
   test 'should not extract raw counts unless specified' do
     params = AnnDataIngestParameters.new(anndata_file: 'gs://bucket_id/test.h5ad', file_size: 100.gigabytes)
     assert_equal AnnDataIngestParameters::PARAM_DEFAULTS[:extract], params.extract

--- a/test/models/differential_expression_parameters_test.rb
+++ b/test/models/differential_expression_parameters_test.rb
@@ -32,7 +32,8 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
       cluster_file: 'gs://test_bucket/cluster.tsv',
       cluster_name: 'UMAP',
       matrix_file_path: 'gs://test_bucket/matrix.h5ad',
-      matrix_file_type: 'h5ad'
+      matrix_file_type: 'h5ad',
+      file_size: 10.gigabytes
     }
   end
 
@@ -97,7 +98,15 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
 
   test 'should set default machine type for DE jobs' do
     params = DifferentialExpressionParameters.new
+    assert_equal 'n2d-highmem-8', params.default_machine_type
     assert_equal 'n2d-highmem-8', params.machine_type
+  end
+
+  test 'should scale machine type for h5ad files' do
+    params = DifferentialExpressionParameters.new(
+      matrix_file_path: 'gs://test_bucket/matrix.h5ad', matrix_file_type: 'h5ad', file_size: 64.gigabytes
+    )
+    assert_equal 'n2d-highmem-32', params.machine_type
   end
 
   test 'should remove non-attribute values from attribute hash' do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds the auto-scaling logic found during AnnData extraction to automated differential expression calculation jobs for AnnData files.  Additionally, the scaling algorithm has been updated such that both parameters classes (`AnnDataIngestParameters` and `DifferentialExpressionParameters`) have their own unique scaling coefficient, meaning they scale differently with respect to file size.  This is controlled via the `GB_PER_CORE` constant in each class.  For extraction jobs, we set a max of 1.75GB/core, and DE jobs have double that (3.5).  This makes the machine types scale as follows:

Extraction machine types
```
n2d-highmem-4: 0-7 GB
n2d-highmem-8: 7-14 GB
n2d-highmem-16: 14-28 GB
n2d-highmem-32: 28-56 GB
n2d-highmem-48: 56-84 GB
n2d-highmem-64: 84-224 GB
```
Differential expression machine types
```
n2d-highmem-4: 0-14 GB
n2d-highmem-8: 14-28 GB
n2d-highmem-16: 28-56 GB
n2d-highmem-32: 56-112 GB
n2d-highmem-48: 112-168 GB
n2d-highmem-64: 168-448 GB
```
Any file larger than the "max" file size is automatically assigned the largest machine type of `n2d-highmem-64`.  Any manual overrides provided are still honored.

#### MANUAL TESTING
1. Enter a Rails console session
2. Create a parameters object for each class using a mock file size of `100.gigabytes`:
```
file_size = 100.gigabytes
extract = AnnDataIngestParameters.new(file_size:)
de = DifferentialExpressionParameters.new(file_size:, matrix_file_type: 'h5ad')
```
3. Confirm the machine types scale to the `32` and `64` core versions, respectively:
```
de.machine_type
=> "n2d-highmem-32"
irb(main):060:0> extract.machine_type
=> "n2d-highmem-64"
```