### PR TITLE
Use correct auth token, properly sanitize descriptions in text export (SCP-6036)

### DIFF
--- a/app/controllers/api/v1/study_search_results_objects.rb
+++ b/app/controllers/api/v1/study_search_results_objects.rb
@@ -137,7 +137,7 @@ module Api
             'SCP',
             study.accession,
             study.name,
-            study.description,
+            Api::V1::StudySearchResultsObjects.strip_newlines(study.description),
             study.public,
             study.detached,
             study.cell_count,
@@ -156,7 +156,7 @@ module Api
             study[:hca_result] ? 'HCA' : 'TDR',
             study[:accession],
             study[:name],
-            study[:description].gsub(/\n/, ''),
+            Api::V1::StudySearchResultsObjects.strip_newlines(study[:description]),
             true,
             false,
             0,
@@ -180,6 +180,11 @@ module Api
         else
           "https://data.humancellatlas.org/explore/projects/#{study[:hca_project_id]}"
         end
+      end
+
+      # deal with very old or external descriptions which may have newlines in them
+      def self.strip_newlines(text)
+        text.to_s.gsub(/\n/, ' ').gsub(/\r/, '').strip
       end
 
       # flatten facet matches into a text string for export

--- a/app/javascript/lib/scp-api.jsx
+++ b/app/javascript/lib/scp-api.jsx
@@ -516,7 +516,7 @@ export async function exportSearchResultsText(searchParams, mock=false) {
   const init = {
     method: 'GET',
     headers: {
-      Authorization: `Bearer ${getOAuthToken()}`
+      Authorization: `Bearer ${getAccessToken()}`
     }
   }
   const [searchResults, perfTimes] = await scpApi(path, init, mock, false, false)

--- a/test/lib/study_search_results_objects_test.rb
+++ b/test/lib/study_search_results_objects_test.rb
@@ -23,4 +23,11 @@ class StudySearchResultsObjectsTest < ActiveSupport::TestCase
     expected_names = ['B cell', 'bipolar neuron', 'retinal bipolar neuron', 'retinal cone cell', 'amacrine cell']
     assert_equal expected_names, merged_data[:cell_type].map { |filter| filter[:name]}
   end
+
+  test 'should remove any newlines from result descriptions' do
+    description = "This is a study description.\nIt has newlines.\n\nAnd some more.\r\n\r\nAnd some Windows newlines."
+    cleaned_description = Api::V1::StudySearchResultsObjects.strip_newlines(description)
+    assert_equal 'This is a study description. It has newlines.  And some more.  And some Windows newlines.',
+                 cleaned_description
+  end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This deals with two separate issues surrounding the new text export feature for search results:

- The incorrect auth token was being passed with requests.  It was using the readonly access token rather than the user's.
- Very old studies that have descriptions that contained newlines or even Windows-style carriage returns were not being sanitized properly, causing the exported file to be malformed and not useable.  These are only in studies that predate the CKEditor 5 update back in 2018 (e.g. prior to SCP203), and one other study (SCP2702) that has tabular data in their description that was copied from somewhere external and contains Windows newlines.

#### MANUAL TESTING
1. Boot as normal and sign in
2. Go to any private study and share it with a non-admin account
3. Sign in with that new account and run a search that will return that study, then click the text export button to confirm it is present
4. Open a Rails console session and load any study
5. Add Windows-style newlines to the study description:
```
study = Study.all.sample
study.description += "\r\n\r\nextra text"
study.save(validate: false)
```
6. Back in the UI, run a search that will return the above study (using the accession is easiest), click the text export button and confirm that you get a single line in the exported file and the description is not malformed.

