### PR TITLE
Adding scripts for dealing with scheduled instance restart (SCP-5949)

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,5 +1,7 @@
 name: Deploy to staging SCP instance
 on:
+  schedule:
+    - cron: "15 8 * * 1-5"
   workflow_run:
     workflows: ["Build and publish single-cell-portal Docker image"]
     types:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,7 +1,5 @@
 name: Deploy to staging SCP instance
 on:
-  schedule:
-    - cron: "15 8 * * 1-5"
   workflow_run:
     workflows: ["Build and publish single-cell-portal Docker image"]
     types:

--- a/bin/remount_portal_source.sh
+++ b/bin/remount_portal_source.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+
+# script to add to the root crontab to remount attached disk in correct location after scheduled instance restart
+# crontab should be entered as follows
+# @reboot /root/remout_portal_source.sh > /dev/null 2>&1
+MOUNT_DIR=$(ls -l /dev/disk/by-id/google-* | grep google-singlecell-data-disk | awk -F '/' '{ print $NF }')
+if [[ -n "$MOUNT_DIR" ]]; then
+  echo "$(date): remounting google-singlecell-data-disk from /dev/$MOUNT_DIR" >> /home/jenkins/remount_log.txt
+  mount -o discard,defaults /dev/$MOUNT_DIR /home/jenkins/deployments
+else
+  echo -e "$(date): cannot remount google-singlecell-data-disk, available disks:\n$(ls -l /dev/disk/by-id/google-*)" >> /home/jenkins/remount_log.txt
+fi

--- a/bin/remount_portal_source.sh
+++ b/bin/remount_portal_source.sh
@@ -1,8 +1,12 @@
 #! /usr/bin/env bash
 
-# script to add to the root crontab to remount attached disk in correct location after scheduled instance restart
+# script to add to the root crontab to remount attached disk in correct location after scheduled instance restart,
+# which is used for staging and development VMs, but not production
+
 # crontab should be entered as follows
 # @reboot /root/remout_portal_source.sh > /dev/null 2>&1
+
+# More context: https://github.com/broadinstitute/single_cell_portal_core/pull/2216
 MOUNT_DIR=$(ls -l /dev/disk/by-id/google-* | grep google-singlecell-data-disk | awk -F '/' '{ print $NF }')
 if [[ -n "$MOUNT_DIR" ]]; then
   echo "$(date): remounting google-singlecell-data-disk from /dev/$MOUNT_DIR" >> /home/jenkins/remount_log.txt

--- a/bin/restart_portal_container.sh
+++ b/bin/restart_portal_container.sh
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+
+# script to add to root crontab on a deployed host to check for crashed Docker containers and restart
+# crontab entry should be as follows:
+# */5 * * * * /root/restart_portal_container.sh > /dev/null 2>&1
+docker ps --filter "status=exited" | grep -e 'single_cell' | while read -r line ; do
+	container_id=`echo $line | awk '{print $1}'`
+	container_name=`echo $line | awk '{print $NF}'`
+	echo "Restarting $container_name ($container_id) on $(date)" >> /home/jenkins/deployments/single_cell_portal_core/log/cron_out.log
+	docker restart $container_id
+done

--- a/bin/restart_portal_container.sh
+++ b/bin/restart_portal_container.sh
@@ -3,6 +3,8 @@
 # script to add to root crontab on a deployed host to check for crashed Docker containers and restart
 # crontab entry should be as follows:
 # */5 * * * * /root/restart_portal_container.sh > /dev/null 2>&1
+
+# More context: https://github.com/broadinstitute/single_cell_portal_core/pull/2216
 docker ps --filter "status=exited" | grep -e 'single_cell' | while read -r line ; do
   container_id=`echo $line | awk '{print $1}'`
   container_name=`echo $line | awk '{print $NF}'`

--- a/bin/restart_portal_container.sh
+++ b/bin/restart_portal_container.sh
@@ -4,8 +4,8 @@
 # crontab entry should be as follows:
 # */5 * * * * /root/restart_portal_container.sh > /dev/null 2>&1
 docker ps --filter "status=exited" | grep -e 'single_cell' | while read -r line ; do
-	container_id=`echo $line | awk '{print $1}'`
-	container_name=`echo $line | awk '{print $NF}'`
-	echo "Restarting $container_name ($container_id) on $(date)" >> /home/jenkins/deployments/single_cell_portal_core/log/cron_out.log
-	docker restart $container_id
+  container_id=`echo $line | awk '{print $1}'`
+  container_name=`echo $line | awk '{print $NF}'`
+  echo "Restarting $container_name ($container_id) on $(date)" >> /home/jenkins/deployments/single_cell_portal_core/log/cron_out.log
+  docker restart $container_id
 done


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds two scripts to source that are used for restarting the staging portal Docker container after the VM restarts on schedule.  The issue had been that when a GCE VM automatically reboots, the data disk did not automatically remount at the correct location.  Since this disk holds all of the portal source code, the Docker container could not automatically restart, which led to irrecoverable issues that required a full deployment to address.  Now, the script determines the correct attachment point and mounts automatically on reboot, and then the cron restarts the container 5 minutes later.  No deployment is required as all processes inside the container can resume without error.  Both scripts have been added to the staging VM and the `root` crontab:
```
(ansible) [root@singlecell-01 ~]# crontab -l
0 * * * * service google-fluentd restart
*/5 * * * * /root/restart_portal_container.sh > /dev/null 2>&1
@reboot /root/remount_portal_source.sh > /dev/null 2>&1
```

This unfortunately takes about 15 minutes total to recover due to our "less than ideal" load balancer health check setup that shunts traffic away from the VM when the container becomes unavailable.  It takes ~1 min for the VM to restart at 8 AM, and the Docker container restarts at 8:05.  It takes ~2 min to boot, and then the health check will run again between 8:10 and 8:15.  Once the backend service (i.e. portal container) is deemed healthy, the load balancer then recovers and normal traffic resumes.  There is no way to apply a schedule to health checks - only an interval - and classic HTTPS load balancers can't be used without a health check.

#### MANUAL TESTING
The simplest way to verify this is that the staging instance restarted this morning without any direct intervention.  Additionally, the `remount_log.txt` file has activity from this morning showing the disk remounted correctly (note the time is UTC and the VM runs in `us-central1`):
```
(ansible) [root@singlecell-01 ~]# cat /home/jenkins/remount_log.txt
Tue Mar 11 12:00:37 PM UTC 2025: remounting google-singlecell-data-disk from /dev/sdc
```

