### PR TITLE
Workaround for false positive Rawls healthcheck issue (SCP-5916)

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -666,7 +666,7 @@ class SiteController < ApplicationController
       if api_status.is_a?(Hash)
         system_status = api_status['systems']
         sam_ok = system_status.dig(FireCloudClient::SAM_SERVICE, 'ok') == true # do equality check in case 'ok' node isn't present
-        #  2025-01-31 quick and dirty workaround for false negative Rawls availability issue
+        #  2025-01-31 quick and dirty workaround for false positive Rawls availability issue
         #  long term mitigation exploration in SCP-5647        
         # rawls_ok = system_status.dig(FireCloudClient::RAWLS_SERVICE, 'ok') == true
         rawls_ok = true

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -666,7 +666,10 @@ class SiteController < ApplicationController
       if api_status.is_a?(Hash)
         system_status = api_status['systems']
         sam_ok = system_status.dig(FireCloudClient::SAM_SERVICE, 'ok') == true # do equality check in case 'ok' node isn't present
-        rawls_ok = system_status.dig(FireCloudClient::RAWLS_SERVICE, 'ok') == true
+        #  2025-01-31 quick and dirty workaround for false negative Rawls availability issue
+        #  long term mitigation exploration in SCP-5647        
+        # rawls_ok = system_status.dig(FireCloudClient::RAWLS_SERVICE, 'ok') == true
+        rawls_ok = true
         buckets_ok = system_status.dig(FireCloudClient::BUCKETS_SERVICE, 'ok') == true
         @allow_downloads = buckets_ok
         @allow_edits = sam_ok && rawls_ok

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1148,7 +1148,10 @@ class StudiesController < ApplicationController
 
   # check on FireCloud API status and respond accordingly
   def check_firecloud_status
-    unless ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE, FireCloudClient::RAWLS_SERVICE)
+    #  2025-01-31 quick and dirty workaround for false negative Rawls availability issue
+    #  long term mitigation exploration in SCP-5647
+    #  unless ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE, FireCloudClient::RAWLS_SERVICE
+    unless ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE)
       alert = "Study workspaces are temporarily unavailable, so we cannot complete your request.  Please try again later.  #{SCP_SUPPORT_EMAIL}"
       respond_to do |format|
         format.js {render js: "$('.modal').modal('hide'); alert('#{alert}')" and return}

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1148,7 +1148,7 @@ class StudiesController < ApplicationController
 
   # check on FireCloud API status and respond accordingly
   def check_firecloud_status
-    #  2025-01-31 quick and dirty workaround for false negative Rawls availability issue
+    #  2025-01-31 quick and dirty workaround for false positive Rawls availability issue
     #  long term mitigation exploration in SCP-5647
     #  unless ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE, FireCloudClient::RAWLS_SERVICE
     unless ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE)

--- a/test/integration/external/fire_cloud_client_test.rb
+++ b/test/integration/external/fire_cloud_client_test.rb
@@ -88,10 +88,12 @@ class FireCloudClientTest < ActiveSupport::TestCase
   def test_firecloud_api_status
     status = @fire_cloud_client.api_status
     assert status.is_a?(Hash), "Did not get expected status Hash object; found #{status.class.name}"
-    assert status['ok'].present?, 'Did not find root status message'
+    # assert status['ok'].present?, 'Did not find root status message'
     assert status['systems'].present?, 'Did not find system statuses'
     # look for presence of systems that SCP depends on
-    services = [FireCloudClient::RAWLS_SERVICE, FireCloudClient::SAM_SERVICE, FireCloudClient::AGORA_SERVICE,
+    # 2025-01-31 quick and dirty workaround for false negative Rawls availability issue
+    # services = [FireCloudClient::RAWLS_SERVICE, FireCloudClient::SAM_SERVICE, FireCloudClient::AGORA_SERVICE,
+    services = [FireCloudClient::SAM_SERVICE, FireCloudClient::AGORA_SERVICE,
                 FireCloudClient::THURLOE_SERVICE, FireCloudClient::BUCKETS_SERVICE]
     services.each do |service|
       assert status['systems'][service].present?, "Did not find required service: #{service}"


### PR DESCRIPTION
## Issue: false positives checking on Rawls health

Starting 2025-01-31, Rawls health from https://api.firecloud.org/status was not "ok". Discussion with #dsp-core-services confirmed that the GoogleGenomics service is irrelevant now. 
Current output from `/status` endpoint:
`{"ok":false,"systems":{"Thurloe":{"ok":true},"Sam":{"ok":true},"Rawls":{"messages":["BillingProfileManager: CloudSQL: (ok: true, message: none), Sam: (ok: true, message: none)","GoogleGenomics: Timed out after 1 minute waiting for a response from GoogleGenomics"],"ok":false},"Agora":{"ok":true},"GoogleBuckets":{"ok":true},"LibraryIndex":{"ok":true},"OntologyIndex":{"ok":true}}}`

## External mitigation - Rawls to remove GoogleGenomics check

#dsp-core-services is removing that check from Rawls but recommend not using the /status endpoint to check for Rawls health but rather to look for `500` errors from actual requests. (see also [SCP-5647](https://broadworkbench.atlassian.net/browse/SCP-5647))

## Short-term mitigation for SCP - this PR
IF it takes a while for the Rawls change to take effect, we can use this PR to bypass rawls health checks until the change from  #dsp-core-services is in production. If the status endpoint has updated (ie. you can access study settings tab in production), this PR is no longer needed.

#### MANUAL TESTING
1. Boot all services and sign in
2. Visit a study where you have edit privileges and confirm the "Settings" tab is active (currently in production, the tab is greyed out and you'll see a tooltip with "Study workspaces are currently unavailable - please try again later".
3. Click on the "+ Create study" link and confirm you're directed to the study creation form.

[SCP-5647]: https://broadworkbench.atlassian.net/browse/SCP-5647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ