### PR TITLE
Use latest published date for feature announcement slug (SCP-5759)

### DIFF
--- a/app/models/feature_announcement.rb
+++ b/app/models/feature_announcement.rb
@@ -70,9 +70,19 @@ class FeatureAnnouncement
   private
 
   def set_slug
-    if new_record? || title_changed? && !published
-      today = created_at.nil? ? Time.zone.today : created_at
-      self.slug = "#{today.strftime('%F')}-#{title.downcase.gsub(/[^a-zA-Z0-9]+/, '-').chomp('-')}"
+    if published
+      published_date = history[:published] || Date.today
+      # determine if we have an existing title slug we need to preserve
+      # this prevents published links from breaking when the title changes
+      # NOTE: unpublishing a feature will always break any published links
+      if new_record? || slug&.starts_with?('unpublished-')
+        title_entry = title.downcase.gsub(/[^a-zA-Z0-9]+/, '-')
+      else
+        title_entry = slug.split('-')[3..].join('-')
+      end
+      self.slug = "#{published_date.strftime('%F')}-#{title_entry.chomp('-')}"
+    else
+      self.slug = "unpublished-#{id}"
     end
   end
 end

--- a/test/models/feature_announcement_test.rb
+++ b/test/models/feature_announcement_test.rb
@@ -21,18 +21,19 @@ class FeatureAnnouncementTest< ActiveSupport::TestCase
     FeatureAnnouncement.update_all(published: true, archived: false)
   end
 
-  test 'should set slug on save until published' do
+  test 'should set slug on save when published' do
     feature = FeatureAnnouncement.create(
       title: 'Unpublished Feature',
       content: '<p>This is the content.</p>',
       doc_link: 'https://singlecell.zendesk.com/hc/en-us',
+      created_at: Date.today.in_time_zone - 1.day,
       published: false,
       archived: false
     )
-    assert_equal "#{@today}-unpublished-feature", feature.slug
+    assert_equal "unpublished-#{feature.id}", feature.slug
     feature.update(title: 'Announcing a New Feature!!')
     feature.reload
-    assert_equal "#{@today}-announcing-a-new-feature", feature.slug
+    assert_equal "unpublished-#{feature.id}", feature.slug
     feature.update(published: true)
     feature.reload
     assert_equal "#{@today}-announcing-a-new-feature", feature.slug


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a small issue with dates in url slugs of feature announcements where an announcement that stays in an unpublished state for days/weeks will use the date the announcement was created rather than the date of publishing when setting the slug.  While this doesn't break functionality, it makes some announcements seem out of date even before they have been published.  Now, all unpublished announcements use the pattern `unpublished-{id}` for slugs (similar to unpublished Github release tags), and once published the slug date will always that of the most recent publishing.  The existing behavior of preserving the original title will still hold if a published announcement is renamed (until it is unpublished, at which point the slug resets).

#### MANUAL TESTING
1. Boot as normal and sign in and go edit any existing published feature announcement
2. Un-publish the announcement and confirm the slug changes to `unpublished-{id}` (you can hover over the link to see this)
3. Re-publish the announcement and confirm the slug now uses today's date