### PR TITLE
Include timestamps in SiteStudy

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -529,6 +529,16 @@ class Study
       key :default, 0
       key :description, 'Number of unique gene names in Study (set from Expression Matrix or 10X Genes File)'
     end
+    property :created_at do
+      key :type, :string
+      key :format, :date_time
+      key :description, 'Creation timestamp'
+    end
+    property :updated_at do
+      key :type, :string
+      key :format, :date_time
+      key :description, 'Last update timestamp'
+    end
   end
 
   swagger_schema :SiteStudyWithFiles do

--- a/app/views/api/v1/site/_study_in_list.json.jbuilder
+++ b/app/views/api/v1/site/_study_in_list.json.jbuilder
@@ -5,3 +5,5 @@ json.set! :public, study.public
 json.set! :detached, study.detached
 json.set! :cell_count, study.cell_count
 json.set! :gene_count, study.gene_count
+json.set! :created_at, study.created_at
+json.set! :updated_at, study.updated_at


### PR DESCRIPTION
Exposes created_at and updated_at timestamps in responses to /site/studies requests. This gives users who are not study owners/editors some additional context surrounding a study of interest.

I did not find relevant tests for this model or API endpoint, so I didn't test my changes. Please let me know if you'd like me to take additional steps.