### PR TITLE
Removing unused name-as-id method (SCP-5828)

### DIFF
--- a/app/models/study_file.rb
+++ b/app/models/study_file.rb
@@ -1242,11 +1242,6 @@ class StudyFile
     "container-#{self.id}"
   end
 
-  # DOM ID for use in Selenium for accessing difference elements
-  def name_as_id
-    self.upload_file_name.gsub(/\./, '_')
-  end
-
   def generate_expression_matrix_cells
     begin
       study = self.study

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -228,7 +228,7 @@
                   <%= study_file.species_name %> <%= study_file.genome_assembly.present? ? " (#{study_file.genome_assembly_name})" : nil %>
                 <% end %>
               </td>
-              <td class="study-file-parsed" id="<%= study_file.name_as_id %>-parse-status" data-parsed="<%= study_file.parsed? %>"><%= study_file.parseable? ? get_parse_label(study_file.parse_status) : get_na_label %></td>
+              <td class="study-file-parsed" id="<%= study_file.id %>-parse-status" data-parsed="<%= study_file.parsed? %>"><%= study_file.parseable? ? get_parse_label(study_file.parse_status) : get_na_label %></td>
               <td><%= render partial: '/layouts/download_link', locals: {study: @study, study_file: study_file} %></td>
             </tr>
           <% end %>


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug with an obsolete method that was previously used in Selenium UI tests that can break the study details page if a file doesn't have a value for `upload_file_name`.  Since this method is no longer needed, it as been removed.

#### MANUAL TESTING
1. In a Rails console session, pick a file at random and unset the value for `upload_file_name`, saving the value for later:
```
file = StudyFile.all.sample
filename = file.upload_file_name
file.update(upload_file_name: nil)
accession = file.study.accession
```
2. On the portal homepage, enter the accession as a search term to load the study, then click into Settings tab and then click `Study details` at the bottom
3. Confirm there is no error in loading the page
4. Back in the console, reset the value for `upload_file_name`:
```
file.update(upload_file_name: filename)
```