### PR TITLE
Prevent raw counts requirement on deleting files (SCP-5849)

### DIFF
--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -110,7 +110,10 @@ class ExpressionFileInfo
   # will check for exemption from any users associated with given study
   def enforce_raw_counts_associations
     raw_counts_required = FeatureFlag.find_by(name: 'raw_counts_required_backend')
-    return true if raw_counts_required.nil? || raw_counts_required.default_value == false || study_file.is_anndata?
+    return true if raw_counts_required.nil? ||
+      raw_counts_required.default_value == false ||
+      study_file.is_anndata? ||
+      study_file.is_deleting?
 
     # first ensure raw matrix is present
     if raw_counts_associations.any?

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -405,7 +405,9 @@ class IngestJob
         new_machine = params_object.next_machine_type
         params_object.machine_type = new_machine
         cloned_file = study_file.clone
-        # free up filename and other values so cloned_file can save properly
+        # free up filename and other values so cloned_file can save properly, including deleting nested documents
+        # this prevents Frozen BSON::Document error
+        study_file = DeleteQueueJob.delete_nested_associations(study_file)
         DeleteQueueJob.prepare_file_for_deletion(study_file.id)
         cloned_file.update!(parse_status: 'parsing')
         file_identifier = "#{cloned_file.upload_file_name}:#{cloned_file.id} (#{study.accession})"

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -407,7 +407,6 @@ class IngestJob
         cloned_file = study_file.clone
         # free up filename and other values so cloned_file can save properly, including deleting nested documents
         # this prevents Frozen BSON::Document error
-        study_file = DeleteQueueJob.delete_nested_associations(study_file)
         DeleteQueueJob.prepare_file_for_deletion(study_file.id)
         cloned_file.update!(parse_status: 'parsing')
         file_identifier = "#{cloned_file.upload_file_name}:#{cloned_file.id} (#{study.accession})"

--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1061,6 +1061,11 @@ class StudyFile
     is_anndata? && !is_reference_anndata?
   end
 
+  # shorthand for when a file is in the deletion queue (for skipping some validations)
+  def is_deleting?
+    queued_for_deletion || file_type == 'DELETE'
+  end
+
   # helper to reduce duplicates when reporting anndata ingest summaries to Mixpanel
   def has_anndata_summary?
     is_viz_anndata? && !!options[:anndata_summary]

--- a/test/models/delete_queue_job_test.rb
+++ b/test/models/delete_queue_job_test.rb
@@ -249,6 +249,7 @@ class DeleteQueueJobTest < ActiveSupport::TestCase
 
     cloned_matrix = matrix.clone
     DeleteQueueJob.prepare_file_for_deletion(matrix.id)
+    assert matrix.is_deleting?
     assert cloned_matrix.valid?
     cloned_matrix.save!
     assert cloned_matrix.persisted?

--- a/test/models/delete_queue_job_test.rb
+++ b/test/models/delete_queue_job_test.rb
@@ -249,6 +249,7 @@ class DeleteQueueJobTest < ActiveSupport::TestCase
 
     cloned_matrix = matrix.clone
     DeleteQueueJob.prepare_file_for_deletion(matrix.id)
+    matrix.reload
     assert matrix.is_deleting?
     assert cloned_matrix.valid?
     cloned_matrix.save!

--- a/test/models/study_file_test.rb
+++ b/test/models/study_file_test.rb
@@ -146,6 +146,25 @@ class StudyFileTest < ActiveSupport::TestCase
     assert matrix.valid?
   end
 
+  test 'should not enforce raw counts associations' do
+    raw_counts_required = FeatureFlag.find_or_create_by(name: 'raw_counts_required_backend')
+    raw_counts_required.update(default_value: true)
+    matrix = FactoryBot.create(:ann_data_file,
+                               name: 'matrix.h5ad',
+                               study: @study,
+                               cell_input: %w[A B C D],
+                               annotation_input: [
+                                 { name: 'disease', type: 'group', values: %w[cancer cancer normal normal] }
+                               ],
+                               coordinate_input: [
+                                 { tsne: { x: [1, 2, 3, 4], y: [5, 6, 7, 8] } }
+                               ],
+                               expression_input: {
+                                 'phex' => [['A', 0.3], ['B', 1.0], ['C', 0.5], ['D', 0.1]]
+                               })
+    assert matrix.valid? # will fail here if raw counts are being enforced
+  end
+
   test 'should enforce metadata convention' do
     convention_required = FeatureFlag.find_or_create_by(name: 'convention_required')
     convention_required.update(default_value: true)

--- a/test/models/study_file_test.rb
+++ b/test/models/study_file_test.rb
@@ -147,11 +147,15 @@ class StudyFileTest < ActiveSupport::TestCase
   end
 
   test 'should not enforce raw counts associations' do
+    study = FactoryBot.create(:detached_study,
+                              name_prefix: 'Raw Counts Test',
+                              user: @user,
+                              test_array: @@studies_to_clean)
     raw_counts_required = FeatureFlag.find_or_create_by(name: 'raw_counts_required_backend')
     raw_counts_required.update(default_value: true)
     matrix = FactoryBot.create(:ann_data_file,
                                name: 'matrix.h5ad',
-                               study: @study,
+                               study:,
                                cell_input: %w[A B C D],
                                annotation_input: [
                                  { name: 'disease', type: 'group', values: %w[cancer cancer normal normal] }


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update prevents two errors from occurring when attempting to relaunch an AnnData extraction that failed due to an OOM exception.

- *Raw counts required*: When the first file is cloned and then queued for deletion, since its file type is no longer `AnnData` but it still has an `ExpressionFileInfo` document, this validation is now enforced (if enabled).  This causes an error preventing the new file from being ingested as the entire job fails without successfully launching the retry.
- `FrozenError: can't modify frozen BSON::Document`: while this doesn't have a user-facing component, this error is nonetheless thrown when trying to delete the original file because the `AnnDataFileInfo#data_fragments` entries are BSON documents.  Now, these documents are removed prior to preparing the file for deletion.

With these two errors addressed, now failed AnnData extractions will correctly retry in the event of an OOM exception.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Go to the Feature Flags page and set `raw_counts_required_backend` to `True` for your email account (or if the flag is enabled, remove any overrides for your account/study)
3. Follow the steps from #2154 and ensure that the retry launches successfully even with `raw_counts_required_backend` enabled