### PR TITLE
Stop forcing isAuthorDe on pairwise results (SCP-5967)

### DIFF
--- a/app/javascript/components/explore/DifferentialExpressionPanel.jsx
+++ b/app/javascript/components/explore/DifferentialExpressionPanel.jsx
@@ -762,6 +762,7 @@ export default function DifferentialExpressionPanel({
           countsByLabelForDe={countsByLabelForDe}
           deObjects={deObjects}
           setDeFilePath={setDeFilePath}
+          isAuthorDe={isAuthorDe}
           deGroupB={deGroupB}
           setDeGroupB={setDeGroupB}
           hasOneVsRestDe={hasOneVsRestDe}
@@ -851,7 +852,7 @@ export default function DifferentialExpressionPanel({
           bucketId={bucketId}
           deFilePath={deFilePath}
           handleClear={handleClear}
-          isAuthorDe={hasPairwiseDe}
+          isAuthorDe={isAuthorDe}
           sizeMetric={sizeMetric}
           significanceMetric={significanceMetric}
           deFacets={deFacets}

--- a/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
+++ b/app/javascript/components/visualization/controls/DifferentialExpressionGroupPicker.jsx
@@ -320,7 +320,7 @@ export function PairwiseDifferentialExpressionGroupLists({
 export function PairwiseDifferentialExpressionGroupPicker({
   bucketId, clusterName, annotation, deGenes, deGroup, setDeGroup,
   setDeGenes, countsByLabelForDe, deObjects, setDeFilePath,
-  deGroupB, setDeGroupB, hasOneVsRestDe, significanceMetric
+  deGroupB, setDeGroupB, hasOneVsRestDe, significanceMetric, isAuthorDe
 }) {
   const groups = getLegendSortedLabels(countsByLabelForDe)
 
@@ -343,7 +343,6 @@ export function PairwiseDifferentialExpressionGroupPicker({
 
     setDeFilePath(deFilePath)
 
-    const isAuthorDe = true // SCP doesn't currently automatically compute pairwise DE
     const deGenes = await fetchDeGenes(bucketId, deFilePath, isAuthorDe)
     setDeGenes(deGenes)
   }
@@ -441,7 +440,6 @@ export function OneVsRestDifferentialExpressionGroupPicker({
     const deFilePath = basePath + deFileName
 
     setDeFilePath(deFilePath)
-
     const deGenes = await fetchDeGenes(bucketId, deFilePath, isAuthorDe)
 
     setDeGroup(newGroup)


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug with where any existing result DE result that has pairwise comparisons will evaluate as having been author supplied.  This causes a UI bug where the column indices are skewed by one, which renders incorrect values for log fold change and adjusted p value.  The expression data rendered is still correct, but none of the genes shown by default are in fact differentially expressed, leading to a confusing UX.

#### MANUAL TESTING
1. Load any existing DE result that has pairwise comparisons
2. Download the result file locally and open in a text editor
3. Confirm the order matches in the file and the table, and that the values for log fold change and adjusted p value match