### PR TITLE
Add spinner for remote validation, improved timing (SCP-5797, SCP-5776)

### DIFF
--- a/app/javascript/components/upload/FileUploadControl.jsx
+++ b/app/javascript/components/upload/FileUploadControl.jsx
@@ -104,11 +104,11 @@ export default function FileUploadControl({
     }
 
     // don't continue unless a dot is present (otherwise, no valid file extension)
-    if (trimmedPath.indexOf('.') < 0 ) { return false }
+    if (!trimmedPath.includes('.')) { return false }
 
     const fileType = file.file_type
     const fileExtension = `.${trimmedPath.split('.').slice(-1)[0]}`
-    if (!inputAcceptExts.includes(fileExtension)) {
+    if (fileExtension.length > 1 && !inputAcceptExts.includes(fileExtension)) {
       const invalidExt = {
         errors: [
           [

--- a/app/javascript/components/upload/FileUploadControl.jsx
+++ b/app/javascript/components/upload/FileUploadControl.jsx
@@ -112,8 +112,8 @@ export default function FileUploadControl({
       const invalidExt = {
         errors: [
           [
-            'error', 'file:invalid-ext',
-            `${fileExtension} is not an allowed file extension for ${fileType} files: ${inputAcceptExts.join(', ')}`
+            'error', 'filename:extension',
+            `Allowed extensions are ${allowedFileExts.join(', ')}`
           ]
         ]
       }

--- a/test/js/upload-wizard/file-upload-control.test.js
+++ b/test/js/upload-wizard/file-upload-control.test.js
@@ -382,7 +382,7 @@ describe('file upload control validates the selected file', () => {
     expect(bucketPathInput).toHaveValue('bad.pdf')
     await waitFor(() => {
       expect(screen.getByTestId('validation-error')).toBeInTheDocument()
-      expect(screen.getByText('Allowed extensions are: .tsv')).toBeVisible()
+      expect(screen.getByText('Allowed extensions are .tsv')).toBeVisible()
     })
   })
 })

--- a/test/js/upload-wizard/file-upload-control.test.js
+++ b/test/js/upload-wizard/file-upload-control.test.js
@@ -382,7 +382,7 @@ describe('file upload control validates the selected file', () => {
     expect(bucketPathInput).toHaveValue('bad.pdf')
     await waitFor(() => {
       expect(screen.getByTestId('validation-error')).toBeInTheDocument()
-      expect(screen.getByText('.pdf is not an allowed file extension for Cluster files: .tsv')).toBeVisible()
+      expect(screen.getByText('Allowed extensions are: .tsv')).toBeVisible()
     })
   })
 })

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -219,7 +219,7 @@ class IngestJobTest < ActiveSupport::TestCase
                                       study: @basic_study,
                                       upload_file_size: 1.megabyte,
                                       cell_input: %w[A B C D],
-                                      has_raw_counts: false,
+                                      has_raw_counts: true,
                                       reference_file: false,
                                       annotation_input: [
                                         { name: 'disease', type: 'group', values: %w[cancer cancer normal normal] }
@@ -232,9 +232,9 @@ class IngestJobTest < ActiveSupport::TestCase
                                       })
     params_object = AnnDataIngestParameters.new(
       anndata_file: ann_data_file.gs_url, obsm_keys: ann_data_file.ann_data_file_info.obsm_key_names,
-      file_size: ann_data_file.upload_file_size
+      file_size: ann_data_file.upload_file_size, extract_raw_counts: true
     )
-    assert_not params_object.extract.include?('raw_counts')
+    assert params_object.extract.include?('raw_counts')
     job = IngestJob.new(
       study: @basic_study, study_file: ann_data_file, user: @user, action: :ingest_anndata, params_object:
     )
@@ -269,7 +269,7 @@ class IngestJobTest < ActiveSupport::TestCase
         studyAccession: @basic_study.accession,
         jobStatus: 'success',
         referenceAnnDataFile: false,
-        extractedFileTypes: %w[cluster metadata processed_expression],
+        extractedFileTypes: %w[cluster metadata processed_expression raw_counts],
         machineType: 'n2d-highmem-4',
         bootDiskSizeGb: 300,
         exitStatus: 0


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update improves several aspects of remote file validation when using the "bucket path" feature in the upload wizard:

* **Faster invocation**: validation is now invoked after a 300ms delay, removing the need to click outside the input field.  Additionally, this timeout is cleared on every change event, meaning that only one validation request will be issued.
* **File extension check**: validation is not invoked unless the user has provided a file extension (denoted by the existence of a . in the filename).  Once provided, this will be checked against the list of allowed file extensions like uploads are.
* **Clearing validations**: if a user empties the input field, all existing validations are cleared out, returning the control to the default state

Demo of updated functionality:

https://github.com/user-attachments/assets/fc69a2ea-4d6b-48b2-b585-b9693468ad46

#### MANUAL TESTING
1. Boot as normal and go to the upload wizard for a new/empty study
2. In any form, click the "Use bucket path" button and then "Browse bucket"
3. After authenticating, place both valid and invalid files in the bucket (e.g. for AnnData, use `test/test_data/anndata_test.h5ad` as a valid file and `test/test_data/anndata_test_invalid_disease.h5ad` as an invalid file)
4. Copy the GS URL of a valid file
5. Back in the upload wizard, paste this into the input field and confirm you see the `Validating...` message after a brief delay
6. Confirm there are no errors
7. Copy the GS URL of the invalid file and repeat, confirming that error messages are shown
8. Clear out the input and confirm that the error messages disappear and the input is back in the default state
9. Start typing a filename and confirm no validation executes until a period is typed
