### PR TITLE
Reduce redundant automated DE jobs (SCP-5905)

### DIFF
--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -164,7 +164,9 @@ class DifferentialExpressionService
     return true if dry_run # exit before submission if specified as annotation was already validated
 
     # check if there's already a job running using these parameters and exit if so
-    job_params = ['--study-file-id', study_file.id.to_s] + params_object.to_options_array
+    job_params = ApplicationController.batch_api_client.format_command_line(
+      study_file:, action: :differential_expression, user_metrics_uuid: user.metrics_uuid, params_object:
+    )
     running = ApplicationController.batch_api_client.find_matching_jobs(
       params: job_params, job_states: BatchApiClient::RUNNING_STATES
     )

--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -169,9 +169,10 @@ class DifferentialExpressionService
       params: job_params, job_states: BatchApiClient::RUNNING_STATES
     )
     if running.any?
-      log_message "Found #{running.count} running DE jobs using these params: #{running.map(&:name).join(', ')}"
-      log_message "Params: #{job_params.join(' ')}"
+      log_message "Found #{running.count} running DE jobs: #{running.map(&:name).join(', ')}"
+      log_message "Matching these parameters: #{job_params.join(' ')}"
       log_message "Exiting without queuing new job"
+      false
     elsif params_object.valid?
       # launch DE job
       job = IngestJob.new(study:, study_file:, user:, action: :differential_expression, params_object:)

--- a/app/models/batch_api_client.rb
+++ b/app/models/batch_api_client.rb
@@ -95,6 +95,22 @@ class BatchApiClient
     service.list_project_location_jobs(project_location, page_token:)
   end
 
+  # find any existing jobs using command line parameters & job states
+  #
+  # * *params*
+  #   - +params+ (Array<String>) => array of params sent to job to match on
+  #   - +job_state+ (Array<String>) => optional states to filter on (defaults to completed jobs)
+  #
+  # * *returns*
+  #   - (Array<Google::Apis::BatchV1::Job>)
+  def find_matching_jobs(params: [], job_states: COMPLETED_STATES)
+    jobs = list_jobs.jobs
+    jobs.select do |job|
+      commands = get_job_command_line(job:)
+      (params & commands).sort == params.sort && job_states.include?(job.status.state)
+    end
+  end
+
   # main handler to create and run a Batch API job
   #
   # * *params*

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -516,6 +516,7 @@ class IngestJob
       set_has_image_cache
     when :ingest_anndata
       launch_anndata_subparse_jobs if study_file.is_viz_anndata?
+      launch_differential_expression_jobs if study_file.is_viz_anndata?
       set_anndata_file_info
     end
     set_study_initialized

--- a/test/services/differential_expression_service_test.rb
+++ b/test/services/differential_expression_service_test.rb
@@ -100,13 +100,15 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
     job_mock.expect(:push_remote_and_launch_ingest, Delayed::Job.new)
     mock = Minitest::Mock.new
     mock.expect(:delay, job_mock)
-    IngestJob.stub :new, mock do
-      job_launched = DifferentialExpressionService.run_differential_expression_job(
-        @cluster_group, @basic_study, @user, **@job_params
-      )
-      assert job_launched
-      mock.verify
-      job_mock.verify
+    ApplicationController.batch_api_client.stub :find_matching_jobs, [] do
+      IngestJob.stub :new, mock do
+        job_launched = DifferentialExpressionService.run_differential_expression_job(
+          @cluster_group, @basic_study, @user, **@job_params
+        )
+        assert job_launched
+        mock.verify
+        job_mock.verify
+      end
     end
 
     # test pairwise job
@@ -118,13 +120,15 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
     job_mock.expect(:push_remote_and_launch_ingest, Delayed::Job.new)
     mock = Minitest::Mock.new
     mock.expect(:delay, job_mock)
-    IngestJob.stub :new, mock do
-      job_launched = DifferentialExpressionService.run_differential_expression_job(
-        @cluster_group, @basic_study, @user, **@job_params
-      )
-      assert job_launched
-      mock.verify
-      job_mock.verify
+    ApplicationController.batch_api_client.stub :find_matching_jobs, [] do
+      IngestJob.stub :new, mock do
+        job_launched = DifferentialExpressionService.run_differential_expression_job(
+          @cluster_group, @basic_study, @user, **@job_params
+        )
+        assert job_launched
+        mock.verify
+        job_mock.verify
+      end
     end
   end
 
@@ -197,13 +201,15 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
     job_mock.expect(:push_remote_and_launch_ingest, Delayed::Job.new)
     mock = Minitest::Mock.new
     mock.expect(:delay, job_mock)
-    IngestJob.stub :new, mock do
-      job_launched = DifferentialExpressionService.run_differential_expression_job(
-        cluster_group, study, @user, **annotation
-      )
-      assert job_launched
-      mock.verify
-      job_mock.verify
+    ApplicationController.batch_api_client.stub :find_matching_jobs, [] do
+      IngestJob.stub :new, mock do
+        job_launched = DifferentialExpressionService.run_differential_expression_job(
+          cluster_group, study, @user, **annotation
+        )
+        assert job_launched
+        mock.verify
+        job_mock.verify
+      end
     end
   end
 
@@ -220,11 +226,13 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
     job_mock.expect(:push_remote_and_launch_ingest, Delayed::Job.new)
     mock = Minitest::Mock.new
     mock.expect(:delay, job_mock)
-    IngestJob.stub :new, mock do
-      job_launched = DifferentialExpressionService.run_differential_expression_on_default(@basic_study.accession)
-      assert job_launched
-      mock.verify
-      job_mock.verify
+    ApplicationController.batch_api_client.stub :find_matching_jobs, [] do
+      IngestJob.stub :new, mock do
+        job_launched = DifferentialExpressionService.run_differential_expression_on_default(@basic_study.accession)
+        assert job_launched
+        mock.verify
+        job_mock.verify
+      end
     end
   end
 
@@ -253,12 +261,14 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
     mock.expect(:delay, job_mock_one)
     mock.expect(:delay, job_mock_two)
     # cell_type__ontology_label and seurat_clusters should be marked as eligible
-    IngestJob.stub :new, mock do
-      jobs_launched = DifferentialExpressionService.run_differential_expression_on_all(@basic_study.accession)
-      assert_equal 2, jobs_launched
-      mock.verify
-      job_mock_one.verify
-      job_mock_two.verify
+    ApplicationController.batch_api_client.stub :find_matching_jobs, [] do
+      IngestJob.stub :new, mock do
+        jobs_launched = DifferentialExpressionService.run_differential_expression_on_all(@basic_study.accession)
+        assert_equal 2, jobs_launched
+        mock.verify
+        job_mock_one.verify
+        job_mock_two.verify
+      end
     end
   end
 
@@ -340,13 +350,15 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
     job_mock.expect(:push_remote_and_launch_ingest, Delayed::Job.new)
     mock = Minitest::Mock.new
     mock.expect(:delay, job_mock)
-    IngestJob.stub :new, mock do
-      # restrict to this study to prevent any dangling studies being picked up
-      stats = DifferentialExpressionService.backfill_new_results(study_accessions: [@basic_study.accession])
-      assert_equal 1, stats[:total_jobs]
-      assert_equal 1, stats[@basic_study.accession]
-      mock.verify
-      job_mock.verify
+    ApplicationController.batch_api_client.stub :find_matching_jobs, [] do
+      IngestJob.stub :new, mock do
+        # restrict to this study to prevent any dangling studies being picked up
+        stats = DifferentialExpressionService.backfill_new_results(study_accessions: [@basic_study.accession])
+        assert_equal 1, stats[:total_jobs]
+        assert_equal 1, stats[@basic_study.accession]
+        mock.verify
+        job_mock.verify
+      end
     end
   end
 
@@ -380,11 +392,13 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
     mock = Minitest::Mock.new
     mock.expect(:delay, job_mock)
     # cell_type__ontology_label and seurat_clusters should be marked as eligible
-    IngestJob.stub :new, mock do
-      jobs_launched = DifferentialExpressionService.run_differential_expression_on_all(study.accession)
-      assert_equal 1, jobs_launched
-      mock.verify
-      job_mock.verify
+    ApplicationController.batch_api_client.stub :find_matching_jobs, [] do
+      IngestJob.stub :new, mock do
+        jobs_launched = DifferentialExpressionService.run_differential_expression_on_all(study.accession)
+        assert_equal 1, jobs_launched
+        mock.verify
+        job_mock.verify
+      end
     end
   end
 end

--- a/test/services/differential_expression_service_test.rb
+++ b/test/services/differential_expression_service_test.rb
@@ -401,4 +401,17 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test 'should skip launching DE job if matching running job found' do
+    running_job = Google::Apis::BatchV1::Job.new(
+      name: 'running-de-job',
+      status: Google::Apis::BatchV1::JobStatus.new(state: 'RUNNING')
+    )
+    DataArray.create!(@all_cells_array_params)
+    ApplicationController.batch_api_client.stub :find_matching_jobs, [running_job] do
+      assert_not DifferentialExpressionService.run_differential_expression_job(
+        @cluster_group, @basic_study, @user, **@job_params
+      )
+    end
+  end
 end


### PR DESCRIPTION
#### BACKGROUND
Currently, any study eligible for differential expression will automatically launch jobs upon successful ingest of clustering, metadata, or any expression file (raw or processed).  There are checks in place to skip any results that already exist, however if those results are currently processing, this will return false.  This can lead to duplicate jobs being launched after every qualifying ingest until those result files are created.  This doesn't have any negative downstream effect other than needless cloud spend on ingest jobs and duplicate notifications - the result files will be identical, so no data is clobbered by the duplicates - but there could be dozens of redundant jobs launched depending on how many eligible clusters/annotations are present in a study.  AnnData studies are particularly prone to this as their primary ingest jobs are launched within seconds of each other.

#### CHANGES
Now, the `DifferentialExpressionService` will check to see if there are any matching jobs currently running in the Batch API before submitting a new job.  If a job is found, the service will log a message like the following and then exit silently:

```
Checking DE job for SCP167: umap (cell_type__ontology_label--group--study)
Found 1 running DE jobs: projects/broad-singlecellportal-bistlin/locations/us-central1/jobs/job-3eef7a9a-f447-4086-a0af-ab8166d9ee44
Matching these parameters: python ingest_pipeline.py --study-id 67914d3c94ec8f858cdf09ba --study-file-id 679a4c68aafb37e8782f4cb8 --user-metrics-uuid c6a08597-c735-4c93-b069-4b4a74b708ee differential_expression --study-accession SCP167 --annotation-name cell_type__ontology_label --annotation-type group --annotation-scope study --annotation-file gs://fc-4b11a7be-c5d0-40da-8d42-53f58a5a1294/_scp_internal/anndata_ingest/SCP167_679a4c68aafb37e8782f4cb8/h5ad_frag.metadata.tsv.gz --cluster-file gs://fc-4b11a7be-c5d0-40da-8d42-53f58a5a1294/_scp_internal/anndata_ingest/SCP167_679a4c68aafb37e8782f4cb8/h5ad_frag.cluster.X_umap.tsv.gz --cluster-name umap --de-type rest --matrix-file-path gs://fc-4b11a7be-c5d0-40da-8d42-53f58a5a1294/HTAPP-330-SMP-1082_compliant.h5ad --matrix-file-type h5ad --differential-expression
Exiting without queuing new job
```

New jobs using the referenced parameters will be blocked for submission unless the previous run fails or an admin manually launches a new job from the Rails console.

It should be noted that this isn't perfect - it is still subject to a race condition as new jobs do not appear instantly in the Batch API jobs list after submission.  If two qualifying files in the same study finish ingesting within seconds of each other, the upstream check will likely not see the newly created jobs and then submit duplicates.  The window for this is small - usually only about 10-15 seconds - so this drastically reduced the incidence of this issue.

Note: you may have issues testing this manually until [OLS addresses an issue](https://github.com/EBISPOT/ols4/issues/834#issuecomment-2621685051) with some ontology queries.  If you are seeing metadata validation fail, you can comment out the following lines in in `BatchApiClient#format_command_line` (in `app/models/batch_api_client.rb`, staring on line 520):

```
if study_file.use_metadata_convention
  command_line += [
    '--validate-convention', '--bq-dataset', CellMetadatum::BIGQUERY_DATASET,
    '--bq-table', CellMetadatum::BIGQUERY_TABLE
  ]
end
``` 

#### MANUAL TESTING
1. Boot all services and sign in
2. Create a new study, and upload a valid AnnData file (like [compliant_liver.h5ad](https://github.com/broadinstitute/scp-ingest-pipeline/blob/development/tests/data/anndata/compliant_liver.h5ad)), ensuring that you specify you have raw counts
3. Once the cluster/metadata/expression jobs finish, look in `development.log` for a message like the above one.  Note that you potentially could get one set of duplicates, but at least the final ingest should detect the upstream jobs and block submission