### PR TITLE
Ensure email delivery on 'special action' failures (SCP-5807)

### DIFF
--- a/app/mailers/single_cell_mailer.rb
+++ b/app/mailers/single_cell_mailer.rb
@@ -57,13 +57,13 @@ class SingleCellMailer < ApplicationMailer
   def notify_user_parse_complete(email, title, message, study)
     @message = message
     @study = study
-    mail(to: email, subject: '[Single Cell Portal Notifier] ' + title)
+    mail(to: email, subject: "[Single Cell Portal Notifier] #{title}")
   end
 
   def notify_user_parse_fail(email, title, error, study)
     @error = error
     @study = study
-    mail(to: email, subject: '[Single Cell Portal Notifier] ' + title)
+    mail(to: email, subject: "[Single Cell Portal Notifier] #{title}")
   end
 
   def notify_admin_parse_fail(user_email, title, contents)

--- a/app/mailers/single_cell_mailer.rb
+++ b/app/mailers/single_cell_mailer.rb
@@ -38,7 +38,7 @@ class SingleCellMailer < ApplicationMailer
     @study_file = study_file
     @error = error
     @user = @study.user
-    mail(to: emails, subject: '[Single Cell Portal ERROR] FireCloud auto-upload fail in ' + @study.accession) do |format|
+    mail(to: emails, subject: "[Single Cell Portal ERROR] FireCloud auto-upload fail in #{@study.accession}") do |format|
       format.html
     end
   end
@@ -51,7 +51,7 @@ class SingleCellMailer < ApplicationMailer
     dev_email_config = AdminConfiguration.find_by(config_type: 'QA Dev Email')
     dev_email = dev_email_config.present? ? dev_email_config.value : nil
     title = "#{study_file.upload_file_name} did not finish uploading"
-    mail(to: user.email, bcc: dev_email, subject: '[Single Cell Portal Notifier] ' + title)
+    mail(to: user.email, bcc: dev_email, subject: "[Single Cell Portal Notifier] #{title}")
   end
 
   def notify_user_parse_complete(email, title, message, study)
@@ -72,7 +72,7 @@ class SingleCellMailer < ApplicationMailer
       dev_email = dev_email_config.value
       @contents = contents
       @user_email = user_email
-      mail(to: dev_email, subject: '[Single Cell Portal Admin Notification] ' + title)
+      mail(to: dev_email, subject: "[Single Cell Portal Admin Notification] #{title}")
     end
   end
 
@@ -91,7 +91,7 @@ class SingleCellMailer < ApplicationMailer
     @error = error
     @action = ingest_action
     title = 'Ingest Pipeline Launch Failure'
-    mail(to: emails, subject: '[Single Cell Portal Admin Notification] ' + title)
+    mail(to: emails, subject: "[Single Cell Portal Admin Notification] #{title}")
   end
 
   def daily_disk_status

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -234,6 +234,7 @@ class IngestJobTest < ActiveSupport::TestCase
       anndata_file: ann_data_file.gs_url, obsm_keys: ann_data_file.ann_data_file_info.obsm_key_names,
       file_size: ann_data_file.upload_file_size
     )
+    assert_not params_object.extract.include?('raw_counts')
     job = IngestJob.new(
       study: @basic_study, study_file: ann_data_file, user: @user, action: :ingest_anndata, params_object:
     )


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a bug where 'special action' ingest jobs (most notably automated differential expression) do not deliver a parse failure email if the job does not succeed.  All other required steps (data cleanup, state setting, Mixpanel/Sentry reporting) execute correctly, but the final step of delivering the admin email wasn't able to deliver as the email subject was not being set, and the mailer wasn't correctly interpolating the value, resulting in a `TypeError`.  The problem was tracked to [this commit](https://github.com/broadinstitute/single_cell_portal_core/commit/d3be368aa083596aeefab9d98520f8aae5ea2ff2), and has occurred [31 times](https://broad-institute.sentry.io/issues/5723616546/?environment=production&project=1424198) since it was released as a part of [`1.79.0`](https://github.com/broadinstitute/single_cell_portal_core/releases/tag/1.79.0).

Now, the subject is correctly set, and additionally all mailer methods use [proper string interpolation](https://github.com/rubocop/ruby-style-guide?tab=readme-ov-file#string-interpolation) for setting email subjects.

#### MANUAL TESTING
Testing this manually is difficult and time consuming as it requires a DE job that is known to fail.  If you have a file/annotation combination in your local instance that is a known "bad" scenario, you can manually launch that job from the Rails console and then confirm that you see a failure email.

Alternatively, the automated test `IngestJobTest: test_should_ensure_email_delivery_on_special_action_failures` validates that the mailer is called without error.  To run this test directly, initialize your local environment and run the following command, noting similar output:

```
$ rails test test/models/ingest_job_test.rb -n /delivery/
Run options: -n /delivery/ --seed 63322

# Running:

SUITE IngestJobTest starting
...
ingest_job_test.rb:803 test_should_ensure_email_delivery_on_special_action_failures starting
ingest_job_test.rb:803 test_should_ensure_email_delivery_on_special_action_failures completed (3.828 sec)
.IngestJobTest: Cleaning up 2 studies, 1 users
SUITE IngestJobTest completed (8.769 sec)


Finished in 8.773318s, 0.1140 runs/s, 0.0000 assertions/s.

1 runs, 0 assertions, 0 failures, 0 errors, 0 skips
...
```