### PR TITLE
Updating tests for stability

### DIFF
--- a/bin/run_orch_smoke_test.sh
+++ b/bin/run_orch_smoke_test.sh
@@ -18,6 +18,8 @@ DOCKER_IMAGE_NAME="gcr.io/broad-singlecellportal-staging/single-cell-portal"
 DOCKER_IMAGE_VERSION="development"
 PASSENGER_APP_ENV="test"
 NON_DOCKERIZED="false"
+# disable warnings about frozen literals
+export RUBYOPT=--disable-frozen-string-literal
 
 while getopts "k:e:v:d" OPTION; do
 case $OPTION in

--- a/test/integration/external/study_validation_test.rb
+++ b/test/integration/external/study_validation_test.rb
@@ -130,8 +130,6 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
     end
     puts "After #{seconds_slept} seconds, " + (example_files.values.map { |e| "#{e[:name]} is #{e[:object].parse_status}"}).join(", ") + '.'
 
-    study.reload
-
     example_files.values.each do |e|
       e[:object].reload # address potential race condition between parse_status setting to 'failed' and DeleteQueueJob executing
       assert_equal 'failed', e[:object].parse_status, "Incorrect parse_status for #{e[:name]}"
@@ -140,6 +138,8 @@ class StudyValidationTest < ActionDispatch::IntegrationTest
       assert cached_file.present?, "Did not find cached file at #{e[:cache_location]} in #{study.bucket_id}"
     end
 
+    sleep(5)
+    study.reload
     assert_equal 0, study.cell_metadata.size
     assert_equal 0, study.genes.size
     assert_equal 0, study.cluster_groups.size


### PR DESCRIPTION
This fixes two tests that have become unstable in recent weeks.
1. StudyValidationTest#test_should_fail_all_ingest_pipeline_parse_jobs: a race condition is happened during cleanup after failed parse jobs.  The files are correctly marked as 'failed', but underlying source data doesn't always clean up in time before an assertion is checked.  A 5 second sleep has been added to help avoid this
2. SummaryStatsUtilsTest#test_should_get_data_retention_policy_report: depending on what other test suites have been run before this test, the number of expected studies can change.  Now, a query is run to get the correct number and all mocks are assembled to avoid errors.

Lastly, the `--disable-frozen-string-literal` cli option has been set for the Terra Orchestration smoke test to avoid polluting the log with `/usr/local/rvm/rubies/ruby-3.4.2/lib/ruby/3.4.0/open-uri.rb:455: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)` repeatedly.
