### PR TITLE
Update human milk study metadata file (SCP-5955)

### DIFF
--- a/db/seed/example_studies/human_milk_de_49k_cell/study_info.json
+++ b/db/seed/example_studies/human_milk_de_49k_cell/study_info.json
@@ -1,15 +1,15 @@
 {
   "study": {
-    "name": "Human milk - differential expression",
+    "name": "Human milk - differential expression Mar 2025 update",
     "description": "(Based on SCP1671) Human breast milk is a dynamic fluid that contains millions of cells, but their identities and phenotypic properties are poorly understood. We used single-cell RNA-seq (scRNA-seq) to characterize the transcriptomes of cells from human breast milk (hBM) across lactational time from 3 to 632 days postpartum in 15 donors. We find that the majority of cells in human breast milk are lactocytes, a specialized epithelial subset, and cell type frequencies shift over the course of lactation yielding greater epithelial diversity at later points. Analysis of lactocytes reveals a continuum of cell states characterized by transcriptional changes in hormone, growth factor, and milk production related pathways. Generalized additive models suggest that one sub-cluster, LC1 epithelial cells, increase as a function of time postpartum, daycare attendance, and the use of hormonal birth control. We identify several sub-clusters of macrophages in hBM that are enriched for tolerogenic functions, possibly playing a role in protecting the mammary gland during lactation. Our description of the cellular components of breast milk, their association with maternal-infant dyad metadata and quantification of alterations at the gene and pathways levels provides the first detailed longitudinal picture of human breast milk cells across lactational time. This work paves the way for future investigations of how a potential division of cellular labor and differential hormone regulation might be leveraged therapeutically to support healthy lactation and potentially aid in milk production.",
     "data_dir": "test"
   },
   "files": [
     {
       "type": "Metadata",
-      "filename": "MIT_milk_study_metadata.csv.gz",
+      "filename": "MIT_milk_study_metadata_Mar2025update.csv.gz",
       "use_metadata_convention": true,
-      "bucket_url": "gs://broad-singlecellportal-public/test/studies/SCP1671/MIT_milk_study_metadata.csv.gz"
+      "bucket_url": "gs://broad-singlecellportal-public/test/studies/SCP1671/MIT_milk_study_metadata_Mar2025update.csv.gz"
     },
     {
       "type": "Expression Matrix",


### PR DESCRIPTION
### Background

In January, ontology changes (in both CL and HANCESTRO ontologies) caused metadata validation to fail for our reference human milk study (see [Slack discussion](https://broadinstitute.slack.com/archives/CBEHTH601/p1737468028640919) for context). Having a validation-compliant version of the metadata file for this key example study seemed prudent. Historically, this study could be created locally using `SyntheticStudyPopulator`. To differentiate between any existing human milk study and this updated version, has "Mar 2025 update" appended to the original study title.

While updating the metadata file, several issues around this metadata file update seemed worthwhile to call out.

1. `SyntheticStudyPopulator` is somewhat out of date (it will not handle AnnData files as inputs and the gcloud commands to copy files do not work on staging). `SyntheticStudyPopulator` may also have parallels with `ImportService` and perhaps having one automated study creation mechanism rather than two might be preferable.

2. The `genome_annotation_name` specified in `study_info.json` MUST match the genome annotation associated with GRCh38 in the Portal's Species configuration (If your local instance's `genome_annotation_name` is not Ensembl 94, adjust `genome_annotation_name` in `study_info.json` to match the genome annotation listed for your instance before running  `SyntheticStudyPopulator`)

3. CSFV will erroneously fail the **uncompressed** updated metadata file. The metadata file is comma delimited and has some quoted fields with internal commas that are confusing CSFV - this is not an issue for `SyntheticStudyPopulator` which bypasses CSFV. If direct file upload is used to create the human milk study, use the CSFV feature flag to bypass CSFV. Note: ontology validation is currently only available for AnnData.

### Manual testing

#### Direct file upload - recommended option

1. Boot all services and sign in
2. Obtain the updated metadata file from gs://fc-51dcce50-d5e1-4682-87b2-d7fd07dcee9d/MIT_milk_study_metadata_Mar2025update.csv.gz
3. IF using an uncompressed version of the metadata file, set the CSFV feature flag to bypass CSFV 
4. Confirm that the updated file passes server-side metadata validation

#### `SyntheticStudyPopulator` option:

1. Boot all services and sign in
2. Visit the `Species` configuration for human. If the genome annotation version set locally for GRCh38 is not Ensemble 94, update the `genome_annotation_name` fields for both `Expression Matrix` file entries in `db/seed/example_studies/human_milk_de_49k_cell/study_info.json` to match the local human genome annotation.
4. Trigger a `SyntheticStudyPopulator` event with the following command:
`echo "SyntheticStudyPopulator.populate('human_milk_de_49k_cell')" | bundle exec rails console -e development`
