### PR TITLE
Robustify pathway search and visualization (SCP-5990)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -25,7 +25,8 @@ import BookmarkManager from '~/components/bookmarks/BookmarkManager'
 import { EXPRESSION_SORT_OPTIONS } from '~/components/visualization/PlotDisplayControls'
 
 /** Get the selected clustering and annotation, or their defaults */
-function getSelectedClusterAndAnnot(exploreInfo, exploreParams) {
+export function getSelectedClusterAndAnnot(exploreInfo, exploreParams) {
+  if (!exploreInfo) {return [null, null]}
   const annotList = exploreInfo.annotationList
   let selectedCluster
   let selectedAnnot

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -23,7 +23,7 @@ import useResizeEffect from '~/hooks/useResizeEffect'
 import LoadingSpinner from '~/lib/LoadingSpinner'
 import { log } from '~/lib/metrics-api'
 import { getFeatureFlagsWithDefaults } from '~/providers/UserProvider'
-import ExploreDisplayPanelManager from './ExploreDisplayPanelManager'
+import ExploreDisplayPanelManager, {getSelectedClusterAndAnnot} from './ExploreDisplayPanelManager'
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger'
 import Tooltip from 'react-bootstrap/lib/Tooltip'
 import PlotTabs from './PlotTabs'
@@ -32,22 +32,6 @@ import {
 } from '~/lib/cell-faceting'
 import { getIsPathway } from '~/lib/search-utils'
 
-/** Get the selected clustering and annotation, or their defaults */
-export function getSelectedClusterAndAnnot(exploreInfo, exploreParams) {
-  if (!exploreInfo) {return [null, null]}
-  const annotList = exploreInfo.annotationList
-  let selectedCluster
-  let selectedAnnot
-  if (exploreParams?.cluster) {
-    selectedCluster = exploreParams.cluster
-    selectedAnnot = exploreParams.annotation
-  } else {
-    selectedCluster = annotList.default_cluster
-    selectedAnnot = annotList.default_annotation
-  }
-
-  return [selectedCluster, selectedAnnot]
-}
 
 /** Determine if current annotation has one-vs-rest or pairwise DE */
 function getHasComparisonDe(exploreInfo, exploreParams, comparison) {
@@ -539,6 +523,9 @@ export default function ExploreDisplayTabs({
     queries = exploreParams.genes
   }
 
+  console.log('in ExploreDisplayTabs')
+  const [_, selectedAnnotation] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
+
   return (
     <>
       {/* Render top content for Explore view, i.e. gene search box and plot tabs */}
@@ -550,7 +537,9 @@ export default function ExploreDisplayTabs({
               queryFn={queryFn}
               allGenes={exploreInfo ? exploreInfo.uniqueGenes : []}
               isLoading={!exploreInfo}
-              speciesList={exploreInfo ? exploreInfo.taxonNames : []}/>
+              speciesList={exploreInfo ? exploreInfo.taxonNames : []}
+              selectedAnnotation={selectedAnnotation}
+            />
             { // show if this is gene search || gene list
               (isGene || isGeneList || hasIdeogramOutputs || isPathway) &&
                 <OverlayTrigger placement="top" overlay={

--- a/app/javascript/components/explore/ExploreDisplayTabs.jsx
+++ b/app/javascript/components/explore/ExploreDisplayTabs.jsx
@@ -523,7 +523,7 @@ export default function ExploreDisplayTabs({
     queries = exploreParams.genes
   }
 
-  console.log('in ExploreDisplayTabs')
+  // eslint-disable-next-line no-unused-vars
   const [_, selectedAnnotation] = getSelectedClusterAndAnnot(exploreInfo, exploreParams)
 
   return (

--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -64,7 +64,7 @@ function getQueriesFromSearchOptions(newQueryArray, speciesList, selectedAnnotat
 }
 
 /** Indicate whether pathway view should be available for this study */
-function getIsEligibleForPathwayExplore(speciesList, selectedAnnotation) {
+export function getIsEligibleForPathwayExplore(speciesList, selectedAnnotation) {
   const isEligibleForPathwayExplore = (
     speciesList.length === 1 && speciesList[0] === 'Homo sapiens' &&
     selectedAnnotation.type === 'group' &&
@@ -104,11 +104,9 @@ export default function StudyGeneField({
 }) {
   const [inputText, setInputText] = useState('')
 
-  console.log('selectedAnnotation', selectedAnnotation)
   const includePathways = getIsEligibleForPathwayExplore(speciesList, selectedAnnotation)
   const rawSuggestions = getAutocompleteSuggestions(inputText, allGenes, includePathways)
   const searchOptions = getSearchOptions(rawSuggestions, speciesList, selectedAnnotation)
-
 
   let enteredQueryArray = []
   if (inputText.length === 0 && queries && queries.length > 0) {
@@ -232,7 +230,7 @@ export default function StudyGeneField({
     if (queries.join(',') !== queryArray.map(opt => opt.value).join(',')) {
       // the genes have been updated elsewhere -- resync
       const queriesSearchOptions = getSearchOptions(queries, speciesList, selectedAnnotation)
-      const newQueryArray = getQueryArrayFromSearchOptions(queriesSearchOptions, speciesList)
+      const newQueryArray = getQueryArrayFromSearchOptions(queriesSearchOptions, speciesList, selectedAnnotation)
       setQueryArray(newQueryArray)
       setInputText('')
       setNotPresentQueries(new Set([]))

--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -101,7 +101,8 @@ function getQueryArrayFromSearchOptions(searchOptions, speciesList) {
 export default function StudyGeneField({ queries, queryFn, allGenes, speciesList, isLoading=false }) {
   const [inputText, setInputText] = useState('')
 
-  const rawSuggestions = getAutocompleteSuggestions(inputText, allGenes)
+  const includePathways = getIsEligibleForPathwayExplore(speciesList)
+  const rawSuggestions = getAutocompleteSuggestions(inputText, allGenes, includePathways)
   const searchOptions = getSearchOptions(rawSuggestions, speciesList)
 
 
@@ -354,7 +355,7 @@ export default function StudyGeneField({ queries, queryFn, allGenes, speciesList
 /** Last filtering applied before showing selectable autocomplete options */
 function finalFilterOptions(option, rawInput) {
   const input = rawInput.toLowerCase()
-  const label = option.label.toLowerCase()
+  const label = 'label' in option ? option.label.toLowerCase() : option.toLowerCase()
   const isPathway = option.data.isGene === false
   return isPathway || label.includes(input) // partial match
 }

--- a/app/javascript/components/visualization/Pathway.jsx
+++ b/app/javascript/components/visualization/Pathway.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { Popover, OverlayTrigger } from 'react-bootstrap'
-import { manageDrawPathway } from '~/lib/pathway-expression'
+import { manageDrawPathway, writeLoadingIndicator } from '~/lib/pathway-expression'
 import { getIdentifierForAnnotation, naturalSort } from '~/lib/cluster-utils'
 import { round } from '~/lib/metrics-perf'
 
@@ -136,6 +136,7 @@ export default function Pathway({
   moveDescription()
   document.addEventListener('ideogramDrawPathway', configurePathwayTooltips)
   document.addEventListener('ideogramDrawPathway', updatePathwayOntologies)
+  document.addEventListener('ideogramDrawPathway', writeLoadingIndicator)
 
   /** Upon clicking a pathway node, show new pathway and expression overlay */
   function handlePathwayNodeClick(event, pathwayId) {

--- a/app/javascript/lib/pathway-expression.js
+++ b/app/javascript/lib/pathway-expression.js
@@ -32,6 +32,8 @@ window.onerror = function(error) {
   }
 }
 
+const loadingCls = 'pathway-loading-expression'
+
 /**
  * Get mean, percent, and color per gene, by annotation label
  *
@@ -279,7 +281,7 @@ function writePathwayAnnotationLabelMenu(label, dotPlotMetrics) {
 }
 
 /** Update pathway header with SCP label menu, info icon */
-function writePathwayExpressionHeader(loadingCls, dotPlotMetrics, label, pathwayGenes) {
+function writePathwayExpressionHeader(dotPlotMetrics, label, pathwayGenes) {
   // Remove "Loading expression...", as load is done
   document.querySelector(`.${loadingCls}`)?.remove()
 
@@ -288,9 +290,12 @@ function writePathwayExpressionHeader(loadingCls, dotPlotMetrics, label, pathway
 }
 
 /** Add "Loading expression..." to pathway header while dot plot metrics are being fetched */
-function writeLoadingIndicator(loadingCls) {
+export function writeLoadingIndicator() {
   document.querySelector('.pathway-label-menu-container')?.remove()
   const headerLink = document.querySelector('._ideoPathwayHeader a')
+  if (!headerLink) {
+    return
+  }
   const style = 'color: #777; font-style: italic; margin-left: 10px;'
   const loading = `<span class="${loadingCls}" style="${style}">Loading expression...</span>`
   document.querySelector(`.${loadingCls}`)?.remove()
@@ -322,9 +327,6 @@ export async function renderPathwayExpression(studyAccession, cluster, annotatio
 
   const annotationLabels = getEligibleLabels()
 
-  const loadingCls = 'pathway-loading-expression'
-  writeLoadingIndicator(loadingCls)
-
   if (label === '') {
     return
   }
@@ -353,11 +355,11 @@ export async function renderPathwayExpression(studyAccession, cluster, annotatio
 
     allDotPlotMetrics = mergeDotPlotMetrics(dotPlotMetrics, allDotPlotMetrics)
 
-    writePathwayExpressionHeader(loadingCls, allDotPlotMetrics, label, pathwayGenes)
+    writePathwayExpressionHeader(allDotPlotMetrics, label, pathwayGenes)
 
     colorPathwayGenesByExpression(label, allDotPlotMetrics)
 
-    if (numRenders <= dotPlotGeneBatches.length) {
+    if (numRenders < dotPlotGeneBatches.length - 1) {
       numRenders += 1
       // Future optimization: render background dot plot one annotation at a time.  This would
       // speed up initial pathway expression overlay rendering, and increase the practical limit

--- a/app/javascript/lib/pathway-expression.js
+++ b/app/javascript/lib/pathway-expression.js
@@ -322,12 +322,12 @@ export async function renderPathwayExpression(studyAccession, cluster, annotatio
 
   const annotationLabels = getEligibleLabels()
 
+  const loadingCls = 'pathway-loading-expression'
+  writeLoadingIndicator(loadingCls)
+
   if (label === '') {
     return
   }
-
-  const loadingCls = 'pathway-loading-expression'
-  writeLoadingIndicator(loadingCls)
 
   /** After invisible dot plot renders, color each gene by expression metrics */
   function backgroundDotPlotDrawCallback(dotPlot) {

--- a/app/javascript/lib/search-utils.js
+++ b/app/javascript/lib/search-utils.js
@@ -182,9 +182,9 @@ function getPathwaySuggestions(inputText, maxPathwaySuggestions) {
  *
  * @param {String} inputString String typed by user into text input
  * @param {Array<String>} targets List of strings to match against
- * @param {Integer} numSuggestions Number of suggestions to show
+ * @param {Boolean} includePathways Whether include pathway suggestions
  */
-export function getAutocompleteSuggestions(inputText, targets, numSuggestions=NUM_SUGGESTIONS) {
+export function getAutocompleteSuggestions(inputText, targets, includePathways) {
   // Autocomplete when user starts typing
   if (!targets?.length || !inputText) {
     return []
@@ -203,7 +203,7 @@ export function getAutocompleteSuggestions(inputText, targets, numSuggestions=NU
       .sort((a, b) => {return a.localeCompare(b)})
 
   let topMatches = prefixMatches
-  if (prefixMatches.length < numSuggestions) {
+  if (prefixMatches.length < NUM_SUGGESTIONS) {
     // Get similarly-named genes, as measured by Dice coefficient (`rating`)
     const similar = stringSimilarity.findBestMatch(inputText, targets)
     const similarMatches =
@@ -220,10 +220,13 @@ export function getAutocompleteSuggestions(inputText, targets, numSuggestions=NU
 
   if (exactMatch) {topMatches.unshift(exactMatch)} // Put any exact match first
 
-  const maxPathwaySuggestions = numSuggestions - prefixMatches.length
-  const pathwaySuggestions = getPathwaySuggestions(inputText, maxPathwaySuggestions)
+  const maxPathwaySuggestions = NUM_SUGGESTIONS - prefixMatches.length
+  let pathwaySuggestions = []
+  if (includePathways) {
+    pathwaySuggestions = getPathwaySuggestions(inputText, maxPathwaySuggestions)
+  }
 
-  const topGeneMatches = topMatches.slice(0, numSuggestions)
+  const topGeneMatches = topMatches.slice(0, NUM_SUGGESTIONS)
 
   topMatches = topGeneMatches.concat(pathwaySuggestions)
 

--- a/test/js/explore/study-gene-keyword.test.js
+++ b/test/js/explore/study-gene-keyword.test.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { render, waitFor, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 
-import StudyGeneField, { getIsInvalidQuery } from 'components/explore/StudyGeneField'
+import StudyGeneField, { getIsInvalidQuery, getIsEligibleForPathwayExplore } from 'components/explore/StudyGeneField'
 import * as UserProvider from '~/providers/UserProvider'
 import { interestingNames, interactionCacheCsn1s1 } from './../visualization/pathway.test-data'
 
@@ -67,7 +67,10 @@ describe('Search query display text', () => {
       })
 
     const { container } = render(
-      <StudyGeneField queries={[]} queryFn={() => {}} allGenes={['PTEN']} speciesList={['Homo sapiens']} />
+      <StudyGeneField
+        queries={[]} queryFn={() => {}} allGenes={['PTEN']}
+        speciesList={['Homo sapiens']} selectedAnnotation={{ type: 'group' }}
+      />
     )
 
     // Find the input field inside react-select
@@ -97,5 +100,26 @@ describe('Search query display text', () => {
     const pathwayIsInvalid = getIsInvalidQuery('CSN1S1', ['PTEN'])
     expect(pathwayIsInvalid).toBe(false)
   })
+
+  it('determines if view is eligible for pathway exploration', async () => {
+    jest
+      .spyOn(UserProvider, 'getFeatureFlagsWithDefaults')
+      .mockReturnValue({
+        show_pathway_expression: true
+      })
+
+    // Confirm mouse is not eligible
+    const isMouseEligible = getIsEligibleForPathwayExplore(['Mus musculus'], { type: 'group' })
+    expect(isMouseEligible).toBe(false)
+
+    // Confirm numeric annotation is not eligible
+    const isNumericAnnotationEligible = getIsEligibleForPathwayExplore(['Homo sapiens'], { type: 'numeric' })
+    expect(isNumericAnnotationEligible).toBe(false)
+
+    // Confirm group annotation for human is eligible
+    const isHumanGroupAnnotationEligible = getIsEligibleForPathwayExplore(['Homo sapiens'], { type: 'group' })
+    expect(isHumanGroupAnnotationEligible).toBe(true)
+  })
+
 })
 


### PR DESCRIPTION
This refines new pathway exploration functionality before it is launched.

### Overview
Previously, per #2206, the search box in study pages had a new way to search and visualize biological pathway diagrams.  It's a big new feature, but had some inefficiencies and bugs:

* The loading icon often did not appear when it should have.
* Pathways don't yet work for mouse, because homology-converted pathways aren't yet integrated.  This broke study gene search for mouse.
* Pathways should not have shown for numeric annotations.  Such annotations have continuous values, and nodes are colored by expression in discrete group labels.
* A couple of useless Morpheus / dot plot SCP API requests were sent upon searching a pathway, slowing the UI and adding unnecessary server load

Now that's refined and fixed.

### Video
Here's how it looks!

https://github.com/user-attachments/assets/7f08aaa7-98c0-4b6e-8df1-16b448914b67

### Tests
A new automated test helps verify these changes work.  To optionally manually test:
1.  Set `pathway_expression_overlay` feature flag to true
2.  Go to "Cellular and transcriptional diversity over the course of human lactation" study
3.  In search box, type "lac"
4.  Confirm suggestions appear in "Genes" and "Pathways" groups in autocomplete
5.  Select first pathway suggestion
6.  Confirm "Loading expression..." appears, then "Mammary gland development: pregnancy and lactation - stage 3 of 4" pathway nodes are filled with color
7.  Click "Reset view"
8.  Switch annotation to "time_post_partum_days"
9.  Search "PTEN"
10.  Gene only genes are suggestion, and no pathways are suggested
11.  Go to an initialized mouse study
12.  Search a gene
13.  Confirm expression scatter plot is shown

This satisfies SCP-5990.