### PR TITLE
Restore IGV filtering (SCP-5851)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -198,6 +198,23 @@ function getCellFacetingData(cluster, annotation, setterFunctions, context, prev
   }
 }
 
+/** Determine whether to enable cell filtering tab for ATAC data */
+function allowIgvFiltering(shownTab, exploreInfo) {
+  const flags = getFeatureFlagsWithDefaults()
+
+  // Consider refining upload UI or processing to more specifically
+  // determine if BED file is for _multiome_.  Users could theoretically
+  // upload non-multiome BED, though that's unlikely and showing this
+  // functionality in that case is low impact.
+  const hasBedGenomeFiles = exploreInfo && exploreInfo?.bedBundleList?.length > 0
+
+  const allowIgvFiltering =
+    shownTab === 'genome' &&
+    (flags?.show_igv_multiome && flags.show_cell_facet_filtering) &&
+    hasBedGenomeFiles
+  return allowIgvFiltering
+}
+
 /**
  * Renders the gene search box and the tab selection
  * Responsible for determining which tabs are available for a given view of the study
@@ -303,9 +320,14 @@ export default function ExploreDisplayTabs({
   const isCorrelatedScatter = enabledTabs.includes('correlatedScatter')
 
   // decide whether or not to allow the cell filtering UX
-  // must be in the scatter or distribution tab with less than 2 genes, or using consensus metric
-  const allowCellFiltering = (exploreParams?.genes?.length <= 1 || exploreParams?.consensus !== null) &&
-    ['scatter', 'distribution'].includes(shownTab)
+  // must be in the scatter or distribution tab with less than 2 genes, or using consensus metric,
+  // or in genome tab with IGV multiome enabled
+  const allowCellFiltering =
+    (exploreParams?.genes?.length <= 1 || exploreParams?.consensus !== null) &&
+    (
+      allowIgvFiltering(shownTab, exploreInfo) ||
+      ['scatter', 'distribution'].includes(shownTab)
+    )
 
   // hide cell filtering panel in non-applicable settings, but remember state
   // will reload if user returns to a scenario where cell filtering can be re-applied

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -199,7 +199,7 @@ function getCellFacetingData(cluster, annotation, setterFunctions, context, prev
 }
 
 /** Determine whether to enable cell filtering tab for ATAC data */
-function allowIgvFiltering(shownTab, exploreInfo) {
+function shouldAllowIgvFiltering(shownTab, exploreInfo) {
   const flags = getFeatureFlagsWithDefaults()
 
   // Consider refining upload UI or processing to more specifically
@@ -319,13 +319,15 @@ export default function ExploreDisplayTabs({
 
   const isCorrelatedScatter = enabledTabs.includes('correlatedScatter')
 
+  const allowIgvFiltering = shouldAllowIgvFiltering(shownTab, exploreInfo)
+
   // decide whether or not to allow the cell filtering UX
   // must be in the scatter or distribution tab with less than 2 genes, or using consensus metric,
   // or in genome tab with IGV multiome enabled
   const allowCellFiltering =
     (exploreParams?.genes?.length <= 1 || exploreParams?.consensus !== null) &&
     (
-      allowIgvFiltering(shownTab, exploreInfo) ||
+      allowIgvFiltering ||
       ['scatter', 'distribution'].includes(shownTab)
     )
 

--- a/test/js/explore/explore-display-tabs.test.js
+++ b/test/js/explore/explore-display-tabs.test.js
@@ -2,15 +2,11 @@
 
 // mock various modules from genome tab as these aren't being used, and throw compilation errors from jest
 jest.mock('components/explore/GenomeView', () => {
-  return {
-    igv: jest.fn(() => mockPromise)
-  }
+  return jest.fn(() => <div>Mocked GenomeView</div>)
 })
 
 jest.mock('components/visualization/RelatedGenesIdeogram', () => {
-  return {
-    Ideogram: jest.fn(() => mockPromise)
-  }
+  return jest.fn(() => <div>Mocked RelatedGenesIdeogram</div>)
 })
 
 jest.mock('components/visualization/InferCNVIdeogram', () => {
@@ -457,6 +453,47 @@ describe('explore tabs are activated based on study info and parameters', () => 
       />
     ))
     expect(screen.getByTestId('cell-filtering-button-disabled')).toHaveTextContent('Filtering unavailable')
+  })
+
+  it('shows cell filtering for IGV multiome', async () => {
+    jest
+      .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
+      .mockReturnValue({
+        show_cell_facet_filtering: true,
+        show_igv_multiome: true
+      })
+
+    const bedBundleList = [
+      { 'name': 'pbmc_3k_atac_fragments.possorted.bed.gz', 'file_type': 'BED' },
+      { 'name': 'pbmc_3k_atac_fragments.possorted.bed.gz.tbi', 'file_type': 'Tab Index' }
+    ]
+
+    const exploreInfoIgv = Object.assign({ bedBundleList }, exploreInfoDe)
+
+
+    const newExplore = {
+      'cluster': 'All Cells UMAP',
+      'annotation': {
+        'name': 'biosample_id',
+        'type': 'group',
+        'scope': 'study'
+      },
+      'consensus': null,
+      'genes': ['A1BG'],
+      'facets': '',
+      'tab': 'genome'
+    }
+
+    render((
+      <ExploreDisplayTabs
+        studyAccession={'SCP123'}
+        exploreParams={newExplore}
+        exploreParamsWithDefaults={newExplore}
+        exploreInfo={exploreInfoIgv}
+      />
+    ))
+
+    expect(screen.getByTestId('cell-filtering-button')).toHaveTextContent('Filter plotted cells')
   })
 
   it('shows cell filtering when using consensus metric', async () => {


### PR DESCRIPTION
This fixes the "Filter plotted cells" button being unexpectedly disabled when a study has eligible ATAC multiome data.

### Demo
Here's the bug, and the fix!

https://github.com/user-attachments/assets/9d404c27-fc75-4d08-83a8-ccc8f4d1fa4e

### Test
A new automated test protects against this regression.  To manually test, if you'd like:
1.  Go to a study that has an ATAC fragment BED file, e.g. the 3k cell PBMC 10x multiome example dataset
* Staging: https://singlecell-staging.broadinstitute.org/single_cell/study/SCP395
* Production: https://singlecell.broadinstitute.org/single_cell/study/SCP2699
2.  Search gene SPIB
3.  Go to "Genome" tab
4.  Click "Filter plotted cells"
5.  Click root checkbox in "Atac cluster" facet, to deselect all filters
6.  Click filter for "5"
7.  Confirm ATAC fragment track updates

This satisfies SCP-5851.