### PR TITLE
Removing pre-flight Terra status checks (SCP-5647)

### DIFF
--- a/app/controllers/analysis_configurations_controller.rb
+++ b/app/controllers/analysis_configurations_controller.rb
@@ -3,7 +3,6 @@ class AnalysisConfigurationsController < ApplicationController
                                                     :submission_preview, :load_study_for_submission_preview,
                                                     :update_analysis_parameter]
   before_action :set_analysis_parameter, only: [:update_analysis_parameter]
-  before_action :check_firecloud_status, only: [:new, :create]
   before_action do
     authenticate_user!
     authenticate_admin
@@ -176,17 +175,5 @@ class AnalysisConfigurationsController < ApplicationController
                                                                                            :attribute_value, :association_source,
                                                                                            :association_method, :association_data_type,
                                                                                            :_destroy])
-    end
-
-    def check_firecloud_status
-      unless ApplicationController.firecloud_client.services_available?(FireCloudClient::RAWLS_SERVICE)
-        alert = 'The Methods Repository is temporarily unavailable, so we cannot complete your request.  Please try again later.'
-        respond_to do |format|
-          format.js {render js: "$('.modal').modal('hide'); alert('#{alert}')" and return}
-          format.html {redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
-                                   alert: alert and return}
-          format.json {head 503}
-        end
-      end
     end
 end

--- a/app/controllers/api/v1/studies_controller.rb
+++ b/app/controllers/api/v1/studies_controller.rb
@@ -1,8 +1,6 @@
 module Api
   module V1
     class StudiesController < ApiBaseController
-      include Concerns::FireCloudStatus
-
       def firecloud_independent_methods
         # add file_info is essentially a more extensive 'show' method
         [:index, :show, :file_info]

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -1,8 +1,6 @@
 module Api
   module V1
     class StudyFilesController < ApiBaseController
-      include Concerns::FireCloudStatus
-
       before_action :authenticate_api_user!
       before_action :set_study
       before_action :check_study_edit_permission

--- a/app/controllers/api/v1/study_shares_controller.rb
+++ b/app/controllers/api/v1/study_shares_controller.rb
@@ -1,8 +1,6 @@
 module Api
   module V1
     class StudySharesController < ApiBaseController
-      include Concerns::FireCloudStatus
-
       before_action :authenticate_api_user!
       before_action :set_study
       before_action :check_study_permission

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -264,7 +264,7 @@ class ApplicationController < ActionController::Base
     # next check if downloads have been disabled by administrator, this will abort the download
     # download links shouldn't be rendered in any case, this just catches someone doing a straight GET on a file
     # also check if workspace google buckets are available
-    if !AdminConfiguration.firecloud_access_enabled? || !ApplicationController.firecloud_client.services_available?(FireCloudClient::BUCKETS_SERVICE)
+    if !AdminConfiguration.firecloud_access_enabled?
       head 503 and return
     end
   end

--- a/app/controllers/billing_projects_controller.rb
+++ b/app/controllers/billing_projects_controller.rb
@@ -18,7 +18,6 @@ class BillingProjectsController < ApplicationController
   respond_to :html, :js, :json
   before_action :authenticate_user!
   before_action :check_firecloud_registration, except: :access_request
-  before_action :check_firecloud_status, except: :access_request
   before_action :create_firecloud_client, except: :access_request
   before_action :check_project_permissions, except: [:index, :create, :access_request]
   before_action :load_service_account, except: [:new_user, :create_user, :delete_user, :storage_estimate, :access_request]
@@ -212,19 +211,6 @@ class BillingProjectsController < ApplicationController
     unless projects.map {|project| project['projectName']}.include?(params[:project_name])
       redirect_to merge_default_redirect_params(billing_projects_path, scpbr: params[:scpbr]),
                   alert: "You do not have permission to perform that action.  #{SCP_SUPPORT_EMAIL}" and return
-    end
-  end
-
-  # check on FireCloud API status and respond accordingly
-  def check_firecloud_status
-    unless ApplicationController.firecloud_client.services_available?(FireCloudClient::THURLOE_SERVICE)
-      alert = "Billing projects are temporarily unavailable, so we cannot complete your request.  Please try again later.  #{SCP_SUPPORT_EMAIL}"
-      respond_to do |format|
-        format.js {render js: "$('.modal').modal('hide'); alert('#{alert}')" and return}
-        format.html {redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]),
-                                 alert: alert and return}
-        format.json {head 503}
-      end
     end
   end
 end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -748,21 +748,12 @@ class SiteController < ApplicationController
 
   # check compute permissions for study
   def check_compute_permissions
-    if ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE, FireCloudClient::RAWLS_SERVICE)
-      if !user_signed_in? || !@study.can_compute?(current_user)
-        @alert = "You do not have permission to perform that action.  #{SCP_SUPPORT_EMAIL}"
-        respond_to do |format|
-          format.js {render action: :notice}
-          format.html {redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: @alert and return}
-          format.json {head 403}
-        end
-      end
-    else
-      @alert = "Compute services are currently unavailable - please check back later.  #{SCP_SUPPORT_EMAIL}"
+    if !user_signed_in? || !@study.can_compute?(current_user)
+      @alert = "You do not have permission to perform that action.  #{SCP_SUPPORT_EMAIL}"
       respond_to do |format|
         format.js {render action: :notice}
         format.html {redirect_to merge_default_redirect_params(site_path, scpbr: params[:scpbr]), alert: @alert and return}
-        format.json {head 503}
+        format.json {head 403}
       end
     end
   end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -118,12 +118,7 @@ class SiteController < ApplicationController
             @cluster_annotations = ClusterVizService.load_cluster_group_annotations(@study, @cluster, current_user)
             set_selected_annotation
           end
-
-          # double check on download availability: first, check if administrator has disabled downloads
-          # then check if FireCloud is available and disable download links if either is true
-          @allow_downloads = ApplicationController.firecloud_client.services_available?(FireCloudClient::BUCKETS_SERVICE)
         end
-        set_firecloud_permissions(@study.detached?)
         set_study_permissions(@study.detached?)
         set_study_default_options
         set_study_download_options
@@ -156,7 +151,6 @@ class SiteController < ApplicationController
     # double check on download availability: first, check if administrator has disabled downloads
     # then check individual statuses to see what to enable/disable
     # if the study is 'detached', then everything is set to false by default
-    set_firecloud_permissions(@study.detached?)
     set_study_permissions(@study.detached?)
     set_study_default_options
     set_study_download_options
@@ -652,46 +646,19 @@ class SiteController < ApplicationController
     end
   end
 
-  # check various firecloud statuses/permissions, but only if a study is not 'detached'
-  def set_firecloud_permissions(study_detached)
-    @allow_firecloud_access = false
-    @allow_downloads = false
-    @allow_edits = false
-    return if study_detached
-    begin
-      @allow_firecloud_access = AdminConfiguration.firecloud_access_enabled?
-      api_status = ApplicationController.firecloud_client.api_status
-      # reuse status object because firecloud_client.services_available? each makes a separate status call
-      # calling Hash#dig will gracefully handle any key lookup errors in case of a larger outage
-      if api_status.is_a?(Hash)
-        system_status = api_status['systems']
-        sam_ok = system_status.dig(FireCloudClient::SAM_SERVICE, 'ok') == true # do equality check in case 'ok' node isn't present
-        rawls_ok = system_status.dig(FireCloudClient::RAWLS_SERVICE, 'ok') == true
-        buckets_ok = system_status.dig(FireCloudClient::BUCKETS_SERVICE, 'ok') == true
-        @allow_downloads = buckets_ok
-        @allow_edits = sam_ok && rawls_ok
-      end
-    rescue => e
-      logger.error "Error checking FireCloud API status: #{e.class.name} -- #{e.message}"
-      ErrorTracker.report_exception(e, current_user, @study, { firecloud_status: api_status})
-      MetricsService.report_error(e, request, current_user, @study)
-    end
-  end
-
   # set various study permissions based on the results of the above FC permissions
   def set_study_permissions(study_detached)
     @user_can_edit = false
     @user_can_compute = false
     @user_can_download = false
     @user_embargoed = false
+    @allow_firecloud_access = AdminConfiguration.firecloud_access_enabled?
 
     return if study_detached || !@allow_firecloud_access
     begin
       @user_can_edit = @study.can_edit?(current_user)
-      if @allow_downloads
-        @user_can_download = @user_can_edit ? true : @study.can_download?(current_user)
-        @user_embargoed = @user_can_edit ? false : @study.embargoed?(current_user)
-      end
+      @user_can_download = @user_can_edit ? true : @study.can_download?(current_user)
+      @user_embargoed = @user_can_edit ? false : @study.embargoed?(current_user)
     rescue => e
       logger.error "Error setting study permissions: #{e.class.name} -- #{e.message}"
       ErrorTracker.report_exception(e, current_user, @study)

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -22,9 +22,6 @@ class StudiesController < ApplicationController
     authenticate_user!
     check_access_settings
   end
-  # special before_action to make sure FireCloud is available and pre-empt any calls when down
-  before_action :check_firecloud_status, except: [:index, :do_upload, :resume_upload, :update_status,
-                                                  :retrieve_wizard_upload, :parse]
   before_action :check_study_detached, only: [:edit, :update, :initialize_study, :sync_study, :sync_submission_outputs]
   helper_method :visible_unsynced_files, :hidden_unsynced_files
   ###
@@ -1142,19 +1139,6 @@ class StudiesController < ApplicationController
         format.js {render js: "alert('#{alert}')" and return}
         format.html {redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
                                  alert: alert and return}
-      end
-    end
-  end
-
-  # check on FireCloud API status and respond accordingly
-  def check_firecloud_status
-    unless ApplicationController.firecloud_client.services_available?(FireCloudClient::SAM_SERVICE, FireCloudClient::RAWLS_SERVICE)
-      alert = "Study workspaces are temporarily unavailable, so we cannot complete your request.  Please try again later.  #{SCP_SUPPORT_EMAIL}"
-      respond_to do |format|
-        format.js {render js: "$('.modal').modal('hide'); alert('#{alert}')" and return}
-        format.html {redirect_to merge_default_redirect_params(studies_path, scpbr: params[:scpbr]),
-                                 alert: alert and return}
-        format.json {head 503}
       end
     end
   end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -46,7 +46,7 @@ class StudiesController < ApplicationController
     @directories = @study.directory_listings.are_synced
     @primary_data = @study.directory_listings.primary_data
     @other_data = @study.directory_listings.non_primary_data
-    @allow_downloads = ApplicationController.firecloud_client.services_available?(FireCloudClient::BUCKETS_SERVICE) && !@study.detached
+    @allow_downloads = !@study.detached
     @analysis_metadata = @study.analysis_metadata.to_a
     # load study default options
     set_study_default_options

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -7,16 +7,9 @@
     <li role="presentation" class="profile-nav active" id="profile-emails-nav">
       <a href="#profile-emails" data-toggle="tab">Preferences</a>
     </li>
-    <% if @profiles_available %>
-      <li role="presentation" class="profile-nav" id="profile-terra-nav">
-        <a href="#profile-terra" data-toggle="tab">Terra Profile</a>
-      </li>
-    <% else %>
-      <li role="presentation" class="profile-nav disabled" id="profile-terra-nav">
-        <a href="#profile-terra" data-toggle="tooltip"
-           title="Terra profiles are currently unavailable, please check back later.">Terra Profile</a>
-      </li>
-    <% end %>
+    <li role="presentation" class="profile-nav" id="profile-terra-nav">
+      <a href="#profile-terra" data-toggle="tab">Terra Profile</a>
+    </li>
   </ul>
 
   <div class="tab-content top-pad">
@@ -144,28 +137,26 @@
         </tbody>
       </table>
     </div>
-    <% if @profiles_available %>
-      <div class="tab-pane" id="profile-terra" role="tabpanel">
-        <% if current_user.registered_for_firecloud %>
-          <%= render partial: 'user_firecloud_profile' %>
-        <% else %>
-          <div class="container">
-            <div class="bs-callout bs-callout-danger">
-              <h4>Please complete your Terra registration</h4>
-              <p>
-                You may not update your Terra profile until you have registered with Terra and accepted the terms of service.
-                Please <%= link_to 'visit Terra', 'https://app.terra.bio', target: :_blank, rel: 'noopener noreferrer' %>,
-                select 'Sign in with Google' from the top-lefthand nav menu, and complete the sign in and registration process.
-              </p>
-              <p class="text-center">
-                <%= link_to "Complete Registration Now <i class='fas fa-external-link-alt'></i>".html_safe, 'https://app.terra.bio',
-                            target: :_blank, rel: 'noopener noreferrer', class: 'btn btn-lg btn-default' %>
-              </p>
-            </div>
+    <div class="tab-pane" id="profile-terra" role="tabpanel">
+      <% if current_user.registered_for_firecloud %>
+        <%= render partial: 'user_firecloud_profile' %>
+      <% else %>
+        <div class="container">
+          <div class="bs-callout bs-callout-danger">
+            <h4>Please complete your Terra registration</h4>
+            <p>
+              You may not update your Terra profile until you have registered with Terra and accepted the terms of service.
+              Please <%= link_to 'visit Terra', 'https://app.terra.bio', target: :_blank, rel: 'noopener noreferrer' %>,
+              select 'Sign in with Google' from the top-lefthand nav menu, and complete the sign in and registration process.
+            </p>
+            <p class="text-center">
+              <%= link_to "Complete Registration Now <i class='fas fa-external-link-alt'></i>".html_safe, 'https://app.terra.bio',
+                          target: :_blank, rel: 'noopener noreferrer', class: 'btn btn-lg btn-default' %>
+            </p>
           </div>
-        <% end %>
-      </div>
-    <% end %>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>
 

--- a/app/views/site/_study_download_data.html.erb
+++ b/app/views/site/_study_download_data.html.erb
@@ -4,10 +4,9 @@
   <div class="col-xs-12">
     <h2>Study Files
       <span class="badge"><%= @study_files.count %></span>
-      <%= link_to "<i class='fas fa-question-circle'></i> Bulk download".html_safe, '#/', class: "btn btn-default pull-right #{!@allow_downloads ? 'disabled' : nil}", id: 'download-help' %>
+      <%= link_to "<i class='fas fa-question-circle'></i> Bulk download".html_safe, '#/', class: "btn btn-default pull-right", id: 'download-help' %>
     </h2>
 
-    <% if @allow_downloads %>
     <div class="modal fade" id="download-help-modal" role="dialog" aria-labelledby="download-help-modal" aria-hidden="true">
       <div class="modal-dialog modal-lg">
         <div class="modal-content">
@@ -194,7 +193,6 @@
           writeDownloadCommand(downloadObject, fileTypes);
         });
     </script>
-    <% end %>
   </div>
 </div>
 <div class="table-responsive">
@@ -224,11 +222,7 @@
           <% end %>
         </td>
         <td>
-          <% if @allow_downloads && @allow_firecloud_access %>
-            <%= render partial: '/layouts/download_link', locals: {study: @study, study_file: study_file} %>
-          <% else %>
-            <%= link_to 'Currently Unavailable', '#/', class: 'btn btn-danger disabled-download', disabled: true %>
-          <% end %>
+          <%= render partial: '/layouts/download_link', locals: {study: @study, study_file: study_file} %>
         </td>
       </tr>
     <% end %>
@@ -271,11 +265,7 @@
                 <% end %>
               </td>
               <td>
-                <% if @allow_downloads %>
-                  <%= render partial: '/layouts/download_link', locals: {study: @study, study_file: file} %>
-                <% else %>
-                  <%= link_to 'Currently Unavailable', '#/', class: 'btn btn-danger disabled-download', disabled: true %>
-                <% end %>
+                <%= render partial: '/layouts/download_link', locals: {study: @study, study_file: file} %>
               </td>
             </tr>
           <% end %>

--- a/app/views/site/_study_tabs_nav.html.erb
+++ b/app/views/site/_study_tabs_nav.html.erb
@@ -45,19 +45,9 @@
       <a href="#study-analysis" data-toggle="tab">Analysis <i class="fas fa-fw fa-tasks"></i></a>
     </li>
     <% if @allow_firecloud_access && @user_can_edit %>
-      <% if @allow_edits %>
-        <li role="presentation" class="study-nav" id="study-settings-nav">
-          <a href="#study-settings" data-toggle="tab">Settings <i class="fas fa-fw fa-cogs"></i></a>
-        </li>
-      <% else %>
-        <li role="presentation" class="study-nav disabled" id="study-settings-nav">
-          <a href="#study-settings" data-toggle="tooltip"
-             title="Study workspaces are currently unavailable - please try again later.">
-            Settings <i class="fas fa-fw fa-cogs"></i>
-          </a>
-        </li>
-
-      <% end %>
+      <li role="presentation" class="study-nav" id="study-settings-nav">
+        <a href="#study-settings" data-toggle="tab">Settings <i class="fas fa-fw fa-cogs"></i></a>
+      </li>
     <% end %>
     <li role="presentation" class="study-badges">
       <span class="badge" id="cell-count"> <%= @study.cell_count %> cells</span>

--- a/app/views/site/study.html.erb
+++ b/app/views/site/study.html.erb
@@ -18,7 +18,7 @@
       </div>
     <% end %>
 
-    <% if @allow_firecloud_access && @allow_edits && @user_can_edit %>
+    <% if @allow_firecloud_access && @user_can_edit %>
       <div class="tab-pane" id="study-settings" role="tabpanel">
         <div class="row">
           <div class="col-xs-12" id="study-settings-form-target">

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -269,10 +269,10 @@
               </td>
               </td>
               <td>
-                <% if @allow_downloads %>
+                <% if !@study.detached %>
                   <%= render partial: '/layouts/download_link', locals: {study: @study, study_file: file} %>
                 <% else %>
-                  <%= button_to 'Currently Unavailable', '#/', class: 'btn btn-danger disabled-download', disabled: true %>
+                  <%= button_to 'Workspace unavailable', '#/', class: 'btn btn-danger disabled-download', disabled: true %>
                 <% end %>
               </td>
             </tr>

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -41,21 +41,15 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     profile_mock = Minitest::Mock.new
     profile_error = proc { raise 'user is not registered' }
     profile_mock.expect :get_profile, profile_error
-    thurloe_mock = Minitest::Mock.new
-    thurloe_mock.expect :services_available?, true, [String]
-    ApplicationController.stub :firecloud_client, thurloe_mock do
-      FireCloudClient.stub :new, profile_mock do
-        post update_user_firecloud_profile_path(@user.id, params: {fire_cloud_profile: profile.to_json})
-        assert_redirected_to view_profile_path(@user.id)
-        follow_redirect!
-        thurloe_mock.verify
-        profile_mock.verify
+    FireCloudClient.stub :new, profile_mock do
+      post update_user_firecloud_profile_path(@user.id, params: {fire_cloud_profile: profile.to_json})
+      assert_redirected_to view_profile_path(@user.id)
+      follow_redirect!
+      profile_mock.verify
 
-        # make sure user has not been registered
-        @user.reload
-        assert_not @user.registered_for_firecloud
-      end
-
+      # make sure user has not been registered
+      @user.reload
+      assert_not @user.registered_for_firecloud
     end
   end
 end

--- a/test/controllers/site_controller_test.rb
+++ b/test/controllers/site_controller_test.rb
@@ -160,13 +160,6 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
     mock_not_detached @study, :find_by do
       file = @study.study_files.sample
       mock = Minitest::Mock.new
-      mock.expect :services_available?, true, [String]
-      systems = [FireCloudClient::SAM_SERVICE, FireCloudClient::RAWLS_SERVICE, FireCloudClient::BUCKETS_SERVICE]
-      ok = { ok: true }
-      api_status = {
-        systems: Hash[systems.zip(Array.new(3) { ok })]
-      }.with_indifferent_access
-      mock.expect :api_status, api_status
       file_mock = Minitest::Mock.new
       file_mock.expect :present?, true
       file_mock.expect :size, file.upload_file_size

--- a/test/detached_helper.rb
+++ b/test/detached_helper.rb
@@ -28,7 +28,6 @@ end
 def generate_download_file_mock(study_files, parent_study: nil, private: false)
   download_file_mock = Minitest::Mock.new
   study_files.each do |file|
-    assign_services_mock!(download_file_mock, private)
     assign_get_file_mock!(download_file_mock)
     assign_url_mock!(download_file_mock, file, parent_study:)
   end
@@ -52,14 +51,6 @@ def assign_get_file_mock!(mock)
   file_mock.expect :present?, true
   file_mock.expect :size, 1.megabyte
   mock.expect :execute_gcloud_method, file_mock, [:get_workspace_file, 0, String, String]
-end
-
-def assign_services_mock!(mock, private)
-  if private
-    # private file downloads have an extra call to :services_available? for Sam and Rawls in addition to GoogleBuckets
-    mock.expect :services_available?, true, [String, String]
-  end
-  mock.expect :services_available?, true, [String]
 end
 
 # helper to mock all calls to Terra orchestration API when saving a new study & creating workspace

--- a/test/integration/external/study_validation_test.rb
+++ b/test/integration/external/study_validation_test.rb
@@ -243,7 +243,6 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
       assert initial_bq_row_count > 0, "wrong number of BQ rows found to test deletion capability"
 
       mock = Minitest::Mock.new
-      mock.expect :services_available?, true, [String, String]
       mock.expect :execute_gcloud_method, true, [:workspace_file_exists?, Integer, String, String]
       mock.expect :execute_gcloud_method, true, [:delete_workspace_file, Integer, String, String]
 


### PR DESCRIPTION
#### BACKGROUND
SCP has a practice of using pre-flight status checks for Terra API calls to guard against outages/latency in the event of upstream instability.  While this usually results in a much smoother UX where errors are prevented by checking various Terra services in the `/status` information, false positives can lead to situations where users are blocked from normal operations like uploading files or editing studies because a Terra service reports a problem when in fact there is not one.  Sometimes these false outage persist for hours, leading to widespread user impact.

This update removes almost all pre-flight checks and instead allows API calls to proceed and move through normal error handling.  This will all but eliminate the prior false positive issue.  The one place where a check was left in place was when checking whether a [user has access to a study via a group share](https://broadworkbench.atlassian.net/browse/SCP-2325).  This caused study overview pages to hang in the event of upstream outages, so an explicit check was put in place to guard against this.  All other service checks have been removed.

It should be noted that this could raise the incidence of 500-level errors that result in users seeing the "We're sorry, something went wrong" page.  However, the risk is quite low, and any such errors would be reported upstream to Sentry and can be triaged appropriately.

#### MANUAL TESTING
1. Boot all services and sign in
2. Load a study with visualizations and confirm nothing is affected and all tabs are enabled
3. Download a file and confirm it succeeds
4. Make an edit in the study settings page (like to the visualization defaults) and confirm there are no issues
5. Go to the upload wizard and add a file, confirming there are no issues
6. To simulate an outage, on line 237 of `app/models/fire_cloud_client.rb`, add the following call to throw an error:
```
raise 'internal error'
response = RestClient::Request.execute(method: http_method, url: path, payload: payload, headers: headers)
...
```
7. Repeat steps 2-4 to confirm that there is no interruption to normal usage
8. Attempt to share the study with another user and confirm in `development.log` you see a similar error, but the UI does not break and you can continue to use the site:
```
2025-02-26 13:48:01 -0500: Creating FireCloud ACLs for study Parse Flag Logic - share jonbistline@gmail.com, permission: View
FireCloud API request (PATCH) https://api.firecloud.org/api/workspaces/single-cell-portal-development/parse-flag-logic/acl?inviteUsersNotFound=true with tracking identifier: 63e27b72f39faa00560c1e25
Unknown error: RuntimeError - internal error
Completed 500 Internal Server Error in 1137ms (MongoDB: 0.7ms | Allocations: 153746)


internal error excluded from capture: DSN not set
  
RuntimeError (internal error):
  
app/models/fire_cloud_client.rb:237:in `process_firecloud_request'
app/models/fire_cloud_client.rb:445:in `update_workspace_acl'
app/models/study_share.rb:213:in `set_firecloud_acl'
app/controllers/site_controller.rb:112:in `update_study_settings'
app/controllers/application_controller.rb:82:in `set_current_user'
app/controllers/concerns/real_ip_logger.rb:15:in `log_real_ip'
```
Note: the modal will not close because we did not explicitly handle this exception.  Normally, a `RestClient::Exception` would be thrown and handled, but simulating those types of errors is complicated and unnecessary for this test.