### PR TITLE
Fix default state for options checkbox, text select behavior (SCP-6051)

### DIFF
--- a/app/javascript/components/search/controls/OptionsControl.jsx
+++ b/app/javascript/components/search/controls/OptionsControl.jsx
@@ -2,15 +2,28 @@ import React, { useState } from 'react'
 
 /** checkbox control for adding optional parameters to search query */
 export default function OptionsControl({ searchContext, searchProp, value, label, multiple = false }) {
-  const defaultChecked = searchContext.params[searchProp] === value
+  const defaultChecked = isDefaultChecked()
   const [isChecked, setIsChecked] = useState(defaultChecked)
 
+  /** return existing url query params for this option */
+  function getExistingOpts() {
+    return searchContext.params[searchProp]?.split(',').filter(o => o !== '') || []
+  }
+
+  /** set the default state for this option checkbox */
+  function isDefaultChecked() {
+    if (multiple) {
+      return getExistingOpts().filter(v => v === value).length > 0
+    } else {
+      return searchContext.params[searchProp] === value
+    }
+  }
 
   /** toggle state of checkbox */
   function toggleCheckbox(checked) {
     setIsChecked(checked)
     if (multiple) {
-      const existingOpts = searchContext.params[searchProp]?.split(',').filter(o => o !== '') || []
+      const existingOpts = getExistingOpts()
       const newOpts = checked ? existingOpts.concat(value) : existingOpts.filter(v => v !== value)
       searchContext.updateSearch({ [searchProp] : newOpts.join(',') })
     } else {
@@ -21,8 +34,11 @@ export default function OptionsControl({ searchContext, searchProp, value, label
   return (
     <li id={`options-control-${searchProp}`} key={`options-control-${searchProp}`}>
       <label>
-        <input type="checkbox" checked={isChecked} onChange={() => {toggleCheckbox(!isChecked)}}/>
-          <span onClick={() => {toggleCheckbox(!isChecked)}} >{ label }</span>
+        <input data-testid={`options-checkbox-${searchProp}-${value}`}
+               type="checkbox"
+               checked={isChecked}
+               onChange={() => {toggleCheckbox(!isChecked)}}/>
+        <span onClick={() => {toggleCheckbox(!isChecked)}} >{ label }</span>
       </label>
     </li>
   )

--- a/app/javascript/components/search/controls/OptionsControl.jsx
+++ b/app/javascript/components/search/controls/OptionsControl.jsx
@@ -13,7 +13,7 @@ export default function OptionsControl({ searchContext, searchProp, value, label
   /** set the default state for this option checkbox */
   function isDefaultChecked() {
     if (multiple) {
-      return getExistingOpts().filter(v => v === value).length > 0
+      return getExistingOpts().includes(value)
     } else {
       return searchContext.params[searchProp] === value
     }

--- a/app/javascript/styles/_search.scss
+++ b/app/javascript/styles/_search.scss
@@ -68,6 +68,7 @@ nav.search-links, #search-panel {
       width: 100%;
       box-sizing: border-box;
       display: inline-block;
+      user-select: none;
     }
     &.active > a, &.selected > a {
       background-color: $action-color;

--- a/test/js/search/options-control.test.js
+++ b/test/js/search/options-control.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 
 import OptionsControl from '~/components/search/controls/OptionsControl'
@@ -7,15 +7,28 @@ import OptionsControl from '~/components/search/controls/OptionsControl'
 describe('OptionsControl component', () => {
   it('renders with default checked state', () => {
     const searchContext = {
-      params: { 'external': 'hca' },
+      params: { 'external': 'hca', 'data_types': 'raw_counts,spatial' },
       updateSearch: jest.fn()
     }
     const { getByText, getByRole } = render(
-      <OptionsControl searchContext={searchContext} searchProp='external' value='hca' label='Include HCA results' />
+      <>
+        <OptionsControl searchContext={searchContext} searchProp='external' value='hca' label='Include HCA results' />
+        <OptionsControl
+          searchContext={searchContext} searchProp='data_types' value='raw_counts'
+          label='Has raw counts' multiple={true}
+        />
+        <OptionsControl
+          searchContext={searchContext} searchProp='data_types' value='spatial' label='Has spatial' multiple={true}
+        />
+      </>
     )
 
     expect(getByText('Include HCA results')).toBeInTheDocument()
-    expect(getByRole('checkbox')).toBeChecked()
+    expect(getByText('Has raw counts')).toBeInTheDocument()
+    expect(getByText('Has spatial')).toBeInTheDocument()
+    expect(screen.getByTestId('options-checkbox-external-hca')).toBeChecked()
+    expect(screen.getByTestId('options-checkbox-data_types-raw_counts')).toBeChecked()
+    expect(screen.getByTestId('options-checkbox-data_types-spatial')).toBeChecked()
   })
 
   it('toggles checkbox state on click', () => {


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This fixes a UI bug with `OptionsControl` components where the default checked state is not properly set on controls with `multiple=true` when more than one options is checked.  Additionally, this addresses a small UI papercut where clicks will select facet names in the facet bar.

#### MANUAL TESTING
1. Boot as normal and select all search options
2. Close the search options facet and confirm that all checkboxes stay checked when reopening
3. Open and close any facet dropdown quickly and confirm that the names are not selected