### PR TITLE
Updating to scp-ingest-pipeline:1.40.1 (SCP-5902)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.40.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.40.1'
 
     # Docker image for image pipeline jobs
     config.image_pipeline_docker_image = 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_c2b090043'

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ Bundler.require(*Rails.groups)
 
 module SingleCellPortal
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
+    # Initialize configuration defaults for originally generated Rails version
     config.load_defaults 6.1
 
     config.time_zone = 'Eastern Time (US & Canada)'


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates to `scp-ingest-pipeline:1.40.1` to allow logging to `STDOUT` from ingest pipeline.  This will enable real-time logs in the Batch API for running jobs.