### PR TITLE
Allow setting of expression axis label in AnnData studies (SCP-5856)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -392,9 +392,14 @@ module Api
 
         if ['Expression Matrix', 'MM Coordinate Matrix'].include?(study_file.file_type) && !safe_file_params[:y_axis_label].blank?
           # if user is supplying an expression axis label, update default options hash
-          options = study.default_options.dup
-          options.merge!(expression_label: safe_file_params[:y_axis_label])
-          study.update(default_options: options)
+          study.default_options[:expression_label] = safe_file_params[:y_axis_label]
+          study.save
+        elsif study_file.is_viz_anndata?
+          expression_label = study_file.ann_data_file_info.expression_axis_label
+          if expression_label
+            study.default_options[:expression_label] = expression_label
+            study.save
+          end
         end
 
         if safe_file_params[:upload].present? && !is_chunked || safe_file_params[:remote_location].present?

--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -154,6 +154,14 @@ class AnnDataFileInfo
     exp_info.assign_attributes(**info_update) if info_update
   end
 
+  # extract description field from expression fragment to use as axis label
+  def expression_axis_label
+    exp_fragment = find_fragment(data_type: :expression) || fragments_by_type(:expression).first
+    return nil if exp_fragment.nil?
+
+    exp_fragment.with_indifferent_access[:y_axis_label]&.to_s
+  end
+
   private
 
   # select out keys from source hash and return new one, rejecting blank values

--- a/db/migrate/20241112195205_set_ann_data_expression_label.rb
+++ b/db/migrate/20241112195205_set_ann_data_expression_label.rb
@@ -6,6 +6,7 @@ class SetAnnDataExpressionLabel < Mongoid::Migration
       next if expression_label.blank?
 
       study = study_file.study
+      Rails.logger.info "Setting expression axis label to #{expression_label} in #{study.accession}"
       study.default_options[:expression_label] = expression_label
       study.save
     end

--- a/db/migrate/20241112195205_set_ann_data_expression_label.rb
+++ b/db/migrate/20241112195205_set_ann_data_expression_label.rb
@@ -1,0 +1,16 @@
+class SetAnnDataExpressionLabel < Mongoid::Migration
+  def self.up
+    study_files = StudyFile.where(file_type: 'AnnData', 'ann_data_file_info.reference_file' => false)
+    study_files.each do |study_file|
+      expression_label = study_file.ann_data_file_info.expression_axis_label
+      next if expression_label.blank?
+
+      study = study_file.study
+      study.default_options[:expression_label] = expression_label
+      study.save
+    end
+  end
+
+  def self.down
+  end
+end

--- a/test/api/study_files_controller_test.rb
+++ b/test/api/study_files_controller_test.rb
@@ -266,6 +266,7 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     ann_data.reload
     assert_equal 'updated', ann_data.description
+    assert_equal 'log(TPM) expression', ann_data.ann_data_file_info.expression_axis_label
     ann_data.ann_data_file_info.data_fragments.each do |fragment|
       assert_equal 'updated', fragment[:description]
     end

--- a/test/api/study_files_controller_test.rb
+++ b/test/api/study_files_controller_test.rb
@@ -215,7 +215,7 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
           _id: exp_frag_id,
           taxon_id: taxon_id,
           description: 'expression description',
-          y_axis_title: 'log(TPM) expression'
+          y_axis_label: 'log(TPM) expression'
         },
         metadata_form_info_attributes: {
           use_metadata_convention: false # check that override is in place to enforce convention
@@ -253,7 +253,7 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
                 description: 'updated'
               },
               {
-                _id: exp_frag_id, data_type: 'expression', taxon_id: taxon_id, y_axis_title: 'log(TPM) expression',
+                _id: exp_frag_id, data_type: 'expression', taxon_id: taxon_id, y_axis_label: 'log(TPM) expression',
                 description: 'updated', expression_file_info: { biosample_input_type: 'Single nuclei' }
               }
             ].to_json


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug where studies using the AnnData upload UX do not propagate the "expression axis label" field to any plots in the Explore tab.  The value was being saved but not used - now it is wired in the same as in the "Classic" upload UX.  Additionally, a migration has been added to backfill any existing data.

#### MANUAL TESTING
1. Initialize your environment and run the migration to set the axis label on any existing studies
2. In `development.log`, you will see a message if any studies were updated:
```
Setting expression axis label to log(TPM) expression in SCP150
```
3. Go to the Explore tab for any matching studies and validate that the axis is now labeled
4. If you do not have any matching studies, go to the upload wizard for any AnnData study and specify a label in the expression form, then repeat step 3