### PR TITLE
Fix logic for saveAnnDataFileHelper (SCP-5809)

### DIFF
--- a/app/javascript/components/upload/UploadWizard.jsx
+++ b/app/javascript/components/upload/UploadWizard.jsx
@@ -275,12 +275,17 @@ export function RawUploadWizard({ studyAccession, name }) {
     setTimeout(() => deleteFileFromServer(requestCanceller.fileId), 500)
   }
 
+  /** helper for determining when to use saveAnnDataFileHelper (sets ids/values correctly for AnnData UX **/
+  function useAnnDataFileHelper(file) {
+    return isAnnDataExperience && (file?.file_type === 'AnnData' || Object.keys(file).includes("data_type"))
+  }
+
   /** save the given file and perform an upload if a selected file is present */
   async function saveFile(file) {
     let fileToSave = file
     let studyFileId = file._id
 
-    if (isAnnDataExperience && fileToSave?.file_type === 'AnnData') {
+    if (useAnnDataFileHelper(fileToSave)) {
       fileToSave = saveAnnDataFileHelper(file, fileToSave)
       studyFileId = fileToSave._id
     }


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug in the AnnData upload UX where a [recent PR](https://github.com/broadinstitute/single_cell_portal_core/pull/2125) broke the ability to update existing clustering or expression information.  Now, when a user revisits an existing AnnData file, they are able to make updates.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Load any existing AnnData study in the upload wizard
3. Add a description to an existing clustering entry and click save
4. Confirm that you get a success dialog and that the information is persisted