### PR TITLE
Bypass CSFV for reference AnnData files (SCP-5824)

### DIFF
--- a/app/javascript/components/upload/FileUploadControl.jsx
+++ b/app/javascript/components/upload/FileUploadControl.jsx
@@ -72,7 +72,7 @@ export default function FileUploadControl({
     }
 
     setFileValidation({ validating: true, issues: {}, fileName: selectedFile.name })
-    const [issues, notes] = await ValidateFile.validateLocalFile(selectedFile, file, allFiles, allowedFileExts)
+    const [issues, notes] = await ValidateFile.validateLocalFile(selectedFile, file, allFiles, allowedFileExts, isAnnDataExperience)
     setFileValidation({ validating: false, issues, fileName: selectedFile.name, notes })
     if (issues.errors.length === 0) {
       updateFile(file._id, {
@@ -133,7 +133,7 @@ export default function FileUploadControl({
     setFileValidation({ validating: true, issues: {}, fileName: trimmedPath })
     try {
       const issues = await ValidateFile.validateRemoteFile(
-        bucketName, trimmedPath, fileType, fileOptions
+        bucketName, trimmedPath, fileType, fileOptions, isAnnDataExperience
       )
       setFileValidation({ validating: false, issues, fileName: trimmedPath })
 

--- a/app/javascript/lib/validation/validate-file-content.js
+++ b/app/javascript/lib/validation/validate-file-content.js
@@ -337,7 +337,7 @@ export async function validateGzipEncoding(file, fileType) {
  */
 async function parseFile(
   file, fileType, fileOptions={},
-  sizeProps={}, remoteProps={}, isAnnDataExperience=false
+  sizeProps={}, remoteProps={}, isAnnDataExperience
 ) {
   const startTime = performance.now()
 

--- a/app/javascript/lib/validation/validate-file-content.js
+++ b/app/javascript/lib/validation/validate-file-content.js
@@ -337,7 +337,7 @@ export async function validateGzipEncoding(file, fileType) {
  */
 async function parseFile(
   file, fileType, fileOptions={},
-  sizeProps={}, remoteProps={}
+  sizeProps={}, remoteProps={}, isAnnDataExperience=false
 ) {
   const startTime = performance.now()
 
@@ -354,6 +354,12 @@ async function parseFile(
   }
 
   const parseResult = { fileInfo, issues: [] }
+
+  // bypass validation for reference AnnData files
+  if (fileType === 'AnnData' && !isAnnDataExperience) {
+    parseResult.perfTime = Math.round(performance.now() - startTime)
+    return parseResult
+  }
 
   try {
     fileInfo.isGzipped = await validateGzipEncoding(file, fileType)

--- a/app/javascript/lib/validation/validate-file.js
+++ b/app/javascript/lib/validation/validate-file.js
@@ -49,9 +49,10 @@ function validateFileName(file, studyFile, allStudyFiles, allowedFileExts=['*'])
  * @param studyFile {StudyFile} the JS object corresponding to the StudyFile
  * @param allStudyFiles {StudyFile[]} the array of all files for the study, used for name uniqueness checks
  * @param allowedFileExts { String[] } array of allowable extensions, ['*'] for all
+ * @param isAnnDataExperience {Boolean} controls finding nested AnnData data fragments
  */
 async function validateLocalFile(
-  file, studyFile, allStudyFiles=[], allowedFileExts=['*'], isAnnDataExperience=false
+  file, studyFile, allStudyFiles=[], allowedFileExts=['*'], isAnnDataExperience
 ) {
   // if clientside file validation feature flag is false skip validation
   const flags = getFeatureFlagsWithDefaults()
@@ -72,7 +73,7 @@ async function validateLocalFile(
       use_metadata_convention: studyFile.use_metadata_convention
     }
     const { fileInfo, issues, perfTime, notes } =
-      await ValidateFileContent.parseFile(file, studyFileType, fileOptions)
+      await ValidateFileContent.parseFile(file, studyFileType, fileOptions,  {}, {}, isAnnDataExperience)
     const allIssues = issues.concat(nameIssues)
     issuesObj = formatIssues(allIssues)
     notesObj = notes
@@ -138,6 +139,7 @@ function getSizeProps(contentRange, contentLength, file) {
 *  @param {String} fileName Name of file object in GCS bucket
 *  @param {String} fileType SCP file type
 *  @param {Object} [fileOptions]
+*  @param isAnnDataExperience {Boolean} controls finding nested AnnData data fragments
 *
 * @return {Object} issueObj Validation results, where:
 *   - `errors` is an array of errors,
@@ -145,7 +147,7 @@ function getSizeProps(contentRange, contentLength, file) {
 *   - `summary` is a message like "Your file had 2 errors"
 */
 async function validateRemoteFile(
-  bucketName, fileName, fileType, fileOptions, isAnnDataExperience=false
+  bucketName, fileName, fileType, fileOptions, isAnnDataExperience
 ) {
   const startTime = performance.now()
 
@@ -180,7 +182,7 @@ async function validateRemoteFile(
 
     // Equivalent block exists in validateFileContent
     const parseResults = await ValidateFileContent.parseFile(
-      file, fileType, fileOptions, sizeProps, remoteProps
+      file, fileType, fileOptions, sizeProps, remoteProps, isAnnDataExperience
     )
     fileInfo = parseResults['fileInfo']
     issues = parseResults['issues']

--- a/app/javascript/lib/validation/validate-file.js
+++ b/app/javascript/lib/validation/validate-file.js
@@ -50,7 +50,9 @@ function validateFileName(file, studyFile, allStudyFiles, allowedFileExts=['*'])
  * @param allStudyFiles {StudyFile[]} the array of all files for the study, used for name uniqueness checks
  * @param allowedFileExts { String[] } array of allowable extensions, ['*'] for all
  */
-async function validateLocalFile(file, studyFile, allStudyFiles=[], allowedFileExts=['*']) {
+async function validateLocalFile(
+  file, studyFile, allStudyFiles=[], allowedFileExts=['*'], isAnnDataExperience=false
+) {
   // if clientside file validation feature flag is false skip validation
   const flags = getFeatureFlagsWithDefaults()
   if (flags && flags.clientside_validation === false) {
@@ -143,7 +145,7 @@ function getSizeProps(contentRange, contentLength, file) {
 *   - `summary` is a message like "Your file had 2 errors"
 */
 async function validateRemoteFile(
-  bucketName, fileName, fileType, fileOptions
+  bucketName, fileName, fileType, fileOptions, isAnnDataExperience=false
 ) {
   const startTime = performance.now()
 

--- a/test/js/upload-wizard/file-upload-control.test.js
+++ b/test/js/upload-wizard/file-upload-control.test.js
@@ -242,6 +242,41 @@ describe('file upload control validates the selected file', () => {
       .toHaveTextContent('First row, first column must be "NAME" (case insensitive). Your value was "notNAME')
   })
 
+  it('skips validating reference AnnData files', async () => {
+    const file = {
+      _id: '123',
+      name: '',
+      status: 'new',
+      file_type: 'AnnData'
+    }
+
+    const updateFileHolder = { updateFile: () => {} }
+    const updateFileSpy = jest.spyOn(updateFileHolder, 'updateFile')
+
+    render((
+      <StudyContext.Provider value={{ accession: 'SCP123' }}>
+        <FileUploadControl
+          file={file}
+          allFiles={[file]}
+          updateFile={updateFileHolder.updateFile}
+          allowedFileExts={['.h5ad']}
+          validationMessages={{}}
+          isAnnDataExperience={false}/>
+      </StudyContext.Provider>
+    ))
+
+    const fileObj = fireFileSelectionEvent(screen.getByTestId('file-input'), {
+      fileName: 'data.h5ad'
+    }, true)
+    await waitForElementToBeRemoved(() => screen.getByTestId('file-validation-spinner'))
+    expect(updateFileSpy).toHaveBeenLastCalledWith('123', {
+      uploadSelection: fileObj,
+      name: 'data.h5ad',
+      upload_file_name: 'data.h5ad'
+    })
+    expect(screen.queryByTestId('validation-error')).not.toBeInTheDocument()
+  })
+
   it('renders multiple content errors', async () => {
     const file = {
       _id: '123',


### PR DESCRIPTION
#### BACKGROUND & CHANGES
Recent updates to CSFV for AnnData files have greatly improved the user experience for initializing studies with a single AnnData file.  However, an unintended consequence of this was that reference AnnData files (i.e. not parsed for visualization) were now subject to validation.  While not in and of itself a bad thing, it is misleading in that the files will not be parsed and as such would not be validated server-side.

Now, any reference AnnData files can be uploaded without invoking CSFV, and will only be opened and confirm that data can be read via existing ingest pipeline validation.  Visualizable AnnData files are still validated as normal.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Go to an empty/new study and select the classic upload UX
3. Go down to the AnnData tab and upload `test/test_data/anndata/invalid_disease_label.h5ad`
4. Confirm you get not validation error
5. Click "use bucket path" and upload that file to the bucket
6. Use the bucket path feature back in the upload wizard and confirm there is still no error
7. Switch to the AnnData UX, and confirm the file fails CSFV with an appropriate error message