### PR TITLE
Ensure best available annotation is valid for default cluster (SCP-6021)

### DIFF
--- a/app/lib/cluster_cache_service.rb
+++ b/app/lib/cluster_cache_service.rb
@@ -112,15 +112,12 @@ class ClusterCacheService
     clustering = annotations.detect { |a| a[:annotation_name] =~ DifferentialExpressionService::CLUSTERING_MATCHER }
     category = annotations.detect { |a| a[:annotation_name] =~ DifferentialExpressionService::CATEGORY_MATCHER }
     best_annotations = [ontology, author_cell_type, cell_type, clustering, category].compact
-    best_avail = best_annotations.first
+    default_cluster = study.default_cluster
 
     # ensure cluster-based annotations are valid for the default cluster
-    default_cluster = study.default_cluster
-    if best_avail[:annotation_scope] == 'cluster' && !default_cluster.id != best_avail[:cluster_group_id]
-      best_avail = best_annotations.detect do |annot|
-        annot[:annotation_scope] == 'study' ||
-          (annot[:annotation_scope] == 'cluster' && default_cluster.id == annot[:cluster_group_id])
-      end
+    best_avail = best_annotations.detect do |annot|
+      annot[:annotation_scope] == 'study' ||
+        (annot[:annotation_scope] == 'cluster' && default_cluster&.id == annot[:cluster_group_id])
     end
 
     best_avail ? [best_avail[:annotation_name], 'group', best_avail[:annotation_scope]].join('--') : nil

--- a/app/lib/cluster_cache_service.rb
+++ b/app/lib/cluster_cache_service.rb
@@ -106,16 +106,19 @@ class ClusterCacheService
     annotations = DifferentialExpressionService.find_eligible_annotations(study)
     return nil if annotations.empty?
 
-    ontology = annotations.detect { |a| a[:annotation_name] == 'cell_type__ontology_label' }
-    author_cell_type = annotations.detect { |a| a[:annotation_name] =~ /author.*cell.*type/i }
-    cell_type = annotations.detect { |a| a[:annotation_name] =~ DifferentialExpressionService::CELL_TYPE_MATCHER }
-    clustering = annotations.detect { |a| a[:annotation_name] =~ DifferentialExpressionService::CLUSTERING_MATCHER }
-    category = annotations.detect { |a| a[:annotation_name] =~ DifferentialExpressionService::CATEGORY_MATCHER }
-    best_annotations = [ontology, author_cell_type, cell_type, clustering, category].compact
-    default_cluster = study.default_cluster
+    # ordered by priority, so the first match is the best one
+    matchers = [
+      'cell_type__ontology_label', /author.*cell.*type/i, DifferentialExpressionService::CELL_TYPE_MATCHER,
+      DifferentialExpressionService::CLUSTERING_MATCHER, DifferentialExpressionService::CATEGORY_MATCHER
+    ]
+    best_annotations = matchers.map do |matcher|
+      comparison = matcher.is_a?(Regexp) ? :=~ : :==
+      annotations.detect { |annot| annot[:annotation_name].send(comparison, matcher) }
+    end
 
     # ensure cluster-based annotations are valid for the default cluster
-    best_avail = best_annotations.detect do |annot|
+    default_cluster = study.default_cluster
+    best_avail = best_annotations.compact.detect do |annot|
       annot[:annotation_scope] == 'study' ||
         (annot[:annotation_scope] == 'cluster' && default_cluster&.id == annot[:cluster_group_id])
     end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a bug introduced in #2266 where new default annotations that are cluster-specific may not have been valid for the default cluster.  Now, an extra check has been added to ensure the annotation is present on the cluster, if specified.

#### MANUAL TESTING
1. Open a Rails console session and load the `Chicken raw counts` synthetic study (or populate it if you don't have it)
```
study = Study.find_by(name: 'Chicken raw counts')
```
2. Set the default cluster to `X cluster`:
```
study.default_options[:cluster] = 'X cluster'
study.save
```
3. Ensure that there is no "best available" annotation for this cluster:
```
ClusterCacheService.best_available_annotation(study)
=> nil
```
4. Set the default cluster to `cluster_odd_labels` and confirm that there is an available annotation:
```
study.default_options[:cluster] = 'cluster_odd_labels'
study.save
ClusterCacheService.best_available_annotation(study)
=> "odd_labels--group--cluster"
```