### PR TITLE
Allow providing external link for AnnData clusters (SCP-5816)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -749,7 +749,8 @@ module Api
           heatmap_file_info_attributes: [:id, :_destroy, :custom_scaling, :color_min, :color_max, :legend_label],
           cluster_form_info_attributes: [
             :_id, :name, :obsm_key_name, :description, :x_axis_label, :y_axis_label, :x_axis_min, :x_axis_max,
-            :y_axis_min, :y_axis_max, :z_axis_min, :z_axis_max, spatial_cluster_associations: []
+            :y_axis_min, :y_axis_max, :z_axis_min, :z_axis_max, :external_link_url, :external_link_title,
+            :external_link_description, spatial_cluster_associations: []
           ],
           metadata_form_info_attributes: [:_id, :use_metadata_convention, :description],
           extra_expression_form_info_attributes: [:_id, :taxon_id, :description, :y_axis_label],

--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -256,11 +256,7 @@ module Api
             customColors: custom_annotation_colors,
             clusterFileId: cluster.study_file_id.to_s,
             isSplitLabelArrays: is_split_label_arrays,
-            externalLink: {
-              url: cluster.study_file[:external_link_url],
-              title: cluster.study_file[:external_link_title],
-              description: cluster.study_file[:external_link_description]
-            }
+            externalLink: get_cluster_external_link(cluster, cluster.study_file)
           }
         end
 
@@ -275,6 +271,19 @@ module Api
             subsample = param.to_i
           end
           subsample
+        end
+
+        def self.get_cluster_external_link(cluster, study_file)
+          if study_file.is_viz_anndata?
+            data = study_file.ann_data_file_info.find_fragment(data_type: :cluster, name: cluster.name)
+          else
+            data = study_file.attributes
+          end
+          {
+            url: data[:external_link_url],
+            title: data[:external_link_title],
+            description: data[:external_link_description]
+          }
         end
       end
     end

--- a/test/models/ann_data_file_info_test.rb
+++ b/test/models/ann_data_file_info_test.rb
@@ -59,7 +59,10 @@ class AnnDataFileInfoTest < ActiveSupport::TestCase
           x_axis_min: '-10',
           x_axis_max: '10',
           y_axis_min: '-10',
-          y_axis_max: '10'
+          y_axis_max: '10',
+          external_link_url: 'https://example.com',
+          external_link_title: 'Example Link',
+          external_link_description: 'This is an external link'
       }
     }
     merged_data = AnnDataFileInfo.new.merge_form_data(form_params)
@@ -71,6 +74,9 @@ class AnnDataFileInfoTest < ActiveSupport::TestCase
     assert_equal 'x axis', cluster_fragment[:x_axis_label]
     assert_equal '10', cluster_fragment[:x_axis_max]
     assert_equal 'cluster description', cluster_fragment[:description]
+    assert_equal 'https://example.com', cluster_fragment[:external_link_url]
+    assert_equal 'Example Link', cluster_fragment[:external_link_title]
+    assert_equal 'This is an external link', cluster_fragment[:external_link_description]
     expr_fragment = merged_data.dig(root_form_key, :data_fragments).detect { |f| f[:data_type] == :expression }
     assert_equal 'expression description', expr_fragment[:description]
     assert_equal 'log(TPM) expression', expr_fragment[:y_axis_label]

--- a/test/models/delete_queue_job_test.rb
+++ b/test/models/delete_queue_job_test.rb
@@ -188,15 +188,15 @@ class DeleteQueueJobTest < ActiveSupport::TestCase
                                      { name: 'disease', type: 'group', values: %w[cancer cancer normal normal] }
                                    ],
                                    coordinate_input: [
-                                     { x_tsne: { x: [1, 2, 3, 4], y: [5, 6, 7, 8] } }
+                                     { tsne: { x: [1, 2, 3, 4], y: [5, 6, 7, 8] } }
                                    ])
-    study.update(default_options: { cluster: 'x_tsne', annotation: 'disease--group--study' })
+    study.update(default_options: { cluster: 'tsne', annotation: 'disease--group--study' })
     study.reload
     assert_equal 1, study.cluster_groups.size
     assert_equal 1, study.cell_metadata.size
     assert_equal %w[A B C D], study.all_cells_array
     assert_equal study_file, study.metadata_file
-    assert_equal 'x_tsne', study.default_cluster.name
+    assert_equal 'tsne', study.default_cluster.name
     mock = Minitest::Mock.new
     mock.expect(:get_workspace_files, [], [String, Hash])
     ApplicationController.stub :firecloud_client, mock do

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -225,7 +225,7 @@ class IngestJobTest < ActiveSupport::TestCase
                                         { name: 'disease', type: 'group', values: %w[cancer cancer normal normal] }
                                       ],
                                       coordinate_input: [
-                                        { X_umap: { x: [1, 2, 3, 4], y: [5, 6, 7, 8] } }
+                                        { umap: { x: [1, 2, 3, 4], y: [5, 6, 7, 8] } }
                                       ],
                                       expression_input: {
                                         'phex' => [['A', 0.3], ['B', 1.0], ['C', 0.5], ['D', 0.1]]
@@ -774,7 +774,7 @@ class IngestJobTest < ActiveSupport::TestCase
                                      { name: 'disease', type: 'group', values: %w[cancer cancer normal normal] }
                                    ],
                                    coordinate_input: [
-                                     { x_tsne: { x: [1, 2, 3, 4], y: [5, 6, 7, 8] } }
+                                     { tsne: { x: [1, 2, 3, 4], y: [5, 6, 7, 8] } }
                                    ],
                                    expression_input: {
                                      'phex' => [['A', 0.3], ['B', 1.0], ['C', 0.5], ['D', 0.1]]
@@ -815,7 +815,7 @@ class IngestJobTest < ActiveSupport::TestCase
                                      { name: 'disease', type: 'group', values: %w[cancer cancer normal normal] }
                                    ],
                                    coordinate_input: [
-                                     { X_umap: { x: [1, 2, 3, 4], y: [5, 6, 7, 8] } }
+                                     { umap: { x: [1, 2, 3, 4], y: [5, 6, 7, 8] } }
                                    ])
     annotation_file = 'gs://test_bucket/anndata/h5ad_frag.metadata.tsv'
     cluster_file = 'gs://test_bucket/anndata/h5ad_frag.cluster.X_umap.tsv'

--- a/test/services/cluster_viz_service_test.rb
+++ b/test/services/cluster_viz_service_test.rb
@@ -245,7 +245,7 @@ class ClusterVizServiceTest < ActiveSupport::TestCase
   end
 
   test 'should retrieve clustering information for AnnData files' do
-    cluster_name = 'x_tsne'
+    cluster_name = 'tsne'
     study = FactoryBot.create(:detached_study,
                               name_prefix: 'AnnData Cluster Test',
                               user: @user,


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes an issue with the AnnData upload UX where the external link feature for clustering data does not persist when saving the form.  This was due to how the data is validated and saved inside the `AnnDataFileInfo` object and the parameters not being allowed or handled correctly.  Now, these parameters are allowed and the data is saved correctly.  Additionally, this cleans up some tests where names of clustering in AnnData files were accidentally prepending `X_`.

This does bring up a frequent issue when adding attributes to models - the need to add them to the "strong parameters" block in associated controllers (e.g. `params.require(model_name).permit`).  I created SCP-5818 to track this.  It's not critical work, but would hopefully alleviate this issue.

#### MANUAL TESTING
You will need to turn off caching for this to work properly, or start DelayedJob.

1. Boot as normal and sign in
2. Load the upload wizard for any AnnData-based study
3. Go to the clustering tab and add an external link for one of the clusters
4. Open the explore tab for the above study/cluster and confirm the link is present above the scatter plot legend