### PR TITLE
Account for missing labels on some convention-based metadata (SCP-6025)

### DIFF
--- a/app/models/search_facet.rb
+++ b/app/models/search_facet.rb
@@ -362,7 +362,10 @@ class SearchFacet
       minmax.compact.empty? ? [] : [{ MIN: minmax.first.to_f, MAX: minmax.last.to_f }]
     else
       ids = metadatum.values.map { |i| i.gsub(/:/, '_') } # deal with ontology id format issues
-      values = CellMetadatum.find_by(study_id: metadatum.study_id, name: big_query_name_column).values
+      values = CellMetadatum.find_by(study_id: metadatum.study_id, name: big_query_name_column)&.values
+      # some non-required convention entries like cell_type may not have ontology labels so return if either are blank
+      return [] if ids.blank? || values.blank?
+
       # deal with array-based annotations
       if is_array_based
         ids = ids.map { |i| i.split('|') }.flatten


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This addresses a corner case that exists only in production where some studies have the `cell_type` metadatum, but not `cell_type__ontology_label`.  The inverse is required - you cannot provide `cell_type__ontology_label` without `cell_type`, but it is possible to provide only ontology IDs and have your metadata file validate.  This causes issues when attempting to get all of the possible unique filter values for the corresponding `cell_type` search facet, which prevents it from updating after users upload new data.  Now, if the facet cannot find either the id or value entries for any associated metadata objects, it exits silently and continues to the next entry.

#### MANUAL TESTING
1. Enter a Rails console session and load any convention-compliant study that does not have an annotation specifically called `cell_type`:
```
study = Study.find_by(accession: <accession of your study>)
study_file = study.metadata_file
```
2. Create a bogus `cell_type` metadata object:
```
meta = CellMetadatum.create(name: 'cell_type', annotation_type: 'group', values: ["CL_0000066", "CL_0000075", "CL_0000094"], study:, study_file:)
=> #<CellMetadatum _id: 685adce494ec8f5f99164ffb, study_id: BSON::ObjectId('6812720494ec8f761aa568c5'), study_file_id: BSON::ObjectId('...
```
3. Load the `cell_type` facet and confirm that it can source unique filter values without throwing an error, and that this specific metadata object returns an empty array for filters:
```
facet = SearchFacet.find_by(identifier: 'cell_type')
facet.get_unique_filter_values
=> 
[{id: "CL_0000066", name: "epithelial cell"},
 {id: "CL_0000075", name: "columnar/cuboidal epithelial cell"},
 {id: "CL_0000094", name: "granulocyte"},
...

facet.filters_from_metadatum(meta)
=> []
```
4. Clean up the metadata object with `meta.destroy`