### PR TITLE
Relax constraints for setting AnnData cell count (SCP-5439)

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1314,18 +1314,18 @@ class Study
 
   # helper method to get number of unique single cells
   def set_cell_count
-    cell_count = self.all_cells_array.size
-    Rails.logger.info "Setting cell count in #{self.name} to #{cell_count}"
-    self.update(cell_count: cell_count)
-    Rails.logger.info "Cell count set for #{self.name}"
+    cells = all_cells_array.size
+    Rails.logger.info "Setting cell count in #{accession} to #{cells}"
+    self.update(cell_count: cells)
+    Rails.logger.info "Cell count set for #{accession}"
   end
 
   # helper method to set the number of unique genes in this study
   def set_gene_count
-    gene_count = self.unique_genes.size
-    Rails.logger.info "Setting gene count in #{self.name} to #{gene_count}"
-    self.update(gene_count: gene_count)
-    Rails.logger.info "Gene count set for #{self.name}"
+    genes = unique_genes.size
+    Rails.logger.info "Setting gene count in #{accession} to #{genes}"
+    self.update(gene_count: genes)
+    Rails.logger.info "Gene count set for #{accession}"
   end
 
   # get all unique gene names for a study; leverage index on Gene model to improve performance
@@ -1399,10 +1399,11 @@ class Study
   # return an array of all single cell names in study, will check for main list of cells or concatenate all
   # cell lists from individual expression matrices
   def all_cells_array
-    if self.metadata_file&.parsed? # nil-safed via &
+    metadata_file&.reload # refresh association for checking parsed state
+    if metadata_file&.parsed? || (metadata_file&.is_viz_anndata? && has_cell_metadata?)
       query = {
-        name: 'All Cells', array_type: 'cells', linear_data_type: 'Study', linear_data_id: self.id,
-        study_id: self.id, study_file_id: self.metadata_file.id, cluster_group_id: nil, subsample_annotation: nil,
+        name: 'All Cells', array_type: 'cells', linear_data_type: 'Study', linear_data_id: id,
+        study_id: id, study_file_id: metadata_file.id, cluster_group_id: nil, subsample_annotation: nil,
         subsample_threshold: nil
       }
       DataArray.concatenate_arrays(query)


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This (attempts) to address a long-running issue where visualization AnnData files do not consistently set the cell count in the study once ingest has completed.  The theory is that the multiple ingest processes associated with the AnnData file are continually setting the `parse_status` flag to `parsing`, which is causing `Study#all_cells_array` to return an empty array due to the parsing check on the metadata file (which is the AnnData file in this case).  Now, the presence of any cell metadata in the study will ensure that the query returns the correct "All Cells" array for AnnData files.

#### MANUAL TESTING
Since the underlying problem is indeterminant, we cannot assert that the bug is fixed - we can only show that the cell count is set when ingesting any valid AnnData file.