### PR TITLE
Fixing bug with casting datetime to string (SCP-6162)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -226,7 +226,7 @@ class ApplicationController < ActionController::Base
         invalid_permission: "You either do not have permission to perform that action, or #{study.accession} does not exist.",
         not_authenticated: "You must be signed in to download data from #{study.accession}.",
         detached: "We were unable to complete your request as #{study.accession} is detached from the workspace (maybe the workspace was deleted?)",
-        embargoed: "You may not download any data from #{study.accession} until #{study.embargo.try(:to_s, :long)}."
+        embargoed: "You may not download any data from #{study.accession} until #{study.embargo.try(:to_fs, :long)}."
     }
     # store redirect_url and message for later
     redirect_parameters = {}


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This addresses a new regression with the change of `to_fs` replacing `to_s` for datetime entities.  This was identified here: https://broad-institute.sentry.io/issues/7707614266

#### MANUAL TESTING
1. Load any study with an embargo date
2. Run the following command in the console and confirm it does not error:
```
"You may not download any data from #{study.accession} until #{study.embargo.try(:to_fs, :long)}."
=> "You may not download any data from SCP150 until January 08, 2035."
```