### PR TITLE
Fix mouse ideogram gene popover, add more human pathways (SCP-6002)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "exifreader": "4.6.0",
     "fflate": "^0.7.3",
     "hdf5-indexed-reader": "1.0.1",
-    "ideogram": "1.52.0",
+    "ideogram": "1.53.0",
     "jquery": "3.5.1",
     "jquery-ui": "1.13.2",
     "morpheus-app": "1.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5261,10 +5261,10 @@ iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ideogram@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.npmjs.org/ideogram/-/ideogram-1.52.0.tgz"
-  integrity sha512-YPaH26sz02yeHQ7XlGnafIpG92ZgnMv71vfCff7GRFiehRUMGQrg6NttCT31NuTLvSf/EiOETHNpNx7xK8NvBQ==
+ideogram@1.53.0:
+  version "1.53.0"
+  resolved "https://registry.yarnpkg.com/ideogram/-/ideogram-1.53.0.tgz#2d161598089d07416cb0df9c9ebdb91af6482d40"
+  integrity sha512-7oRJPvdKBtgRpaQPlQNNDCsVc8AEcA28PfA/mX4JviEcX5kOSsbuYFdUMhjoPeaxTzK8QY0Sq//jZBMmm9pmVA==
   dependencies:
     crossfilter2 "1.5.2"
     d3-array "^2.8.0"


### PR DESCRIPTION
This fixes a bug in related genes ideogram for mouse, and adds more pathways for search and visualization.

It does this by pulling in upstream changes in Ideogram.js.

Here's how it looks!

_Gene popover restored for mouse in related genes ideogram_

https://github.com/user-attachments/assets/45cd1a5a-1f7d-454b-96dc-f36a9d4bf8b0

_More human pathways for search and visualization_

https://github.com/user-attachments/assets/84bbb02d-c454-4588-9a5d-4c73b0bd890a

### Test
1.  Go to a mouse study
2.  Search for a gene
3.  Hover over it in related genes ideogram
4.  Confirm gene popover / tooltip displays
5.  Go to a human study
6.  Type "multiple sclerosis" into search box
7.  Confirm "Multiple sclerosis mechanism and treatments" is suggested in autocomplete
8.  Click suggestion
9.  Confirm pathway appears and gets gene metrics populated

This satisfies SCP-6002.