### PR TITLE
Automatic retries of OOM failures for ingest processes (SCP-5827)

### DIFF
--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -6,7 +6,7 @@ class AnnDataIngestParameters
   include ComputeScaling
 
   # RAM scaling coefficient for auto-selecting machine_type
-  GB_PER_CORE = 1.75
+  RAM_SCALING = 1.75
 
   # default values for parameters, also used as control list for attributes hash
   # attributes marked as true are passed to the command line as a standalone flag with no value

--- a/app/models/concerns/compute_scaling.rb
+++ b/app/models/concerns/compute_scaling.rb
@@ -4,11 +4,11 @@ module ComputeScaling
 
   # GCE machine types and file size ranges
   # produces a hash with entries like { 'n2-highmem-4' => 0..16.gigabytes }
-  # change GB_PER_CORE in parent class to adjust scaling (1-8, higher number means more aggressive scaling)
+  # change GB_PER_CORE in parent class to adjust scaling (1-8, lower number means more aggressive scaling)
   def scaled_machine_types
     gb_per_core = defined?(self.class::GB_PER_CORE) && self.class::GB_PER_CORE || 4
     num_cores = [4, 8, 16, 32, 48, 64]
-    ram_per_core = num_cores.map { |core| (core * gb_per_core).gigabytes }.freeze
+    ram_per_core = num_cores.map { |core| (core * gb_per_core).gigabytes }
     num_cores.map.with_index do |cores, index|
       floor = index == 0 ? 0 : ram_per_core[index - 1]
       limit = index == num_cores.count - 1 ? ram_per_core[index] * 2 : ram_per_core[index]
@@ -36,7 +36,7 @@ module ComputeScaling
   # find the next largest machine to use for an ingest process
   def next_machine_type
     machine_names = scaled_machine_types.keys
-    # return if there are no larger machines available
+    # nil return used as escape clause for stopping retries after largest machine fails
     return nil if machine_type == machine_names.last
 
     current_machine_idx = machine_names.index(machine_type)

--- a/app/models/concerns/compute_scaling.rb
+++ b/app/models/concerns/compute_scaling.rb
@@ -32,4 +32,14 @@ module ComputeScaling
     scaled_machine = scaled_machine_types.detect { |_, mem_range| mem_range === file_size }&.first
     scaled_machine || default_machine_type
   end
+
+  # find the next largest machine to use for an ingest process
+  def next_machine_type
+    machine_names = scaled_machine_types.keys
+    # return if there are no larger machines available
+    return nil if machine_type == machine_names.last
+
+    current_machine_idx = machine_names.index(machine_type)
+    machine_names[current_machine_idx + 1]
+  end
 end

--- a/app/models/concerns/compute_scaling.rb
+++ b/app/models/concerns/compute_scaling.rb
@@ -4,9 +4,9 @@ module ComputeScaling
 
   # GCE machine types and file size ranges
   # produces a hash with entries like { 'n2-highmem-4' => 0..16.gigabytes }
-  # change GB_PER_CORE in parent class to adjust scaling (1-8, lower number means more aggressive scaling)
+  # change RAM_SCALING in parent class to adjust scaling (1-8, lower number means faster scaling relative to file size)
   def scaled_machine_types
-    gb_per_core = defined?(self.class::GB_PER_CORE) && self.class::GB_PER_CORE || 4
+    gb_per_core = defined?(self.class::RAM_SCALING) && self.class::RAM_SCALING || 4
     num_cores = [4, 8, 16, 32, 48, 64]
     ram_per_core = num_cores.map { |core| (core * gb_per_core).gigabytes }
     num_cores.map.with_index do |cores, index|

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -155,7 +155,7 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
     end
   end
 
-  # prepare a StudyFile for permanent deletion by unsetting protected attributes
+  # prepare a StudyFile for permanent deletion by unsetting attributes with uniqueness constraints
   # this allows these values to be immediately reused, like when retrying a failed upload/ingest
   def self.prepare_file_for_deletion(study_file_id)
     new_name = "DELETE-#{SecureRandom.uuid}"

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -119,15 +119,8 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
       # delete any "orphaned" DataArray that might have persisted due to some kind of earlier error
       delete_orphaned_arrays(study.id)
 
-      # overwrite attributes to allow their immediate reuse
-      # this must be done with a fresh StudyFile reference, otherwise upload_file_name may not overwrite
-      new_name = "DELETE-#{SecureRandom.uuid}"
-      file_reference = StudyFile.find(object.id)
-      file_reference.update!(queued_for_deletion: true,
-                             upload_file_name: new_name,
-                             remote_location: new_name,
-                             name: new_name,
-                             file_type: 'DELETE')
+      # enqueue StudyFile for actual deletion
+      self.class.prepare_file_for_deletion(object.id)
 
       # reset initialized if needed
       if study.cluster_groups.empty? || study.genes.empty? || study.cell_metadata.empty?
@@ -160,7 +153,20 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
       study_file = StudyFile.find(study_file_id)
       delete_parsed_anndata_entries(study_file_id, study_file.study._id, object)
     end
+  end
 
+  # prepare a StudyFile for permanent deletion by unsetting protected attributes
+  # this allows these values to be immediately reused, like when retrying a failed upload/ingest
+  def self.prepare_file_for_deletion(study_file_id)
+    new_name = "DELETE-#{SecureRandom.uuid}"
+    file_reference = StudyFile.find(study_file_id)
+    return false unless file_reference
+
+    file_reference.update!(queued_for_deletion: true,
+                           upload_file_name: new_name,
+                           remote_location: new_name,
+                           name: new_name,
+                           file_type: 'DELETE')
   end
 
   private

--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -8,7 +8,7 @@ class DifferentialExpressionParameters
   PARAMETER_NAME = '--differential-expression'.freeze
 
   # RAM scaling coefficient for auto-selecting machine_type
-  GB_PER_CORE = 3.5
+  RAM_SCALING = 3.5
 
   # annotation_name: name of annotation to use for DE
   # annotation_scope: scope of annotation (study, cluster)

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -97,8 +97,9 @@ class IngestJob
       else
         if can_launch_ingest?
           Rails.logger.info "Remote found for #{file_identifier}, launching Ingest job"
-          submission = ApplicationController.life_sciences_api_client.run_pipeline(study_file: study_file, user: user,
-                                                                                   action: action, params_object: params_object)
+          submission = ApplicationController.life_sciences_api_client.run_pipeline(
+            study_file:, user:, action:, params_object:
+          )
           Rails.logger.info "Ingest run initiated: #{submission.name}, queueing Ingest poller"
           IngestJob.new(pipeline_name: submission.name, study: study, study_file: study_file,
                         user: user, action: action, reparse: reparse,
@@ -405,7 +406,7 @@ class IngestJob
         cloned_file = study_file.clone
         # free up filename and other values so cloned_file can save properly
         DeleteQueueJob.prepare_file_for_deletion(study_file.id)
-        cloned_file.save!
+        cloned_file.update!(parse_status: 'parsing')
         Rails.logger.info "Retrying #{action} after #{exit_code} failure with machine_type: #{new_machine}"
         retry_job = IngestJob.new(study:, study_file: cloned_file, user:, params_object:, action:, persist_on_fail:)
         retry_job.push_remote_and_launch_ingest

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -410,6 +410,8 @@ class IngestJob
         Rails.logger.info "Retrying #{action} after #{exit_code} failure with machine_type: #{new_machine}"
         retry_job = IngestJob.new(study:, study_file: cloned_file, user:, params_object:, action:, persist_on_fail:)
         retry_job.push_remote_and_launch_ingest
+        # notify admins that the parse failed for visibility purposes
+        SingleCellMailer.notify_admin_parse_fail(user.email, subject, admin_email_content).deliver_now
       else
         admin_email_content = generate_error_email_body(email_type: :dev)
         SingleCellMailer.notify_admin_parse_fail(user.email, subject, admin_email_content).deliver_now

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -407,7 +407,8 @@ class IngestJob
         # free up filename and other values so cloned_file can save properly
         DeleteQueueJob.prepare_file_for_deletion(study_file.id)
         cloned_file.update!(parse_status: 'parsing')
-        Rails.logger.info "Retrying #{action} after #{exit_code} failure with machine_type: #{new_machine}"
+        file_identifier = "#{cloned_file.upload_file_name}:#{cloned_file.id} (#{study.accession})"
+        Rails.logger.info "Retrying #{action} after #{exit_code} failure for #{file_identifier} with machine_type: #{new_machine}"
         retry_job = IngestJob.new(study:, study_file: cloned_file, user:, params_object:, action:, persist_on_fail:)
         retry_job.push_remote_and_launch_ingest
         # notify admins that the parse failed for visibility purposes

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -400,6 +400,7 @@ class IngestJob
       subject = "Error: #{study_file.file_type} file: '#{study_file.upload_file_name}' parse has failed"
       retry_job = should_retry?
       handle_ingest_failure(subject, retry_job:) unless special_action?
+      admin_email_content = generate_error_email_body(email_type: :dev)
       if retry_job && params_object&.next_machine_type
         new_machine = params_object.next_machine_type
         params_object.machine_type = new_machine
@@ -414,7 +415,6 @@ class IngestJob
         # notify admins that the parse failed for visibility purposes
         SingleCellMailer.notify_admin_parse_fail(user.email, subject, admin_email_content).deliver_now
       else
-        admin_email_content = generate_error_email_body(email_type: :dev)
         SingleCellMailer.notify_admin_parse_fail(user.email, subject, admin_email_content).deliver_now
       end
     else


### PR DESCRIPTION
#### BACKGROUND
With the addition of AnnData parsing & automated differential expression calculation for qualifying studies, we have seen a rise of ingest processes failing with error codes of `137` or `139`, both of which indicate an out of memory exception.  Usually, these jobs can be re-rerun using larger GCE instances and will eventually successfully ingest.  However, this process is entirely manual and requires direct admin intervention which can be quite cumbersome as it requires reconstituting files/parameters from various sources.

#### CHANGES
Now, any ingest process that fails to ingest with either of the above error codes and uses a parameters class (i.e. `AnnDataIngestParameters`, `DifferentialExpressionParameters`) will automatically retry the job using the next available machine type.  For instance, if a file fails with `n2d-highmem-8`, it will automatically retry with `n2d-highmem-16`.  This process will continue all the way up to `n2d-highmem-64`, after which if the file fails to ingest, all retries cease and end user is finally notified.  Normal admin messaging & cleanup procedures still apply for all retries, ensuring visibility into the process.  Additionally, we could also set up Mixpanel alerts for any job failures with the corresponding error codes to further enhance visibility.

The reason for the requirement on the parameters class is that normal ingest jobs of "classic" SCP files do not employ dynamic scaling of machines, and would require more significant refactoring to enable.  Furthermore, since we starting tracking `exitStatus` for ingest jobs, there have been no instances of non-AnnData files failing due to OOM exceptions.

#### MANUAL TESTING
To properly test, this does require the use of a large AnnData file that is known to fail on the default `machine_type` used for its ingest.  Such a file can be found here if you do not have access to one locally: https://console.cloud.google.com/storage/browser/_details/broad-singlecellportal-staging-testing-data/SCP2807/HRCA_snRNA_AC.h5ad;tab=live_object?project=broad-singlecellportal-staging

1. Boot all services and create a new study, selecting the AnnData upload UX
2. Copy the above file to the study's bucket and save the file using the "bucket path" option
3. In `development.log`, look for the following message (the ID/accession will be different):
```
Retrying ingest_anndata after 137 failure for HRCA_snRNA_AC.h5ad:6706c4a794ec8f2272dc977f (SCP161) with machine_type: n2d-highmem-16
```
4. Note a new job is launched immediately afterwards with the correct `machine_type`:
```
Request object sent to Google Life Sciences API, excluding 'environment' parameters:
---
:actions:
  :commands:
  - python
  - ingest_pipeline.py
  - "--study-id"
  - 66d8bcf394ec8f692a4ebea8
  - "--study-file-id"
  - 6706c4a794ec8f2272dc977f
  - "--user-metrics-uuid"
  - c6a08597-c735-4c93-b069-4b4a74b708ee
  - ingest_anndata
  - "--ingest-anndata"
  - "--anndata-file"
  - gs://fc-b04eabc0-55c0-4047-9a02-5d0f98a8f528/HRCA_snRNA_AC.h5ad
  - "--obsm-keys"
  - '["X_umap"]'
  - "--extract"
  - '["cluster", "metadata", "processed_expression", "raw_counts"]'
  :image_uri: gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.35.0
  :labels: {}
  :timeout: {}
:resources:
  :regions:
  - us-central1
  :virtual_machine:
    :boot_disk_size_gb: 300
    :labels:
      :study_accession: scp161
      :user_id: 63e27b72f39faa00560c1e25
      :filename: hrca_snrna_ac_h5ad
      :action: ingest_pipeline
      :docker_image: scp-ingest-pipeline
      :docker_tag: '1_35_0'
      :environment: development
      :file_type: anndata
      :machine_type: n2d-highmem-16
      :boot_disk_size_gb: '300'
    :machine_type: n2d-highmem-16 <==== now on 16 instead of 8
...
```

Note: you do not need to let the file complete the ingest process as this will take quite a while - it is still running 90 min into the retry for my manual test.