### PR TITLE
Check file_type in AnnData UX when saving (SCP-5747)

### DIFF
--- a/app/javascript/components/upload/UploadWizard.jsx
+++ b/app/javascript/components/upload/UploadWizard.jsx
@@ -280,7 +280,7 @@ export function RawUploadWizard({ studyAccession, name }) {
     let fileToSave = file
     let studyFileId = file._id
 
-    if (isAnnDataExperience) {
+    if (isAnnDataExperience && fileToSave?.file_type === 'AnnData') {
       fileToSave = saveAnnDataFileHelper(file, fileToSave)
       studyFileId = fileToSave._id
     }


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a bug where users in the AnnData UX cannot upload "non-visualizable" files ahead of saving the main AnnData file.  This was due to a bug where form components from the AnnData fields were merged into the other upload forms, causing validation errors.  Now, only the AnnData file will leverage these extra form fields.  

It is worth noting that these extra form fields are only present on the initial upload, and removing them entirely and creating the same data structures that are present after the initial save (e.g. `expression_file_info_attributes`, `ann_data_file_info_attributes`, etc.) would be a more maintainable and architecturally consistent approach.  However, that would require updates at the view, controller, and model levels, and in the end would result in the same user experience and level of functionality that is achieved here.  As such, it is preferable (for now) to maintain the technical debt until such time when the proper refactoring is warranted.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Create a new study, or select an empty study and load the AnnData uploader
3. Go down to the `Documentation & other files` section and select any file to upload, such as `test/test_data/table_1.xlsx`.
4. Click "Save" and confirm the file saves without error