### PR TITLE
Adding morphology and electrophysiology facets (SCP-5980)

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -238,10 +238,20 @@ module Api
         if @studies.count > 0 && @facets.any?
           sort_type = :facet
           @studies_by_facet = {}
-          @big_query_search = self.class.generate_bq_query_string(@facets)
-          logger.info "Searching BigQuery using facet-based query: #{@big_query_search}"
-          query_results = ApplicationController.big_query_client.dataset(CellMetadatum::BIGQUERY_DATASET).query @big_query_search
-          job_id = query_results.job_gapi.job_reference.job_id
+          mongo_facets, bq_facets = self.class.divide_facets_by_source(@facets)
+          if bq_facets.any?
+            @big_query_search = self.class.generate_bq_query_string(bq_facets)
+            query_results = ApplicationController.big_query_client.dataset(CellMetadatum::BIGQUERY_DATASET).query @big_query_search
+          else
+            query_results = []
+          end
+          # run a query for any mongo-based facets
+          mongo_facets.map do |facet|
+            db_facet = facet[:db_facet]
+            mongo_results = StudySearchService.perform_mongo_facet_search(db_facet, facet[:filters])
+            query_results += mongo_results
+          end
+
           # build up map of study matches by facet & filter value (for adding labels in UI)
           @studies_by_facet = self.class.match_studies_by_facet(query_results, @facets)
           # uniquify result list as one study may match multiple facets/filters
@@ -254,7 +264,7 @@ module Api
           existing_total_matches = @match_by_data['numResults:scp'].to_i
           @match_by_data['numResults:scp:metadata'] = total_metadata_matches.size
           @match_by_data['numResults:scp'] = existing_total_matches + total_metadata_matches.size
-          logger.info "Found #{@convention_accessions.count} matching studies from BQ job #{job_id}: #{@convention_accessions}"
+          logger.info "Found #{@convention_accessions.count} matching studies from query: #{@convention_accessions}"
           @studies = @studies.where(:accession.in => @convention_accessions)
         end
 
@@ -763,6 +773,11 @@ module Api
         else
           matching_facet[:filters].detect { |filter| filter[:id] == search_result[result_key] || filter[:name] == search_result[result_key]}
         end
+      end
+
+      # divide facets into mongo- and bigquery-based
+      def self.divide_facets_by_source(facets)
+        facets.partition { |facet| facet[:db_facet].is_mongo_based }
       end
 
       # properly escape any single quotes in a filter value (double quotes are correctly handled already)

--- a/app/lib/study_search_service.rb
+++ b/app/lib/study_search_service.rb
@@ -162,9 +162,8 @@ class StudySearchService
   # also accounts for presence-based facets like has_morphology
   def self.perform_mongo_facet_search(facet, filter_values)
     results = []
-    values = filter_values.map { |entry| [entry[:id], entry[:name]] }.flatten
-    matches = CellMetadatum.where(:name.in => [facet.metadatum_name])
-    matches = matches.where(:values.in => values) unless facet.is_presence_facet
+    values = filter_values.map { |entry| [convert_id_format(entry[:id]), entry[:name]] }.flatten
+    matches = facet.associated_metadata(values)
     matches.each do |metadata|
       next if metadata.study.queued_for_deletion
 
@@ -175,6 +174,12 @@ class StudySearchService
       end
     end
     results
+  end
+
+  # deal with ontology id formatting inconsistencies
+  def self.convert_id_format(id)
+    parts = id.split(/[_:]/)
+    [parts.join('_'), parts.join(':')]
   end
 
   # take a term and match to a possible search facet/filter

--- a/app/lib/study_search_service.rb
+++ b/app/lib/study_search_service.rb
@@ -158,6 +158,25 @@ class StudySearchService
     accessions_to_filters.with_indifferent_access
   end
 
+  # search Mongo for facets that don't use BigQuery to source data
+  # also accounts for presence-based facets like has_morphology
+  def self.perform_mongo_facet_search(facet, filter_values)
+    results = []
+    values = filter_values.map { |entry| [entry[:id], entry[:name]] }.flatten
+    matches = CellMetadatum.where(:name.in => [facet.metadatum_name])
+    matches = matches.where(:values.in => values) unless facet.is_presence_facet
+    matches.each do |metadata|
+      next if metadata.study.queued_for_deletion
+
+      accession = metadata.study.accession
+      matched_values = facet.is_presence_facet ? [facet.identifier] : values & metadata.values
+      matched_values.map do |val|
+        results << { study_accession: accession, facet.identifier.to_sym => val }
+      end
+    end
+    results
+  end
+
   # take a term and match to a possible search facet/filter
   # will return a single hash with keys as facet names, and values as an array of filter matches
   def self.match_facet_filters_from_terms(term_list)

--- a/app/lib/study_search_service.rb
+++ b/app/lib/study_search_service.rb
@@ -163,7 +163,7 @@ class StudySearchService
   def self.perform_mongo_facet_search(facet, filter_values)
     results = []
     values = filter_values.map { |entry| [convert_id_format(entry[:id]), entry[:name]] }.flatten
-    matches = facet.associated_metadata(values)
+    matches = facet.associated_metadata(values:)
     matches.each do |metadata|
       next if metadata.study.queued_for_deletion
 

--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -43,9 +43,9 @@ class SearchFacet
   }.with_indifferent_access.freeze
   TIME_UNITS = TIME_MULTIPLIERS.keys.freeze
 
-  validates_presence_of :name, :identifier, :data_type, :convention_name, :convention_version
-  validates :big_query_id_column, :big_query_name_column, presence: true, unless: :is_mongo_based
-  validates_uniqueness_of :big_query_id_column, scope: [:convention_name, :convention_version], unless: :is_mongo_based
+  validates_presence_of :name, :identifier, :data_type, :big_query_id_column, :big_query_name_column, :convention_name,
+                        :convention_version
+  validates_uniqueness_of :big_query_id_column, scope: [:convention_name, :convention_version]
   validate :ensure_ontology_url_format, if: proc {|attributes| attributes[:is_ontology_based]}
   before_validation :set_data_type_and_array, on: :create,
                     if: proc {|attr| (![true, false].include?(attr[:is_array_based]) || attr[:data_type].blank?) && attr[:big_query_id_column].present?}

--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -27,7 +27,7 @@ class SearchFacet
   field :max, type: Float # maximum allowed value for number-based facets
   field :visible, type: Boolean, default: true # default visibility (false will not show in UI but can be queried via API)
   field :is_mongo_based, type: Boolean, default: false # controls whether to source data from Mongo or BQ
-  field :is_presence_facet, type: Boolean, default: true # doesn't display filter values, just Y
+  field :is_presence_facet, type: Boolean, default: false # doesn't display filter values, just Y
 
   DATA_TYPES = %w(string number boolean)
   BQ_DATA_TYPES = %w(STRING FLOAT64 BOOL)

--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -534,6 +534,8 @@ class SearchFacet
 
   # determine if this facet references array-based data in BQ as data_type will look like "ARRAY<STRING>"
   def set_data_type_and_array
+    return true if is_mongo_based
+
     column_schema = SearchFacet.get_table_schema(column_name: big_query_id_column)
     detected_type = column_schema[:data_type]
     self.is_array_based = detected_type.include?('ARRAY')

--- a/db/migrate/20250501135335_add_morph_and_electro_facets.rb
+++ b/db/migrate/20250501135335_add_morph_and_electro_facets.rb
@@ -1,0 +1,18 @@
+class AddMorphAndElectroFacets < Mongoid::Migration
+  @names = %w[has_morphology has_electrophysiology]
+  @columns = %w[bil_url dandi_url]
+  @new_facets = @names.zip(@columns).to_h
+  def self.up
+    @new_facets.each do |identifier, column|
+      SearchFacet.create!(
+        name: identifier.humanize, identifier:, big_query_id_column: column, big_query_name_column: column,
+        is_mongo_based: true, is_presence_facet: true, convention_name: 'alexandria_convention', data_type: 'string',
+        convention_version: '3.0.0', visible: true
+      )
+    end
+  end
+
+  def self.down
+    SearchFacet.where(:identifier.in => @names).delete_all
+  end
+end

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -567,4 +567,18 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test 'should divide facets by data source' do
+    identifier = 'has_morphology'
+    column = 'bil_url'
+    morph_facet = SearchFacet.create!(
+      name: identifier.humanize, identifier:, big_query_id_column: column, big_query_name_column: column,
+      is_mongo_based: true, is_presence_facet: true, convention_name: 'alexandria_convention', data_type: 'string',
+      convention_version: '3.0.0', visible: true
+    )
+    facets = SearchFacet.all.map { |db_facet| { db_facet: }}.reduce({}, :merge)
+    mongo_facets, bq_facets = Api::V1::SearchController.divide_facets_by_source(facets)
+    assert_equal mongo_facets.first.identifier, morph_facet.identifier
+    assert_equal SearchFacet.count - 1, bq_facets.count
+  end
 end

--- a/test/api/search_controller_test.rb
+++ b/test/api/search_controller_test.rb
@@ -576,9 +576,9 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       is_mongo_based: true, is_presence_facet: true, convention_name: 'alexandria_convention', data_type: 'string',
       convention_version: '3.0.0', visible: true
     )
-    facets = SearchFacet.all.map { |db_facet| { db_facet: }}.reduce({}, :merge)
+    facets = SearchFacet.all.map { |db_facet| { db_facet: } }
     mongo_facets, bq_facets = Api::V1::SearchController.divide_facets_by_source(facets)
-    assert_equal mongo_facets.first.identifier, morph_facet.identifier
+    assert_equal mongo_facets.first[:db_facet].identifier, morph_facet.identifier
     assert_equal SearchFacet.count - 1, bq_facets.count
   end
 end

--- a/test/models/search_facet_test.rb
+++ b/test/models/search_facet_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'detached_helper'
 
 class SearchFacetTest < ActiveSupport::TestCase
 
@@ -293,11 +294,13 @@ class SearchFacetTest < ActiveSupport::TestCase
       { id: 'CL_0000561', name: 'amacrine cell' },
       { id: 'CL_0000573', name: 'retinal cone cell' }
     ]
-    facet.reload
-    byebug
-    assert_equal expected_filters, facet.get_unique_filter_values(public_only: true)
-    metadata_ids = study.cell_metadata.pluck(:id)
-    assert_equal metadata_ids, facet.associated_metadata.pluck(:id)
+
+    mock_query_not_detached [study] do
+      facet.reload
+      assert_equal expected_filters, facet.get_unique_filter_values(public_only: true)
+      metadata_ids = [study.cell_metadata.first.id]
+      assert_equal metadata_ids, facet.associated_metadata.pluck(:id)
+    end
   end
 
   test 'should get presence-based filters' do

--- a/test/services/study_search_service_test.rb
+++ b/test/services/study_search_service_test.rb
@@ -49,6 +49,10 @@ class StudySearchServiceTest < ActiveSupport::TestCase
                                        convention_name: 'Alexandria Metadata Convention', convention_version: '2.2.0')
   end
 
+  after(:all) do
+    SearchFacet.destroy_all
+  end
+
   test 'should generate query for keyword search' do
     terms = 'cell'
     query = StudySearchService.generate_mongo_query_by_context(terms: terms, base_studies: @base_studies,
@@ -123,5 +127,20 @@ class StudySearchServiceTest < ActiveSupport::TestCase
     terms_with_escapes = %w[foo foo$ foo. foo/]
     expected_escapes = /(foo|foo\$|foo\.|foo\/)/i
     assert_equal expected_escapes, StudySearchService.escape_terms_for_regex(term_list: terms_with_escapes)
+  end
+
+  test 'should perform mongo-based search when specified' do
+    filter = @filters.sample
+    results = StudySearchService.perform_mongo_facet_search(@search_facet, [filter])
+    safe_result = results.first.with_indifferent_access
+    assert_equal @metadata_study.accession, safe_result[:study_accession]
+    assert_equal filter[:name], safe_result[@search_facet.identifier]
+  end
+
+  test 'should convert ontology id to multiple formats' do
+    id = @filters.sample[:id]
+    converted = StudySearchService.convert_id_format(id)
+    assert_includes converted, id
+    assert_includes converted, id.gsub(/_/, ':')
   end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This adds two new search facets to the "more facets" menu on the homepage: `has_morphology` and `has_electrophysiology`.  Both of these search facets are MongoDB-based, meaning they do not source data from BigQuery for either filter values or search results.  Additionally, these facets have a new property called `is_presence_facet` which means that no exact filter matches are made, but rather only the presence of a given metadatum name within a study.  This update also lays the groundwork for retiring BigQuery entirely for study-based search.  More work is needed, but the main foundation of being able to source filter labels and perform searches directly in MongoDB is now in place.

#### MANUAL TESTING
1. Run the migration to create the new facets with `rails db:migrate`
2. Boot all services and sign in
3. Download the metadata file from [SCP2674](https://singlecell.broadinstitute.org/single_cell/study/SCP2674/phenotypic-variation-of-transcriptomic-cell-types-in-mouse-motor-cortex?scpbr=brain-multi-modal#study-download) and upload it to a new study
4. Once the metadata ingest completes, go back to the home page and click "more facets"
5. Confirm both new facets are present, and that they both return the new study you created when used