### PR TITLE
Fix search via DE genes click (SCP-6010)

### DIFF
--- a/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
+++ b/app/javascript/components/explore/ExploreDisplayPanelManager.jsx
@@ -203,7 +203,7 @@ function getExpressionSort(exploreInfo, exploreParams) {
  *  */
 export default function ExploreDisplayPanelManager({
   studyAccession, exploreInfo, setExploreInfo, exploreParams, updateExploreParams, clearExploreParams,
-  exploreParamsWithDefaults, routerLocation, searchGenes, countsByLabelForDe, setShowUpstreamDifferentialExpressionPanel,
+  exploreParamsWithDefaults, routerLocation, queryFn, countsByLabelForDe, setShowUpstreamDifferentialExpressionPanel,
   setShowDifferentialExpressionPanel, showUpstreamDifferentialExpressionPanel, togglePanel, shownTab,
   showDifferentialExpressionPanel, setIsCellSelecting, currentPointsSelected, isCellSelecting, deGenes,
   setDeGenes, setShowDeGroupPicker,
@@ -572,7 +572,7 @@ export default function ExploreDisplayPanelManager({
             <DifferentialExpressionPanel
               deGroup={deGroup}
               deGenes={deGenes}
-              searchGenes={searchGenes}
+              searchGenes={queryFn}
               exploreParamsWithDefaults={exploreParamsWithDefaults}
               exploreInfo={exploreInfo}
               clusterName={exploreParamsWithDefaults.cluster}


### PR DESCRIPTION
This fixes a regression introduced by pathway search and visualization refinements last release.

### Test
1.  Go to study with, click "Differential expression"
2.  Select a group
3.  Click a row in DE result table
4.  Confirm gene expression scatter plot renders

This satisfies SCP-6010.