### PR TITLE
Log pathway search, click, and hover analytics to Mixpanel (SCP-5989)

### DIFF
--- a/app/javascript/components/visualization/Pathway.jsx
+++ b/app/javascript/components/visualization/Pathway.jsx
@@ -3,6 +3,7 @@ import { Popover, OverlayTrigger } from 'react-bootstrap'
 import { manageDrawPathway, writeLoadingIndicator } from '~/lib/pathway-expression'
 import { getIdentifierForAnnotation, naturalSort } from '~/lib/cluster-utils'
 import { round } from '~/lib/metrics-perf'
+import { log } from '~/lib/metrics-api'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
@@ -80,6 +81,17 @@ function handleGeneNodeHover(event, geneName) {
   node.setAttribute('data-toggle', 'tooltip')
   node.setAttribute('data-html', 'true')
   node.setAttribute('data-original-title', content)
+
+  const pathwayId = window.Ideogram.pathwayJson.pathway.id
+  const pathwayName = window.Ideogram.pathwayJson.pathway.name
+
+  log('pathway-node-tooltip', {
+    pathway: pathwayId,
+    pathwayName,
+    name: geneName,
+    nodeType: 'gene'
+  })
+
   return ''
 }
 
@@ -141,6 +153,14 @@ export default function Pathway({
   /** Upon clicking a pathway node, show new pathway and expression overlay */
   function handlePathwayNodeClick(event, pathwayId) {
     queryFn([pathwayId])
+
+    const pathwayName = window.Ideogram.pathwayJson.pathway.name
+
+    log('pathway-node-click', {
+      pathway: pathwayId,
+      pathwayName,
+      nodeType: 'pathway'
+    })
   }
 
   const dimensionString = JSON.stringify(dimensions)

--- a/app/javascript/lib/search-metrics.js
+++ b/app/javascript/lib/search-metrics.js
@@ -202,9 +202,16 @@ function detectSearchedGenesElsewhere(searchedGenes) {
 
 /** log a search from the study explore tab */
 export function logStudyGeneSearch(genes, trigger, speciesList, otherProps) {
+  let searchType = 'gene'
+
+  const pathwayRegEx = /^WP\d+$/
+  if (genes.length === 1 && pathwayRegEx.test(genes[0])) {
+    searchType = 'pathway'
+  }
+
   // Properties logged for all gene searches from Study Overview
   const logProps = {
-    type: 'gene',
+    type: searchType,
     context: 'study',
     genes,
     numGenes: genes.length,

--- a/test/js/explore/study-gene-keyword.test.js
+++ b/test/js/explore/study-gene-keyword.test.js
@@ -5,6 +5,8 @@ import '@testing-library/jest-dom/extend-expect'
 
 import StudyGeneField, { getIsInvalidQuery, getIsEligibleForPathwayExplore } from 'components/explore/StudyGeneField'
 import * as UserProvider from '~/providers/UserProvider'
+import { logStudyGeneSearch } from '~/lib/search-metrics'
+import * as MetricsApi from '~/lib/metrics-api'
 import { interestingNames, interactionCacheCsn1s1 } from './../visualization/pathway.test-data'
 
 describe('Search query display text', () => {
@@ -121,5 +123,34 @@ describe('Search query display text', () => {
     expect(isHumanGroupAnnotationEligible).toBe(true)
   })
 
+  it('distinguishes pathway from gene search types in analytics loggging', async () => {
+    const fakeLog = jest.spyOn(MetricsApi, 'log')
+    fakeLog.mockImplementation(() => { })
+
+    let queries = ['PTEN']
+    const trigger = 'click'
+    const speciesList = ['Homo sapiens']
+
+    logStudyGeneSearch(queries, trigger, speciesList)
+
+    expect(fakeLog).toHaveBeenCalledWith(
+      'search',
+      expect.objectContaining({
+        type: 'gene'
+      })
+    )
+
+    queries = ['WP1234']
+
+    logStudyGeneSearch(queries, trigger, speciesList)
+
+    expect(fakeLog).toHaveBeenCalledWith(
+      'search',
+      expect.objectContaining({
+        type: 'pathway'
+      })
+    )
+
+  })
 })
 

--- a/test/js/explore/study-gene-keyword.test.js
+++ b/test/js/explore/study-gene-keyword.test.js
@@ -123,7 +123,7 @@ describe('Search query display text', () => {
     expect(isHumanGroupAnnotationEligible).toBe(true)
   })
 
-  it('distinguishes pathway from gene search types in analytics loggging', async () => {
+  it('distinguishes pathway from gene search types in analytics logging', async () => {
     const fakeLog = jest.spyOn(MetricsApi, 'log')
     fakeLog.mockImplementation(() => { })
 


### PR DESCRIPTION
This tracks user interactions with new pathway exploration features introduced in #2206.  It helps assess usage.

Previously, queries from the main search box in Study Overview were all logged as "gene" searches.  Interactions with the pathway diagram were also unlogged.  We had very little observability on user engagement for this significant new feature.

Now, if a user clicks on one of the new pathway suggestions in the search autocomplete, then the search is logged as a "pathway" search.  Hover / mouseover on gene nodes in the pathway diagram, and click on pathway nodes, are also now logged.

### Test
A new automated test verifies some new logging.  To optionally manually test:
1.  Go to "Cellular and transcriptional diversity over the course of human lactation" study
2.  Open Network panel in Chrom DevTools, filter to "event method:POST"
3.  In search box, type "lac"
4. Select first pathway suggestion
5.  Confirm an event request is posted to Mixpanel with name "search" and type "pathway"
6.  Hover over a gene node in the pathway diagram
7.  Confirm event request with name "pathway-node-hover"
8.  Click on a green pathway node
7.  Confirm event request with name "pathway-node-click"

This satisfies SCP-5989.