### PR TITLE
Prevent errors when assembling ingestSummary properties (SCP-6015)

### DIFF
--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -1062,9 +1062,29 @@ class IngestJob
         pipeline_args.detect { |c| c == study_file.id.to_s } &&
         (pipeline_args & CORE_ACTIONS).any?
     end
+    if previous_jobs.empty?
+      run = get_ingest_run
+      perftime = (TimeDifference.between(
+        event_timestamp(run.create_time), event_timestamp(run.update_time)
+      ).in_seconds * 1000).to_i
+      status = run.status.state == "FAILED" ? 'failed' : 'success'
+      return {
+        perfTime: perftime,
+        fileName: study_file.name,
+        fileType: study_file.file_type,
+        fileSize: study_file.upload_file_size,
+        studyAccession: study.accession,
+        trigger: study_file.upload_trigger,
+        jobStatus: status,
+        numFilesExtracted: 0,
+        machineType: params_object.machine_type,
+        action: 'unknown',
+        exitCode: exit_code
+      }
+    end
     # get total runtime from initial extract to final parse
-    initial_extract = previous_jobs.last
-    final_parse = previous_jobs.first
+    initial_extract = previous_jobs.min_by(&:create_time)
+    final_parse = previous_jobs.max_by(&:create_time)
     start_time = event_timestamp(initial_extract.create_time)
     end_time = event_timestamp(final_parse.update_time) # update_time is a proxy for last event timestamp
     job_perftime = (TimeDifference.between(start_time, end_time).in_seconds * 1000).to_i
@@ -1079,7 +1099,7 @@ class IngestJob
     if job_status == 'failed'
       first_failure = previous_jobs.reverse.detect { |job| client.job_error(job.name).present? }
       args = client.get_job_command_line(job: first_failure)
-      error_action = args.detect {|c| BatchApiClient::FILE_TYPES_BY_ACTION.keys.include?(c.to_sym) }
+      error_action = args.detect { |c| BatchApiClient::FILE_TYPES_BY_ACTION.keys.include?(c.to_sym) }
       code = client.exit_code_from_task(first_failure.name)
     end
     # count total number of files extracted


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This handles an extreme corner case where an AnnData file failed an ingest process, and when attempting to collect data for an `ingestSummary` event no upstream ingest jobs are found.  This could be due to latency in status propagating through the Batch API history, though this is uncertain.  This issue caused an error which then prevented the user from receiving a error email, and the file subsequently never properly cleaned up, leading to a state where an admin had to intervene.  Now, if this situation arises, the summary will simply use the current process for sourcing all properties and return.  Other method invocations have been updated to prevent `NoMethodError` issues.

#### MANUAL TESTING
Since it is almost impossible to replicate the upstream event, the best way to test this is the monkey-patch the BatchApiClient:
1. Open a Rails console session and the most recent AnnData file:
```
study_file = StudyFile.where(file_type: 'AnnData', 'ann_data_file_info.reference_file'=> false).last
```
2. Find the corresponding extract job for this file in the history:
```
client = BatchApiClient.new
pipeline = client.find_matching_jobs(params: ['--study-file-id', study_file.id.to_s, 'ingest_anndata']).min_by(&:create_time)
```
3. Assemble necessary objects:
```
study = study_file.study
user = study.user
action = :ingest_anndata
params_object = AnnDataIngestParameters.new(anndata_file: study_file.gs_url, file_size: study_file.upload_file_size, raw_location: study_file.ann_data_file_info.raw_location)
```
4. In your IDE edit `app/models/batch_api_client.rb#list_jobs`:
```
def list_jobs(page_token: nil)
  return Google::Apis::BatchV1::ListJobsResponse.new(jobs: [])
  service.list_project_location_jobs(project_location, page_token:)
end
```
5. Reload your console with `reload!`
6. Create an instance of `IngestJob`:
```
job = IngestJob.new(pipeline_name: pipeline.name, study_file:, study:, user:, action:, params_object:)
```
7. Call `anndata_summary_props` and confirm no error is thrown (your values will be different):
```
job.anndata_summary_props
=> 
{perfTime: 124296,
 fileName: "compliant_liver.h5ad",
 fileType: "AnnData",
 fileSize: 5635514,
 studyAccession: "SCP168",
 trigger: "upload",
 jobStatus: "success",
 numFilesExtracted: 0,
 machineType: "n2d-highmem-4",
 action: "unknown",
 exitCode: nil}
```