### PR TITLE
Clear out existing cached filename on validation failure (SCP-5771)

### DIFF
--- a/app/javascript/components/upload/FileUploadControl.jsx
+++ b/app/javascript/components/upload/FileUploadControl.jsx
@@ -77,6 +77,13 @@ export default function FileUploadControl({
         name: newName,
         notes
       })
+    } else if (issues.errors.length > 0 && file.uploadSelection) {
+      // clear out a previous known good file, if present
+      updateFile(file._id, {
+        uploadSelection: null,
+        upload_file_name: '',
+        name: ''
+      })
     }
   }
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This addresses a corner case where a previous valid file is cached after a CSFV failure, leading to an inconsistent state where it appears that you can save an obviously bad file.  This can happen if a user uploads a valid file then uses the `Replace` button and supplies a file that fails validation.  Now, if an uploaded file fails validation, the filename/upload button is cleared out, which also disables the save button.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Go to the upload wizard for any study (non-AnnData is easier in this case)
3. In any main tab (expression, metadata, or clustering) that will accept a file upload, add a known good file
4. Once CSFV passes, use the `Replace` link and add a file that fails validation
5. Confirm the previous file is cleared out, the upload button reverts back to `Choose file` and the `Save` button is disabled