### PR TITLE
Update study default cluster orders when CRUDing clusters (SCP-6037)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -385,7 +385,6 @@ module Api
               study.save
             end
             cluster.update(name: study_file.name)
-            cluster.reload
           end
         end
 

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -384,7 +384,11 @@ module Api
               study.default_options[:cluster] = study_file.name
               study.save
             end
+            # handle cluster order updates in background to reduce ui blocking
+            @study.delay.update_cluster_order(cluster, action: :remove)
             cluster.update(name: study_file.name)
+            cluster.reload
+            @study.delay.update_cluster_order(cluster, action: :append)
           end
         end
 

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -384,11 +384,8 @@ module Api
               study.default_options[:cluster] = study_file.name
               study.save
             end
-            # handle cluster order updates in background to reduce ui blocking
-            @study.delay.update_cluster_order(cluster, action: :remove)
             cluster.update(name: study_file.name)
             cluster.reload
-            @study.delay.update_cluster_order(cluster, action: :append)
           end
         end
 

--- a/app/models/cluster_group.rb
+++ b/app/models/cluster_group.rb
@@ -74,6 +74,8 @@ class ClusterGroup
       'cell_annotations.type' => %w(group numeric)
   }
 
+  before_update :update_cluster_in_study_options
+
   # method to return a single data array of values for a given data array name, annotation name, and annotation value
   # gathers all matching data arrays and orders by index, then concatenates into single array
   # can also load subsample arrays by supplying optional subsample_threshold
@@ -164,6 +166,21 @@ class ClusterGroup
     else
       true
     end
+  end
+
+  # whenever a cluster is updated, we need to update the study default_options ordering to reflect this
+  def update_cluster_in_study_options
+    return unless name_changed?
+
+    study = self.study
+    list_name = spatial? ? :spatial_order : :cluster_order
+    return unless study.present? && study.default_options[list_name].present?
+
+    old_name, new_name = name_change
+    idx = study.default_options[list_name].index(old_name)
+    idx ? study.default_options[list_name][idx] = new_name : study.default_options[list_name] << new_name
+    study.save(validate: false) # skip validations to avoid circular dependency issues
+    CacheRemovalJob.new(study.accession).delay.perform
   end
 
   # method used during parsing to generate representative sub-sampled data_arrays for rendering

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -36,6 +36,7 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
       case file_type
       when 'Cluster'
         cluster_group = ClusterGroup.find_by(study:, study_file_id: object.id)
+        study.update_cluster_order(cluster_group, action: :remove)
         delete_differential_expression_results(study:, study_file: object)
         delete_parsed_data(object.id, study.id, ClusterGroup, DataArray)
         delete_dot_plot_data(study.id, query: { cluster_group_id: cluster_group&.id })

--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -543,6 +543,7 @@ class IngestJob
     when 'Cluster'
       set_default_cluster
       set_default_annotation
+      update_cluster_ordering
     when 'AnnData'
       set_default_cluster
       set_default_annotation
@@ -599,6 +600,12 @@ class IngestJob
       cluster = study.cluster_groups.by_name(cluster_name_by_file_type)
       study.default_options[:cluster] = cluster.name if cluster.present?
     end
+  end
+
+  # update the study.default_cluster_order after clustering finishes ingesting
+  def update_cluster_ordering
+    cluster = study.cluster_groups.by_name(cluster_name_by_file_type)
+    study.update_cluster_order(cluster, action: :append)
   end
 
   # set the point count on a cluster group after successful ingest

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -1324,6 +1324,24 @@ class Study
     default_options[:spatial_order] || spatial_cluster_groups.map(&:name)
   end
 
+  # handle updates to the cluster order menus
+  def update_cluster_order(cluster, action:)
+    return nil unless cluster
+
+    list_name = cluster.spatial? ? :spatial_order : :cluster_order
+    case action.to_sym
+    when :append
+      new_list = send("default_#{list_name}").push(cluster.name).uniq
+    when :remove
+      new_list = send("default_#{list_name}").reject { |c| c == cluster.name }
+    else
+      return nil # invalid action
+    end
+    default_options[list_name] = new_list
+    save
+    CacheRemovalJob.new(accession).perform
+  end
+
   ###
   #
   # INSTANCE VALUE SETTERS & GETTERS

--- a/test/models/study_test.rb
+++ b/test/models/study_test.rb
@@ -274,5 +274,11 @@ class StudyTest < ActiveSupport::TestCase
     study.update_cluster_order(new_cluster, action: :append)
     study.reload
     assert_equal [cluster.name, new_cluster.name], study.default_cluster_order
+
+    # test renaming cluster directly
+    new_name = 'Renamed Cluster'
+    cluster.update(name: new_name)
+    study.reload
+    assert_equal [new_name, new_cluster.name], study.default_cluster_order
   end
 end

--- a/test/models/study_test.rb
+++ b/test/models/study_test.rb
@@ -252,4 +252,27 @@ class StudyTest < ActiveSupport::TestCase
     study.set_cell_count
     assert_equal 4, study.cell_count
   end
+
+  test 'should update cluster order' do
+    study = FactoryBot.create(:detached_study,
+                              user: @user,
+                              name_prefix: 'Cluster Order Test',
+                              test_array: @@studies_to_clean)
+    assert_empty study.default_cluster_order
+    cell_input = {
+      x: [1, 4, 6],
+      y: [7, 5, 3],
+      cells: %w(A B C)
+    }
+    FactoryBot.create(:cluster_file, name: 'cluster_example.txt', study:, cell_input:)
+    cluster = study.cluster_groups.first
+    study.update_cluster_order(cluster, action: :append)
+    study.reload
+    assert_equal [cluster.name], study.default_cluster_order
+    FactoryBot.create(:cluster_file, name: 'cluster_2_example.txt', study:, cell_input:)
+    new_cluster = study.cluster_groups.last
+    study.update_cluster_order(new_cluster, action: :append)
+    study.reload
+    assert_equal [cluster.name, new_cluster.name], study.default_cluster_order
+  end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This addresses a regression introduced in #2289 where once the order has been set for a clustering menu, it will not update further as clusters are added/updated/deleted.  Now, any CRUD action on a cluster will cause an update to the corresponding menu: new clusters are appended to the end, existing clusters that are renamed are replaced, and deleted clusters are removed.  Caches are also cleared asynchronously to avoid UI blocking.

#### MANUAL TESTING
Note: you may need to wait a few seconds in between each update for DelayedJob to clear caches if you have caching enabled
1. Boot all services including DelayedJob and sign in
2. Load any study with multiple clusterings (Chicken raw counts is a good candidate), go to the Settings > View options tab and set the order of one of the menus, then save
3. Go to the upload wizard for this study and rename one of the clusters
4. Go back to the Explore tab and confirm it has been renamed correctly in both the menu and the View options tab
5. Back In the upload wizard, delete a cluster
6. Back in the Explore tab, ensure the cluster has been removed from all menus