### PR TITLE
Handle corner case of nil file size (SCP-5811)

### DIFF
--- a/app/lib/download_quota_service.rb
+++ b/app/lib/download_quota_service.rb
@@ -19,7 +19,7 @@ class DownloadQuotaService
   def self.download_exceeds_quota?(user, requested_bytes)
     return false if user.daily_download_quota.nil?
 
-    user_quota = user.daily_download_quota + requested_bytes
+    user_quota = user.daily_download_quota + requested_bytes.to_i
     user_quota > download_quota
   end
 
@@ -28,7 +28,7 @@ class DownloadQuotaService
     # skip incrementing quota if exemption is set via nil value
     return true if user.daily_download_quota.nil?
 
-    user_quota = user.daily_download_quota + requested_bytes
+    user_quota = user.daily_download_quota + requested_bytes.to_i
     user.update(daily_download_quota: user_quota)
   end
 

--- a/test/services/download_quota_service_test.rb
+++ b/test/services/download_quota_service_test.rb
@@ -57,4 +57,11 @@ class DownloadQuotaServiceTest < ActiveSupport::TestCase
     )
     assert_equal 1.megabyte, DownloadQuotaService.download_quota
   end
+
+  test 'should handle nil file size' do
+    starting_quota = @user.daily_download_quota
+    DownloadQuotaService.increment_user_quota(@user, nil)
+    @user.reload
+    assert_equal starting_quota, @user.daily_download_quota
+  end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a corner case bug where a file with a size of `nil` causes a study to not be able to load as an error is thrown in the `_download_link` view partial for that file.  The bug was in attempting to determine if the user's download quota would be exceeded.  Now, all file sizes are casted as integers to avoid this problem.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Load any study with files
3. In a Rails console session, load that study and select a file at random:
```
accession = '<your study>'
study = Study.find_by(accession:)
study_file = study.study_files.sample
```
4. Temporarily unset `upload_file_size`, saving the value to restore it later:
```
upload_file_size = study_file.upload_file_size
study_file.update(upload_file_size: nil)
```
5. Back in the UI, reload the page and confirm there is no error
6. Back in the console, reset the file size:
```
study_file.update(upload_file_size:)
```