### PR TITLE
Allow specifying order of expression scatter plot sorting (SCP-5885)

### DIFF
--- a/app/controllers/api/v1/visualization/explore_controller.rb
+++ b/app/controllers/api/v1/visualization/explore_controller.rb
@@ -158,6 +158,7 @@ module Api
             differentialExpression: AnnotationVizService.differential_expression_menu_opts(study),
             hasImageCache: study.cluster_groups.where(has_image_cache: true).pluck(:name),
             clusterPointAlpha: study.default_cluster_point_alpha,
+            expressionSort: study.default_expression_sort,
             colorProfile: study.default_color_profile,
             bucketId: study.bucket_id,
             isPublic: study.public

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -728,7 +728,7 @@ class SiteController < ApplicationController
                                   :default_options => [:cluster, :annotation, :color_profile, :expression_label,
                                                        :deliver_emails, :cluster_point_size, :cluster_point_alpha,
                                                        :cluster_point_border, :precomputed_heatmap_label,
-                                                       override_viz_limit_annotations: []],
+                                                       :expression_sort, override_viz_limit_annotations: []],
                                   study_shares_attributes: [:id, :_destroy, :email, :permission],
                                   study_detail_attributes: [:id, :full_description],
                                   reviewer_access_attributes: [:id, :expires_at],

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1041,7 +1041,8 @@ class StudiesController < ApplicationController
   def default_options_params
     params.require(:study_default_options).permit(:cluster, :annotation, :color_profile, :expression_label,
                                                   :cluster_point_size, :cluster_point_alpha, :cluster_point_border,
-                                                  :precomputed_heatmap_label, override_viz_limit_annotations: [])
+                                                  :precomputed_heatmap_label, :expression_sort,
+                                                  override_viz_limit_annotations: [])
   end
 
   def set_file_types

--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -21,6 +21,7 @@ import DifferentialExpressionModal from '~/components/explore/DifferentialExpres
 import CellFilteringModal from '~/components/explore/CellFilteringModal'
 import { CellFilteringPanel, CellFilteringPanelHeader } from './CellFilteringPanel'
 import BookmarkManager from '~/components/bookmarks/BookmarkManager'
+import { EXPRESSION_SORT_OPTIONS } from '~/components/visualization/PlotDisplayControls'
 
 /** Get the selected clustering and annotation, or their defaults */
 function getSelectedClusterAndAnnot(exploreInfo, exploreParams) {
@@ -185,6 +186,11 @@ function getIsAuthorDe(exploreInfo, exploreParams) {
   return isAuthorDe
 }
 
+// get the current value for expression sorting (or study default, if present)
+function getExpressionSort(exploreInfo, exploreParams) {
+  return exploreParams?.expressionSort || exploreInfo?.expressionSort || EXPRESSION_SORT_OPTIONS[0]
+}
+
 /**
  * Manages the right panel section of the explore view of a study. We have three options for the right side
  * panel with different controls to adjust the plots: Options (or default), Differential Expression, and
@@ -226,6 +232,7 @@ export default function ExploreDisplayPanelManager({
   const hasPairwiseDe = getHasComparisonDe(exploreInfo, exploreParams, 'pairwise')
   const deHeaders = getDeHeaders(exploreInfo, exploreParams)
   const isAuthorDe = getIsAuthorDe(exploreInfo, exploreParams)
+  const expressionSort = getExpressionSort(exploreInfo, exploreParams)
 
   // exploreParams object without genes specified, to pass to cluster comparison plots
   const referencePlotDataParams = _clone(exploreParams)
@@ -514,6 +521,7 @@ export default function ExploreDisplayPanelManager({
               shownTab={shownTab}
               exploreParams={exploreParamsWithDefaults}
               updateExploreParams={updateExploreParams}
+              expressionSort={expressionSort}
               allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}/>
             <div id={useBookmarkContainer ? 'bookmark-container' : ''} className={useRowClass ? 'row' : ''}>
               <div className={useRowClass ? 'col-xs-12' : ''}>

--- a/app/javascript/components/explore/ExploreTabRouter.jsx
+++ b/app/javascript/components/explore/ExploreTabRouter.jsx
@@ -117,7 +117,7 @@ function buildExploreParamsFromQuery(query) {
       exploreParams.expressionFilter = filterArray
     }
   }
-
+  exploreParams.expressionSort = queryParams.expressionSort
   exploreParams.hiddenTraces = queryParams.hiddenTraces ? queryParams.hiddenTraces.split(',') : []
   exploreParams.isSplitLabelArrays = queryParams.isSplitLabelArrays === 'true' ? true : null
 
@@ -145,6 +145,7 @@ function buildQueryFromParams(exploreParams) {
     trackFileName: exploreParams.trackFileName,
     ideogramFileId: exploreParams.ideogramFileId,
     expressionFilter: exploreParams.expressionFilter ? exploreParams.expressionFilter.join(FILTER_RANGE_DELIMITER) : undefined,
+    expressionSort: exploreParams.expressionSort,
     hiddenTraces: exploreParams.hiddenTraces.join(','),
     isSplitLabelArrays: exploreParams.isSplitLabelArrays ? 'true' : undefined,
     facets: exploreParams.facets
@@ -166,7 +167,7 @@ function buildQueryFromParams(exploreParams) {
 const PARAM_LIST_ORDER = [
   'geneList', 'genes', 'cluster', 'spatialGroups', 'annotation', 'subsample', 'consensus',
   'tab', 'scatterColor', 'distributionPlot', 'distributionPoints',
-  'heatmapFit', 'heatmapRowCentering', 'trackFileName', 'ideogramFileId', 'expressionFilter',
+  'heatmapFit', 'heatmapRowCentering', 'trackFileName', 'ideogramFileId', 'expressionFilter', 'expressionSort',
   'isSplitLabelArrays', 'hiddenTraces', 'facets'
 ]
 /** sort function for passing to stringify to ensure url params are specified in a user-friendly order */

--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -25,6 +25,8 @@ export default function ScatterTab({
     updateExploreParamsWithDefaults({ scatterColor: color }, false)
   }
 
+  const expressionSort = exploreParamsWithDefaults?.expressionSort
+
   // identify any repeat graphs
   const newContextMap = getNewContextMap(scatterParams, plotlyContextMap.current)
 
@@ -55,6 +57,7 @@ export default function ScatterTab({
               canEdit={exploreInfo.canEdit}
               bucketId={exploreInfo.bucketId}
               filteredCells={filteredCells}
+              expressionSort={expressionSort}
               dimensionProps={{
                 isMultiRow,
                 isTwoColumn: isTwoColRow,

--- a/app/javascript/components/explore/ScatterTab.jsx
+++ b/app/javascript/components/explore/ScatterTab.jsx
@@ -25,7 +25,7 @@ export default function ScatterTab({
     updateExploreParamsWithDefaults({ scatterColor: color }, false)
   }
 
-  const expressionSort = exploreParamsWithDefaults?.expressionSort
+  const expressionSort = exploreParamsWithDefaults?.expressionSort || exploreInfo?.expressionSort
 
   // identify any repeat graphs
   const newContextMap = getNewContextMap(scatterParams, plotlyContextMap.current)

--- a/app/javascript/components/visualization/PlotDisplayControls.jsx
+++ b/app/javascript/components/visualization/PlotDisplayControls.jsx
@@ -59,7 +59,7 @@ export default function RenderControls({ shownTab, exploreParams, updateExploreP
   const showColorScale = !!(showScatter && (exploreParams.annotation.type === 'numeric' || exploreParams.genes.length))
   const filterValues = exploreParams.expressionFilter ?? [0, 1]
   const showExpressionFilter = ENABLE_EXPRESSION_FILTER && exploreParams.genes.length && showScatter
-  const expressionSort = exploreParams?.expressionSort || 'max'
+  const expressionSort = exploreParams?.expressionSort || 'high'
   const showExpressionSort = exploreParams.genes.length > 0 && showScatter
 
   return (

--- a/app/javascript/components/visualization/PlotDisplayControls.jsx
+++ b/app/javascript/components/visualization/PlotDisplayControls.jsx
@@ -85,7 +85,7 @@ export default function RenderControls({ shownTab, exploreParams, updateExploreP
         <label className="labeled-select">Order expression by&nbsp;
           <a className="action help-icon"
              data-toggle="tooltip"
-             data-original-title="Brings cells to the front of plots by value.  Use 'none' to disable ordering.">
+             data-original-title="Brings cells to the front of scatter plots by expression value.  Use 'none' to disable ordering.">
             <FontAwesomeIcon icon={faInfoCircle}/>
           </a>
           <Select

--- a/app/javascript/components/visualization/PlotDisplayControls.jsx
+++ b/app/javascript/components/visualization/PlotDisplayControls.jsx
@@ -30,9 +30,9 @@ const railStyle = {
 // the code is in because it allows easier testing of the trace filtering logic implemented in plot.js
 const ENABLE_EXPRESSION_FILTER = false
 
-const EXPRESSION_SORT_OPTIONS = ['high', 'low', 'unsorted']
+export const EXPRESSION_SORT_OPTIONS = ['high', 'low', 'unsorted']
 /** the graph customization controls for the exlore tab */
-export default function RenderControls({ shownTab, exploreParams, updateExploreParams, allGenes }) {
+export default function RenderControls({ shownTab, exploreParams, updateExploreParams, expressionSort, allGenes }) {
   const scatterColorValue = exploreParams.scatterColor ? exploreParams.scatterColor : defaultScatterColor
   let distributionPlotValue = DISTRIBUTION_PLOT_OPTIONS.find(opt => opt.value === exploreParams.distributionPlot)
   if (!distributionPlotValue) {
@@ -59,7 +59,6 @@ export default function RenderControls({ shownTab, exploreParams, updateExploreP
   const showColorScale = !!(showScatter && (exploreParams.annotation.type === 'numeric' || exploreParams.genes.length))
   const filterValues = exploreParams.expressionFilter ?? [0, 1]
   const showExpressionFilter = ENABLE_EXPRESSION_FILTER && exploreParams.genes.length && showScatter
-  const expressionSort = exploreParams?.expressionSort || 'high'
   const showExpressionSort = exploreParams.genes.length > 0 && showScatter
 
   return (

--- a/app/javascript/components/visualization/PlotDisplayControls.jsx
+++ b/app/javascript/components/visualization/PlotDisplayControls.jsx
@@ -5,6 +5,8 @@ import { Slider, Rail, Handles, Tracks, Ticks } from 'react-compound-slider'
 import Select from '~/lib/InstrumentedSelect'
 import { Handle, Track, Tick } from '~/components/search/controls/slider/components'
 import PlotOptions from './plot-options'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 const {
   SCATTER_COLOR_OPTIONS, defaultScatterColor, DISTRIBUTION_PLOT_OPTIONS, DISTRIBUTION_POINTS_OPTIONS,
   ROW_CENTERING_OPTIONS, FIT_OPTIONS
@@ -28,7 +30,7 @@ const railStyle = {
 // the code is in because it allows easier testing of the trace filtering logic implemented in plot.js
 const ENABLE_EXPRESSION_FILTER = false
 
-
+const EXPRESSION_SORT_OPTIONS = ['max', 'min', 'none']
 /** the graph customization controls for the exlore tab */
 export default function RenderControls({ shownTab, exploreParams, updateExploreParams, allGenes }) {
   const scatterColorValue = exploreParams.scatterColor ? exploreParams.scatterColor : defaultScatterColor
@@ -57,6 +59,8 @@ export default function RenderControls({ shownTab, exploreParams, updateExploreP
   const showColorScale = !!(showScatter && (exploreParams.annotation.type === 'numeric' || exploreParams.genes.length))
   const filterValues = exploreParams.expressionFilter ?? [0, 1]
   const showExpressionFilter = ENABLE_EXPRESSION_FILTER && exploreParams.genes.length && showScatter
+  const expressionSort = exploreParams?.expressionSort || 'max'
+  const showExpressionSort = exploreParams.genes.length > 0 && showScatter
 
   return (
     <div>
@@ -65,13 +69,40 @@ export default function RenderControls({ shownTab, exploreParams, updateExploreP
           <span className="detail"> (for numeric data)</span>
           <Select
             data-analytics-name="scatter-color-picker"
-            options={SCATTER_COLOR_OPTIONS.map(opt => ({ label: opt, value: opt }))}
-            value={{ label: scatterColorValue, value: scatterColorValue }}
+            options={SCATTER_COLOR_OPTIONS.map(opt => ({
+              label: opt,
+              value: opt
+            }))}
+            value={{
+              label: scatterColorValue,
+              value: scatterColorValue
+            }}
             clearable={false}
             onChange={option => updateExploreParams({ scatterColor: option.value })}/>
         </label>
-      </div> }
-      { showExpressionFilter && <div className="render-controls">
+      </div>}
+      {showExpressionSort && <div className="render-controls">
+        <label className="labeled-select">Order expression by&nbsp;
+          <a className="action help-icon"
+             data-toggle="tooltip"
+             data-original-title="Brings cells to the front of plots by value.  Use 'none' to disable ordering.">
+            <FontAwesomeIcon icon={faInfoCircle}/>
+          </a>
+          <Select
+            data-analytics-name="expression-sort-select"
+            options={EXPRESSION_SORT_OPTIONS.map(opt => ({
+              label: opt,
+              value: opt
+            }))}
+            value={{
+              label: expressionSort,
+              value: expressionSort
+            }}
+            clearable={false}
+            onChange={option => updateExploreParams({ expressionSort: option.value })}/>
+        </label>
+      </div>}
+      {showExpressionFilter && <div className="render-controls">
         <label>Expression filter</label>
         <Slider
           mode={1}

--- a/app/javascript/components/visualization/PlotDisplayControls.jsx
+++ b/app/javascript/components/visualization/PlotDisplayControls.jsx
@@ -6,7 +6,8 @@ import Select from '~/lib/InstrumentedSelect'
 import { Handle, Track, Tick } from '~/components/search/controls/slider/components'
 import PlotOptions from './plot-options'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
+import { faExternalLinkSquareAlt, faInfoCircle } from '@fortawesome/free-solid-svg-icons'
+import { Popover, OverlayTrigger } from 'react-bootstrap'
 const {
   SCATTER_COLOR_OPTIONS, defaultScatterColor, DISTRIBUTION_PLOT_OPTIONS, DISTRIBUTION_POINTS_OPTIONS,
   ROW_CENTERING_OPTIONS, FIT_OPTIONS
@@ -61,6 +62,15 @@ export default function RenderControls({ shownTab, exploreParams, updateExploreP
   const showExpressionFilter = ENABLE_EXPRESSION_FILTER && exploreParams.genes.length && showScatter
   const showExpressionSort = exploreParams.genes.length > 0 && showScatter
 
+  const expressionSortPopover = <Popover id={`expression-sort-popover`}>
+    Specify which cells to bring to the front of expression-based scatter plots based on expression value.&nbsp;
+    <a href="https://singlecell.zendesk.com/hc/en-us/articles/31772258040475" target="_blank">Learn more</a>.
+  </Popover>
+  const sortDocumentationLink =
+    <OverlayTrigger trigger={['hover', 'focus']} rootClose placement="left" overlay={expressionSortPopover} delayHide={1500}>
+        <a className="action help-icon"><FontAwesomeIcon icon={faInfoCircle}/></a>
+    </OverlayTrigger>
+
   return (
     <div>
       { showColorScale && <div className="render-controls">
@@ -82,11 +92,7 @@ export default function RenderControls({ shownTab, exploreParams, updateExploreP
       </div>}
       {showExpressionSort && <div className="render-controls">
         <label className="labeled-select">Order expression by&nbsp;
-          <a className="action help-icon"
-             data-toggle="tooltip"
-             data-original-title="Brings cells to the front of scatter plots by expression value.  Use 'unsorted' to disable ordering.">
-            <FontAwesomeIcon icon={faInfoCircle}/>
-          </a>
+          {sortDocumentationLink}
           <Select
             data-analytics-name="expression-sort-select"
             options={EXPRESSION_SORT_OPTIONS.map(opt => ({

--- a/app/javascript/components/visualization/PlotDisplayControls.jsx
+++ b/app/javascript/components/visualization/PlotDisplayControls.jsx
@@ -30,7 +30,7 @@ const railStyle = {
 // the code is in because it allows easier testing of the trace filtering logic implemented in plot.js
 const ENABLE_EXPRESSION_FILTER = false
 
-const EXPRESSION_SORT_OPTIONS = ['max', 'min', 'none']
+const EXPRESSION_SORT_OPTIONS = ['high', 'low', 'unsorted']
 /** the graph customization controls for the exlore tab */
 export default function RenderControls({ shownTab, exploreParams, updateExploreParams, allGenes }) {
   const scatterColorValue = exploreParams.scatterColor ? exploreParams.scatterColor : defaultScatterColor
@@ -85,7 +85,7 @@ export default function RenderControls({ shownTab, exploreParams, updateExploreP
         <label className="labeled-select">Order expression by&nbsp;
           <a className="action help-icon"
              data-toggle="tooltip"
-             data-original-title="Brings cells to the front of scatter plots by expression value.  Use 'none' to disable ordering.">
+             data-original-title="Brings cells to the front of scatter plots by expression value.  Use 'unsorted' to disable ordering.">
             <FontAwesomeIcon icon={faInfoCircle}/>
           </a>
           <Select

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -46,7 +46,7 @@ window.Plotly = Plotly
 function RawScatterPlot({
   studyAccession, cluster, annotation, subsample, consensus, genes, scatterColor, dimensionProps,
   isAnnotatedScatter=false, isCorrelatedScatter=false, isCellSelecting=false, plotPointsSelected, dataCache,
-  canEdit, bucketId, expressionFilter=[0, 1], setCountsByLabelForDe, hiddenTraces=[],
+  canEdit, bucketId, expressionFilter=[0, 1], expressionSort, setCountsByLabelForDe, hiddenTraces=[],
   isSplitLabelArrays, updateExploreParams, filteredCells
 }) {
   const [countsByLabel, setCountsByLabel] = useState(null)
@@ -199,6 +199,7 @@ function RawScatterPlot({
       scatter,
       activeTraceLabel,
       expressionFilter,
+      expressionSort,
       isSplitLabelArrays: isSplitLabelArrays ?? scatter.isSplitLabelArrays,
       isRefGroup: isRG,
       originalLabels,
@@ -501,7 +502,7 @@ function RawScatterPlot({
     fetchData()
   }, [
     cluster, loadedAnnotation, subsample, genes.join(','), isAnnotatedScatter, consensus,
-    filteredCells?.join(',')
+    filteredCells?.join(','), expressionSort
   ])
 
   useUpdateEffect(() => {
@@ -721,6 +722,7 @@ function getPlotlyTraces({
   },
   activeTraceLabel,
   expressionFilter,
+  expressionSort,
   isSplitLabelArrays,
   isRefGroup,
   originalLabels,
@@ -777,7 +779,7 @@ function getPlotlyTraces({
     let workingTrace = traces[0]
     let colors
     if (isGeneExpressionForColor) {
-      workingTrace = sortTraceByExpression(workingTrace)
+      workingTrace = sortTraceByExpression(workingTrace, expressionSort)
       colors = workingTrace.expression
     } else {
       colors = isGeneExpressionForColor ? workingTrace.expression : workingTrace.annotations

--- a/app/javascript/lib/plot.js
+++ b/app/javascript/lib/plot.js
@@ -261,13 +261,11 @@ PlotUtils.weightedZeroSort = function(a, b, sortOrder) {
     return 1
   }
 
-  if (sortOrder === 'high') {
-    return a - b
-  } else if (sortOrder === 'low') {
+  if (sortOrder === 'low') {
     return b - a
   } else {
     return a - b
-  }
+  } 
 }
 
 /**

--- a/app/javascript/lib/plot.js
+++ b/app/javascript/lib/plot.js
@@ -246,14 +246,39 @@ PlotUtils.sortTraces = function(traces, activeTraceLabel) {
 }
 
 /**
+ * sorting algorithm that prepends zero values before applying sort logic
+ * this causes non-zero expression to be plotted on top of zeros in specified order
+ *
+ * @param a first element to compare
+ * @param b second element to compare
+ * @param sortOrder order of sorting preference (high, low)
+ * @returns {number}
+ */
+PlotUtils.weightedZeroSort = function(a, b, sortOrder) {
+  if (a === 0) {
+    return -1
+  } else if (b === 0) {
+    return 1
+  }
+
+  if (sortOrder === 'high') {
+    return a - b
+  } else if (sortOrder === 'low') {
+    return b - a
+  } else {
+    return a - b
+  }
+}
+
+/**
  * sort the passed in trace by expression value
  *
  * @param trace {Object} Plotly trace data
- * @param sortType {String} type of sort to perform (max, min, or none)
+ * @param sortOrder {String} order of sorting preference (high, low, or unsorted)
  *
  * */
-PlotUtils.sortTraceByExpression = function(trace, sortType) {
-  if (sortType === 'unsorted') { return trace }
+PlotUtils.sortTraceByExpression = function(trace, sortOrder) {
+  if (sortOrder === 'unsorted') { return trace }
   const hasZ = !!trace.z
   const traceLength = trace.x.length
   const sortedTrace = {
@@ -265,19 +290,7 @@ PlotUtils.sortTraceByExpression = function(trace, sortType) {
   for (let i = 0; i < traceLength; i++) {
     expressionsWithIndices[i] = [trace.expression[i], i]
   }
-  let compareFn
-  switch (sortType) {
-    case 'high':
-      compareFn = function(a,b) { return a[0] - b[0] }
-      break
-    case 'low':
-      compareFn = function(a,b) { return b[0] - a[0] }
-      break
-    default:
-      compareFn = function(a,b) { return a[0] - b[0] }
-      break
-  }
-  expressionsWithIndices.sort(compareFn)
+  expressionsWithIndices.sort(function(a,b) { return PlotUtils.weightedZeroSort(a[0], b[0], sortOrder) })
 
   // initialize the other arrays with their size
   // (see https://codeabitwiser.com/2015/01/high-performance-javascript-arrays-pt1/ for performance rationale)

--- a/app/javascript/lib/plot.js
+++ b/app/javascript/lib/plot.js
@@ -253,7 +253,7 @@ PlotUtils.sortTraces = function(traces, activeTraceLabel) {
  *
  * */
 PlotUtils.sortTraceByExpression = function(trace, sortType) {
-  if (sortType === 'none') { return trace }
+  if (sortType === 'unsorted') { return trace }
   const hasZ = !!trace.z
   const traceLength = trace.x.length
   const sortedTrace = {
@@ -267,10 +267,10 @@ PlotUtils.sortTraceByExpression = function(trace, sortType) {
   }
   let compareFn
   switch (sortType) {
-    case 'max':
+    case 'high':
       compareFn = function(a,b) { return a[0] - b[0] }
       break
-    case 'min':
+    case 'low':
       compareFn = function(a,b) { return b[0] - a[0] }
       break
     default:

--- a/app/javascript/lib/plot.js
+++ b/app/javascript/lib/plot.js
@@ -245,8 +245,15 @@ PlotUtils.sortTraces = function(traces, activeTraceLabel) {
   return traces.sort(traceCountsSort)
 }
 
-/** sort the passsed in trace by expression value */
-PlotUtils.sortTraceByExpression = function(trace) {
+/**
+ * sort the passed in trace by expression value
+ *
+ * @param trace {Object} Plotly trace data
+ * @param sortType {String} type of sort to perform (max, min, or none)
+ *
+ * */
+PlotUtils.sortTraceByExpression = function(trace, sortType) {
+  if (sortType === 'none') { return trace }
   const hasZ = !!trace.z
   const traceLength = trace.x.length
   const sortedTrace = {
@@ -258,7 +265,19 @@ PlotUtils.sortTraceByExpression = function(trace) {
   for (let i = 0; i < traceLength; i++) {
     expressionsWithIndices[i] = [trace.expression[i], i]
   }
-  expressionsWithIndices.sort((a, b) => a[0] - b[0])
+  let compareFn
+  switch (sortType) {
+    case 'max':
+      compareFn = function(a,b) { return a[0] - b[0] }
+      break
+    case 'min':
+      compareFn = function(a,b) { return b[0] - a[0] }
+      break
+    default:
+      compareFn = function(a,b) { return a[0] - b[0] }
+      break
+  }
+  expressionsWithIndices.sort(compareFn)
 
   // initialize the other arrays with their size
   // (see https://codeabitwiser.com/2015/01/high-performance-javascript-arrays-pt1/ for performance rationale)

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1226,6 +1226,11 @@ class Study
     self.default_options[:color_profile].presence
   end
 
+  # default sorting direction for expression-based scatter plots
+  def default_expression_sort
+    default_options[:expression_sort]
+  end
+
   # array of names of annotations to ignore the unique values limit for visualizing
   def override_viz_limit_annotations
     self.default_options[:override_viz_limit_annotations] || []

--- a/app/views/site/_study_settings_viz.html.erb
+++ b/app/views/site/_study_settings_viz.html.erb
@@ -46,7 +46,14 @@
         </div>
       </div>
       <div class="form-group row">
-        <div class="col-sm-12">
+        <div class="col-sm-3">
+          <%= opts.label :expression_sort, 'Expression ordering' %>&nbsp
+          <span class="fas fa-question-circle" data-toggle="popover" data-placement="right" data-html="true"
+                data-content='Specify which cells to bring to the front of expression-based scatter plots based on expression value.  <a href="https://singlecell.zendesk.com/hc/en-us/articles/31772258040475" target="_blank">Learn more</a>.'>
+          </span> <br />
+          <%= opts.select :expression_sort, options_for_select(%w[high low unsorted], @study.default_expression_sort), { include_blank: true }, class: 'form-control' %>
+        </div>
+        <div class="col-sm-9">
           <%= opts.label :expression_label, 'Expression axis label' %>&nbsp;<span class="fas fa-question-circle" data-toggle="tooltip" data-placement="right" title='This is displayed as the axis label for box & scatter plots showing expression values.  This label is global to all expression values.'></span> <br />
           <%= opts.text_field :expression_label, value: @study.default_options[:expression_label], placeholder: @study.default_expression_label, class: 'form-control' %>
         </div>

--- a/app/views/studies/_study_default_options_form.html.erb
+++ b/app/views/studies/_study_default_options_form.html.erb
@@ -51,6 +51,19 @@
           <% end %>
         </div>
       </div>
+      <div class="form-group row">
+        <div class="col-sm-3">
+          <%= f.label :expression_sort, 'Expression ordering' %>&nbsp
+          <span class="fas fa-question-circle" data-toggle="popover" data-placement="right" data-html="true"
+                data-content='Specify which cells to bring to the front of expression-based scatter plots based on expression value.  <a href="https://singlecell.zendesk.com/hc/en-us/articles/31772258040475" target="_blank">Learn more</a>.'>
+          </span> <br />
+          <%= f.select :expression_sort, options_for_select(%w[high low unsorted], @study.default_expression_sort), { include_blank: true }, class: 'form-control' %>
+        </div>
+        <div class="col-sm-9">
+          <%= f.label :expression_label, 'Expression axis label' %>&nbsp;<span class="fas fa-question-circle" data-toggle="tooltip" data-placement="right" title='This is displayed as the axis label for box & scatter plots showing expression values.  This label is global to all expression values.'></span> <br />
+          <%= f.text_field :expression_label, value: @study.default_options[:expression_label], placeholder: @study.default_expression_label, class: 'form-control' %>
+        </div>
+      </div>
       <script type="text/javascript" nonce="<%= content_security_policy_script_nonce %>">
         $('#study_default_options_annotation').change(function() {
             var annotType = $(this).val().split('--')[1];

--- a/test/api/visualization/explore_controller_test.rb
+++ b/test/api/visualization/explore_controller_test.rb
@@ -47,6 +47,11 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
     }
     UserAnnotationService.create_user_annotation(@public_study, 'user_annot',
       user_annot_data, 'clusterP.txt', 'foo--group--cluster', nil, @user)
+    @basic_study.update(default_options: {
+      cluster: 'clusterA.txt',
+      annotation: 'foo--group--cluster',
+      expression_sort: 'low'
+    })
   end
 
   teardown do
@@ -79,9 +84,13 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
     assert_equal [cluster_name], json['clusterGroupNames']
     assert_equal [{"name" => 'spatialA.txt', "associated_clusters" => []}], json['spatialGroups']
     assert_includes json['hasImageCache'], cluster_name
+    assert_equal @basic_study.default_cluster.name, json.dig('annotationList', 'default_cluster')
+    assert_equal @basic_study.default_annotation, json.dig('annotationList', 'default_annotation', 'identifier')
+    assert_equal @basic_study.default_expression_sort, json['expressionSort']
 
     execute_http_request(:get, api_v1_study_explore_path(@empty_study))
     assert_equal [], json['clusterGroupNames']
+
   end
 
   test 'should get annotation listings' do

--- a/test/js/explore/plot-utils.test.js
+++ b/test/js/explore/plot-utils.test.js
@@ -126,7 +126,7 @@ describe('Plot grouping function cache', () => {
     expect(traces).toHaveLength(1)
     expect(traces[0].x).toEqual([1, 2, 3, 4, 5])
 
-    const sortedTraceMax = PlotUtils.sortTraceByExpression(traces[0], 'max')
+    const sortedTraceMax = PlotUtils.sortTraceByExpression(traces[0], 'high')
     expect(sortedTraceMax).toEqual({
       x: [1, 5, 3, 2, 4],
       y: [4, 8, 6, 5, 7],
@@ -135,7 +135,7 @@ describe('Plot grouping function cache', () => {
       expression: [0, 0, 1, 4, 5.5]
     })
 
-    const sortedTraceMin = PlotUtils.sortTraceByExpression(traces[0], 'min')
+    const sortedTraceMin = PlotUtils.sortTraceByExpression(traces[0], 'low')
     expect(sortedTraceMin).toEqual({
       annotations: ["a", "b", "c", "a", "b"],
       cells: ["c4", "c2", "c3", "c1", "c5"],
@@ -144,7 +144,7 @@ describe('Plot grouping function cache', () => {
       y: [7, 5, 6, 4, 8]
     })
 
-    const sortedTraceNone = PlotUtils.sortTraceByExpression(traces[0], 'none')
+    const sortedTraceNone = PlotUtils.sortTraceByExpression(traces[0], 'unsorted')
     expect(sortedTraceNone).toEqual(data)
   })
 

--- a/test/js/explore/plot-utils.test.js
+++ b/test/js/explore/plot-utils.test.js
@@ -126,26 +126,42 @@ describe('Plot grouping function cache', () => {
     expect(traces).toHaveLength(1)
     expect(traces[0].x).toEqual([1, 2, 3, 4, 5])
 
+    // zero expression points are always returned first now
     const sortedTraceMax = PlotUtils.sortTraceByExpression(traces[0], 'high')
     expect(sortedTraceMax).toEqual({
-      x: [1, 5, 3, 2, 4],
-      y: [4, 8, 6, 5, 7],
-      annotations: ['a', 'b', 'c', 'b', 'a'],
-      cells: ['c1', 'c5', 'c3', 'c2', 'c4'],
+      x: [5, 1, 3, 2, 4],
+      y: [8, 4, 6, 5, 7],
+      annotations: ['b', 'a', 'c', 'b', 'a'],
+      cells: ['c5', 'c1', 'c3', 'c2', 'c4'],
       expression: [0, 0, 1, 4, 5.5]
     })
 
     const sortedTraceMin = PlotUtils.sortTraceByExpression(traces[0], 'low')
     expect(sortedTraceMin).toEqual({
-      annotations: ["a", "b", "c", "a", "b"],
-      cells: ["c4", "c2", "c3", "c1", "c5"],
-      expression: [5.5, 4, 1, 0, 0],
-      x: [4, 2, 3, 1, 5],
-      y: [7, 5, 6, 4, 8]
+      x: [ 5, 1, 4, 2, 3 ],
+      y: [ 8, 4, 7, 5, 6 ],
+      annotations: [ 'b', 'a', 'a', 'b', 'c' ],
+      cells: [ 'c5', 'c1', 'c4', 'c2', 'c3' ],
+      expression: [ 0, 0, 5.5, 4, 1 ]
     })
 
     const sortedTraceNone = PlotUtils.sortTraceByExpression(traces[0], 'unsorted')
     expect(sortedTraceNone).toEqual(data)
+  })
+
+  it('sorts values but prioritizes zeros', async () => {
+    // confirm that 0 is always prioritized even when comparison is less
+    expect(PlotUtils.weightedZeroSort(0, -1, 'high')).toEqual(-1)
+    expect(PlotUtils.weightedZeroSort(-1,0, 'high')).toEqual(1)
+    expect(PlotUtils.weightedZeroSort(0, -1, 'low')).toEqual(-1)
+    expect(PlotUtils.weightedZeroSort(-1,0, 'low')).toEqual(1)
+    // testing sort direction
+    expect(PlotUtils.weightedZeroSort(1, 1, 'high')).toEqual(0)
+    expect(PlotUtils.weightedZeroSort(1, 2, 'high')).toEqual(-1)
+    expect(PlotUtils.weightedZeroSort(2, 1, 'high')).toEqual(1)
+    expect(PlotUtils.weightedZeroSort(1, 1, 'low')).toEqual(0)
+    expect(PlotUtils.weightedZeroSort(1, 2, 'low')).toEqual(1)
+    expect(PlotUtils.weightedZeroSort(2, 1, 'low')).toEqual(-1)
   })
 
   it('filters on expression data ', async () => {

--- a/test/js/explore/plot-utils.test.js
+++ b/test/js/explore/plot-utils.test.js
@@ -126,14 +126,26 @@ describe('Plot grouping function cache', () => {
     expect(traces).toHaveLength(1)
     expect(traces[0].x).toEqual([1, 2, 3, 4, 5])
 
-    const sortedTrace = PlotUtils.sortTraceByExpression(traces[0])
-    expect(sortedTrace).toEqual({
+    const sortedTraceMax = PlotUtils.sortTraceByExpression(traces[0], 'max')
+    expect(sortedTraceMax).toEqual({
       x: [1, 5, 3, 2, 4],
       y: [4, 8, 6, 5, 7],
       annotations: ['a', 'b', 'c', 'b', 'a'],
       cells: ['c1', 'c5', 'c3', 'c2', 'c4'],
       expression: [0, 0, 1, 4, 5.5]
     })
+
+    const sortedTraceMin = PlotUtils.sortTraceByExpression(traces[0], 'min')
+    expect(sortedTraceMin).toEqual({
+      annotations: ["a", "b", "c", "a", "b"],
+      cells: ["c4", "c2", "c3", "c1", "c5"],
+      expression: [5.5, 4, 1, 0, 0],
+      x: [4, 2, 3, 1, 5],
+      y: [7, 5, 6, 4, 8]
+    })
+
+    const sortedTraceNone = PlotUtils.sortTraceByExpression(traces[0], 'none')
+    expect(sortedTraceNone).toEqual(data)
   })
 
   it('filters on expression data ', async () => {

--- a/test/js/visualization/scatter-plot.test.js
+++ b/test/js/visualization/scatter-plot.test.js
@@ -212,11 +212,13 @@ describe('getPlotlyTraces handles expression graphs', () => {
     // should return just a single trace, since we are plotting by expression rather than annotation
     expect(traces).toHaveLength(1)
     const trace = traces[0]
+    console.log(trace)
     expect(trace.type).toEqual('scattergl')
-    expect(trace.x).toEqual([2, 5, 7, 1, 3, 8, 4, 6])
-    expect(trace.y).toEqual([2, 5, 7, 1, 3, 8, 4, 6])
+    expect(trace.x).toEqual([7, 5, 2, 1, 3, 8, 4, 6])
+    expect(trace.y).toEqual([7, 5, 2, 1, 3, 8, 4, 6])
+    expect(trace.expression).toEqual([0, 0, 0, 0.1, 2, 3.1, 4.5, 6.5])
     expect(trace.marker.color).toEqual([0, 0, 0.0, 0.1, 2, 3.1, 4.5, 6.5])
-    expect(trace.cells).toEqual(['B', 'E', 'G', 'A', 'C', 'H', 'D', 'F'])
+    expect(trace.cells).toEqual(['G', 'E', 'B', 'A', 'C', 'H', 'D', 'F'])
     expect(trace.annotations).toEqual(['s1', 's2', 's1', 's1', 's1', 's2', 's1', 's2'])
     expect(trace.hovertemplate).toEqual('(%{x}, %{y})<br>%{text} (%{meta})<br>Expression: %{marker.color}<extra></extra>')
   })


### PR DESCRIPTION
#### BACKGROUND
By default, SCP sorts all expression-based scatter plots by the observed expression for each cell from lowest to highest and then plots in that order.  This has the visible effect of bringing the cells with the highest expression to the front, as earlier cells are plotted underneath those later in the array.  While this does surface significant expression values for users, it is biased towards highly expressed cells.  This may not be what a user is intending or expecting to find, and can be confusing.  Furthermore, this feature is not documented anywhere and is completely opaque to users.

#### CHANGES
Now, all expression-based scatter plots will render a control labeled `Order expression by` with three values: `high`, `low`, and `unsorted`.  The default is `high` which behaves exactly as plots do now.  Selecting `low` will invert this behavior with a special caveat - any cells with no observed expression (i.e. a value of `0.0`) will still render in the background.  This will surface cells with low observed expression which are normally hidden by highly expressed cells.  Finally, selecting `unsorted` will turn off this behavior and plot cells in the order in which they appear in the clustering file.  This last option gives study owners the ability to control rendering order explicitly for expression scatter plots.

Also, there is now a study default option that maps to this control.  It can be configured in either the Study settings > View options tab or in the Study details page.  More information about how SCP sorts scatter plot data has also been added to a new guide page: https://singlecell.zendesk.com/hc/en-us/articles/31772258040475-How-SCP-renders-data-in-scatter-plots (you must log in as scp-zendesk to view as it is unpublished).

#### MANUAL TESTING
1. Boot as normal and sign in
2. Load the `Human milk - differential expression` study
3. Query for `CLDN4` and confirm the default rendering appears as it normally does with highly expressed cells in the `LC1` region
![Screenshot 2024-12-11 at 2 51 54 PM](https://github.com/user-attachments/assets/241d0f91-7c7d-43fb-8a28-44e9ec0a79c3)
4. In the options panel, change the sorting to `low` and confirm the plot updates accordingly:
![Screenshot 2024-12-11 at 2 53 38 PM](https://github.com/user-attachments/assets/7371e89c-4008-4de9-a7fd-e57f494579a3)
5. Repeat with the `unsorted` option and confirm the display updates:
![Screenshot 2024-12-11 at 2 53 50 PM](https://github.com/user-attachments/assets/5b80a0e7-3181-424c-b6cb-418390ec7997)
6. Hover over the info icon next to the select menu and confirm you can click the link to the documentation page
7. Go into the Settings > View options panel and select `low` as the default sorting and save
8. Go back to the explore tab, click "Reset view" (**this is important!**) and then re-query for `CLDN4` and confirm the sorting is set to `low` without the URL parameter being specified