### PR TITLE
Simplifying parse_status flag logic (SCP-5911)

### DIFF
--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -731,13 +731,6 @@ class IngestJobTest < ActiveSupport::TestCase
     pipeline_name = SecureRandom.uuid
 
     job = IngestJob.new(pipeline_name:, study:, study_file: cluster_file, user: @user, action: :ingest_subsample)
-    metadata = {
-      pipeline: {
-        actions: [
-          { commands: %w[foo bar bing baz] }
-        ]
-      }
-    }.with_indifferent_access
 
     error_log = "parse_logs/#{cluster_file.id}/user_log.txt"
     mock = Minitest::Mock.new
@@ -889,6 +882,7 @@ class IngestJobTest < ActiveSupport::TestCase
       annotation_file:, cluster_file:, cluster_name: 'umap', annotation_name: 'disease', annotation_scope: 'study'
     )
     pipeline_name = SecureRandom.uuid
+    study_file.update(parse_status: 'parsing')
     job = IngestJob.new(
       pipeline_name:, study:, study_file:, user: @user, action: :differential_expression, params_object:
     )
@@ -925,6 +919,9 @@ class IngestJobTest < ActiveSupport::TestCase
     ApplicationController.stub :batch_api_client, mock do
       SingleCellMailer.stub :notify_admin_parse_fail, email_mock do
         job.poll_for_completion
+        # ensure that parse_status flag is reset after failure
+        study_file.reload
+        assert study_file.parsed?
         mock.verify
         email_mock.verify
       end

--- a/test/models/ingest_job_test.rb
+++ b/test/models/ingest_job_test.rb
@@ -855,7 +855,7 @@ class IngestJobTest < ActiveSupport::TestCase
     end
   end
 
-  test 'should ensure email delivery on special action failures' do
+  test 'should ensure email delivery and parse_status reset on special action failures' do
     study = FactoryBot.create(:detached_study,
                               name_prefix: 'Special Action Email',
                               user: @user,


### PR DESCRIPTION
#### BACKGROUND & CHANGES
We have found corner cases where the value for `parse_status` on a file can get stuck in the `parsing` state when an admin has to manually re-launch failed subsampling from the console.  It is unclear the exact chain of events that causes this, but it appears that this flag was very reliant on order of operations and the outcome of upstream jobs to be set correctly.  If an admin has to intervene and manually retry failed jobs, then it can get out of sync.  This leads to issues where admins cannot launch new jobs because certain checks fail (like `can_subsample?`) and have to set the flag first before proceeding.  This also blocks users from removing files because the application thinks they are still being processed.

Now, whenever an ingest job completes, the value is reset to `parsed` regardless of the outcome of the job.  Any new jobs launched will then reset this flag to 'parsing' using existing automation.  This will ensure users cannot delete files that are processing, and also prevents files from being stuck in that state when certain jobs unexpectedly fail.

#### MANUAL TESTING
As stated, this error is extremely state-dependent.  It is not entirely clear what mechanism causes the flag to be stuck, but when it is, no new subsampling can be run until this flag is manually reset.  Rather than trying to manually recreate this, there is an automated test that covers this explicitly.

1. Initialize your environment and run this test:
```
bin/rails test test/models/ingest_job_test.rb -n 'test_should_ensure_email_delivery_and_parse_status_reset_on_special_action_failures'
```
2. Confirm there are no errors/failures.