### PR TITLE
Create default `X_umap` cluster fragment for AnnData upload unless specified (SCP-5796)

### DIFF
--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -202,7 +202,10 @@ class AnnDataFileInfo
     default_obsm_keys = AnnDataIngestParameters::PARAM_DEFAULTS[:obsm_keys]
     default_obsm_keys.each do |obsm_key_name|
       name = obsm_key_name.delete_prefix('X_')
-      data_fragments << { _id: BSON::ObjectId.new.to_s, data_type: :cluster, name:, obsm_key_name: }
+      fragment = {
+        _id: BSON::ObjectId.new.to_s, data_type: :cluster, name:, obsm_key_name:, spatial_cluster_associations: []
+      }
+      data_fragments << fragment
     end
   end
 

--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -39,7 +39,7 @@ class AnnDataFileInfo
   # }
   # { _id: '6033f531e241391884633748', data_type: :expression, description: 'log(TMP) expression' }
   field :data_fragments, type: Array, default: []
-  before_validation :sanitize_fragments!
+  before_validation :set_default_cluster_fragments!, :sanitize_fragments!
   validate :validate_fragments
   after_validation :update_expression_file_info
 
@@ -193,6 +193,17 @@ class AnnDataFileInfo
       sanitized_fragments << sanitized_fragment
     end
     self.data_fragments = sanitized_fragments
+  end
+
+  # create the default cluster data_fragment entries
+  def set_default_cluster_fragments!
+    return false if fragments_by_type(:cluster).any?
+
+    default_obsm_keys = AnnDataIngestParameters::PARAM_DEFAULTS[:obsm_keys]
+    default_obsm_keys.each do |obsm_key_name|
+      name = obsm_key_name.delete_prefix('X_')
+      data_fragments << { _id: BSON::ObjectId.new.to_s, data_type: :cluster, name:, obsm_key_name: }
+    end
   end
 
   # ensure all fragments have required keys and are unique

--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -32,7 +32,7 @@ class AnnDataIngestParameters
   PARAM_DEFAULTS = {
     ingest_anndata: true,
     anndata_file: nil,
-    obsm_keys: %w[X_umap X_tsne],
+    obsm_keys: %w[X_umap],
     ingest_cluster: false,
     cluster_file: nil,
     name: nil,

--- a/test/models/ann_data_file_info_test.rb
+++ b/test/models/ann_data_file_info_test.rb
@@ -120,6 +120,17 @@ class AnnDataFileInfoTest < ActiveSupport::TestCase
     assert_equal %w[X_umap X_tsne], ann_data_info.obsm_key_names
   end
 
+  test 'should set default cluster fragments' do
+    ann_data_info = AnnDataFileInfo.new
+    assert ann_data_info.valid?
+    default_keys = AnnDataIngestParameters::PARAM_DEFAULTS[:obsm_keys]
+    default_keys.each do |obsm_key_name|
+      name = obsm_key_name.delete_prefix('X_')
+      matcher = { data_type: :cluster, name:, obsm_key_name: }.with_indifferent_access
+      assert ann_data_info.find_fragment(**matcher).present?
+    end
+  end
+
   test 'should validate data fragments' do
     ann_data_info = AnnDataFileInfo.new(
       data_fragments: [
@@ -224,7 +235,7 @@ class AnnDataFileInfoTest < ActiveSupport::TestCase
       ]
     )
     assert anndata_info.valid? # invokes validations
-    exp_frag = anndata_info.data_fragments.first
+    exp_frag = anndata_info.fragments_by_type(:expression).first
     assert_nil exp_frag.with_indifferent_access.dig(:expression_file_info, :units)
   end
 end

--- a/test/models/ann_data_ingest_parameters_test.rb
+++ b/test/models/ann_data_ingest_parameters_test.rb
@@ -56,7 +56,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
       assert extraction.send(attr).blank?
     end
 
-    cmd = '--ingest-anndata --anndata-file gs://bucket_id/test.h5ad --obsm-keys ["X_umap", "X_tsne"] --extract ' \
+    cmd = '--ingest-anndata --anndata-file gs://bucket_id/test.h5ad --obsm-keys ["X_umap"] --extract ' \
           '["cluster", "metadata", "processed_expression", "raw_counts"]'
     assert_equal cmd, extraction.to_options_array.join(' ')
     assert_equal 'n2d-highmem-32', extraction.machine_type


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update addresses a corner case in the AnnData upload UX where the user never clicks into the Clustering tab.  This results in that form never being initialized, and as such the required validations don't run.  This ends up creating an invalid Python command line for ingest where `obsm_keys` is not set.  Now, if the user does not interact with the Clustering tab, the app adds a clustering data fragment for the `X_umap` key by default.  Additionally, the `X_tsne` default has been removed.  If a user does interact with the clustering tab, then this default fragment is not created as they cannot submit the form until completing the required fields.  Overall, this makes uploading an AnnData file simpler as now the only required interactions are specifying a species, library preparation protocol, and then providing a file.

#### MANUAL TESTING
1. Boot all services and sign in
2. Create a new study, or select and empty one and load the AnnData upload UX
3. Select a species/protocol and the go directly to the AnnData tab _**without clicking the Clustering tab**_
4. Use the "Bucket path" option to specify a path to a remote file and then click Save
5. Confirm you see a success confirmation
6. Go back to the Clustering tab and confirm there is an entry with `X_umap` as the `obsm_key_name`