### PR TITLE
Disabling external NeMO tests (SCP-6007)

### DIFF
--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -49,12 +49,12 @@ module ImportServiceConfig
     end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    test 'should traverse associations to set ids' do
-      config = ImportServiceConfig::Nemo.new(file_id: @attributes[:file_id])
-      config.traverse_associations!
-      assert_equal @attributes[:study_id], config.study_id
-      assert_equal 'nemo:grn-gyy3k8j', config.project_id
-    end
+    # test 'should traverse associations to set ids' do
+    #   config = ImportServiceConfig::Nemo.new(file_id: @attributes[:file_id])
+    #   config.traverse_associations!
+    #   assert_equal @attributes[:study_id], config.study_id
+    #   assert_equal 'nemo:grn-gyy3k8j', config.project_id
+    # end
 
     test 'should load defaults' do
       study_defaults = {
@@ -93,91 +93,91 @@ module ImportServiceConfig
       assert_equal 'application/octet-stream', @configuration.get_file_content_type('csv')
     end
 
-    test 'should load study analog' do
-      study = @configuration.load_study
-      assert_equal '"Human variation study (10x), GRU"', study['name']
-      assert_equal ["10x chromium 3' v3 sequencing"], study['techniques']
-      assert_equal [{"name"=>"human", "cv_term_id"=>"NCBI:txid9606"}], study['taxa']
-    end
+    # test 'should load study analog' do
+    #   study = @configuration.load_study
+    #   assert_equal '"Human variation study (10x), GRU"', study['name']
+    #   assert_equal ["10x chromium 3' v3 sequencing"], study['techniques']
+    #   assert_equal [{"name"=>"human", "cv_term_id"=>"NCBI:txid9606"}], study['taxa']
+    # end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    test 'should load file analog' do
-      file = @configuration.load_file
-      assert_equal 'human_var_scVI_VLMC.h5ad', file['file_name']
-      assert_equal 'h5ad', file['file_format']
-      assert_equal 'counts', file['data_type']
-    end
+    # test 'should load file analog' do
+    #   file = @configuration.load_file
+    #   assert_equal 'human_var_scVI_VLMC.h5ad', file['file_name']
+    #   assert_equal 'h5ad', file['file_format']
+    #   assert_equal 'counts', file['data_type']
+    # end
 
-    test 'should load collection analog' do
-      collection = @configuration.load_collection
-      assert_equal 'ecker_sn_mCseq_proj', collection['short_name']
-    end
-
-    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    test 'should extract association ids' do
-      file = @configuration.load_file
-      study = @configuration.load_study
-      assert_equal @attributes[:study_id], @configuration.id_from(file, :collections)
-      assert_equal 'nemo:grn-gyy3k8j', @configuration.id_from(study, :projects)
-    end
-
-    test 'should load taxon common names' do
-      assert_equal %w[human], @configuration.taxon_names
-    end
-
-    test 'should find library preparation protocol' do
-      assert_equal "10x 3' v3", @configuration.find_library_prep("10x chromium 3' v3 sequencing")
-      assert_equal 'Drop-seq', @configuration.find_library_prep('drop-seq')
-    end
+    # test 'should load collection analog' do
+    #   collection = @configuration.load_collection
+    #   assert_equal 'ecker_sn_mCseq_proj', collection['short_name']
+    # end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    test 'should populate study and study_file' do
-      scp_study = @configuration.populate_study
-      assert_equal 'Human variation study (10x), GRU', scp_study.name
-      assert_not scp_study.public
-      assert scp_study.full_description.present?
-      assert_equal @user_id, scp_study.user_id
-      assert_equal @branding_group_id, scp_study.branding_group_ids.first
-      assert_equal @configuration.service_name, scp_study.imported_from
-      # populate StudyFile, using above study
-      scp_study_file = @configuration.populate_study_file(scp_study.id)
-      assert scp_study_file.use_metadata_convention
-      assert_equal 'human_var_scVI_VLMC.h5ad', scp_study_file.upload_file_name
-      assert_equal "10x 3' v3", scp_study_file.expression_file_info.library_preparation_protocol
-      assert_equal @configuration.service_name, scp_study_file.imported_from
-      assert_not scp_study_file.ann_data_file_info.reference_file
-      @configuration.obsm_keys.each do |obsm_key_name|
-        assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?
-      end
-      assert scp_study_file.ann_data_file_info.find_fragment(data_type: :expression).present?
-    end
+    # test 'should extract association ids' do
+    #   file = @configuration.load_file
+    #   study = @configuration.load_study
+    #   assert_equal @attributes[:study_id], @configuration.id_from(file, :collections)
+    #   assert_equal 'nemo:grn-gyy3k8j', @configuration.id_from(study, :projects)
+    # end
+
+    # test 'should load taxon common names' do
+    #   assert_equal %w[human], @configuration.taxon_names
+    # end
+    #
+    # test 'should find library preparation protocol' do
+    #   assert_equal "10x 3' v3", @configuration.find_library_prep("10x chromium 3' v3 sequencing")
+    #   assert_equal 'Drop-seq', @configuration.find_library_prep('drop-seq')
+    # end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    test 'should import all from service' do
-      access_url = 'gs://nemo-public/other/grant/u01_lein/lein/transcriptome/sncell/10x_v3/' \
-                   'human/processed/counts/human_var_scVI_VLMC.h5ad'
-      file_mock = ::Minitest::Mock.new
-      file_mock.expect :generation, '123456789'
-      # for study to save, we need to mock all Terra orchestration API calls for creating workspace & setting acls
-      fc_client_mock = ::Minitest::Mock.new
-      owner_group = { groupEmail: 'sa-owner-group@firecloud.org' }.with_indifferent_access
-      assign_workspace_mock!(fc_client_mock, owner_group, 'human-variation-study-10x-gru')
-      AdminConfiguration.stub :find_or_create_ws_user_group!, owner_group do
-        ImportService.stub :copy_file_to_bucket, file_mock do
-          ApplicationController.stub :firecloud_client, fc_client_mock do
-            @configuration.stub :taxon_from, Taxon.new(common_name: 'human') do
-              study, study_file = @configuration.import_from_service
-              file_mock.verify
-              fc_client_mock.verify
-              assert study.persisted?
-              assert study_file.persisted?
-              assert_equal study.external_identifier, @attributes[:study_id]
-              assert_equal study_file.external_identifier, @attributes[:file_id]
-              assert_equal study_file.external_link_url, access_url
-            end
-          end
-        end
-      end
-    end
+    # test 'should populate study and study_file' do
+    #   scp_study = @configuration.populate_study
+    #   assert_equal 'Human variation study (10x), GRU', scp_study.name
+    #   assert_not scp_study.public
+    #   assert scp_study.full_description.present?
+    #   assert_equal @user_id, scp_study.user_id
+    #   assert_equal @branding_group_id, scp_study.branding_group_ids.first
+    #   assert_equal @configuration.service_name, scp_study.imported_from
+    #   # populate StudyFile, using above study
+    #   scp_study_file = @configuration.populate_study_file(scp_study.id)
+    #   assert scp_study_file.use_metadata_convention
+    #   assert_equal 'human_var_scVI_VLMC.h5ad', scp_study_file.upload_file_name
+    #   assert_equal "10x 3' v3", scp_study_file.expression_file_info.library_preparation_protocol
+    #   assert_equal @configuration.service_name, scp_study_file.imported_from
+    #   assert_not scp_study_file.ann_data_file_info.reference_file
+    #   @configuration.obsm_keys.each do |obsm_key_name|
+    #     assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?
+    #   end
+    #   assert scp_study_file.ann_data_file_info.find_fragment(data_type: :expression).present?
+    # end
+
+    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+    # test 'should import all from service' do
+    #   access_url = 'gs://nemo-public/other/grant/u01_lein/lein/transcriptome/sncell/10x_v3/' \
+    #                'human/processed/counts/human_var_scVI_VLMC.h5ad'
+    #   file_mock = ::Minitest::Mock.new
+    #   file_mock.expect :generation, '123456789'
+    #   # for study to save, we need to mock all Terra orchestration API calls for creating workspace & setting acls
+    #   fc_client_mock = ::Minitest::Mock.new
+    #   owner_group = { groupEmail: 'sa-owner-group@firecloud.org' }.with_indifferent_access
+    #   assign_workspace_mock!(fc_client_mock, owner_group, 'human-variation-study-10x-gru')
+    #   AdminConfiguration.stub :find_or_create_ws_user_group!, owner_group do
+    #     ImportService.stub :copy_file_to_bucket, file_mock do
+    #       ApplicationController.stub :firecloud_client, fc_client_mock do
+    #         @configuration.stub :taxon_from, Taxon.new(common_name: 'human') do
+    #           study, study_file = @configuration.import_from_service
+    #           file_mock.verify
+    #           fc_client_mock.verify
+    #           assert study.persisted?
+    #           assert study_file.persisted?
+    #           assert_equal study.external_identifier, @attributes[:study_id]
+    #           assert_equal study_file.external_identifier, @attributes[:file_id]
+    #           assert_equal study_file.external_link_url, access_url
+    #         end
+    #       end
+    #     end
+    #   end
+    # end
   end
 end

--- a/test/integration/external/nemo_client_test.rb
+++ b/test/integration/external/nemo_client_test.rb
@@ -55,55 +55,55 @@ class NemoClientTest < ActiveSupport::TestCase
   end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  test 'should get an entity' do
-    skip_if_api_down
-    entity_type = @identifiers.keys.sample
-    identifier = @identifiers[entity_type]
-    entity = @nemo_client.fetch_entity(entity_type, identifier)
-    assert entity.present?
-  end
-
-  test 'should get collection' do
-    skip_if_api_down
-    identifier = @identifiers[:collection]
-    collection = @nemo_client.collection(identifier)
-    assert collection.present?
-    assert_equal 'human_variation_10X', collection['short_name']
-  end
-
-  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  test 'should get file' do
-    skip_if_api_down
-    identifier = @identifiers[:file]
-    file = @nemo_client.file(identifier)
-    assert file.present?
-    filename = 'human_var_scVI_VLMC.h5ad'
-    assert_equal filename, file['file_name']
-    assert_equal 'h5ad', file['file_format']
-    access_url = file['manifest_file_urls'].first['url']
-    assert_equal filename, access_url.split('/').last
-  end
+  # test 'should get an entity' do
+  #   skip_if_api_down
+  #   entity_type = @identifiers.keys.sample
+  #   identifier = @identifiers[entity_type]
+  #   entity = @nemo_client.fetch_entity(entity_type, identifier)
+  #   assert entity.present?
+  # end
+  #
+  # test 'should get collection' do
+  #   skip_if_api_down
+  #   identifier = @identifiers[:collection]
+  #   collection = @nemo_client.collection(identifier)
+  #   assert collection.present?
+  #   assert_equal 'human_variation_10X', collection['short_name']
+  # end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  test 'should get grant' do
-    skip_if_api_down
-    identifier = @identifiers[:grant]
-    grant = @nemo_client.grant(identifier)
-    assert grant.present?
-    assert_equal 'Allen Institute Funder', grant.dig('grant_info','grant_number')
-    assert_equal 'Allen Institute Funder', grant['funding_agency']
-  end
+  # test 'should get file' do
+  #   skip_if_api_down
+  #   identifier = @identifiers[:file]
+  #   file = @nemo_client.file(identifier)
+  #   assert file.present?
+  #   filename = 'human_var_scVI_VLMC.h5ad'
+  #   assert_equal filename, file['file_name']
+  #   assert_equal 'h5ad', file['file_format']
+  #   access_url = file['manifest_file_urls'].first['url']
+  #   assert_equal filename, access_url.split('/').last
+  # end
 
-  test 'should get project' do
-    skip_if_api_down
-    identifier = @identifiers[:project]
-    project = @nemo_client.project(identifier)
-    assert project.present?
-    assert_equal 'DNA methylation profiling of genomic DNA in individual mouse brain cell nuclei (RS1.1)',
-                 project['title']
-    assert_equal 'biccn', project['program']
-    assert_equal 'ecker_sn_mCseq_proj', project['short_name']
-  end
+  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+  # test 'should get grant' do
+  #   skip_if_api_down
+  #   identifier = @identifiers[:grant]
+  #   grant = @nemo_client.grant(identifier)
+  #   assert grant.present?
+  #   assert_equal 'Allen Institute Funder', grant.dig('grant_info','grant_number')
+  #   assert_equal 'Allen Institute Funder', grant['funding_agency']
+  # end
+  #
+  # test 'should get project' do
+  #   skip_if_api_down
+  #   identifier = @identifiers[:project]
+  #   project = @nemo_client.project(identifier)
+  #   assert project.present?
+  #   assert_equal 'DNA methylation profiling of genomic DNA in individual mouse brain cell nuclei (RS1.1)',
+  #                project['title']
+  #   assert_equal 'biccn', project['program']
+  #   assert_equal 'ecker_sn_mCseq_proj', project['short_name']
+  # end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
   # test 'should get publication' do
@@ -117,23 +117,23 @@ class NemoClientTest < ActiveSupport::TestCase
   # end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  test 'should get sample' do
-    skip_if_api_down
-    identifier = @identifiers[:sample]
-    sample = @nemo_client.sample(identifier)
-    assert sample.present?
-    assert_equal 'marm028_M1', sample['sample_name']
-    assert sample['subjects'].any?
-  end
+  # test 'should get sample' do
+  #   skip_if_api_down
+  #   identifier = @identifiers[:sample]
+  #   sample = @nemo_client.sample(identifier)
+  #   assert sample.present?
+  #   assert_equal 'marm028_M1', sample['sample_name']
+  #   assert sample['subjects'].any?
+  # end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  test 'should get subject' do
-    skip_if_api_down
-    identifier = @identifiers[:subject]
-    subject = @nemo_client.subject(identifier)
-    assert subject.present?
-    assert_equal 'nonhuman-1U01MH114819', subject.dig('cohort_info', 'cohort_name')
-    assert_equal 'A Molecular and cellular atlas of the marmoset brain', subject['grant_title']
-    assert subject['samples'].any?
-  end
+  # test 'should get subject' do
+  #   skip_if_api_down
+  #   identifier = @identifiers[:subject]
+  #   subject = @nemo_client.subject(identifier)
+  #   assert subject.present?
+  #   assert_equal 'nonhuman-1U01MH114819', subject.dig('cohort_info', 'cohort_name')
+  #   assert_equal 'A Molecular and cellular atlas of the marmoset brain', subject['grant_title']
+  #   assert subject['samples'].any?
+  # end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This disables all external NeMO API tests until such a time as the production API is released.

#### MANUAL TESTING
This PR should have a clean CI run, or at least any failures are not related to NeMO or ImportService functionality.