### PR TITLE
Extending cache filtering of malicious requests (SCP-5967)

### DIFF
--- a/test/api/visualization/annotations_controller_test.rb
+++ b/test/api/visualization/annotations_controller_test.rb
@@ -212,10 +212,16 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should reject bogus requests' do
     sign_in_and_update @user
-    execute_http_request(:get, api_v1_study_annotations_facets_path(
-      @basic_study, cluster: 'xssdetected', annotations: 'not-found--group--study'
-    ))
-    assert_response :bad_request
+    %w[xssdetected UPDATEXML CODE_POINTS_TO_STRING .git].each do |bogus|
+      execute_http_request(:get, api_v1_study_annotations_facets_path(
+        @basic_study, cluster: bogus, annotations: 'not-found--group--study'
+      ))
+      assert_response :bad_request
+      execute_http_request(:get, api_v1_study_annotations_facets_path(
+        @basic_study, cluster: 'clusterA.txt', annotations: "#{bogus}--group--study"
+      ))
+      assert_response :bad_request
+    end
   end
 
   test 'should not reject legit requests' do

--- a/test/api/visualization/clusters_controller_test.rb
+++ b/test/api/visualization/clusters_controller_test.rb
@@ -195,10 +195,16 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
 
   test 'should reject bogus requests' do
     sign_in_and_update @user
-    execute_http_request(:get, api_v1_study_cluster_path(
-      @basic_study, 'xssdetected', {annotation_name: 'species', annotation_scope: 'study', annotation_type: 'group'}
-    ))
-    assert_response :bad_request
+    %w[xssdetected UPDATEXML CODE_POINTS_TO_STRING .git].each do |bogus|
+      execute_http_request(:get, api_v1_study_cluster_path(
+        @basic_study, bogus, {annotation_name: 'species', annotation_scope: 'study', annotation_type: 'group'}
+      ))
+      assert_response :bad_request
+      execute_http_request(:get, api_v1_study_cluster_path(
+        @basic_study, 'clusterA.txt', {annotation_name: bogus, annotation_scope: 'study', annotation_type: 'group'}
+      ))
+      assert_response :bad_request
+    end
   end
 
   test 'should get external links' do

--- a/test/api/visualization/expression_controller_test.rb
+++ b/test/api/visualization/expression_controller_test.rb
@@ -120,10 +120,17 @@ class ExpressionControllerTest < ActionDispatch::IntegrationTest
 
   test 'should reject bogus requests' do
     sign_in_and_update @user
-    execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'violin', {
-      cluster: 'xssdetected',
-      genes: 'PTEN'
-    }), user: @user)
-    assert_response :bad_request
+    %w[xssdetected UPDATEXML CODE_POINTS_TO_STRING .git].each do |bogus|
+      execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'violin', {
+        cluster: bogus,
+        genes: 'PTEN'
+      }), user: @user)
+      assert_response :bad_request
+      execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'violin', {
+        cluster: 'clusterA.txt',
+        genes: bogus
+      }), user: @user)
+      assert_response :bad_request
+    end
   end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This extends work started in #2025 to filter out more obvious malicious requests from API caching.  Currently, the default behavior in loading annotations is to grab the "first found" annotation if a request specifies a non-existent value.  This provides a backstop that prevents a visualization request from returning `404` when there is data that could be rendered.  This unfortunately means that during a security scan, a large volume of malicious requests in a short time period can result in the app overloading as it attempts to load default responses for a huge number of studies.  This update now automatically blocks many of those requests and responds `400` to prevent this from happening.  This is done at the routing level before any queries are run, so there is no load on the app/database.

It is worth noting that this does not address the underlying issue - there will be updates to these scans resulting in more exploits that will then need to be blocked in a similar fashion.  A better fix would be to _not_ load default clusters/annotations in these scenarios and let the app respond `404`.  However, there is a fair amount of functionality that depends on this default response, and therefore that approach is not a simple refactor.

#### MANUAL TESTING
1. Boot as normal and load the Swagger doc for [cluster visualization](https://localhost:3000/single_cell/api/v1#/Visualization/study_cluster_path) (note: it helps to load a smaller study with less than 5K points)
2. Enter a valid study/cluster/annotation combo and confirm you get a `200 OK` response
3. Change any value in the params (like `cluster_name` or `annot_name`) to one of these values: `.git`, `NULL OR 1`, `CODE_POINTS_TO_STRING`, `UPDATEXML`, or `$%7Benv` and submit
4. Confirm you get a `400 (Bad Request)` response