### PR TITLE
Updating `ImportServiceConfig:NeMO`, re-enabling tests (SCP-5565)

### DIFF
--- a/app/models/import_service_config.rb
+++ b/app/models/import_service_config.rb
@@ -147,14 +147,11 @@ module ImportServiceConfig
   end
 
   # get a value for library_preparation_protocol
-  def find_library_prep(libs)
-    sanitized_libs = libs.map {|lib| lib.gsub(/(\schromium|\ssequencing)/, '') }
-    libraries = sanitized_libs.map do |sanitized_lib|
-      ExpressionFileInfo::LIBRARY_PREPARATION_VALUES.detect do |lib_prep|
-        lib_prep.casecmp(sanitized_lib) == 0
-      end
-    end.compact
-    libraries.first # in case of multiple, first matching value
+  def find_library_prep(lib)
+    sanitized_lib = lib.gsub(/(\schromium|\ssequencing)/, '')
+    ExpressionFileInfo::LIBRARY_PREPARATION_VALUES.detect do |lib_prep|
+      lib_prep.casecmp(sanitized_lib) == 0
+    end
   end
 
   # default cluster embedding data fragments, assuming X_umap slot

--- a/app/models/import_service_config.rb
+++ b/app/models/import_service_config.rb
@@ -147,11 +147,14 @@ module ImportServiceConfig
   end
 
   # get a value for library_preparation_protocol
-  def find_library_prep(lib)
-    sanitized_lib = lib.gsub(/(\schromium|\ssequencing)/, '')
-    ExpressionFileInfo::LIBRARY_PREPARATION_VALUES.detect do |lib_prep|
-      lib_prep.casecmp(sanitized_lib) == 0
-    end
+  def find_library_prep(libs)
+    sanitized_libs = libs.map {|lib| lib.gsub(/(\schromium|\ssequencing)/, '') }
+    libraries = sanitized_libs.map do |sanitized_lib|
+      ExpressionFileInfo::LIBRARY_PREPARATION_VALUES.detect do |lib_prep|
+        lib_prep.casecmp(sanitized_lib) == 0
+      end
+    end.compact
+    libraries.first # in case of multiple, first matching value
   end
 
   # default cluster embedding data fragments, assuming X_umap slot

--- a/app/models/import_service_config/nemo.rb
+++ b/app/models/import_service_config/nemo.rb
@@ -58,7 +58,7 @@ module ImportServiceConfig
 
     # return hash of file access info, like url, sizes, etc
     def file_access_info(protocol: nil)
-      urls = load_file&.[]('urls')
+      urls = load_file&.[]('manifest_file_urls')
       protocol ? urls.detect { |url| url.with_indifferent_access[:protocol] == protocol.to_s } : urls
     end
 
@@ -90,7 +90,7 @@ module ImportServiceConfig
         upload_file_size: :size,
         name: :file_name,
         expression_file_info: {
-          library_preparation_protocol: :technique
+          library_preparation_protocol: :techniques
         }
       }.with_indifferent_access
     end
@@ -108,7 +108,7 @@ module ImportServiceConfig
       study_file = to_study_file(scp_study_id, preferred_name)
       library = study_file.expression_file_info.library_preparation_protocol
       if library.blank?
-        library = load_study&.[]('technique')
+        library = load_study&.[]('techniques')
       end
       study_file.expression_file_info.library_preparation_protocol = find_library_prep(library)
       exp_fragment = expression_data_fragment(study_file)

--- a/app/models/import_service_config/nemo.rb
+++ b/app/models/import_service_config/nemo.rb
@@ -108,9 +108,10 @@ module ImportServiceConfig
       study_file = to_study_file(scp_study_id, preferred_name)
       library = study_file.expression_file_info.library_preparation_protocol
       if library.blank?
-        library = load_study&.[]('techniques')
+        libs = load_study&.[]('techniques')
+        libraries = libs.map { |lib| find_library_prep(lib) }.compact
+        study_file.expression_file_info.library_preparation_protocol = libraries.first
       end
-      study_file.expression_file_info.library_preparation_protocol = find_library_prep(library)
       exp_fragment = expression_data_fragment(study_file)
       study_file.ann_data_file_info.data_fragments << exp_fragment
       http_url = file_access_info(protocol: :http)&.[]('url')

--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -153,7 +153,7 @@ module ImportServiceConfig
     end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    test 'should import from service' do
+    test 'should import all from service' do
       access_url = 'https://data.nemoarchive.org/other/grant/u01_lein/lein/transcriptome/sncell/10x_v3/human/' \
                    'processed/counts/human_var_scVI_VLMC.h5ad.tar'
       file_mock = MiniTest::Mock.new

--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -12,7 +12,7 @@ module ImportServiceConfig
         file_id: 'nemo:der-ah1o5qb',
         project_id: 'nemo:grn-gyy3k8j',
         study_id: 'nemo:col-hwmwd2x',
-        obsm_key_names: %w[X_tsne X_umap],
+        obsm_key_names: %w[X_umap],
         user_id: @user.id,
         branding_group_id: @branding_group.id
       }
@@ -126,8 +126,8 @@ module ImportServiceConfig
     end
 
     test 'should find library preparation protocol' do
-      assert_equal "10x 3' v3", @configuration.find_library_prep(["10x chromium 3' v3 sequencing"])
-      assert_equal 'Drop-seq', @configuration.find_library_prep(['drop-seq'])
+      assert_equal "10x 3' v3", @configuration.find_library_prep("10x chromium 3' v3 sequencing")
+      assert_equal 'Drop-seq', @configuration.find_library_prep('drop-seq')
     end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test

--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -49,12 +49,12 @@ module ImportServiceConfig
     end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    # test 'should traverse associations to set ids' do
-    #   config = ImportServiceConfig::Nemo.new(file_id: @attributes[:file_id])
-    #   config.traverse_associations!
-    #   assert_equal @attributes[:study_id], config.study_id
-    #   assert_equal @attributes[:project_id], config.project_id
-    # end
+    test 'should traverse associations to set ids' do
+      config = ImportServiceConfig::Nemo.new(file_id: @attributes[:file_id])
+      config.traverse_associations!
+      assert_equal @attributes[:study_id], config.study_id
+      assert_equal @attributes[:project_id], config.project_id
+    end
 
     test 'should load defaults' do
       study_defaults = {
@@ -80,7 +80,7 @@ module ImportServiceConfig
       end
       assert_equal :file_name, study_file_mappings[:name]
       assert_equal :file_name, study_file_mappings[:upload_file_name]
-      assert_equal :technique, study_file_mappings.dig(:expression_file_info, :library_preparation_protocol)
+      assert_equal :techniques, study_file_mappings.dig(:expression_file_info, :library_preparation_protocol)
     end
 
     test 'should sanitize attribute values' do
@@ -93,91 +93,91 @@ module ImportServiceConfig
       assert_equal 'application/octet-stream', @configuration.get_file_content_type('csv')
     end
 
-    # test 'should load study analog' do
-    #   study = @configuration.load_study
-    #   assert_equal '"Human variation study (10x), GRU"', study['name']
-    #   assert_equal ["10x chromium 3' v3 sequencing"], study['techniques']
-    #   assert_equal [{"name"=>"human", "cv_term_id"=>"NCBI:txid9606"}], study['taxa']
-    # end
+    test 'should load study analog' do
+      study = @configuration.load_study
+      assert_equal '"Human variation study (10x), GRU"', study['name']
+      assert_equal ["10x chromium 3' v3 sequencing"], study['techniques']
+      assert_equal [{"name"=>"human", "cv_term_id"=>"NCBI:txid9606"}], study['taxa']
+    end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    # test 'should load file analog' do
-    #   file = @configuration.load_file
-    #   assert_equal 'human_var_scVI_VLMC.h5ad.tar', file['file_name']
-    #   assert_equal 'h5ad', file['file_format']
-    #   assert_equal 'counts', file['data_type']
-    # end
+    test 'should load file analog' do
+      file = @configuration.load_file
+      assert_equal 'human_var_scVI_VLMC.h5ad.tar', file['file_name']
+      assert_equal 'h5ad', file['file_format']
+      assert_equal 'counts', file['data_type']
+    end
 
-    # test 'should load collection analog' do
-    #   collection = @configuration.load_collection
-    #   assert_equal 'AIBS Internal', collection['short_name']
-    # end
-
-    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    # test 'should extract association ids' do
-    #   file = @configuration.load_file
-    #   study = @configuration.load_study
-    #   assert_equal @attributes[:study_id], @configuration.id_from(file, :collections)
-    #   assert_equal @attributes[:project_id], @configuration.id_from(study, :projects)
-    # end
-
-    # test 'should load taxon common names' do
-    #   assert_equal %w[human], @configuration.taxon_names
-    # end
-    #
-    # test 'should find library preparation protocol' do
-    #   assert_equal "10x 3' v3", @configuration.find_library_prep("10x chromium 3' v3 sequencing")
-    #   assert_equal 'Drop-seq', @configuration.find_library_prep('drop-seq')
-    # end
+    test 'should load collection analog' do
+      collection = @configuration.load_collection
+      assert_equal 'AIBS Internal', collection['short_name']
+    end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    # test 'should populate study and study_file' do
-    #   scp_study = @configuration.populate_study
-    #   assert_equal 'Human variation study (10x), GRU', scp_study.name
-    #   assert_not scp_study.public
-    #   assert scp_study.full_description.present?
-    #   assert_equal @user_id, scp_study.user_id
-    #   assert_equal @branding_group_id, scp_study.branding_group_ids.first
-    #   assert_equal @configuration.service_name, scp_study.imported_from
-    #   # populate StudyFile, using above study
-    #   scp_study_file = @configuration.populate_study_file(scp_study.id)
-    #   assert scp_study_file.use_metadata_convention
-    #   assert_equal 'human_var_scVI_VLMC.h5ad.tar', scp_study_file.upload_file_name
-    #   assert_equal "10x 3' v3", scp_study_file.expression_file_info.library_preparation_protocol
-    #   assert_equal @configuration.service_name, scp_study_file.imported_from
-    #   assert_not scp_study_file.ann_data_file_info.reference_file
-    #   @configuration.obsm_keys.each do |obsm_key_name|
-    #     assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?
-    #   end
-    #   assert scp_study_file.ann_data_file_info.find_fragment(data_type: :expression).present?
-    # end
+    test 'should extract association ids' do
+      file = @configuration.load_file
+      study = @configuration.load_study
+      assert_equal @attributes[:study_id], @configuration.id_from(file, :collections)
+      assert_equal @attributes[:project_id], @configuration.id_from(study, :projects)
+    end
+
+    test 'should load taxon common names' do
+      assert_equal %w[human], @configuration.taxon_names
+    end
+
+    test 'should find library preparation protocol' do
+      assert_equal "10x 3' v3", @configuration.find_library_prep(["10x chromium 3' v3 sequencing"])
+      assert_equal 'Drop-seq', @configuration.find_library_prep(['drop-seq'])
+    end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    # test 'should import from service' do
-    #   access_url = 'https://data.nemoarchive.org/other/grant/u01_lein/lein/transcriptome/sncell/10x_v3/human/' \
-    #                'processed/counts/human_var_scVI_VLMC.h5ad.tar'
-    #   file_mock = MiniTest::Mock.new
-    #   file_mock.expect :generation, '123456789'
-    #   # for study to save, we need to mock all Terra orchestration API calls for creating workspace & setting acls
-    #   fc_client_mock = Minitest::Mock.new
-    #   owner_group = { groupEmail: 'sa-owner-group@firecloud.org' }.with_indifferent_access
-    #   assign_workspace_mock!(fc_client_mock, owner_group, 'human-variation-study-10x-gru')
-    #   AdminConfiguration.stub :find_or_create_ws_user_group!, owner_group do
-    #     ImportService.stub :copy_file_to_bucket, file_mock do
-    #       ApplicationController.stub :firecloud_client, fc_client_mock do
-    #         @configuration.stub :taxon_from, Taxon.new(common_name: 'human') do
-    #           study, study_file = @configuration.import_from_service
-    #           file_mock.verify
-    #           fc_client_mock.verify
-    #           assert study.persisted?
-    #           assert study_file.persisted?
-    #           assert_equal study.external_identifier, @attributes[:study_id]
-    #           assert_equal study_file.external_identifier, @attributes[:file_id]
-    #           assert_equal study_file.external_link_url, access_url
-    #         end
-    #       end
-    #     end
-    #   end
-    # end
+    test 'should populate study and study_file' do
+      scp_study = @configuration.populate_study
+      assert_equal 'Human variation study (10x), GRU', scp_study.name
+      assert_not scp_study.public
+      assert scp_study.full_description.present?
+      assert_equal @user_id, scp_study.user_id
+      assert_equal @branding_group_id, scp_study.branding_group_ids.first
+      assert_equal @configuration.service_name, scp_study.imported_from
+      # populate StudyFile, using above study
+      scp_study_file = @configuration.populate_study_file(scp_study.id)
+      assert scp_study_file.use_metadata_convention
+      assert_equal 'human_var_scVI_VLMC.h5ad.tar', scp_study_file.upload_file_name
+      assert_equal "10x 3' v3", scp_study_file.expression_file_info.library_preparation_protocol
+      assert_equal @configuration.service_name, scp_study_file.imported_from
+      assert_not scp_study_file.ann_data_file_info.reference_file
+      @configuration.obsm_keys.each do |obsm_key_name|
+        assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?
+      end
+      assert scp_study_file.ann_data_file_info.find_fragment(data_type: :expression).present?
+    end
+
+    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+    test 'should import from service' do
+      access_url = 'https://data.nemoarchive.org/other/grant/u01_lein/lein/transcriptome/sncell/10x_v3/human/' \
+                   'processed/counts/human_var_scVI_VLMC.h5ad.tar'
+      file_mock = MiniTest::Mock.new
+      file_mock.expect :generation, '123456789'
+      # for study to save, we need to mock all Terra orchestration API calls for creating workspace & setting acls
+      fc_client_mock = Minitest::Mock.new
+      owner_group = { groupEmail: 'sa-owner-group@firecloud.org' }.with_indifferent_access
+      assign_workspace_mock!(fc_client_mock, owner_group, 'human-variation-study-10x-gru')
+      AdminConfiguration.stub :find_or_create_ws_user_group!, owner_group do
+        ImportService.stub :copy_file_to_bucket, file_mock do
+          ApplicationController.stub :firecloud_client, fc_client_mock do
+            @configuration.stub :taxon_from, Taxon.new(common_name: 'human') do
+              study, study_file = @configuration.import_from_service
+              file_mock.verify
+              fc_client_mock.verify
+              assert study.persisted?
+              assert study_file.persisted?
+              assert_equal study.external_identifier, @attributes[:study_id]
+              assert_equal study_file.external_identifier, @attributes[:file_id]
+              assert_equal study_file.external_link_url, access_url
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/test/integration/external/nemo_client_test.rb
+++ b/test/integration/external/nemo_client_test.rb
@@ -56,55 +56,55 @@ class NemoClientTest < ActiveSupport::TestCase
   end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  # test 'should get an entity' do
-  #   skip_if_api_down
-  #   entity_type = @identifiers.keys.sample
-  #   identifier = @identifiers[entity_type]
-  #   entity = @nemo_client.fetch_entity(entity_type, identifier)
-  #   assert entity.present?
-  # end
+  test 'should get an entity' do
+    skip_if_api_down
+    entity_type = @identifiers.keys.sample
+    identifier = @identifiers[entity_type]
+    entity = @nemo_client.fetch_entity(entity_type, identifier)
+    assert entity.present?
+  end
 
-  # test 'should get collection' do
-  #   skip_if_api_down
-  #   identifier = @identifiers[:collection]
-  #   collection = @nemo_client.collection(identifier)
-  #   assert collection.present?
-  #   assert_equal 'adey_sciATAC_human_cortex', collection['short_name']
-  # end
-
-  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  # test 'should get file' do
-  #   skip_if_api_down
-  #   identifier = @identifiers[:file]
-  #   file = @nemo_client.file(identifier)
-  #   assert file.present?
-  #   filename = 'human_var_scVI_VLMC.h5ad.tar'
-  #   assert_equal filename, file['file_name']
-  #   assert_equal 'h5ad', file['file_format']
-  #   access_url = file['urls'].first['url']
-  #   assert_equal filename, access_url.split('/').last
-  # end
+  test 'should get collection' do
+    skip_if_api_down
+    identifier = @identifiers[:collection]
+    collection = @nemo_client.collection(identifier)
+    assert collection.present?
+    assert_equal 'adey_sciATAC_human_cortex', collection['short_name']
+  end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  # test 'should get grant' do
-  #   skip_if_api_down
-  #   identifier = @identifiers[:grant]
-  #   grant = @nemo_client.grant(identifier)
-  #   assert grant.present?
-  #   assert_equal '1U01MH114825-01', grant['grant_number']
-  #   assert_equal 'NIMH', grant['funding_agency']
-  # end
+  test 'should get file' do
+    skip_if_api_down
+    identifier = @identifiers[:file]
+    file = @nemo_client.file(identifier)
+    assert file.present?
+    filename = 'human_var_scVI_VLMC.h5ad.tar'
+    assert_equal filename, file['file_name']
+    assert_equal 'h5ad', file['file_format']
+    access_url = file['manifest_file_urls'].first['url']
+    assert_equal filename, access_url.split('/').last
+  end
 
-  # test 'should get project' do
-  #   skip_if_api_down
-  #   identifier = @identifiers[:project]
-  #   project = @nemo_client.project(identifier)
-  #   assert project.present?
-  #   assert_equal 'Single-nucleus analysis of preoptic area development from late embryonic to adult stages',
-  #                project['title']
-  #   assert_equal 'biccn', project['program']
-  #   assert_equal 'dulac_poa_dev_sn_10x_proj', project['short_name']
-  # end
+  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+  test 'should get grant' do
+    skip_if_api_down
+    identifier = @identifiers[:grant]
+    grant = @nemo_client.grant(identifier)
+    assert grant.present?
+    assert_equal '1U01MH114825', grant.dig('grant_info','grant_number')
+    assert_equal 'NIMH', grant['funding_agency']
+  end
+
+  test 'should get project' do
+    skip_if_api_down
+    identifier = @identifiers[:project]
+    project = @nemo_client.project(identifier)
+    assert project.present?
+    assert_equal 'Single-nucleus analysis of preoptic area development from late embryonic to adult stages',
+                 project['title']
+    assert_equal 'biccn', project['program']
+    assert_equal 'dulac_poa_dev_sn_10x_proj', project['short_name']
+  end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
   # test 'should get publication' do
@@ -118,23 +118,23 @@ class NemoClientTest < ActiveSupport::TestCase
   # end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  # test 'should get sample' do
-  #   skip_if_api_down
-  #   identifier = @identifiers[:sample]
-  #   sample = @nemo_client.sample(identifier)
-  #   assert sample.present?
-  #   assert_equal 'marm028_M1', sample['source_sample_id']
-  #   assert sample['files'].any?
-  # end
+  test 'should get sample' do
+    skip_if_api_down
+    identifier = @identifiers[:sample]
+    sample = @nemo_client.sample(identifier)
+    assert sample.present?
+    assert_equal 'marm028_M1', sample['sample_name']
+    assert sample['subjects'].any?
+  end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  # test 'should get subject' do
-  #   skip_if_api_down
-  #   identifier = @identifiers[:subject]
-  #   subject = @nemo_client.subject(identifier)
-  #   assert subject.present?
-  #   assert_equal 'CEMBA180911_4H', subject['source_subject_id']
-  #   assert_equal 'DNA methylation profiling of genomic DNA in individual mouse brain cell nuclei (RS1.1)',
-  #                subject['grant_title']
-  # end
+  test 'should get subject' do
+    skip_if_api_down
+    identifier = @identifiers[:subject]
+    subject = @nemo_client.subject(identifier)
+    assert subject.present?
+    assert_equal 'nonhuman-1U01MH114819', subject.dig('cohort_info', 'cohort_name')
+    assert_equal 'A Molecular and cellular atlas of the marmoset brain', subject['grant_title']
+    assert subject['samples'].any?
+  end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update re-enables most NeMO-related tests and makes small updates to underlying clients/services associated with `ImportService`.  This is in response to the forthcoming public release of the NeMO Identifier API.

Changes are minor in the structure of the data.  Whereas the analog for `library_preparation_protocol` used to be a single value called `technique`, now this is an array called `techniques`.  Access urls for files are now called `manifest_file_urls`.  Otherwise, the data is largely the same, and most tests work as expected with existing identifiers.  There does seem to be some sparseness in the data - there are no publications that I can find, and the `sample` entities don't have as many values populated as before.  This doesn't affect CI or intended usage much, so the risk is very minor.

There is an issue with API stability that can cause one large integration test to fail roughly 50% of the time.  The upstream issue appears to be the API losing connection to their MySQL instance while reading response data.  I don't anticipate this being an issue long-term.  If we find that the test is too unreliable, it can be disabled while we work with the NeMO team on API stability.

#### MANUAL TESTING
You can run both test suites manually with the following commands (once you have initialized your dev environment) to confirm they work.  Note that the `import_service_config/nemo_test.rb` may fail on the `import all from service` test due to the aforementioned stability issue.

- `NemoClient` - `rails test test/integration/external/nemo_client_test.rb`
- `ImportServiceConfig::Nemo` - `rails test test/integration/external/import_service_config/nemo_test.rb`

Alternatively, you can validate the tests ran successfully from the associated CI for this PR. 