### PR TITLE
Correctly identify bundled files in upload wizard (SCP-5941)

### DIFF
--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -111,7 +111,7 @@ export function findBundleChildren(file, files) {
       f.study_file_bundle_id
     ]
     return parentFields.includes(file._id) ||
-      file.study_file_bundle_id && parentFields.includes(file.study_file_bundle_id)
+      file.study_file_bundle_id && parentFields.includes(file.study_file_bundle_id) && f._id !== file._id
   })
 }
 

--- a/test/js/upload-wizard/file-info-responses.js
+++ b/test/js/upload-wizard/file-info-responses.js
@@ -323,7 +323,7 @@ export const RAW_COUNTS_MTX_FILE = {
     ''
   ],
   'status': 'uploaded',
-  'study_file_bundle_id': 'null',
+  'study_file_bundle_id': '618bd61acc7ba038ac7cb091',
   'study_id': {
     '$oid': '60a2b9f4cc7ba082358b5448'
   },
@@ -368,7 +368,7 @@ export const BARCODES_FILE = {
   remote_location: '',
   spatial_cluster_associations: [''],
   status: 'uploaded',
-  study_file_bundle_id: { $oid: '618bd61acc7ba038ac7cb091' },
+  study_file_bundle_id: '618bd61acc7ba038ac7cb091',
   study_id: { $oid: '618aacbfcc7ba038ac7cb00f' },
   taxon_id: null,
   updated_at: '2021-11-10T09:24:57.640-05:00',
@@ -408,7 +408,7 @@ export const FEATURES_FILE = {
   remote_location: '',
   spatial_cluster_associations: [''],
   status: 'uploaded',
-  study_file_bundle_id: { $oid: '618bd61acc7ba038ac7cb091' },
+  study_file_bundle_id: '618bd61acc7ba038ac7cb091',
   study_id: { $oid: '618aacbfcc7ba038ac7cb00f' },
   taxon_id: null,
   updated_at: '2021-11-10T09:24:57.640-05:00',
@@ -428,6 +428,70 @@ export const FEATURES_FILE = {
   z_axis_max: null,
   z_axis_min: null,
   _id: { $oid: '618bd61acc7ba038ac22334' }
+}
+
+export const BED_FILE =   {
+  _id: { $oid: "668360b1fb648e9c7c7d3380" },
+  parse_status: "unparsed",
+  x_axis_label: "",
+  y_axis_label: "",
+  z_axis_label: "",
+  spatial_cluster_associations: [""],
+  remote_location: "pbmc_3k_atac_fragments.possorted.bed.gz",
+  options: { upload_trigger: "bucket" },
+  study_id: { $oid: "66835832771a5b0202fcfeae" },
+  human_data: false,
+  use_metadata_convention: false,
+  is_spatial: false,
+  queued_for_deletion: false,
+  taxon_id: { $oid: '604009b7cc7ba03e1b277a38' },
+  genome_assembly_id: { $oid: '604009b7cc7ba03e1b277a39' },
+  name: "pbmc_3k_atac_fragments.possorted.bed.gz",
+  description: "",
+  file_type: "BED",
+  human_fastq_url: "",
+  data_dir: "b2695100728ad64155d462d59e57bfd7c2200e979114dbc534c17866b935067f",
+  status: "uploaded",
+  upload_file_name: "pbmc_3k_atac_fragments.possorted.bed.gz",
+  upload_content_type: "application/x-gzip",
+  upload_file_size: 539109524,
+  generation: "1719884843494138",
+  updated_at: "2024-07-02T02:07:19.309Z",
+  created_at: "2024-07-02T02:07:07.182Z",
+  version: 2,
+  study_file_bundle_id: "668360d7771a5b0202fcff56",
+  is_complete: true
+}
+
+export const BED_INDEX_FILE = {
+  _id: { $oid: "668360bdb51a86c2885fd5e6" },
+  parse_status: "unparsed",
+  x_axis_label: "",
+  y_axis_label: "",
+  z_axis_label: "",
+  spatial_cluster_associations: [""],
+  remote_location: "pbmc_3k_atac_fragments.possorted.bed.gz.tbi",
+  options: { upload_trigger: "bucket", bed_id: "668360b1fb648e9c7c7d3380" },
+  study_id: { $oid: "66835832771a5b0202fcfeae" },
+  human_data: false,
+  use_metadata_convention: false,
+  is_spatial: false,
+  queued_for_deletion: false,
+  name: "pbmc_3k_atac_fragments.possorted.bed.gz",
+  description: "",
+  file_type: "Tab Index",
+  human_fastq_url: "",
+  data_dir: "b2695100728ad64155d462d59e57bfd7c2200e979114dbc534c17866b935067f",
+  status: "uploaded",
+  upload_file_name: "pbmc_3k_atac_fragments.possorted.bed.gz.tbi",
+  upload_content_type: null,
+  upload_file_size: 645077,
+  generation: "1719884679213326",
+  updated_at: "2024-07-02T02:07:19.316Z",
+  created_at: "2024-07-02T02:07:19.287Z",
+  version: 2,
+  study_file_bundle_id: "668360d7771a5b0202fcff56",
+  is_complete: true
 }
 
 export const IMAGE_FILE = {

--- a/test/js/upload-wizard/validations.test.js
+++ b/test/js/upload-wizard/validations.test.js
@@ -1,4 +1,5 @@
-import { validateFile } from 'components/upload/upload-utils'
+import { validateFile, findBundleChildren } from 'components/upload/upload-utils'
+import { BED_FILE, BED_INDEX_FILE, RAW_COUNTS_MTX_FILE, FEATURES_FILE, BARCODES_FILE } from './file-info-responses'
 
 describe('upload file validation name checks', () => {
   it('allows files with unique names and valid extensions', async () => {
@@ -160,5 +161,20 @@ describe('it checks presence of required fields', () => {
     })
     expect(msgs['expression_file_info.units']).toEqual(undefined)
     expect(msgs['expression_file_info.biosample_input_type']).toEqual('You must specify: biosample input type')
+  })
+})
+
+describe('it finds bundled files', () => {
+  it('find sequence index files', () => {
+    const serverFiles = [BED_FILE, BED_INDEX_FILE]
+    const bundledIndex = findBundleChildren(BED_FILE, serverFiles)[0]
+    expect(bundledIndex.upload_file_name).toEqual(BED_INDEX_FILE.upload_file_name)
+  })
+
+  it('finds features/barcodes files for MTX', () => {
+    const serverFiles = [RAW_COUNTS_MTX_FILE, FEATURES_FILE, BARCODES_FILE]
+    const bundledFiles = findBundleChildren(RAW_COUNTS_MTX_FILE, serverFiles)
+    const fileNames = bundledFiles.map(f => { return f.upload_file_name })
+    expect(fileNames).toEqual([FEATURES_FILE.upload_file_name, BARCODES_FILE.upload_file_name])
   })
 })


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug in the upload wizard where bundled sequence index files were not correctly identified.  The parent files was instead being supplied to the index form as it was matching on the `study_file_bundle_id` first before finding the index file.  Now, an added check to ignore the file by its ID allows the index to be found.  This appears to have affect BAM files as well, but given their sparsity in SCP it wasn't identified until now due to the fragment BED file work.

#### MANUAL TEST
1. Boot as normal and load the upload wizard for any study that has BED or BAM files
2. Confirm the index file is correct for the parent sequence file