### PR TITLE
Ensure subsampling flags are always reset on job completion (SCP-5774)

### DIFF
--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -661,10 +661,11 @@ class IngestJob
   # Set correct subsampling flags on a cluster after job completion
   def set_subsampling_flags
     cluster_group = ClusterGroup.find_by(study_id: study.id, study_file_id: study_file.id, name: cluster_name_by_file_type)
-    if cluster_group.is_subsampling? && cluster_group.find_subsampled_data_arrays.any?
-      Rails.logger.info "Setting subsampled flags for #{study_file.upload_file_name}:#{study_file.id} (#{cluster_group.name}) for visualization"
-      cluster_group.update(subsampled: true, is_subsampling: false)
-    end
+    return false if cluster_group.nil? # can happen during AnnData ingest failures
+
+    subsampled = cluster_group.find_subsampled_data_arrays.any?
+    Rails.logger.info "Setting subsampling flags for #{study_file.upload_file_name}:#{study_file.id} (#{cluster_group.name})"
+    cluster_group.update(subsampled:, is_subsampling: false)
   end
 
   # determine if differential expression should be run for study, and submit available jobs (skipping existing results)

--- a/test/models/ann_data_file_info_test.rb
+++ b/test/models/ann_data_file_info_test.rb
@@ -225,7 +225,6 @@ class AnnDataFileInfoTest < ActiveSupport::TestCase
     )
     assert anndata_info.valid? # invokes validations
     exp_frag = anndata_info.data_fragments.first
-    puts exp_frag
     assert_nil exp_frag.with_indifferent_access.dig(:expression_file_info, :units)
   end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update addresses a corner case where some users uploaded classic SCP-formatted metadata/clustering files that were eligible to be subsampled, but upon job completion the `is_subsampling` flag was not correctly reset.  This led to the files being "stuck" and unable to be removed by the end user, requiring direct database intervention.  This was caused by a corner case where the job did not fail, but also did not generate any subsampled data.  Now, the `is_subsampled` flag is always reset upon job completion, unless the underlying clustering object has been deleted (in which case file deletion has already happened).

#### MANUAL TESTING
1. Boot all services, log in, and create a new study
2. Select the "classic" upload UX
3. Upload the following two files:
    * Metadata: [scp_metadata.v2.col_1_to_13.tsv](https://console.cloud.google.com/storage/browser/_details/broad-singlecellportal-staging-testing-data/SCP2685/scp_metadata.v2.col_1_to_13.tsv?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&project=broad-singlecellportal-staging)
    * Clustering: [umap_coordinates.tsv](https://console.cloud.google.com/storage/browser/_details/broad-singlecellportal-staging-testing-data/SCP2685/umap_coordinates.tsv?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&project=broad-singlecellportal-staging)
4. In a separate terminal, open a Rails console session and load the study:
```
study = Study.last
```
5. Wait until you see the success email for the cluster/metadata ingest, and then load the extracted clustering object:
```
cluster = study.cluster_groups.first
```
6. Confirm the cluster is in the process of subsampling:
```
cluster.is_subsampling
=> true
```
7. Wait for the success email for the subsampling run, then reload the cluster and confirm it is no longer subsampling:
```
cluster.reload
cluster.is_subsampling
=> false
```
8. Back in the upload UI, delete both files and confirm you receive a success dialog stating the file was deleted.