### PR TITLE
Better sorting/uniquifying of facet filters (SCP-6023)

### DIFF
--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -402,7 +402,7 @@ class SearchFacet
     end
     return filter_map if is_numeric?
 
-    filter_map.uniq { |filter| [filter[:id].downcase, filter[:name].downcase] }.reject do |filter|
+    filter_map.uniq { |filter| [filter[:id]&.downcase, filter[:name]&.downcase] }.reject do |filter|
       filter[:id].blank? || filter[:name].blank?
     end
   end
@@ -456,7 +456,7 @@ class SearchFacet
       merged_values = values.dup
       if external_facet[:filters]
         Rails.logger.info "Merging #{external_facet[:filters]} into '#{name}' facet filters"
-        external_facet[:filters].each do |filter|
+        external_facet[:filters].uniq(&:downcase).each do |filter|
           merged_values << { id: filter, name: filter } unless filters_include?(filter)
         end
       end

--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -400,10 +400,14 @@ class SearchFacet
         filter_map += filters_from_metadatum(metadatum)
       end
     end
-    filter_map.uniq
+    return filter_map if is_numeric?
+
+    filter_map.uniq { |filter| [filter[:id].downcase, filter[:name].downcase] }.reject do |filter|
+      filter[:id].blank? || filter[:name].blank?
+    end
   end
 
-  # find all matching CellMetadum objects for a given facet
+  # find all matching CellMetadatum objects for a given facet
   # can scope query to matching values array if needed or by a sub-query if provided
   def associated_metadata(values:, query: {})
     annotation_type = is_numeric? ? 'numeric' : 'group'
@@ -458,9 +462,9 @@ class SearchFacet
       end
       return false if values.empty? # found no results, meaning an error occurred
 
-      values.sort_by! { |f| f[:name] }
-      merged_values.sort_by! { |f| f[:name] }
-      public_values = get_unique_filter_values(public_only: true)
+      values.sort_by! { |f| f[:name].downcase }
+      merged_values.sort_by! { |f| f[:name].downcase }
+      public_values = get_unique_filter_values(public_only: true).sort_by { |f| f[:name].downcase }
       update(filters: values, public_filters: public_values, filters_with_external: merged_values)
     end
   end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a new regression where it is more likely to see duplicate or improperly sorted facet filters since the switch to MongoDB as the data source.  Now, there is more aggressive pruning of duplicates, and facets are sorted case-insensitively.

#### MANUAL TESTING
1. Open a Rails console session and update all search facet filters (there's no migration for this as it will happen automatically whenever a metadata file is updated)
```
SearchFacet.update_all_facet_filters
```
2. Boot as normal and sign in
3. Open any search facet and confirm there are no duplicate filter values, and all filters are sorted alphabetically regardless of case