### PR TITLE
Bugfix for deleting bundled files (SCP-6094)

### DIFF
--- a/app/javascript/components/upload/upload-utils.js
+++ b/app/javascript/components/upload/upload-utils.js
@@ -238,7 +238,8 @@ function validateNameUniqueness(file, allFiles, validationMessages) {
   const allOtherNames = allOtherFiles.map(f => f.name)
   // require 'isDirty' so we only show the error on the file being updated
   if (file.name && allOtherNames.includes(file.name) && file.isDirty) {
-    validationMessages.fileName = `A file named ${file.name} already exists in your study`
+    validationMessages.fileName = `A file named ${file.name} already exists in your study.  If you recently deleted ` +
+    `this file and are reusing it, please refresh the page to clear it from the cache.`
   }
 }
 

--- a/app/javascript/lib/validation/validate-file.js
+++ b/app/javascript/lib/validation/validate-file.js
@@ -30,7 +30,8 @@ function validateFileName(file, studyFile, allStudyFiles, allowedFileExts=['*'])
   if (otherNames.includes(file.name) ||
     otherUploadFileNames.includes(file.name) ||
     otherLocalFileNames.includes(file.name)) {
-    const msg = `A file named ${file.name} already exists in your study`
+    const msg = `A file named ${file.name} already exists in your study.  If you recently deleted ` +
+      `this file and are reusing it, please refresh the page to clear it from the cache.`
     issues.push(['error', 'filename:duplicate', msg])
   }
 

--- a/app/models/delete_queue_job.rb
+++ b/app/models/delete_queue_job.rb
@@ -113,7 +113,12 @@ class DeleteQueueJob < Struct.new(:object, :study_file_id)
       if object.is_bundle_parent?
         object.bundled_files.each do |file|
           Rails.logger.info "Deleting bundled file #{file.upload_file_name} from #{study.name} due to parent deletion: #{object.upload_file_name}"
-          DeleteQueueJob.new(file).perform
+          # remove file from bucket since no API call was made to do this
+          study = file.study
+          if ApplicationController.firecloud_client.workspace_file_exists?(study.bucket_id, file.bucket_location)
+            ApplicationController.firecloud_client.delete_workspace_file(study.bucket_id, file.bucket_location)
+          end
+          DeleteQueueJob.new(file).delay.perform
         end
         object.study_file_bundle.destroy
       end

--- a/test/factories/study_file.rb
+++ b/test/factories/study_file.rb
@@ -116,6 +116,10 @@ FactoryBot.define do
                             study_file: file
           )
         end
+        # create study_file bundle
+        cluster_file = StudyFile.find(evaluator.cluster.study_file_id)
+        bundle = StudyFileBundle.initialize_from_parent(file.study, cluster_file)
+        bundle.add_files(file)
       end
     end
     factory :ideogram_output do

--- a/test/models/delete_queue_job_test.rb
+++ b/test/models/delete_queue_job_test.rb
@@ -307,4 +307,8 @@ class DeleteQueueJobTest < ActiveSupport::TestCase
     assert_equal %w[cluster_2.txt cluster_3.txt], study.default_cluster_order,
                  'Did not update cluster order after deleting a cluster file'
   end
+
+  test 'should delete bundled files when removing parent' do
+
+  end
 end

--- a/test/models/delete_queue_job_test.rb
+++ b/test/models/delete_queue_job_test.rb
@@ -309,6 +309,38 @@ class DeleteQueueJobTest < ActiveSupport::TestCase
   end
 
   test 'should delete bundled files when removing parent' do
-
+    study = FactoryBot.create(:detached_study,
+                              name_prefix: 'Bundle Delete Test',
+                              user: @user,
+                              test_array: @@studies_to_clean)
+    cell_input = { x: [1, 2, 3], y: [4, 5, 6], cells: %w[A B C] }
+    cluster_file = FactoryBot.create(:cluster_file, name: "cluster.txt", study:, cell_input:, status: 'uploaded')
+    cluster = ClusterGroup.find_by(study:, study_file: cluster_file)
+    label_input = {
+      x: [1, 2, 3],
+      y: [4, 5, 6],
+      text: ['Group 1', 'Group 2', 'Group 3']
+    }
+    label_file = FactoryBot.create(
+      :coordinate_label_file, name: 'labels.txt', status: 'uploaded', study:, cluster:, label_input:
+    )
+    label_file.reload
+    cluster_file.reload
+    bundle = cluster_file.study_file_bundle
+    assert bundle.valid?
+    assert bundle.completed?
+    mock = Minitest::Mock.new
+    mock.expect(:workspace_file_exists?, true, [study.bucket_id, String])
+    mock.expect(:delete_workspace_file, true, [study.bucket_id, String])
+    ApplicationController.stub :firecloud_client, mock do
+      DeleteQueueJob.new(cluster_file).perform
+      sleep(5) # ensure any delayed jobs have completed
+      cluster_file.reload
+      label_file.reload
+      assert cluster_file.queued_for_deletion, 'Cluster file was not queued for deletion'
+      assert label_file.queued_for_deletion, 'Bundled label file was not queued for deletion'
+      assert_not StudyFileBundle.where(id: bundle.id).exists?, 'StudyFileBundle was not deleted'
+      mock.verify
+    end
   end
 end


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a bug found by a user where deleting bundled files does not always remove those files from the study bucket.  This can lead to issues during ingest where old versions of files are still present and can block the user from re-uploading files.  Additionally, when a file is deleted from the upload wizard (due to failed ingest) and the user has not reloaded the page, the UI erroneously states the file is still present.  Now, a prompt is sent to the user to reload the page to clear the cache.

#### MANUAL TESTING
1. Boot all services, sign in, and load the upload wizard for a classic study
2. Upload any file that requires a bundle, such as an MTX matrix
3. Once all files have completed ingesting, delete the parent matrix
4. Open the bucket in a browser and confirm all 3 files have been deleted
5. Refresh the page and then upload all 3 files again, confirming you are not told that any of them still exist