### PR TITLE
Adding cluster-specific cell counts to scatter tab (SCP-5501)

### DIFF
--- a/app/javascript/components/visualization/PlotTitle.jsx
+++ b/app/javascript/components/visualization/PlotTitle.jsx
@@ -54,7 +54,7 @@ export function getTitleTexts(cluster, genes, consensus, subsample, isCorrelated
 
 /** Renders a plot title for scatter plots */
 export default function PlotTitle({
-  titleTexts, isCorrelatedScatter, correlation
+  titleTexts, isCorrelatedScatter, correlation, numPoints
 }) {
   const tooltipText =
     `If this value looks different than what you expect given the plot,
@@ -63,7 +63,9 @@ export default function PlotTitle({
   const [titleText, detailText] = titleTexts
 
   return <h5 className="plot-title">
-    <span className="cluster-title">{titleText} </span>
+    <span className="cluster-title">{titleText} </span> { numPoints &&
+    <span className='badge badge-inverse cluster-cell-count'>{numPoints} cells</span>
+  }
     <span className="detail"> {detailText} </span>
     { isCorrelatedScatter && !!correlation &&
     <>

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -605,7 +605,9 @@ function RawScatterPlot({
       <PlotTitle
         titleTexts={titleTexts}
         isCorrelatedScatter={isCorrelatedScatter}
-        correlation={bulkCorrelation}/>
+        correlation={bulkCorrelation}
+        numPoints={scatterData?.numPoints}
+      />
       { hasMissingAnnot &&
         <div className="alert-warning text-center error-boundary">
           "{cluster}" does not have the requested annotation {loadedAnnotation !== '----' && loadedAnnotation}

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -53,6 +53,7 @@
     height: 1.2em;
     margin-left: 1em;
     margin-top: 0.5em;
+    margin-bottom: 0.5em;
 
     .badge {
       font-weight: normal;

--- a/app/views/site/_study_tabs_nav.html.erb
+++ b/app/views/site/_study_tabs_nav.html.erb
@@ -50,7 +50,7 @@
       </li>
     <% end %>
     <li role="presentation" class="study-badges">
-      <span class="badge" id="cell-count"> <%= @study.cell_count %> cells</span>
+      <span class="badge" id="cell-count"> <%= @study.cell_count %> total cells</span>
       <span class="badge" id="gene-count"> <%= @study.gene_count %> genes</span>
     </li>
   <% end %>

--- a/test/js/explore/scatter-tab.test.js
+++ b/test/js/explore/scatter-tab.test.js
@@ -187,9 +187,9 @@ describe('getNewContextMap correctly assigns contexts', () => {
 
     expect(plotTitles).toHaveLength(4)
     const expectedTitles = [
-      'farsa expression clusterA',
+      'farsa expression 130 cells clusterA',
       'clusterA',
-      'farsa expression spatialClusterA',
+      'farsa expression 130 cells spatialClusterA',
       'spatialClusterA'
     ]
     plotTitles.forEach((titleEl, index) => {


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds cluster-specific cell counts to the scatter tab once a plot has finished rendering.  This count will always show the full resolution count, and in the case of subsampling extra detail text will note that this is not the full compliment of cells while giving the user an indication of how much downsampling has occurred.  The cell count badge in the navbar now reads "total cells" and indicates the count of cells from the study metadata file.

All cells:
<img width="441" height="39" alt="cell-count-all-cells" src="https://github.com/user-attachments/assets/2369801b-77dd-4c1f-b6ea-120c7123ee44" />

Subsampled:
<img width="553" height="39" alt="cell-count-subsample" src="https://github.com/user-attachments/assets/eea093d0-1d26-463d-926d-9b0d9ba07894" />

#### MANUAL TESTING
1. Boot as normal and load any study with clustering
2. Confirm you see the cell count badge next to the plot title once it finishes rendering
