### PR TITLE
Handle missing cluster-based annotation in plot data cache (SCP-5799)

### DIFF
--- a/app/javascript/components/explore/plot-data-cache.js
+++ b/app/javascript/components/explore/plot-data-cache.js
@@ -289,7 +289,8 @@ export function createCache() {
     Fields.cellsAndCoords.merge(cacheEntry, scatter)
     // only merge in annotation values if the annotation matches (or the default was requested, so
     // we can then assume the response matches)
-    if (!requestedAnnotation.name || scatter.annotParams.name === requestedAnnotation.name) {
+    // annotParams may be undefined in spatial UX if a cluster-based annotation does not exist for the plot
+    if (!requestedAnnotation.name || scatter.annotParams?.name === requestedAnnotation.name) {
       Fields.annotation.merge(cacheEntry, scatter)
     }
     if (scatter.genes.length && scatter.genes.join('') === requestedGenes.join('')) {

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -598,16 +598,14 @@ function RawScatterPlot({
   return (
     <div className="plot">
       { ErrorComponent }
+      <PlotTitle
+        titleTexts={titleTexts}
+        isCorrelatedScatter={isCorrelatedScatter}
+        correlation={bulkCorrelation}/>
       { hasMissingAnnot &&
         <div className="alert-warning text-center error-boundary">
           "{cluster}" does not have the requested annotation "{loadedAnnotation}"
         </div>
-      }
-      { !hasMissingAnnot &&
-        <PlotTitle
-          titleTexts={titleTexts}
-          isCorrelatedScatter={isCorrelatedScatter}
-          correlation={bulkCorrelation}/>
       }
       <div
         className="scatter-graph"

--- a/app/models/import_service_config/nemo.rb
+++ b/app/models/import_service_config/nemo.rb
@@ -72,7 +72,7 @@ module ImportServiceConfig
 
     # retrieve common species names from associated collection
     def taxon_names
-      load_study&.[]('taxonomies') || []
+      load_study&.[]('taxa')&.map { |t| t['name']} || []
     end
 
     # map attribute names SCP Study attributes onto NeMO attribute names

--- a/db/seed/synthetic_studies/chicken_raw_counts/study_info.json
+++ b/db/seed/synthetic_studies/chicken_raw_counts/study_info.json
@@ -41,6 +41,11 @@
     },
     {
       "type": "Cluster",
+      "filename": "cluster_odd_labels.txt",
+      "name": "cluster_odd_labels"
+    },
+    {
+      "type": "Cluster",
       "filename": "cluster_square.txt",
       "name": "cluster_square"
     },

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -173,6 +173,7 @@ FactoryBot.define do
         #   phex: [['cellA', 0.6],['cellB', 6.1], ['cellC', 4.5]]
         # }
         expression_input { {} }
+        has_raw_counts { true }
       end
       after(:create) do |file, evaluator|
         file.build_ann_data_file_info
@@ -195,7 +196,7 @@ FactoryBot.define do
           file.build_expression_file_info(library_preparation_protocol: "10x 5' v3")
           file.expression_file_info.save
           file.ann_data_file_info.has_expression = true
-          file.ann_data_file_info.has_raw_counts = true
+          file.ann_data_file_info.has_raw_counts = evaluator.has_raw_counts
           %w[raw processed].each do |matrix_type|
             FactoryBot.create(:data_array,
                               array_type: 'cells',

--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -96,8 +96,8 @@ module ImportServiceConfig
     test 'should load study analog' do
       study = @configuration.load_study
       assert_equal '"Human variation study (10x), GRU"', study['name']
-      assert_equal "10x chromium 3' v3 sequencing", study['technique']
-      assert_equal %w[human], study['taxonomies']
+      assert_equal ["10x chromium 3' v3 sequencing"], study['techniques']
+      assert_equal [{"name"=>"human", "cv_term_id"=>"NCBI:txid9606"}], study['taxa']
     end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -187,13 +187,22 @@ class IngestJobTest < ActiveSupport::TestCase
 
   test 'should identify AnnData parses with extraction in mixpanel' do
     # parsed AnnData
-    ann_data_file = FactoryBot.create(:ann_data_file, name: 'test.h5ad', study: @basic_study)
-    ann_data_file.ann_data_file_info.reference_file = false
-    ann_data_file.ann_data_file_info.data_fragments = [
-      { _id: BSON::ObjectId.new.to_s, data_type: :cluster, obsm_key_name: 'X_umap', name: 'UMAP' }
-    ]
-    ann_data_file.upload_file_size = 1.megabyte
-    ann_data_file.save
+    ann_data_file = FactoryBot.create(:ann_data_file,
+                                      name: 'test.h5ad',
+                                      study: @basic_study,
+                                      upload_file_size: 1.megabyte,
+                                      cell_input: %w[A B C D],
+                                      has_raw_counts: false,
+                                      reference_file: false,
+                                      annotation_input: [
+                                        { name: 'disease', type: 'group', values: %w[cancer cancer normal normal] }
+                                      ],
+                                      coordinate_input: [
+                                        { X_umap: { x: [1, 2, 3, 4], y: [5, 6, 7, 8] } }
+                                      ],
+                                      expression_input: {
+                                        'phex' => [['A', 0.3], ['B', 1.0], ['C', 0.5], ['D', 0.1]]
+                                      })
     params_object = AnnDataIngestParameters.new(
       anndata_file: ann_data_file.gs_url, obsm_keys: ann_data_file.ann_data_file_info.obsm_key_names,
       file_size: ann_data_file.upload_file_size


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug where a missing cluster-based annotation in spatial plots causes all expression-based scatter plots to throw an error.  This was due to the `scatter` object having a value of `undefined` for `annotParams` in the response when trying to populate the cache.  Now, the plot correctly shows the warning that the requested annotation does not exist on that plot.

Example:
 
![Screenshot 2024-09-16 at 11 08 27 AM](https://github.com/user-attachments/assets/b80a9299-2e0d-4e62-b445-589d309bee83)

This update also deals with some test instability issues in `ingest_job_test.rb` and `import_service_config/nemo_test.rb` due to recent updates, order of operations, etc.

#### MANUAL TESTING
1. Boot all services and sign in
2. If you do not have a copy of the `chick_raw_counts` synthetic study in your instance, you can load it from the Rails console with:
```
SyntheticStudyPopulator.populate('chicken_raw_counts')
```
3. If you do have a copy, go to the upload wizard for that study and upload `db/seed/synthetic_studies/chicken_raw_counts/cluster_odd_labels.txt` file as a **normal** cluster file
4. Once ingested, go to the Explore tab for this study and select `cluster_odd_labels`, and then `odd_labels` as the annotation
5. Load the spatial cluster `spatial_letters` to confirm you see the `"spatial_letters" does not have the requested annotation "odd_labels--group--cluster"` warning
6. Search for the gene `RAD51` and confirm you see the same warning in the `spatial_letters` expression plot