### PR TITLE
Updating to Ubuntu 24.04 GHA runners

### DIFF
--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: production-deployment
     steps:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: staging-deployment
     steps:

--- a/test/services/differential_expression_service_test.rb
+++ b/test/services/differential_expression_service_test.rb
@@ -74,10 +74,11 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
 
   teardown do
     DataArray.find_by(@all_cells_array_params)&.destroy
-    @basic_study.differential_expression_results.destroy_all
+    DifferentialExpressionResult.delete_all
     StudyFile.where(file_type: 'Differential Expression').delete_all
     @basic_study.public = true
     @basic_study.save(validate: false) # skip callbacks for performance
+    @basic_study.reload
   end
 
   test 'should validate parameters and launch differential expression job' do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes the issue with deployments/Docker builds failing due to the retirement of `ubuntu-20.04` Github runner images.  This updates to `24.04`, which is the same as our base Docker image.  Additionally, this tries to update a test that fails only in CI, but not locally - possibly due to a state object and calling `save(validate: false)`.

#### MANUAL TESTING
N/A, only applies to actions