### PR TITLE
Updating NeMO tests for missing entities (SCP-5966)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,8 @@ gem 'ostruct'
 gem 'logger'
 gem 'benchmark'
 gem 'drb'
+gem 'reline'
+gem 'irb'
 
 group :development, :test do
   # Access an IRB console on exception pages or by using <%= console %> in views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,10 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    io-console (0.8.0)
+    irb (1.14.3)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     jquery-fileupload-rails (1.0.0)
@@ -424,6 +428,8 @@ GEM
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
     regexp_parser (2.6.0)
+    reline (0.6.0)
+      io-console (~> 0.5)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -580,6 +586,7 @@ DEPENDENCIES
   google-cloud-bigquery
   google-cloud-storage
   googleauth
+  irb
   jbuilder (~> 2.7)
   jquery-datatables-rails!
   jquery-fileupload-rails
@@ -610,6 +617,7 @@ DEPENDENCIES
   rack-brotli
   rack-mini-profiler
   rails (= 6.1.7.9)
+  reline
   rest-client
   rubocop
   rubocop-rails

--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -9,8 +9,8 @@ module ImportServiceConfig
       @user_id = @user.id
       @branding_group_id = @branding_group.id
       @attributes = {
-        file_id: 'nemo:der-ah1o5qb',
-        project_id: 'nemo:grn-gyy3k8j',
+        file_id: 'nemo:drc-jcvnj7k',
+        project_id: 'nemo:std-5jvcwm1',
         study_id: 'nemo:col-hwmwd2x',
         obsm_key_names: %w[X_umap],
         user_id: @user.id,
@@ -53,7 +53,7 @@ module ImportServiceConfig
       config = ImportServiceConfig::Nemo.new(file_id: @attributes[:file_id])
       config.traverse_associations!
       assert_equal @attributes[:study_id], config.study_id
-      assert_equal @attributes[:project_id], config.project_id
+      assert_equal 'nemo:grn-gyy3k8j', config.project_id
     end
 
     test 'should load defaults' do
@@ -103,14 +103,14 @@ module ImportServiceConfig
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
     test 'should load file analog' do
       file = @configuration.load_file
-      assert_equal 'human_var_scVI_VLMC.h5ad.tar', file['file_name']
+      assert_equal 'human_var_scVI_VLMC.h5ad', file['file_name']
       assert_equal 'h5ad', file['file_format']
       assert_equal 'counts', file['data_type']
     end
 
     test 'should load collection analog' do
       collection = @configuration.load_collection
-      assert_equal 'AIBS Internal', collection['short_name']
+      assert_equal 'ecker_sn_mCseq_proj', collection['short_name']
     end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
@@ -118,7 +118,7 @@ module ImportServiceConfig
       file = @configuration.load_file
       study = @configuration.load_study
       assert_equal @attributes[:study_id], @configuration.id_from(file, :collections)
-      assert_equal @attributes[:project_id], @configuration.id_from(study, :projects)
+      assert_equal 'nemo:grn-gyy3k8j', @configuration.id_from(study, :projects)
     end
 
     test 'should load taxon common names' do
@@ -142,7 +142,7 @@ module ImportServiceConfig
       # populate StudyFile, using above study
       scp_study_file = @configuration.populate_study_file(scp_study.id)
       assert scp_study_file.use_metadata_convention
-      assert_equal 'human_var_scVI_VLMC.h5ad.tar', scp_study_file.upload_file_name
+      assert_equal 'human_var_scVI_VLMC.h5ad', scp_study_file.upload_file_name
       assert_equal "10x 3' v3", scp_study_file.expression_file_info.library_preparation_protocol
       assert_equal @configuration.service_name, scp_study_file.imported_from
       assert_not scp_study_file.ann_data_file_info.reference_file
@@ -154,8 +154,8 @@ module ImportServiceConfig
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
     test 'should import all from service' do
-      access_url = 'https://data.nemoarchive.org/other/grant/u01_lein/lein/transcriptome/sncell/10x_v3/human/' \
-                   'processed/counts/human_var_scVI_VLMC.h5ad.tar'
+      access_url = 'gs://nemo-public/other/grant/u01_lein/lein/transcriptome/sncell/10x_v3/' \
+                   'human/processed/counts/human_var_scVI_VLMC.h5ad'
       file_mock = ::Minitest::Mock.new
       file_mock.expect :generation, '123456789'
       # for study to save, we need to mock all Terra orchestration API calls for creating workspace & setting acls

--- a/test/integration/external/nemo_client_test.rb
+++ b/test/integration/external/nemo_client_test.rb
@@ -8,11 +8,10 @@ class NemoClientTest < ActiveSupport::TestCase
     @nemo_is_ok = @nemo_client.api_available?
     @skip_message = '-- skipping due to NeMO API being unavailable --'
     @identifiers = {
-      collection: 'nemo:col-pxwhesp',
-      file: 'nemo:der-ah1o5qb',
-      grant: 'nemo:grn-qwzp05p',
-      project: 'nemo:std-hoxfi7n',
-      publication: 'nemo:dat-tfmg0va',
+      collection: 'nemo:col-hwmwd2x',
+      file: 'nemo:drc-jcvnj7k',
+      grant: 'nemo:grn-gyy3k8j',
+      project: 'nemo:std-5jvcwm1',
       sample: 'nemo:smp-xmd8d0y',
       subject: 'nemo:sbj-njhfvw6'
     }
@@ -69,7 +68,7 @@ class NemoClientTest < ActiveSupport::TestCase
     identifier = @identifiers[:collection]
     collection = @nemo_client.collection(identifier)
     assert collection.present?
-    assert_equal 'adey_sciATAC_human_cortex', collection['short_name']
+    assert_equal 'human_variation_10X', collection['short_name']
   end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
@@ -78,7 +77,7 @@ class NemoClientTest < ActiveSupport::TestCase
     identifier = @identifiers[:file]
     file = @nemo_client.file(identifier)
     assert file.present?
-    filename = 'human_var_scVI_VLMC.h5ad.tar'
+    filename = 'human_var_scVI_VLMC.h5ad'
     assert_equal filename, file['file_name']
     assert_equal 'h5ad', file['file_format']
     access_url = file['manifest_file_urls'].first['url']
@@ -91,8 +90,8 @@ class NemoClientTest < ActiveSupport::TestCase
     identifier = @identifiers[:grant]
     grant = @nemo_client.grant(identifier)
     assert grant.present?
-    assert_equal '1U01MH114825', grant.dig('grant_info','grant_number')
-    assert_equal 'NIMH', grant['funding_agency']
+    assert_equal 'Allen Institute Funder', grant.dig('grant_info','grant_number')
+    assert_equal 'Allen Institute Funder', grant['funding_agency']
   end
 
   test 'should get project' do
@@ -100,10 +99,10 @@ class NemoClientTest < ActiveSupport::TestCase
     identifier = @identifiers[:project]
     project = @nemo_client.project(identifier)
     assert project.present?
-    assert_equal 'Single-nucleus analysis of preoptic area development from late embryonic to adult stages',
+    assert_equal 'DNA methylation profiling of genomic DNA in individual mouse brain cell nuclei (RS1.1)',
                  project['title']
     assert_equal 'biccn', project['program']
-    assert_equal 'dulac_poa_dev_sn_10x_proj', project['short_name']
+    assert_equal 'ecker_sn_mCseq_proj', project['short_name']
   end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates both `test/integration/external/nemo_client_test.rb` and `test/integration/external/import_service_config/nemo_test.rb` to replace identifiers that no longer resolve in the existing NeMO API.  Note this does not address ongoing stability issues with the API, so 500-level errors are still possible if the API loses the connection to the database host.

Additionally, two gems were added to silence deprecation warnings when loading the Rails console due to changes in `stdlib` libraries imports.

#### MANUAL TESTING
1. Run both test libraries and confirm there are no `404` responses or test assertion failures:
```
bin/rails test test/integration/external/import_service_config/nemo_test.rb
... #test output

Finished in 42.809361s, 0.3971 runs/s, 1.3315 assertions/s.

17 runs, 57 assertions, 0 failures, 0 errors, 0 skips
```
```
bin/rails test test/integration/external/nemo_client_test.rb
... #test output

Finished in 4.425930s, 2.7113 runs/s, 6.3264 assertions/s.

12 runs, 28 assertions, 0 failures, 0 errors, 0 skips
```
