### PR TITLE
Disabling NeMO queries for CI (SCP-5817)

### DIFF
--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -93,12 +93,12 @@ module ImportServiceConfig
       assert_equal 'application/octet-stream', @configuration.get_file_content_type('csv')
     end
 
-    test 'should load study analog' do
-      study = @configuration.load_study
-      assert_equal '"Human variation study (10x), GRU"', study['name']
-      assert_equal ["10x chromium 3' v3 sequencing"], study['techniques']
-      assert_equal [{"name"=>"human", "cv_term_id"=>"NCBI:txid9606"}], study['taxa']
-    end
+    # test 'should load study analog' do
+    #   study = @configuration.load_study
+    #   assert_equal '"Human variation study (10x), GRU"', study['name']
+    #   assert_equal ["10x chromium 3' v3 sequencing"], study['techniques']
+    #   assert_equal [{"name"=>"human", "cv_term_id"=>"NCBI:txid9606"}], study['taxa']
+    # end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
     # test 'should load file analog' do
@@ -108,10 +108,10 @@ module ImportServiceConfig
     #   assert_equal 'counts', file['data_type']
     # end
 
-    test 'should load collection analog' do
-      collection = @configuration.load_collection
-      assert_equal 'AIBS Internal', collection['short_name']
-    end
+    # test 'should load collection analog' do
+    #   collection = @configuration.load_collection
+    #   assert_equal 'AIBS Internal', collection['short_name']
+    # end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
     # test 'should extract association ids' do
@@ -121,14 +121,14 @@ module ImportServiceConfig
     #   assert_equal @attributes[:project_id], @configuration.id_from(study, :projects)
     # end
 
-    test 'should load taxon common names' do
-      assert_equal %w[human], @configuration.taxon_names
-    end
-
-    test 'should find library preparation protocol' do
-      assert_equal "10x 3' v3", @configuration.find_library_prep("10x chromium 3' v3 sequencing")
-      assert_equal 'Drop-seq', @configuration.find_library_prep('drop-seq')
-    end
+    # test 'should load taxon common names' do
+    #   assert_equal %w[human], @configuration.taxon_names
+    # end
+    #
+    # test 'should find library preparation protocol' do
+    #   assert_equal "10x 3' v3", @configuration.find_library_prep("10x chromium 3' v3 sequencing")
+    #   assert_equal 'Drop-seq', @configuration.find_library_prep('drop-seq')
+    # end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
     # test 'should populate study and study_file' do

--- a/test/integration/external/nemo_client_test.rb
+++ b/test/integration/external/nemo_client_test.rb
@@ -64,13 +64,13 @@ class NemoClientTest < ActiveSupport::TestCase
   #   assert entity.present?
   # end
 
-  test 'should get collection' do
-    skip_if_api_down
-    identifier = @identifiers[:collection]
-    collection = @nemo_client.collection(identifier)
-    assert collection.present?
-    assert_equal 'adey_sciATAC_human_cortex', collection['short_name']
-  end
+  # test 'should get collection' do
+  #   skip_if_api_down
+  #   identifier = @identifiers[:collection]
+  #   collection = @nemo_client.collection(identifier)
+  #   assert collection.present?
+  #   assert_equal 'adey_sciATAC_human_cortex', collection['short_name']
+  # end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
   # test 'should get file' do
@@ -95,16 +95,16 @@ class NemoClientTest < ActiveSupport::TestCase
   #   assert_equal 'NIMH', grant['funding_agency']
   # end
 
-  test 'should get project' do
-    skip_if_api_down
-    identifier = @identifiers[:project]
-    project = @nemo_client.project(identifier)
-    assert project.present?
-    assert_equal 'Single-nucleus analysis of preoptic area development from late embryonic to adult stages',
-                 project['title']
-    assert_equal 'biccn', project['program']
-    assert_equal 'dulac_poa_dev_sn_10x_proj', project['short_name']
-  end
+  # test 'should get project' do
+  #   skip_if_api_down
+  #   identifier = @identifiers[:project]
+  #   project = @nemo_client.project(identifier)
+  #   assert project.present?
+  #   assert_equal 'Single-nucleus analysis of preoptic area development from late embryonic to adult stages',
+  #                project['title']
+  #   assert_equal 'biccn', project['program']
+  #   assert_equal 'dulac_poa_dev_sn_10x_proj', project['short_name']
+  # end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
   # test 'should get publication' do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This disables most query-based tests in `test/integration/external/import_service_config/nemo_test.rb`.  Many endpoints on the beta NeMO Identifiers API are returning `500` right now, so there is nothing we can do on our end to fix this.  As per [SCP-5565](https://broadworkbench.atlassian.net/browse/SCP-5565) we will reconnect with the NeMO team to ascertain the status of the API at a later date.

#### MANUAL TESTING
1. Initialize your environment and run `rails test test/integration/external/import_service_config/nemo_test.rb`, confirming you see similar output:
```
Run options: --seed 3356

# Running:

SUITE ImportServiceConfig::NemoTest starting
nemo_test.rb:27 test_should_instantiate_config starting
nemo_test.rb:27 test_should_instantiate_config completed (0.002 sec)
.nemo_test.rb:76 test_should_load_attribute_mappings starting
nemo_test.rb:76 test_should_load_attribute_mappings completed (0.0 sec)
.nemo_test.rb:42 test_should_return_correct_service_name starting
nemo_test.rb:42 test_should_return_correct_service_name completed (0.0 sec)
.nemo_test.rb:46 test_should_load_associated_user/collection starting
nemo_test.rb:46 test_should_load_associated_user/collection completed (0.084 sec)
.nemo_test.rb:90 test_should_get_file_content_type starting
nemo_test.rb:90 test_should_get_file_content_type completed (0.0 sec)
.nemo_test.rb:86 test_should_sanitize_attribute_values starting
nemo_test.rb:86 test_should_sanitize_attribute_values completed (0.009 sec)
.nemo_test.rb:59 test_should_load_defaults starting
nemo_test.rb:59 test_should_load_defaults completed (0.001 sec)
.nemo_test.rb:36 test_should_reference_correct_methods starting
nemo_test.rb:36 test_should_reference_correct_methods completed (0.0 sec)
.ImportServiceConfig::NemoTest: Cleaning up 0 studies, 1 users
SUITE ImportServiceConfig::NemoTest completed (0.76 sec)


Finished in 0.764484s, 10.4646 runs/s, 32.7018 assertions/s.

8 runs, 25 assertions, 0 failures, 0 errors, 0 skips
```

[SCP-5565]: https://broadworkbench.atlassian.net/browse/SCP-5565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ