### PR TITLE
Updating terms of service with data retention policy (SCP-5792)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,8 @@ class ApplicationController < ActionController::Base
   before_action :get_download_quota
   before_action :get_deployment_notification
   before_action :set_selected_branding_group
-  before_action :check_tos_acceptance
+  # allow users to view privacy policy even if they haven't accepted the ToS yet
+  before_action :check_tos_acceptance, except: :privacy_policy
   before_action :set_ab_test_assignments
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :invalid_csrf

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -96,7 +96,11 @@ class ProfilesController < ApplicationController
     end
   end
 
-  def accept_tos; end
+  def accept_tos
+    @previous_acceptance = TosAcceptance.where(
+      email: @user.email, :version.ne => TosAcceptance::CURRENT_VERSION
+    ).order_by(&:version).last
+  end
 
   def record_tos_action
     user_accepted = tos_params[:action] == 'accept'

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1884,10 +1884,10 @@ class Study
   ###
 
   def enforce_embargo_max_length
-    return true if embargo.blank?
+    return true if embargo.blank? || !public
 
     unless embargo <= created_at + MAX_EMBARGO
-      errors.add(:embargo, "cannot be longer than two years from date of creation (#{created_at.to_date.strftime('%m/%d/%Y')})")
+      errors.add(:embargo, "cannot be longer than two years from date of creation (#{created_at.to_date.strftime('%m/%d/%Y')}) for public studies")
     end
   end
 

--- a/app/models/tos_acceptance.rb
+++ b/app/models/tos_acceptance.rb
@@ -2,7 +2,7 @@ class TosAcceptance
   include Mongoid::Document
   include Mongoid::Timestamps
 
-  CURRENT_VERSION = Date.parse('2018-08-29') # current revision of ToS
+  CURRENT_VERSION = Date.parse('2025-01-15') # current revision of ToS
 
   field :email, type: String
   field :version, type: Date, default: CURRENT_VERSION

--- a/app/views/profiles/accept_tos.html.erb
+++ b/app/views/profiles/accept_tos.html.erb
@@ -1,5 +1,13 @@
 <h1 id="tos-title">Terms of service, revised [<%= TosAcceptance.current_version %>]</h1>
 <div id="tos-content">
+  <% if @previous_acceptance %>
+    <div class="bs-callout bs-callout-primary">
+      <p>
+        Our terms have updated since the last version on <%= @previous_acceptance.version %>.  Please review carefully
+        the terms in their entirety by scrolling to the bottom of the page.
+      </p>
+    </div>
+  <% end %>
   <%= render :partial => '/site/tos_content' %>
 </div>
 <%= form_for :tos, url: record_tos_action_path, html: {class: 'form', id: 'tos-form'} do |f| %>

--- a/app/views/site/_study_settings_general.html.erb
+++ b/app/views/site/_study_settings_general.html.erb
@@ -14,7 +14,7 @@
     <span class='fas fa-question-circle' data-toggle='tooltip' data-placement='right'
           title='Setting a data release date will prevent downloads for everyone except study owners & shared users,
           and will expire at 12AM on the date specified (leave blank to allow downloads).  This has a maximum length of
-          <%= Study.max_embargo_text %>.'>
+          <%= Study.max_embargo_text %> from date of creation for public studies.'>
     </span><br />
     <%= f.date_field :embargo, class: 'form-control', max: f.object.max_embargo %>
   </div>

--- a/app/views/site/_study_settings_general.html.erb
+++ b/app/views/site/_study_settings_general.html.erb
@@ -11,11 +11,12 @@
 <div class="form-group row">
   <div class="col-md-4">
     <%= f.label :embargo, 'Data release date' %>&nbsp;
-    <span class='fas fa-question-circle' data-toggle='tooltip'
+    <span class='fas fa-question-circle' data-toggle='tooltip' data-placement='right'
           title='Setting a data release date will prevent downloads for everyone except study owners & shared users,
-          and will expire at 12AM on the date specified (leave blank to allow downloads)' data-placement='right'>
+          and will expire at 12AM on the date specified (leave blank to allow downloads).  This has a maximum length of
+          <%= Study.max_embargo_text %>.'>
     </span><br />
-    <%= f.date_field :embargo, class: 'form-control' %>
+    <%= f.date_field :embargo, class: 'form-control', max: f.object.max_embargo %>
   </div>
   <div class="col-md-4">
     <%= f.label :public %><br />

--- a/app/views/site/_tos_content.html.erb
+++ b/app/views/site/_tos_content.html.erb
@@ -72,7 +72,7 @@
 <h3>Data Retention Policy</h3>
 <p>All users creating a new study are permitted to upload and host data on SCP free of charge by selecting the "Default"
   Terra billing project.  Any study created in that project will be subject to the following data retention policy.
-  Any study created using a user-controlled Terra billing project is not subject to this policy.</p>
+  Any study created in a user-controlled Terra billing project is exempt.</p>
 <h4>Public Studies</h4>
 <p>Any study marked as "public" that provides visualizations and/or downloadable data files can be stored indefinitely
   provided it remains public and accessible.</p>

--- a/app/views/site/_tos_content.html.erb
+++ b/app/views/site/_tos_content.html.erb
@@ -68,8 +68,23 @@
     or confidential data unless appropriate consents and/or approvals have been obtained.</li>
   <li>Assure the owner and individuals who have sharing access to a study agree to having their emails associated publicly
     with the study or have sharing access removed before the study is public.</li>
-
 </ul>
+<h3>Data Retention Policy</h3>
+<p>All users creating a new study are permitted to upload and host data on SCP free of charge by selecting the "Default"
+  Terra billing project.  Any study created in that project will be subject to the following data retention policy.
+  Any study created using a user-controlled Terra billing project is not subject to this policy.</p>
+<h4>Public Studies</h4>
+<p>Any study marked as "public" that provides visualizations and/or downloadable data files can be stored indefinitely
+  provided it remains public and accessible.</p>
+<h4>Private Studies</h4>
+<p>Any study that is not publicly accessible may be stored for a term of up to one year from the data of creation.
+  After this term expires, such studies will be candidates for removal.  Study owners will be notified prior to
+  any removal and given a period of 30 days in which to convert their study to public.  After this period expires, any
+  remaining private studies are subject to removal at the discretion of SCP admins.</p>
+<h3>Data Embargoes</h3>
+<p>All studies in SCP may enforce a data embargo (regardless of study visibility) that will prevent other users from
+  downloading data files before the embargo expires.  The embargo will have a maximum length of two (2) years from date
+  of study creation.</p>
 <h3>Access Levels</h3>
 <p>Your level of access to SCP is limited to ensure your access is no more than necessary to perform your legitimate tasks
   or assigned duties. If you believe you are being granted access that you should not have, you must immediately notify

--- a/app/views/site/_tos_content.html.erb
+++ b/app/views/site/_tos_content.html.erb
@@ -73,14 +73,21 @@
 <p>All users creating a new study are permitted to upload and host data on SCP free of charge by selecting the "Default"
   Terra billing project.  Any study created in that project will be subject to the following data retention policy.
   Any study created in a user-controlled Terra billing project is exempt.</p>
+<h4>Storage Amount</h4>
+<p>
+  There is a soft cap of 200 GB total for all uploads to an individual study.  Any data in excess of this cap may be
+  subject to removal unless approved at the discretion SCP admins.  A notification will be sent to the study owner 30
+  days prior to any data removal, and the study owner may elect to download their data prior to removal.
+</p>
 <h4>Public Studies</h4>
 <p>Any study marked as "public" that provides visualizations and/or downloadable data files can be stored indefinitely
-  provided it remains public and accessible.</p>
+  provided it remains public and accessible.  We ask that study owners not upload intermediate analysis files unless they
+  are also made available for download.</p>
 <h4>Private Studies</h4>
 <p>Any study that is not publicly accessible may be stored for a term of up to one year from the data of creation.
-  After this term expires, such studies will be candidates for removal.  Study owners will be notified prior to
-  any removal and given a period of 30 days in which to convert their study to public.  After this period expires, any
-  remaining private studies are subject to removal at the discretion of SCP admins.</p>
+  After this term expires, such studies will be candidates for removal.  Study owners will be notified prior to any
+  removal and given a period of 30 days in which to convert their study to public or download their data.  After this
+  period expires, any remaining private studies are subject to removal at the discretion of SCP admins.</p>
 <h3>Data Embargoes</h3>
 <p>All studies in SCP may enforce a data embargo that will prevent other users from downloading data files before the
   embargo expires.  The embargo will have a maximum length of two (2) years from date of study creation if the study is

--- a/app/views/site/_tos_content.html.erb
+++ b/app/views/site/_tos_content.html.erb
@@ -82,9 +82,9 @@
   any removal and given a period of 30 days in which to convert their study to public.  After this period expires, any
   remaining private studies are subject to removal at the discretion of SCP admins.</p>
 <h3>Data Embargoes</h3>
-<p>All studies in SCP may enforce a data embargo (regardless of study visibility) that will prevent other users from
-  downloading data files before the embargo expires.  The embargo will have a maximum length of two (2) years from date
-  of study creation.</p>
+<p>All studies in SCP may enforce a data embargo that will prevent other users from downloading data files before the
+  embargo expires.  The embargo will have a maximum length of two (2) years from date of study creation if the study is
+  public.</p>
 <h3>Access Levels</h3>
 <p>Your level of access to SCP is limited to ensure your access is no more than necessary to perform your legitimate tasks
   or assigned duties. If you believe you are being granted access that you should not have, you must immediately notify

--- a/app/views/studies/_form.html.erb
+++ b/app/views/studies/_form.html.erb
@@ -30,8 +30,14 @@
   </div>
   <div class="form-group row">
 		<div class="col-md-3">
-      <%= f.label :embargo, 'Data release date' %>&nbsp;<span class='fas fa-question-circle' data-toggle='tooltip' title='Setting a data release date will prevent downloads for everyone except study owners & shared users, and will expire at 12AM on the date specified (leave blank to allow downloads)' data-placement='right'></span><br />
-			<%= f.date_field :embargo, class: 'form-control' %>
+      <%= f.label :embargo, 'Data release date' %>&nbsp;
+      <span class='fas fa-question-circle' data-toggle='tooltip' data-placement='right'
+            title='Setting a data release date will prevent downloads for everyone except study owners & shared users,
+            and will expire at 12AM on the date specified (leave blank to allow downloads).  This has a maximum length
+            of <%= Study.max_embargo_text %>.'
+      ></span>
+      <br />
+			<%= f.date_field :embargo, class: 'form-control', max: f.object.max_embargo %>
 		</div>
 		<div class="col-md-2">
 			<%= f.label :public %><br />

--- a/app/views/studies/_form.html.erb
+++ b/app/views/studies/_form.html.erb
@@ -34,7 +34,7 @@
       <span class='fas fa-question-circle' data-toggle='tooltip' data-placement='right'
             title='Setting a data release date will prevent downloads for everyone except study owners & shared users,
             and will expire at 12AM on the date specified (leave blank to allow downloads).  This has a maximum length
-            of <%= Study.max_embargo_text %>.'
+            of <%= Study.max_embargo_text %> from date of creation for public studies.'
       ></span>
       <br />
 			<%= f.date_field :embargo, class: 'form-control', max: f.object.max_embargo %>

--- a/test/models/study_test.rb
+++ b/test/models/study_test.rb
@@ -201,4 +201,12 @@ class StudyTest < ActiveSupport::TestCase
     assert_equal cells, @study.expression_matrix_cells(ann_data_file, matrix_type: 'processed')
     assert_equal cells, @study.expression_matrix_cells(ann_data_file, matrix_type: 'raw')
   end
+
+  test 'should prevent data embargo longer than max' do
+    study = FactoryBot.create(:detached_study, user: @user, name_prefix: 'Embargo Test', test_array: @@studies_to_clean)
+    assert study.valid?
+    study.embargo = study.max_embargo + 1.day
+    assert_not study.valid?
+    assert study.errors.has_key?(:embargo)
+  end
 end

--- a/test/models/study_test.rb
+++ b/test/models/study_test.rb
@@ -208,5 +208,7 @@ class StudyTest < ActiveSupport::TestCase
     study.embargo = study.max_embargo + 1.day
     assert_not study.valid?
     assert study.errors.has_key?(:embargo)
+    study.public = false
+    assert study.valid?
   end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates our terms of service to include language regarding a data retention policy.  These new terms only apply to studies in the default billing project, and they have been reviewed & approved by both legal & compliance.  The new terms in short:

- There is now a soft cap of 200GB per study
- Private studies can only be kept for up to 1 year, after which they must convert to public or be subject to removal
- Data embargoes have a maximum length of 2 years from creation

When users sign in next, they will be prompted to re-accept the terms of service.  There will be a small notification at the top of the screen stating that terms have updated since the last version, and instruct users to scroll down to the bottom in order to review all new terms.  Example notification:

![Screenshot 2025-01-29 at 12 21 42 PM](https://github.com/user-attachments/assets/aa4bd024-666e-4c13-a336-fa3637b03d94)

Also, the embargo field (i.e. `Data release date` in the UI) now has a validation in place to prevent dates more that two years after study creation date for public studies.  This is enforced both client- and server-side.

Note: there is no enforcement currently for either the private study age or the storage cap.  Further downstream work will be required to identify these studies (outlined in SCP-5910).

#### MANUAL TESTING
1. Boot as normal and sign in
2. Confirm you are redirected to the terms of service page, and that you see the above notification
3. Accept the terms and confirm normal usage is allowed
4. Go to any public study you own and load the settings tab
5. Confirm the date picker for `Data release date` does not allow a date after two years from study creation
6. Manually enter a date past the validation limit and confirm you see a similar error when saving:
![Screenshot 2025-01-29 at 12 33 31 PM](https://github.com/user-attachments/assets/cb0e7832-d6cb-4de1-8136-786cabb8d469)
