### PR TITLE
Properly scope existing results query to given cluster (SCP-6053)

### DIFF
--- a/app/models/ingest_job.rb
+++ b/app/models/ingest_job.rb
@@ -750,7 +750,7 @@ class IngestJob
 
   # determine if differential expression should be run for study, and submit available jobs (skipping existing results)
   def launch_differential_expression_jobs
-    if DifferentialExpressionService.study_eligible?(study, skip_existing: true)
+    if DifferentialExpressionService.study_eligible?(study)
       Rails.logger.info "#{study.accession} is eligible for differential expression, launching available jobs"
       DifferentialExpressionService.run_differential_expression_on_all(study.accession, skip_existing: true)
     end

--- a/test/services/differential_expression_service_test.rb
+++ b/test/services/differential_expression_service_test.rb
@@ -283,9 +283,9 @@ class DifferentialExpressionServiceTest < ActiveSupport::TestCase
     )
     assert result.present?
     @basic_study.reload
-    assert DifferentialExpressionService.results_exist?(@basic_study, annotation)
-    no_results = { annotation_name: 'foo', annotation_scope: 'cluster', cluster_group_id: cluster.id }
-    assert_not DifferentialExpressionService.results_exist?(@basic_study, no_results)
+    assert DifferentialExpressionService.results_exist?(@basic_study, cluster, annotation)
+    no_results = { annotation_name: 'foo', annotation_scope: 'cluster' }
+    assert_not DifferentialExpressionService.results_exist?(@basic_study, cluster, no_results)
   end
 
   test 'should find eligible annotations' do


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a bug with DE automation where existing results from other clusters prevent new clustering objects from calculating their own results.  This appears to work fine if a user adds several clusterings all at once, but if there are enough such that downstream parses end after the first batch of results come in, then all downstream DE jobs are blocked for that annotation.  Now, the query for existing results is scoped to the cluster in question.  

This was found by the owner of SCP2817 & SCP3055.  That study has ~20 clusterings each with over 50 eligible annotations in each.  It is worth noting that this would have resulted in thousands of jobs that potentially could have clogged up ingest since we have a quota in the total number of CPUs available at any given point in GCE, and DE jobs are the most compute-intensive jobs.  Luckily, the clusterings are tiny and each job completed in a matter of minutes, so the total batch of jobs would have completed in a few hours.  A manual backfill ran to add results for the cell type annotation in both studies (other annotations were skipped for now).  

However, we may see that the number of DE jobs increases greatly with this bugfix, and we may want to add sufficient guardrails to prevent this, or at least throttle them such that they do not block new file uploads.  This could probably be achieved by putting a cap on the total number of concurrent DE jobs (say, 50) and then adding logic to all DE job submissions to re-queue a job if the cap has been met.  There is already automation to skip submitting new jobs if a matching job exists, so this could be extended to include any DE job and to re-queue jobs when under load.

#### MANUAL TESTING
1. Boot all services as normal and sign in
2. Go to any study with existing DE results
3. Create a copy of one of the clustering files (with a new name) and upload this file as a new cluster
4. Once ingest has completed, confirm that you see new DE jobs launching on existing annotations