### PR TITLE
Strip undefined attributes during StudyFile creation (SCP-5996)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -332,14 +332,11 @@ module Api
         if safe_file_params[:custom_color_updates]
           parsed_update = JSON.parse(safe_file_params[:custom_color_updates])
           safe_file_params['cluster_file_info'] = {custom_colors: ClusterFileInfo.merge_color_updates(study_file, parsed_update)}
-          safe_file_params.delete(:custom_color_updates)
         end
 
         # manually check first if species/assembly was supplied by name
         species_name = safe_file_params[:species]
-        safe_file_params.delete(:species)
         assembly_name = safe_file_params[:assembly]
-        safe_file_params.delete(:assembly)
         set_taxon_and_assembly_by_name({species: species_name, assembly: assembly_name})
         # clear the id so that it doesn't get overwritten -- this would be a security hole for existing files
         # and for new files the id will have been set along with creation of the StudyFile object in the `create`
@@ -347,7 +344,6 @@ module Api
         safe_file_params.delete(:_id)
 
         parse_on_upload = safe_file_params[:parse_on_upload]
-        safe_file_params.delete(:parse_on_upload)
         cleaned_params = self.class.strip_undefined_params(safe_file_params)
 
         # check if the name of the file has changed as we won't be able to tell after we saved

--- a/test/api/study_files_controller_test.rb
+++ b/test/api/study_files_controller_test.rb
@@ -355,4 +355,30 @@ class StudyFilesControllerTest < ActionDispatch::IntegrationTest
       assert ann_data_file.needs_raw_counts_extraction?
     end
   end
+
+  test 'should remove undefined parameters' do
+    params = {
+      name: 'matrix.tsv',
+      upload_file_name: 'matrix.tsv',
+      upload_content_type: 'application/octet-stream',
+      upload_file_size: 1.megabyte,
+      file_type: 'Expression Matrix',
+      this_is_not_an_attribute: 'foo',
+      expression_file_info_attributes: {
+        is_raw_counts: true,
+        biosample_input_type: 'Whole cell',
+        modality: 'Transcriptomic: unbiased',
+        raw_counts_associations: [''],
+        units: 'raw counts',
+        library_preparation_protocol: "10x 5' v3",
+        also_not_an_attribute: 'bar'
+      }
+    }
+    clean_params = Api::V1::StudyFilesController.strip_undefined_params(params).with_indifferent_access
+    assert_equal params[:name], clean_params[:name]
+    assert_equal params[:file_type], clean_params[:file_type]
+    assert_equal params[:expression_file_info_attributes][:units], clean_params[:expression_file_info_attributes][:units]
+    assert_nil clean_params[:this_is_not_an_attribute]
+    assert_nil clean_params[:expression_file_info_attributes][:also_not_an_attribute]
+  end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This addresses a rare corner case where a user attempted to upload a classic plain text expression matrix file and encountered the following error:
```
(Mongoid::Errors::UnknownAttribute)
message:
  Attempted to set a value for 'raw_location' which is not allowed on the model ExpressionFileInfo.
```
This should not be possible, as `raw_location` is only present in the AnnData UX.  The associated [error report](https://broad-institute.sentry.io/issues/6635746066/events/ea1dadd8260343b9ad98f661715f3545) also shows that no upload is being provided by the user, so it is unclear how they got into this state.

Now, when a StudyFile is being processed by the API, a final sanitization step will run that strips out all key/value pairs that are not defined fields for either the StudyFile or any of the nested associations (ExpressionFileInfo, AnnDataFileInfo, etc).  This will remove the need to manually prune any extra fields that are added to forms that don't map to model attributes, such as control-oriented fields like `parse_on_upload`.

#### MANUAL TESTING
Since it is unclear how the user got into this state, and all attempts to recreate it have failed, there is not currently a way to manually test as the Swagger API documentation does not allow adding additional fields.  You could try directly via `cURL`, but this seems overly complicated as it requires reconstructing the exact form structure for the POST.