### PR TITLE
Updating to production NeMO API (SCP-6047)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -546,6 +546,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21

--- a/app/models/nemo_client.rb
+++ b/app/models/nemo_client.rb
@@ -4,7 +4,7 @@ class NemoClient
 
   attr_accessor :api_root, :username, :password
 
-  BASE_URL = 'https://beta-assets.nemoarchive.org/api'.freeze
+  BASE_URL = 'https://assets.nemoarchive.org/api'.freeze
 
   DEFAULT_HEADERS = {
     'Accept' => 'application/json',
@@ -12,7 +12,7 @@ class NemoClient
   }.freeze
 
   # types of available entities
-  ENTITY_TYPES = %w[collection file grant project publication sample subject].freeze
+  ENTITY_TYPES = %w[collection file grant project sample subject].freeze
 
   # identifier format validator
   IDENTIFIER_FORMAT = /nemo:[a-z]{3}-[a-z0-9]{7}$/
@@ -21,10 +21,8 @@ class NemoClient
   #
   # * *return*
   #   - +NemoClient+ object
-  def initialize(api_root: BASE_URL, username: ENV['NEMO_API_USERNAME'], password: ENV['NEMO_API_PASSWORD'])
+  def initialize(api_root: BASE_URL)
     self.api_root = api_root.chomp('/')
-    self.username = username
-    self.password = password
   end
 
   # submit a request to NeMO API
@@ -68,12 +66,6 @@ class NemoClient
     end
   end
 
-  # add basic HTTP auth header
-  # TODO: remove after public release of API
-  def authorization_header
-    { Authorization: "Basic #{Base64.encode64("#{username}:#{password}")}" }
-  end
-
   # sub-handler for making external HTTP request
   # does not have error handling, this is done by process_api_request
   # allows for some methods to implement their own error handling (like health checks)
@@ -89,8 +81,7 @@ class NemoClient
   # * *raises*
   #   - (RestClient::Exception) => if HTTP request fails for any reason
   def execute_http_request(http_method, path, payload = nil)
-    headers = authorization_header.merge(DEFAULT_HEADERS)
-    response = RestClient::Request.execute(method: http_method, url: path, payload:, headers:)
+    response = RestClient::Request.execute(method: http_method, url: path, payload:, headers: DEFAULT_HEADERS)
     # handle response using helper
     handle_response(response)
   end
@@ -192,17 +183,6 @@ class NemoClient
   #   - (Hash) => File metadata
   def project(identifier)
     fetch_entity(:project, identifier)
-  end
-
-  # get information about a publication
-  #
-  # * *params*
-  #   - +identifier+ (String) => sample identifier
-  #
-  # * *returns*
-  #   - (Hash) => publication metadata
-  def publication(identifier)
-    fetch_entity(:publication, identifier)
   end
 
   # get information about a sample

--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -49,12 +49,12 @@ module ImportServiceConfig
     end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    # test 'should traverse associations to set ids' do
-    #   config = ImportServiceConfig::Nemo.new(file_id: @attributes[:file_id])
-    #   config.traverse_associations!
-    #   assert_equal @attributes[:study_id], config.study_id
-    #   assert_equal 'nemo:grn-gyy3k8j', config.project_id
-    # end
+    test 'should traverse associations to set ids' do
+      config = ImportServiceConfig::Nemo.new(file_id: @attributes[:file_id])
+      config.traverse_associations!
+      assert_equal @attributes[:study_id], config.study_id
+      assert_equal 'nemo:grn-gyy3k8j', config.project_id
+    end
 
     test 'should load defaults' do
       study_defaults = {
@@ -93,91 +93,91 @@ module ImportServiceConfig
       assert_equal 'application/octet-stream', @configuration.get_file_content_type('csv')
     end
 
-    # test 'should load study analog' do
-    #   study = @configuration.load_study
-    #   assert_equal '"Human variation study (10x), GRU"', study['name']
-    #   assert_equal ["10x chromium 3' v3 sequencing"], study['techniques']
-    #   assert_equal [{"name"=>"human", "cv_term_id"=>"NCBI:txid9606"}], study['taxa']
-    # end
+    test 'should load study analog' do
+      study = @configuration.load_study
+      assert_equal '"Human variation study (10x), GRU"', study['name']
+      assert_equal ["10x chromium 3' v3 sequencing"], study['techniques']
+      assert_equal [{"name"=>"human", "cv_term_id"=>"NCBI:txid9606"}], study['taxa']
+    end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    # test 'should load file analog' do
-    #   file = @configuration.load_file
-    #   assert_equal 'human_var_scVI_VLMC.h5ad', file['file_name']
-    #   assert_equal 'h5ad', file['file_format']
-    #   assert_equal 'counts', file['data_type']
-    # end
+    test 'should load file analog' do
+      file = @configuration.load_file
+      assert_equal 'human_var_scVI_VLMC.h5ad', file['file_name']
+      assert_equal 'h5ad', file['file_format']
+      assert_equal 'counts', file['data_type']
+    end
 
-    # test 'should load collection analog' do
-    #   collection = @configuration.load_collection
-    #   assert_equal 'ecker_sn_mCseq_proj', collection['short_name']
-    # end
-
-    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    # test 'should extract association ids' do
-    #   file = @configuration.load_file
-    #   study = @configuration.load_study
-    #   assert_equal @attributes[:study_id], @configuration.id_from(file, :collections)
-    #   assert_equal 'nemo:grn-gyy3k8j', @configuration.id_from(study, :projects)
-    # end
-
-    # test 'should load taxon common names' do
-    #   assert_equal %w[human], @configuration.taxon_names
-    # end
-    #
-    # test 'should find library preparation protocol' do
-    #   assert_equal "10x 3' v3", @configuration.find_library_prep("10x chromium 3' v3 sequencing")
-    #   assert_equal 'Drop-seq', @configuration.find_library_prep('drop-seq')
-    # end
+    test 'should load collection analog' do
+      collection = @configuration.load_collection
+      assert_equal 'ecker_sn_mCseq_proj', collection['short_name']
+    end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    # test 'should populate study and study_file' do
-    #   scp_study = @configuration.populate_study
-    #   assert_equal 'Human variation study (10x), GRU', scp_study.name
-    #   assert_not scp_study.public
-    #   assert scp_study.full_description.present?
-    #   assert_equal @user_id, scp_study.user_id
-    #   assert_equal @branding_group_id, scp_study.branding_group_ids.first
-    #   assert_equal @configuration.service_name, scp_study.imported_from
-    #   # populate StudyFile, using above study
-    #   scp_study_file = @configuration.populate_study_file(scp_study.id)
-    #   assert scp_study_file.use_metadata_convention
-    #   assert_equal 'human_var_scVI_VLMC.h5ad', scp_study_file.upload_file_name
-    #   assert_equal "10x 3' v3", scp_study_file.expression_file_info.library_preparation_protocol
-    #   assert_equal @configuration.service_name, scp_study_file.imported_from
-    #   assert_not scp_study_file.ann_data_file_info.reference_file
-    #   @configuration.obsm_keys.each do |obsm_key_name|
-    #     assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?
-    #   end
-    #   assert scp_study_file.ann_data_file_info.find_fragment(data_type: :expression).present?
-    # end
+    test 'should extract association ids' do
+      file = @configuration.load_file
+      study = @configuration.load_study
+      assert_equal @attributes[:study_id], @configuration.id_from(file, :collections)
+      assert_equal 'nemo:grn-gyy3k8j', @configuration.id_from(study, :projects)
+    end
+
+    test 'should load taxon common names' do
+      assert_equal %w[human], @configuration.taxon_names
+    end
+
+    test 'should find library preparation protocol' do
+      assert_equal "10x 3' v3", @configuration.find_library_prep("10x chromium 3' v3 sequencing")
+      assert_equal 'Drop-seq', @configuration.find_library_prep('drop-seq')
+    end
 
     # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-    # test 'should import all from service' do
-    #   access_url = 'gs://nemo-public/other/grant/u01_lein/lein/transcriptome/sncell/10x_v3/' \
-    #                'human/processed/counts/human_var_scVI_VLMC.h5ad'
-    #   file_mock = ::Minitest::Mock.new
-    #   file_mock.expect :generation, '123456789'
-    #   # for study to save, we need to mock all Terra orchestration API calls for creating workspace & setting acls
-    #   fc_client_mock = ::Minitest::Mock.new
-    #   owner_group = { groupEmail: 'sa-owner-group@firecloud.org' }.with_indifferent_access
-    #   assign_workspace_mock!(fc_client_mock, owner_group, 'human-variation-study-10x-gru')
-    #   AdminConfiguration.stub :find_or_create_ws_user_group!, owner_group do
-    #     ImportService.stub :copy_file_to_bucket, file_mock do
-    #       ApplicationController.stub :firecloud_client, fc_client_mock do
-    #         @configuration.stub :taxon_from, Taxon.new(common_name: 'human') do
-    #           study, study_file = @configuration.import_from_service
-    #           file_mock.verify
-    #           fc_client_mock.verify
-    #           assert study.persisted?
-    #           assert study_file.persisted?
-    #           assert_equal study.external_identifier, @attributes[:study_id]
-    #           assert_equal study_file.external_identifier, @attributes[:file_id]
-    #           assert_equal study_file.external_link_url, access_url
-    #         end
-    #       end
-    #     end
-    #   end
-    # end
+    test 'should populate study and study_file' do
+      scp_study = @configuration.populate_study
+      assert_equal 'Human variation study (10x), GRU', scp_study.name
+      assert_not scp_study.public
+      assert scp_study.full_description.present?
+      assert_equal @user_id, scp_study.user_id
+      assert_equal @branding_group_id, scp_study.branding_group_ids.first
+      assert_equal @configuration.service_name, scp_study.imported_from
+      # populate StudyFile, using above study
+      scp_study_file = @configuration.populate_study_file(scp_study.id)
+      assert scp_study_file.use_metadata_convention
+      assert_equal 'human_var_scVI_VLMC.h5ad', scp_study_file.upload_file_name
+      assert_equal "10x 3' v3", scp_study_file.expression_file_info.library_preparation_protocol
+      assert_equal @configuration.service_name, scp_study_file.imported_from
+      assert_not scp_study_file.ann_data_file_info.reference_file
+      @configuration.obsm_keys.each do |obsm_key_name|
+        assert scp_study_file.ann_data_file_info.find_fragment(data_type: :cluster, obsm_key_name:).present?
+      end
+      assert scp_study_file.ann_data_file_info.find_fragment(data_type: :expression).present?
+    end
+
+    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
+    test 'should import all from service' do
+      access_url = 'gs://nemo-public/other/grant/u01_lein/lein/transcriptome/sncell/10x_v3/' \
+                   'human/processed/counts/human_var_scVI_VLMC.h5ad'
+      file_mock = ::Minitest::Mock.new
+      file_mock.expect :generation, '123456789'
+      # for study to save, we need to mock all Terra orchestration API calls for creating workspace & setting acls
+      fc_client_mock = ::Minitest::Mock.new
+      owner_group = { groupEmail: 'sa-owner-group@firecloud.org' }.with_indifferent_access
+      assign_workspace_mock!(fc_client_mock, owner_group, 'human-variation-study-10x-gru')
+      AdminConfiguration.stub :find_or_create_ws_user_group!, owner_group do
+        ImportService.stub :copy_file_to_bucket, file_mock do
+          ApplicationController.stub :firecloud_client, fc_client_mock do
+            @configuration.stub :taxon_from, Taxon.new(common_name: 'human') do
+              study, study_file = @configuration.import_from_service
+              file_mock.verify
+              fc_client_mock.verify
+              assert study.persisted?
+              assert study_file.persisted?
+              assert_equal study.external_identifier, @attributes[:study_id]
+              assert_equal study_file.external_identifier, @attributes[:file_id]
+              assert_equal study_file.external_link_url, access_url
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/test/integration/external/import_service_config/nemo_test.rb
+++ b/test/integration/external/import_service_config/nemo_test.rb
@@ -48,7 +48,6 @@ module ImportServiceConfig
       assert_equal @branding_group, @configuration.branding_group
     end
 
-    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
     test 'should traverse associations to set ids' do
       config = ImportServiceConfig::Nemo.new(file_id: @attributes[:file_id])
       config.traverse_associations!
@@ -100,7 +99,6 @@ module ImportServiceConfig
       assert_equal [{"name"=>"human", "cv_term_id"=>"NCBI:txid9606"}], study['taxa']
     end
 
-    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
     test 'should load file analog' do
       file = @configuration.load_file
       assert_equal 'human_var_scVI_VLMC.h5ad', file['file_name']
@@ -113,7 +111,6 @@ module ImportServiceConfig
       assert_equal 'ecker_sn_mCseq_proj', collection['short_name']
     end
 
-    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
     test 'should extract association ids' do
       file = @configuration.load_file
       study = @configuration.load_study
@@ -130,7 +127,6 @@ module ImportServiceConfig
       assert_equal 'Drop-seq', @configuration.find_library_prep('drop-seq')
     end
 
-    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
     test 'should populate study and study_file' do
       scp_study = @configuration.populate_study
       assert_equal 'Human variation study (10x), GRU', scp_study.name
@@ -152,7 +148,6 @@ module ImportServiceConfig
       assert scp_study_file.ann_data_file_info.find_fragment(data_type: :expression).present?
     end
 
-    # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
     test 'should import all from service' do
       access_url = 'gs://nemo-public/other/grant/u01_lein/lein/transcriptome/sncell/10x_v3/' \
                    'human/processed/counts/human_var_scVI_VLMC.h5ad'

--- a/test/integration/external/import_service_test.rb
+++ b/test/integration/external/import_service_test.rb
@@ -10,15 +10,15 @@ class ImportServiceTest < ActiveSupport::TestCase
   end
 
   # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  # test 'should call API client method' do
-  #   client = NemoClient.new
-  #   nemo_file = ImportService.call_api_client(client, :file, @nemo_attributes[:file_id])
-  #   assert_equal 'BI006_marm028_Munchkin_M1_rxn1.4.bam.bai', nemo_file['file_name']
-  #   assert_equal 'bam', nemo_file['file_format']
-  #   assert_raises ArgumentError do
-  #     ImportService.call_api_client(FireCloudClient.new, :api_available?)
-  #   end
-  # end
+  test 'should call API client method' do
+    client = NemoClient.new
+    nemo_file = ImportService.call_api_client(client, :file, @nemo_attributes[:file_id])
+    assert_equal 'BI006_marm028_Munchkin_M1_rxn1.4.bam.bai', nemo_file['file_name']
+    assert_equal 'bam', nemo_file['file_format']
+    assert_raises ArgumentError do
+      ImportService.call_api_client(FireCloudClient.new, :api_available?)
+    end
+  end
 
   test 'should call import from external service' do
     mock = Minitest::Mock.new

--- a/test/integration/external/import_service_test.rb
+++ b/test/integration/external/import_service_test.rb
@@ -9,7 +9,6 @@ class ImportServiceTest < ActiveSupport::TestCase
     }
   end
 
-  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
   test 'should call API client method' do
     client = NemoClient.new
     nemo_file = ImportService.call_api_client(client, :file, @nemo_attributes[:file_id])
@@ -40,7 +39,6 @@ class ImportServiceTest < ActiveSupport::TestCase
     bucket = ImportService.load_public_bucket bucket_id
     assert bucket.present?
     bucket.is_a?(Google::Cloud::Storage::Bucket)
-    assert bucket.lazy? # skip_lookup: true
   end
 
   test 'should get public file from bucket' do
@@ -51,7 +49,6 @@ class ImportServiceTest < ActiveSupport::TestCase
     assert file.is_a?(Google::Cloud::Storage::File)
     assert_equal filepath, file.name
     assert_equal bucket_id, file.bucket
-    assert file.lazy? # skip_lookup: true
   end
 
   test 'should parse gs URL' do

--- a/test/integration/external/nemo_client_test.rb
+++ b/test/integration/external/nemo_client_test.rb
@@ -15,7 +15,7 @@ class NemoClientTest < ActiveSupport::TestCase
     }
   end
 
-  # skip a test if Azul is not up ; prevents unnecessary build failures due to releases/maintenance
+  # skip a test if Nemo API is not up ; prevents unnecessary build failures due to releases/maintenance
   def skip_if_api_down
     unless @nemo_is_ok
       puts @skip_message; skip

--- a/test/integration/external/nemo_client_test.rb
+++ b/test/integration/external/nemo_client_test.rb
@@ -2,8 +2,6 @@ require 'test_helper'
 
 class NemoClientTest < ActiveSupport::TestCase
   before(:all) do
-    @username = ENV['NEMO_API_USERNAME']
-    @password = ENV['NEMO_API_PASSWORD']
     @nemo_client = NemoClient.new
     @nemo_is_ok = @nemo_client.api_available?
     @skip_message = '-- skipping due to NeMO API being unavailable --'
@@ -27,19 +25,11 @@ class NemoClientTest < ActiveSupport::TestCase
   test 'should instantiate client' do
     client = NemoClient.new
     assert_equal NemoClient::BASE_URL, client.api_root
-    assert_equal @username, client.username
-    assert_equal @password, client.password
   end
 
   test 'should check if NeMO is up' do
     skip_if_api_down
     assert @nemo_client.api_available?
-  end
-
-  test 'should format authentication header' do
-    auth_header = @nemo_client.authorization_header
-    username_password = auth_header[:Authorization].split.last # trim off 'Basic '
-    assert_equal "#{@nemo_client.username}:#{@nemo_client.password}", Base64.decode64(username_password)
   end
 
   test 'should validate entity type' do
@@ -54,86 +44,70 @@ class NemoClientTest < ActiveSupport::TestCase
     end
   end
 
-  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  # test 'should get an entity' do
-  #   skip_if_api_down
-  #   entity_type = @identifiers.keys.sample
-  #   identifier = @identifiers[entity_type]
-  #   entity = @nemo_client.fetch_entity(entity_type, identifier)
-  #   assert entity.present?
-  # end
-  #
-  # test 'should get collection' do
-  #   skip_if_api_down
-  #   identifier = @identifiers[:collection]
-  #   collection = @nemo_client.collection(identifier)
-  #   assert collection.present?
-  #   assert_equal 'human_variation_10X', collection['short_name']
-  # end
+  test 'should get an entity' do
+    skip_if_api_down
+    entity_type = @identifiers.keys.sample
+    identifier = @identifiers[entity_type]
+    entity = @nemo_client.fetch_entity(entity_type, identifier)
+    assert entity.present?
+  end
 
-  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  # test 'should get file' do
-  #   skip_if_api_down
-  #   identifier = @identifiers[:file]
-  #   file = @nemo_client.file(identifier)
-  #   assert file.present?
-  #   filename = 'human_var_scVI_VLMC.h5ad'
-  #   assert_equal filename, file['file_name']
-  #   assert_equal 'h5ad', file['file_format']
-  #   access_url = file['manifest_file_urls'].first['url']
-  #   assert_equal filename, access_url.split('/').last
-  # end
+  test 'should get collection' do
+    skip_if_api_down
+    identifier = @identifiers[:collection]
+    collection = @nemo_client.collection(identifier)
+    assert collection.present?
+    assert_equal 'human_variation_10X', collection['short_name']
+  end
 
-  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  # test 'should get grant' do
-  #   skip_if_api_down
-  #   identifier = @identifiers[:grant]
-  #   grant = @nemo_client.grant(identifier)
-  #   assert grant.present?
-  #   assert_equal 'Allen Institute Funder', grant.dig('grant_info','grant_number')
-  #   assert_equal 'Allen Institute Funder', grant['funding_agency']
-  # end
-  #
-  # test 'should get project' do
-  #   skip_if_api_down
-  #   identifier = @identifiers[:project]
-  #   project = @nemo_client.project(identifier)
-  #   assert project.present?
-  #   assert_equal 'DNA methylation profiling of genomic DNA in individual mouse brain cell nuclei (RS1.1)',
-  #                project['title']
-  #   assert_equal 'biccn', project['program']
-  #   assert_equal 'ecker_sn_mCseq_proj', project['short_name']
-  # end
+  test 'should get file' do
+    skip_if_api_down
+    identifier = @identifiers[:file]
+    file = @nemo_client.file(identifier)
+    assert file.present?
+    filename = 'human_var_scVI_VLMC.h5ad'
+    assert_equal filename, file['file_name']
+    assert_equal 'h5ad', file['file_format']
+    access_url = file['manifest_file_urls'].first['url']
+    assert_equal filename, access_url.split('/').last
+  end
 
-  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  # test 'should get publication' do
-  #   skip_if_api_down
-  #   identifier = @identifiers[:publication]
-  #   publication = @nemo_client.publication(identifier)
-  #   assert publication.present?
-  #   assert_equal 'eLife', publication['journal']
-  #   assert_equal 'https://doi.org/10.7554/eLife.64875', publication['doi']
-  #   assert_equal ["human", "macaques", "house mouse"].sort, publication['taxonomies'].sort
-  # end
+  test 'should get grant' do
+    skip_if_api_down
+    identifier = @identifiers[:grant]
+    grant = @nemo_client.grant(identifier)
+    assert grant.present?
+    assert_equal 'Allen Institute Funder', grant.dig('grant_info','grant_number')
+    assert_equal 'Allen Institute Funder', grant['funding_agency']
+  end
 
-  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  # test 'should get sample' do
-  #   skip_if_api_down
-  #   identifier = @identifiers[:sample]
-  #   sample = @nemo_client.sample(identifier)
-  #   assert sample.present?
-  #   assert_equal 'marm028_M1', sample['sample_name']
-  #   assert sample['subjects'].any?
-  # end
+  test 'should get project' do
+    skip_if_api_down
+    identifier = @identifiers[:project]
+    project = @nemo_client.project(identifier)
+    assert project.present?
+    assert_equal 'DNA methylation profiling of genomic DNA in individual mouse brain cell nuclei (RS1.1)',
+                 project['title']
+    assert_equal 'biccn', project['program']
+    assert_equal 'ecker_sn_mCseq_proj', project['short_name']
+  end
 
-  # TODO: SCP-5565 Check with NeMO re API, update and re-enable this test
-  # test 'should get subject' do
-  #   skip_if_api_down
-  #   identifier = @identifiers[:subject]
-  #   subject = @nemo_client.subject(identifier)
-  #   assert subject.present?
-  #   assert_equal 'nonhuman-1U01MH114819', subject.dig('cohort_info', 'cohort_name')
-  #   assert_equal 'A Molecular and cellular atlas of the marmoset brain', subject['grant_title']
-  #   assert subject['samples'].any?
-  # end
+  test 'should get sample' do
+    skip_if_api_down
+    identifier = @identifiers[:sample]
+    sample = @nemo_client.sample(identifier)
+    assert sample.present?
+    assert_equal 'marm028_M1', sample['sample_name']
+    assert sample['subjects'].any?
+  end
+
+  test 'should get subject' do
+    skip_if_api_down
+    identifier = @identifiers[:subject]
+    subject = @nemo_client.subject(identifier)
+    assert subject.present?
+    assert_equal 'nonhuman-1U01MH114819', subject.dig('cohort_info', 'cohort_name')
+    assert_equal 'A Molecular and cellular atlas of the marmoset brain', subject['grant_title']
+    assert subject['samples'].any?
+  end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates to the production instance of the new NeMO identifiers API (assets.nemoarchive.org) and re-enables tests that were previously disabled.  Changes from the previous beta instance:

* Authentication is no longer required
* Publications have been removed as a first-class entity

Otherwise, functionality between beta and production is identical and the prod instance appears to be backed with the same available datasets.

#### MANUAL TESTING
The easiest way to test this is to use the existing unit/integration tests:
1. Initialize your environment as usual
2. Run the two associated test suites for the NeMO API:
```
bin/rails test test/integration/external/nemo_client_test.rb 
# Running:

SUITE NemoClientTest starting
...
SUITE NemoClientTest completed (3.33 sec)
Finished in 3.334353s, 3.2990 runs/s, 7.4977 assertions/s.

11 runs, 25 assertions, 0 failures, 0 errors, 0 skips
```
```
bin/rails test test/integration/external/import_service_config/nemo_test.rb
# Running:

SUITE ImportServiceConfig::NemoTest starting
...
.ImportServiceConfig::NemoTest: Cleaning up 0 studies, 1 users
SUITE ImportServiceConfig::NemoTest completed (18.44 sec)
Finished in 18.445724s, 0.9216 runs/s, 3.0901 assertions/s.

17 runs, 57 assertions, 0 failures, 0 errors, 0 skips
```