### PR TITLE
Updating bundler due to install errors (SCP-5891)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -616,4 +616,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.3.19
+   2.6.0

--- a/test/models/differential_expression_result_test.rb
+++ b/test/models/differential_expression_result_test.rb
@@ -137,7 +137,7 @@ class DifferentialExpressionResultTest < ActiveSupport::TestCase
     result.pairwise_comparisons.each_pair do |label, comparisons|
       comparisons.each do |comparison_group|
         # should sort labels naturally and put 'Custom 2' in front of 'Custom 10'
-        expected_filename = "#{prefix}/cluster_diffexp_txt--#{name}--Custom_2--Custom_10--study--wilcoxon.tsv"
+        expected_filename = "#{prefix}/cluster_diffexp_txt--#{name}--Custom_10--Custom_2--study--wilcoxon.tsv"
         assert_equal expected_filename, result.bucket_path_for(label, comparison_group:)
       end
     end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates `bundler` to the most recent release of `2.6.0` to address [build errors](https://github.com/broadinstitute/single_cell_portal_core/actions/runs/12377207275) when merging PRs.  Deployments to staging and production are blocked until this is addressed.

#### MANUAL TESTING
A [manual run](https://github.com/broadinstitute/single_cell_portal_core/actions/runs/12378402176/job/34550181658) of the Docker build job with this branch succeeded and published [this image](https://console.cloud.google.com/gcr/images/broad-singlecellportal-staging/global/single-cell-portal@sha256:831108231526b53b87170e95b9c9f73e08cbf62e54d413993655be2019a9048c/details?project=broad-singlecellportal-staging) to GCR.