### PR TITLE
Adding DotPlotGene, DotPlotService for preprocessing dot plot data

### DIFF
--- a/app/lib/dot_plot_service.rb
+++ b/app/lib/dot_plot_service.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# service that handles preprocessing expression/annotation data to speed up dot plot rendering
+class DotPlotService
+
+  # main handler for launching ingest job to process expression data
+  #
+  # * *params*
+  #   - +study+ (Study) => the study that owns the data
+  #   - +cluster_group+ (ClusterGroup) => the cluster to source cell names from
+  #   - +annotation_file+ (StudyFile) => the StudyFile containing annotation data
+  #   - +expression_file+ (StudyFile) => the StudyFile to source data from
+  #
+  # * *yields*
+  #   - (IngestJob) => the job that will be run to process the data
+  def self.run_preprocess_expression_job(study, cluster_group, annotation_file, expression_file)
+    study_eligible?(study) # method stub, waiting for scp-ingest-pipeline implementation
+  end
+
+  # determine study eligibility - can only have one processed matrix and be able to visualize clusters
+  #
+  # * *params*
+  #   - +study+ (Study) the study that owns the data
+  # * *returns*
+  #   - (Boolean) true if the study is eligible for dot plot visualization
+  def self.study_eligible?(study)
+    processed_matrices = study.expression_matrices.select do |matrix|
+      matrix.is_viz_anndata? || !matrix.is_raw_counts_file?
+    end
+    study.can_visualize_clusters? && study.has_expression_data? && processed_matrices.size == 1
+  end
+end

--- a/app/lib/dot_plot_service.rb
+++ b/app/lib/dot_plot_service.rb
@@ -2,7 +2,6 @@
 
 # service that handles preprocessing expression/annotation data to speed up dot plot rendering
 class DotPlotService
-
   # main handler for launching ingest job to process expression data
   #
   # * *params*
@@ -24,9 +23,85 @@ class DotPlotService
   # * *returns*
   #   - (Boolean) true if the study is eligible for dot plot visualization
   def self.study_eligible?(study)
-    processed_matrices = study.expression_matrices.select do |matrix|
+    processed_matrices = study_processed_matrices(study)
+    study.can_visualize_clusters? && study.has_expression_data? && processed_matrices.size == 1
+  end
+
+  # check if the given study/cluster has already been preprocessed
+  # * *params*
+  #   - +study+ (Study) the study that owns the data
+  #   - +cluster_group+ (ClusterGroup) the cluster to check for processed data
+  #
+  # * *returns*
+  #   - (Boolean) true if the study/cluster has already been processed
+  def self.cluster_processed?(study, cluster_group)
+    DotPlotGene.where(study:, cluster_group:).exists?
+  end
+
+  # get processed expression matrices for a study
+  #
+  # * *params*
+  #   - +study+ (Study) the study to get matrices for
+  #
+  # * *returns*
+  #   - (Array<StudyFile>) an array of processed expression matrices for the study
+  def self.study_processed_matrices(study)
+    study.expression_matrices.select do |matrix|
       matrix.is_viz_anndata? || !matrix.is_raw_counts_file?
     end
-    study.can_visualize_clusters? && study.has_expression_data? && processed_matrices.size == 1
+  end
+
+  # seeding method for testing purposes, will be removed once pipeline is in place
+  # data is random and not representative of actual expression data
+  def self.seed_dot_plot_genes(study)
+    return false unless study_eligible?(study)
+
+    DotPlotGene.where(study_id: study.id).delete_all
+    puts "Seeding dot plot genes for #{study.accession}"
+    expression_matrix = study.expression_matrices.first
+    print 'assembling genes and annotations...'
+    genes = Gene.where(study:, study_file: expression_matrix).pluck(:name)
+    annotations = AnnotationVizService.available_metadata_annotations(
+      study, annotation_type: 'group'
+    ).reject { |a| a[:scope] == 'invalid' }
+    puts " done. Found #{genes.size} genes and #{annotations.size} study-wide annotations."
+    study.cluster_groups.each do |cluster_group|
+      next if cluster_processed?(study, cluster_group)
+
+      cluster_annotations = ClusterVizService.available_annotations_by_cluster(
+        cluster_group, 'group'
+      ).reject { |a| a[:scope] == 'invalid' }
+      all_annotations = annotations + cluster_annotations
+      puts "Processing #{cluster_group.name} with #{all_annotations.size} annotations."
+      documents = []
+      genes.each do |gene|
+        exp_scores = all_annotations.map do |annotation|
+          {
+            "#{annotation[:name]}--#{annotation[:type]}--#{annotation[:scope]}" => annotation[:values].map do |value|
+              { value => [rand.round(3), rand.round(3)] }
+            end.reduce({}, :merge)
+          }
+        end.reduce({}, :merge)
+        documents << DotPlotGene.new(
+          study:, study_file: expression_matrix, cluster_group:, gene_symbol: gene, searchable_gene: gene.downcase,
+          exp_scores:
+        ).attributes
+        if documents.size == 1000
+          DotPlotGene.collection.insert_many(documents)
+          count = DotPlotGene.where(study_id: study.id, cluster_group_id: cluster_group.id).size
+          puts "Inserted #{count}/#{genes.size} DotPlotGenes for #{cluster_group.name}."
+          documents.clear
+        end
+      end
+      DotPlotGene.collection.insert_many(documents)
+      count = DotPlotGene.where(study_id: study.id, cluster_group_id: cluster_group.id).size
+      puts "Inserted #{count}/#{genes.size} DotPlotGenes for #{cluster_group.name}."
+      puts "Finished processing #{cluster_group.name}"
+    end
+    puts "Seeding complete for #{study.accession}, #{DotPlotGene.where(study_id: study.id).size} DotPlotGenes created."
+    true
+  rescue StandardError => e
+    puts "Error seeding DotPlotGenes in #{study.accession}: #{e.message}"
+    false
   end
 end

--- a/app/lib/expression_viz_service.rb
+++ b/app/lib/expression_viz_service.rb
@@ -472,4 +472,16 @@ class ExpressionVizService
       ]
     }
   end
+
+  # load precomputed dot plot data for a given study and cluster and gene set
+  def self.load_precomputed_dot_plot_data(study, cluster_group, annotation: {}, genes: [])
+    data = { annotation_name: annotation[:name], values: annotation[:values], genes: {} }
+    dot_plot_genes = DotPlotGene.where(study:, cluster_group:, :searchable_gene.in => genes.map(&:downcase))
+    dot_plot_genes.map do |gene|
+      data[:genes][gene.gene_symbol] = gene.scores_by_annotation(
+        annotation[:name], annotation[:scope], annotation[:values]
+      )
+    end
+    data
+  end
 end

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -35,8 +35,10 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
       # now remove all child objects first to free them up to be re-used.
       case file_type
       when 'Cluster'
+        cluster_group = ClusterGroup.find_by(study:, study_file_id: object.id)
         delete_differential_expression_results(study:, study_file: object)
         delete_parsed_data(object.id, study.id, ClusterGroup, DataArray)
+        delete_dot_plot_data(study.id, cluster_group_id: cluster_group&.id)
         delete_user_annotations(study:, study_file: object)
         reset_default_cluster(study:)
         reset_default_annotation(study:)
@@ -45,6 +47,7 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
         remove_file_from_bundle
       when 'Expression Matrix'
         delete_parsed_data(object.id, study.id, Gene, DataArray)
+        delete_dot_plot_data(study.id)
         delete_differential_expression_results(study:, study_file: object)
         study.set_gene_count
       when 'MM Coordinate Matrix'
@@ -73,6 +76,7 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
         end
         delete_differential_expression_results(study:, study_file: object)
         delete_parsed_data(object.id, study.id, CellMetadatum, DataArray)
+        delete_dot_plot_data(study.id)
         delete_cell_index_arrays(study)
         study.update(cell_count: 0)
         reset_default_annotation(study:)
@@ -81,6 +85,7 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
           # delete user annotations first as we lose associations later
           delete_user_annotations(study:, study_file: object)
           delete_parsed_data(object.id, study.id, ClusterGroup, CellMetadatum, Gene, DataArray)
+          delete_dot_plot_data(study.id)
           delete_fragment_files(study:, study_file: object)
           delete_differential_expression_results(study:, study_file: object)
           # reset default options/counts
@@ -337,5 +342,13 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
       cluster_group.delete
       data_arrays.delete_all
     end
+  end
+
+  # delete preprocessed dot plot data for a study with a specific query
+  # if a user deletes expression/metadata file, all data is cleaned up
+  # if a user delete a cluster file, only matching entries are removed
+  def delete_dot_plot_data(study_id, cluster_group_id: nil)
+    dot_query = cluster_group_id.blank? ? { study_id: } : { study_id:, cluster_group_id: }
+    DotPlotGene.where(dot_query).delete_all
   end
 end

--- a/app/models/dot_plot_gene.rb
+++ b/app/models/dot_plot_gene.rb
@@ -3,7 +3,7 @@ class DotPlotGene
   include Mongoid::Timestamps
 
   belongs_to :study
-  belongs_to :study_file # expression matrix, not clustering file
+  belongs_to :study_file # expression matrix, not clustering file - needed for data cleanup
   belongs_to :cluster_group
 
   field :gene_symbol, type: String
@@ -14,6 +14,9 @@ class DotPlotGene
   validates :gene_symbol, uniqueness: { scope: %i[study study_file cluster_group] }, presence: true
 
   before_validation :set_searchable_gene, on: :create
+  index({ study_id: 1, study_file_id: 1, cluster_group_id: 1 }, { unique: false, background: true })
+  index({ study_id: 1, cluster_group_id: 1, searchable_gene: 1 },
+        { unique: true, background: true })
 
   def scores_by_annotation(annotation_name, annotation_scope, values)
     identifier = "#{annotation_name}--group--#{annotation_scope}"

--- a/app/models/dot_plot_gene.rb
+++ b/app/models/dot_plot_gene.rb
@@ -1,0 +1,29 @@
+class DotPlotGene
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  belongs_to :study
+  belongs_to :study_file # expression matrix, not clustering file
+  belongs_to :cluster_group
+
+  field :gene_symbol, type: String
+  field :searchable_gene, type: String
+  field :exp_scores, type: Hash, default: {}
+
+  validates :study, :study_file, :cluster_group, presence: true
+  validates :gene_symbol, uniqueness: { scope: %i[study study_file cluster_group] }, presence: true
+
+  before_validation :set_searchable_gene, on: :create
+
+  def scores_by_annotation(annotation_name, annotation_scope, values)
+    identifier = "#{annotation_name}--group--#{annotation_scope}"
+    scores = exp_scores[identifier] || {}
+    values.map { |val| scores[val] || [0.0, 0.0] }
+  end
+
+  private
+
+  def set_searchable_gene
+    self.searchable_gene = gene_symbol.downcase
+  end
+end

--- a/db/migrate/20250616192718_create_dot_plot_gene_collection.rb
+++ b/db/migrate/20250616192718_create_dot_plot_gene_collection.rb
@@ -1,0 +1,11 @@
+class CreateDotPlotGeneCollection < Mongoid::Migration
+  def self.up
+    # since these documents will be created by scp-ingest-pipeline, the collection needs to exist first to
+    # prevent errors when the job tries to create them
+    DotPlotGene.collection.create
+  end
+
+  def self.down
+    DotPlotGene.collection.drop
+  end
+end

--- a/test/models/dot_plot_gene_test.rb
+++ b/test/models/dot_plot_gene_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+class DotPlotGeneTest < ActiveSupport::TestCase
+  before(:all) do
+    @user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                               name_prefix: 'DotPlotGene Test Study',
+                               user: @user,
+                               test_array: @@studies_to_clean)
+    @cluster_file = FactoryBot.create(:cluster_file, name: 'cluster_example.txt', study: @study)
+    @expression_file = FactoryBot.create(:expression_file, name: 'expression_example.txt', study: @study)
+    @metadata_file = FactoryBot.create(:metadata_file,
+                                       name: 'metadata.txt',
+                                       study: @study,
+                                       cell_input: %w[A B C],
+                                       annotation_input: [
+                                         { name: 'species', type: 'group', values: %w[dog cat dog] },
+                                         { name: 'disease', type: 'group', values: %w[none none measles] }
+                                       ])
+    @cluster_group = @study.cluster_groups.first
+    DotPlotGene.create(
+      study: @study,
+      study_file: @expression_file,
+      cluster_group: @cluster_group,
+      gene_symbol: 'Pten',
+      exp_scores: {
+        'species--group--study' => { dog: [0.5, 0.666], cat: [0.25, 0.333] },
+        'disease--group--study' => { none: [0.125, 0.666], measles: [0.75, 0.333] }
+      }
+    )
+    DotPlotGene.create(
+      study: @study,
+      study_file: @expression_file,
+      cluster_group: @cluster_group,
+      gene_symbol: 'Agpat2',
+      exp_scores: {
+        'species--group--study' => { dog: [4.15, 0.666], cat: [2.25, 0.333] },
+        'disease--group--study' => { none: [3.125, 0.666], measles: [1.5, 0.333] }
+      }
+    )
+  end
+
+  test 'should load expression scores by annotation' do
+    %w[Pten Agpat2].each do |gene_symbol|
+      %w[species disease].each do |annotation_name|
+        gene = DotPlotGene.find_by(gene_symbol:, study: @study, cluster_group: @cluster_group)
+        assert gene.present?
+        assert_equal gene_symbol.downcase, gene.searchable_gene
+        metadata = @study.cell_metadata.by_name_and_type(annotation_name, 'group')
+        annotation = { name: annotation_name, scope: 'study', values: metadata.values }
+        scores = gene.scores_by_annotation(annotation[:name], annotation[:scope], annotation[:values])
+        annotation[:values].each_with_index do |value, index|
+          identifier = "#{annotation[:name]}--group--study"
+          assert_equal scores[index], gene.exp_scores.dig(identifier, value)
+        end
+        assert_equal [0.0, 0.0],
+                     gene.scores_by_annotation(annotation[:name], annotation[:scope], ['nonexistent']).first
+      end
+    end
+  end
+end

--- a/test/services/dot_plot_service_test.rb
+++ b/test/services/dot_plot_service_test.rb
@@ -50,6 +50,15 @@ class DotPlotServiceTest < ActiveSupport::TestCase
     assert DotPlotService.cluster_processed?(@study, @cluster_group)
   end
 
+  test 'should get processed matrices for study' do
+    assert_includes DotPlotService.study_processed_matrices(@study), @expression_file
+    empty_study = FactoryBot.create(:detached_study,
+                                    name_prefix: 'Empty DotPlot',
+                                    user: @user,
+                                    test_array: @@studies_to_clean)
+    assert_empty DotPlotService.study_processed_matrices(empty_study)
+  end
+
   test 'should run preprocess expression job' do
     assert DotPlotService.run_preprocess_expression_job(@study, @cluster_group, @metadata_file, @expression_file)
   end

--- a/test/services/dot_plot_service_test.rb
+++ b/test/services/dot_plot_service_test.rb
@@ -38,6 +38,18 @@ class DotPlotServiceTest < ActiveSupport::TestCase
     assert_not DotPlotService.study_eligible?(empty_study)
   end
 
+  test 'should determine if cluster has been processed' do
+    assert_not DotPlotService.cluster_processed?(@study, @cluster_group)
+    DotPlotGene.create(
+      study: @study,
+      study_file: @expression_file,
+      cluster_group: @cluster_group,
+      gene_symbol: 'Pten',
+      exp_scores: {}
+    )
+    assert DotPlotService.cluster_processed?(@study, @cluster_group)
+  end
+
   test 'should run preprocess expression job' do
     assert DotPlotService.run_preprocess_expression_job(@study, @cluster_group, @metadata_file, @expression_file)
   end

--- a/test/services/dot_plot_service_test.rb
+++ b/test/services/dot_plot_service_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class DotPlotServiceTest < ActiveSupport::TestCase
+  before(:all) do
+    @user = FactoryBot.create(:user, test_array: @@users_to_clean)
+    @study = FactoryBot.create(:detached_study,
+                               name_prefix: 'DotPlotService Test Study',
+                               user: @user,
+                               test_array: @@studies_to_clean)
+    cells = %w[A B C]
+    genes = %w[pten agpat2]
+    expression_input = genes.index_with(cells.map { |c| [c, rand.floor(3)] })
+    @cluster_file = FactoryBot.create(:cluster_file,
+                                      name: 'cluster_example.txt',
+                                      study: @study,
+                                      cell_input: { x: cells, y: cells })
+    @expression_file = FactoryBot.create(:expression_file,
+                                         name: 'expression_example.txt',
+                                         study: @study,
+                                         expression_input:)
+    @metadata_file = FactoryBot.create(:metadata_file,
+                                       name: 'metadata.txt',
+                                       study: @study,
+                                       cell_input: cells,
+                                       annotation_input: [
+                                         { name: 'species', type: 'group', values: %w[dog cat dog] },
+                                         { name: 'disease', type: 'group', values: %w[none none measles] }
+                                       ])
+    @cluster_group = @study.cluster_groups.first
+  end
+
+  test 'should determine study eligibility for preprocessing' do
+    assert DotPlotService.study_eligible?(@study)
+    empty_study = FactoryBot.create(:detached_study,
+                                    name_prefix: 'Empty DotPlot',
+                                    user: @user,
+                                    test_array: @@studies_to_clean)
+    assert_not DotPlotService.study_eligible?(empty_study)
+  end
+
+  test 'should run preprocess expression job' do
+    assert DotPlotService.run_preprocess_expression_job(@study, @cluster_group, @metadata_file, @expression_file)
+  end
+end


### PR DESCRIPTION
#### BACKGROUND
One of the biggest scaling issues for SCP is rendering dot plots.  Each gene in the request has to be loaded sequentially, and then the expression data is transformed into a GCT-formatted matrix and transmitted back to the client.  The data is then processed client-side to compute the scaled mean expression and percent of cells expressing for each gene.  This introduces significant load on the portal, and as such we restrict dot plot visualizations to only 50 genes per request.  This entire user flow is as inefficient as it is slow - if we're only going to show the user two metrics per gene, why should we load and transmit the full resolution data?

#### CHANGES
The solution to this bottleneck is to precompute both metrics at the gene & cluster level and store those values in the database.  Since this will require a completely new ingest job to handle the processing, this update adds `DotPlotGene` (model/collection for storing data) and `DotPlotService` (service that will handle submitting ingest jobs) as well as rendering methods in the expression controller pipeline.  This will allow rendering of tens to hundreds of genes simultaneously at scale once the data has been processed.  The control flow for ingesting this data will be similar to that of differential expression data - once the required files have ingested (expression, metadata, and clustering) the jobs will launch to process and save the data.  When corresponding files are removed, the data are deleted from the database.  Each `DotPlotGene` maps to a single gene/cluster pair, and stores the scaled mean expression and % cells expressing of every available group-based annotation for that cluster.  While this collection will be very large - on the scale of the `Gene` and `DataArray` collections - the documents will be relatively small, and indexed such that both querying and cleanup will be very fast.

The rendering response will have the following structure: it will contain the name of the requested annotation, the unique labels for that annotation _in the order of rendering_, and then a hash of genes with the names as the keys, and then an array of arrays for the expression data.  The outer array index maps to the corresponding annotation value, and the inner array is the scaled mean expression and % cells expressing, in that order.

Example:
```
{
  "annotation_name": "author_cell_type",
  "values": ["NK","Monocyte","Macrophage","Epithelial","Fibroblast","Dendritic","B","Undefined","Plasma","T","Endothelial","Mast"],
  "genes": {
    "ACBD6": [[0.717,0.6],[0.996,0.983],[0.593,0.164],[0.747,0.204],[0.77,0.538],[0.093,0.553],[0.55,0.612],[0.886,0.627],[0.189,0.654],[0.963,0.425],[0.65,0.37],[0.88,0.937]],
    "AGGF1": ...
```

#### MANUAL TESTING
There is a temporary seeding method (`DotPlotService.seed_dot_plot_genes`) that can be used to generate synthetic data.   These data are not representative of the actual underlying expression - this method only seeds entries so that requests can be rendered.
1. Open a Rails console session and load any study that has a single processed expression matrix along with clustering & annotation data (an AnnData study is a good candidate)
2. Run `DotPlotService.seed_dot_plot_genes(study)` to generate fake data (this should take a couple minutes to run, and you will see messages like the following as it processes):
```
$ DotPlotService.seed_dot_plot_genes(study)

Seeding dot plot genes for SCP170
assembling genes and annotations... done. Found 22547 genes and 16 study-wide annotations.
Processing umap with 16 annotations.
Inserted 1000/22547 DotPlotGenes for umap.
Inserted 2000/22547 DotPlotGenes for umap.
Inserted 3000/22547 DotPlotGenes for umap.
...
Inserted 22000/22547 DotPlotGenes for umap.
Inserted 22547/22547 DotPlotGenes for umap.
Finished processing umap
Seeding complete for SCP170, 22547 DotPlotGenes created.
=> true
```
3. Boot as normal and open the Swagger endpoint for [rendering expression plots](https://localhost:3000/single_cell/api/v1#/Visualization/study_visualization_expression_show)
4. Back in the console, get a list of 100 genes for the above study to use in the request:
```
DotPlotGene.pluck(:gene_symbol).shuffle.take(100).join(',')
=> "IL18R1,DAGLB,CITF22-49E9.3,EMB,HRH4,SUPV3L1,SOX11,RP11-536K7.5,MYBPC3,LMLN,CHST14, ...
```
5. Back in the Swagger, fill out the request form with the study accession, genes, cluster name, requested annotation (must be group-based), and specify the data type of `dotplot`
6. Confirm you get a valid response that renders in ~1-2s, and that it has the same structure as the above example.