### PR TITLE
Setting maximum machine type for certain OOM retries (SCP-5896)

### DIFF
--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -10,6 +10,9 @@ class DifferentialExpressionParameters
   # RAM scaling coefficient for auto-selecting machine_type
   RAM_SCALING = 3.5
 
+  # largest machine to use for auto-scaling (equates to n2d-highmem-16)
+  MAX_MACHINE_CORES = 16
+
   # annotation_name: name of annotation to use for DE
   # annotation_scope: scope of annotation (study, cluster)
   # annotation_file: source file for above annotation

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -40,9 +40,6 @@ class IngestJob
     differential_expression render_expression_arrays image_pipeline ingest_anndata
   ].freeze
 
-  # normal ingest VMs to use for "classic" file OOM retries
-  STANDARD_MACHINE_TYPES = %w[n2d-highmem-4 n2d-highmem-8 n2d-highmem-16]
-
   # Name of pipeline submission running in GCP (from [BatchApiClient#run_job])
   attr_accessor :pipeline_name
   # Study object where file is being ingested
@@ -334,17 +331,6 @@ class IngestJob
   #   - (String) => machine_type name, e.g. n2d-highmem-4
   def machine_type
     params_object&.machine_type || get_ingest_run.allocation_policy.instances.first.policy.machine_type
-  end
-
-  # helper for getting the next available GCE machine type, if possible
-  #
-  # * *returns*
-  #   - (String) => machine_type name, e.g. n2d-highmem-8
-  def next_machine_type
-    return params_object.next_machine_type if params_object.present?
-
-    current_machine = STANDARD_MACHINE_TYPES.index(machine_type)
-    current_machine && STANDARD_MACHINE_TYPES[current_machine + 1]
   end
 
   # Get a timestamp from a metadata event or datetime string

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -40,6 +40,9 @@ class IngestJob
     differential_expression render_expression_arrays image_pipeline ingest_anndata
   ].freeze
 
+  # normal ingest VMs to use for "classic" file OOM retries
+  STANDARD_MACHINE_TYPES = %w[n2d-highmem-4 n2d-highmem-8 n2d-highmem-16]
+
   # Name of pipeline submission running in GCP (from [BatchApiClient#run_job])
   attr_accessor :pipeline_name
   # Study object where file is being ingested
@@ -331,6 +334,17 @@ class IngestJob
   #   - (String) => machine_type name, e.g. n2d-highmem-4
   def machine_type
     params_object&.machine_type || get_ingest_run.allocation_policy.instances.first.policy.machine_type
+  end
+
+  # helper for getting the next available GCE machine type, if possible
+  #
+  # * *returns*
+  #   - (String) => machine_type name, e.g. n2d-highmem-8
+  def next_machine_type
+    return params_object.next_machine_type if params_object.present?
+
+    current_machine = STANDARD_MACHINE_TYPES.index(machine_type)
+    current_machine && STANDARD_MACHINE_TYPES[current_machine + 1]
   end
 
   # Get a timestamp from a metadata event or datetime string

--- a/test/models/ann_data_ingest_parameters_test.rb
+++ b/test/models/ann_data_ingest_parameters_test.rb
@@ -121,4 +121,13 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
     params = AnnDataIngestParameters.new(anndata_file: 'gs://bucket_id/test.h5ad', file_size: 100.gigabytes)
     assert_equal AnnDataIngestParameters::PARAM_DEFAULTS[:extract], params.extract
   end
+
+  test 'should set next machine type' do
+    params = AnnDataIngestParameters.new(@extract_params)
+    assert_equal 'n2d-highmem-32', params.machine_type
+    new_machine = params.next_machine_type
+    assert_equal 'n2d-highmem-48', new_machine
+    params.machine_type = 'n2d-highmem-64'
+    assert_nil params.next_machine_type
+  end
 end

--- a/test/models/differential_expression_parameters_test.rb
+++ b/test/models/differential_expression_parameters_test.rb
@@ -132,11 +132,12 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
     assert_equal 'n2d-highmem-8', params.machine_type
   end
 
-  test 'should scale machine type for h5ad files' do
+  test 'should scale machine type for h5ad files up to limit' do
     params = DifferentialExpressionParameters.new(
-      matrix_file_path: 'gs://test_bucket/matrix.h5ad', matrix_file_type: 'h5ad', file_size: 64.gigabytes
+      matrix_file_path: 'gs://test_bucket/matrix.h5ad', matrix_file_type: 'h5ad', file_size: 32.gigabytes
     )
-    assert_equal 'n2d-highmem-32', params.machine_type
+    assert_equal 'n2d-highmem-16', params.machine_type
+    assert_nil params.next_machine_type
   end
 
   test 'should remove non-attribute values from attribute hash' do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
As a follow-on to the investigation into the [costs for certain differential expression](https://docs.google.com/document/d/10GgBHQV5XMOyNsVD05pZ_Slg9By48tifuSzYKTOej7A/edit?tab=t.0#heading=h.x4jtl67nwvnb) jobs, a "maximum" machine type of `n2d-highmem-16` is being enforced for OOM retries.  This is to limit the potential costs of automated retries, as larger machine types above `n2d-highmem-16` incur significant hourly costs, and DE jobs can potentially run for days depending on factors such as cell count and data density.  Now a DE job will start on an `n2d-highmem-8` and retry once on `n2d-highmem-16` before ceasing all retries.  Note this only covers _automated_ retries on DE jobs - we can still manually launch a job on whatever machine type we want.  AnnData extraction/ingest jobs will continue to scale as normal as these jobs are much shorter-lived.

#### MANUAL TESTING
1. Pull branch and open a Rails console session
2. Create a blank DE parameters object and confirm it has the default `machine_type` of `n2d-highmem-8`:
```
params = DifferentialExpressionParameters.new
params.machine_type
=> "n2d-highmem-8"
```
3. Assign the next `machine_type` and then confirm there are no more machines available after that:
```
params.machine_type = params.next_machine_type
=> "n2d-highmem-16"
params.next_machine_type
=> nil
```
4. Confirm that AnnData params still scale normally:
```
anndata = AnnDataIngestParameters.new
anndata.machine_type
=> "n2d-highmem-4"

while anndata.next_machine_type
  anndata.machine_type = anndata.next_machine_type
  puts "machine_type: #{anndata.machine_type}"
end
...
machine_type: n2d-highmem-8
machine_type: n2d-highmem-16                                                                              
machine_type: n2d-highmem-32                                                                              
machine_type: n2d-highmem-48                                                                              
machine_type: n2d-highmem-64                                                                              
=> nil                  
```