### PR TITLE
Fixing issues with reporting ingestSummary events (SCP-5802)

### DIFF
--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -228,7 +228,7 @@ class DifferentialExpressionResult
     # in production, DeleteQueueJob will handle all necessary cleanup
     return true if study.nil? || study.detached || study.queued_for_deletion
 
-    identifier = "#{study.accession}:#{annotation_identifier}"
+    identifier = "#{study.accession}:#{annotation_name}--group--#{annotation_scope}"
     bucket_files.each do |filepath|
       remote = ApplicationController.firecloud_client.get_workspace_file(study.bucket_id, filepath)
       if remote.present?

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -32,6 +32,9 @@ class IngestJob
   # steps that need to be accounted for
   SPECIAL_ACTIONS = %i[differential_expression render_expression_arrays image_pipeline].freeze
 
+  # main processes that extract or ingest data for core visualizations (scatter, violin, dot, etc)
+  CORE_ACTIONS = %w[ingest_anndata ingest_expression ingest_cell_metadata ingest_cluster]
+
   # jobs that need parameters objects in order to launch correctly
   PARAMS_OBJ_REQUIRED = %i[
     differential_expression render_expression_arrays image_pipeline ingest_anndata
@@ -996,7 +999,7 @@ class IngestJob
       pipeline_args = op.metadata.dig('pipeline', 'actions').first['commands']
       op.done? &&
         pipeline_args.detect { |c| c == study_file.id.to_s } &&
-        (!pipeline_args.include?('--differential-expression') && !pipeline_args.include?('--subsample'))
+        (pipeline_args & CORE_ACTIONS).any?
     end
     # get total runtime from initial extract to final parse
     initial_extract = previous_jobs.last

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -333,7 +333,7 @@ class IngestJobTest < ActiveSupport::TestCase
     end
   end
 
-  test 'should get ingest summary for AnnData parsing' do
+  test 'should get ingestSummary for AnnData parsing' do
     ann_data_file = FactoryBot.create(:ann_data_file, name: 'data.h5ad', study: @basic_study)
     ann_data_file.ann_data_file_info.reference_file = false
     ann_data_file.ann_data_file_info.data_fragments = [
@@ -369,7 +369,7 @@ class IngestJobTest < ActiveSupport::TestCase
     }.with_indifferent_access
 
     pipeline_mock = MiniTest::Mock.new
-    4.times {pipeline_mock.expect :metadata, metadata_mock }
+    5.times {pipeline_mock.expect :metadata, metadata_mock }
     2.times {pipeline_mock.expect :error, nil  }
     pipeline_mock.expect :done?, true
 
@@ -482,7 +482,7 @@ class IngestJobTest < ActiveSupport::TestCase
     pipeline = { actions: }
     failed_metadata = { pipeline:, events:, startTime: (now - 1.hour).to_s, endTime: now.to_s }.with_indifferent_access
     failed_pipeline = Minitest::Mock.new
-    6.times { failed_pipeline.expect(:metadata, failed_metadata) }
+    7.times { failed_pipeline.expect(:metadata, failed_metadata) }
     3.times { failed_pipeline.expect(:error, true) }
     failed_pipeline.expect :done?, true
     operations_mock = Minitest::Mock.new


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update addresses some issues surrounding reporting the `ingestSummary` event for AnnData files.  These events are a rollup of the 3 main ingest processes for AnnData files - clustering, metadata, and processed expression.  Recent updates to how related jobs were identified proved to be prone to race conditions that meant jobs checking simultaneously would identify each other as "still processing" and both exit, leading to no summary being sent.  Now, the query specifically looks for jobs of the 3 main types that are not "done" according to their status in the LifeSciences API.  Furthermore, this check can happen after _any_ job that is submitted for this file, be it main ingest, differential expression, subsampling, etc.  Once it is determined that there are no more jobs running that are extracting data, a summary is sent, and then that file is marked as having submitted an `ingestSummary`.  No further summaries will be sent for that file.  

Additional clusterings or raw counts data can theoretically still be extracted, but neither will result in submitting an `ingestSummary` - only the standard `ingest` event will be reported.  Since the point of the `ingestSummary` is to gauge the amount of time it takes a user to go from initial upload to an "initialized" study and whether or not this was successful, this is acceptable.

This also addresses an unrelated bug with deleting AnnData files where DE output files could not be clean up due to missing annotation data (was being used only for logging).

#### MANUAL TESTING
This is complicated to test, especially since in normal development the race condition can never happen as it requires multiple concurrent job workers processing jobs for the same AnnData file.  However, you can start DelayedJob locally with multiple workers using the following command (once your environment is initialized):
```
bin/delayed_job start development --pool=default:6, --pool=cache:2
```
Note that once you are done testing, you will need to manually stop the workers as they are launched headlessly.  This can be done with `bin/delayed_job stop development`.

Once your workers are running, follow these steps:
1. Boot as normal, sign in, and create a new study
2. Select the AnnData UX and fill out the forms as normal (supplying multiple clusterings and raw counts helps, if possible)
3. Once the file is uploaded, look in the logs for the extraction job and copy both the filename and MongoDB ID
4. In a separate terminal, go to the project root and tail your `development.log` file to look for messages regarding the AnnData summary (your filename/id will be different but the wording will be exact).  It will take several minutes to appear, but while you may see multiple "Checking" messages you should only see one message that says "Sending AnnData summary" and no further messages after that:
```
$ LOG_MESSAGE="AnnData summary for compliant_pbmc3K.h5ad (66f5b7b38bdcc6e804f001cb)"
$ tail -f log/development.log | grep -e $LOG_MESSAGE
...
Checking AnnData summary for compliant_pbmc3K.h5ad (66f5b7b38bdcc6e804f001cb) after ingest_expression
Sending AnnData summary for compliant_pbmc3K.h5ad (66f5b7b38bdcc6e804f001cb) after ingest_expression
```
5. Go to the [Dev Mixpanel events list](https://mixpanel.com/project/2085496/view/19055/app/events) and query for your event (note it may take a minute or so for it to appear):
    * event: `ingestSummary`
    * studyAccession: `<your accession>`
    * fileName: `<your file>`
 
![Screenshot 2024-09-26 at 4 49 46 PM](https://github.com/user-attachments/assets/e62a781f-8e2a-4753-a707-9c2d95a7a77a)

6. Your event should have the correct number for `numFilesExtracted`: 1 each for expression/metadata, 1 if you extracted raw counts, and 1 per clustering.