### PR TITLE
Adding `raw_location` for AnnData files (SCP-5961)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -749,7 +749,7 @@ module Api
           ],
           expression_file_info_attributes: [
             :_id, :_destroy, :library_preparation_protocol, :units, :biosample_input_type, :modality, :is_raw_counts,
-            raw_counts_associations: []
+            :raw_location, raw_counts_associations: []
           ],
           heatmap_file_info_attributes: [:id, :_destroy, :custom_scaling, :color_min, :color_max, :legend_label],
           cluster_form_info_attributes: [
@@ -758,8 +758,8 @@ module Api
             :external_link_description, spatial_cluster_associations: []
           ],
           metadata_form_info_attributes: [:_id, :use_metadata_convention, :description],
-          extra_expression_form_info_attributes: [:_id, :taxon_id, :description, :y_axis_label],
-          ann_data_file_info_attributes: [:_id, :reference_file, :data_fragments],
+          extra_expression_form_info_attributes: [:_id, :taxon_id, :description, :y_axis_label, :raw_location],
+          ann_data_file_info_attributes: [:_id, :reference_file, :data_fragments, :raw_location],
           differential_expression_file_info_attributes: [
             :_id, :clustering_association, :annotation_name, :annotation_scope, :computational_method,
             :gene_header, :group_header, :comparison_group_header,

--- a/app/javascript/components/upload/AnnDataExpressionStep.jsx
+++ b/app/javascript/components/upload/AnnDataExpressionStep.jsx
@@ -10,6 +10,7 @@ const DEFAULT_NEW_PROCESSED_FILE = {
     is_raw_counts: false,
     biosample_input_type: 'Whole cell',
     modality: 'Transcriptomic: unbiased',
+    raw_location: '',
     raw_counts_associations: []
   },
   file_type: 'Expression Matrix'

--- a/app/javascript/components/upload/ExpressionFileForm.jsx
+++ b/app/javascript/components/upload/ExpressionFileForm.jsx
@@ -8,6 +8,9 @@ import ExpandableFileForm from './ExpandableFileForm'
 
 import { TextFormField } from './form-components'
 import { findBundleChildren, validateFile } from './upload-utils'
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
+import { OverlayTrigger, Popover } from 'react-bootstrap'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 const REQUIRED_FIELDS = [{ label: 'species', propertyName: 'taxon_id' },
   { label: 'Biosample input type', propertyName: 'expression_file_info.biosample_input_type' },
@@ -68,9 +71,45 @@ export default function ExpressionFileForm({
     setShowRawCountsUnits(rawCountsVal)
   }
 
+  /** create the tooltip and message for the .obsm key name section */
+  function rawSlotMessage() {
+    const rawSlotToolTip = <span>
+      <OverlayTrigger
+        trigger={['hover', 'focus']}
+        rootClose placement="top"
+        delayHide={1500}
+        overlay={rawSlotHelpContent()}>
+        <span> Raw count data location * <FontAwesomeIcon icon={faQuestionCircle}/></span>
+      </OverlayTrigger>
+    </span>
+
+    return <span >
+      {rawSlotToolTip}
+    </span>
+  }
+
+  /** gets the popup message to describe .obsm keys */
+  function rawSlotHelpContent() {
+    const layersLink = <a href="https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.layers.html"
+                          target="_blank">layers</a>
+    const rawLink = <a href="https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.raw.html"
+                                target="_blank">.raw</a>
+    return <Popover id="cluster-obsm-key-name-popover" className="tooltip-wide">
+      <div>
+        Location of raw count data in your AnnData file. This can be the raw slot ({rawLink}) or the name of a layer in
+        the {layersLink} section.
+      </div>
+    </Popover>
+  }
+
   return <ExpandableFileForm {...{
-    file, allFiles, updateFile, saveFile,
-    allowedFileExts, deleteFile, validationMessages, bucketName, isInitiallyExpanded, isAnnDataExperience
+    file,
+    allFiles,
+    updateFile,
+    saveFile,
+    allowedFileExts,
+    deleteFile,
+    validationMessages, bucketName, isInitiallyExpanded, isAnnDataExperience
   }}>
     {!isAnnDataExperience &&
     <div className="form-group">
@@ -149,7 +188,7 @@ export default function ExpressionFileForm({
           </label>
         </div>
         {requireLocation && <div className="col-sm-4">
-          <TextFormField label="Raw count data location *"
+          <TextFormField label={rawSlotMessage()}
                          fieldName="raw_location"
                          file={file}
                          updateFile={updateFile}

--- a/app/javascript/components/upload/ExpressionFileForm.jsx
+++ b/app/javascript/components/upload/ExpressionFileForm.jsx
@@ -19,6 +19,9 @@ const RAW_COUNTS_REQUIRED_FIELDS = REQUIRED_FIELDS.concat([{
 const PROCESSED_ASSOCIATION_FIELD = [
   { label: 'Associated raw counts files', propertyName: 'expression_file_info.raw_counts_associations' }
 ]
+const RAW_LOCATION_FIELD = [
+  { label: 'Raw count data location', propertyName: 'raw_location' },
+]
 
 /** renders a form for editing/uploading an expression file (raw or processed) and any bundle children */
 export default function ExpressionFileForm({
@@ -48,6 +51,10 @@ export default function ExpressionFileForm({
   const rawCountsRequired = featureFlagState && featureFlagState.raw_counts_required_frontend && !isAnnDataExperience
   if (rawCountsRequired && !isRawCountsFile ) {
     requiredFields = requiredFields.concat(PROCESSED_ASSOCIATION_FIELD)
+  }
+  const requireLocation = (rawCountsRequired || isRawCountsFile) && isAnnDataExperience
+  if (requireLocation) {
+    requiredFields = requiredFields.concat(RAW_LOCATION_FIELD)
   }
   const validationMessages = validateFile({ file, allFiles, allowedFileExts, requiredFields, isAnnDataExperience })
 
@@ -123,13 +130,13 @@ export default function ExpressionFileForm({
     { isAnnDataExperience &&
       <div className="row">
         <div className="form-radio col-sm-4">
-          <label className="labeled-select">I have raw count data in the <strong>adata.raw</strong> slot</label>
+          <label className="labeled-select">I have raw count data</label>
           <label className="sublabel">
             <input type="radio"
                    name={`anndata-raw-counts-${file._id}`}
                    value="true"
                    checked={isRawCountsFile}
-                   onChange={e => toggleIsRawCounts(true) } />
+                   onChange={e => toggleIsRawCounts(true)}/>
             &nbsp;Yes
           </label>
           <label className="sublabel">
@@ -137,11 +144,18 @@ export default function ExpressionFileForm({
                    name={`anndata-raw-counts-${file._id}`}
                    value="false"
                    checked={!isRawCountsFile}
-                   onChange={e => toggleIsRawCounts(false) }/>
+                   onChange={e => toggleIsRawCounts(false)}/>
             &nbsp;No
           </label>
         </div>
-        {showRawCountsUnits && <div className="col-sm-8">
+        {requireLocation && <div className="col-sm-4">
+          <TextFormField label="Raw count data location *"
+                         fieldName="raw_location"
+                         file={file}
+                         updateFile={updateFile}
+                         placeholderText='Specify .raw or name of layer'/></div>
+        }
+        { showRawCountsUnits && <div className="col-sm-4">
           <ExpressionFileInfoSelect label="Units *"
                                     propertyName="units"
                                     rawOptions={fileMenuOptions.units}

--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -161,6 +161,7 @@ class DifferentialExpressionService
     elsif raw_matrix.file_type == 'AnnData'
       de_params[:matrix_file_type] = 'h5ad'
       de_params[:file_size] = raw_matrix.upload_file_size
+      de_params[:raw_location] = raw_matrix.ann_data_file_info.raw_location
     else
       de_params[:matrix_file_type] = 'dense'
     end

--- a/app/lib/file_parse_service.rb
+++ b/app/lib/file_parse_service.rb
@@ -112,13 +112,15 @@ class FileParseService
             )
           elsif study_file.needs_raw_counts_extraction?
             params_object = AnnDataIngestParameters.new(
-              anndata_file: study_file.gs_url, extract: %w[raw_counts], obsm_keys: nil,
+              anndata_file: study_file.gs_url, extract: %w[raw_counts],
+              raw_location: study_file.ann_data_file_info.raw_location, obsm_keys: nil,
               file_size: study_file.upload_file_size
             )
           else
             params_object = AnnDataIngestParameters.new(
               anndata_file: study_file.gs_url, obsm_keys: study_file.ann_data_file_info.obsm_key_names,
-              file_size: study_file.upload_file_size, extract_raw_counts: study_file.is_raw_counts_file?
+              file_size: study_file.upload_file_size, extract_raw_counts: study_file.is_raw_counts_file?,
+              raw_location: study_file.ann_data_file_info.raw_location
             )
           end
           # TODO extract and parse Raw Exp Data (SCP-4710)

--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -85,7 +85,7 @@ class AnnDataFileInfo
       when :expression
         merged_data[:taxon_id] = fragment_form[:taxon_id]
         anndata_info_attributes[:raw_location] = merged_data.dig(:expression_file_info_attributes, :raw_location)
-        merged_data[:expression_file_info_attributes].delete(:raw_location) # prevent UnknownAttribute error
+        merged_data[:expression_file_info_attributes]&.delete(:raw_location) # prevent UnknownAttribute error
         merged_exp_fragment = fragment_form.merge(expression_file_info: merged_data[:expression_file_info_attributes])
         fragments << extract_form_fragment(merged_exp_fragment, key, *allowed_params)
       end

--- a/app/models/ann_data_file_info.rb
+++ b/app/models/ann_data_file_info.rb
@@ -18,7 +18,7 @@ class AnnDataFileInfo
       y_axis_max z_axis_min z_axis_max external_link_url external_link_title external_link_description
       parse_status spatial_cluster_associations
     ],
-    expression: %i[_id data_type taxon_id description expression_file_info y_axis_label]
+    expression: %i[_id data_type taxon_id description expression_file_info y_axis_label raw_location]
   }.freeze
 
   # required keys for data_fragments, by type
@@ -32,6 +32,8 @@ class AnnDataFileInfo
   field :has_expression, type: Boolean, default: false
   # controls whether or not to ingest data (true: should not ingest data, this is like an 'Other' file)
   field :reference_file, type: Boolean, default: true
+  # location of raw count data, either .raw attribute or in layers[{name}]
+  field :raw_location, type: String, default: ''
   # information from form about data contained inside AnnData file, such as names/descriptions
   # examples:
   # {
@@ -40,8 +42,8 @@ class AnnDataFileInfo
   # }
   # { _id: '6033f531e241391884633748', data_type: :expression, description: 'log(TMP) expression' }
   field :data_fragments, type: Array, default: []
-  before_validation :set_default_cluster_fragments!, :sanitize_fragments!
-  validate :validate_fragments
+  before_validation :set_default_cluster_fragments!, :set_raw_location!, :sanitize_fragments!
+  validate :validate_fragments, :enforce_raw_location
   after_validation :update_expression_file_info
 
   # collect data frame key_names for clustering data inside AnnData flle
@@ -82,6 +84,8 @@ class AnnDataFileInfo
         fragments << extract_form_fragment(fragment_form, key, *allowed_params)
       when :expression
         merged_data[:taxon_id] = fragment_form[:taxon_id]
+        anndata_info_attributes[:raw_location] = merged_data.dig(:expression_file_info_attributes, :raw_location)
+        merged_data[:expression_file_info_attributes].delete(:raw_location) # prevent UnknownAttribute error
         merged_exp_fragment = fragment_form.merge(expression_file_info: merged_data[:expression_file_info_attributes])
         fragments << extract_form_fragment(merged_exp_fragment, key, *allowed_params)
       end
@@ -151,7 +155,16 @@ class AnnDataFileInfo
     return nil if reference_file || exp_fragment.nil? || exp_info.nil?
 
     info_update = exp_fragment.with_indifferent_access[:expression_file_info]
+    info_update.delete(:raw_location) if info_update[:raw_location]
     exp_info.assign_attributes(**info_update) if info_update
+  end
+
+  # pull out raw_location from expression fragment and set as top-level attribute for ease of access
+  def set_raw_location!
+    exp_fragment = find_fragment(data_type: :expression) || fragments_by_type(:expression).first
+    return nil if reference_file || exp_fragment.nil?
+
+    self.raw_location = exp_fragment.with_indifferent_access[:raw_location]
   end
 
   # extract description field from expression fragment to use as axis label
@@ -218,7 +231,7 @@ class AnnDataFileInfo
     REQUIRED_FRAGMENT_KEYS.each do |data_type, keys|
       fragments = fragments_by_type(data_type)
       fragments.each do |fragment|
-        unset_units_in_exp_fragment(fragment) if data_type == :expression
+        unset_fields_in_exp_fragment(fragment) if data_type == :expression
         missing_keys = keys.map(&:to_s) - fragment.keys.map(&:to_s)
         missing_values = keys.select { |key| fragment[key].blank? }
         next if missing_keys.empty? && missing_values.empty?
@@ -239,9 +252,15 @@ class AnnDataFileInfo
     end
   end
 
-  # unset units in expression fragment since form data won't have value
+  def enforce_raw_location
+    if study_file.is_raw_counts_file? && !reference_file && raw_location.blank?
+      errors.add(:raw_location, 'must have a value for raw count matrices')
+    end
+  end
+
+  # unset units and raw_location in expression fragment since form data won't have value
   # element must be replaced by index in order to persist
-  def unset_units_in_exp_fragment(fragment)
+  def unset_fields_in_exp_fragment(fragment)
     exp_info = fragment[:expression_file_info]
     return nil unless exp_info
 
@@ -249,6 +268,7 @@ class AnnDataFileInfo
       exp_info.delete(:units)
       frag_idx = fragment_index_of(fragment)
       data_fragments[frag_idx][:expression_file_info] = exp_info
+      data_fragments[frag_idx][:raw_location] = ''
     end
   end
 end

--- a/app/models/ann_data_ingest_parameters.rb
+++ b/app/models/ann_data_ingest_parameters.rb
@@ -39,6 +39,7 @@ class AnnDataIngestParameters
     domain_ranges: nil,
     extract: %w[cluster metadata processed_expression],
     extract_raw_counts: false,
+    raw_location: nil,
     cell_metadata_file: nil,
     ingest_cell_metadata: false,
     study_accession: nil,
@@ -60,6 +61,7 @@ class AnnDataIngestParameters
             format: { with: Parameterizable::GS_URL_REGEXP, message: 'is not a valid GS url' },
             allow_blank: true
   validates :machine_type, inclusion: Parameterizable::GCE_MACHINE_TYPES
+  validates :raw_location, presence: true, if: proc { extract_raw_counts || extract.to_a.include?(:raw_counts) }
 
   def initialize(attributes = nil)
     super

--- a/app/models/differential_expression_parameters.rb
+++ b/app/models/differential_expression_parameters.rb
@@ -25,6 +25,7 @@ class DifferentialExpressionParameters
   # matrix_file_path: raw counts matrix with source expression data
   # matrix_file_type: type of raw counts matrix (dense, sparse)
   # matrix_file_id: BSON ID of raw matrix StudyFile for associations
+  # raw_location: slot in AnnData file where raw data resides (only needed for AnnData matrices)
   # gene_file (optional): genes/features file for sparse matrix
   # barcode_file (optional): barcodes file for sparse matrix
   # machine_type (optional): override for default ingest machine type (uses 'n2d-highmem-8')
@@ -43,6 +44,7 @@ class DifferentialExpressionParameters
     matrix_file_path: nil,
     matrix_file_type: nil,
     matrix_file_id: nil,
+    raw_location: nil,
     gene_file: nil,
     barcode_file: nil,
     machine_type: 'n2d-highmem-8',
@@ -62,6 +64,7 @@ class DifferentialExpressionParameters
   validates :de_type, inclusion: %w[rest pairwise]
   validates :group1, :group2, presence: true, if: -> { de_type == 'pairwise' }
   validates :matrix_file_type, inclusion: %w[dense mtx h5ad]
+  validates :raw_location, presence: true, if: -> { matrix_file_type == 'h5ad' }
   validates :machine_type, inclusion: Parameterizable::GCE_MACHINE_TYPES
   validates :gene_file, :barcode_file,
             presence: true,

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.40.1'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.41.0'
 
     # Docker image for image pipeline jobs
     config.image_pipeline_docker_image = 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_c2b090043'

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.41.0'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.41.1'
 
     # Docker image for image pipeline jobs
     config.image_pipeline_docker_image = 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_c2b090043'

--- a/db/migrate/20250401141733_set_raw_location_on_ann_data_files.rb
+++ b/db/migrate/20250401141733_set_raw_location_on_ann_data_files.rb
@@ -1,0 +1,28 @@
+class SetRawLocationOnAnnDataFiles < Mongoid::Migration
+  def self.up
+    files = StudyFile.where(
+      file_type: 'AnnData', 'ann_data_file_info.reference_file' => false, parse_status: 'parsed'
+    ).select(&:is_raw_counts_file?)
+    files.each do |file|
+      adata = file.ann_data_file_info
+      exp_fragment = file.ann_data_file_info.find_fragment(data_type: :expression)
+      next if adata.raw_location.present? || exp_fragment.blank?
+
+      adata.raw_location = '.raw'
+      exp_fragment[:raw_location] = '.raw'
+      idx = file.ann_data_file_info.fragment_index_of(exp_fragment)
+      file.ann_data_file_info.data_fragments[idx] = exp_fragment
+      file.save
+    end
+  end
+
+  def self.down
+    files = StudyFile.where(
+      file_type: 'AnnData', 'ann_data_file_info.reference_file' => false, parse_status: 'parsed'
+    ).select(&:is_raw_counts_file?)
+    files.each do |file|
+      file.ann_data_file_info.raw_location = nil
+      file.save
+    end
+  end
+end

--- a/test/api/study_files_controller_test.rb
+++ b/test/api/study_files_controller_test.rb
@@ -324,6 +324,9 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
         expression_file_info_attributes: {
           is_raw_counts: true,
           units: 'raw counts'
+        },
+        ann_data_file_info_attributes: {
+          raw_location: '.raw'
         }
       }
     }

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -199,6 +199,7 @@ FactoryBot.define do
             file.expression_file_info.is_raw_counts = evaluator.has_raw_counts
             file.expression_file_info.units = 'raw counts'
             file.ann_data_file_info.has_raw_counts = evaluator.has_raw_counts
+            file.ann_data_file_info.raw_location = '.raw'
           end
           file.expression_file_info.save
           matrix_types = %w[processed]

--- a/test/models/ann_data_ingest_parameters_test.rb
+++ b/test/models/ann_data_ingest_parameters_test.rb
@@ -6,7 +6,8 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
     @extract_params = {
       anndata_file: 'gs://bucket_id/test.h5ad',
       extract_raw_counts: true,
-      file_size: 50.gigabytes
+      file_size: 50.gigabytes,
+      raw_location: '.raw'
     }
 
     @file_id = BSON::ObjectId.new
@@ -57,7 +58,7 @@ class AnnDataIngestParametersTest < ActiveSupport::TestCase
     end
 
     cmd = '--ingest-anndata --anndata-file gs://bucket_id/test.h5ad --obsm-keys ["X_umap"] --extract ' \
-          '["cluster", "metadata", "processed_expression", "raw_counts"]'
+          '["cluster", "metadata", "processed_expression", "raw_counts"] --raw-location .raw'
     assert_equal cmd, extraction.to_options_array.join(' ')
     assert_equal 'n2d-highmem-32', extraction.machine_type
   end

--- a/test/models/batch_api_client_test.rb
+++ b/test/models/batch_api_client_test.rb
@@ -128,6 +128,7 @@ class BatchApiClientTest < ActiveSupport::TestCase
       matrix_file_path: @ann_data_file.gs_url,
       matrix_file_type: 'h5ad',
       matrix_file_id: @ann_data_file.id,
+      raw_location: '.raw',
       file_size: @ann_data_file.upload_file_size
     }
     params_object = DifferentialExpressionParameters.new(**anndata_options)

--- a/test/models/differential_expression_parameters_test.rb
+++ b/test/models/differential_expression_parameters_test.rb
@@ -41,6 +41,7 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
       matrix_file_path: 'gs://test_bucket/matrix.h5ad',
       matrix_file_type: 'h5ad',
       matrix_file_id:,
+      raw_location: '.raw',
       file_size: 10.gigabytes
     }
 
@@ -83,6 +84,8 @@ class DifferentialExpressionParametersTest < ActiveSupport::TestCase
     assert_equal [:machine_type, :gene_file], sparse_params.errors.attribute_names
     pairwise_params.group1 = ''
     assert_not pairwise_params.valid?
+    anndata_params.raw_location = nil
+    assert_not anndata_params.valid?
   end
 
   test 'should format differential expression parameters for python cli' do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds client- and server-side integration of the `raw_location` attribute for visualization AnnData files.  This allows users to specify where they have stored count information.  Users can specify either `.raw` or the name of a layer in the `layers` section (such as `counts`).  This value is then stored inside the `AnnDataFileInfo` object and passed to ingest both for AnnData extraction and DE calculation.  The form input contains a tooltip with links to the AnnData doc pages for both [.raw](https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.raw.html) and [layers](https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.layers.html).

Screenshot of the new form input:
![raw-location-field](https://github.com/user-attachments/assets/a836ab2e-21e9-45b5-8bf1-df945985b327)

Additionally, there is a migration to set this value on existing AnnData files that have raw counts.  Since we only supported `.raw` up until now, any parsed AnnData file in SCP with count data would use that slot.

#### MANUAL TESTING
1. Boot all services
2. In a separate console, run the migration and then enter a Rails console and validate that `.raw` has been set for existing AnnData files with raw counts:
```
files = StudyFile.where(file_type: 'AnnData', 'ann_data_file_info.reference_file' => false, parse_status: 'parsed').select(&:is_raw_counts_file?)
=> [#<StudyFile _id: 66b12ac32361e48b542bc7cd, ... ]
files.map {|f| f.ann_data_file_info.raw_location }
=> [".raw", ".raw", ".raw", ".raw", ".raw"]
```
3. In a browser tab, sign in and create a new study, then upload an AnnData file that contains count information, specifying the location in the expression form
4. Confirm that extraction completes without error (this validates the presence of the count data) and parsing continues all the way through DE