### PR TITLE
Report ingestSummary even if AnnData extraction fails (SCP-5973)

### DIFF
--- a/app/javascript/lib/validation/validate-anndata.js
+++ b/app/javascript/lib/validation/validate-anndata.js
@@ -28,7 +28,7 @@ async function getOntologyIds(key, hdf5File) {
   if (internalCategories) {
     resolvedCategories = await Promise.all(internalCategories.values)
   }
-  const group = resolvedCategories.find(o => o.name.endsWith(key))
+  const group = resolvedCategories.find(o => findMatchingGroup(o, key))
   if (group) {
     let categories
     if (internalCategories) {
@@ -40,6 +40,11 @@ async function getOntologyIds(key, hdf5File) {
   }
 
   return ontologyIds
+}
+
+/** find a group in /obs based on exact name match */
+export function findMatchingGroup(category, key) {
+  return category.name.split('/').slice(-1)[0] === key
 }
 
 /** Get annotation headers for a key (e.g. obs) from an HDF5 file */
@@ -197,8 +202,8 @@ export async function getOntologyIdsAndLabels(columnName, hdf5File) {
   const idKey = columnName
   const labelKey = `${columnName}__ontology_label`
 
-  const idGroup = obsValues.find(o => o.name.endsWith(idKey))
-  const labelGroup = obsValues.find(o => o.name.endsWith(labelKey))
+  const idGroup = obsValues.find(o => findMatchingGroup(o, idKey))
+  const labelGroup = obsValues.find(o => findMatchingGroup(o, labelKey))
 
   // exit when optional metadata isn't found, like cell_type
   if (!idGroup && !isRequired) { return }

--- a/test/js/lib/validate-anndata.test.js
+++ b/test/js/lib/validate-anndata.test.js
@@ -1,5 +1,6 @@
 import {
-  getHdf5File, parseAnnDataFile, getAnnDataHeaders, checkOntologyIdFormat, getOntologyIdsAndLabels, checkOntologyLabelsAndIds
+  getHdf5File, parseAnnDataFile, getAnnDataHeaders, checkOntologyIdFormat, getOntologyIdsAndLabels,
+  checkOntologyLabelsAndIds, findMatchingGroup
 } from 'lib/validation/validate-anndata'
 import { fetchOntologies } from '~/lib/validation/ontology-validation'
 const fetch = require('node-fetch')
@@ -113,6 +114,13 @@ describe('Client-side file validation for AnnData', () => {
     const groups = await getOntologyIdsAndLabels(key, hdf5File)
     let issues = await checkOntologyLabelsAndIds(key, ontologies, groups)
     expect(issues).toHaveLength(1)
+  })
+
+  it('finds the correct obs group based on name', () => {
+    const validGroup = { name: '/obs/cell_type' }
+    const invalidGroup = { name: '/obs/author_cell_type' }
+    expect(findMatchingGroup(validGroup, 'cell_type')).toBeTruthy()
+    expect(findMatchingGroup(invalidGroup, 'cell_type')).not.toBeTruthy()
   })
 
   // TODO (SCP-5813): Uncomment this test upon completing "Enable ontology validation for remote AnnData"


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a corner case in Mixpanel reporting where AnnData files that fail during the initial extraction phase do not report an `ingestSummary` event.  These events are the main indication SCP has in Mixpanel for AnnData ingest as only one event is ever sent per AnnData file.  The lack of these extraction events means we are underreporting on AnnData ingest attempts.  Now, if the initial extraction fails and is not going to be retried due to an OOM exception, the summary is sent.

Also, this fixes a regression introduced in #2242 where metadata properties in AnnData files that have names ending in values that match ontology-based properties (e.g. `author_cell_type` matching to `cell_type`) incorrectly attempt to validate that column.  Now, exact name matches are enforced rather than relying on `endsWith()`.

#### MANUAL TESTS
1. Boot all services, sign in, and go to the upload wizard for a new/empty study and select the AnnData UX
2. Upload the [compliant_liver.h5ad](https://github.com/broadinstitute/scp-ingest-pipeline/blob/development/tests/data/anndata/compliant_liver.h5ad) AnnData file
    * Specify `raw_location: does_not_exist` in the Expression tab to ensure the extraction fails
3. Complete the upload and wait for the job to fail
4. Go the the [Dev Mixpanel events queue](https://mixpanel.com/project/2085496/view/19055/app/events) and search for an `ingestSummary` event
5. Confirm you see your upload with `jobStatus: failed` and `numFilesExtracted: 0`