### PR TITLE
Adding Bluesky profile link (SCP-5876)

### DIFF
--- a/app/javascript/styles/_brand.scss
+++ b/app/javascript/styles/_brand.scss
@@ -150,6 +150,23 @@
   height: 54px;
   padding: 5px 30px 0 15px;
   display: inline-block;
+
+  a {
+    margin-right: 17px;
+  }
+}
+
+.bluesky-logo {
+  color: white;
+  position: relative;
+  top: 8px;
+  left: 3px;
+}
+
+.bluesky-link {
+  color: transparent !important;
+  background-color: transparent !important;
+  margin-top: 10px;
 }
 
 .study-panel, .study-genes-panel {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -203,7 +203,7 @@
       <% end %>
     </div>
     <div class="footer-social-media-icons-block pull-right">
-      <a class="bluesky-link" href="https://bsky.app/profile/singlecell.broadinstitute.org" target="_blank">
+      <a class="bluesky-link" href="https://bsky.app/profile/singlecell.broadinstitute.org" target="_blank" data-analytics-name="bluesky-link" aria-label="Bluesky">
         <svg class="bluesky-logo" xmlns="http://www.w3.org/2000/svg" fill="none" width="35" height="35" viewBox="0 0 628 561">
           <path fill="currentColor" d="M123.121 33.664C188.241 82.553 258.281 181.68 284 234.873c25.719-53.192 95.759-152.32 160.879-201.21C491.866-1.611 568-28.906 568 57.947c0 17.346-9.945 145.713-15.778 166.555-20.275 72.453-94.155 90.933-159.875 79.748C507.222 323.8 536.444 388.56 473.333 453.32c-119.86 122.992-172.272-30.859-185.702-70.281-2.462-7.227-3.614-10.608-3.631-7.733-.017-2.875-1.169.506-3.631 7.733-13.43 39.422-65.842 193.273-185.702 70.281-63.111-64.76-33.89-129.52 80.986-149.071-65.72 11.185-139.6-7.295-159.875-79.748C9.945 203.659 0 75.291 0 57.946 0-28.906 76.135-1.612 123.121 33.664Z"></path>
         </svg>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -202,12 +202,15 @@
         <%= link_to "<i class='fas fa-chevron-circle-left fa-fw'></i> Return to Single Cell Portal".html_safe, site_path %>
       <% end %>
     </div>
-    <div class="footer-social-media-icons-block pull-right ">
-    <%= link_to "<i class='fab fa-youtube'></i>".html_safe, "https://www.youtube.com/channel/UCp_UGD74MW8up1YkWZrWkKw", target: :_blank, 'data-analytics-name' => 'youtube-link',  'aria-label' => 'YouTube' %>
-    &nbsp;
-    <%= link_to "<i class='fab fa-twitter-square', data-analytics-name='twitter-link' ></i>".html_safe, "https://twitter.com/SingleCellBroad", target: :_blank, 'data-analytics-name' => 'twitter-link', 'aria-label' => 'Twitter' %>
-    &nbsp;
-  </div>
+    <div class="footer-social-media-icons-block pull-right">
+      <a class="bluesky-link" href="https://bsky.app/profile/singlecell.broadinstitute.org" target="_blank">
+        <svg class="bluesky-logo" xmlns="http://www.w3.org/2000/svg" fill="none" width="35" height="35" viewBox="0 0 628 561">
+          <path fill="currentColor" d="M123.121 33.664C188.241 82.553 258.281 181.68 284 234.873c25.719-53.192 95.759-152.32 160.879-201.21C491.866-1.611 568-28.906 568 57.947c0 17.346-9.945 145.713-15.778 166.555-20.275 72.453-94.155 90.933-159.875 79.748C507.222 323.8 536.444 388.56 473.333 453.32c-119.86 122.992-172.272-30.859-185.702-70.281-2.462-7.227-3.614-10.608-3.631-7.733-.017-2.875-1.169.506-3.631 7.733-13.43 39.422-65.842 193.273-185.702 70.281-63.111-64.76-33.89-129.52 80.986-149.071-65.72 11.185-139.6-7.295-159.875-79.748C9.945 203.659 0 75.291 0 57.946 0-28.906 76.135-1.612 123.121 33.664Z"></path>
+        </svg>
+      </a>
+      <%= link_to "<i class='fab fa-youtube'></i>".html_safe, "https://www.youtube.com/channel/UCp_UGD74MW8up1YkWZrWkKw", target: :_blank, 'data-analytics-name' => 'youtube-link',  'aria-label' => 'YouTube' %>
+      <%= link_to "<i class='fab fa-twitter-square', data-analytics-name='twitter-link' ></i>".html_safe, "https://twitter.com/SingleCellBroad", target: :_blank, 'data-analytics-name' => 'twitter-link', 'aria-label' => 'Twitter' %>
+    </div>
     <div class="clearfix"></div>
 
 </div>


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds a link to the [SCP Bluesky profile](https://bsky.app/profile/singlecell.broadinstitute.org), as well as updating our DNS to use our hostname as the username.