### PR TITLE
Global mass-assignment of scatter plot custom colors (SCP-6052)

### DIFF
--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -336,7 +336,7 @@ module Api
           }
           safe_file_params.delete(:custom_color_updates)
           if safe_file_params[:global_color_update]
-            @study.clustering_files.reject { |f| f.id.to_s == safe_file_params[:id] }.each do |file|
+            @study.clustering_files.reject { |f| f.id.to_s == params[:id] }.each do |file|
               update_params = {
                 'cluster_file_info' => { custom_colors: ClusterFileInfo.merge_color_updates(file, parsed_update) }
               }

--- a/app/controllers/api/v1/study_files_controller.rb
+++ b/app/controllers/api/v1/study_files_controller.rb
@@ -331,8 +331,19 @@ module Api
         end
         if safe_file_params[:custom_color_updates]
           parsed_update = JSON.parse(safe_file_params[:custom_color_updates])
-          safe_file_params['cluster_file_info'] = {custom_colors: ClusterFileInfo.merge_color_updates(study_file, parsed_update)}
+          safe_file_params['cluster_file_info'] = {
+            custom_colors: ClusterFileInfo.merge_color_updates(study_file, parsed_update)
+          }
           safe_file_params.delete(:custom_color_updates)
+          if safe_file_params[:global_color_update]
+            @study.clustering_files.reject { |f| f.id.to_s == safe_file_params[:id] }.each do |file|
+              update_params = {
+                'cluster_file_info' => { custom_colors: ClusterFileInfo.merge_color_updates(file, parsed_update) }
+              }
+              file.delay.update(update_params)
+            end
+          end
+          safe_file_params.delete(:global_color_update)
         end
 
         # manually check first if species/assembly was supplied by name
@@ -741,7 +752,7 @@ module Api
           :human_fastq_url, :human_data, :use_metadata_convention, :cluster_type, :generation, :x_axis_label,
           :y_axis_label, :z_axis_label, :x_axis_min, :x_axis_max, :y_axis_min, :y_axis_max, :z_axis_min, :z_axis_max,
           :species, :assembly, :external_link_url, :external_link_title, :external_link_description, :parse_on_upload,
-          :custom_color_updates, :reference_anndata_file,
+          :custom_color_updates, :global_color_update, :reference_anndata_file,
           spatial_cluster_associations: [],
           options: [
             :cluster_group_id, :font_family, :font_size, :font_color, :matrix_id, :submission_id, :bam_id, :bed_id,

--- a/app/javascript/components/visualization/ScatterPlot.jsx
+++ b/app/javascript/components/visualization/ScatterPlot.jsx
@@ -143,13 +143,14 @@ function RawScatterPlot({
   }, [editedCustomColors])
 
   /** Save any changes to the legend colors */
-  async function saveCustomColors(newColors) {
+  async function saveCustomColors(newColors, globalColorUpdate = false) {
     const colorObj = {}
     // read the annotation name off of scatterData to ensure it's the real name, and not '' or '_default'
     colorObj[scatterData?.annotParams?.name] = newColors
     const newFileObj = {
       _id: scatterData?.clusterFileId,
-      custom_color_updates: colorObj
+      custom_color_updates: colorObj,
+      global_color_update: globalColorUpdate
     }
     setIsLoading(true)
     try {

--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
@@ -6,7 +6,7 @@ import {
   faTimes,
   faSearch,
   faFileUpload,
-  faGlobe, faGlobeAmericas
+  faGlobe, faGlobeAmericas, faFileDownload
 } from '@fortawesome/free-solid-svg-icons'
 import Modal from 'react-bootstrap/lib/Modal'
 import { HexColorPicker, HexColorInput } from 'react-colorful'
@@ -268,6 +268,28 @@ export default function ScatterPlotLegend({
     setShowColorControls(false)
   }
 
+  function exportColors() {
+    const colorMap = Object.keys(customColors).length > 0 ? customColors : refColorMap
+    const lines = Object.entries(colorMap).map(([label, color]) => {
+      return `${label}\t${color}\n`
+    })
+
+    // Create an element with an anchor link and connect this to the blob
+    const element = document.createElement('a')
+    const colorExport = new Blob(lines, { type: 'text/plain' })
+    element.href = URL.createObjectURL(colorExport)
+
+    // name the file and indicate it should download
+    element.download = `${name}_color_map.tsv`
+
+    // Simulate clicking the link resulting in downloading the file
+    document.body.appendChild(element)
+    element.click()
+
+    // Cleanup
+    document.body.removeChild(element)
+  }
+
   /** collect general information when a user's mouse enters the legend  */
   function logMouseEnter() {
     log('hover:scatterlegend', { numLabels })
@@ -356,6 +378,16 @@ export default function ScatterPlotLegend({
     fileReader.readAsText(file)
   }
 
+  const globalSwitch =
+    <label htmlFor="global-color-update"
+           data-toggle="tooltip"
+           className="color-update-toggle"
+           title="Apply color changes globally for this annotation">
+      <span className={globalColorUpdate ? 'text-info' : 'text-muted'} onClick={handleToggleGlobalColor}>Global&nbsp;
+        <i className={`fa fa-fw ${toggleClassName}`}></i>
+      </span>
+    </label>
+
   return (
     <div
       className={`scatter-legend ${filteredClass}`}
@@ -412,7 +444,7 @@ export default function ScatterPlotLegend({
                   <a role="button" className="pull-right" data-analytics-name="legend-color-picker-cancel" onClick={cancelColors}>
                     Cancel
                   </a><br/>
-                  &nbsp;
+                  {globalSwitch}
                   <a role="button" className="pull-right" data-analytics-name="legend-color-picker-reset" onClick={resetColors}>
                     Reset to defaults
                   </a>
@@ -421,25 +453,29 @@ export default function ScatterPlotLegend({
             }
             { !showColorControls &&
               <>
-                <a role="button" data-analytics-name="legend-color-picker-show" onClick={() => setShowColorControls(true)}>
+                <a role="button"
+                   className='customize-color-palette'
+                   data-analytics-name="legend-color-picker-show"
+                   onClick={() => setShowColorControls(true)}
+                >
                   Customize <FontAwesomeIcon icon={faPalette}/>
                 </a>
-                <label htmlFor="global-color-update"
-                       data-toggle="tooltip"
-                       className="color-update-toggle"
-                       title="Apply color changes globally to all clusters">
-                  <span className={globalColorUpdate ? 'text-info' : 'text-muted'} onClick={handleToggleGlobalColor}>global&nbsp;
-                    <i className={`fa fa-fw ${toggleClassName}`}></i>
-                  </span>
-                </label>
+                {globalSwitch}
                 <label htmlFor="color-manifest-upload"
                        data-toggle="tooltip"
                        className="icon-button"
-                       title="Upload a file of annotation labels to color hex codes">
+                       title="Upload a manifest of annotation labels to color hex codes">
                   <input id="color-manifest-upload"
                          type="file"
                          onChange={e => readColorManifest(e.target.files[0])}/>
                   <FontAwesomeIcon className="action fa-lg" icon={faFileUpload} />
+                </label>
+                <label htmlFor="color-manifest-export"
+                       data-toggle="tooltip"
+                       title="Export current color manifest"
+                       onClick={exportColors}
+                >
+                  <FontAwesomeIcon className="action fa-lg" icon={faFileDownload} />
                 </label>
               </>
       }

--- a/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
+++ b/app/javascript/components/visualization/controls/ScatterPlotLegend.jsx
@@ -1,6 +1,13 @@
 import React, { useEffect, useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faPalette, faExternalLinkAlt, faTimes, faSearch } from '@fortawesome/free-solid-svg-icons'
+import {
+  faPalette,
+  faExternalLinkAlt,
+  faTimes,
+  faSearch,
+  faFileUpload,
+  faGlobe, faGlobeAmericas
+} from '@fortawesome/free-solid-svg-icons'
 import Modal from 'react-bootstrap/lib/Modal'
 import { HexColorPicker, HexColorInput } from 'react-colorful'
 import Button from 'react-bootstrap/lib/Button'
@@ -215,6 +222,9 @@ export default function ScatterPlotLegend({
 }) {
   // is the user currently in color-editing mode
   const [showColorControls, setShowColorControls] = useState(false)
+  const [globalColorUpdate, setGlobalColorUpdate] = useState(false)
+  const [toggleClassName, setToggleClassName] = useState('fa-toggle-off')
+
   // whether a request to the server to save colors is pending
   const labels = getLegendSortedLabels(countsByLabel)
   const numLabels = labels.length
@@ -246,7 +256,7 @@ export default function ScatterPlotLegend({
   /** resets any unsaved changes to user colors and clears custom colors */
   async function resetColors() {
     setEditedCustomColors({})
-    await saveCustomColors({})
+    await saveCustomColors({}, globalColorUpdate)
     setShowColorControls(false)
   }
 
@@ -254,7 +264,7 @@ export default function ScatterPlotLegend({
   async function saveColors() {
     // merge the user picked colors with existing custom colors so previously saved values are preserved
     const colorsToSave = Object.assign(customColors, editedCustomColors)
-    await saveCustomColors(colorsToSave)
+    await saveCustomColors(colorsToSave, globalColorUpdate)
     setShowColorControls(false)
   }
 
@@ -323,6 +333,29 @@ export default function ScatterPlotLegend({
     setLabelsToShow(labels)
   }
 
+  // handle clicking global color update toggle
+  function handleToggleGlobalColor() {
+    const toggleClass = toggleClassName === 'fa-toggle-on' ? 'fa-toggle-off' : 'fa-toggle-on'
+    setGlobalColorUpdate(!globalColorUpdate)
+    setToggleClassName(toggleClass)
+  }
+
+  function readColorManifest(file) {
+    const colorUpdate = {}
+    const fileReader = new FileReader()
+    fileReader.onloadend = () => {
+      const lines = fileReader.result.trim().split(/\n/)
+      lines.map((line, _) => {
+        const entry = line.split(/[\t,]/).map((l, _) => {return l.trim()})
+        const label = entry[0]
+        const color = entry[1]
+        colorUpdate[label] = color
+      })
+      saveCustomColors(colorUpdate, globalColorUpdate)
+    }
+    fileReader.readAsText(file)
+  }
+
   return (
     <div
       className={`scatter-legend ${filteredClass}`}
@@ -387,10 +420,29 @@ export default function ScatterPlotLegend({
               </>
             }
             { !showColorControls &&
-              <a role="button" data-analytics-name="legend-color-picker-show" onClick={() => setShowColorControls(true)}>
-                Customize colors <FontAwesomeIcon icon={faPalette}/>
-              </a>
-            }
+              <>
+                <a role="button" data-analytics-name="legend-color-picker-show" onClick={() => setShowColorControls(true)}>
+                  Customize <FontAwesomeIcon icon={faPalette}/>
+                </a>
+                <label htmlFor="global-color-update"
+                       data-toggle="tooltip"
+                       className="color-update-toggle"
+                       title="Apply color changes globally to all clusters">
+                  <span className={globalColorUpdate ? 'text-info' : 'text-muted'} onClick={handleToggleGlobalColor}>global&nbsp;
+                    <i className={`fa fa-fw ${toggleClassName}`}></i>
+                  </span>
+                </label>
+                <label htmlFor="color-manifest-upload"
+                       data-toggle="tooltip"
+                       className="icon-button"
+                       title="Upload a file of annotation labels to color hex codes">
+                  <input id="color-manifest-upload"
+                         type="file"
+                         onChange={e => readColorManifest(e.target.files[0])}/>
+                  <FontAwesomeIcon className="action fa-lg" icon={faFileUpload} />
+                </label>
+              </>
+      }
           </div>
         }
         <div>

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -76,7 +76,10 @@
 
   .color-update-toggle {
     font-weight: normal;
-    margin-left: 6px;
+  }
+
+  .customize-color-palette {
+    margin-right: 1em;
   }
 }
 

--- a/app/javascript/styles/_explore.scss
+++ b/app/javascript/styles/_explore.scss
@@ -73,6 +73,11 @@
   .violin-title {
     margin-left: 110px;
   }
+
+  .color-update-toggle {
+    font-weight: normal;
+    margin-left: 6px;
+  }
 }
 
 .popover-badge {
@@ -204,7 +209,7 @@
   margin-left: 4px;
 }
 
-#gene-list-upload {
+#gene-list-upload, #color-manifest-upload {
   display: none;
 }
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update is a user-requested feature to allow updating scatter plot colors globally.  This was in response to a study that is about to be published that has several dozen clusterings (both standard and spatial) and the owner was having to update each annotation label individually in each clustering.  Now, the user can click the new Global control to apply these changes to all clusterings at once.  Additionally, users can now import/export color manifests (2-column csv/tsv files of annotation labels to color hex codes) to further simplify this process.

Short demo of associated functionality:

https://github.com/user-attachments/assets/596cfaa8-1b0c-43c3-8fa5-870780970aa4

#### MANUAL TESTING
1.  Boot all services and sign in
2. Load any study with more than one scatter plot
3. Load a study-wide annotation and click click the "Customize" link
4. Chose a new color for one annotation, and also click the "Global" button
5. Click save, and then load the other scatter plot, confirming the color is updated there as well
6. Click the manifest export button and confirm you get a file
7. Open the file and edit one of the other labels to use a new color
8. Re-upload this manifest with the import button (ensuring the colors update in the other scatter plots)