### PR TITLE
Update filtering tooltip to indicate data is unfiltered (SCP-5819)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -478,7 +478,7 @@ export default function ExploreDisplayPanelManager({
                           className={`btn btn-primary`}
                           data-testid="cell-filtering-button-disabled"
                           data-toggle="tooltip"
-                          data-original-title={`Cell filtering cannot be shown in this context (only scatter or distribution tabs)`}
+                          data-original-title={`Cell filtering cannot be applied in this context (only scatter or distribution tabs) - visible plots are unfiltered`}
                         >Filtering unavailable</button>
                       </div>
                     </div>


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This changes the tooltip when cell filtering has been unapplied due to UX state (e.g., multi-gene view) to indicate that the data has in fact reverted to the unfiltered state.

#### MANUAL TESTING
1. Follow instructions from #2148, but in step for confirm the tooltip now displays `Cell filtering cannot be applied in this context (only scatter or distribution tabs) - visible plots are unfiltered`