### PR TITLE
Allow sequence file upload for AnnData UX (SCP-5679)

### DIFF
--- a/app/javascript/components/upload/UploadWizard.jsx
+++ b/app/javascript/components/upload/UploadWizard.jsx
@@ -55,8 +55,8 @@ const ALL_POSSIBLE_STEPS = [
   AnnDataUploadStep,
   DifferentialExpressionStep,
   SpatialStep,
-  CoordinateLabelStep,
   SequenceFileStep,
+  CoordinateLabelStep,
   GeneListStep,
   MiscellaneousStep,
   SeuratStep,
@@ -101,7 +101,7 @@ export function RawUploadWizard({ studyAccession, name }) {
   // set the additional steps to display, based on classic or AnnData experience
   if (isAnnDataExperience) {
     MAIN_STEPS = MAIN_STEPS_ANNDATA
-    SUPPLEMENTAL_STEPS = ALL_POSSIBLE_STEPS.slice(6, 7)
+    SUPPLEMENTAL_STEPS = ALL_POSSIBLE_STEPS.slice(6, 8)
     // SUPPLEMENTAL_STEPS.splice(1, 0, DifferentialExpressionStep)
     // TODO enable after raw counts are sorted for AnnData (SCP-5110)
     NON_VISUALIZABLE_STEPS = ALL_POSSIBLE_STEPS.slice(10, 12)


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This adds the `Sequence files` tab to the upload wizard in the AnnData UX.  This is necessary work for our continued NeMO collaboration as this will support the ATAC fragment visualization UX.  Additionally, this changes the order slightly so that sequence files are above coordinate label files as the former are much more common.

Note: the associated ticket said to evaluate the other supplemental steps and determine which were appropriate for AnnData studies.  We have not received any `Gene List` or `Coordinate Labels` files on production in over 18 months, so while they could be applicable, there doesn't seem to be any demand.  The last two remaining types (spatial and author DE) have not been verified to work with AnnData studies.  It is highly probable that they are, but it seemed safest not to hold up this ticket as sequence file support is needed now, and there is a possibility that extra work would be needed to support other file types in AnnData studies.

#### MANUAL TESTING
1. Boot all services and sign in
2. Go to the upload wizard for an AnnData study
3. Verify that you see the `Sequence files` step under `Other files`
4. Use the steps from #2202 to copy the `10k_PBMC.fragments.sorted.tsv.gz` file (and `.csi` index) to your study's bucket and then add them as sequence files using the bucket path option
5. Go to the Explore tab for you study and search for a gene, then confirm the `Genome` tab shows up and the fragment file is visible

Note: if you do not see the Genome tab, make sure that your delayed job worker is running as the Explore response is cached and needs to be updated.  Also check the state of your feature flags for the `show_igv_multiome` flag.