### PR TITLE
Fix gene-list paste search in study views not eligible for pathways (SCP-6000)

### DIFF
--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -182,7 +182,14 @@ export default function StudyGeneField({
       }
     }
     const searchOptions = getSearchOptions(inputTextValues, speciesList, selectedAnnotation)
-    const queryOptions = searchOptions[0].options
+
+    let queryOptions
+    if (getIsEligibleForPathwayExplore(speciesList, selectedAnnotation)) {
+      queryOptions = searchOptions[0].options
+    } else {
+      queryOptions = searchOptions
+    }
+
     const newQueryArray = queryArray.concat(queryOptions)
     setInputText('')
     setQueryArray(newQueryArray)

--- a/app/javascript/components/visualization/Pathway.jsx
+++ b/app/javascript/components/visualization/Pathway.jsx
@@ -88,7 +88,7 @@ function handleGeneNodeHover(event, geneName) {
   log('pathway-node-tooltip', {
     pathway: pathwayId,
     pathwayName,
-    name: geneName,
+    nodeName: geneName,
     nodeType: 'gene'
   })
 


### PR DESCRIPTION
This fixes a common way to search for multiple genes, which affected mouse, spatial studies, and a few other views.

This bug in search-by-paste in non-human studies was introduced yesterday, due to the new pathway search and visualization feature (#2206).

### Test
1.  Enable pathway exploration
2.  Go to an initialized mouse study
3.  Paste "Pten Brca1 Brca2" into box, then blur focus
4.  Confirm dot plot renders
5.  Go to an initialized human study
6.  Paste "PTEN BRCA1 BRCA2" into search box, then blur focus

This satisfies SCP-6000.