### PR TITLE
Autocomplete on gene symbol & id (SCP-5853)

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1322,7 +1322,8 @@ class Study
 
   # get all unique gene names for a study; leverage index on Gene model to improve performance
   def unique_genes
-    Gene.where(study_id: self.id, :study_file_id.in => self.expression_matrix_files.map(&:id)).pluck(:name).uniq
+    Gene.where(study_id: self.id, :study_file_id.in => self.expression_matrix_files.map(&:id))
+        .pluck(:name, :gene_id).flatten.compact.uniq
   end
 
   # List unique scientific names of species for all expression matrices in study

--- a/test/api/visualization/expression_controller_test.rb
+++ b/test/api/visualization/expression_controller_test.rb
@@ -37,6 +37,7 @@ class ExpressionControllerTest < ActionDispatch::IntegrationTest
                                               study: @basic_study)
     @pten_gene = FactoryBot.create(:gene_with_expression,
                                    name: 'PTEN',
+                                   gene_id: 'ENSG00000171862',
                                    study_file: @basic_study_exp_file,
                                    expression_input: [['A', 0],['B', 3],['C', 1.5]])
 
@@ -94,6 +95,18 @@ class ExpressionControllerTest < ActionDispatch::IntegrationTest
       genes: 'PTEN'
     }), user: @user)
     assert_equal 400, response.status # 400 since study is not visualizable
+  end
+
+  test 'should query by gene ID' do
+    gene_id = @basic_study.genes.first.gene_id
+    sign_in_and_update @user
+    execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'heatmap', {
+      cluster: 'clusterA.txt',
+      genes: gene_id
+    }), user: @user)
+    assert_equal 200, response.status
+    # will still use gene symbol in response body
+    assert_equal "#1.2\n1\t3\nName\tDescription\tA\tB\tC\nPTEN\t\t0.0\t3.0\t1.5", response.body
   end
 
   test "should prevent searches over #{StudySearchService::MAX_GENE_SEARCH} genes" do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update allows the autocomplete feature in the study gene search to also accept gene IDs, when provided by the study owner.  This does not appear to noticeably impact autocomplete performance - on average there are ~30K genes to a study, so going from 30K to 60K doesn't appear to slow down autocomplete.

#### MANUAL TESTING
The 10x ATAC demo study has both gene names and gene IDs, so this makes a good testing candidate.  If you do not have that in your local instance, you'll need to ingest expression data either in MTX or AnnData form that has both.
1. Boot as normal and load a study that supports both gene names and IDs
2. Run as search for `ENSG` and see that results are shown
3. Run a normal search on a gene symbol and see that it also is shown