### PR TITLE
Don't create default cluster fragment for reference AnnData files (SCP-5825)

### DIFF
--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -193,7 +193,7 @@ class AnnDataFileInfo
 
   # create the default cluster data_fragment entries
   def set_default_cluster_fragments!
-    return false if fragments_by_type(:cluster).any?
+    return false if fragments_by_type(:cluster).any? || reference_file
 
     default_obsm_keys = AnnDataIngestParameters::PARAM_DEFAULTS[:obsm_keys]
     default_obsm_keys.each do |obsm_key_name|

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -347,7 +347,7 @@ class IngestJob
     if done? && !failed?
       Rails.logger.info "IngestJob poller: #{pipeline_name} is done!"
       Rails.logger.info "IngestJob poller: #{pipeline_name} status: #{current_status}"
-      unless special_action? || action == :ingest_anndata
+      unless special_action? || (action == :ingest_anndata && study_file.is_viz_anndata?)
         study_file.update(parse_status: 'parsed')
         study_file.bundled_files.each { |sf| sf.update(parse_status: 'parsed') }
       end

--- a/test/models/ann_data_file_info_test.rb
+++ b/test/models/ann_data_file_info_test.rb
@@ -127,7 +127,7 @@ class AnnDataFileInfoTest < ActiveSupport::TestCase
   end
 
   test 'should set default cluster fragments' do
-    ann_data_info = AnnDataFileInfo.new
+    ann_data_info = AnnDataFileInfo.new(reference_file: false)
     assert ann_data_info.valid?
     default_keys = AnnDataIngestParameters::PARAM_DEFAULTS[:obsm_keys]
     default_keys.each do |obsm_key_name|
@@ -135,6 +135,11 @@ class AnnDataFileInfoTest < ActiveSupport::TestCase
       matcher = { data_type: :cluster, name:, obsm_key_name: }.with_indifferent_access
       assert ann_data_info.find_fragment(**matcher).present?
     end
+    # ensure non-parseable AnnData files don't create fragment
+    reference_anndata = AnnDataFileInfo.new
+    assert reference_anndata.valid?
+    assert_empty reference_anndata.data_fragments
+    assert_empty reference_anndata.obsm_key_names
   end
 
   test 'should validate data fragments' do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a regression introduced in #2127 where reference AnnData files (i.e. non-parsed files, added in Classic upload UX) have a default clustering `X_umap` fragment created.  This ends up accidentally switching the user in the AnnData upload experience, even if they have existing normal files.  Additionally, this fixes a logic bug where reference AnnData files never had their `parse_status` flag updated after uploading, meaning they could never be deleted normally by a user.

#### MANUAL TESTING
Note: there is an existing bug where reference AnnData files are still being validated.  For testing, you will need to use a valid file.
1. Boot all services, sign in, and go to a new or empty study
2. Select the "Classic" upload UX and go to the AnnData tab
3. Upload a file (or use bucket path) and save, confirming the file saves
4. In a separate Rails console session, load the file and confirm that it did not create the `X_umap` cluster fragment:
```
file = StudyFile.last
file.is_reference_anndata?
=> true

file.ann_data_file_info.data_fragments
=> []

file.ann_data_file_info.obsm_key_names
=> []
```
5. Wait for the ingest process to complete and confirm that the `Delete` button is now enabled in the upload wizard