### PR TITLE
Adjusting size/spacing of study viz settings menus (SCP-6032)

### DIFF
--- a/app/javascript/styles/_forms.scss
+++ b/app/javascript/styles/_forms.scss
@@ -200,14 +200,14 @@ hr.divider {
         margin: 0 4px 0 0;
       }
     }
-    li:hover {
-      background-color: #f4f4f4;
-    }
   }
 }
 
 li.cluster-order {
-  cursor: pointer;
+  cursor: grab;
+}
+li.cluster-order:active {
+  cursor: grabbing;
 }
 
 .large-checkbox {


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adjusts the size and spacing of the new cluster order menus to be both larger and more consistent with the existing annotation override menu.  Now both menus show a max of 5 items, and each item is the same size across all menus.  Below are some screenshots:

Chrome
<img width="774" height="183" alt="chrome" src="https://github.com/user-attachments/assets/ea3a34d4-8164-4fba-82bc-a4f89eae5258" />

Firefox
<img width="754" height="177" alt="firefox" src="https://github.com/user-attachments/assets/d0d5e997-a50a-4ba7-8980-aeee555ac3c0" />

#### MANUAL TESTING
1. Boot as normal and sign in
2. Load any study with multiple clusterings and confirm the menus look identical.