### PR TITLE
Update to Ingest 1.37.0: Better gene search for CELLxGENE AnnData

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.36.1'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.37.0'
 
     # Docker image for image pipeline jobs
     config.image_pipeline_docker_image = 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_c2b090043'


### PR DESCRIPTION
This upgrades Ingest Pipeline to version 1.37.0, enabling [search by gene name for CXG AnnData](https://github.com/broadinstitute/scp-ingest-pipeline/pull/370).