### PR TITLE
Enable pathway diagrams to use precomputed dot plot data (SCP-6119)

### DIFF
--- a/app/javascript/lib/dot-plot-precompute-patch.js
+++ b/app/javascript/lib/dot-plot-precompute-patch.js
@@ -76,8 +76,17 @@
         // Series 1: percent expressing (for size) - will be scaled to 0-100
         // Data format: values[0] = mean_expression, values[1] = percent_expressing
         geneNames.forEach((gene, i) => {
-          const geneData = data.genes[gene]
-
+          // gotcha for pathway diagrams and precomputed dot plots
+          // this is because the pathway diagram may contain genes that were not included in the dot plot data
+          // (e.g. because they were not expressed)
+          let geneData = data.genes[gene]
+          if (!geneData) {
+            geneData = []
+            // If gene is missing from data, fill with zeros
+            for (let j = 0; j < nCols; j++) {
+              geneData.push([0.0, 0.0])
+            }
+          }
           // Map data from original order to sorted order
           geneData.forEach((values, originalIndex) => {
             const sortedIndex = originalToSortedIndex[originalIndex]

--- a/app/javascript/lib/dot-plot-precompute-patch.js
+++ b/app/javascript/lib/dot-plot-precompute-patch.js
@@ -82,9 +82,9 @@
           let geneData = data.genes[gene]
           if (!geneData) {
             geneData = []
-            // If gene is missing from data, fill with zeros
+            // If gene is missing from data, fill with NaN and 0 cells expressing
             for (let j = 0; j < nCols; j++) {
-              geneData.push([0.0, 0.0])
+              geneData.push([NaN, 0])
             }
           }
           // Map data from original order to sorted order

--- a/app/javascript/lib/pathway-expression.js
+++ b/app/javascript/lib/pathway-expression.js
@@ -21,6 +21,7 @@ import { renderDotPlot } from '~/components/visualization/DotPlot'
 import { getEligibleLabels } from '~/lib/cluster-utils'
 import { fetchMorpheusJson } from '~/lib/scp-api'
 import { getFeatureFlagsWithDefaults } from '~/providers/UserProvider'
+import { shouldUsePreprocessedData } from '~/components/visualization/DotPlot'
 
 // Denoise DevTools console log by not showing error that lacks user impact
 window.onerror = function(error) {
@@ -83,7 +84,7 @@ window.SCP.renderBackgroundDotPlotRegister = {}
 export async function renderBackgroundDotPlot(
   studyAccession, genes=[], cluster, annotation={},
   subsample, annotationValues, drawCallback,
-  topContainerSelector
+  topContainerSelector, usePreprocessed
 ) {
   const graphId = 'background-dot-plot'
   document.querySelector(`#${graphId}`)?.remove()
@@ -122,7 +123,9 @@ export async function renderBackgroundDotPlot(
       annotation.name,
       annotation.type,
       annotation.scope,
-      subsample
+      subsample,
+      false, // mock flag
+      usePreprocessed
     )
     dataset = results[0]
 
@@ -317,6 +320,8 @@ function mergeDotPlotMetrics(newMetrics, oldMetrics) {
 
 /** Color pathway gene nodes by expression */
 export async function renderPathwayExpression(studyAccession, cluster, annotation, label, labels) {
+  const flags = getFeatureFlagsWithDefaults()
+  const usePreprocessed = shouldUsePreprocessedData(flags, window.SCP?.exploreInfo)
   let allDotPlotMetrics = {}
 
   const pathwayGenes = getPathwayGenes()
@@ -337,10 +342,9 @@ export async function renderPathwayExpression(studyAccession, cluster, annotatio
     // the second render is for collapsed label-x-gene metrics (dotplot)
 
     numDraws += 1
-    if (numDraws === 1) {return}
+    if (numDraws === 1 && !usePreprocessed) {return}
 
     const dotPlotMetrics = getDotPlotMetrics(dotPlot)
-
     if (!dotPlotMetrics) {
       // Occurs upon resizing window, artifact of internal Morpheus handling
       // of pre-dot-plot heatmap matrix.  No user-facing impact.
@@ -367,7 +371,7 @@ export async function renderPathwayExpression(studyAccession, cluster, annotatio
       renderBackgroundDotPlot(
         studyAccession, dotPlotGeneBatches[numRenders], cluster, annotation,
         'All', annotationLabels, backgroundDotPlotDrawCallback,
-        '#_ideogramPathwayContainer'
+        '#_ideogramPathwayContainer', usePreprocessed
       )
     }
   }
@@ -378,7 +382,7 @@ export async function renderPathwayExpression(studyAccession, cluster, annotatio
   renderBackgroundDotPlot(
     studyAccession, dotPlotGeneBatches[0], cluster, annotation,
     'All', annotationLabels, backgroundDotPlotDrawCallback,
-    '#_ideogramPathwayContainer'
+    '#_ideogramPathwayContainer', usePreprocessed
   )
 }
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update enables pathway diagrams to leverage precomputed dot plot data from `DotPlotService`.  Since pathways often contain large numbers of genes, using precomputed data will vastly improve render times and reduce load on the server when trying to transmit large amounts of dot plot data.

Below is a comparison of a study with 38K cells running in development with caching turned off.
Regular data (~1 min to load all data for single annotation):

https://github.com/user-attachments/assets/d18bd3d4-75b7-4f88-b51c-80e222164401

Precomputed data (each annotation loads in ~5-10s):

https://github.com/user-attachments/assets/95a4b62c-ad78-40c3-8e6c-258f28d6b82d

In production, these render times will be even faster for precomputed data (usually < 1s).

#### MANUAL TESTING
1. Boot as normal and load any study with precomputed dot plot data
2. Query for pathways and confirm data loads and diagrams overlay expression
3. (Optional): Turn off `dot_plot_preprocessing_frontend` feature flag and confirm data still loads for same study