### PR TITLE
Updating to scp-ingest-pipeline:1.41.3 (SCP-5984)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SingleCellPortal
     config.middleware.use Rack::Brotli
 
     # Docker image for file parsing via scp-ingest-pipeline
-    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.41.2'
+    config.ingest_docker_image = 'gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline:1.41.3'
 
     # Docker image for image pipeline jobs
     config.image_pipeline_docker_image = 'gcr.io/broad-singlecellportal-staging/image-pipeline:0.1.0_c2b090043'


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates to the latest ingest release to fix a breaking bug with non-AnnData DE.  All jobs were failing due to the `raw_location` parameter not being set, even though it wasn't used.  Since this was marked as required, all jobs failed in Batch with an exit status of `2`.  Now, the parameter is only set for AnnData DE, and all jobs execute as normal.

#### MANUAL TESTING
1. Boot all services, sign in, and create a new study in classic mode
2. Upload the following files from `scp-ingest-pipeline` source (we don't need processed expression for this, just raw counts):
    * raw counts: `tests/data/differential_expression/de_dense_matrix.tsv`
    * metadata: `tests/data/differential_expression/de_dense_metadata.tsv`
    * cluster: `tests/data/differential_expression/de_dense_cluster.tsv`
3. Confirm that all files ingest properly and that you see DE jobs launch eventually for `cell_type__ontology_label` and `seurat_clusters`
4. Confirm that the DE jobs complete and that output files are created and the results save