### PR TITLE
Better handling of non-existent annotations (SCP-5867, SCP-5868)

### DIFF
--- a/app/controllers/api/v1/concerns/api_caching.rb
+++ b/app/controllers/api/v1/concerns/api_caching.rb
@@ -44,7 +44,7 @@ module Api
         # ignore obvious malicious/bogus requests that can lead to invalid cache path entries
         def validate_cache_request
           if request.fullpath =~ XSS_MATCHER || request.fullpath =~ SCAN_MATCHER
-            head 400 and return
+            render json: { error: 'Bad request' }, status: 400 and return
           end
         end
       end

--- a/app/controllers/api/v1/visualization/annotations_controller.rb
+++ b/app/controllers/api/v1/visualization/annotations_controller.rb
@@ -100,6 +100,10 @@ module Api
 
         def show
           annotation = self.class.get_selected_annotation(@study, params)
+          if annotation.nil?
+            head :not_found and return
+          end
+
           render json: annotation
         end
 
@@ -148,6 +152,10 @@ module Api
 
         def cell_values
           annotation = self.class.get_selected_annotation(@study, params)
+          if annotation.nil?
+            head :not_found and return
+          end
+
           cell_cluster = @study.cluster_groups.by_name(params[:cluster])
           if cell_cluster.nil?
             cell_cluster = @study.default_cluster
@@ -364,9 +372,6 @@ module Api
         # parses the url params to identify the selected cluster
         def self.get_selected_annotation(study, params)
           annot_params = get_annotation_params(params)
-          if annot_params[:name] == '_default'
-            annot_params[:name] = nil
-          end
           cluster = nil
           if annot_params[:scope] == 'cluster'
             if params[:cluster].blank?
@@ -384,7 +389,7 @@ module Api
         def self.get_facet_annotations(study, cluster, annot_param)
           annotations = annot_param.split(',').map { |annot| convert_annotation_param(annot) }
           annotations.map do |annotation|
-            AnnotationVizService.get_selected_annotation(study, cluster:, fallback: false, **annotation)
+            AnnotationVizService.get_selected_annotation(study, cluster:, **annotation)
           end.compact
         end
 

--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -89,19 +89,19 @@ module Api
               key :type, :string
             end
             parameter do
-              key :name, :annot_name
+              key :name, :annotation_name
               key :in, :query
               key :description, 'Name of the annotation to categorize the cluster data.  Blank for default annotation.'
               key :type, :string
             end
             parameter do
-              key :name, :annot_type
+              key :name, :annotation_type
               key :in, :query
               key :description, 'Type of the annotation to retrieve--numeric or category.  Blank for default annotation.'
               key :type, :string
             end
             parameter do
-              key :name, :annot_scope
+              key :name, :annotation_scope
               key :in, :query
               key :description, 'Scope of the annotation to retrieve--study or cluster.  Blank for default annotation.'
               key :type, :string
@@ -156,7 +156,8 @@ module Api
                                                        annot_type: annot_params[:type],
                                                        annot_scope: annot_params[:scope])
           if !annotation
-            raise ArgumentError, "Annotation \"#{annot_params[:name]}\" could not be found"
+            annot_identifier = annot_params.values.compact.join('--')
+            raise ArgumentError, "Annotation \"#{annot_identifier}\" could not be found for \"#{cluster.name}\""
           end
 
           subsample = get_selected_subsample_threshold(url_params[:subsample], cluster)

--- a/app/controllers/api/v1/visualization/clusters_controller.rb
+++ b/app/controllers/api/v1/visualization/clusters_controller.rb
@@ -156,7 +156,7 @@ module Api
                                                        annot_type: annot_params[:type],
                                                        annot_scope: annot_params[:scope])
           if !annotation
-            raise ArgumentError, "Annotation \"#{annot_params[:annot_name]}\" could not be found"
+            raise ArgumentError, "Annotation \"#{annot_params[:name]}\" could not be found"
           end
 
           subsample = get_selected_subsample_threshold(url_params[:subsample], cluster)

--- a/app/controllers/api/v1/visualization/expression_controller.rb
+++ b/app/controllers/api/v1/visualization/expression_controller.rb
@@ -105,6 +105,10 @@ module Api
             }, status: :bad_request and return
           end
 
+          if @annotation.nil?
+            render json: { error: 'Requested annotation not found' }, status: :not_found and return
+          end
+
           data_type = params[:data_type]
           case data_type
           when 'violin'
@@ -161,10 +165,6 @@ module Api
         def render_morpheus_json
           if @cluster.nil?
             render json: { error: 'Requested cluster not found' }, status: :not_found and return
-          end
-
-          if @annotation.nil?
-            render json: { error: 'Requested annotation not found' }, status: :not_found and return
           end
 
           expression_data = ExpressionVizService.get_morpheus_json_data(

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -175,8 +175,11 @@ function RawScatterPlot({
   /** Update layout, without recomputing traces */
   function resizePlot() {
     const scatter = updateScatterLayout()
-    Plotly.relayout(graphElementId, scatter.layout)
-    setScatterData(scatter)
+    // in cases where an annotation wasn't found, skip calling Plotly.relayout before plot is instantiated
+    if (document.getElementById(graphElementId).data) {
+      Plotly.relayout(graphElementId, scatter.layout)
+      setScatterData(scatter)
+    }
   }
 
   /** Update legend counts and recompute traces, without recomputing layout */
@@ -604,7 +607,7 @@ function RawScatterPlot({
         correlation={bulkCorrelation}/>
       { hasMissingAnnot &&
         <div className="alert-warning text-center error-boundary">
-          "{cluster}" does not have the requested annotation "{loadedAnnotation}"
+          "{cluster}" does not have the requested annotation {loadedAnnotation !== '----' && loadedAnnotation}
         </div>
       }
       <div

--- a/test/api/visualization/annotations_controller_test.rb
+++ b/test/api/visualization/annotations_controller_test.rb
@@ -212,10 +212,16 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should reject bogus requests' do
     sign_in_and_update @user
-    execute_http_request(:get, api_v1_study_annotations_facets_path(
-      @basic_study, cluster: 'xssdetected', annotations: 'not-found--group--study'
-    ))
-    assert_response :bad_request
+    %w[xssdetected UPDATEXML CODE_POINTS_TO_STRING .git].each do |bogus|
+      execute_http_request(:get, api_v1_study_annotations_facets_path(
+        @basic_study, cluster: bogus, annotations: 'not-found--group--study'
+      ))
+      assert_response :bad_request
+      execute_http_request(:get, api_v1_study_annotations_facets_path(
+        @basic_study, cluster: 'clusterA.txt', annotations: "#{bogus}--group--study"
+      ))
+      assert_response :bad_request
+    end
   end
 
   test 'should not reject legit requests' do

--- a/test/api/visualization/annotations_controller_test.rb
+++ b/test/api/visualization/annotations_controller_test.rb
@@ -112,8 +112,7 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
                                                                cluster: 'clusterA.txt'}))
     assert_equal json['name'], 'foo'
     execute_http_request(:get, api_v1_study_annotation_path(@basic_study, 'nonExistentAnnotation'))
-    # returns the default annotation if it's not found by name/type
-    assert_equal 'species', json['name']
+    assert_response :not_found
   end
 
   test 'cell_values should return visualization tsv' do

--- a/test/api/visualization/clusters_controller_test.rb
+++ b/test/api/visualization/clusters_controller_test.rb
@@ -195,10 +195,16 @@ class ClustersControllerTest < ActionDispatch::IntegrationTest
 
   test 'should reject bogus requests' do
     sign_in_and_update @user
-    execute_http_request(:get, api_v1_study_cluster_path(
-      @basic_study, 'xssdetected', {annotation_name: 'species', annotation_scope: 'study', annotation_type: 'group'}
-    ))
-    assert_response :bad_request
+    %w[xssdetected UPDATEXML CODE_POINTS_TO_STRING .git].each do |bogus|
+      execute_http_request(:get, api_v1_study_cluster_path(
+        @basic_study, bogus, {annotation_name: 'species', annotation_scope: 'study', annotation_type: 'group'}
+      ))
+      assert_response :bad_request
+      execute_http_request(:get, api_v1_study_cluster_path(
+        @basic_study, 'clusterA.txt', {annotation_name: bogus, annotation_scope: 'study', annotation_type: 'group'}
+      ))
+      assert_response :bad_request
+    end
   end
 
   test 'should get external links' do

--- a/test/api/visualization/expression_controller_test.rb
+++ b/test/api/visualization/expression_controller_test.rb
@@ -120,10 +120,17 @@ class ExpressionControllerTest < ActionDispatch::IntegrationTest
 
   test 'should reject bogus requests' do
     sign_in_and_update @user
-    execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'violin', {
-      cluster: 'xssdetected',
-      genes: 'PTEN'
-    }), user: @user)
-    assert_response :bad_request
+    %w[xssdetected UPDATEXML CODE_POINTS_TO_STRING .git].each do |bogus|
+      execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'violin', {
+        cluster: bogus,
+        genes: 'PTEN'
+      }), user: @user)
+      assert_response :bad_request
+      execute_http_request(:get, api_v1_study_expression_path(@basic_study, 'violin', {
+        cluster: 'clusterA.txt',
+        genes: bogus
+      }), user: @user)
+      assert_response :bad_request
+    end
   end
 end

--- a/test/services/annotation_viz_service_test.rb
+++ b/test/services/annotation_viz_service_test.rb
@@ -43,9 +43,13 @@ class AnnotationVizServiceTest < ActiveSupport::TestCase
     assert_equal 'Category', annotation[:name]
     assert_equal %w[bar baz], annotation[:values]
 
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, annot_scope: 'study')
-    assert_equal 'species', annotation[:name]
-    assert_equal %w[dog cat], annotation[:values]
+    # explicit request for default
+    annotation = AnnotationVizService.get_selected_annotation(@basic_study, annot_name: '_default')
+    assert_equal 'Category', annotation[:name]
+    assert_equal %w[bar baz], annotation[:values]
+
+    # partial specifications result in nil responses, only empty or "_default" requests load the default annotation
+    assert_nil AnnotationVizService.get_selected_annotation(@basic_study, annot_scope: 'study')
 
     fizz_cluster = @basic_study.cluster_groups.find_by(name: 'cluster_2.txt')
     annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: fizz_cluster)
@@ -69,12 +73,10 @@ class AnnotationVizServiceTest < ActiveSupport::TestCase
     assert_equal [1.1, 2.2, 3.3], annotation[:values]
   end
 
-  test 'returns first study/cluster annotation if no matching annotation is found' do
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, annot_name: 'foobar', annot_scope: 'group', annot_type: 'study')
-    assert_equal 'species', annotation[:name]
+  test 'returns nothing if no matching annotation is found' do
+    assert_nil AnnotationVizService.get_selected_annotation(@basic_study, annot_name: 'foobar', annot_scope: 'group', annot_type: 'study')
     cluster = @basic_study.cluster_groups.first
-    annotation = AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: 'foobar', annot_type: 'group', annot_scope: 'cluster')
-    assert_equal 'Category', annotation[:name]
+    assert_nil AnnotationVizService.get_selected_annotation(@basic_study, cluster: cluster, annot_name: 'foobar', annot_type: 'group', annot_scope: 'cluster')
   end
 
   test 'available annotations returns the available annotations' do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
Currently, if the specified annotation is not found in a visualization request, the API will fall back to the default (or first available) annotation for that study.  This has several unintended consequences, one of them being that normal penetration scans that look for security vulnerabilities can result in memory/CPU saturation for a deployed instance as multiple bogus requests result in loading default data.  Now, if an annotation is specified and not found, the API will correctly respond `404`.  Normal "empty" requests that do not specify an annotation will still load the default annotation for a study, if one is available.

Additionally, known malicious requests that can lead to potential caching issues are blocked at the routing level with `400`.  While not strictly necessary, this will further reduce load by exiting before checking the cache on requests that are part of a security scan.  Since these scans are ever-evolving, the `404` approach is the more complete solution.

#### MANUAL TESTING
1. Boot as normal and load any study with visualizations
2. Confirm the empty default view renders without issue
3. Open the Network tab in Chrome Dev Tools
4. Select a different annotation to populate parameters into the URL
5. In the URL, change the name of the annotation to `not-found`.  For example, if the `annotation` parameter is `cell_type__ontology_label--group--study`, change it to `not-found--group--study` and submit the request.
6. Confirm that you see the error message `Error: Annotation "not-found" could not be found` and that the associated request in the network tab has a status of `404`.
7. Select a different annotation and confirm the plot is restored
8. Repeat step 5, but use `UPDATEXML` as the annotation name
9. Confirm the plot shows an error with the message `Bad request` and the associated request in the network tab shows a status of `400`