### PR TITLE
Add optional message to search Azul on empty results (SCP-6024)

### DIFF
--- a/app/javascript/components/search/results/ResultsPanel.jsx
+++ b/app/javascript/components/search/results/ResultsPanel.jsx
@@ -18,6 +18,16 @@ import LoadingSpinner from '~/lib/LoadingSpinner'
  */
 const ResultsPanel = ({ studySearchState, studyComponent, noResultsDisplay, bookmarks }) => {
   const results = studySearchState.results
+  const hcaMessage = <a
+    className='hca-link'
+    onClick={() => studySearchState.updateSearch({ external: 'hca' })}
+    data-analytics-event='search-hca-empty-results'>
+    Search HCA Data Portal?
+  </a>
+
+  const emptyResultMessage =  <div>
+    No results found. { studySearchState?.params?.external === "" ? hcaMessage : null }
+  </div>
 
   let panelContent
   if (studySearchState.isError) {
@@ -47,7 +57,7 @@ const ResultsPanel = ({ studySearchState, studyComponent, noResultsDisplay, book
       </>
     )
   } else {
-    noResultsDisplay = noResultsDisplay ? noResultsDisplay : <div> No results found. </div>
+    noResultsDisplay = noResultsDisplay ? noResultsDisplay : emptyResultMessage
     panelContent = (
       <>
         <SearchQueryDisplay terms={results.termList} facets={results.facets} />

--- a/app/javascript/styles/_resultsPanel.scss
+++ b/app/javascript/styles/_resultsPanel.scss
@@ -150,3 +150,8 @@
   min-width: 120px;
   height: 20px;
 }
+
+.hca-link {
+  font-weight: bold;
+  cursor: pointer;
+}

--- a/test/js/resultsPanel.test.js
+++ b/test/js/resultsPanel.test.js
@@ -40,4 +40,37 @@ describe('<StudyResultsContainer/> rendering>', () => {
     expect(container.getElementsByClassName('error-panel')).toHaveLength(0)
     expect(container.getElementsByClassName('results-header')).toHaveLength(1)
   })
+  it('should render message about HCA when no results found', () => {
+    const studySearchState = {
+      isError: false,
+      isLoaded: true,
+      params: { external: '' },
+      results: {
+        studies: [],
+        facets: {}
+      }
+    }
+    const { container } = render(
+      <ResultsPanel studySearchState={studySearchState}/>
+    )
+    expect(container.getElementsByClassName('loading-panel')).toHaveLength(0)
+    expect(container.getElementsByClassName('error-panel')).toHaveLength(0)
+    expect(container.getElementsByClassName('results-header')).toHaveLength(0)
+    expect(container.textContent).toContain('Search HCA Data Portal?')
+  })
+  it('should not render message about HCA if already requested', () => {
+    const studySearchState = {
+      isError: false,
+      isLoaded: true,
+      params: { external: 'hca' },
+      results: {
+        studies: [],
+        facets: { cell_type: 'CL_0000548' }
+      }
+    }
+    const { container } = render(
+      <ResultsPanel studySearchState={studySearchState} />
+    )
+    expect(container.textContent).not.toContain('Search HCA Data Portal?')
+  })
 })


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds an optional control to automatically resubmit a search to include Azul on empty results.  While this can be done manually by clicking the "Options" button (which [a few users](https://mixpanel.com/project/2120588/view/19059/app/insights#st6N3cfsHydF) are doing), this will reduce friction for users when they expect to find results from a given filter that unbeknownst to them only corresponds to entities in Azul.  This message will not be shown if any results from SCP are found.

Quick demo in action:

https://github.com/user-attachments/assets/da1b17f3-dab6-47a2-a439-ef4f3544c077

#### MANUAL TESTING
1. Boot as normal and sign in to populate facet filters with values from Azul
2. Run a search for `organ:abdominal wall` or another value that does not correspond to any SCP studies
3. Confirm the search returns no results and the link to `Search HCA Data Portal?` appears
4. Click the link and confirm the search is resubmitted and that results from Azul appear
5. Clear out the search and run another for `cell_type:animal cell`
6. Confirm the `Human milk - differential expression` study returns, and that there is no suggestion to search HCA