### PR TITLE
Updating base image and bundler (SCP-6034)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use SCP base Rails image, configure only project-specific items here
-FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:3.0.0
+FROM gcr.io/broad-singlecellportal-staging/rails-baseimage:3.0.1
 
 # Set ruby version
 RUN bash -lc 'rvm --default use ruby-3.4.2'
@@ -8,8 +8,6 @@ RUN bash -lc 'rvm rvmrc warning ignore /home/app/webapp/Gemfile'
 # Set up project dir, install gems, set up script to migrate database and precompile static assets on run
 RUN mkdir /home/app/webapp
 RUN sudo chown app:app /home/app/webapp # fix permission issues in local development on MacOSX
-RUN gem update --system
-RUN gem install bundler
 COPY Gemfile /home/app/webapp/Gemfile
 COPY Gemfile.lock /home/app/webapp/Gemfile.lock
 WORKDIR /home/app/webapp

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -641,4 +641,4 @@ RUBY VERSION
    ruby 3.4.2p28
 
 BUNDLED WITH
-   2.6.2
+   2.7.1


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates to `gcr.io/broad-singlecellportal-staging/rails-baseimage:3.0.1` to apply normal security patches and to also change how we update `rubygems` and `bundler`.  These will now be managed by the base image, rather than the dowstream `single-cell-portal` image that gets build with every PR merge.  This is also addressing warnings like `already initialized constant Gem::Platform::X64_LINUX` that have started polluting logs.

Note: this was also supposed to update to Ruby 3.4.4, but phusion-passenger incorrectly stated they had updated to this when in fact rel-3.1.3 is still pinned at 3.4.2.

#### MANUAL TESTING
The easiest way to test the fix for the warnings is to compare the output from previous test runs.  Note that before the fix, there are numerous warnings about `already initialized constant`.  In the latter CI run, these warnings are no longer present.

Before fix: https://github.com/broadinstitute/single_cell_portal_core/actions/runs/16423368516/job/46407469041#step:6:72
After fix: https://github.com/broadinstitute/single_cell_portal_core/actions/runs/16503548963/job/46668259524#step:6:72