### PR TITLE
Add "Parse Evercode WT v3" and "Mini" version to menu in upload UI (SCP-6011)

### DIFF
--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -58,7 +58,8 @@ class ExpressionFileInfo
                                 'MERFISH', # spatial transcriptomic
                                 'NanoString CosMx', #spatial transcriptomic
                                 'osmFISH', # spatial transcriptomic
-                                'Parse Evercode Whole Transcriptome v3', # Similar to SPLiT-seq; https://broadinstitute.zendesk.com/agent/tickets/328801
+                                'Parse Evercode WT v3', # Similar to SPLiT-seq; https://broadinstitute.zendesk.com/agent/tickets/328801
+                                'Parse Evercode WT Mini v3', # Similar to SPLiT-seq; https://broadinstitute.zendesk.com/agent/tickets/328801
                                 'Patch-seq', # multimodal: scRNAseq, electrophys, morphology
                                 'PIP-seq', # scRNA-seq, https://www.nature.com/articles/s41587-023-01685-z
                                 'scATAC-seq/Fluidigm', # scATAC-seq

--- a/app/models/expression_file_info.rb
+++ b/app/models/expression_file_info.rb
@@ -58,6 +58,7 @@ class ExpressionFileInfo
                                 'MERFISH', # spatial transcriptomic
                                 'NanoString CosMx', #spatial transcriptomic
                                 'osmFISH', # spatial transcriptomic
+                                'Parse Evercode Whole Transcriptome v3', # Similar to SPLiT-seq; https://broadinstitute.zendesk.com/agent/tickets/328801
                                 'Patch-seq', # multimodal: scRNAseq, electrophys, morphology
                                 'PIP-seq', # scRNA-seq, https://www.nature.com/articles/s41587-023-01685-z
                                 'scATAC-seq/Fluidigm', # scATAC-seq


### PR DESCRIPTION
This adds "[Parse Evercode WT v3](https://www.ebi.ac.uk/ols4/ontologies/efo/classes?short_form=EFO_0022602)" and "Parse Evercode WT Mini v3" to the "Library preparation protocol" menu dropdown in the upload wizard UI.

Context: https://broadinstitute.zendesk.com/agent/tickets/328801

<img width="1512" alt="New_options_for_menu_in_upload_UI__SCP_2025-05-20" src="https://github.com/user-attachments/assets/5fe61435-3935-4388-b76c-3f14598eb265" />

This satisfies SCP-6011.