### PR TITLE
Add PIP-seq as option for library preparation protocol (SCP-5972)

### DIFF
--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -48,7 +48,7 @@ class ExpressionFileInfo
                                 '10x TCR enrichment', # targeted transcriptomic
                                 '10x Visium', # spatial transcriptomic
                                 '10x Xenium', # spatial transcriptomic
-				'CEL-seq2', # scRNAseq
+                                'CEL-seq2', # scRNAseq
                                 'Drop-ChIP', # scChIP-seq
                                 'Drop-seq', # scRNAseq
                                 'dsc-ATAC-seq', # scATAC-seq
@@ -56,10 +56,11 @@ class ExpressionFileInfo
                                 'inDrop', # scRNAseq
                                 'MARS-seq', # scRNAseq
                                 'MERFISH', # spatial transcriptomic
-				'NanoString CosMx', #spatial transcriptomic
+                                'NanoString CosMx', #spatial transcriptomic
                                 'osmFISH', # spatial transcriptomic
                                 'Patch-seq', # multimodal: scRNAseq, electrophys, morphology
-				'scATAC-seq/Fluidigm', # scATAC-seq
+                                'PIP-seq', # scRNA-seq, https://www.nature.com/articles/s41587-023-01685-z
+                                'scATAC-seq/Fluidigm', # scATAC-seq
                                 'sci-ATAC-seq', # scATAC-seq
                                 'sci-RNA-seq', # scRNAseq
                                 'scTHS-seq', # scATAC-seq


### PR DESCRIPTION
This enables study authors to select [PIP-seq](https://www.nature.com/articles/s41587-023-01685-z) as the library preparation protocol in SCP's upload UI matrix tabs.

Here's how it looks:

https://github.com/user-attachments/assets/2792c589-6ac0-49ba-9016-5e5c6a26823f

### Test
1.  Go to SCP upload UI
2.  In "Raw count matrices" tab, set "Library preparation protocol" to "PIP-seq"
3.  Do the same for "Processed matrices"

This satisfies SCP-5972.