### PR TITLE
Configuring study defaults with relevant biological annotations (SCP-6014)

### DIFF
--- a/app/lib/differential_expression_service.rb
+++ b/app/lib/differential_expression_service.rb
@@ -5,8 +5,10 @@ class DifferentialExpressionService
   CELL_TYPE_MATCHER = /cell.*type/i
   # possible clustering algorithm results
   CLUSTERING_MATCHER = /(clust|seurat|leiden|louvain|snn_res)/i
+  # any categorical-type labels
+  CATEGORY_MATCHER = /(categor|labels)/i
   # union of all allowed annotations
-  ALLOWED_ANNOTS = Regexp.union(CELL_TYPE_MATCHER, CLUSTERING_MATCHER)
+  ALLOWED_ANNOTS = Regexp.union(CELL_TYPE_MATCHER, CLUSTERING_MATCHER, CATEGORY_MATCHER)
   # specific annotations to exclude from automation
   EXCLUDED_ANNOTS = /(enrichment__cell_type)/i
   # default quota for user-requested DE jobs
@@ -250,7 +252,7 @@ class DifferentialExpressionService
     annotations += metadata.map { |meta| { annotation_name: meta.name, annotation_scope: 'study' } }
     # special gotcha to remove 'cell_type' metadata annotation if 'cell_type__ontology_label' is present
     if annotations.detect { |annot| annot[:annotation_name] == 'cell_type__ontology_label' }.present?
-      annotations.reject! { |annot| annot[:annotation_name] == 'cell_type'}
+      annotations.reject! { |annot| annot[:annotation_name] == 'cell_type' }
     end
     cell_annotations = []
     groups_to_process = study.cluster_groups.select { |cg| cg.cell_annotations.any? }

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -557,6 +557,8 @@ class IngestJob
 
   # set the default annotation for the study, if not already set
   def set_default_annotation
+    ClusterCacheService.configure_default_annotation(study)
+    study.reload
     return if study.default_options[:annotation].present?
 
     cell_metadatum = study.cell_metadata.keep_if(&:can_visualize?).first || study.cell_metadata.first

--- a/db/migrate/20250528160832_set_relevant_default_annotations.rb
+++ b/db/migrate/20250528160832_set_relevant_default_annotations.rb
@@ -1,0 +1,17 @@
+class SetRelevantDefaultAnnotations < Mongoid::Migration
+  def self.up
+    accessions = Study.where(queued_for_deletion: false).pluck(:accession)
+    accessions.each do |accession|
+      study = Study.find_by(accession:)
+      begin
+        ClusterCacheService.configure_default_annotation(study)
+      rescue => e
+        ErrorTracker.report_exception(e, nil,{ study: })
+      end
+    end
+  end
+
+  def self.down
+    # default annotations can be reset manually if needed
+  end
+end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update changes the logic for setting default annotations from the first available to more relevant biologically-based annotations, such as cell types or clustering-based labels.  This will only apply to studies where the author has not configured their default annotation - in those cases, the user preference will be kept.  All other studies that simply default to the first available annotation (often biosample_id) will now implement this new logic.  A migration has been added to apply this to all existing studies, and new studies moving forward will have this applied automatically.  A new custom Mixpanel event called `study-default-annotation` has been added to track these events.  Additionally, annotations that are category- or label-like are now considered eligible for differential expression, and by extension default annotations.

#### MANUAL TESTING
1. Run the migration for setting defaults with `rails db:migrate`
2. Note in the log messages like the following:
```
Changing default annotation in SCP47 from biosample_id--group--study to cell_type__ontology_label--group--study
2025-05-28 13:42:31 -0400: Logging analytics to Mixpanel for event name: study-default-annotation
```
3. Studies that had no previous configured value for `default_options[:annotation]` will show up as `unassigned`
4. For any of the newly configured studies, boot as normal and load the study to confirm the annotation has in fact been changed