### PR TITLE
Updating action versions for Node 24 (SCP-6128)

### DIFF
--- a/.github/actions/docker-build-env-setup/action.yml
+++ b/.github/actions/docker-build-env-setup/action.yml
@@ -9,7 +9,7 @@ runs:
   steps:
     - name: Detect changes to Dockerfile
       id: changed-dockerfile
-      uses: tj-actions/changed-files@v44.3.0
+      uses: tj-actions/changed-files@v47.0.5
       with:
         files: Dockerfile
     - name: Rebuild local image if Dockerfile changed

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           bin/load_env_secrets.sh -p $SCP_CONFIG -s $DEFAULT_SA -r $READONLY_SA -g $GOOGLE_CLOUD_PROJECT -e test -v $DOCKER_IMAGE_TAG -n single-cell-portal-test
       - name: Preserve all test logs
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: test-logs

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           bin/load_env_secrets.sh -p $SCP_CONFIG -s $DEFAULT_SA -r $READONLY_SA -g $GOOGLE_CLOUD_PROJECT -e test -v $DOCKER_IMAGE_TAG -n single-cell-portal-test
       - name: Preserve all test logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: test-logs

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
       - name: Preserve all test logs
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: test-logs

--- a/.github/workflows/run-orch-smoketest.yml
+++ b/.github/workflows/run-orch-smoketest.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
       - name: Preserve all test logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: test-logs


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates the remaining Github actions to use Node 24.  Affected actions were `tj-actions/changed-files` and `actions/upload-artifact`