### PR TITLE
Adding study-creation and study-state Mixpanel events

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -724,7 +724,7 @@ module Api
 
           safe_params[param] = val if StudyFile.fields[param.to_s].present?
         end
-        safe_params
+        safe_params.with_indifferent_access
       end
 
       private

--- a/app/lib/metrics_service.rb
+++ b/app/lib/metrics_service.rb
@@ -123,7 +123,6 @@ class MetricsService
       headers: headers,
       payload: post_body
     }
-
     self.post_to_bard(params, user)
   end
 

--- a/test/models/study_test.rb
+++ b/test/models/study_test.rb
@@ -211,4 +211,22 @@ class StudyTest < ActiveSupport::TestCase
     study.public = false
     assert study.valid?
   end
+
+  test 'should determine if a study was just published/initialized' do
+    study = FactoryBot.create(:detached_study,
+                              user: @user,
+                              name_prefix: 'State Test',
+                              public: false,
+                              test_array: @@studies_to_clean)
+    assert_not study.was_just_published?
+    assert_not study.was_just_initialized?
+    study.update(public: true)
+    assert study.was_just_published?
+    assert_equal study.updated_at.to_s, study.last_public_date.to_s
+    assert study.last_change_for(:public).present?
+    study.update(initialized: true)
+    assert study.was_just_initialized?
+    assert_equal study.updated_at.to_s, study.last_initialized_date.to_s
+    assert study.last_change_for(:initialized).present?
+  end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds two new Mixpanel events: `study-creation` and `study-state`.  These events track when new studies are created, and whenever a study is published or initialized, giving us robust longitudinal data moving forward regarding study state management.  Each event will contain the following properties:

- studyAccession
- created_at: study creation date
- domain: email domain of the user
- numCells
- public: current state of public flag
- last_public_date: date of latest change to public state
- initialized: current state of initialized flag
- last_initialized_date: date of latest change to initialized state

#### MANUAL TESTING
1. Boot as normal and sign in
2. In a separate tab, open the [Dev Mixpanel Events](https://mixpanel.com/project/2085496/view/19055/app/events) feed
3. Back in SCP, create a new study, marking it as private
4. In Mixpanel, find the `study-creation` event and confirm that `public` and `initialized` are both `false` and neither has a date
5. In the Rails console, load your new study
6. Sequentially update both `public` and `initialized` to `true` and confirm you see a `study-state` event with the correct values
7. (Optional): reset `public` and `initialized` to `false` and confirm there are no Mixpanel events