### PR TITLE
Adding pairwise differential expression to `DifferentialExpressionService` (SCP-5848)

### DIFF
--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -111,6 +111,7 @@ class DifferentialExpressionService
   #   - +user+             (User) => User initiating parse action (for email delivery)
   #   - +annotation_name+  (String) => Name of requested annotation
   #   - +annotation_scope+ (String) => Scope of requested annotation ('study' or 'cluster')
+  #   - +de_type+          (String) => Type of differential expression calculation: 'rest' (one-vs-rest) or 'pairwise'
   #   - +machine_type+     (String) => Override default VM machine type
   #   - +dry_run+          (Boolean) => Indication of whether or not this is a pre-flight check
   #
@@ -123,7 +124,7 @@ class DifferentialExpressionService
   # * *raises*
   #   - (ArgumentError) => if requested parameters do not validate
   def self.run_differential_expression_job(cluster_group, study, user, annotation_name:, annotation_scope:,
-                                           machine_type: nil, dry_run: nil)
+                                           de_type: 'rest', group1: nil, group2: nil, machine_type: nil, dry_run: nil)
     validate_study(study)
     validate_annotation(cluster_group, study, annotation_name, annotation_scope)
     cluster_url = cluster_file_url(cluster_group)
@@ -133,8 +134,11 @@ class DifferentialExpressionService
                      study.metadata_file.gs_url
     # begin assembling parameters
     de_params = {
-      annotation_name: annotation_name,
-      annotation_scope: annotation_scope,
+      annotation_name:,
+      annotation_scope:,
+      de_type:,
+      group1:,
+      group2:,
       annotation_file: annotation_scope == 'cluster' ? cluster_url : metadata_url,
       cluster_file: cluster_url,
       cluster_name: cluster_group.name
@@ -321,16 +325,26 @@ class DifferentialExpressionService
   #   - +study+            (Study) => Study to which StudyFile belongs
   #   - +annotation_name+  (String) => Name of requested annotation
   #   - +annotation_scope+ (String) => Scope of requested annotation ('study' or 'cluster')
+  #   - +group1+           (String) => first annotation label for pairwise
+  #   - +group2+           (String) => second annotation label for pairwise
   #
   # * *raises*
   #   - (ArgumentError) => if requested parameters do not validate
-  def self.validate_annotation(cluster_group, study, annotation_name, annotation_scope)
+  def self.validate_annotation(cluster_group, study, annotation_name, annotation_scope, group1: nil, group2: nil)
+    pairwise = group1.present? || group2.present?
+    validate_pairwise(group1, group2) if pairwise
+
     result = DifferentialExpressionResult.find_by(study:, cluster_group:, annotation_name:, annotation_scope:)
-    if result.present?
+    if result.present? && !pairwise
       raise ArgumentError,
             "#{annotation_name} already exists for #{study.accession}:#{cluster_group.name}, " \
             "please delete result #{result.id} before retrying"
+    elsif pairwise && result.present? && result.has_pairwise_comparison?(group1, group2)
+      raise ArgumentError,
+            "#{group1} vs. #{group2} pairwise already exists for #{annotation_name} on " \
+              "#{study.accession}:#{cluster_group.name}, you must remove that entry from #{result.id} before retrying"
     end
+
     can_visualize = false
     if annotation_scope == 'cluster'
       annotation = cluster_group.cell_annotations&.detect do |annot|
@@ -348,8 +362,15 @@ class DifferentialExpressionService
     # last, validate that the requested annotation & cluster will provide a valid intersection of annotation values
     # specifically, discard any annotation/cluster combos that only result in one distinct label
     cells_by_label = ClusterVizService.cells_by_annotation_label(cluster_group, annotation_name, annotation_scope)
-    if cells_by_label.keys.count < 2
+    if !pairwise && cells_by_label.keys.count < 2
       raise ArgumentError, "#{identifier} does not have enough labels represented in #{cluster_group.name}"
+    elsif pairwise
+      missing = {
+        "#{group1}" => cells_by_label[group1].count,
+        "#{group2}" => cells_by_label[group2].count
+      }.keep_if { |_, c| c < 2 }
+      raise ArgumentError,
+            "#{missing.keys.join(', ')} does not have enough cells represented in #{identifier}" if missing.any?
     end
   end
 
@@ -363,6 +384,19 @@ class DifferentialExpressionService
   def self.validate_study(study)
     raise ArgumentError, 'Requested study does not exist' if study.nil?
     raise ArgumentError, "#{study.accession} cannot view cluster plots" unless study.can_visualize_clusters?
+  end
+
+  # ensure both group1 and group2 are provided for pairwise calculations
+  #
+  # * *params*
+  #   - +group1+ (String) => first annotation label for pairwise
+  #   - +group2+ (String) => second annotation label for pairwise
+  #
+  # * *raises*
+  #   - (ArgumentError) => If requested study is not eligible for DE
+  def self.validate_pairwise(group1, group2)
+    missing = { group1:, group2: }.keep_if { |_, v| v.blank? }
+    raise ArgumentError, "must provide #{missing.keys.join(', ')} for pairwise calculation" unless missing.empty?
   end
 
   # determine if a study has author-uploaded DE results

--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -126,7 +126,7 @@ class DifferentialExpressionService
   def self.run_differential_expression_job(cluster_group, study, user, annotation_name:, annotation_scope:,
                                            de_type: 'rest', group1: nil, group2: nil, machine_type: nil, dry_run: nil)
     validate_study(study)
-    validate_annotation(cluster_group, study, annotation_name, annotation_scope)
+    validate_annotation(cluster_group, study, annotation_name, annotation_scope, group1:, group2:)
     cluster_url = cluster_file_url(cluster_group)
     study_file = cluster_group.study_file
     metadata_url = study_file.is_viz_anndata? ?

--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -15,6 +15,9 @@ class DifferentialExpressionParameters
   # annotation_file: source file for above annotation
   # cluster_file: clustering file with cells to use as control list for DE
   # cluster_name: name of associated ClusterGroup object
+  # de_type: type of differential expression calculation: 'rest' (one-vs-rest) or 'pairwise'
+  # group1: first group for pairwise comparison
+  # group2: second group for pairwise comparison
   # matrix_file_path: raw counts matrix with source expression data
   # matrix_file_type: type of raw counts matrix (dense, sparse)
   # gene_file (optional): genes/features file for sparse matrix
@@ -28,6 +31,9 @@ class DifferentialExpressionParameters
     annotation_file: nil,
     cluster_file: nil,
     cluster_name: nil,
+    de_type: 'rest',
+    group1: nil,
+    group2: nil,
     matrix_file_path: nil,
     matrix_file_type: nil,
     gene_file: nil,
@@ -46,6 +52,8 @@ class DifferentialExpressionParameters
   validates :annotation_file, :cluster_file, :matrix_file_path,
             format: { with: Parameterizable::GS_URL_REGEXP, message: 'is not a valid GS url' }
   validates :annotation_scope, inclusion: %w[cluster study]
+  validates :de_type, inclusion: %w[rest pairwise]
+  validates :group1, :group2, presence: true, if: -> { de_type == 'pairwise' }
   validates :matrix_file_type, inclusion: %w[dense mtx h5ad]
   validates :machine_type, inclusion: Parameterizable::GCE_MACHINE_TYPES
   validates :gene_file, :barcode_file,

--- a/app/models/differential_expression_result.rb
+++ b/app/models/differential_expression_result.rb
@@ -86,12 +86,7 @@ class DifferentialExpressionResult
   # will convert non-word characters to underscores "_", except plus signs "+" which are changed to "pos"
   # this is to handle cases where + or - are the only difference in labels, such as CD4+ and CD4-
   def filename_for(label, comparison_group: nil)
-    if comparison_group.present?
-      first_label, second_label = Naturally.sort([label, comparison_group]) # comparisons must be sorted
-      values = [cluster_name, annotation_name, first_label, second_label, annotation_scope, computational_method]
-    else
-      values = [cluster_name, annotation_name, label, annotation_scope, computational_method]
-    end
+    values = [cluster_name, annotation_name, label, comparison_group, annotation_scope, computational_method].compact
     basename = DifferentialExpressionService.encode_filename(values)
     "#{basename}.tsv"
   end

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -380,7 +380,11 @@ class IngestJob
         set_study_state_after_ingest
         study_file.invalidate_cache_by_file_type # clear visualization caches for file
         log_to_mixpanel
-        subject = "#{study_file.file_type} file: '#{study_file.upload_file_name}' has completed parsing"
+        if action == :differential_expression
+          subject = "Differential expression analysis for #{study_file.file_type} file: '#{study_file.upload_file_name}' has completed processing"
+        else
+          subject = "#{study_file.file_type} file: '#{study_file.upload_file_name}' has completed parsing"
+        end
         message = generate_success_email_array
         if special_action?
           # don't email users for 'special actions' like DE or image pipeline, instead notify admins
@@ -397,7 +401,11 @@ class IngestJob
       log_error_messages
       log_to_mixpanel # log before queuing file for deletion to preserve properties
       # don't delete files or notify users if this is a 'special action', like DE or image pipeline jobs
-      subject = "Error: #{study_file.file_type} file: '#{study_file.upload_file_name}' parse has failed"
+      if action == :differential_expression
+        subject = "Error: Differential expression analysis for #{study_file.file_type} file: '#{study_file.upload_file_name}' has failed processing"
+      else
+        subject = "Error: #{study_file.file_type} file: '#{study_file.upload_file_name}' parse has failed"
+      end
       handle_ingest_failure(subject) unless (special_action? || should_retry?)
 
       admin_email_content = generate_error_email_body(email_type: :dev)

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -1189,6 +1189,9 @@ class IngestJob
     when :differential_expression
       message << "Differential expression calculations for #{params_object.cluster_name} have completed"
       message << "Selected annotation: #{params_object.annotation_name} (#{params_object.annotation_scope})"
+      if params_object.de_type == 'pairwise'
+        message << "Pairwise selections: #{params_object.group1} vs. #{params_object.group2}"
+      end
     when :render_expression_arrays
       matrix_name = params_object.matrix_file_path.split('/').last
       matrix = study.expression_matrices.find_by(name: matrix_name)

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -722,11 +722,12 @@ class IngestJob
     matrix_file = StudyFile.where(study: study, 'expression_file_info.is_raw_counts' => true).any_of(
       { upload_file_name: matrix_filename }, { remote_location: matrix_filename }
     ).first
-    de_result = DifferentialExpressionResult.new(
+    de_result = DifferentialExpressionResult.find_or_initialize_by(
       study: study, cluster_group: cluster, cluster_name: cluster.name,
       annotation_name: params_object.annotation_name, annotation_scope: params_object.annotation_scope,
       matrix_file_id: matrix_file.id
     )
+    de_result.set_automated_comparisons(group1: params_object.group1, group2: params_object.group2)
     de_result.save
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.37.1'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.38.0'
 
     # Docker image for image pipeline jobs
     config.image_pipeline_docker_image = 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_c2b090043'

--- a/test/models/differential_expression_result_test.rb
+++ b/test/models/differential_expression_result_test.rb
@@ -290,4 +290,23 @@ class DifferentialExpressionResultTest < ActiveSupport::TestCase
       assert_equal de_file.id, result.study_file_id
     end
   end
+
+  test 'should set observations on results' do
+    cell_type = DifferentialExpressionResult.new(
+      study: @study, cluster_group: @cluster_file.cluster_groups.first, annotation_name: 'cell_type__ontology_label',
+      annotation_scope: 'study', matrix_file_id: @raw_matrix.id
+    )
+    cell_type.set_automated_comparisons
+    assert_equal ['B cell', 'T cell'], cell_type.one_vs_rest_comparisons
+    assert_empty cell_type.pairwise_comparisons
+
+    custom = DifferentialExpressionResult.new(
+      study: @study, cluster_group: @cluster_file.cluster_groups.first, annotation_name: 'cell_type__custom',
+      annotation_scope: 'study', matrix_file_id: @raw_matrix.id
+    )
+    types = @custom_cell_types.uniq
+    custom.set_automated_comparisons(group1: types.first, group2: types.last)
+    assert_equal ['Custom 10'], custom.pairwise_comparisons['Custom 2']
+    assert_empty custom.one_vs_rest_comparisons
+  end
 end

--- a/test/services/differential_expression_service_test.rb
+++ b/test/services/differential_expression_service_test.rb
@@ -108,6 +108,24 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
       mock.verify
       job_mock.verify
     end
+
+    # test pairwise job
+    @job_params[:de_type] = 'pairwise'
+    @job_params[:group1] = 'dog'
+    @job_params[:group2] = 'cat'
+
+    job_mock = Minitest::Mock.new
+    job_mock.expect(:push_remote_and_launch_ingest, Delayed::Job.new)
+    mock = Minitest::Mock.new
+    mock.expect(:delay, job_mock)
+    IngestJob.stub :new, mock do
+      job_launched = DifferentialExpressionService.run_differential_expression_job(
+        @cluster_group, @basic_study, @user, **@job_params
+      )
+      assert job_launched
+      mock.verify
+      job_mock.verify
+    end
   end
 
   test 'should run differential expression job with sparse matrix' do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds basic integration for running pairwise differential expression jobs from the Rails console via the `DifferentialExpressionService.run_differential_expression_job` method.  There is no UI/UX for requesting these jobs yet, but the existing differential expression UX already supports storing and viewing pairwise results.

#### MANUAL TESTING
Before beginning, you should ingest the AnnData file referenced in [this PR](https://github.com/broadinstitute/scp-ingest-pipeline/pull/372) from the scp-ingest-pipeline repo.  This file is small and should ingest quickly.  Be sure to indicate that you have raw counts information in the file, otherwise you will not be able to run DE jobs.  You will need to wait for the automated DE calculations to complete; the reason being that we want to validate that pairwise results can be appended to existing results objects.  You can use a different AnnData file (or even a different matrix type) but then you will need to assemble different parameters for your job based off of the available annotations.

To begin:
1. Boot all services including `DelayedJob`
2. In a Rails console session, load the study with the correct AnnData file
```
study = Study.find_by(accession: <your accession>)
```
3. Assemble the parameters for the DE job
```
cluster_group = study.cluster_groups.by_name('umap')
study_file = study.study_files.last
user = study.user
annotation_name = 'leiden'
annotation_scope = 'study'
de_type = 'pairwise'
group1 = '1'
group2 = '2'
```
4. Run the job:
```
DifferentialExpressionService.run_differential_expression_job(cluster_group, study, user, annotation_name:, annotation_scope:, de_type:, group1:, group2:)
=> true
```
5. In `development.log`, confirm you see a job launched:
```
Request object sent to Google Life Sciences API, excluding 'environment' parameters:
---
:actions:
  :commands:
  - python
  - ingest_pipeline.py
  - "--study-id"
  - 674f483694ec8f30dc166dad
  - "--study-file-id"
  - 674f48f9a2e4c9f5758a38fb
  - "--user-metrics-uuid"
  - c6a08597-c735-4c93-b069-4b4a74b708ee
  - differential_expression
  - "--study-accession"
  - SCP163
  - "--annotation-name"
  - leiden
  - "--annotation-type"
  - group
  - "--annotation-scope"
  - study
  - "--annotation-file"
  - gs://fc-f9979815-c163-43cb-afcc-be4b4f61da23/_scp_internal/anndata_ingest/SCP163_674f48f9a2e4c9f5758a38fb/h5ad_frag.metadata.tsv.gz
  - "--cluster-file"
  - gs://fc-f9979815-c163-43cb-afcc-be4b4f61da23/_scp_internal/anndata_ingest/SCP163_674f48f9a2e4c9f5758a38fb/h5ad_frag.cluster.X_umap.tsv.gz
  - "--cluster-name"
  - umap
  - "--de-type"
  - pairwise
  - "--group1"
  - '1'
  - "--group2"
  - '2'
  - "--matrix-file-path"
  - gs://fc-f9979815-c163-43cb-afcc-be4b4f61da23/HTAPP-330-SMP-1082_compliant.h5ad
  - "--matrix-file-type"
  - h5ad
  - "--differential-expression"
  :image_uri: gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.38.0
...
```
6. Wait for the job to complete and confirm you see the following in the success email:
```
Total parse time: 1 Minute and 29 Seconds
Differential expression calculations for umap have completed
Selected annotation: leiden (study)
Pairwise selections: 1 vs. 2
```
7. Load the DE result and confirm you have both pairwise & one vs. rest comparisons (yours may be in a different order but the content should be the same):
```
result = study.differential_expression_results.find_by(annotation_name: 'leiden')
result.one_vs_rest_comparisons
=> ["3", "6", "5", "2", "4", "0", "7", "8", "1"]

result.pairwise_comparisons
=> {"1"=>["2"]}
```
8. Load the Explore tab for this study and select the `leiden` annotation from the DE picker, then select `1` as the first label and `2` as the second:
![Screenshot 2024-12-11 at 10 21 59 AM](https://github.com/user-attachments/assets/84690492-4954-4964-9050-1ad87702bdf6)
9. Confirm the first gene listed is `RPL15` with a log foldchange of `2.248` and an adj. P val of  `0.024`
![Screenshot 2024-12-11 at 10 23 29 AM](https://github.com/user-attachments/assets/e066756a-22c8-4fc0-9e36-61da2526ad52)


