### PR TITLE
Updating all runners/actions to use node 24 (SCP-6120)

### DIFF
--- a/.github/actions/setup-gcloud/action.yml
+++ b/.github/actions/setup-gcloud/action.yml
@@ -14,13 +14,13 @@ runs:
       shell: bash
       run: sudo apt-get update && sudo apt-get -y install jq
     - name: Auth to GCP
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v3
       with:
         project_id: ${{ inputs.google_cloud_project }}
         workload_identity_provider: "projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider"
         service_account: ${{ inputs.service_account_email }}
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@v3
       with:
         project_id: ${{ inputs.google_cloud_project }}
     - name: Authenticate docker

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure gcloud
         uses: ./.github/actions/setup-gcloud
         with:

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -29,7 +29,7 @@ jobs:
       group: production-deployment
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure gcloud
         uses: ./.github/actions/setup-gcloud
         with:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -25,7 +25,7 @@ jobs:
       group: staging-deployment
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure gcloud
         uses: ./.github/actions/setup-gcloud
         with:

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -17,8 +17,12 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure gcloud
         uses: ./.github/actions/setup-gcloud
         with:

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -14,8 +14,12 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure gcloud
         uses: ./.github/actions/setup-gcloud
         with:


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates all affected actions to use Node 24 as per the recent deprecation notice from Github: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

In the case of our self-hosted runner for CI, this will now use `actions/setup-node@v6` to pre-configure Node 24 on our runner.  This should be cached after the first time it runs, so it won't need to re-install every time.  Github hosted runners already have Node 24 available.  