### PR TITLE
Dynamically hide cell filtering UX when not applicable (SCP-5819)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -454,7 +454,7 @@ export default function ExploreDisplayPanelManager({
                     </div>
                   </>
                 }
-                { showCellFiltering && !clusterCanFilter &&
+                { showCellFiltering && !clusterCanFilter && allowCellFiltering &&
                   <>
                     <div className="row">
                       <div className={`col-xs-12 cell-filtering-button ${shownTab === 'scatter' && !studyHasDe ? 'create-annotation-cell-filtering' : ''}`}>

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -200,7 +200,7 @@ export default function ExploreDisplayPanelManager({
   showDifferentialExpressionPanel, setIsCellSelecting, currentPointsSelected, isCellSelecting, deGenes,
   setDeGenes, setShowDeGroupPicker,
   cellFaceting, cellFilteringSelection, cellFilterCounts, clusterCanFilter, filterErrorText,
-  updateFilteredCells, panelToShow, toggleViewOptions, canFilter
+  updateFilteredCells, panelToShow, toggleViewOptions, shouldShowFiltering
 }) {
   const [, setRenderForcer] = useState({})
   const [dataCache] = useState(createCache())
@@ -213,7 +213,9 @@ export default function ExploreDisplayPanelManager({
     hasSpatialGroups = exploreInfo.spatialGroups.length > 0
   }
 
-  const showCellFiltering = getFeatureFlagsWithDefaults()?.show_cell_facet_filtering && !hasSpatialGroups && canFilter
+  const showCellFiltering = getFeatureFlagsWithDefaults()?.show_cell_facet_filtering &&
+    !hasSpatialGroups &&
+    shouldShowFiltering
 
 
   // Differential expression settings

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -200,7 +200,7 @@ export default function ExploreDisplayPanelManager({
   showDifferentialExpressionPanel, setIsCellSelecting, currentPointsSelected, isCellSelecting, deGenes,
   setDeGenes, setShowDeGroupPicker,
   cellFaceting, cellFilteringSelection, cellFilterCounts, clusterCanFilter, filterErrorText,
-  updateFilteredCells, panelToShow, toggleViewOptions, shouldShowFiltering
+  updateFilteredCells, panelToShow, toggleViewOptions, allowCellFiltering
 }) {
   const [, setRenderForcer] = useState({})
   const [dataCache] = useState(createCache())
@@ -213,9 +213,7 @@ export default function ExploreDisplayPanelManager({
     hasSpatialGroups = exploreInfo.spatialGroups.length > 0
   }
 
-  const showCellFiltering = getFeatureFlagsWithDefaults()?.show_cell_facet_filtering &&
-    !hasSpatialGroups &&
-    shouldShowFiltering
+  const showCellFiltering = getFeatureFlagsWithDefaults()?.show_cell_facet_filtering && !hasSpatialGroups
 
 
   // Differential expression settings
@@ -361,7 +359,7 @@ export default function ExploreDisplayPanelManager({
                 </button>
               </>
           }
-          {showCellFiltering && panelToShow === 'cell-filtering' &&
+          {showCellFiltering && panelToShow === 'cell-filtering' && allowCellFiltering &&
             <CellFilteringPanelHeader
               togglePanel={togglePanel}
               setShowDifferentialExpressionPanel={setShowDifferentialExpressionPanel}
@@ -372,8 +370,7 @@ export default function ExploreDisplayPanelManager({
               setDeGroupB={setDeGroupB}
               isAuthorDe={isAuthorDe}
               updateFilteredCells={updateFilteredCells}
-              deGenes={deGenes}
-            />
+              deGenes={deGenes}/>
           }
           {panelToShow === 'differential-expression' &&
               <DifferentialExpressionPanelHeader
@@ -449,7 +446,7 @@ export default function ExploreDisplayPanelManager({
                   </div>
                 </>
                 }
-                { showCellFiltering && clusterCanFilter &&
+                { showCellFiltering && clusterCanFilter && allowCellFiltering &&
                   <>
                     <div className="row">
                       <div className={`col-xs-12 cell-filtering-button ${shownTab === 'scatter' && !studyHasDe ? 'create-annotation-cell-filtering' : ''}`}>
@@ -474,6 +471,21 @@ export default function ExploreDisplayPanelManager({
                           data-testid="cell-filtering-button"
                           data-toggle="tooltip"
                           data-original-title={`Cell filtering cannot be displayed for this selection: ${filterErrorText}.`}
+                        >Filtering unavailable</button>
+                      </div>
+                    </div>
+                  </>
+                }
+                { showCellFiltering && !allowCellFiltering &&
+                  <>
+                    <div className="row">
+                      <div className={`col-xs-12 cell-filtering-button ${shownTab === 'scatter' && !studyHasDe ? 'create-annotation-cell-filtering' : ''}`}>
+                        <button
+                          disabled="disabled"
+                          className={`btn btn-primary`}
+                          data-testid="cell-filtering-button-disabled"
+                          data-toggle="tooltip"
+                          data-original-title={`Cell filtering cannot be shown in this context (only scatter or distribution tabs)`}
                         >Filtering unavailable</button>
                       </div>
                     </div>

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -200,7 +200,7 @@ export default function ExploreDisplayPanelManager({
   showDifferentialExpressionPanel, setIsCellSelecting, currentPointsSelected, isCellSelecting, deGenes,
   setDeGenes, setShowDeGroupPicker,
   cellFaceting, cellFilteringSelection, cellFilterCounts, clusterCanFilter, filterErrorText,
-  updateFilteredCells, panelToShow, toggleViewOptions
+  updateFilteredCells, panelToShow, toggleViewOptions, canFilter
 }) {
   const [, setRenderForcer] = useState({})
   const [dataCache] = useState(createCache())
@@ -213,7 +213,7 @@ export default function ExploreDisplayPanelManager({
     hasSpatialGroups = exploreInfo.spatialGroups.length > 0
   }
 
-  const showCellFiltering = getFeatureFlagsWithDefaults()?.show_cell_facet_filtering && !hasSpatialGroups
+  const showCellFiltering = getFeatureFlagsWithDefaults()?.show_cell_facet_filtering && !hasSpatialGroups && canFilter
 
 
   // Differential expression settings

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -244,14 +244,7 @@ export default function ExploreDisplayPanelManager({
 
   const shownAnnotation = getShownAnnotation(exploreParamsWithDefaults.annotation, annotationList)
 
-  const isSubsampled = exploreParamsWithDefaults.subsample !== 'all'
   let cellFilteringTooltipAttrs = {}
-  if (isSubsampled) {
-    cellFilteringTooltipAttrs = {
-      'data-toggle': 'tooltip',
-      'data-original-title': 'Clicking will remove subsampling; plots might be noticeably slower.'
-    }
-  }
 
   /** Toggle cell filtering panel */
   function toggleCellFilterPanel() {

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -254,15 +254,6 @@ export default function ExploreDisplayTabs({
 
   const [cellFilteringSelection, setCellFilteringSelection] = useState(null)
 
-  // hide cell filtering in non-applicable settings, but remember state
-  // will re-enable if user returns to a UX scenario where cell filtering can be re-applied
-  const shouldShowFiltering = (exploreParams?.genes?.length <= 1 || exploreParams?.consensus !== null)
-  if (panelToShow === 'cell-filtering' && !shouldShowFiltering) {
-    togglePanel('options')
-  } else if (shouldShowFiltering && filteredCells && panelToShow === 'options') {
-    togglePanel('cell-filtering')
-  }
-
   // flow/error handling for cell filtering
   const [clusterCanFilter, setClusterCanFilter] = useState(true)
   const [filterErrorText, setFilterErrorText] = useState(null)
@@ -311,6 +302,18 @@ export default function ExploreDisplayTabs({
 
   const isCorrelatedScatter = enabledTabs.includes('correlatedScatter')
 
+  // decide whether or not to allow the cell filtering UX
+  // must be in the scatter or distribution tab with less than 2 genes, or using consensus metric
+  const allowCellFiltering = (exploreParams?.genes?.length <= 1 || exploreParams?.consensus !== null) &&
+    ['scatter', 'distribution'].includes(shownTab)
+
+  // hide cell filtering panel in non-applicable settings, but remember state
+  // will reload if user returns to a scenario where cell filtering can be re-applied
+  if (panelToShow === 'cell-filtering' && !allowCellFiltering) {
+    togglePanel('options')
+  } else if (allowCellFiltering && filteredCells && panelToShow === 'options') {
+    togglePanel('cell-filtering')
+  }
 
   // If clustering or annotation changes, then update facets shown for cell filtering
   useEffect(() => {
@@ -705,7 +708,7 @@ export default function ExploreDisplayTabs({
             updateFilteredCells={updateFilteredCells}
             panelToShow={panelToShow}
             toggleViewOptions={toggleViewOptions}
-            shouldShowFiltering={shouldShowFiltering}
+            allowCellFiltering={allowCellFiltering}
           />
         </div>
       </div>

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -235,13 +235,19 @@ export default function ExploreDisplayTabs({
   const [showDifferentialExpressionPanel, setShowDifferentialExpressionPanel] = useState(deGenes !== null)
   const [showUpstreamDifferentialExpressionPanel, setShowUpstreamDifferentialExpressionPanel] = useState(deGenes !== null)
 
+  const canFilter = (exploreParams?.genes?.length <= 1 || exploreParams?.consensus !== null)
   let initialPanel = 'options'
   if (showDifferentialExpressionPanel || showUpstreamDifferentialExpressionPanel) {
     initialPanel = 'differential-expression'
-  } else if (exploreParams.facets !== '') {
+  } else if (exploreParams.facets !== '' && canFilter) {
     initialPanel = 'cell-filtering'
   }
   const [panelToShow, setPanelToShow] = useState(initialPanel)
+
+  // gotcha to hide cell filtering UX if user searches for more than one gene
+  if (panelToShow == 'cell-filtering' && !canFilter) {
+    setPanelToShow('options')
+  }
 
   // Hash of trace label names to the number of points in that trace
   const [countsByLabelForDe, setCountsByLabelForDe] = useState(null)
@@ -696,6 +702,7 @@ export default function ExploreDisplayTabs({
             updateFilteredCells={updateFilteredCells}
             panelToShow={panelToShow}
             toggleViewOptions={toggleViewOptions}
+            canFilter={canFilter}
           />
         </div>
       </div>

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -235,19 +235,13 @@ export default function ExploreDisplayTabs({
   const [showDifferentialExpressionPanel, setShowDifferentialExpressionPanel] = useState(deGenes !== null)
   const [showUpstreamDifferentialExpressionPanel, setShowUpstreamDifferentialExpressionPanel] = useState(deGenes !== null)
 
-  const canFilter = (exploreParams?.genes?.length <= 1 || exploreParams?.consensus !== null)
   let initialPanel = 'options'
   if (showDifferentialExpressionPanel || showUpstreamDifferentialExpressionPanel) {
     initialPanel = 'differential-expression'
-  } else if (exploreParams.facets !== '' && canFilter) {
+  } else if (exploreParams.facets !== '') {
     initialPanel = 'cell-filtering'
   }
   const [panelToShow, setPanelToShow] = useState(initialPanel)
-
-  // gotcha to hide cell filtering UX if user searches for more than one gene
-  if (panelToShow == 'cell-filtering' && !canFilter) {
-    setPanelToShow('options')
-  }
 
   // Hash of trace label names to the number of points in that trace
   const [countsByLabelForDe, setCountsByLabelForDe] = useState(null)
@@ -259,6 +253,15 @@ export default function ExploreDisplayTabs({
   const [cellFilterCounts, setCellFilterCounts] = useState(null)
 
   const [cellFilteringSelection, setCellFilteringSelection] = useState(null)
+
+  // hide cell filtering in non-applicable settings, but remember state
+  // will re-enable if user returns to a UX scenario where cell filtering can be re-applied
+  const shouldShowFiltering = (exploreParams?.genes?.length <= 1 || exploreParams?.consensus !== null)
+  if (panelToShow === 'cell-filtering' && !shouldShowFiltering) {
+    togglePanel('options')
+  } else if (shouldShowFiltering && filteredCells && panelToShow === 'options') {
+    togglePanel('cell-filtering')
+  }
 
   // flow/error handling for cell filtering
   const [clusterCanFilter, setClusterCanFilter] = useState(true)
@@ -702,7 +705,7 @@ export default function ExploreDisplayTabs({
             updateFilteredCells={updateFilteredCells}
             panelToShow={panelToShow}
             toggleViewOptions={toggleViewOptions}
-            canFilter={canFilter}
+            shouldShowFiltering={shouldShowFiltering}
           />
         </div>
       </div>

--- a/app/javascript/components/explore/PlotTabs.jsx
+++ b/app/javascript/components/explore/PlotTabs.jsx
@@ -55,7 +55,10 @@ export default function PlotTabs({
           const tooltip = disabledTooltips[tabKey]
           const numGenes = tooltip.numToSearch
           const geneText = `gene${tooltip.isMulti ? 's' : ''}`
-          const text = `To show this plot, search ${numGenes} ${geneText} using the box at left`
+          let text = `To show this plot, search ${numGenes} ${geneText} using the box at left`
+          if (['scatter', 'distribution'].includes(tabKey)) {
+            text += " or use the 'Collapse genes by' menu for multiple genes"
+          }
           return (
             <li key={tabKey}
               role="presentation"


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update changes the logic of when the cell filtering UX is enabled.  Previously, any cluster that met requirements (i.e. was indexed, annotations available) would enable the cell filtering button.  However, dot plots, heatmaps, and annotated & consensus scatter plots all do not support cell filtering.  The panel will load, but none of the controls affect the plot.  This is confusing to users, and can lead to spurious error reports.

Now, only the scatter & distribution tabs will allow the user to filter plots.  These tabs are only enabled in non-expression contexts, when a single gene has been queried, or when multiple genes have been collapsed by a consensus metric.  Any existing filtered state will be saved if the user enters a view that doesn't support cell filtering, and the panel will be hidden.  The `Filter plotted cells` button will now display `Filtering unavailable` with a message that it is only supported in the above contexts.  Once the user returns to a view that supports cell filtering, the filtering panel reopens with previous state already loaded.

Short demo of how this looks in normal usage:

https://github.com/user-attachments/assets/fb99cd0b-5de1-4001-bf7c-289136a0fc34

Also, this removes a tooltip from the cell filtering button about subsampling.  Since cell filtering is now available on subsampled data, this message no longer applies.

#### MANUAL TESTING
1. Boot as normal and load any study that has clustering, expression data, and allows cell filtering
2. Open the cell filtering panel and select any filter(s)
3. Query for one gene and confirm the filtering panel stays open and the filtered state persists
4. Query for another gene and confirm that the options panel is now shown, no cells are filtered and the filtering button is disabled with the tooltip `Cell filtering cannot be shown in this context (only scatter or distribution tabs)`
5. Use the "Collapse genes by" menu and confirm the cell filtering panel reopens with the previous filtered state preserved
6. Remove one of the genes and confirm the cell filtering panel remains open