### PR TITLE
Robustify search autocomplete to misformated pathways (SCP-6012)

### DIFF
--- a/app/javascript/components/explore/StudyGeneField.jsx
+++ b/app/javascript/components/explore/StudyGeneField.jsx
@@ -362,9 +362,9 @@ export default function StudyGeneField({
 }
 
 /** Last filtering applied before showing selectable autocomplete options */
-function finalFilterOptions(option, rawInput) {
+export function finalFilterOptions(option, rawInput) {
   const input = rawInput.toLowerCase()
-  const label = 'label' in option ? option.label.toLowerCase() : option.toLowerCase()
+  const label = 'label' in option ? option.label?.toLowerCase() : option.toLowerCase()
   const isPathway = option.data.isGene === false
   return isPathway || label.includes(input) // partial match
 }

--- a/app/javascript/lib/search-utils.js
+++ b/app/javascript/lib/search-utils.js
@@ -39,8 +39,11 @@ function getPathwayIdsByName() {
 
   const pathwayCache = window.Ideogram.interactionCache
 
-  // Lower-quality pathways
-  const omittedPathways = ['WP1984', 'WP615', 'WP5096']
+  // Lower-quality or buggy pathways
+  const omittedPathways = [
+    'WP1984', 'WP615', 'WP5096',
+    'WP5520', 'WP5522', 'WP5523'
+  ]
 
   const pathwayIdsByName = {}
   const pathwayEntries = Object.entries(pathwayCache)

--- a/test/js/explore/study-gene-keyword.test.js
+++ b/test/js/explore/study-gene-keyword.test.js
@@ -3,7 +3,9 @@ import React from 'react'
 import { render, waitFor, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 
-import StudyGeneField, { getIsInvalidQuery, getIsEligibleForPathwayExplore } from 'components/explore/StudyGeneField'
+import StudyGeneField, {
+  getIsInvalidQuery, getIsEligibleForPathwayExplore, finalFilterOptions
+} from 'components/explore/StudyGeneField'
 import * as UserProvider from '~/providers/UserProvider'
 import { logStudyGeneSearch } from '~/lib/search-metrics'
 import * as MetricsApi from '~/lib/metrics-api'
@@ -151,6 +153,23 @@ describe('Search query display text', () => {
       })
     )
 
+  })
+
+  it('handles unexpected pathway data structures', () => {
+    // This tests pathway autocomplete handling for edge-case issues in
+    // upstreams WikiPathway data, which can occur upon upgrading Ideogram.js library
+    // to a new version that updates interactions cache data.  The resulting bug
+    // breaks the Explore page when the search box autocompletes an affected gene
+    // (e.g. TCF4) -- a low incidence, high severity bug.
+
+    const rawInput = 'TCF4'
+    const option = {
+      label: undefined,
+      value: 'WP5523',
+      data: { value: 'WP5523', isGene: false }
+    }
+    const isPathway = finalFilterOptions(option, rawInput)
+    expect(isPathway).toBe(true)
   })
 })
 


### PR DESCRIPTION
This adds handling for a low-incidence, high-severity issue caused by malformed pathways.  It was caught before launch.

Recently updated human pathway data (#2260) incorporated some pathways with unexpectedly-missing titles.  This is a problem with upstream WikiPathways data for small handful of very new pathways.  If you typed the name of a gene from an affected pathway into the Explore search box, the page would break.

Now, those particular few are omitted, and general handling has been added to prevent any new similar cases in the future.

### Test
A new unit test verifies this behavior.  To optionally manually test:
1.  Go to a human study
2.  Enter "TCF4" gene into search autocomplete
3.  Confirm no user-facing big red error message appears, and page generally functions as usual

This satisfies SCP-6012.